### PR TITLE
Making AWS org to be optional when creating a provider. Closes #194

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ make-migrations:
 
 run-migrations:
 	sleep 1
-	DJANGO_READ_DOT_ENV_FILE=True $(PYTHON) $(PYDIR)/manage.py migrate
+	DJANGO_READ_DOT_ENV_FILE=True $(PYTHON) $(PYDIR)/manage.py migrate_schemas
 
 gen-apidoc:
 	rm -fr $(PYDIR)/staticfiles/

--- a/koku/api/provider/serializers.py
+++ b/koku/api/provider/serializers.py
@@ -201,7 +201,7 @@ class ProviderSerializer(serializers.ModelSerializer):
             key = 'provider_resource_name'
             message = 'Unable to obtain organization data with {}.'.format(
                 provider_resource_name)
-            raise serializers.ValidationError(error_obj(key, message))
+            LOG.info(message)
 
         auth = ProviderAuthentication.objects.create(**authentication)
         bill = ProviderBillingSource.objects.create(**billing_source)

--- a/koku/api/provider/test/tests_serializers.py
+++ b/koku/api/provider/test/tests_serializers.py
@@ -222,9 +222,8 @@ class ProviderSerializerTest(IamTestCase):
         context = {'request': request}
         serializer = ProviderSerializer(data=provider, context=context)
         if serializer.is_valid(raise_exception=True):
-            with self.assertRaises(serializers.ValidationError):
-                serializer.save()
-                check_org_access.assert_called_once()
+            serializer.save()
+            check_org_access.assert_called_once()
 
     @patch('boto3.client')
     def test_get_sts_access_no_cred(self, mock_boto3):


### PR DESCRIPTION
Lifting the requirement for an AWS Organization to be configured when adding a provider.

Closes #194 
For the Makefile change I was hitting this:
```
(koku) (koku) docurtis-mac:issue_194 curtisd$ make run-migrations
sleep 1
DJANGO_READ_DOT_ENV_FILE=True /Users/curtisd/py_env/koku/bin/python koku/manage.py migrate_schemas
Loading : /Users/curtisd/projects/repos/issue_194/.env
The .env file has been loaded.
/Users/curtisd/py_env/koku/lib/python3.6/site-packages/psycopg2/__init__.py:144: UserWarning: The psycopg2 wheel package will be renamed from release 2.8; in order to keep installing from binary please use "pip install psycopg2-binary" instead. For details see: <http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>.
  """)
System check identified some issues:

WARNINGS:
?: (tenant_schemas.W003) Your default storage engine is not tenant aware.
	HINT: Set settings.DEFAULT_FILE_STORAGE to 'tenant_schemas.storage.TenantFileSystemStorage'
[standard:public] === Running migrate for schema public
[standard:public] System check identified some issues:

WARNINGS:
?: (tenant_schemas.W003) Your default storage engine is not tenant aware.
	HINT: Set settings.DEFAULT_FILE_STORAGE to 'tenant_schemas.storage.TenantFileSystemStorage'
[standard:public] Operations to perform:
[standard:public]   Apply all migrations: admin, api, auth, authtoken, contenttypes, reporting, sessions
[standard:public] Running migrations:
[standard:public]   No migrations to apply.
(koku) (koku) docurtis-mac:issue_194 curtisd$ 
```