### PR TITLE
Add ability to specify a filter limit that will return the data ranked by total.

### DIFF
--- a/docs/source/specs/openapi.yml
+++ b/docs/source/specs/openapi.yml
@@ -920,6 +920,10 @@ definitions:
   ReportFilter:
     type: object
     properties:
+      limit:
+        type: integer
+        description: Limits the data points returns and aggregates remaining data.
+        example: 5
       resolution:
         $ref: '#/definitions/ReportResolution'
       time_scope_value:

--- a/koku/api/report/serializers.py
+++ b/koku/api/report/serializers.py
@@ -145,6 +145,7 @@ class FilterSerializer(serializers.Serializer):
                                                required=False)
     resource_scope = StringOrListField(child=serializers.CharField(),
                                        required=False)
+    limit = serializers.IntegerField(required=False, min_value=1)
 
     def validate(self, data):
         """Validate incoming data.

--- a/koku/api/report/test/tests_serializers.py
+++ b/koku/api/report/test/tests_serializers.py
@@ -72,6 +72,16 @@ class FilterSerializerTest(TestCase):
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
+    def test_filter_params_invalid_limit(self):
+        """Test parse of filter params for invalid month time_scope_units."""
+        filter_params = {'resolution': 'monthly',
+                         'time_scope_value': '-1',
+                         'time_scope_units': 'month',
+                         'limit': 'invalid'}
+        serializer = FilterSerializer(data=filter_params)
+        with self.assertRaises(serializers.ValidationError):
+            serializer.is_valid(raise_exception=True)
+
 
 class GroupBySerializerTest(TestCase):
     """Tests for the group_by serializer."""


### PR DESCRIPTION
Added the _limit_ option to the filter query parameter. This will give you back the limited data points plus one aggregate "Other" data point for the remaining items beyond the limit.

*Endpoint Query:* /api/v1/reports/costs/?filter[time_scope_value]=-2&group_by[account]=*&filter[limit]=2
```
{
    "group_by": {
        "account": [
            "*"
        ]
    },
    "filter": {
        "time_scope_value": "-2",
        "limit": 2
    },
    "data": [
        {
            "date": "2018-07",
            "accounts": [
                {
                    "account": "5546097672515",
                    "values": [
                        {
                            "date": "2018-07",
                            "units": "USD",
                            "account": "5546097672515",
                            "total": 18598.206266076
                        }
                    ]
                },
                {
                    "account": "6078912875515",
                    "values": [
                        {
                            "date": "2018-07",
                            "units": "USD",
                            "account": "6078912875515",
                            "total": 15164.695126399
                        }
                    ]
                },
                {
                    "account": "Other",
                    "values": [
                        {
                            "date": "2018-07",
                            "units": "USD",
                            "account": "Other",
                            "total": 42111.122857602
                        }
                    ]
                }
            ]
        }
    ],
    "total": {
        "value": 75874.024250077,
        "units": "USD"
    }
}
```