### PR TITLE
Handling boto3 exception NoCredentialsError during STS verification

### DIFF
--- a/koku/api/provider/serializers.py
+++ b/koku/api/provider/serializers.py
@@ -18,7 +18,7 @@
 import logging
 
 import boto3
-from botocore.exceptions import ClientError
+from botocore.exceptions import ClientError, NoCredentialsError
 from django.db import transaction
 from django.utils.translation import ugettext as _
 from requests.exceptions import ConnectionError as BotoConnectionError
@@ -91,7 +91,7 @@ def _get_sts_access(provider_resource_name):
             access_key_id = credentials.get('AccessKeyId')
             secret_access_key = credentials.get('SecretAccessKey')
             session_token = credentials.get('SessionToken')
-    except (ClientError, BotoConnectionError) as boto_error:
+    except (ClientError, BotoConnectionError, NoCredentialsError) as boto_error:
         LOG.exception(boto_error)
 
     return (access_key_id, secret_access_key, session_token)


### PR DESCRIPTION
This fixes #184 

As a service admin, I want koku to remain stable and operational when a user attempts to create a provider with missing credentials, So that the service is resilient to such conditions and the user can be properly informed of what the problem is.

When complete, I will be able to:
Create a provider using a customer account such that koku does not crash when credentials could not be found.

Functional Test Results:
[issue_184_ut.txt](https://github.com/project-koku/koku/files/2039911/issue_184_ut.txt)
