### PR TITLE
Workaround grouping issue when units are missing that can cause multiple entries.

### DIFF
--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -478,8 +478,11 @@ class ReportQueryHandler(object):
             grouped = ReportQueryHandler._group_data_by_list(group_by_list,
                                                              (group_index + 1),
                                                              grouped)
-            if out_data.get(key):
+            datapoint = out_data.get(key)
+            if datapoint and isinstance(datapoint, dict):
                 out_data[key].update(grouped)
+            elif datapoint and isinstance(datapoint, list):
+                out_data[key] = grouped + datapoint
             else:
                 out_data[key] = grouped
         return out_data

--- a/koku/api/report/test/tests_queries.py
+++ b/koku/api/report/test/tests_queries.py
@@ -116,6 +116,19 @@ class ReportQueryUtilsTest(TestCase):
                         's2': [{'account': 'a2', 'service': 's2', 'units': 'USD', 'total': 5}]}}
         self.assertEqual(expected, out_data)
 
+    def test_group_data_by_list_missing_units(self):
+        """Test the _group_data_by_list method when duplicates occur due to missing units."""
+        group_by = ['account']
+        data = [{'account': 'a1', 'units': 'USD', 'total': 4},
+                {'account': 'a1', 'units': '', 'total': 5},
+                {'account': 'a2', 'units': 'USD', 'total': 6}]
+        out_data = ReportQueryHandler._group_data_by_list(group_by, 0, data)
+        print(out_data)
+        expected = {'a1': [
+                    {'account': 'a1', 'units': 'USD', 'total': 4}, {'account': 'a1', 'units': '', 'total': 5}],
+                    'a2': [{'account': 'a2', 'units': 'USD', 'total': 6}]}
+        self.assertEqual(expected, out_data)
+
 
 class ReportQueryTest(IamTestCase):
     """Tests the report queries."""

--- a/koku/api/report/test/tests_queries.py
+++ b/koku/api/report/test/tests_queries.py
@@ -118,15 +118,17 @@ class ReportQueryUtilsTest(TestCase):
 
     def test_group_data_by_list_missing_units(self):
         """Test the _group_data_by_list method when duplicates occur due to missing units."""
-        group_by = ['account']
-        data = [{'account': 'a1', 'units': 'USD', 'total': 4},
-                {'account': 'a1', 'units': '', 'total': 5},
-                {'account': 'a2', 'units': 'USD', 'total': 6}]
+        group_by = ['instance_type']
+        data = [{'date': '2018-07-22', 'units': '', 'instance_type': 't2.micro', 'total': 30.0, 'count': 0},
+                {'date': '2018-07-22', 'units': 'Hrs', 'instance_type': 't2.small', 'total': 17.0, 'count': 0},
+                {'date': '2018-07-22', 'units': 'Hrs', 'instance_type': 't2.micro', 'total': 1.0, 'count': 0}]
         out_data = ReportQueryHandler._group_data_by_list(group_by, 0, data)
         print(out_data)
-        expected = {'a1': [
-                    {'account': 'a1', 'units': 'USD', 'total': 4}, {'account': 'a1', 'units': '', 'total': 5}],
-                    'a2': [{'account': 'a2', 'units': 'USD', 'total': 6}]}
+        expected = {'t2.micro': [
+            {'date': '2018-07-22', 'units': 'Hrs', 'instance_type': 't2.micro', 'total': 1.0, 'count': 0},
+            {'date': '2018-07-22', 'units': '', 'instance_type': 't2.micro', 'total': 30.0, 'count': 0}],
+            't2.small': [
+                {'date': '2018-07-22', 'units': 'Hrs', 'instance_type': 't2.small', 'total': 17.0, 'count': 0}]}
         self.assertEqual(expected, out_data)
 
 


### PR DESCRIPTION
Fixes issue where a date and type can have multiple aggregate entries because the units are missing. For now the values will just be appended to the same values list as shown below.

```
{
            "date": "2018-07-22",
            "instance_types": [
                {
                    "instance_type": "t2.micro",
                    "values": [
                        {
                            "date": "2018-07-22",
                            "units": "Hrs",
                            "instance_type": "t2.micro",
                            "total": 1.0,
                            "count": 0
                        },
                        {
                            "date": "2018-07-22",
                            "units": "",
                            "instance_type": "t2.micro",
                            "total": 30.0,
                            "count": 0
                        }
                    ]
                },
                {
                    "instance_type": "t2.small",
                    "values": [
                        {
                            "date": "2018-07-22",
                            "units": "Hrs",
                            "instance_type": "t2.small",
                            "total": 17.0,
                            "count": 0
                        }
                    ]
                }
            ]
        },
```