### PR TITLE
add support for CSV output. (closes #154)

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -17,6 +17,7 @@ requests = ">=2.18.0"
 django-tenant-schemas = "==1.9.0"
 django-cors-headers = "==2.2.0"
 querystring-parser = ">=1.2.3"
+djangorestframework-csv = "==1.3.3"
 
 [dev-packages]
 pylint = "==1.9.1"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1c9c9852601eec6889590a4c46d6a01fd567950bde536fea29402bd04271bbda"
+            "sha256": "68bae15b3c45b10e33e9bac94ddfd608cc48c651d6ceb1b1571f39a2525485ec"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,18 +18,18 @@
     "default": {
         "boto3": {
             "hashes": [
-                "sha256:5bd25459c8f506858753cb5e699c4c43af8c9b27e4aae32d9772f677068231b5",
-                "sha256:f4411a75892d3184324dabeeca23d40e5d0986e0a8c8659ba283ff04d2047068"
+                "sha256:1bee9184ff54e078a9e50931511e413fbcfceb4c6467e3c8726ddbcf509c586b",
+                "sha256:c39040e73e12f43f906e8aaa3d32490e37d1f25f257f18be06e6cea65dd409bf"
             ],
             "index": "pypi",
-            "version": "==1.7.44"
+            "version": "==1.7.60"
         },
         "botocore": {
             "hashes": [
-                "sha256:2202634c6e0dcf4f7886fa87878af8cdba42a340bc6e56ff84515db8ba65cc5b",
-                "sha256:f59795d7817273ca021b0e2544e78e2b8665a9ab724381afee273e66f86cb7de"
+                "sha256:c03fd2b80c3f369f0b892c05a8dade0b6383ce076ad6ba43c3aabea408a163ea",
+                "sha256:d60dcbc5209978fbf6147de39cc5ac7c3dbfb23d19b123ed378880627088c35a"
             ],
-            "version": "==1.10.44"
+            "version": "==1.10.60"
         },
         "certifi": {
             "hashes": [
@@ -47,11 +47,11 @@
         },
         "django": {
             "hashes": [
-                "sha256:3eb25c99df1523446ec2dc1b00e25eb2ecbdf42c9d8b0b8b32a204a8db9011f8",
-                "sha256:69ff89fa3c3a8337015478a1a0744f52a9fef5d12c1efa01a01f99bcce9bf10c"
+                "sha256:97886b8a13bbc33bfeba2ff133035d3eca014e2309dff2b6da0bdfc0b8656613",
+                "sha256:e900b73beee8977c7b887d90c6c57d68af10066b9dac898e1eaf0f82313de334"
             ],
             "index": "pypi",
-            "version": "==2.0.6"
+            "version": "==2.0.7"
         },
         "django-cors-headers": {
             "hashes": [
@@ -63,19 +63,19 @@
         },
         "django-environ": {
             "hashes": [
-                "sha256:e9c171b9d5f540e6f3bc42866941d9cd0bd77fb110a7c13a7c4857a2c08cfa40",
-                "sha256:ee2f8405d83137e3328b26b3de01bd715b5395fca22feb919dcc905fb6099cfa"
+                "sha256:6c9d87660142608f63ec7d5ce5564c49b603ea8ff25da595fd6098f6dc82afde",
+                "sha256:c57b3c11ec1f319d9474e3e5a79134f40174b17c7cc024bbb2fad84646b120c4"
             ],
             "index": "pypi",
-            "version": "==0.4.4"
+            "version": "==0.4.5"
         },
         "django-filter": {
             "hashes": [
-                "sha256:ea204242ea83790e1512c9d0d8255002a652a6f4986e93cee664f28955ba0c22",
-                "sha256:ec0ef1ba23ef95b1620f5d481334413700fb33f45cd76d56a63f4b0b1d76976a"
+                "sha256:6f4e4bc1a11151178520567b50320e5c32f8edb552139d93ea3e30613b886f56",
+                "sha256:86c3925020c27d072cdae7b828aaa5d165c2032a629abbe3c3a1be1edae61c58"
             ],
             "index": "pypi",
-            "version": "==1.1.0"
+            "version": "==2.0.0"
         },
         "django-tenant-schemas": {
             "hashes": [
@@ -91,6 +91,13 @@
             ],
             "index": "pypi",
             "version": "==3.8.2"
+        },
+        "djangorestframework-csv": {
+            "hashes": [
+                "sha256:5e1199ae8c46937b1a7a5dfa4b83f3f249c2fa2b490f492e41fdb8a91ba5c331"
+            ],
+            "index": "pypi",
+            "version": "==1.3.3"
         },
         "docutils": {
             "hashes": [
@@ -110,11 +117,11 @@
         },
         "gunicorn": {
             "hashes": [
-                "sha256:7ef2b828b335ed58e3b64ffa84caceb0a7dd7c5ca12f217241350dec36a1d5dc",
-                "sha256:bc59005979efb6d2dd7d5ba72d99f8a8422862ad17ff3a16e900684630dd2a10"
+                "sha256:aa8e0b40b4157b36a5df5e599f45c9c76d6af43845ba3b3b0efe2c70473c2471",
+                "sha256:fa2662097c66f920f53f70621c6c58ca4a3c4d3434205e608e121b5b3b71f4f3"
             ],
             "index": "pypi",
-            "version": "==19.8.1"
+            "version": "==19.9.0"
         },
         "idna": {
             "hashes": [
@@ -132,6 +139,7 @@
         },
         "psycopg2": {
             "hashes": [
+                "sha256:0b9e48a1c1505699a64ac58815ca99104aacace8321e455072cee4f7fe7b2698",
                 "sha256:0f4c784e1b5a320efb434c66a50b8dd7e30a7dc047e8f45c0a8d2694bfe72781",
                 "sha256:0fdbaa32c9eb09ef09d425dc154628fca6fa69d2f7c1a33f889abb7e0efb3909",
                 "sha256:11fbf688d5c953c0a5ba625cc42dea9aeb2321942c7c5ed9341a68f865dc8cb1",
@@ -145,8 +153,10 @@
                 "sha256:6e737915de826650d1a5f7ff4ac6cf888a26f021a647390ca7bafdba0e85462b",
                 "sha256:6ed9b2cfe85abc720e8943c1808eeffd41daa73e18b7c1e1a228b0b91f768ccc",
                 "sha256:711ec617ba453fdfc66616db2520db3a6d9a891e3bf62ef9aba4c95bb4e61230",
+                "sha256:844dacdf7530c5c612718cf12bc001f59b2d9329d35b495f1ff25045161aa6af",
                 "sha256:86b52e146da13c896e50c5a3341a9448151f1092b1a4153e425d1e8b62fec508",
                 "sha256:985c06c2a0f227131733ae58d6a541a5bc8b665e7305494782bebdb74202b793",
+                "sha256:a86dfe45f4f9c55b1a2312ff20a59b30da8d39c0e8821d00018372a2a177098f",
                 "sha256:aa3cd07f7f7e3183b63d48300666f920828a9dbd7d7ec53d450df2c4953687a9",
                 "sha256:b1964ed645ef8317806d615d9ff006c0dadc09dfc54b99ae67f9ba7a1ec9d5d2",
                 "sha256:b2abbff9e4141484bb89b96eb8eae186d77bc6d5ffbec6b01783ee5c3c467351",
@@ -178,8 +188,11 @@
                 "sha256:5221f5a3f4ca2ddf0d58e8b8a32ca50948be9a43351fda797eb4e72d7a7aa34d",
                 "sha256:5c6ca0b507540a11eaf9e77dee4f07c131c2ec80ca0cffa146671bf690bc1c02",
                 "sha256:789bd89d71d704db2b3d5e67d6d518b158985d791d3b2dec5ab85457cfc9677b",
+                "sha256:7b94d29239efeaa6a967f3b5971bd0518d2a24edd1511edbf4a2c8b815220d07",
                 "sha256:89bc65ef3301c74cf32db25334421ea6adbe8f65601ea45dcaaf095abed910bb",
+                "sha256:89d6d3a549f405c20c9ae4dc94d7ed2de2fa77427a470674490a622070732e62",
                 "sha256:97521704ac7127d7d8ba22877da3c7bf4a40366587d238ec679ff38e33177498",
+                "sha256:a395b62d5f44ff6f633231abe568e2203b8fabf9797cd6386aa92497df912d9a",
                 "sha256:a6d32c37f714c3f34158f3fa659f3a8f2658d5f53c4297d45579b9677cc4d852",
                 "sha256:a89ee5c26f72f2d0d74b991ce49e42ddeb4ac0dc2d8c06a0f2770a1ab48f4fe0",
                 "sha256:b4c8b0ef3608e59317bfc501df84a61e48b5445d45f24d0391a24802de5f2d84",
@@ -205,10 +218,10 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:65ae0c8101309c45772196b21b74c46b2e5d11b6275c45d251b150d5da334555",
-                "sha256:c06425302f2cf668f1bba7a0a03f3c1d34d4ebeef2c72003da308b3947c7f749"
+                "sha256:a061aa0a9e06881eb8b3b2b43f05b9439d6583c206d0a6c340ff72a7b6669053",
+                "sha256:ffb9ef1de172603304d9d2819af6f5ece76f2e85ec10692a524dd876e72bf277"
             ],
-            "version": "==2018.4"
+            "version": "==2018.5"
         },
         "querystring-parser": {
             "hashes": [
@@ -293,25 +306,25 @@
         },
         "boto": {
             "hashes": [
-                "sha256:13be844158d1bd80a94c972c806ec8381b9ea72035aa06123c5db6bc6a6f3ead",
-                "sha256:deb8925b734b109679e3de65856018996338758f4b916ff4fe7bb62b6d7000d1"
+                "sha256:147758d41ae7240dc989f0039f27da8ca0d53734be0eb869ef16e3adcfa462e8",
+                "sha256:ea0d3b40a2d852767be77ca343b58a9e3a4b00d9db440efb8da74b4e58025e5a"
             ],
-            "version": "==2.48.0"
+            "version": "==2.49.0"
         },
         "boto3": {
             "hashes": [
-                "sha256:5bd25459c8f506858753cb5e699c4c43af8c9b27e4aae32d9772f677068231b5",
-                "sha256:f4411a75892d3184324dabeeca23d40e5d0986e0a8c8659ba283ff04d2047068"
+                "sha256:1bee9184ff54e078a9e50931511e413fbcfceb4c6467e3c8726ddbcf509c586b",
+                "sha256:c39040e73e12f43f906e8aaa3d32490e37d1f25f257f18be06e6cea65dd409bf"
             ],
             "index": "pypi",
-            "version": "==1.7.44"
+            "version": "==1.7.60"
         },
         "botocore": {
             "hashes": [
-                "sha256:2202634c6e0dcf4f7886fa87878af8cdba42a340bc6e56ff84515db8ba65cc5b",
-                "sha256:f59795d7817273ca021b0e2544e78e2b8665a9ab724381afee273e66f86cb7de"
+                "sha256:c03fd2b80c3f369f0b892c05a8dade0b6383ce076ad6ba43c3aabea408a163ea",
+                "sha256:d60dcbc5209978fbf6147de39cc5ac7c3dbfb23d19b123ed378880627088c35a"
             ],
-            "version": "==1.10.44"
+            "version": "==1.10.60"
         },
         "certifi": {
             "hashes": [
@@ -326,9 +339,12 @@
                 "sha256:1553d1e99f035ace1c0544050622b7bc963374a00c467edafac50ad7bd276aef",
                 "sha256:1b0493c091a1898f1136e3f4f991a784437fac3673780ff9de3bcf46c80b6b50",
                 "sha256:2ba8a45822b7aee805ab49abfe7eec16b90587f7f26df20c71dd89e45a97076f",
+                "sha256:3bb6bd7266598f318063e584378b8e27c67de998a43362e8fce664c54ee52d30",
                 "sha256:3c85641778460581c42924384f5e68076d724ceac0f267d66c757f7535069c93",
                 "sha256:3eb6434197633b7748cea30bf0ba9f66727cdce45117a712b29a443943733257",
+                "sha256:495c5c2d43bf6cebe0178eb3e88f9c4aa48d8934aa6e3cddb865c058da76756b",
                 "sha256:4c91af6e967c2015729d3e69c2e51d92f9898c330d6a851bf8f121236f3defd3",
+                "sha256:57b2533356cb2d8fac1555815929f7f5f14d68ac77b085d2326b571310f34f6e",
                 "sha256:770f3782b31f50b68627e22f91cb182c48c47c02eb405fd689472aa7b7aa16dc",
                 "sha256:79f9b6f7c46ae1f8ded75f68cf8ad50e5729ed4d590c74840471fc2823457d04",
                 "sha256:7a33145e04d44ce95bcd71e522b478d282ad0eafaf34fe1ec5bbd73e662f22b6",
@@ -337,11 +353,13 @@
                 "sha256:95d5251e4b5ca00061f9d9f3d6fe537247e145a8524ae9fd30a2f8fbce993b5b",
                 "sha256:9d1d3e63a4afdc29bd76ce6aa9d58c771cd1599fbba8cf5057e7860b203710dd",
                 "sha256:a36c5c154f9d42ec176e6e620cb0dd275744aa1d804786a71ac37dc3661a5e95",
+                "sha256:a6a5cb8809091ec9ac03edde9304b3ad82ad4466333432b16d78ef40e0cce0d5",
                 "sha256:ae5e35a2c189d397b91034642cb0eab0e346f776ec2eb44a49a459e6615d6e2e",
                 "sha256:b0f7d4a3df8f06cf49f9f121bead236e328074de6449866515cea4907bbc63d6",
                 "sha256:b75110fb114fa366b29a027d0c9be3709579602ae111ff61674d28c93606acca",
                 "sha256:ba5e697569f84b13640c9e193170e89c13c6244c24400fc57e88724ef610cd31",
                 "sha256:be2a9b390f77fd7676d80bc3cdc4f8edb940d8c198ed2d8c0be1319018c778e1",
+                "sha256:ca1bd81f40adc59011f58159e4aa6445fc585a32bb8ac9badf7a2c1aa23822f2",
                 "sha256:d5d8555d9bfc3f02385c1c37e9f998e2011f0db4f90e250e5bc0c0a85a813085",
                 "sha256:e55e22ac0a30023426564b1059b035973ec82186ddddbac867078435801c7801",
                 "sha256:e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4",
@@ -350,7 +368,6 @@
                 "sha256:edabd457cd23a02965166026fd9bfd196f4324fe6032e866d0f3bd0301cd486f",
                 "sha256:fdf1c1dc5bafc32bc5d08b054f94d659422b05aba244d6be4ddc1c72d9aa70fb"
             ],
-            "markers": "platform_python_implementation != 'pypy'",
             "version": "==1.11.5"
         },
         "chardet": {
@@ -419,32 +436,34 @@
         },
         "cryptography": {
             "hashes": [
-                "sha256:3f3b65d5a16e6b52fba63dc860b62ca9832f51f1a2ae5083c78b6840275f12dd",
-                "sha256:551a3abfe0c8c6833df4192a63371aa2ff43afd8f570ed345d31f251d78e7e04",
-                "sha256:5cb990056b7cadcca26813311187ad751ea644712022a3976443691168781b6f",
-                "sha256:60bda7f12ecb828358be53095fc9c6edda7de8f1ef571f96c00b2363643fa3cd",
-                "sha256:6fef51ec447fe9f8351894024e94736862900d3a9aa2961528e602eb65c92bdb",
-                "sha256:77d0ad229d47a6e0272d00f6bf8ac06ce14715a9fd02c9a97f5a2869aab3ccb2",
-                "sha256:808fe471b1a6b777f026f7dc7bd9a4959da4bfab64972f2bbe91e22527c1c037",
-                "sha256:9b62fb4d18529c84b961efd9187fecbb48e89aa1a0f9f4161c61b7fc42a101bd",
-                "sha256:9e5bed45ec6b4f828866ac6a6bedf08388ffcfa68abe9e94b34bb40977aba531",
-                "sha256:9fc295bf69130a342e7a19a39d7bbeb15c0bcaabc7382ec33ef3b2b7d18d2f63",
-                "sha256:abd070b5849ed64e6d349199bef955ee0ad99aefbad792f0c587f8effa681a5e",
-                "sha256:ba6a774749b6e510cffc2fb98535f717e0e5fd91c7c99a61d223293df79ab351",
-                "sha256:c332118647f084c983c6a3e1dba0f3bcb051f69d12baccac68db8d62d177eb8a",
-                "sha256:d6f46e862ee36df81e6342c2177ba84e70f722d9dc9c6c394f9f1f434c4a5563",
-                "sha256:db6013746f73bf8edd9c3d1d3f94db635b9422f503db3fc5ef105233d4c011ab",
-                "sha256:f57008eaff597c69cf692c3518f6d4800f0309253bb138b526a37fe9ef0c7471",
-                "sha256:f6c821ac253c19f2ad4c8691633ae1d1a17f120d5b01ea1d256d7b602bc59887"
+                "sha256:21af753934f2f6d1a10fe8f4c0a64315af209ef6adeaee63ca349797d747d687",
+                "sha256:27bb401a20a838d6d0ea380f08c6ead3ccd8c9d8a0232dc9adcc0e4994576a66",
+                "sha256:29720c4253263cff9aea64585adbbe85013ba647f6e98367efff9db2d7193ded",
+                "sha256:2a35b7570d8f247889784010aac8b384fd2e4a47b33e15c4a60b45a7c1944120",
+                "sha256:42c531a6a354407f42ee07fda5c2c0dc822cf6d52744949c182f2b295fbd4183",
+                "sha256:5eb86f03f9c4f0ac2336ac5431271072ddf7ecc76b338e26366732cfac58aa19",
+                "sha256:67f7f57eae8dede577f3f7775957f5bec93edd6bdb6ce597bb5b28e1bdf3d4fb",
+                "sha256:6ec84edcbc966ae460560a51a90046503ff0b5b66157a9efc61515c68059f6c8",
+                "sha256:7ba834564daef87557e7fcd35c3c3183a4147b0b3a57314e53317360b9b201b3",
+                "sha256:7d7f084cbe1fdb82be5a0545062b59b1ad3637bc5a48612ac2eb428ff31b31ea",
+                "sha256:82409f5150e529d699e5c33fa8fd85e965104db03bc564f5f4b6a9199e591f7c",
+                "sha256:87d092a7c2a44e5f7414ab02fb4145723ebba411425e1a99773531dd4c0e9b8d",
+                "sha256:8c56ef989342e42b9fcaba7c74b446f0cc9bed546dd00034fa7ad66fc00307ef",
+                "sha256:9449f5d4d7c516a6118fa9210c4a00f34384cb1d2028672100ee0c6cce49d7f6",
+                "sha256:bc2301170986ad82d9349a91eb8884e0e191209c45f5541b16aa7c0cfb135978",
+                "sha256:c132bab45d4bd0fff1d3fe294d92b0a6eb8404e93337b3127bdec9f21de117e6",
+                "sha256:c3d945b7b577f07a477700f618f46cbc287af3a9222cd73035c6ef527ef2c363",
+                "sha256:cee18beb4c807b5c0b178f4fa2fae03cef9d51821a358c6890f8b23465b7e5d2",
+                "sha256:d01dfc5c2b3495184f683574e03c70022674ca9a7be88589c5aba130d835ea90"
             ],
-            "version": "==2.2.2"
+            "version": "==2.3"
         },
         "docker": {
             "hashes": [
-                "sha256:dbed56b8ba57b23919794e7cdcf7340c5052e9fd1cbe64b90b4eb9106437e0e3",
-                "sha256:e9cc39e24905e67ba9e2df14c94488f5cf030fb72ae1c60de505ce5ea90503f7"
+                "sha256:52cf5b1c3c394f9abf897638bfc3336d6b63a0f65969d0d4d2da6d3b1d8032b6",
+                "sha256:ad077b49660b711d20f50f344f70cfae014d635ef094bf21b0d7df5f0aeedf99"
             ],
-            "version": "==3.4.0"
+            "version": "==3.4.1"
         },
         "docker-pycreds": {
             "hashes": [
@@ -463,11 +482,11 @@
         },
         "faker": {
             "hashes": [
-                "sha256:04645d946256b835c675c1cef7c03817a164b0c4e452018fd50b212ddff08c22",
-                "sha256:fe48f35aa3443bc5655b0782d3a2f594bf4882d0e2a947b80207a60494d32907"
+                "sha256:0e9a1227a3a0f3297a485715e72ee6eb77081b17b629367042b586e38c03c867",
+                "sha256:b4840807a94a3bad0217d6ed3f9b65a1cc6e1db1c99e1184673056ae2c0a4c4d"
             ],
             "index": "pypi",
-            "version": "==0.8.16"
+            "version": "==0.8.17"
         },
         "idna": {
             "hashes": [
@@ -588,10 +607,10 @@
         },
         "pbr": {
             "hashes": [
-                "sha256:3747c6f017f2dc099986c325239661948f9f5176f6880d9fdef164cb664cd665",
-                "sha256:a9c27eb8f0e24e786e544b2dbaedb729c9d8546342b5a6818d8eda098ad4340d"
+                "sha256:4f2b11d95917af76e936811be8361b2b19616e5ef3b55956a429ec7864378e0c",
+                "sha256:e0f23b61ec42473723b2fec2f33fb12558ff221ee551962f01dd4de9053c2055"
             ],
-            "version": "==4.0.4"
+            "version": "==4.1.0"
         },
         "pluggy": {
             "hashes": [
@@ -603,10 +622,10 @@
         },
         "py": {
             "hashes": [
-                "sha256:29c9fab495d7528e80ba1e343b958684f4ace687327e6f789a94bf3d1915f881",
-                "sha256:983f77f3331356039fdd792e9220b7b8ee1aa6bd2b25f567a963ff1de5a64f6a"
+                "sha256:3fd59af7435864e1a243790d322d763925431213b6b8529c6ca71081ace3bbf7",
+                "sha256:e31fb2767eb657cbde86c454f02e99cb846d3cd9d61b318525140214fdc0e98e"
             ],
-            "version": "==1.5.3"
+            "version": "==1.5.4"
         },
         "pyaml": {
             "hashes": [
@@ -658,29 +677,26 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:65ae0c8101309c45772196b21b74c46b2e5d11b6275c45d251b150d5da334555",
-                "sha256:c06425302f2cf668f1bba7a0a03f3c1d34d4ebeef2c72003da308b3947c7f749"
+                "sha256:a061aa0a9e06881eb8b3b2b43f05b9439d6583c206d0a6c340ff72a7b6669053",
+                "sha256:ffb9ef1de172603304d9d2819af6f5ece76f2e85ec10692a524dd876e72bf277"
             ],
-            "version": "==2018.4"
+            "version": "==2018.5"
         },
         "pyyaml": {
             "hashes": [
-                "sha256:0c507b7f74b3d2dd4d1322ec8a94794927305ab4cebbe89cc47fe5e81541e6e8",
-                "sha256:16b20e970597e051997d90dc2cddc713a2876c47e3d92d59ee198700c5427736",
-                "sha256:3262c96a1ca437e7e4763e2843746588a965426550f3797a79fca9c6199c431f",
-                "sha256:326420cbb492172dec84b0f65c80942de6cedb5233c413dd824483989c000608",
-                "sha256:4474f8ea030b5127225b8894d626bb66c01cda098d47a2b0d3429b6700af9fd8",
-                "sha256:592766c6303207a20efc445587778322d7f73b161bd994f227adaa341ba212ab",
-                "sha256:5ac82e411044fb129bae5cfbeb3ba626acb2af31a8d17d175004b70862a741a7",
-                "sha256:5f84523c076ad14ff5e6c037fe1c89a7f73a3e04cf0377cb4d017014976433f3",
-                "sha256:827dc04b8fa7d07c44de11fabbc888e627fa8293b695e0f99cb544fdfa1bf0d1",
-                "sha256:b4c423ab23291d3945ac61346feeb9a0dc4184999ede5e7c43e1ffb975130ae6",
-                "sha256:bc6bced57f826ca7cb5125a10b23fd0f2fff3b7c4701d64c439a300ce665fff8",
-                "sha256:c01b880ec30b5a6e6aa67b09a2fe3fb30473008c85cd6a67359a1b15ed6d83a4",
-                "sha256:ca233c64c6e40eaa6c66ef97058cdc80e8d0157a443655baa1b2966e812807ca",
-                "sha256:e863072cdf4c72eebf179342c94e6989c67185842d9997960b3e69290b2fa269"
+                "sha256:3d7da3009c0f3e783b2c873687652d83b1bbfd5c88e9813fb7e5b03c0dd3108b",
+                "sha256:3ef3092145e9b70e3ddd2c7ad59bdd0252a94dfe3949721633e41344de00a6bf",
+                "sha256:40c71b8e076d0550b2e6380bada1f1cd1017b882f7e16f09a65be98e017f211a",
+                "sha256:558dd60b890ba8fd982e05941927a3911dc409a63dcb8b634feaa0cda69330d3",
+                "sha256:a7c28b45d9f99102fa092bb213aa12e0aaf9a6a1f5e395d36166639c1f96c3a1",
+                "sha256:aa7dd4a6a427aed7df6fb7f08a580d68d9b118d90310374716ae90b710280af1",
+                "sha256:bc558586e6045763782014934bfaf39d48b8ae85a2713117d16c39864085c613",
+                "sha256:d46d7982b62e0729ad0175a9bc7e10a566fc07b224d2c79fafb5e032727eaa04",
+                "sha256:d5eef459e30b09f5a098b9cea68bebfeb268697f78d647bd255a085371ac7f3f",
+                "sha256:e01d3203230e1786cd91ccfdc8f8454c8069c91bee3962ad93b87a4b2860f537",
+                "sha256:e170a9e6fcfd19021dd29845af83bb79236068bf5fd4df3327c1be18182b2531"
             ],
-            "version": "==3.12"
+            "version": "==3.13"
         },
         "requests": {
             "hashes": [
@@ -720,11 +736,11 @@
         },
         "sphinx": {
             "hashes": [
-                "sha256:85f7e32c8ef07f4ba5aeca728e0f7717bef0789fba8458b8d9c5c294cad134f3",
-                "sha256:d45480a229edf70d84ca9fae3784162b1bc75ee47e480ffe04a4b7f21a95d76d"
+                "sha256:217ad9ece2156ed9f8af12b5d2c82a499ddf2c70a33c5f81864a08d8c67b9efc",
+                "sha256:a765c6db1e5b62aae857697cd4402a5c1a315a7b0854bbcd0fc8cdc524da5896"
             ],
             "index": "pypi",
-            "version": "==1.7.5"
+            "version": "==1.7.6"
         },
         "sphinx-rtd-theme": {
             "hashes": [
@@ -750,11 +766,11 @@
         },
         "tox": {
             "hashes": [
-                "sha256:96efa09710a3daeeb845561ebbe1497641d9cef2ee0aea30db6969058b2bda2f",
-                "sha256:9ee7de958a43806402a38c0d2aa07fa8553f4d2c20a15b140e9f771c2afeade0"
+                "sha256:4df108a1fcc93a7ee4ac97e1a3a1fc3d41ddd22445d518976604e2ef05025280",
+                "sha256:9f0cbcc36e08c2c4ae90d02d3d1f9a62231f974bcbc1df85e8045946d8261059"
             ],
             "index": "pypi",
-            "version": "==3.0.0"
+            "version": "==3.1.2"
         },
         "urllib3": {
             "hashes": [

--- a/docs/source/specs/openapi.yml
+++ b/docs/source/specs/openapi.yml
@@ -649,6 +649,7 @@ paths:
       operationId: getCostReports
       produces:
       - 'application/json'
+      - 'text/csv'
       parameters:
       - name: 'filter'
         in: 'query'
@@ -683,6 +684,7 @@ paths:
       operationId: getInventoryInstanceReports
       produces:
       - 'application/json'
+      - 'text/csv'
       parameters:
       - name: 'filter'
         in: 'query'
@@ -717,6 +719,7 @@ paths:
       operationId: getInventoryStorageReports
       produces:
       - 'application/json'
+      - 'text/csv'
       parameters:
       - name: 'filter'
         in: 'query'

--- a/koku/api/common/csv.py
+++ b/koku/api/common/csv.py
@@ -17,14 +17,16 @@
 
 """API views for CSV output."""
 
-from rest_framework.views import APIView
-from rest_framework.settings import api_settings
 from rest_framework_csv.renderers import CSVRenderer
 
+
 class PaginatedCSVRenderer (CSVRenderer):
+    """A Paginated CSV Renderer."""
+
     results_field = 'results'
 
     def render(self, data, *args, **kwargs):
+        """Render a paginated CSV."""
         if not isinstance(data, list):
             data = data.get(self.results_field, [])
         return super(PaginatedCSVRenderer, self).render(data, *args, **kwargs)

--- a/koku/api/common/csv.py
+++ b/koku/api/common/csv.py
@@ -1,0 +1,30 @@
+#
+# Copyright 2018 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""API views for CSV output."""
+
+from rest_framework.views import APIView
+from rest_framework.settings import api_settings
+from rest_framework_csv.renderers import CSVRenderer
+
+class PaginatedCSVRenderer (CSVRenderer):
+    results_field = 'results'
+
+    def render(self, data, *args, **kwargs):
+        if not isinstance(data, list):
+            data = data.get(self.results_field, [])
+        return super(PaginatedCSVRenderer, self).render(data, *args, **kwargs)

--- a/koku/api/common/csv.py
+++ b/koku/api/common/csv.py
@@ -20,10 +20,14 @@
 from rest_framework_csv.renderers import CSVRenderer
 
 
-class PaginatedCSVRenderer (CSVRenderer):
-    """A Paginated CSV Renderer."""
+class PaginatedCSVRenderer(CSVRenderer):
+    """
+    A Paginated CSV Renderer.
 
-    results_field = 'results'
+    To be used with views that paginate data.
+    """
+
+    results_field = 'data'
 
     def render(self, data, *args, **kwargs):
         """Render a paginated CSV."""

--- a/koku/api/report/test/tests_views.py
+++ b/koku/api/report/test/tests_views.py
@@ -210,7 +210,6 @@ class ReportViewTest(IamTestCase):
         # kludge!  see test_get_costs_csv()
         client.credentials(HTTP_AUTHORIZATION=token, HTTP_ACCEPT='text/csv')
 
-
         response = client.get(url, content_type='text/csv')
         response.render()
 

--- a/koku/api/report/test/tests_views.py
+++ b/koku/api/report/test/tests_views.py
@@ -20,6 +20,7 @@ from unittest.mock import Mock
 from django.urls import reverse
 from rest_framework.serializers import ValidationError
 from rest_framework.test import APIClient
+from rest_framework_csv.renderers import CSVRenderer
 
 from api.iam.test.iam_test_case import IamTestCase
 from api.models import Customer, Tenant, User
@@ -161,3 +162,58 @@ class ReportViewTest(IamTestCase):
 
         with self.assertRaises(ValidationError):
             get_tenant(user)
+
+    def test_get_costs_csv(self):
+        """Test CSV output of costs reports."""
+        token = self.get_customer_owner_token(self.customer_data[0])
+        url = reverse('reports-costs')
+        client = APIClient()
+
+        # kludge alert!
+        #
+        # APIClient.credentials() is just a dict of arbitrary headers that the
+        # client ensures are set with every request.
+        #
+        # APIClient doesn't provide a better facility to set headers, so we're
+        # abusing the interface that it does provide to get what we want.
+        client.credentials(HTTP_AUTHORIZATION=token, HTTP_ACCEPT='text/csv')
+
+        response = client.get(url)
+        response.render()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.accepted_media_type, 'text/csv')
+        self.assertIsInstance(response.accepted_renderer, CSVRenderer)
+
+    def test_get_instance_csv(self):
+        """Test CSV output of inventory instance reports."""
+        token = self.get_customer_owner_token(self.customer_data[0])
+        url = reverse('reports-instance-type')
+        client = APIClient()
+
+        # kludge!  see test_get_costs_csv()
+        client.credentials(HTTP_AUTHORIZATION=token, HTTP_ACCEPT='text/csv')
+
+        response = client.get(url, content_type='text/csv')
+        response.render()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.accepted_media_type, 'text/csv')
+        self.assertIsInstance(response.accepted_renderer, CSVRenderer)
+
+    def test_get_storage_csv(self):
+        """Test CSV output of inventory storage reports."""
+        token = self.get_customer_owner_token(self.customer_data[0])
+        url = reverse('reports-storage')
+        client = APIClient()
+
+        # kludge!  see test_get_costs_csv()
+        client.credentials(HTTP_AUTHORIZATION=token, HTTP_ACCEPT='text/csv')
+
+
+        response = client.get(url, content_type='text/csv')
+        response.render()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.accepted_media_type, 'text/csv')
+        self.assertIsInstance(response.accepted_renderer, CSVRenderer)

--- a/koku/api/report/view.py
+++ b/koku/api/report/view.py
@@ -88,7 +88,7 @@ def get_tenant(user):
 
 
 def _generic_report(request, aggregate_key, units_key, **kwargs):
-    """Generic report query function."""
+    """Generically query for reports."""
     LOG.info(f'API: {request.path} USER: {request.user.username}')
 
     url_data = request.GET.urlencode()
@@ -108,6 +108,7 @@ def _generic_report(request, aggregate_key, units_key, **kwargs):
                                  **kwargs)
     output = handler.execute_query()
     return Response(output)
+
 
 @api_view(http_method_names=['GET'])
 @authentication_classes([SessionAuthentication, TokenAuthentication])

--- a/koku/api/report/view.py
+++ b/koku/api/report/view.py
@@ -107,6 +107,7 @@ def _generic_report(request, aggregate_key, units_key, **kwargs):
                                  units_key,
                                  **kwargs)
     output = handler.execute_query()
+    LOG.debug(f'DATA: {output}')
     return Response(output)
 
 
@@ -124,9 +125,11 @@ def costs(request):
     @apiDescription Get cost data.
 
     @apiHeader {String} token User authorization token.
+    @apiHeader {String} accept HTTP Accept header. (See: RFC2616)
     @apiHeaderExample {json} Header-Example:
         {
             "Authorization": "Token 45138a913da44ab89532bab0352ef84b"
+            "Accept": "text/csv;q=0.8, application/json"
         }
 
     @apiParam (Query Param) {Object} filter The filter to apply to the report.
@@ -188,6 +191,15 @@ def costs(request):
                 ]
             ]
         }
+    @apiSuccessExample {text} Success-Response:
+        HTTP/1.1 200 OK
+        date,values.0.date,values.0.total,values.0.units
+        2018-07-16,2018-07-16,0.800000000,USD
+        2018-07-17,2018-07-17,0.768000000,USD
+        2018-07-18,2018-07-18,0.800000000,USD
+        2018-07-19,2018-07-19,0.768000000,USD
+        2018-07-20,2018-07-20,0.448000000,USD
+
     """
     return _generic_report(request, 'unblended_cost', 'currency_code')
 
@@ -206,9 +218,11 @@ def instance_type(request):
     @apiDescription Get inventory instance type data.
 
     @apiHeader {String} token User authorization token.
+    @apiHeader {String} accept HTTP Accept header. (See: RFC2616)
     @apiHeaderExample {json} Header-Example:
         {
             "Authorization": "Token 45138a913da44ab89532bab0352ef84b"
+            "Accept": "text/csv;q=0.8, application/json"
         }
 
     @apiParam (Query Param) {Object} filter The filter to apply to the report.
@@ -279,6 +293,14 @@ def instance_type(request):
                 "count": 4
             }
         }
+    @apiSuccessExample {text} Success-Response:
+        HTTP/1.1 200 OK
+        date,instance_types.0.instance_type,instance_types.0.values.0.count,instance_types.0.values.0.date,instance_types.0.values.0.instance_type,instance_types.0.values.0.total,instance_types.0.values.0.units,instance_types.1.instance_type,instance_types.1.values.0.count,instance_types.1.values.0.date,instance_types.1.values.0.instance_type,instance_types.1.values.0.total,instance_types.1.values.0.units
+        2018-07-15,t2.micro,0,2018-07-15,t2.micro,39.0,,t2.small,0,2018-07-15,t2.small,25.0,Hrs
+        2018-07-17,t2.micro,0,2018-07-17,t2.micro,25.0,,t2.small,0,2018-07-17,t2.small,24.0,Hrs
+        2018-07-18,t2.micro,0,2018-07-18,t2.micro,25.0,,t2.small,0,2018-07-18,t2.small,25.0,Hrs
+        2018-07-19,t2.micro,0,2018-07-19,t2.micro,25.0,,t2.small,0,2018-07-19,t2.small,24.0,Hrs
+
     """
     filter_scope = {'cost_entry_product__instance_type__isnull': False}
     annotations = {'instance_type':
@@ -405,6 +427,14 @@ def storage(request):
                 "units": "GB-Mo"
             }
         }
+    @apiSuccessExample {text} Success-Response:
+        HTTP/1.1 200 OK
+        date,values.0.date,values.0.total,values.0.units
+        2018-07-13,2018-07-13,1.6146062097,
+        2018-07-14,2018-07-14,1.3458355445,
+        2018-07-15,2018-07-15,1.7759989024,
+        2018-07-16,2018-07-16,1.6147669752,
+
     """
     filter_scope = {'cost_entry_product__product_family': 'Storage'}
     extras = {'filter': filter_scope}

--- a/koku/api/status/tests_status.py
+++ b/koku/api/status/tests_status.py
@@ -16,6 +16,7 @@
 #
 """Test the status API."""
 
+import logging
 from collections import namedtuple
 from unittest.mock import ANY, Mock, PropertyMock, patch
 
@@ -28,6 +29,18 @@ from api.status.models import Status
 
 class StatusModelTest(TestCase):
     """Tests against the status functions."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Test Class setup."""
+        # remove filters on logging
+        logging.disable(logging.NOTSET)
+
+    @classmethod
+    def tearDownClass(cls):
+        """Test Class teardown."""
+        # restore filters on logging
+        logging.disable(logging.CRITICAL)
 
     def setUp(self):
         """Create test case setup."""

--- a/koku/koku/settings.py
+++ b/koku/koku/settings.py
@@ -27,6 +27,9 @@ https://docs.djangoproject.com/en/2.0/ref/settings/
 """
 import os
 
+import sys
+import logging
+
 # Database
 # https://docs.djangoproject.com/en/2.0/ref/settings/#databases
 from . import database, email
@@ -289,3 +292,7 @@ KOKU_DEFAULT_LOCALE = ENVIRONMENT.get_value('KOKU_DEFAULT_LOCALE', default='en_U
 CORS_ORIGIN_ALLOW_ALL = DEBUG
 
 APPEND_SLASH = False
+
+# disable log messages less than CRITICAL when running unit tests.
+if len(sys.argv) > 1 and sys.argv[1] == 'test':
+    logging.disable(logging.CRITICAL)

--- a/koku/koku/settings.py
+++ b/koku/koku/settings.py
@@ -87,7 +87,6 @@ SHARED_APPS = (
     'django.contrib.contenttypes',
     'django.contrib.admin',
     'django.contrib.auth',
-    'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.messages',
     'rest_framework',
@@ -203,6 +202,11 @@ REST_FRAMEWORK = {
         'rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly'
     ],
     'DEFAULT_PAGINATION_CLASS': DEFAULT_PAGINATION_CLASS,
+    'DEFAULT_RENDERER_CLASSES': (
+        'rest_framework.renderers.JSONRenderer',
+        'api.common.csv.PaginatedCSVRenderer',
+        'rest_framework.renderers.BrowsableAPIRenderer',
+    )
 }
 
 EMAIL_HOST = email.EMAIL_HOST

--- a/scripts/create_test_customer.py
+++ b/scripts/create_test_customer.py
@@ -7,14 +7,14 @@ import requests
 class TestCustomer:
     """Container for customer specific info."""
 
-     def __init__(self):
-         self.customer_name = 'Test Customer'
-         self.user_name = 'test_customer'
-         self.email = 'test@example.com'
-         self.password = 'str0ng!P@ss'
-         self.provider_resource_name = 'arn:aws:iam::111111111111:role/CostManagement'
-         self.bucket = 'test-bucket'
-         self.provider_name = 'Test Provider'
+    def __init__(self):
+        self.customer_name = 'Test Customer'
+        self.user_name = 'test_customer'
+        self.email = 'test@example.com'
+        self.password = 'str0ng!P@ss'
+        self.provider_resource_name = 'arn:aws:iam::111111111111:role/CostManagement'
+        self.bucket = 'test-bucket'
+        self.provider_name = 'Test Provider'
 
 
 class KokuCustomerOnboarder:
@@ -99,7 +99,7 @@ class KokuCustomerOnboarder:
 
 if __name__ == '__main__':
     default_api_host = os.getenv('KOKU_HOST', 'localhost')
-    default_api_port = os.getenv('KOKU_PORT', '80')
+    default_api_port = os.getenv('KOKU_PORT', '8000')
     default_api_admin = os.getenv('KOKU_ADMIN', 'admin')
     default_api_pass = os.getenv('KOKU_PASSWORD', 'pass')
 

--- a/scripts/create_test_customer.py
+++ b/scripts/create_test_customer.py
@@ -7,14 +7,14 @@ import requests
 class TestCustomer:
     """Container for customer specific info."""
 
-    def __init__(self):
-        self.customer_name = 'Test Customer'
-        self.user_name = 'test_customer'
-        self.email = 'test@example.com'
-        self.password = 'str0ng!P@ss'
-        self.provider_resource_name = 'arn:aws:iam::111111111111:role/CostManagement'
-        self.bucket = 'test-bucket'
-        self.provider_name = 'Test Provider'
+     def __init__(self):
+         self.customer_name = 'Test Customer'
+         self.user_name = 'test_customer'
+         self.email = 'test@example.com'
+         self.password = 'str0ng!P@ss'
+         self.provider_resource_name = 'arn:aws:iam::111111111111:role/CostManagement'
+         self.bucket = 'test-bucket'
+         self.provider_name = 'Test Provider'
 
 
 class KokuCustomerOnboarder:


### PR DESCRIPTION
Changes:
1. Added `PaginatedCSVRenderer` and wired up `api.report.view` to use multiple Renderers. This leverages the existing DRF content negotiation facility (see: http://www.django-rest-framework.org/api-guide/content-negotiation/ ) and the HTTP `Accept` header.

So, the new capability is that if  a `GET` to `/api/v1/reports/inventory/*` is made with `Accept: text/csv`, it will return CSV-formatted data. The `JSONRenderer` is still the default renderer, so requests missing an `Accept` header or with a broadly scoped header (e.g. `Accept: */*`) will continue to receive JSON data.

2. Opportunistically tidied up unit test logging. This disables non-critical log messages from being dumped to stdout when running unit tests. To re-enable logging lower-priority messages, add `logging.disable(logging.NOTSET)` to your test code.

3. Added some polishing to `scripts/create_test_customer.py` to make it a little easier to specify environment-specific details.