### PR TITLE
Enable CORS whitelist via regex and update email template and flow for new users.

### DIFF
--- a/koku/api/iam/email.py
+++ b/koku/api/iam/email.py
@@ -27,10 +27,8 @@ SENDER = ENVIRONMENT.get_value('EMAIL_SENDER',
 APP_DOMAIN = ENVIRONMENT.get_value('APP_DOMAIN',
                                    default='project-koku.com')
 APP_NAMESPACE = ENVIRONMENT.get_value('APP_NAMESPACE',
-                                      default='')
-if not APP_NAMESPACE == '':
-    APP_NAMESPACE = '-' + APP_NAMESPACE
-DEFAULT_LOGIN = f'http://koku-ui{APP_NAMESPACE}.{APP_DOMAIN}'
+                                      default='home')
+DEFAULT_LOGIN = f'http://koku-ui-{APP_NAMESPACE}.{APP_DOMAIN}'
 LOGIN_LINK = ENVIRONMENT.get_value('LOGIN_LINK',
                                    default=DEFAULT_LOGIN)
 

--- a/koku/api/iam/email.py
+++ b/koku/api/iam/email.py
@@ -21,18 +21,23 @@ from django.template.loader import render_to_string
 
 from koku.env import ENVIRONMENT
 
-SUBJECT = 'Welcome to Hybrid Cost Management'
+SUBJECT = 'Welcome to Hybrid Cloud Cost Management'
 SENDER = ENVIRONMENT.get_value('EMAIL_SENDER',
                                default='noreply@project-koku.com')
-DEFAULT_RESET = 'https://koku-ui.project-koku.com/password-reset.html'
-RESET_LINK = ENVIRONMENT.get_value('PASSWORD_RESET_LINK',
-                                   default=DEFAULT_RESET)
+APP_DOMAIN = ENVIRONMENT.get_value('APP_DOMAIN',
+                                   default='project-koku.com')
+APP_NAMESPACE = ENVIRONMENT.get_value('APP_NAMESPACE',
+                                      default='')
+if not APP_NAMESPACE == '':
+    APP_NAMESPACE = '-' + APP_NAMESPACE
+DEFAULT_LOGIN = f'http://koku-ui{APP_NAMESPACE}.{APP_DOMAIN}'
+LOGIN_LINK = ENVIRONMENT.get_value('LOGIN_LINK',
+                                   default=DEFAULT_LOGIN)
 
 
-def new_user_reset_email(username, email, uuid, token):
-    """Send an email with a password reset link for new users."""
-    reset_link = RESET_LINK + '?uuid=' + uuid + '&token=' + token
-    msg_params = {'username': username, 'reset_link': reset_link}
+def new_user_login_email(username, email, uuid, token):
+    """Send an email with a login link for new users."""
+    msg_params = {'username': username, 'login_link': LOGIN_LINK}
     msg_plain = render_to_string('welcome.txt', msg_params)
     msg_html = render_to_string('welcome.html', msg_params)
     send_mail(SUBJECT, msg_plain, SENDER, [email], html_message=msg_html)

--- a/koku/api/iam/serializers.py
+++ b/koku/api/iam/serializers.py
@@ -33,7 +33,7 @@ from django.utils.translation import gettext as _
 from rest_framework import serializers
 from rest_framework.validators import UniqueValidator
 
-from .email import new_user_reset_email
+from .email import new_user_login_email
 from .models import Customer, ResetToken, User, UserPreference
 
 
@@ -75,7 +75,7 @@ def _create_user(username, email, password):
     _create_default_preferences(user=user)
     reset_token = ResetToken(user=user)
     reset_token.save()
-    new_user_reset_email(username, email, str(user.uuid),
+    new_user_login_email(username, email, str(user.uuid),
                          str(reset_token.token))
     return user
 

--- a/koku/koku/settings.py
+++ b/koku/koku/settings.py
@@ -290,6 +290,11 @@ KOKU_DEFAULT_LOCALE = ENVIRONMENT.get_value('KOKU_DEFAULT_LOCALE', default='en_U
 
 # SECURITY WARNING: Replace this with proper origins once UI is deployed in insights
 CORS_ORIGIN_ALLOW_ALL = DEBUG
+if not DEBUG:
+    APP_DOMAIN = ENVIRONMENT.get_value('APP_DOMAIN', default='project-koku.com')
+    APP_DOMAIN_REGEX = APP_DOMAIN.replace('.', '\.')  # pylint: disable=W1401
+    KOKU_UI_REGEX = r'^(http(s)?://)?koku-ui-([a-zA-Z0-9_-]*\.)?{0}$'.format(APP_DOMAIN_REGEX)
+    CORS_ORIGIN_REGEX_WHITELIST = (KOKU_UI_REGEX,)
 
 APPEND_SLASH = False
 

--- a/koku/koku/settings.py
+++ b/koku/koku/settings.py
@@ -290,10 +290,10 @@ KOKU_DEFAULT_LOCALE = ENVIRONMENT.get_value('KOKU_DEFAULT_LOCALE', default='en_U
 
 # SECURITY WARNING: Replace this with proper origins once UI is deployed in insights
 CORS_ORIGIN_ALLOW_ALL = DEBUG
+APP_DOMAIN = ENVIRONMENT.get_value('APP_DOMAIN', default='project-koku.com')
+APP_DOMAIN_REGEX = APP_DOMAIN.replace('.', '\.')  # pylint: disable=W1401
+KOKU_UI_REGEX = r'^(http(s)?://)?koku-ui-([a-zA-Z0-9_-]*\.)?{0}$'.format(APP_DOMAIN_REGEX)
 if not DEBUG:
-    APP_DOMAIN = ENVIRONMENT.get_value('APP_DOMAIN', default='project-koku.com')
-    APP_DOMAIN_REGEX = APP_DOMAIN.replace('.', '\.')  # pylint: disable=W1401
-    KOKU_UI_REGEX = r'^(http(s)?://)?koku-ui-([a-zA-Z0-9_-]*\.)?{0}$'.format(APP_DOMAIN_REGEX)
     CORS_ORIGIN_REGEX_WHITELIST = (KOKU_UI_REGEX,)
 
 APPEND_SLASH = False

--- a/koku/templates/welcome.html
+++ b/koku/templates/welcome.html
@@ -1,14 +1,15 @@
 <html>
 <body>
 <p>
-Welcome to Hybrid Cost Management.
+Welcome to Hybrid Cloud Cost Management.
 Start gaining insights on your costs today.
 <br>
 <br>
 You user has been created with username <strong>{{username}}</strong>.
+A separate email will follow with the associated password.
 <br>
-Point your browser to the following URL to reset your password and begin using the service.
-<a href="{{reset_link}}">{{reset_link}}</a>
+Point your browser to the following URL to login to the service.
+<a href="{{login_link}}">{{login_link}}</a>
 </p>
 </body>
 <html>

--- a/koku/templates/welcome.txt
+++ b/koku/templates/welcome.txt
@@ -1,6 +1,7 @@
-Welcome to Hybrid Cost Management.
+Welcome to Hybrid Cloud Cost Management.
 
 Start gaining insights on your costs today.
 
 You user has been created with username {{username}}.
-Point your browser to the following URL to reset your password and begin using the service. {{reset_link}}
+A separate email will follow with the associated password.
+Point your browser to the following URL to login to the service. {{login_link}}

--- a/openshift/koku-template.yaml
+++ b/openshift/koku-template.yaml
@@ -97,6 +97,8 @@ objects:
     app-config: ${APP_CONFIG}
     app-home: ${APP_HOME}
     app-module: ${APP_MODULE}
+    app-namespace: ${NAMESPACE}
+    app-domain: ${APP_DOMAIN}
     email-service-host: ${EMAIL_HOST}
     email-service-port: ${EMAIL_PORT}
     email-service-host-user: ${EMAIL_HOST_USER}
@@ -172,6 +174,16 @@ objects:
               configMapKeyRef:
                 name: koku-env
                 key: app-module
+          - name: APP_NAMESPACE
+            valueFrom:
+              configMapKeyRef:
+                name: koku-env
+                key: app-namespace
+          - name: APP_DOMAIN
+            valueFrom:
+              configMapKeyRef:
+                name: koku-env
+                key: app-domain
         from:
           kind: ImageStreamTag
           name: python-36-centos7:latest
@@ -309,6 +321,18 @@ objects:
                   name: koku-env
                   key: email-service-host-user
                   optional: false
+            - name: APP_NAMESPACE
+              valueFrom:
+                configMapKeyRef:
+                  name: koku-env
+                  key: app-namespace
+                  optional: true
+            - name: APP_DOMAIN
+              valueFrom:
+                configMapKeyRef:
+                  name: koku-env
+                  key: app-domain
+                  optional: true
           livenessProbe:
             failureThreshold: 3
             httpGet:
@@ -590,3 +614,6 @@ parameters:
 - description: The custom PyPi index URL
   displayName: Custom PyPi Index URL
   name: PIP_INDEX_URL
+- displayName: User Interface Domain
+  value: 'project-koku.com'
+  name: APP_DOMAIN


### PR DESCRIPTION
Adds CORS whitelist regex to handle our deployment into projects via the use of NAMESPACE & APP_DOMAIN parameters to `oc new-app`.

Updates the on-boarding flow for user to get an email to the login URL when they are added. We will manually send password credential for the first release.