### PR TITLE
Log check for Provider SNS notification. Closes #245

### DIFF
--- a/koku/koku/settings.py
+++ b/koku/koku/settings.py
@@ -258,6 +258,18 @@ LOGGING = {
             'handlers': LOGGING_HANDLERS,
             'level': KOKU_LOGGING_LEVEL,
         },
+        'providers': {
+            'handlers': LOGGING_HANDLERS,
+            'level': KOKU_LOGGING_LEVEL,
+        },
+        'reporting': {
+            'handlers': LOGGING_HANDLERS,
+            'level': KOKU_LOGGING_LEVEL,
+        },
+        'reporting_common': {
+            'handlers': LOGGING_HANDLERS,
+            'level': KOKU_LOGGING_LEVEL,
+        },
     },
 }
 

--- a/koku/providers/aws/aws_provider.py
+++ b/koku/providers/aws/aws_provider.py
@@ -80,10 +80,15 @@ def _check_s3_access(access_key_id, secret_access_key,
     return s3_exists
 
 
-def _get_configured_sns_topics(bucket):
+def _get_configured_sns_topics(access_key_id, secret_access_key, session_token, bucket):
     """Get a list of configured SNS topics."""
     # create an SNS client
-    s3_client = boto3.client('s3')
+    s3_client = boto3.client(
+        's3',
+        aws_access_key_id=access_key_id,
+        aws_secret_access_key=secret_access_key,
+        aws_session_token=session_token,
+    )
     topics = []
     try:
         notification_configuration = s3_client.get_bucket_notification_configuration(Bucket=bucket)
@@ -178,7 +183,8 @@ class AWSProvider(ProviderInterface):
                 credential_name)
             LOG.info(message)
 
-        sns_topics = _get_configured_sns_topics(storage_resource_name)
+        sns_topics = _get_configured_sns_topics(access_key_id, secret_access_key,
+                                                session_token, storage_resource_name)
         topics_string = ', '.join(sns_topics)
         if sns_topics:
             LOG.info('S3 Notification Topics: %s for S3 bucket: %s',

--- a/koku/providers/aws/aws_provider.py
+++ b/koku/providers/aws/aws_provider.py
@@ -80,6 +80,28 @@ def _check_s3_access(access_key_id, secret_access_key,
     return s3_exists
 
 
+def _get_configured_sns_topics(bucket):
+    """Check for SNS setup on specified S3 bucket."""
+    # create an SNS client
+    s3_client = boto3.client('s3')
+    topics = []
+    try:
+        notification_configuration = s3_client.get_bucket_notification_configuration(Bucket=bucket)
+        configuration = notification_configuration.get('TopicConfigurations', None)
+        if configuration:
+            for event in configuration:
+                # FIXME: Once we complete Masu #75 user story we probably should verify that
+                # the correct TopicArn is configured as well as the correct
+                # events (i.e. 's3:ObjectCreated:*'). For now lets just keep a list of all
+                # topics subscribed to and log it.
+                topic_arn = event.get('TopicArn')
+                topics.append(topic_arn) if topic_arn else None
+    except (ClientError, BotoConnectionError, NoCredentialsError, ParamValidationError) as boto_error:
+        LOG.exception(boto_error)
+
+    return topics
+
+
 def _check_org_access(access_key_id, secret_access_key, session_token):
     """Check for provider organization access."""
     access_ok = True
@@ -155,3 +177,11 @@ class AWSProvider(ProviderInterface):
             message = 'Unable to obtain organization data with {}.'.format(
                 credential_name)
             LOG.info(message)
+
+        sns_topics = _get_configured_sns_topics(storage_resource_name)
+        topics_string = ', '.join(sns_topics)
+        if sns_topics:
+            LOG.info('S3 Notification Topics: %s for S3 bucket: %s',
+                     topics_string, storage_resource_name)
+        else:
+            LOG.info('SNS is not configured for S3 bucket %s', storage_resource_name)

--- a/koku/providers/aws/aws_provider.py
+++ b/koku/providers/aws/aws_provider.py
@@ -90,7 +90,7 @@ def _get_configured_sns_topics(bucket):
         configuration = notification_configuration.get('TopicConfigurations', None)
         if configuration:
             for event in configuration:
-                # FIXME: Once we complete Masu #75 user story we probably should verify that
+                # FIXME: Once we complete the Masu #75 userstory we should verify that
                 # the correct TopicArn is configured as well as the correct
                 # events (i.e. 's3:ObjectCreated:*'). For now lets just keep a list of all
                 # topics subscribed to and log it.

--- a/koku/providers/aws/aws_provider.py
+++ b/koku/providers/aws/aws_provider.py
@@ -81,7 +81,7 @@ def _check_s3_access(access_key_id, secret_access_key,
 
 
 def _get_configured_sns_topics(bucket):
-    """Check for SNS setup on specified S3 bucket."""
+    """Get a list of configured SNS topics."""
     # create an SNS client
     s3_client = boto3.client('s3')
     topics = []

--- a/koku/providers/test/aws/tests_aws_provider.py
+++ b/koku/providers/test/aws/tests_aws_provider.py
@@ -216,7 +216,7 @@ class AWSProviderTestCase(TestCase):
     @patch('providers.aws.aws_provider._check_org_access')
     @patch('providers.aws.aws_provider._check_cost_report_access')
     def test_get_sns_topics(self, check_org_access, check_cost_report_access):
-        """Verify that the bucket is configured for notifications."""
+        """Verify when the bucket is configured for notifications."""
         check_org_access.return_value = True
         check_cost_report_access.return_value = True
 
@@ -257,7 +257,7 @@ class AWSProviderTestCase(TestCase):
     @patch('providers.aws.aws_provider._check_org_access')
     @patch('providers.aws.aws_provider._check_cost_report_access')
     def test_get_sns_topics_none_set(self, check_org_access, check_cost_report_access):
-        """Verify that the bucket is configured for notifications."""
+        """Verify when the bucket is not configured for notifications."""
         check_org_access.return_value = True
         check_cost_report_access.return_value = True
 


### PR DESCRIPTION
**Overview**
When a customer adds their provider information to Koku we would like to have a log to indicate whether or not the S3 bucket they are specifying is currently configured for SNS.

This is only a one-time check when the provider is added.  The additional check being added to the provider create workflow is for logging purposes only and will never prevent provider creation.

**Testing**
1. Create a provider with the SNS configuration set as expected. Verify logs
2. Create a provider with SNS configuration not setup (No events on S3 bucket). Verify logs
Results: [issue_245.txt](https://github.com/project-koku/koku/files/2190262/issue_245.txt)

**Later work**
There is an outstanding user story related to investigating how our SNS Topic Policy will be configured as well as what guidance we will provider for the customer.  As of now Masu is simply a basic SNS HTTP topic handler.  Similarly, on the Koku side, we are only logging what is configured (or not configured).  After the investigation user story is complete we should come back to this check and enhance it to provide more granular checks and logging.

Also, the work of providing regular configuration checks and alerting will be done in a subsequent user story/PR.

Closes #245 
