### PR TITLE
Bug fixes for issue found during Sprint 1 demo recording.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ whitenoise = ">=3.3.0"
 Django = ">=2.0.0"
 psycopg2-binary = ">=2.7.0"
 drf-nested-routers = ">=0.90.0"
+django-filter = ">=1.1.0"
 
 [dev-packages]
 pylint = "==1.9.1"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8b2501764b1741ae8cb44acaf1c7203236e0f75acb799c28dbe80353b640b862"
+            "sha256": "4d6e86ddd1e458815dc3dbad932ff4a682783a37e1c89b47ef55f1de905f2237"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -46,6 +46,14 @@
             ],
             "index": "pypi",
             "version": "==0.4.4"
+        },
+        "django-filter": {
+            "hashes": [
+                "sha256:ea204242ea83790e1512c9d0d8255002a652a6f4986e93cee664f28955ba0c22",
+                "sha256:ec0ef1ba23ef95b1620f5d481334413700fb33f45cd76d56a63f4b0b1d76976a"
+            ],
+            "index": "pypi",
+            "version": "==1.1.0"
         },
         "djangorestframework": {
             "hashes": [

--- a/docs/source/specs/openapi.yml
+++ b/docs/source/specs/openapi.yml
@@ -24,6 +24,32 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /api/v1/token-auth/:
+    post:
+      summary: Obtain an authentication token
+      operationId: getAuthToken
+      tags:
+        - Token
+      requestBody:
+        description: Username and password to exchange for token
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TokenIn'
+      responses:
+        '200':
+          description: An token object
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TokenOut"
+        '500':
+          description: Unexpected Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /api/v1/customers/:
     post:
       summary: Create a customer
@@ -290,7 +316,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-  /api/v1/users/{id}/reset-password/:
+  /api/v1/users/{uuid}/reset-password/:
     put:
       summary: Reset a user's password
       operationId: resetUserPassword
@@ -670,6 +696,24 @@ components:
         server_id:
           type: string
           example: "ff4eb8e4-ddfb-4b66-8e0e-045a244990f3"
+    TokenIn:
+      required:
+        - username
+        - password
+      properties:
+        username:
+          type: string
+          example: "smithj"
+        password:
+          type: string
+          example: "str0ng!P@ss"
+    TokenOut:
+      required:
+        - token
+      properties:
+        token:
+          type: string
+          example: "9944b09199c62bcf9418ad846dd0e4bbdfc6ee4b"
     User:
       required:
         - username

--- a/koku/api/iam/test/tests_user_view.py
+++ b/koku/api/iam/test/tests_user_view.py
@@ -199,67 +199,48 @@ class UserViewTest(IamTestCase):
     def test_reset_password(self):
         """Test reset password with valid user and token."""
         test_user = self.customers[0]['users'][0]
-        token = test_user['token']
         reset_body = {'token': test_user['reset_token'],
                       'password': self.gen_password()}
         url = reverse('user-reset-password', args=[test_user['uuid']])
         client = APIClient()
-        client.credentials(HTTP_AUTHORIZATION=token)
         response = client.put(url, data=reset_body, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_reset_password_same_pass(self):
         """Test reset password with valid user, token and same password."""
         test_user = self.customers[0]['users'][0]
-        token = test_user['token']
         reset_body = {'token': test_user['reset_token'],
                       'password': test_user['password']}
         url = reverse('user-reset-password', args=[test_user['uuid']])
         client = APIClient()
-        client.credentials(HTTP_AUTHORIZATION=token)
         response = client.put(url, data=reset_body, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_reset_password_no_reuse(self):
         """Test reset password with valid user and token twice."""
         test_user = self.customers[1]['users'][0]
-        token = test_user['token']
         reset_body = {'token': test_user['reset_token'],
                       'password': self.gen_password()}
         url = reverse('user-reset-password', args=[test_user['uuid']])
         client = APIClient()
-        client.credentials(HTTP_AUTHORIZATION=token)
         response = client.put(url, data=reset_body, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response = client.put(url, data=reset_body, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-    def test_reset_password_anon(self):
-        """Test reset password with an anonymous user and valid token."""
-        test_user = self.customers[1]['users'][0]
-        reset_body = {'token': test_user['reset_token'],
-                      'password': self.gen_password()}
-        url = reverse('user-reset-password', args=[test_user['uuid']])
-        client = APIClient()
-        response = client.put(url, data=reset_body, format='json')
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
-
     def test_reset_password_invalid_token(self):
         """Test reset password with valid user and invalid token."""
         test_user = self.customers[1]['users'][0]
-        token = test_user['token']
         reset_body = {'token': 'invalid',
                       'password': self.gen_password()}
         url = reverse('user-reset-password', args=[test_user['uuid']])
         client = APIClient()
-        client.credentials(HTTP_AUTHORIZATION=token)
         response = client.put(url, data=reset_body, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_reset_password_expired_token(self):
         """Test reset password with valid user and expired token."""
         test_user = self.customers[1]['users'][0]
-        token = test_user['token']
         reset_body = {'token': test_user['reset_token'],
                       'password': self.gen_password()}
         rt_qs = ResetToken.objects.filter(token=test_user['reset_token'])
@@ -270,7 +251,6 @@ class UserViewTest(IamTestCase):
         reset_token.save()
         url = reverse('user-reset-password', args=[test_user['uuid']])
         client = APIClient()
-        client.credentials(HTTP_AUTHORIZATION=token)
         response = client.put(url, data=reset_body, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 

--- a/koku/api/iam/view/user.py
+++ b/koku/api/iam/view/user.py
@@ -23,7 +23,7 @@ from rest_framework import mixins, viewsets
 from rest_framework.authentication import (SessionAuthentication,
                                            TokenAuthentication)
 from rest_framework.decorators import action
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.serializers import ValidationError
 
@@ -197,7 +197,7 @@ class UserViewSet(mixins.CreateModelMixin,
         """
         return super().destroy(request=request, args=args, kwargs=kwargs)
 
-    @action(methods=['put'], detail=True, permission_classes=[IsAuthenticated],
+    @action(methods=['put'], detail=True, permission_classes=[AllowAny],
             url_path='reset-password', url_name='reset-password',
             serializer_class=serializers.PasswordChangeSerializer)
     def reset_password(self, request, uuid=None):
@@ -263,6 +263,7 @@ class UserViewSet(mixins.CreateModelMixin,
             raise ValidationError(error)
 
         user.set_password(password)
+        user.save()
         reset_token.used = True
         reset_token.save()
 

--- a/koku/api/iam/view/user_preference.py
+++ b/koku/api/iam/view/user_preference.py
@@ -16,8 +16,8 @@
 #
 
 """View for User Preferences."""
-
 from django.forms.models import model_to_dict
+from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import exceptions, mixins, viewsets
 from rest_framework.authentication import (SessionAuthentication,
                                            TokenAuthentication)
@@ -46,6 +46,8 @@ class UserPreferenceViewSet(mixins.CreateModelMixin,
     authentication_classes = (TokenAuthentication,
                               SessionAuthentication)
     permission_classes = (IsObjectOwner, IsAuthenticated)
+    filter_backends = (DjangoFilterBackend,)
+    filter_fields = ('name',)
 
     def get_queryset(self):
         """Get a queryset that only displays the owner's preferences."""
@@ -119,7 +121,9 @@ class UserPreferenceViewSet(mixins.CreateModelMixin,
                 "Authorizaton": "Token 45138a913da44ab89532bab0352ef84b"
             }
 
-        @apiParam {String} user_uuid User unique ID.
+        @apiParam (Path) {String} user_uuid User unique ID.
+
+        @apiParam (Query) {String} name Filter by preference name.
 
         @apiSuccess {Number} count The number of preferences.
         @apiSuccess {String} previous  The uri of the previous page of results.

--- a/koku/koku/settings.py
+++ b/koku/koku/settings.py
@@ -68,6 +68,7 @@ INSTALLED_APPS = [
     # third-party
     'rest_framework',
     'rest_framework.authtoken',
+    'django_filters',
 
     # local apps
     'api',


### PR DESCRIPTION
* OpenAPI doc had typo and was missing token endpoint
* Customer owners did not get default preferences
* Reset password endpoint incorrectly required authentication
* Reset password did not save the user after password reset
* Added filter by name support to user preferences