### PR TITLE
Enable HEAD requests for response check in Pipeline.

### DIFF
--- a/koku/api/status/views.py
+++ b/koku/api/status/views.py
@@ -25,7 +25,7 @@ from api.status.models import Status
 from api.status.serializers import StatusSerializer
 
 
-@api_view(['GET'])
+@api_view(['GET', 'HEAD'])
 @permission_classes((permissions.AllowAny,))
 def status(request):
     """Provide the server status information.


### PR DESCRIPTION
Added HEAD request so Jenkins CI can check call readiness probe. Before this would have returned a 405.

```
$ curl -I 127.0.0.1:8000/api/v1/status/
HTTP/1.1 200 OK
Date: Thu, 19 Jul 2018 14:13:05 GMT
Server: WSGIServer/0.2 CPython/3.6.5
Content-Type: application/json
Vary: Accept, Cookie
Allow: HEAD, OPTIONS, GET
X-Frame-Options: SAMEORIGIN
Content-Length: 2294

```