### PR TITLE
Add support for filtering by account without grouping the data.

### DIFF
--- a/docs/source/specs/openapi.yml
+++ b/docs/source/specs/openapi.yml
@@ -943,6 +943,10 @@ definitions:
         items:
           $ref: '#/definitions/ReportResourceScope'
         example: []
+      account:
+        type: array
+        items:
+          type: string
   ReportGrouping:
     type: object
     properties:

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -175,6 +175,25 @@ class ReportQueryHandler(object):
         return months
 
     @staticmethod
+    def lists_to_set(list_a, list_b):
+        """Merge two lists into a set.
+
+        Args:
+            list_a (List[String]): List of strings
+            list_b (List[String]): List of strings
+        Return:
+            (Set): unique set of strings
+        """
+        out = set()
+        if list_a:
+            for item in list_a:
+                out.add(item)
+        if list_b:
+            for item in list_b:
+                out.add(item)
+        return out
+
+    @staticmethod
     def has_wildcard(in_list):
         """Check if list has wildcard.
 
@@ -366,9 +385,12 @@ class ReportQueryHandler(object):
             filter_dict.update(self._filter)
 
         service = self.get_query_param_data('group_by', 'service')
-        account = self.get_query_param_data('group_by', 'account')
+        gb_account = self.get_query_param_data('group_by', 'account')
         region = self.get_query_param_data('group_by', 'region')
         avail_zone = self.get_query_param_data('group_by', 'avail_zone')
+        f_account = self.get_query_param_data('filter', 'account')
+        account = list(ReportQueryHandler.lists_to_set(gb_account, f_account))
+
         if not ReportQueryHandler.has_wildcard(service) and service:
             filter_dict['cost_entry_product__product_family__in'] = service
 

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -175,25 +175,6 @@ class ReportQueryHandler(object):
         return months
 
     @staticmethod
-    def lists_to_set(list_a, list_b):
-        """Merge two lists into a set.
-
-        Args:
-            list_a (List[String]): List of strings
-            list_b (List[String]): List of strings
-        Return:
-            (Set): unique set of strings
-        """
-        out = set()
-        if list_a:
-            for item in list_a:
-                out.add(item)
-        if list_b:
-            for item in list_b:
-                out.add(item)
-        return out
-
-    @staticmethod
     def has_wildcard(in_list):
         """Check if list has wildcard.
 
@@ -229,7 +210,7 @@ class ReportQueryHandler(object):
         Returns:
             (Object): The value found with the given key or None
         """
-        value = None
+        value = []
         if self.check_query_params(dictkey, key):
             value = self.query_parameters.get(dictkey).get(key)
         return value
@@ -389,7 +370,7 @@ class ReportQueryHandler(object):
         region = self.get_query_param_data('group_by', 'region')
         avail_zone = self.get_query_param_data('group_by', 'avail_zone')
         f_account = self.get_query_param_data('filter', 'account')
-        account = list(ReportQueryHandler.lists_to_set(gb_account, f_account))
+        account = list(set(gb_account + f_account))
 
         if not ReportQueryHandler.has_wildcard(service) and service:
             filter_dict['cost_entry_product__product_family__in'] = service

--- a/koku/api/report/serializers.py
+++ b/koku/api/report/serializers.py
@@ -153,6 +153,8 @@ class FilterSerializer(serializers.Serializer):
     resource_scope = StringOrListField(child=serializers.CharField(),
                                        required=False)
     limit = serializers.IntegerField(required=False, min_value=1)
+    account = StringOrListField(child=serializers.CharField(),
+                                required=False)
 
     def validate(self, data):
         """Validate incoming data.

--- a/koku/api/report/test/tests_queries.py
+++ b/koku/api/report/test/tests_queries.py
@@ -97,31 +97,6 @@ class ReportQueryUtilsTest(TestCase):
         result = ReportQueryHandler.has_wildcard([])
         self.assertFalse(result)
 
-    def test_lists_to_set_both_none(self):
-        """Test an merging two None returns empty set."""
-        result = ReportQueryHandler.lists_to_set(None, None)
-        self.assertEqual(result, set())
-
-    def test_lists_to_set_one_none(self):
-        """Test an merging one None and a list returns a set of the list contents."""
-        list_b = ['a', 'b']
-        result = ReportQueryHandler.lists_to_set(None, list_b)
-        self.assertEqual(result, set(list_b))
-
-    def test_lists_to_set_independent(self):
-        """Test an merging two independent list returns a set of the merged contents."""
-        list_a = ['1', '2']
-        list_b = ['a', 'b']
-        result = ReportQueryHandler.lists_to_set(list_a, list_b)
-        self.assertEqual(result, set(list_a + list_b))
-
-    def test_lists_to_set_overlap(self):
-        """Test an merging two overlapping list returns a set of the merged contents."""
-        list_a = ['1', '*']
-        list_b = ['*', 'b']
-        result = ReportQueryHandler.lists_to_set(list_a, list_b)
-        self.assertEqual(result, set(['1', '*', 'b']))
-
     def test_group_data_by_list(self):
         """Test the _group_data_by_list method."""
         group_by = ['account', 'service']


### PR DESCRIPTION
We already had `group_by[account]`
**GET** _/api/v1/reports/costs/?filter[time_scope_value]=-1&group_by[account]=*_
```
{
    "group_by": {
        "account": [
            "*"
        ]
    },
    "filter": {
        "time_scope_value": "-1"
    },
    "data": [
        {
            "date": "2018-08",
            "accounts": [
                {
                    "account": "3082416796941",
                    "values": [
                        {
                            "date": "2018-08",
                            "units": "USD",
                            "account": "3082416796941",
                            "total": 3777.23294353
                        }
                    ]
                },
                {
                    "account": "2415722664993",
                    "values": [
                        {
                            "date": "2018-08",
                            "units": "USD",
                            "account": "2415722664993",
                            "total": 3412.812342129
                        }
                    ]
                },
                {
                    "account": "8133889256380",
                    "values": [
                        {
                            "date": "2018-08",
                            "units": "USD",
                            "account": "8133889256380",
                            "total": 2813.732310435
                        }
                    ]
                },
                {
                    "account": "0840549025238",
                    "values": [
                        {
                            "date": "2018-08",
                            "units": "USD",
                            "account": "0840549025238",
                            "total": 2150.714734129
                        }
                    ]
                },
                {
                    "account": "4783090375826",
                    "values": [
                        {
                            "date": "2018-08",
                            "units": "USD",
                            "account": "4783090375826",
                            "total": 1980.258173259
                        }
                    ]
                }
            ]
        }
    ],
    "total": {
        "value": 14134.750503482,
        "units": "USD"
    }
}
```


Total cost for just `2415722664993` without grouping

**GET** _/api/v1/reports/costs/?filter[time_scope_value]=-1&filter[account]=2415722664993_
```
{
    "filter": {
        "time_scope_value": "-1",
        "account": [
            "2415722664993"
        ]
    },
    "data": [
        {
            "date": "2018-08",
            "values": [
                {
                    "date": "2018-08",
                    "units": "USD",
                    "total": 3412.812342129
                }
            ]
        }
    ],
    "total": {
        "value": 3412.812342129,
        "units": "USD"
    }
}
```

