### PR TITLE
A couple of clean-ups to query handling

### DIFF
--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -138,16 +138,16 @@ class ReportQueryHandler(object):
         return (self.query_parameters and key in self.query_parameters and
                 in_key in self.query_parameters.get(key))
 
-    def get_query_param_data(self, dictkey, key):
+    def get_query_param_data(self, dictkey, key, default=None):
         """Extract the value from a query parameter dictionary or return None.
 
         Args:
             dictkey (String): the key to access a query parameter dictionary
             key     (String): the key to obtain from the dictionar data
         Returns:
-            (Object): The value found with the given key or None
+            (Object): The value found with the given key or the default value
         """
-        value = []
+        value = default
         if self.check_query_params(dictkey, key):
             value = self.query_parameters.get(dictkey).get(key)
         return value
@@ -175,8 +175,9 @@ class ReportQueryHandler(object):
         if self.resolution:
             return self.resolution
 
-        self.resolution = self.get_query_param_data('filter', 'resolution')
-        time_scope_value = self.get_query_param_data('filter', 'time_scope_value')
+        self.resolution = self.get_query_param_data('filter', 'resolution', 0)
+        time_scope_value = self.get_query_param_data('filter',
+                                                     'time_scope_value', 0)
         if not self.resolution:
             if not time_scope_value:
                 self.resolution = 'daily'
@@ -206,7 +207,8 @@ class ReportQueryHandler(object):
             return self.time_scope_units
 
         time_scope_units = self.get_query_param_data('filter', 'time_scope_units')
-        time_scope_value = self.get_query_param_data('filter', 'time_scope_value')
+        time_scope_value = self.get_query_param_data('filter',
+                                                     'time_scope_value', 0)
         if not time_scope_units:
             if not time_scope_value:
                 time_scope_units = 'day'
@@ -228,7 +230,8 @@ class ReportQueryHandler(object):
             return self.time_scope_value
 
         time_scope_units = self.get_query_param_data('filter', 'time_scope_units')
-        time_scope_value = self.get_query_param_data('filter', 'time_scope_value')
+        time_scope_value = self.get_query_param_data('filter',
+                                                     'time_scope_value', 0)
         if not time_scope_value:
             if not time_scope_units:
                 time_scope_value = -10
@@ -303,14 +306,14 @@ class ReportQueryHandler(object):
         if self._filter:
             filter_dict.update(self._filter)
 
-        gb_service = self.get_query_param_data('group_by', 'service')
-        gb_account = self.get_query_param_data('group_by', 'account')
-        gb_region = self.get_query_param_data('group_by', 'region')
-        gb_avail_zone = self.get_query_param_data('group_by', 'avail_zone')
-        f_account = self.get_query_param_data('filter', 'account')
-        f_service = self.get_query_param_data('filter', 'service')
-        f_region = self.get_query_param_data('filter', 'region')
-        f_avail_zone = self.get_query_param_data('filter', 'avail_zone')
+        gb_service = self.get_query_param_data('group_by', 'service', [])
+        gb_account = self.get_query_param_data('group_by', 'account', [])
+        gb_region = self.get_query_param_data('group_by', 'region', [])
+        gb_avail_zone = self.get_query_param_data('group_by', 'avail_zone', [])
+        f_account = self.get_query_param_data('filter', 'account', [])
+        f_service = self.get_query_param_data('filter', 'service', [])
+        f_region = self.get_query_param_data('filter', 'region', [])
+        f_avail_zone = self.get_query_param_data('filter', 'avail_zone', [])
         account = list(set(gb_account + f_account))
         service = list(set(gb_service + f_service))
         region = list(set(gb_region + f_region))

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -353,7 +353,6 @@ class ReportQueryHandler(object):
                   'avail_zone': 'availability_zone'}
 
         for q_param, db_field in fields.items():
-            group_by = self.get_query_param_data('group_by', q_param)
             annotations[q_param] = Concat(db_field, Value(''))
 
         return annotations

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -179,18 +179,16 @@ class ReportQueryHandler(object):
         time_scope_value = self.get_query_param_data('filter',
                                                      'time_scope_value', 0)
         if not self.resolution:
-            if not time_scope_value:
-                self.resolution = 'daily'
-            elif int(time_scope_value) == -1 or int(time_scope_value) == -2:
+            self.resolution = 'daily'
+            if time_scope_value in [-1, -2]:
                 self.resolution = 'monthly'
-            else:
-                self.resolution = 'daily'
+
         if self.resolution == 'monthly':
-            self.date_to_string = lambda datetime: datetime.strftime('%Y-%m')
+            self.date_to_string = lambda dt: dt.strftime('%Y-%m')
             self.date_trunc = TruncMonthString
             self.gen_time_interval = DateHelper().list_months
         else:
-            self.date_to_string = lambda datetime: datetime.strftime('%Y-%m-%d')
+            self.date_to_string = lambda dt: dt.strftime('%Y-%m-%d')
             self.date_trunc = TruncDayString
             self.gen_time_interval = DateHelper().list_days
 
@@ -207,15 +205,13 @@ class ReportQueryHandler(object):
             return self.time_scope_units
 
         time_scope_units = self.get_query_param_data('filter', 'time_scope_units')
-        time_scope_value = self.get_query_param_data('filter',
-                                                     'time_scope_value', 0)
+        time_scope_value = self.get_query_param_data('filter', 'time_scope_value')
+
         if not time_scope_units:
-            if not time_scope_value:
-                time_scope_units = 'day'
-            elif int(time_scope_value) == -1 or int(time_scope_value) == -2:
+            time_scope_units = 'day'
+            if time_scope_value in [-1, -2]:
                 time_scope_units = 'month'
-            else:
-                time_scope_units = 'day'
+
         self.time_scope_units = time_scope_units
         return self.time_scope_units
 
@@ -230,15 +226,13 @@ class ReportQueryHandler(object):
             return self.time_scope_value
 
         time_scope_units = self.get_query_param_data('filter', 'time_scope_units')
-        time_scope_value = self.get_query_param_data('filter',
-                                                     'time_scope_value', 0)
+        time_scope_value = self.get_query_param_data('filter', 'time_scope_value')
+
         if not time_scope_value:
-            if not time_scope_units:
-                time_scope_value = -10
-            elif time_scope_units == 'month':
+            time_scope_value = -10
+            if time_scope_units == 'month':
                 time_scope_value = -1
-            else:
-                time_scope_value = -10
+
         self.time_scope_value = int(time_scope_value)
         return self.time_scope_value
 


### PR DESCRIPTION
This cleans up a few issues in the `ReportQueryHandler` that were potential bugs or were behaving inconsistently.

- added a `default` param to `get_query_param_data()` so that consumers can specify desired behavior instead of (ab)using the properties of an empty list.
- simplified down the conditional logic in `get_time_scope_units()` and `get_time_scope_values()`. It could be simplified further, but I think this is a good first pass to improve clarity.
- DRY up a couple of long if-statements by making them into loops that emit the same values.