### PR TITLE
Changed db secret name to match openshift postgres persistent template

### DIFF
--- a/openshift/koku-template.yaml
+++ b/openshift/koku-template.yaml
@@ -54,7 +54,7 @@ objects:
       template.openshift.io/expose-database_name: "{.data['database-name']}"
       template.openshift.io/expose-password: "{.data['database-password']}"
       template.openshift.io/expose-username: "{.data['database-user']}"
-    name: ${DATABASE_SERVICE_NAME}-secret
+    name: ${DATABASE_SERVICE_NAME}
   stringData:
     database-name: ${DATABASE_NAME}
     database-password: ${DATABASE_PASSWORD}
@@ -202,13 +202,13 @@ objects:
               valueFrom:
                 secretKeyRef:
                   key: database-user
-                  name: ${DATABASE_SERVICE_NAME}-secret
+                  name: ${DATABASE_SERVICE_NAME}
                   optional: false
             - name: DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   key: database-password
-                  name: ${DATABASE_SERVICE_NAME}-secret
+                  name: ${DATABASE_SERVICE_NAME}
                   optional: false
             - name: DJANGO_SECRET_KEY
               valueFrom:
@@ -330,17 +330,17 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: database-user
-                name: ${DATABASE_SERVICE_NAME}-secret
+                name: ${DATABASE_SERVICE_NAME}
           - name: POSTGRESQL_PASSWORD
             valueFrom:
               secretKeyRef:
                 key: database-password
-                name: ${DATABASE_SERVICE_NAME}-secret
+                name: ${DATABASE_SERVICE_NAME}
           - name: POSTGRESQL_ADMIN_PASSWORD
             valueFrom:
               secretKeyRef:
                 key: database-admin-password
-                name: ${DATABASE_SERVICE_NAME}-secret
+                name: ${DATABASE_SERVICE_NAME}
           - name: POSTGRESQL_DATABASE
             value: ${DATABASE_NAME}
           image: postgresql:9.6


### PR DESCRIPTION
This change just syncs up the secret name with the `openshift//postgresql-persistent` template for easy interchange when working in the dev environment. 

Openshift objects are always prefixed/labeled with what they are so it will still always be recognizable as a secret after dropping the `-secret` suffix. 