### PR TITLE
Service admin list providers

### DIFF
--- a/koku/api/iam/serializers.py
+++ b/koku/api/iam/serializers.py
@@ -80,6 +80,11 @@ def _create_user(username, email, password):
     return user
 
 
+def _create_schema_name(customer_name):
+    """Create a database schema name."""
+    return re.compile(r'[\W_]+').sub('', customer_name).lower()
+
+
 class UserSerializer(serializers.ModelSerializer):
     """Serializer for the User model."""
 
@@ -130,8 +135,7 @@ class CustomerSerializer(serializers.ModelSerializer):
 
         validated_data['owner_id'] = owner.id
         name = validated_data['name']
-        validated_data['schema_name'] = \
-            re.compile(r'[\W_]+').sub('', name).lower()
+        validated_data['schema_name'] = _create_schema_name(name)
         customer = Customer.objects.create(**validated_data)
         customer.user_set.add(owner)
         customer.save()
@@ -147,6 +151,16 @@ class CustomerSerializer(serializers.ModelSerializer):
     def get_users_for_group(group):
         """Get users that belong to a given authentication group."""
         return group.user_set.all()
+
+
+class AdminCustomerSerializer(CustomerSerializer):
+    """Serializer with admin specific fields."""
+
+    class Meta:
+        """Metadata for the serializer."""
+
+        model = Customer
+        fields = ('uuid', 'name', 'owner', 'date_created', 'schema_name')
 
 
 class NestedUserSerializer(serializers.ModelSerializer):

--- a/koku/api/iam/view/customer.py
+++ b/koku/api/iam/view/customer.py
@@ -59,7 +59,7 @@ class CustomerViewSet(mixins.CreateModelMixin,
 
     lookup_field = 'uuid'
     queryset = models.Customer.objects.all()
-    serializer_class = serializers.CustomerSerializer
+    serializer_class = serializers.AdminCustomerSerializer
     authentication_classes = (TokenAuthentication,
                               SessionAuthentication)
     permission_classes = (IsAdminUser,)

--- a/koku/api/provider/serializers.py
+++ b/koku/api/provider/serializers.py
@@ -24,7 +24,9 @@ from rest_framework import serializers
 from rest_framework.validators import UniqueValidator
 
 from api.iam.models import Customer, User
-from api.iam.serializers import (CustomerSerializer, UserSerializer)
+from api.iam.serializers import (AdminCustomerSerializer,
+                                 CustomerSerializer,
+                                 UserSerializer)
 from api.provider.models import (Provider,
                                  ProviderAuthentication,
                                  ProviderBillingSource)
@@ -131,3 +133,9 @@ class ProviderSerializer(serializers.ModelSerializer):
         provider.billing_source = bill
         provider.save()
         return provider
+
+
+class AdminProviderSerializer(ProviderSerializer):
+    """Provider serializer specific to service admins."""
+
+    customer = AdminCustomerSerializer(read_only=True)

--- a/koku/api/provider/test/tests_views.py
+++ b/koku/api/provider/test/tests_views.py
@@ -122,6 +122,24 @@ class ProviderViewTest(IamTestCase):
         self.assertIsNotNone(results)
         self.assertEqual(len(results), 1)
 
+    def test_list_provider_service_admin(self):
+        """Test list providers as admin."""
+        # Setup a provider
+        iam_arn = 'arn:aws:s3:::my_s3_bucket'
+        token = self.get_customer_owner_token(self.customer_data[0])
+        bucket_name = 'my_s3_bucket'
+        self.create_provider(bucket_name, iam_arn, token)
+
+        url = reverse('provider-list')
+        client = APIClient()
+        client.credentials(HTTP_AUTHORIZATION=self.service_admin_token)
+        response = client.get(url)
+        self.assertEqual(response.status_code, 200)
+        json_result = response.json()
+        results = json_result.get('results')
+        self.assertIsNotNone(results)
+        self.assertEqual(len(results), 1)
+
     def test_list_provider_anon(self):
         """Test list providers with an anonymous user."""
         iam_arn = 'arn:aws:s3:::my_s3_bucket'

--- a/koku/api/provider/view.py
+++ b/koku/api/provider/view.py
@@ -59,10 +59,16 @@ class ProviderViewSet(mixins.CreateModelMixin,
 
     lookup_field = 'uuid'
     queryset = Provider.objects.all()
-    serializer_class = serializers.ProviderSerializer
     authentication_classes = (TokenAuthentication,
                               SessionAuthentication)
     permission_classes = (IsAuthenticated,)
+
+    def get_serializer_class(self):
+        """Return the appropriate serializer depending on user."""
+        if self.request.user.is_superuser:
+            return serializers.AdminProviderSerializer
+        else:
+            return serializers.ProviderSerializer
 
     def get_queryset(self):
         """Get a queryset.

--- a/koku/api/provider/view.py
+++ b/koku/api/provider/view.py
@@ -72,7 +72,9 @@ class ProviderViewSet(mixins.CreateModelMixin,
         """
         queryset = Provider.objects.none()
         group = self.request.user.groups.first()
-        if group:
+        if self.request.user.is_superuser:
+            queryset = Provider.objects.all()
+        elif group:
             customer = Customer.objects.get(pk=group.id)
             queryset = Provider.objects.filter(customer=customer)
         return queryset
@@ -282,7 +284,7 @@ class ProviderViewSet(mixins.CreateModelMixin,
             @apiSuccessExample {json} Success-Response:
                 HTTP/1.1 204 NO CONTENT
             """
-            # Block any users not part of the orginization
+            # Block any users not part of the organization
             if not self.get_queryset():
                 raise PermissionDenied()
 


### PR DESCRIPTION
This is a 👶  👟  in the direction of supporting masu as its own microservice. With our current setup, masu gets provider information directly from the shared database. This koku API change would support getting provider information from masu via an API call instead.  

This is stretch-goal work to be sure, and as it has not been formally discussed, I'll pitch this as a proof of concept. Please let me know your thoughts.

### Highlights

* Allow the service admin access to the entire list of providers when calling the list API
* Created admin serializers for customer and provider that will give additional information when the API is accessed by our service admin user.
  * This makes it so a non-admin customer can use the provider API and the schema_name field is never exposed. 
  * This makes it so that a service admin can use the provider API and the schema_name is exposed 
* Have the customer views use the admin customer serializer since those views are restricted to the admin user

### Examples

#### Admin making a GET call on providers
```
http post http://127.0.0.1:8000/api/v1/token-auth/ username=admin password={admin_pass}
HTTP/1.1 200 OK
Allow: POST, OPTIONS
Content-Length: 52
Content-Type: application/json
Date: Fri, 20 Jul 2018 15:39:23 GMT
Server: WSGIServer/0.2 CPython/3.6.4
Vary: Cookie
X-Frame-Options: SAMEORIGIN

{
    "token": "6fafaf8db571349e75b1cb10511b294eb0fd0837"
}

http get http://127.0.0.1:8000/api/v1/providers/ Authorization:"Token 6fafaf8db571349e75b1cb10511b294eb0fd0837"
HTTP/1.1 200 OK
Allow: GET, POST, HEAD, OPTIONS
Content-Length: 748
Content-Type: application/json
Date: Fri, 20 Jul 2018 15:36:40 GMT
Server: WSGIServer/0.2 CPython/3.6.4
Vary: Accept
X-Frame-Options: SAMEORIGIN

{
    "count": 1,
    "next": null,
    "previous": null,
    "results": [
        {
            "authentication": {
                "provider_resource_name": "arn:aws:iam::589173575009:role/CostManagement",
                "uuid": "7e4ec31b-7ced-4a17-9f7e-f77e9efa8fd6"
            },
            "billing_source": {
                "bucket": "cost-usage-bucket",
                "uuid": "75b17096-319a-45ec-92c1-18dbd5e78f94"
            },
            "created_by": {
                "email": "test@example.com",
                "username": "test_customer",
                "uuid": "83c8098c-bd2f-4a45-a19d-4d8a43e1c816"
            },
            "customer": {
                "date_created": "2018-07-20T13:55:46.798105Z",
                "name": "Test Customer",
                "owner": {
                    "email": "test@example.com",
                    "username": "test_customer",
                    "uuid": "83c8098c-bd2f-4a45-a19d-4d8a43e1c816"
                },
                "schema_name": "testcustomer",
                "uuid": "0e1911ba-ec60-4656-96ea-39b60bd4c5d3"
            },
            "name": "Test Provider",
            "type": "AWS",
            "uuid": "6e212746-484a-40cd-bba0-09a19d132d64"
        }
    ]
}
```

#### Customer making a GET call on providers
```
http post http://127.0.0.1:8000/api/v1/token-auth/ username=test_customer password={test_customer_pass}
HTTP/1.1 200 OK
Allow: POST, OPTIONS
Content-Length: 52
Content-Type: application/json
Date: Fri, 20 Jul 2018 15:37:47 GMT
Server: WSGIServer/0.2 CPython/3.6.4
Vary: Cookie
X-Frame-Options: SAMEORIGIN

{
    "token": "3ec07b8eaf243a5327545e1e40af972a5fb36e2d"
}

http get http://127.0.0.1:8000/api/v1/providers/ Authorization:"Token 3ec07b8eaf243a5327545e1e40af972a5fb36e2d"
HTTP/1.1 200 OK
Allow: GET, POST, HEAD, OPTIONS
Content-Length: 719
Content-Type: application/json
Date: Fri, 20 Jul 2018 15:38:33 GMT
Server: WSGIServer/0.2 CPython/3.6.4
Vary: Accept
X-Frame-Options: SAMEORIGIN

{
    "count": 1,
    "next": null,
    "previous": null,
    "results": [
        {
            "authentication": {
                "provider_resource_name": "arn:aws:iam::589173575009:role/CostManagement",
                "uuid": "7e4ec31b-7ced-4a17-9f7e-f77e9efa8fd6"
            },
            "billing_source": {
                "bucket": "cost-usage-bucket",
                "uuid": "75b17096-319a-45ec-92c1-18dbd5e78f94"
            },
            "created_by": {
                "email": "test@example.com",
                "username": "test_customer",
                "uuid": "83c8098c-bd2f-4a45-a19d-4d8a43e1c816"
            },
            "customer": {
                "date_created": "2018-07-20T13:55:46.798105Z",
                "name": "Test Customer",
                "owner": {
                    "email": "test@example.com",
                    "username": "test_customer",
                    "uuid": "83c8098c-bd2f-4a45-a19d-4d8a43e1c816"
                },
                "uuid": "0e1911ba-ec60-4656-96ea-39b60bd4c5d3"
            },
            "name": "Test Provider",
            "type": "AWS",
            "uuid": "6e212746-484a-40cd-bba0-09a19d132d64"
        }
    ]
}
```
