### PR TITLE
Add ability to query for current month, monthly costs grouped by service.

### DIFF
--- a/koku/api/report/view.py
+++ b/koku/api/report/view.py
@@ -148,7 +148,10 @@ def costs(request):
             status=status.HTTP_400_BAD_REQUEST
         )
     tenant = get_tenant(request.user)
-    handler = ReportQueryHandler(value, tenant)
+    handler = ReportQueryHandler(value,
+                                 tenant,
+                                 'unblended_cost',
+                                 'currency_code')
     output = handler.execute_query()
     return Response(output)
 


### PR DESCRIPTION
Adds support for group_by service.

Below describes getting the current monthly cost grouped by service.
```
http://127.0.0.1:8000/api/v1/reports/costs/?filter[time_scope_value]=-1&group_by[service]=*&filter[time_scope_units]=month&filter[resolution]=monthly
```

Results:
```
{
    "group_by": {
        "service": [
            "*"
        ]
    },
    "filter": {
        "resolution": "monthly",
        "time_scope_value": "-1",
        "time_scope_units": "month"
    },
    "data": [
        {
            "2018-06": [
                {
                    "Storage Snapshot": [
                        {
                            "date": "2018-06",
                            "units": "USD",
                            "service": "Storage Snapshot",
                            "total": 73524.680680838
                        }
                    ]
                },
                {
                    "Storage": [
                        {
                            "date": "2018-06",
                            "units": "USD",
                            "service": "Storage",
                            "total": 8446.981846119
                        }
                    ]
                },
                {
                    "Compute Instance": [
                        {
                            "date": "2018-06",
                            "units": "USD",
                            "service": "Compute Instance",
                            "total": 7255.689
                        }
                    ]
                },
                {
                    "Data Transfer": [
                        {
                            "date": "2018-06",
                            "units": "USD",
                            "service": "Data Transfer",
                            "total": 2.174076039
                        }
                    ]
                }
            ]
        }
    ],
    "total": {
        "value": 89229.525602996,
        "units": "USD"
    }
}
```

A few tweaks from the previous sprint:
- Data points use to have _ total_cost _ its now just _total_.
- Data points also contain the items they were grouped on (i.e. `date` and `service` in the above)
- No generation of "null" items for empty data points


Updated last 10 days total cost (focus item from last sprint) is updated as follows:
```
http://127.0.0.1:8000/api/v1/reports/costs/
```
Response:
```
{
    "data": [
        {
            "2018-06-19": [
                {
                    "date": "2018-06-19",
                    "units": "USD",
                    "total": 3793.164779095
                }
            ]
        },
        {
            "2018-06-20": [
                {
                    "date": "2018-06-20",
                    "units": "USD",
                    "total": 3469.007567622
                }
            ]
        },
        {
            "2018-06-21": [
                {
                    "date": "2018-06-21",
                    "units": "USD",
                    "total": 3386.856317357
                }
            ]
        },
        {
            "2018-06-22": [
                {
                    "date": "2018-06-22",
                    "units": "USD",
                    "total": 2794.619868805
                }
            ]
        },
        {
            "2018-06-23": [
                {
                    "date": "2018-06-23",
                    "units": "USD",
                    "total": 3404.896316126
                }
            ]
        },
        {
            "2018-06-24": [
                {
                    "date": "2018-06-24",
                    "units": "USD",
                    "total": 4032.986082699
                }
            ]
        },
        {
            "2018-06-25": [
                {
                    "date": "2018-06-25",
                    "units": "USD",
                    "total": 3171.341476926
                }
            ]
        },
        {
            "2018-06-26": [
                {
                    "date": "2018-06-26",
                    "units": "USD",
                    "total": 2743.062723355
                }
            ]
        },
        {
            "2018-06-27": [
                {
                    "date": "2018-06-27",
                    "units": "USD",
                    "total": 1399.338203881
                }
            ]
        },
        {
            "2018-06-28": []
        }
    ],
    "total": {
        "value": 28195.273335866,
        "units": "USD"
    }
}
```
_Note:_ DB contains no data for yesterday (2018-06-28), so while the date is present it just presents an empty list.