### PR TITLE
pass region_name into cur client

### DIFF
--- a/koku/providers/aws/aws_provider.py
+++ b/koku/providers/aws/aws_provider.py
@@ -124,7 +124,8 @@ def _check_org_access(access_key_id, secret_access_key, session_token):
     return access_ok
 
 
-def _check_cost_report_access(access_key_id, secret_access_key, session_token):
+def _check_cost_report_access(access_key_id, secret_access_key, session_token,
+                              region='us-east-1'):
     """Check for provider cost and usage report access."""
     access_ok = True
     cur_client = boto3.client(
@@ -132,6 +133,7 @@ def _check_cost_report_access(access_key_id, secret_access_key, session_token):
         aws_access_key_id=access_key_id,
         aws_secret_access_key=secret_access_key,
         aws_session_token=session_token,
+        region_name=region
     )
     try:
         cur_client.describe_report_definitions()


### PR DESCRIPTION
This fixes bug #246. However, it is also exposing another issue.

When creating a test provider, I'm now seeing this error:
```
./scripts/create_test_customer.py --api-admin=USER_REDACTED --api-password='PASSWORD_REDACTED' --api-host=koku-myproject.127.0.0.1.nip.io --api-port=80

ARGS: {'api_host': 'koku-myproject.127.0.0.1.nip.io', 'api_port': '80', 'api_admin': 'user_71iPJB4lHgcY', 'api_password': 'f7rDLs0rGSN4gErB'}
Acquired token 52e0d59a573cf1ceb7ee6e79710565eccc30c14d
{"uuid":"cc83dd0b-bde1-4dae-8e3a-b8f789149ca4","name":"Test Customer 2","owner":{"uuid":"4744d2a0-38e9-496f-8e50-5ff839fcd143","username":"test_customer_2","email":"test_2@example.com"},"date_created":"2018-08-02T20:49:35.666412Z","schema_name":"testcustomer2"}
Acquired token 36d0cd5b6b98f9ee20d2aa57e15d74e7ef833d78
<html><body><h1>504 Gateway Time-out</h1>
The server didn't respond in time.
</body></html>
```

I'm investigating the timeout, but fixing the region_name can probably be merged as-is.