### PR TITLE
Use the environement variables required for Koku for db connection

### DIFF
--- a/scripts/create_test_customer.py
+++ b/scripts/create_test_customer.py
@@ -30,12 +30,6 @@ customer:
   password: Koku Customer Admin Password
   provider_name: Koku Provider Name
   provider_resource_name: AWS Role ARN
-database:
-  host: PostgreSQL Hostname
-  port: PostgreSQL Port
-  user: PostgreSQL Username
-  password: PostgreSQL Password
-  dbname: PostgreSQL DB Name
 koku:
   host: Koku API Hostname
   port: Koku API Port
@@ -61,7 +55,6 @@ class KokuCustomerOnboarder:
         """Constructor."""
         self._config = config
         self.customer = self._config.get('customer')
-        self.database = self._config.get('database')
         self.koku = self._config.get('koku')
 
         self.endpoint_base = f'http://{self.koku.get("host")}:{self.koku.get("port")}/api/v1/'
@@ -111,8 +104,15 @@ class KokuCustomerOnboarder:
 
     def create_provider_db(self):
         """Create a Koku Provider by inserting into the Koku DB."""
+        db_name = os.getenv('DATABASE_NAME')
+        db_host = os.getenv('POSTGRES_SQL_SERVICE_HOST')
+        db_port = os.getenv('POSTGRES_SQL_SERVICE_PORT')
+        db_user = os.getenv('DATABASE_USER')
+        db_password = os.getenv('DATABASE_PASSWORD')
 
-        with psycopg2.connect(**self.database) as conn:
+        with psycopg2.connect(database=db_name, user=db_user,
+                              password=db_password, port=db_port,
+                              host=db_host) as conn:
             cursor = conn.cursor()
 
             auth_sql = """

--- a/scripts/test_customer.yaml
+++ b/scripts/test_customer.yaml
@@ -7,12 +7,6 @@ customer:
   password: str0ng!P@ss
   provider_name: Test Provider
   provider_resource_name: arn:aws:iam::111111111111:role/CostManagement
-database:
-  host: localhost
-  port: 15432
-  user: postgres
-  password: ''
-  dbname: koku
 koku:
   host: localhost
   port: 8000


### PR DESCRIPTION
## Summary
* Eliminated credentials from yaml file so as not to have to track/change database credentials in one more place
   * The use of this script is dependent on koku and the use of koku is dependent on environment variables.
   *.The default in the yaml was set to use the postgres user which causes permissions problems for the koku app user that everything else uses. 