### PR TITLE
refactor create_test_customer to use API for provider creation

### DIFF
--- a/scripts/create_test_customer.py
+++ b/scripts/create_test_customer.py
@@ -1,8 +1,10 @@
+#!/usr/bin/env python3
+
 import argparse
 import os
 
-import psycopg2
 import requests
+
 
 class TestCustomer:
     """Container for customer specific info."""
@@ -20,12 +22,11 @@ class TestCustomer:
 class KokuCustomerOnboarder:
     """Uses the Koku API and SQL to create an onboarded customer."""
 
-    def __init__(self, conn, host='localhost', port=80, admin='admin', password='pass'):
-        self.conn = conn
+    def __init__(self, host='localhost', port=80, admin='admin', password='pass'):
         self.host = host
         self.port = port
         self.customer = TestCustomer()
-        self.endpoint_base = f'http://{self.host}:{self.port}'
+        self.endpoint_base = f'http://{self.host}:{self.port}/api/v1/'
         self.token = self.get_token(admin, password)
         self.headers = {'Authorization': f'Token {self.token}'}
 
@@ -34,8 +35,8 @@ class KokuCustomerOnboarder:
         self.provider = self.create_provider()
 
     def get_token(self, user_name, password):
-        endpoint = self.endpoint_base + '/api/v1/token-auth/'
-        data = {'username': user_name , 'password': password}
+        endpoint = self.endpoint_base + 'token-auth/'
+        data = {'username': user_name, 'password': password}
 
         response = requests.post(endpoint, data=data)
         if response.status_code == 200:
@@ -47,13 +48,13 @@ class KokuCustomerOnboarder:
             raise Exception(f'{response.status_code}: {response.reason}')
 
     def create_customer(self):
-        endpoint = self.endpoint_base + '/api/v1/customers/'
+        endpoint = self.endpoint_base + 'customers/'
         data = {
             'name': self.customer.customer_name,
             'owner': {
-                    'username': self.customer.user_name,
-                    'email': self.customer.email,
-                    'password': self.customer.password
+                'username': self.customer.user_name,
+                'email': self.customer.email,
+                'password': self.customer.password
             }
         }
 
@@ -66,35 +67,29 @@ class KokuCustomerOnboarder:
         return response
 
     def create_provider(self):
-        cursor = self.conn.cursor()
-        auth_sql = """
-            INSERT INTO api_providerauthentication (uuid, provider_resource_name)
-                VALUES ('7e4ec31b-7ced-4a17-9f7e-f77e9efa8fd6', '{resource}')
-            ;
-        """.format(resource=self.customer.provider_resource_name)
+        # get a new auth token using the new customer credentials, so that we
+        # have the correct permissions to create a provider.
+        self.customer.token = self.get_token(self.customer.user_name,
+                                             self.customer.password)
+        self.headers = {'Authorization': f'Token {self.customer.token}'}
 
-        cursor.execute(auth_sql)
-        print('Created provider authentication')
+        endpoint = self.endpoint_base + 'providers/'
+        data = {
+            'name': self.customer.provider_name,
+            'type': 'AWS',
+            'authentication': {
+                'provider_resource_name': self.customer.provider_resource_name
+            },
+            'billing_source': {'bucket': self.customer.bucket}
+        }
 
-        billing_sql = """
-            INSERT INTO api_providerbillingsource (uuid, bucket)
-                VALUES ('75b17096-319a-45ec-92c1-18dbd5e78f94', '{bucket}')
-            ;
-        """.format(bucket=self.customer.bucket)
-
-        cursor.execute(billing_sql)
-        print('Created provider billing source')
-
-        provider_sql = """
-            INSERT INTO api_provider (uuid, name, type, authentication_id, billing_source_id, created_by_id, customer_id)
-                VALUES('6e212746-484a-40cd-bba0-09a19d132d64', '{name}', 'AWS', 1, 1, 2, 1)
-            ;
-        """.format(name=self.customer.provider_name)
-
-        cursor.execute(provider_sql)
-        print('Created provider')
-
-        self.conn.commit()
+        response = requests.post(
+            endpoint,
+            headers=self.headers,
+            json=data
+        )
+        print(response.text)
+        return response
 
 
 if __name__ == '__main__':
@@ -103,38 +98,22 @@ if __name__ == '__main__':
     default_api_admin = os.getenv('KOKU_ADMIN', 'admin')
     default_api_pass = os.getenv('KOKU_PASSWORD', 'pass')
 
-    default_db_host = os.getenv('POSTGRES_SQL_SERVICE_HOST', 'localhost')
-    default_db_port = os.getenv('POSTGRES_SQL_SERVICE_PORT', '15432')
-    default_db_name = os.getenv('DATABASE_NAME', 'koku')
-    default_db_user = os.getenv('DATABASE_USER', 'postgres')
-    default_db_pass = os.getenv('DATABASE_PASSWORD', '')
-
     parser = argparse.ArgumentParser()
 
-    parser.add_argument('--api-host', dest='api_host', default=default_api_host)
-    parser.add_argument('--api-port', dest='api_port', default=default_api_port)
-    parser.add_argument('--api-admin', dest='api_admin', default=default_api_admin)
-    parser.add_argument('--api-password', dest='api_password', default=default_api_pass)
-
-    parser.add_argument('--db-host', dest='db_host', default=default_db_host)
-    parser.add_argument('--db-port', dest='db_port', default=default_db_port)
-    parser.add_argument('--db-database', dest='db_database', default=default_db_name)
-    parser.add_argument('--db-user', dest='db_user', default=default_db_user)
-    parser.add_argument('--db-password', dest='db_password', default=default_db_pass)
+    parser.add_argument('--api-host', dest='api_host',
+                        default=default_api_host)
+    parser.add_argument('--api-port', dest='api_port',
+                        default=default_api_port)
+    parser.add_argument('--api-admin', dest='api_admin',
+                        default=default_api_admin)
+    parser.add_argument('--api-password', dest='api_password',
+                        default=default_api_pass)
 
     args = vars(parser.parse_args())
     print(f'ARGS: {args}')
 
-    db_args = {}
-    for key, value in args.items():
-        if key.startswith('db_'):
-            db_args[key[3:]] = value
-
-    conn = psycopg2.connect(**db_args)
-    onboarder = KokuCustomerOnboarder(conn,
-                                      host=args.get('api_host'),
+    onboarder = KokuCustomerOnboarder(host=args.get('api_host'),
                                       port=args.get('api_port'),
                                       admin=args.get('api_admin'),
                                       password=args.get('api_password'))
     onboarder.onboard()
-    conn.close()


### PR DESCRIPTION
This removes the direct database access in favor of using the API for the entire on-boarding process. This was required to reproduce bug #246 and more closely matches our actual on-boarding workflow.