### PR TITLE
reconcile Makefile between Masu and Koku

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ OC_SOURCE	= registry.access.redhat.com/openshift3/ose
 OC_VERSION	= v3.9
 OC_DATA_DIR	= ${HOME}/.oc/openshift.local.data
 
+PGSQL_VERSION   = 9.6
+
 OS := $(shell uname)
 ifeq ($(OS),Darwin)
 	PREFIX	=
@@ -15,36 +17,51 @@ else
 	PREFIX	= sudo
 endif
 
+define HELP_TEXT =
+Please use \`make <target>' where <target> is one of:
+
+--- General Commands ---
+  clean                    clean the project directory of any scratch files, bytecode, logs, etc.
+  help                     show this message
+  html                     create html documentation for the project
+  lint                     run linting against the project
+
+--- Commands using local services ---
+  collect-static           collect static files to host
+  gen-apidoc               create api documentation
+  make-migrations          make migrations for the database
+  reinitdb                 drop and recreate the database
+  requirements             generate Pipfile.lock and RTD requirements
+  run-migrations           run migrations against database
+  serve                    run the Django server locally
+  serve-with-oc            run Django server locally against an Openshift DB
+  start-db                 start the psql db in detached state
+  stop-compose             stop all containers
+  unittest                 run unittests
+  user                     create a Django super user
+
+--- Commands using an OpenShift Cluster ---
+  oc-clean                 stop openshift cluster & remove local config data
+  oc-create-all            run all application services in openshift cluster
+  oc-create-db             create a Postgres DB in an initialized openshift cluster
+  oc-create-koku           create the Koku app in an initialized openshift cluster
+  oc-create-tags           create image stream tags
+  oc-create-test-db-file   create a Postgres DB dump file for Masu
+  oc-delete-all            delete Openshift objects without a cluster restart
+  oc-down                  stop app & openshift cluster
+  oc-forward-ports         port forward the DB to localhost
+  oc-login-dev             login to an openshift cluster as 'developer'
+  oc-reinit                remove existing app and restart app in initialized openshift cluster
+  oc-run-migrations        run Django migrations in the Openshift DB
+  oc-stop-forwarding-ports stop port forwarding the DB to localhost
+  oc-up                    initialize an openshift cluster
+  oc-up-all                run app in openshift cluster
+  oc-up-db                 run Postgres in an openshift cluster
+endef
+export HELP_TEXT
+
 help:
-	@echo "Please use \`make <target>' where <target> is one of:"
-	@echo "  clean                    to clean the project directory of any scratch files, bytecode, logs, etc."
-	@echo "  help                     to show this message"
-	@echo "  html                     to create html documentation for the project"
-	@echo "  lint                     to run linting against the project"
-	@echo "  reinitdb                 to drop and recreate the database"
-	@echo "  make-migrations          to make migrations for the database"
-	@echo "  run-migrations           to run migrations against database"
-	@echo "  gen-apidoc               to create api documentation"
-	@echo "  collect-static           to collect static files to host"
-	@echo "  requirements             to generate Pipfile.lock and RTD requirements"
-	@echo "  serve                    to run the Django server locally"
-	@echo "  start-db                 to start the psql db in detached state"
-	@echo "  stop-compose             to stop all containers"
-	@echo "  unittest                 to run unittests"
-	@echo "  user                     to create a Django super user"
-	@echo "  oc-up                    to initialize an openshift cluster"
-	@echo "  oc-up-all                to run app in openshift cluster"
-	@echo "  oc-up-db                 to run Postgres in an openshift cluster"
-	@echo "  oc-init                  to start app in initialized openshift cluster"
-	@echo "  oc-reinit                to remove existing app and restart app in initialized openshift cluster"
-	@echo "  oc-create-db             to create a Postgres DB in an initialized openshift cluster"
-	@echo "  oc-create-test-db-file   to create a Postgres DB dump file for Masu"
-	@echo "  oc-forward-ports         to port forward the DB to localhost"
-	@echo "  oc-stop-forwarding-ports to stop port forwarding the DB to localhost"
-	@echo "  oc-run-migrations  	  to run Django migrations in the Openshift DB"
-	@echo "  oc-serve 			 	  to run Django server locally against an Openshift DB"
-	@echo "  oc-down                  to stop app & openshift cluster"
-	@echo "  oc-clean                 to stop openshift cluster & remove local config data"
+	@echo "$$HELP_TEXT"
 
 clean:
 	git clean -fdx -e .idea/ -e *env/
@@ -61,11 +78,9 @@ remove-db:
 	$(PREFIX) rm -rf $(TOPDIR)/pg_data
 
 make-migrations:
-	sleep 1
 	DJANGO_READ_DOT_ENV_FILE=True $(PYTHON) $(PYDIR)/manage.py makemigrations api reporting reporting_common
 
 run-migrations:
-	sleep 1
 	DJANGO_READ_DOT_ENV_FILE=True $(PYTHON) $(PYDIR)/manage.py migrate_schemas
 
 gen-apidoc:
@@ -82,6 +97,11 @@ requirements:
 serve:
 	DJANGO_READ_DOT_ENV_FILE=True $(PYTHON) $(PYDIR)/manage.py runserver
 
+serve-with-oc: oc-forward-ports
+	sleep 3
+	DJANGO_READ_DOT_ENV_FILE=True $(PYTHON) $(PYDIR)/manage.py runserver
+	make oc-stop-forwarding-ports
+
 start-db:
 	docker-compose up -d db
 
@@ -94,66 +114,26 @@ unittest:
 user:
 	$(PYTHON) $(PYDIR)/manage.py createsuperuser
 
-oc-up:
-	oc cluster up \
-		--image=$(OC_SOURCE) \
-		--version=$(OC_VERSION) \
-		--host-data-dir=$(OC_DATA_DIR) \
-		--use-existing-config=true
-	sleep 60
-
-oc-init:
-	openshift/init-app.sh -n myproject -b `git rev-parse --abbrev-ref HEAD`
-
-oc-up-all: oc-up oc-init
-
-oc-up-db: oc-up oc-create-db
-
-oc-reinit:
-	oc login -u developer
-	oc delete all -l app=koku && oc delete configmap/koku-env secret/koku-secret secret/koku-pgsql pvc/koku-pgsql
-	sleep 10
-	make oc-init
-
-oc-down:
-	oc cluster down
-
 oc-clean: oc-down
 	$(PREFIX) rm -rf $(OC_DATA_DIR)
 
+oc-create-tags:
+	oc get istag postgresql:$(PGSQL_VERSION) || oc create istag postgresql:$(PGSQL_VERSION)} --from-image=centos/postgresql-96-centos7
+
 oc-create-db:
-	oc login -u developer
-	oc create istag postgresql:9.6 --from-image=centos/postgresql-96-centos7
 	oc process openshift//postgresql-persistent \
 		-p NAMESPACE=myproject \
 		-p POSTGRESQL_USER=kokuadmin \
 		-p POSTGRESQL_PASSWORD=admin123 \
 		-p POSTGRESQL_DATABASE=koku \
-		-p POSTGRESQL_VERSION=9.6 \
+		-p POSTGRESQL_VERSION=$(PGSQL_VERSION) \
 		-p DATABASE_SERVICE_NAME=koku-pgsql \
 	| oc create -f -
 
-oc-forward-ports:
-	-make oc-stop-forwarding-ports 2>/dev/null
-	oc port-forward $$(oc get pods -o jsonpath='{.items[*].metadata.name}' -l name=koku-pgsql) 15432:5432 >/dev/null 2>&1 &
+oc-create-all: oc-create-tags oc-create-koku
 
-oc-stop-forwarding-ports:
-	kill -HUP $$(ps -eo pid,command | grep "oc port-forward" | grep -v grep | awk '{print $$1}')
-
-oc-make-migrations: oc-forward-ports
-	sleep 3
-	DJANGO_READ_DOT_ENV_FILE=True $(PYTHON) $(PYDIR)/manage.py makemigrations api reporting reporting_common
-	make oc-stop-forwarding-ports
-
-oc-run-migrations: oc-forward-ports
-	sleep 3
-	DJANGO_READ_DOT_ENV_FILE=True $(PYTHON) $(PYDIR)/manage.py migrate_schemas --shared
-	make oc-stop-forwarding-ports
-
-oc-serve: oc-forward-ports
-	sleep 3
-	DJANGO_READ_DOT_ENV_FILE=True $(PYTHON) $(PYDIR)/manage.py runserver
-	make oc-stop-forwarding-ports
+oc-create-koku:
+	openshift/init-app.sh -n myproject -b `git rev-parse --abbrev-ref HEAD`
 
 oc-create-test-db-file: oc-run-migrations
 	sleep 1
@@ -165,5 +145,54 @@ oc-create-test-db-file: oc-run-migrations
 	pg_dump -d $(DATABASE_NAME) -h $(POSTGRES_SQL_SERVICE_HOST) -p $(POSTGRES_SQL_SERVICE_PORT) -U $(DATABASE_USER) > test.sql
 	kill -HUP $$(ps -eo pid,command | grep "manage.py runserver" | grep -v grep | awk '{print $$1}')
 	make oc-stop-forwarding-ports
+
+oc-delete-all:
+	oc delete is --all && \
+	oc delete dc --all && \
+	oc delete bc --all && \
+	oc delete svc --all && \
+	oc delete pvc --all && \
+	oc delete routes --all && \
+	oc delete statefulsets --all && \
+	oc delete configmap/koku-env \
+		secret/koku-secret \
+		secret/koku-pgsql \
+
+oc-down:
+	oc cluster down
+
+oc-forward-ports:
+	-make oc-stop-forwarding-ports 2>/dev/null
+	oc port-forward $$(oc get pods -o jsonpath='{.items[*].metadata.name}' -l name=koku-pgsql) 15432:5432 >/dev/null 2>&1 &
+
+oc-login-dev:
+	oc login -u developer --insecure-skip-tls-verify=true localhost:8443
+
+oc-make-migrations: oc-forward-ports
+	sleep 3
+	DJANGO_READ_DOT_ENV_FILE=True $(PYTHON) $(PYDIR)/manage.py makemigrations api reporting reporting_common
+	make oc-stop-forwarding-ports
+
+oc-reinit: oc-delete-all oc-create-koku
+
+oc-run-migrations: oc-forward-ports
+	sleep 3
+	DJANGO_READ_DOT_ENV_FILE=True $(PYTHON) $(PYDIR)/manage.py migrate_schemas --shared
+	make oc-stop-forwarding-ports
+
+oc-stop-forwarding-ports:
+	kill -HUP $$(ps -eo pid,command | grep "oc port-forward" | grep -v grep | awk '{print $$1}')
+
+oc-up:
+	oc cluster up \
+		--image=$(OC_SOURCE) \
+		--version=$(OC_VERSION) \
+		--host-data-dir=$(OC_DATA_DIR) \
+		--use-existing-config=true
+	sleep 60
+
+oc-up-all: oc-up oc-create-koku
+
+oc-up-db: oc-up oc-create-db
 
 .PHONY: docs


### PR DESCRIPTION
This change reconciles the Makefiles across projects. This structures the command names and the file layout in the same way between the two projects. The goal is to improve usability when working across projects.