### PR TITLE
Fix dense rank plus group_by error for CSV output flow.

### DIFF
--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -634,7 +634,10 @@ class ReportQueryHandler(object):
                 data = self._transform_data(query_group_by, 0, data)
             elif is_csv_output and is_sum:
                 values_out = query_group_by_with_units + ['total']
-                data = list(query_data.values(*values_out))
+                if self._limit:
+                    data = self._ranked_list(list(query_data))
+                else:
+                    data = list(query_data)
             else:
                 values_out = query_group_by_with_units + EXPORT_COLUMNS
                 data = list(query_data.values(*values_out))

--- a/koku/api/report/test/tests_queries.py
+++ b/koku/api/report/test/tests_queries.py
@@ -1025,3 +1025,37 @@ class ReportQueryTest(IamTestCase):
         for data_item in data:
             month = data_item.get('date')
             self.assertEqual(month, cmonth_str)
+
+    def test_execute_query_curr_month_by_account_w_limit_csv(self):
+        """Test execute_query for current month on monthly by account with limt as csv."""
+        self.add_data_to_tenant(rate=Decimal('0.299'))
+        self.add_data_to_tenant(rate=Decimal('0.399'))
+        self.add_data_to_tenant(rate=Decimal('0.099'))
+        self.add_data_to_tenant(rate=Decimal('0.999'))
+        self.add_data_to_tenant(rate=Decimal('0.699'))
+        query_params = {'filter':
+                        {'resolution': 'monthly', 'time_scope_value': -1,
+                         'time_scope_units': 'month', 'limit': 2},
+                        'group_by': {'account': ['*']}}
+        handler = ReportQueryHandler(query_params, '?group_by[account]=*&filter[limit]=2',
+                                     self.tenant, 'unblended_cost',
+                                     'currency_code',
+                                     **{'accept_type': 'text/csv'})
+        query_output = handler.execute_query()
+        data = query_output.get('data')
+        self.assertIsNotNone(data)
+        self.assertIsNotNone(query_output.get('total'))
+        total = query_output.get('total')
+        self.assertIsNotNone(total.get('value'))
+        self.assertEqual(total.get('value'), self.current_month_total)
+
+        current_month = timezone.now().replace(microsecond=0,
+                                               second=0,
+                                               minute=0,
+                                               hour=0,
+                                               day=1)
+        cmonth_str = current_month.strftime('%Y-%m')
+        self.assertEqual(len(data), 3)
+        for data_item in data:
+            month = data_item.get('date')
+            self.assertEqual(month, cmonth_str)


### PR DESCRIPTION
**GET** `text/csv` _api/v1/reports/costs/?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=daily&filter[limit]=5&group_by[service]=*_

```
date,service,total,units
2018-08-05,AmazonEC2,2141.593459800,USD
2018-08-04,AmazonEC2,2730.034482003,USD
2018-08-03,AmazonEC2,3193.377845844,USD
2018-08-02,AmazonEC2,2901.910797997,USD
2018-08-01,AmazonEC2,3167.833917838,USD
```