### PR TITLE
add PIPENV_PYPI_MIRROR env var to BuildConfig

### DIFF
--- a/koku/providers/aws/aws_provider.py
+++ b/koku/providers/aws/aws_provider.py
@@ -124,7 +124,8 @@ def _check_org_access(access_key_id, secret_access_key, session_token):
     return access_ok
 
 
-def _check_cost_report_access(access_key_id, secret_access_key, session_token):
+def _check_cost_report_access(access_key_id, secret_access_key, session_token,
+                              region='us-east-1'):
     """Check for provider cost and usage report access."""
     access_ok = True
     cur_client = boto3.client(
@@ -132,6 +133,7 @@ def _check_cost_report_access(access_key_id, secret_access_key, session_token):
         aws_access_key_id=access_key_id,
         aws_secret_access_key=secret_access_key,
         aws_session_token=session_token,
+        region=region
     )
     try:
         cur_client.describe_report_definitions()

--- a/openshift/koku-template.yaml
+++ b/openshift/koku-template.yaml
@@ -159,6 +159,8 @@ objects:
         env:
           - name: PIP_INDEX_URL
             value: ${PIP_INDEX_URL}
+          - name: PIPENV_PYPI_MIRROR
+            value: ${PIPENV_PYPI_MIRROR}
           - name: ENABLE_PIPENV
             value: "true"
           - name: APP_CONFIG
@@ -628,6 +630,9 @@ parameters:
 - description: The custom PyPi index URL
   displayName: Custom PyPi Index URL
   name: PIP_INDEX_URL
+- description: The custom PipEnv PyPi index URL
+  displayName: Custom PipEnv PyPi Index URL
+  name: PIPENV_PYPI_MIRROR
 - displayName: User Interface Domain
   value: 'project-koku.com'
   name: APP_DOMAIN

--- a/scripts/create_test_customer.py
+++ b/scripts/create_test_customer.py
@@ -10,9 +10,9 @@ class TestCustomer:
     """Container for customer specific info."""
 
     def __init__(self):
-        self.customer_name = 'Test Customer'
-        self.user_name = 'test_customer'
-        self.email = 'test@example.com'
+        self.customer_name = 'Test Customer 3'
+        self.user_name = 'test_customer_3'
+        self.email = 'test-3@example.com'
         self.password = 'str0ng!P@ss'
         self.provider_resource_name = 'arn:aws:iam::111111111111:role/CostManagement'
         self.bucket = 'test-bucket'
@@ -71,6 +71,7 @@ class KokuCustomerOnboarder:
         # have the correct permissions to create a provider.
         self.customer.token = self.get_token(self.customer.user_name,
                                              self.customer.password)
+        self.headers = {'Authorization': f'Token {self.token}'}
 
         endpoint = self.endpoint_base + 'providers/'
         data = {

--- a/scripts/create_test_customer.py
+++ b/scripts/create_test_customer.py
@@ -10,9 +10,9 @@ class TestCustomer:
     """Container for customer specific info."""
 
     def __init__(self):
-        self.customer_name = 'Test Customer 3'
-        self.user_name = 'test_customer_3'
-        self.email = 'test-3@example.com'
+        self.customer_name = 'Test Customer'
+        self.user_name = 'test_customer'
+        self.email = 'test@example.com'
         self.password = 'str0ng!P@ss'
         self.provider_resource_name = 'arn:aws:iam::111111111111:role/CostManagement'
         self.bucket = 'test-bucket'
@@ -71,7 +71,7 @@ class KokuCustomerOnboarder:
         # have the correct permissions to create a provider.
         self.customer.token = self.get_token(self.customer.user_name,
                                              self.customer.password)
-        self.headers = {'Authorization': f'Token {self.token}'}
+        self.headers = {'Authorization': f'Token {self.customer.token}'}
 
         endpoint = self.endpoint_base + 'providers/'
         data = {

--- a/scripts/create_test_customer.py
+++ b/scripts/create_test_customer.py
@@ -1,8 +1,10 @@
+#!/usr/bin/env python3
+
 import argparse
 import os
 
-import psycopg2
 import requests
+
 
 class TestCustomer:
     """Container for customer specific info."""
@@ -20,12 +22,11 @@ class TestCustomer:
 class KokuCustomerOnboarder:
     """Uses the Koku API and SQL to create an onboarded customer."""
 
-    def __init__(self, conn, host='localhost', port=80, admin='admin', password='pass'):
-        self.conn = conn
+    def __init__(self, host='localhost', port=80, admin='admin', password='pass'):
         self.host = host
         self.port = port
         self.customer = TestCustomer()
-        self.endpoint_base = f'http://{self.host}:{self.port}'
+        self.endpoint_base = f'http://{self.host}:{self.port}/api/v1/'
         self.token = self.get_token(admin, password)
         self.headers = {'Authorization': f'Token {self.token}'}
 
@@ -34,8 +35,8 @@ class KokuCustomerOnboarder:
         self.provider = self.create_provider()
 
     def get_token(self, user_name, password):
-        endpoint = self.endpoint_base + '/api/v1/token-auth/'
-        data = {'username': user_name , 'password': password}
+        endpoint = self.endpoint_base + 'token-auth/'
+        data = {'username': user_name, 'password': password}
 
         response = requests.post(endpoint, data=data)
         if response.status_code == 200:
@@ -47,13 +48,13 @@ class KokuCustomerOnboarder:
             raise Exception(f'{response.status_code}: {response.reason}')
 
     def create_customer(self):
-        endpoint = self.endpoint_base + '/api/v1/customers/'
+        endpoint = self.endpoint_base + 'customers/'
         data = {
             'name': self.customer.customer_name,
             'owner': {
-                    'username': self.customer.user_name,
-                    'email': self.customer.email,
-                    'password': self.customer.password
+                'username': self.customer.user_name,
+                'email': self.customer.email,
+                'password': self.customer.password
             }
         }
 
@@ -66,35 +67,28 @@ class KokuCustomerOnboarder:
         return response
 
     def create_provider(self):
-        cursor = self.conn.cursor()
-        auth_sql = """
-            INSERT INTO api_providerauthentication (uuid, provider_resource_name)
-                VALUES ('7e4ec31b-7ced-4a17-9f7e-f77e9efa8fd6', '{resource}')
-            ;
-        """.format(resource=self.customer.provider_resource_name)
+        # get a new auth token using the new customer credentials, so that we
+        # have the correct permissions to create a provider.
+        self.customer.token = self.get_token(self.customer.user_name,
+                                             self.customer.password)
 
-        cursor.execute(auth_sql)
-        print('Created provider authentication')
+        endpoint = self.endpoint_base + 'providers/'
+        data = {
+            'name': self.customer.provider_name,
+            'type': 'AWS',
+            'authentication': {
+                'provider_resource_name': self.customer.provider_resource_name
+            },
+            'billing_source': {'bucket': self.customer.bucket}
+        }
 
-        billing_sql = """
-            INSERT INTO api_providerbillingsource (uuid, bucket)
-                VALUES ('75b17096-319a-45ec-92c1-18dbd5e78f94', '{bucket}')
-            ;
-        """.format(bucket=self.customer.bucket)
-
-        cursor.execute(billing_sql)
-        print('Created provider billing source')
-
-        provider_sql = """
-            INSERT INTO api_provider (uuid, name, type, authentication_id, billing_source_id, created_by_id, customer_id)
-                VALUES('6e212746-484a-40cd-bba0-09a19d132d64', '{name}', 'AWS', 1, 1, 2, 1)
-            ;
-        """.format(name=self.customer.provider_name)
-
-        cursor.execute(provider_sql)
-        print('Created provider')
-
-        self.conn.commit()
+        response = requests.post(
+            endpoint,
+            headers=self.headers,
+            json=data
+        )
+        print(response.text)
+        return response
 
 
 if __name__ == '__main__':
@@ -103,38 +97,22 @@ if __name__ == '__main__':
     default_api_admin = os.getenv('KOKU_ADMIN', 'admin')
     default_api_pass = os.getenv('KOKU_PASSWORD', 'pass')
 
-    default_db_host = os.getenv('POSTGRES_SQL_SERVICE_HOST', 'localhost')
-    default_db_port = os.getenv('POSTGRES_SQL_SERVICE_PORT', '15432')
-    default_db_name = os.getenv('DATABASE_NAME', 'koku')
-    default_db_user = os.getenv('DATABASE_USER', 'postgres')
-    default_db_pass = os.getenv('DATABASE_PASSWORD', '')
-
     parser = argparse.ArgumentParser()
 
-    parser.add_argument('--api-host', dest='api_host', default=default_api_host)
-    parser.add_argument('--api-port', dest='api_port', default=default_api_port)
-    parser.add_argument('--api-admin', dest='api_admin', default=default_api_admin)
-    parser.add_argument('--api-password', dest='api_password', default=default_api_pass)
-
-    parser.add_argument('--db-host', dest='db_host', default=default_db_host)
-    parser.add_argument('--db-port', dest='db_port', default=default_db_port)
-    parser.add_argument('--db-database', dest='db_database', default=default_db_name)
-    parser.add_argument('--db-user', dest='db_user', default=default_db_user)
-    parser.add_argument('--db-password', dest='db_password', default=default_db_pass)
+    parser.add_argument('--api-host', dest='api_host',
+                        default=default_api_host)
+    parser.add_argument('--api-port', dest='api_port',
+                        default=default_api_port)
+    parser.add_argument('--api-admin', dest='api_admin',
+                        default=default_api_admin)
+    parser.add_argument('--api-password', dest='api_password',
+                        default=default_api_pass)
 
     args = vars(parser.parse_args())
     print(f'ARGS: {args}')
 
-    db_args = {}
-    for key, value in args.items():
-        if key.startswith('db_'):
-            db_args[key[3:]] = value
-
-    conn = psycopg2.connect(**db_args)
-    onboarder = KokuCustomerOnboarder(conn,
-                                      host=args.get('api_host'),
+    onboarder = KokuCustomerOnboarder(host=args.get('api_host'),
                                       port=args.get('api_port'),
                                       admin=args.get('api_admin'),
                                       password=args.get('api_password'))
     onboarder.onboard()
-    conn.close()


### PR DESCRIPTION
This adds pipenv-specific environment variable into the BuildConfig so that we can use PyPi mirrors for builds.

Also, I'm updating the `scripts/create_test_customer.py` script to use the API entirely.