### PR TITLE
 Alter services to use lineItem/ProductCode for grouping and filtering.

### DIFF
--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -379,7 +379,7 @@ class ReportQueryHandler(object):
         avail_zone = list(set(gb_avail_zone + f_avail_zone))
 
         if not ReportQueryHandler.has_wildcard(service) and service:
-            filter_dict['cost_entry_product__product_family__in'] = service
+            filter_dict['product_code__in'] = service
 
         if not ReportQueryHandler.has_wildcard(account) and account:
             filter_dict['usage_account_id__in'] = account
@@ -427,7 +427,7 @@ class ReportQueryHandler(object):
         avail_zone = self.get_query_param_data('group_by', 'avail_zone')
         if service:
             annotations['service'] = Concat(
-                'cost_entry_product__product_family', Value(''))
+                'product_code', Value(''))
         if account:
             annotations['account'] = Concat(
                 'usage_account_id', Value(''))

--- a/koku/api/report/test/tests_queries.py
+++ b/koku/api/report/test/tests_queries.py
@@ -454,7 +454,7 @@ class ReportQueryTest(IamTestCase):
             self.assertIsInstance(month_data, list)
             for month_item in month_data:
                 compute = month_item.get('service')
-                self.assertEqual(compute, 'Compute Instance')
+                self.assertEqual(compute, 'AmazonEC2')
                 self.assertIsInstance(month_item.get('values'), list)
 
     def test_execute_query_by_filtered_service(self):
@@ -462,8 +462,8 @@ class ReportQueryTest(IamTestCase):
         query_params = {'filter':
                         {'resolution': 'monthly', 'time_scope_value': -1,
                          'time_scope_units': 'month'},
-                        'group_by': {'service': ['Compute Instance']}}
-        handler = ReportQueryHandler(query_params, '?group_by[service]=Compute Instance',
+                        'group_by': {'service': ['AmazonEC2']}}
+        handler = ReportQueryHandler(query_params, '?group_by[service]=AmazonEC2',
                                      self.tenant, 'unblended_cost',
                                      'currency_code')
         query_output = handler.execute_query()
@@ -487,7 +487,7 @@ class ReportQueryTest(IamTestCase):
             self.assertIsInstance(month_data, list)
             for month_item in month_data:
                 compute = month_item.get('service')
-                self.assertEqual(compute, 'Compute Instance')
+                self.assertEqual(compute, 'AmazonEC2')
                 self.assertIsInstance(month_item.get('values'), list)
 
     def test_execute_query_current_month_by_account(self):
@@ -530,7 +530,7 @@ class ReportQueryTest(IamTestCase):
                          'time_scope_units': 'month'},
                         'group_by': {'account': ['*'],
                                      'service': ['*']}}
-        query_string = '?group_by[account]=*&group_by[service]=Compute Instance'
+        query_string = '?group_by[account]=*&group_by[service]=AmazonEC2'
         handler = ReportQueryHandler(query_params, query_string,
                                      self.tenant, 'unblended_cost',
                                      'currency_code')
@@ -858,7 +858,7 @@ class ReportQueryTest(IamTestCase):
         query_params = {'filter':
                         {'resolution': 'monthly', 'time_scope_value': -1,
                          'time_scope_units': 'month',
-                         'service': ['Compute Instance']}}
+                         'service': ['AmazonEC2']}}
         handler = ReportQueryHandler(query_params, '',
                                      self.tenant, 'unblended_cost',
                                      'currency_code')


### PR DESCRIPTION
**GET** _/api/v1/reports/costs/?filter[time_scope_value]=-1&group_by[service]=*_
```
{
    "group_by": {
        "service": [
            "*"
        ]
    },
    "filter": {
        "time_scope_value": "-1"
    },
    "data": [
        {
            "date": "2018-08",
            "services": [
                {
                    "service": "AmazonEC2",
                    "values": [
                        {
                            "date": "2018-08",
                            "units": "USD",
                            "service": "AmazonEC2",
                            "total": 14134.750503482
                        }
                    ]
                }
            ]
        }
    ],
    "total": {
        "value": 14134.750503482,
        "units": "USD"
    }
}
```
