### PR TITLE
fix chicken-and-egg problem with startup_status()

### DIFF
--- a/koku/api/apps.py
+++ b/koku/api/apps.py
@@ -45,8 +45,10 @@ class ApiConfig(AppConfig):
         """Log the status of the server at startup."""
         # noqa: E402 pylint: disable=C0413
         from django.db import connection
-        if 'status_api' not in connection.introspection.table_names():
+        tables = connection.introspection.table_names()
+        if 'api_status' not in tables:
             logger.warning('status table not found. skipping status output.')
+            logger.warning('available tables: {}'.format(tables))
             return
 
         from api.status.model import Status

--- a/koku/api/apps.py
+++ b/koku/api/apps.py
@@ -44,6 +44,11 @@ class ApiConfig(AppConfig):
     def startup_status(self):  # pylint: disable=R0201
         """Log the status of the server at startup."""
         # noqa: E402 pylint: disable=C0413
+        from django.db import connection
+        if 'status_api' not in connection.introspection.table_names():
+            logger.warning('status table not found. skipping status output.')
+            return
+
         from api.status.model import Status
         status_info = None
         status_count = Status.objects.count()


### PR DESCRIPTION
This fixes a chicken-and-egg problem with new installations where the status table doesn't exist, so the app can't output status. But, the failure to output status breaks migrations, which create the status table.