### PR TITLE
apidoc: Add missing 'name' entry in create user preference request body description

### DIFF
--- a/koku/api/iam/view/user_preference.py
+++ b/koku/api/iam/view/user_preference.py
@@ -76,11 +76,15 @@ class UserPreferenceViewSet(mixins.CreateModelMixin,
 
         @apiParam {String} user_uuid User unique ID.
 
-        @apiParam (Request Body) {String} preference a stringified JSON object
+        @apiParam (Request Body) {String} name User preference name.
+                                               No requirement to match the key in preference
+        @apiParam (Request Body) {Object} preference Preference value
+        @apiParam (Request Body) {String} [description] The description of the user preference.
         @apiParamExample {json} Request Body:
             {
                 "name": "my-preference-name",
-                'preference': {'currency': 'USD'},
+                "preference": {"currency": "USD"},
+                "description": "description of my-preference-name"
             }
 
         @apiSuccess {String} uuid The identifier of the preference.


### PR DESCRIPTION
User create preference - 'name' & optional 'description' was missing from the request body description and example

Also, is there any requirement that the value of 'name' will match the value of the key in preference?