### PR TITLE
Add apidoc generation and hosting. Closes #39.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,10 @@ ENV/
 
 # Local Postgres data
 pg_data/
+
+# apidoc
+apidoc/*
+!apidoc/.apidocignore
+
+# static files
+koku/staticfiles/

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ PYTHON	= $(shell which python)
 
 TOPDIR  = $(shell pwd)
 PYDIR	= koku
+APIDOC = $(TOPDIR)/apidoc
 
 OC_SOURCE	= registry.access.redhat.com/openshift3/ose
 OC_VERSION	= v3.7
@@ -21,7 +22,10 @@ help:
 	@echo "  html                     to create html documentation for the project"
 	@echo "  lint                     to run linting against the project"
 	@echo "  reinitdb                 to drop and recreate the database"
+	@echo "  make-migrations          to make migrations for the database"
 	@echo "  run-migrations           to run migrations against database"
+	@echo "  gen-apidoc               to create api documentation"
+	@echo "  collect-static           to collect static files to host"
 	@echo "  serve                    to run the Django server locally"
 	@echo "  start-db                 to start the psql db in detached state"
 	@echo "  stop-compose             to stop all containers"
@@ -52,6 +56,13 @@ make-migrations:
 run-migrations:
 	sleep 1
 	DJANGO_READ_DOT_ENV_FILE=True $(PYTHON) $(PYDIR)/manage.py migrate
+
+gen-apidoc:
+	rm -fr $(PYDIR)/staticfiles/
+	apidoc -i $(PYDIR) -o $(APIDOC)
+
+collect-static:
+	$(PYTHON) $(PYDIR)/manage.py collectstatic --no-input
 
 serve:
 	DJANGO_READ_DOT_ENV_FILE=True $(PYTHON) $(PYDIR)/manage.py runserver

--- a/README.rst
+++ b/README.rst
@@ -76,6 +76,21 @@ To run a local dev Django server you can use ::
 
     make serve
 
+API Documentation Generation
+----------------------------
+
+To generate and host the API documentation locally you need to `Install APIDoc`_.
+
+Generate the project API documenttion by running the following command ::
+
+  make gen-apidoc
+
+In order to host the docs locally you need to collect the static files ::
+
+  make collect-static
+
+Now start the server with as described above and point your browser to **http://127.0.0.1:8000/apidoc/index.html**.
+
 Testing and Linting
 -------------------
 
@@ -105,6 +120,7 @@ Please refer to Contributing_.
 
 .. _readthedocs: http://koku.readthedocs.io/en/latest/
 .. _tutorial: https://www.postgresql.org/docs/10/static/tutorial-start.html
+.. _`Install APIDoc`: http://apidocjs.com/#install
 .. _`Working with Openshift`: https://koku.readthedocs.io/en/latest/openshift.html
 .. _Contributing: https://koku.readthedocs.io/en/latest/CONTRIBUTING.html
 

--- a/apidoc.json
+++ b/apidoc.json
@@ -1,0 +1,6 @@
+{
+  "name": "Koku",
+  "version": "1.0.0",
+  "description": "This document is intended for developers who want to use the Koku API to write applications that interact with Koku.",
+  "title": "Koku API Documentation"
+}

--- a/docs/source/specs/openapi.yml
+++ b/docs/source/specs/openapi.yml
@@ -35,13 +35,13 @@ components:
           type: integer
           format: int64
           example: 1
-        build:
+        commit:
           type: string
           example: "178d2ea"
         server_address:
           type: string
           example: "127.0.0.1:8000"
-        platform:
+        platform_info:
           type: object
           example: {
             "system": "Darwin",
@@ -51,7 +51,7 @@ components:
             "machine": "x86_64",
             "processor": "i386"
             }
-        python:
+        python_version:
           type: string
           example: "3.6.1"
         modules:

--- a/koku/api/status/view.py
+++ b/koku/api/status/view.py
@@ -28,7 +28,50 @@ from api.status.serializer import StatusSerializer
 @api_view(['GET'])
 @permission_classes((permissions.AllowAny,))
 def status(request):
-    """Provide the server status information."""
+    """Provide the server status information.
+    @api {get} /api/v1/status Request server status
+    @apiName GetStatus
+    @apiGroup Status
+    @apiVersion 1.0.0
+
+    @apiSuccess {Number} api_version The version of the API.
+    @apiSuccess {String} commit  The commit hash of the code base.
+    @apiSuccess {Object} modules  The code modules found on the server.
+    @apiSuccess {Object} platform_info  The server platform information.
+    @apiSuccess {String} python_version  The version of python on the server.
+    @apiSuccess {String} server_address  The address of the server.
+    @apiSuccess {String} server_id  The uuid of the server.
+    @apiSuccessExample {json} Success-Response:
+        HTTP/1.1 200 OK
+        {
+            "api_version": 1,
+            "commit": "178d2ea",
+            "server_address": "127.0.0.1:8000",
+            "platform_info": {
+                "system": "Darwin",
+                "node": "node-1.example.com",
+                "release": "17.5.0",
+                "version": "Darwin Kernel Version 17.5.0",
+                "machine": "x86_64",
+                "processor": "i386"
+                },
+            "python_version": "3.6.1",
+            "modules": {
+                "coverage": "4.5.1",
+                "coverage.version": "4.5.1",
+                "coverage.xmlreport": "4.5.1",
+                "cryptography": "2.0.3",
+                "ctypes": "1.1.0",
+                "ctypes.macholib": "1.0",
+                "decimal": "1.70",
+                "django": "1.11.5",
+                "django.utils.six": "1.10.0",
+                "django_filters": "1.0.4",
+                "http.server": "0.6"
+                },
+            "server_id": "ff4eb8e4-ddfb-4b66-8e0e-045a244990f3"
+        }
+    """
     status_info = Status.objects.get(pk=1)
     serializer = StatusSerializer(status_info)
     server_info = serializer.data

--- a/koku/koku/settings.py
+++ b/koku/koku/settings.py
@@ -142,8 +142,13 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/2.0/howto/static-files/
 
-STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
+
+STATIC_URL = '/apidoc/'
+
+STATICFILES_DIRS = [
+    os.path.join(BASE_DIR, '..', 'apidoc'),
+]
 
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 

--- a/koku/koku/urls.py
+++ b/koku/koku/urls.py
@@ -22,10 +22,16 @@ The `urlpatterns` list routes URLs to views. For more information please see:
 from django.conf.urls import url, include
 from django.contrib import admin
 from django.urls import path
+from django.views.generic import RedirectView
 
 # pylint: disable=invalid-name
 urlpatterns = [
     path('admin/', admin.site.urls),
     url(r'^api-auth/', include('rest_framework.urls')),
     url(r'^api/v1/', include('api.urls')),
+
+    # static files (*.css, *.js, *.jpg etc.)
+    url(r'^(?!/?apidoc/)(?P<path>.*\..*)$',
+        RedirectView.as_view(url='/apidoc/%(path)s', permanent=False),
+        name='apidoc'),
 ]


### PR DESCRIPTION
* Update status endpoint doc with API info
* Added make file targets
* Tweaked app settings to host apidoc
* Added Readme updates

Opened the following issue to allow the openshift container to host the apidoc: https://github.com/project-koku/koku/issues/74