### PR TITLE
Don't run tests on build. Travis should run tests before merge

### DIFF
--- a/openshift/koku-template.yaml
+++ b/openshift/koku-template.yaml
@@ -134,8 +134,6 @@ objects:
       to:
         kind: ImageStreamTag
         name: ${NAME}:latest
-    postCommit:
-      script: cd koku && python manage.py test
     source:
       contextDir: ${CONTEXT_DIR}
       git:


### PR DESCRIPTION
We have tests with required (dev) packages that aren't required for running the app. Because tests will have already been required to pass in Travis before merging to master, let's 💣 the postcommit hook to run tests when building the container.