### PR TITLE
Set build config limit to prevent OSD from applying default resource limits

### DIFF
--- a/openshift/koku-template.yaml
+++ b/openshift/koku-template.yaml
@@ -145,6 +145,9 @@ objects:
       to:
         kind: ImageStreamTag
         name: ${NAME}:latest
+    resources:
+      limits:
+        memory: ${BUILD_MEMORY_LIMIT}
     source:
       contextDir: ${CONTEXT_DIR}
       git:
@@ -499,6 +502,11 @@ parameters:
   name: NAMESPACE
   required: true
   value: project-koku
+- description: Maximum amount of memory the build container can use.
+  displayName: Build Memory Limit
+  name: BUILD_MEMORY_LIMIT
+  required: true
+  value: 1Gi
 - description: Maximum amount of memory the Django container can use.
   displayName: Memory Limit
   name: MEMORY_LIMIT


### PR DESCRIPTION
OpenShift dedicated is enforcing default limits when no resources limits are specified causing the builds to go OOM. This will specify a memory limit for the build container so that OSD defaults aren't applied

OSD Default Resource Limits
limits:
  - default:
      cpu: 300m
      memory: 200Mi
    defaultRequest:
      cpu: 200m
      memory: 100Mi