### PR TITLE
fix DEBUG boolean

### DIFF
--- a/koku/koku/settings.py
+++ b/koku/koku/settings.py
@@ -52,8 +52,7 @@ SECRET_KEY = os.getenv(
 )
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = os.getenv('DJANGO_DEBUG', True)
-DEBUG = (DEBUG == 'True' or DEBUG is True)
+DEBUG = bool(os.getenv('DJANGO_DEBUG', 'True'))
 
 ALLOWED_HOSTS = ['*']
 

--- a/koku/koku/settings.py
+++ b/koku/koku/settings.py
@@ -52,7 +52,8 @@ SECRET_KEY = os.getenv(
 )
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = bool(os.getenv('DJANGO_DEBUG', 'True'))
+# Default value: False
+DEBUG = False if os.getenv('DJANGO_DEBUG', 'False') == 'False' else True
 
 ALLOWED_HOSTS = ['*']
 


### PR DESCRIPTION
This resolves the error found in Travis runs:
`koku/koku/settings.py:55:8: W1508: os.getenv default type is builtins.bool. Expected str or None. (invalid-envvar-default)`