### PR TITLE
Add support for group by region or avail_zone.

### DIFF
--- a/docs/source/specs/openapi.yml
+++ b/docs/source/specs/openapi.yml
@@ -954,6 +954,14 @@ definitions:
         type: array
         items:
           type: string
+      region:
+        type: array
+        items:
+          type: string
+      avail_zone:
+        type: array
+        items:
+          type: string
       instance_type:
         type: array
         items:

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -379,7 +379,7 @@ class ReportQueryHandler(object):
             filter_dict['cost_entry_product__region__in'] = region
 
         if not ReportQueryHandler.has_wildcard(avail_zone) and avail_zone:
-            filter_dict['cost_entry_product__avail_zone__in'] = avail_zone
+            filter_dict['availability_zone__in'] = avail_zone
 
         return filter_dict
 

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -367,18 +367,26 @@ class ReportQueryHandler(object):
 
         service = self.get_query_param_data('group_by', 'service')
         account = self.get_query_param_data('group_by', 'account')
+        region = self.get_query_param_data('group_by', 'region')
+        avail_zone = self.get_query_param_data('group_by', 'avail_zone')
         if not ReportQueryHandler.has_wildcard(service) and service:
             filter_dict['cost_entry_product__product_family__in'] = service
 
         if not ReportQueryHandler.has_wildcard(account) and account:
             filter_dict['usage_account_id__in'] = account
 
+        if not ReportQueryHandler.has_wildcard(region) and region:
+            filter_dict['cost_entry_product__region__in'] = region
+
+        if not ReportQueryHandler.has_wildcard(avail_zone) and avail_zone:
+            filter_dict['cost_entry_product__avail_zone__in'] = avail_zone
+
         return filter_dict
 
     def _get_group_by(self):
         """Create list for group_by parameters."""
         group_by = []
-        group_by_options = ['service', 'account']
+        group_by_options = ['service', 'account', 'region', 'avail_zone']
         for item in group_by_options:
             group_data = self.get_query_param_data('group_by', item)
             if group_data:
@@ -406,12 +414,20 @@ class ReportQueryHandler(object):
             annotations.update(self._annotations)
         service = self.get_query_param_data('group_by', 'service')
         account = self.get_query_param_data('group_by', 'account')
+        region = self.get_query_param_data('group_by', 'region')
+        avail_zone = self.get_query_param_data('group_by', 'avail_zone')
         if service:
             annotations['service'] = Concat(
                 'cost_entry_product__product_family', Value(''))
         if account:
             annotations['account'] = Concat(
                 'usage_account_id', Value(''))
+        if region:
+            annotations['region'] = Concat(
+                'cost_entry_product__region', Value(''))
+        if avail_zone:
+            annotations['avail_zone'] = Concat(
+                'availability_zone', Value(''))
 
         return annotations
 

--- a/koku/api/report/serializers.py
+++ b/koku/api/report/serializers.py
@@ -90,6 +90,10 @@ class GroupBySerializer(serializers.Serializer):
                                       required=False)
     service = StringOrListField(child=serializers.CharField(),
                                 required=False)
+    region = StringOrListField(child=serializers.CharField(),
+                               required=False)
+    avail_zone = StringOrListField(child=serializers.CharField(),
+                                   required=False)
     storage_type = StringOrListField(child=serializers.CharField(),
                                      required=False)
 

--- a/koku/api/report/test/tests_queries.py
+++ b/koku/api/report/test/tests_queries.py
@@ -723,6 +723,39 @@ class ReportQueryTest(IamTestCase):
                 self.assertIsInstance(month_item.get('values'), list)
                 self.assertIsNotNone(month_item.get('values')[0].get('total'))
 
+    def test_execute_query_curr_month_by_filtered_region(self):
+        """Test execute_query for current month on monthly breakdown by filtered region."""
+        query_params = {'filter':
+                        {'resolution': 'monthly', 'time_scope_value': -1,
+                         'time_scope_units': 'month'},
+                        'group_by': {'region': ['us-east-1']}}
+        handler = ReportQueryHandler(query_params, '?group_by[region]=us-east-1',
+                                     self.tenant, 'unblended_cost',
+                                     'currency_code')
+        query_output = handler.execute_query()
+        data = query_output.get('data')
+        self.assertIsNotNone(data)
+        self.assertIsNotNone(query_output.get('total'))
+        total = query_output.get('total')
+        self.assertIsNotNone(total.get('value'))
+        self.assertEqual(total.get('value'), 0)
+
+        current_month = timezone.now().replace(microsecond=0,
+                                               second=0,
+                                               minute=0,
+                                               hour=0,
+                                               day=1)
+        cmonth_str = current_month.strftime('%Y-%m')
+        for data_item in data:
+            month_val = data_item.get('date')
+            month_data = data_item.get('regions')
+            self.assertEqual(month_val, cmonth_str)
+            self.assertIsInstance(month_data, list)
+            for month_item in month_data:
+                self.assertIsInstance(month_item.get('region'), str)
+                self.assertIsInstance(month_item.get('values'), list)
+                self.assertIsNotNone(month_item.get('values')[0].get('total'))
+
     def test_execute_query_curr_month_by_avail_zone(self):
         """Test execute_query for current month on monthly breakdown by avail_zone."""
         query_params = {'filter':
@@ -730,6 +763,40 @@ class ReportQueryTest(IamTestCase):
                          'time_scope_units': 'month'},
                         'group_by': {'avail_zone': ['*']}}
         handler = ReportQueryHandler(query_params, '?group_by[avail_zone]=*',
+                                     self.tenant, 'unblended_cost',
+                                     'currency_code')
+        query_output = handler.execute_query()
+        data = query_output.get('data')
+        self.assertIsNotNone(data)
+        self.assertIsNotNone(query_output.get('total'))
+        total = query_output.get('total')
+        self.assertIsNotNone(total.get('value'))
+        self.assertEqual(total.get('value'), self.current_month_total)
+
+        current_month = timezone.now().replace(microsecond=0,
+                                               second=0,
+                                               minute=0,
+                                               hour=0,
+                                               day=1)
+        cmonth_str = current_month.strftime('%Y-%m')
+        for data_item in data:
+            month_val = data_item.get('date')
+            month_data = data_item.get('avail_zones')
+            self.assertEqual(month_val, cmonth_str)
+            self.assertIsInstance(month_data, list)
+            self.assertEqual(1, len(month_data))
+            for month_item in month_data:
+                self.assertIsInstance(month_item.get('avail_zone'), str)
+                self.assertIsInstance(month_item.get('values'), list)
+                self.assertIsNotNone(month_item.get('values')[0].get('total'))
+
+    def test_execute_query_curr_month_by_filtered_avail_zone(self):
+        """Test execute_query for current month on monthly breakdown by filtered avail_zone."""
+        query_params = {'filter':
+                        {'resolution': 'monthly', 'time_scope_value': -1,
+                         'time_scope_units': 'month'},
+                        'group_by': {'avail_zone': ['us-east-1a']}}
+        handler = ReportQueryHandler(query_params, '?group_by[avail_zone]=us-east-1a',
                                      self.tenant, 'unblended_cost',
                                      'currency_code')
         query_output = handler.execute_query()

--- a/koku/api/report/test/tests_queries.py
+++ b/koku/api/report/test/tests_queries.py
@@ -688,3 +688,71 @@ class ReportQueryTest(IamTestCase):
                 data_point_total = month_item.get('values')[0].get('total')
                 self.assertLess(current_total, data_point_total)
                 current_total = data_point_total
+
+    def test_execute_query_curr_month_by_region(self):
+        """Test execute_query for current month on monthly breakdown by region."""
+        query_params = {'filter':
+                        {'resolution': 'monthly', 'time_scope_value': -1,
+                         'time_scope_units': 'month'},
+                        'group_by': {'region': ['*']}}
+        handler = ReportQueryHandler(query_params, '?group_by[region]=*',
+                                     self.tenant, 'unblended_cost',
+                                     'currency_code')
+        query_output = handler.execute_query()
+        data = query_output.get('data')
+        self.assertIsNotNone(data)
+        self.assertIsNotNone(query_output.get('total'))
+        total = query_output.get('total')
+        self.assertIsNotNone(total.get('value'))
+        self.assertEqual(total.get('value'), self.current_month_total)
+
+        current_month = timezone.now().replace(microsecond=0,
+                                               second=0,
+                                               minute=0,
+                                               hour=0,
+                                               day=1)
+        cmonth_str = current_month.strftime('%Y-%m')
+        for data_item in data:
+            month_val = data_item.get('date')
+            month_data = data_item.get('regions')
+            self.assertEqual(month_val, cmonth_str)
+            self.assertIsInstance(month_data, list)
+            self.assertEqual(1, len(month_data))
+            for month_item in month_data:
+                self.assertIsInstance(month_item.get('region'), str)
+                self.assertIsInstance(month_item.get('values'), list)
+                self.assertIsNotNone(month_item.get('values')[0].get('total'))
+
+    def test_execute_query_curr_month_by_avail_zone(self):
+        """Test execute_query for current month on monthly breakdown by avail_zone."""
+        query_params = {'filter':
+                        {'resolution': 'monthly', 'time_scope_value': -1,
+                         'time_scope_units': 'month'},
+                        'group_by': {'avail_zone': ['*']}}
+        handler = ReportQueryHandler(query_params, '?group_by[avail_zone]=*',
+                                     self.tenant, 'unblended_cost',
+                                     'currency_code')
+        query_output = handler.execute_query()
+        data = query_output.get('data')
+        self.assertIsNotNone(data)
+        self.assertIsNotNone(query_output.get('total'))
+        total = query_output.get('total')
+        self.assertIsNotNone(total.get('value'))
+        self.assertEqual(total.get('value'), self.current_month_total)
+
+        current_month = timezone.now().replace(microsecond=0,
+                                               second=0,
+                                               minute=0,
+                                               hour=0,
+                                               day=1)
+        cmonth_str = current_month.strftime('%Y-%m')
+        for data_item in data:
+            month_val = data_item.get('date')
+            month_data = data_item.get('avail_zones')
+            self.assertEqual(month_val, cmonth_str)
+            self.assertIsInstance(month_data, list)
+            self.assertEqual(1, len(month_data))
+            for month_item in month_data:
+                self.assertIsInstance(month_item.get('avail_zone'), str)
+                self.assertIsInstance(month_item.get('values'), list)
+                self.assertIsNotNone(month_item.get('values')[0].get('total'))


### PR DESCRIPTION
Added support for `group_by[region]=*` and`group_by[avail_zone]=*`.

**GET** _/api/v1/reports/costs/?filter[time_scope_value]=-1&group_by[avail_zone]=*_
```
{
    "group_by": {
        "avail_zone": [
            "*"
        ]
    },
    "filter": {
        "time_scope_value": "-1"
    },
    "data": [
        {
            "date": "2018-08",
            "avail_zones": [
                {
                    "avail_zone": "",  // bug in nise generation (to be fixed)
                    "values": [
                        {
                            "date": "2018-08",
                            "units": "USD",
                            "avail_zone": "",
                            "total": 14006.964503482
                        }
                    ]
                },
                {
                    "avail_zone": "us-west-2a",
                    "values": [
                        {
                            "date": "2018-08",
                            "units": "USD",
                            "avail_zone": "us-west-2a",
                            "total": 22.759
                        }
                    ]
                },
                {
                    "avail_zone": "us-west-1a",
                    "values": [
                        {
                            "date": "2018-08",
                            "units": "USD",
                            "avail_zone": "us-west-1a",
                            "total": 22.705
                        }
                    ]
                },
                {
                    "avail_zone": "us-east-1a",
                    "values": [
                        {
                            "date": "2018-08",
                            "units": "USD",
                            "avail_zone": "us-east-1a",
                            "total": 22.168
                        }
                    ]
                },
                {
                    "avail_zone": "us-west-2b",
                    "values": [
                        {
                            "date": "2018-08",
                            "units": "USD",
                            "avail_zone": "us-west-2b",
                            "total": 21.969
                        }
                    ]
                },
                {
                    "avail_zone": "us-west-1b",
                    "values": [
                        {
                            "date": "2018-08",
                            "units": "USD",
                            "avail_zone": "us-west-1b",
                            "total": 19.874
                        }
                    ]
                },
                {
                    "avail_zone": "us-east-1b",
                    "values": [
                        {
                            "date": "2018-08",
                            "units": "USD",
                            "avail_zone": "us-east-1b",
                            "total": 18.311
                        }
                    ]
                }
            ]
        }
    ],
    "total": {
        "value": 14134.750503482,
        "units": "USD"
    }
}
```

___
Issue captured for Nise test generation missing region/avail_zone for some cases:
https://github.com/project-koku/nise/issues/19