### PR TITLE
Add support for filtering by service without grouping the data.

### DIFF
--- a/docs/source/specs/openapi.yml
+++ b/docs/source/specs/openapi.yml
@@ -947,6 +947,10 @@ definitions:
         type: array
         items:
           type: string
+      service:
+        type: array
+        items:
+          type: string
   ReportGrouping:
     type: object
     properties:

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -365,12 +365,14 @@ class ReportQueryHandler(object):
         if self._filter:
             filter_dict.update(self._filter)
 
-        service = self.get_query_param_data('group_by', 'service')
+        gb_service = self.get_query_param_data('group_by', 'service')
         gb_account = self.get_query_param_data('group_by', 'account')
         region = self.get_query_param_data('group_by', 'region')
         avail_zone = self.get_query_param_data('group_by', 'avail_zone')
         f_account = self.get_query_param_data('filter', 'account')
+        f_service = self.get_query_param_data('filter', 'service')
         account = list(set(gb_account + f_account))
+        service = list(set(gb_service + f_service))
 
         if not ReportQueryHandler.has_wildcard(service) and service:
             filter_dict['cost_entry_product__product_family__in'] = service

--- a/koku/api/report/serializers.py
+++ b/koku/api/report/serializers.py
@@ -155,6 +155,8 @@ class FilterSerializer(serializers.Serializer):
     limit = serializers.IntegerField(required=False, min_value=1)
     account = StringOrListField(child=serializers.CharField(),
                                 required=False)
+    service = StringOrListField(child=serializers.CharField(),
+                                required=False)
 
     def validate(self, data):
         """Validate incoming data.

--- a/koku/api/report/test/tests_queries.py
+++ b/koku/api/report/test/tests_queries.py
@@ -825,11 +825,40 @@ class ReportQueryTest(IamTestCase):
                 self.assertIsNotNone(month_item.get('values')[0].get('total'))
 
     def test_execute_query_current_month_filter_account(self):
-        """Test execute_query for current month on monthly breakdown by account."""
+        """Test execute_query for current month on monthly filtered by account."""
         query_params = {'filter':
                         {'resolution': 'monthly', 'time_scope_value': -1,
                          'time_scope_units': 'month',
                          'account': [self.payer_account_id]}}
+        handler = ReportQueryHandler(query_params, '',
+                                     self.tenant, 'unblended_cost',
+                                     'currency_code')
+        query_output = handler.execute_query()
+        data = query_output.get('data')
+        self.assertIsNotNone(data)
+        self.assertIsNotNone(query_output.get('total'))
+        total = query_output.get('total')
+        self.assertIsNotNone(total.get('value'))
+        self.assertEqual(total.get('value'), self.current_month_total)
+
+        current_month = timezone.now().replace(microsecond=0,
+                                               second=0,
+                                               minute=0,
+                                               hour=0,
+                                               day=1)
+        cmonth_str = current_month.strftime('%Y-%m')
+        for data_item in data:
+            month_val = data_item.get('date')
+            month_data = data_item.get('values')
+            self.assertEqual(month_val, cmonth_str)
+            self.assertIsInstance(month_data, list)
+
+    def test_execute_query_current_month_filter_service(self):
+        """Test execute_query for current month on monthly filtered by service."""
+        query_params = {'filter':
+                        {'resolution': 'monthly', 'time_scope_value': -1,
+                         'time_scope_units': 'month',
+                         'service': ['Compute Instance']}}
         handler = ReportQueryHandler(query_params, '',
                                      self.tenant, 'unblended_cost',
                                      'currency_code')


### PR DESCRIPTION
We already had `group_by[service]`
**GET** _/api/v1/reports/costs/?filter[time_scope_value]=-1&group_by[service]=*_
```
{
    "group_by": {
        "service": [
            "*"
        ]
    },
    "filter": {
        "time_scope_value": "-1"
    },
    "data": [
        {
            "date": "2018-08",
            "services": [
                {
                    "service": "Storage Snapshot",
                    "values": [
                        {
                            "date": "2018-08",
                            "units": "USD",
                            "service": "Storage Snapshot",
                            "total": 12572.251545133
                        }
                    ]
                },
                {
                    "service": "Storage",
                    "values": [
                        {
                            "date": "2018-08",
                            "units": "USD",
                            "service": "Storage",
                            "total": 1434.329558372
                        }
                    ]
                },
                {
                    "service": "Compute Instance",
                    "values": [
                        {
                            "date": "2018-08",
                            "units": "USD",
                            "service": "Compute Instance",
                            "total": 127.786
                        }
                    ]
                },
                {
                    "service": "Data Transfer",
                    "values": [
                        {
                            "date": "2018-08",
                            "units": "USD",
                            "service": "Data Transfer",
                            "total": 0.383399977
                        }
                    ]
                }
            ]
        }
    ],
    "total": {
        "value": 14134.750503482,
        "units": "USD"
    }
}
```


Total cost for just `Storage` without grouping

**GET** _/api/v1/reports/costs/?filter[time_scope_value]=-1&filter[service]=Storage_
```
{
    "filter": {
        "time_scope_value": "-1",
        "service": [
            "Storage"
        ]
    },
    "data": [
        {
            "date": "2018-08",
            "values": [
                {
                    "date": "2018-08",
                    "units": "USD",
                    "total": 1434.329558372
                }
            ]
        }
    ],
    "total": {
        "value": 1434.329558372,
        "units": "USD"
    }
}
```

