### PR TITLE
Add support for filtering by region or avail_zone without grouping the data.

### DIFF
--- a/docs/source/specs/openapi.yml
+++ b/docs/source/specs/openapi.yml
@@ -951,6 +951,14 @@ definitions:
         type: array
         items:
           type: string
+      region:
+        type: array
+        items:
+          type: string
+      avail_zone:
+        type: array
+        items:
+          type: string
   ReportGrouping:
     type: object
     properties:

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -367,12 +367,16 @@ class ReportQueryHandler(object):
 
         gb_service = self.get_query_param_data('group_by', 'service')
         gb_account = self.get_query_param_data('group_by', 'account')
-        region = self.get_query_param_data('group_by', 'region')
-        avail_zone = self.get_query_param_data('group_by', 'avail_zone')
+        gb_region = self.get_query_param_data('group_by', 'region')
+        gb_avail_zone = self.get_query_param_data('group_by', 'avail_zone')
         f_account = self.get_query_param_data('filter', 'account')
         f_service = self.get_query_param_data('filter', 'service')
+        f_region = self.get_query_param_data('filter', 'region')
+        f_avail_zone = self.get_query_param_data('filter', 'avail_zone')
         account = list(set(gb_account + f_account))
         service = list(set(gb_service + f_service))
+        region = list(set(gb_region + f_region))
+        avail_zone = list(set(gb_avail_zone + f_avail_zone))
 
         if not ReportQueryHandler.has_wildcard(service) and service:
             filter_dict['cost_entry_product__product_family__in'] = service

--- a/koku/api/report/serializers.py
+++ b/koku/api/report/serializers.py
@@ -157,6 +157,10 @@ class FilterSerializer(serializers.Serializer):
                                 required=False)
     service = StringOrListField(child=serializers.CharField(),
                                 required=False)
+    region = StringOrListField(child=serializers.CharField(),
+                               required=False)
+    avail_zone = StringOrListField(child=serializers.CharField(),
+                                   required=False)
 
     def validate(self, data):
         """Validate incoming data.

--- a/koku/api/report/test/tests_queries.py
+++ b/koku/api/report/test/tests_queries.py
@@ -881,3 +881,61 @@ class ReportQueryTest(IamTestCase):
             month_data = data_item.get('values')
             self.assertEqual(month_val, cmonth_str)
             self.assertIsInstance(month_data, list)
+
+    def test_execute_query_current_month_filter_region(self):
+        """Test execute_query for current month on monthly filtered by region."""
+        query_params = {'filter':
+                        {'resolution': 'monthly', 'time_scope_value': -1,
+                         'time_scope_units': 'month',
+                         'region': ['us-east-1']}}
+        handler = ReportQueryHandler(query_params, '',
+                                     self.tenant, 'unblended_cost',
+                                     'currency_code')
+        query_output = handler.execute_query()
+        data = query_output.get('data')
+        self.assertIsNotNone(data)
+        self.assertIsNotNone(query_output.get('total'))
+        total = query_output.get('total')
+        self.assertIsNotNone(total.get('value'))
+        self.assertEqual(total.get('value'), 0)
+
+        current_month = timezone.now().replace(microsecond=0,
+                                               second=0,
+                                               minute=0,
+                                               hour=0,
+                                               day=1)
+        cmonth_str = current_month.strftime('%Y-%m')
+        for data_item in data:
+            month_val = data_item.get('date')
+            month_data = data_item.get('values')
+            self.assertEqual(month_val, cmonth_str)
+            self.assertIsInstance(month_data, list)
+
+    def test_execute_query_current_month_filter_avail_zone(self):
+        """Test execute_query for current month on monthly filtered by avail_zone."""
+        query_params = {'filter':
+                        {'resolution': 'monthly', 'time_scope_value': -1,
+                         'time_scope_units': 'month',
+                         'avail_zone': ['us-east-1a']}}
+        handler = ReportQueryHandler(query_params, '',
+                                     self.tenant, 'unblended_cost',
+                                     'currency_code')
+        query_output = handler.execute_query()
+        data = query_output.get('data')
+        self.assertIsNotNone(data)
+        self.assertIsNotNone(query_output.get('total'))
+        total = query_output.get('total')
+        self.assertIsNotNone(total.get('value'))
+        self.assertEqual(total.get('value'), self.current_month_total)
+
+        current_month = timezone.now().replace(microsecond=0,
+                                               second=0,
+                                               minute=0,
+                                               hour=0,
+                                               day=1)
+        cmonth_str = current_month.strftime('%Y-%m')
+        for data_item in data:
+            month_val = data_item.get('date')
+            month_data = data_item.get('values')
+            self.assertEqual(month_val, cmonth_str)
+            self.assertIsInstance(month_data, list)


### PR DESCRIPTION
We already had `group_by[region]` or `group_by[avail_zone]`
**GET** /api/v1/reports/costs/?filter[time_scope_value]=-1&group_by[avail_zone]=us-west-1a&group_by[avail_zone]=us-west-2b_
```
{
    "group_by": {
        "avail_zone": [
            "us-west-1a",
            "us-west-2b"
        ]
    },
    "filter": {
        "time_scope_value": "-1"
    },
    "data": [
        {
            "date": "2018-08",
            "avail_zones": [
                {
                    "avail_zone": "us-west-1a",
                    "values": [
                        {
                            "date": "2018-08",
                            "units": "USD",
                            "avail_zone": "us-west-1a",
                            "total": 22.705
                        }
                    ]
                },
                {
                    "avail_zone": "us-west-2b",
                    "values": [
                        {
                            "date": "2018-08",
                            "units": "USD",
                            "avail_zone": "us-west-2b",
                            "total": 21.969
                        }
                    ]
                }
            ]
        }
    ],
    "total": {
        "value": 44.674,
        "units": "USD"
    }
}
```


Total cost for just `us-west-1a` and `us-west-2b` without grouping

**GET** _/api/v1/reports/costs/?filter[time_scope_value]=-1&filter[avail_zone]=us-west-1a&filter[avail_zone]=us-west-2b_
```
{
    "filter": {
        "time_scope_value": "-1",
        "avail_zone": [
            "us-west-1a",
            "us-west-2b"
        ]
    },
    "data": [
        {
            "date": "2018-08",
            "values": [
                {
                    "date": "2018-08",
                    "units": "USD",
                    "total": 44.674
                }
            ]
        }
    ],
    "total": {
        "value": 44.674,
        "units": "USD"
    }
}
```

