### PR TITLE
Make schema_name read only for customer api

### DIFF
--- a/koku/api/iam/serializers.py
+++ b/koku/api/iam/serializers.py
@@ -156,6 +156,8 @@ class CustomerSerializer(serializers.ModelSerializer):
 class AdminCustomerSerializer(CustomerSerializer):
     """Serializer with admin specific fields."""
 
+    schema_name = serializers.CharField(read_only=True)
+
     class Meta:
         """Metadata for the serializer."""
 


### PR DESCRIPTION
This will keep our API UI from putting `schema_name` in the form when POSTing a customer. It will still return in the results for service admin users at `/api/v1/customers/` and `/api/v1/providers/`