### PR TITLE
Add ability to toggle the ordering for cost.

### DIFF
--- a/docs/rtd_requirements.txt
+++ b/docs/rtd_requirements.txt
@@ -1,13 +1,13 @@
 -i https://pypi.python.org/simple
-boto3==1.7.65
-botocore==1.10.65
+boto3==1.7.68
+botocore==1.10.68
 certifi==2018.4.16
 chardet==3.0.4
 django-cors-headers==2.4.0
 django-environ==0.4.5
 django-filter==2.0.0
 django-tenant-schemas==1.9.0
-django==2.0.7
+django==2.1
 djangorestframework-csv==2.1.0
 djangorestframework==3.8.2
 docutils==0.14
@@ -24,5 +24,6 @@ querystring-parser==1.2.3
 requests==2.19.1
 s3transfer==0.1.13
 six==1.11.0
+unicodecsv==0.14.1
 urllib3==1.23
 whitenoise==3.3.1


### PR DESCRIPTION
Toggle order for cost with `order_by[cost]` query param. Valid inputs are `asc` or `desc`. Default is `desc` if not provided.

*GET* _/api/v1/reports/costs/?filter[time_scope_value]=-2&group_by[account]=*&order_by[cost]=asc_
```
{
    "group_by": {
        "account": [
            "*"
        ]
    },
    "order_by": {
        "cost": "asc"
    },
    "filter": {
        "time_scope_value": "-2"
    },
    "data": [
        {
            "date": "2018-07",
            "accounts": [
                {
                    "account": "9957846612113",
                    "values": [
                        {
                            "date": "2018-07",
                            "units": "USD",
                            "account": "9957846612113",
                            "total": 13428.432970137
                        }
                    ]
                },
                {
                    "account": "8383941263133",
                    "values": [
                        {
                            "date": "2018-07",
                            "units": "USD",
                            "account": "8383941263133",
                            "total": 13731.047508091
                        }
                    ]
                },
                {
                    "account": "1123135387293",
                    "values": [
                        {
                            "date": "2018-07",
                            "units": "USD",
                            "account": "1123135387293",
                            "total": 14951.642379374
                        }
                    ]
                },
                {
                    "account": "6078912875515",
                    "values": [
                        {
                            "date": "2018-07",
                            "units": "USD",
                            "account": "6078912875515",
                            "total": 15164.695126399
                        }
                    ]
                },
                {
                    "account": "5546097672515",
                    "values": [
                        {
                            "date": "2018-07",
                            "units": "USD",
                            "account": "5546097672515",
                            "total": 18598.206266076
                        }
                    ]
                }
            ]
        }
    ],
    "total": {
        "value": 75874.024250077,
        "units": "USD"
    }
}
```