### PR TITLE
Koku API was sometimes returning August data, sometimes September

### DIFF
--- a/koku/api/utils.py
+++ b/koku/api/utils.py
@@ -28,7 +28,9 @@ from pint.errors import UndefinedUnitError
 class DateHelper():
     """Helper class with convenience functions."""
 
-    _now = timezone.now()
+    def __init__(self):
+        """Initialize when now is."""
+        self._now = timezone.now()
 
     @property
     def one_day(self):


### PR DESCRIPTION
## Summary

Hitting a reporting API in koku with `/api/v1/reports/costs/?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&group_by[service]=*` as an example would sometimes deliver last month's data, sometimes this months. The time_scope_value of -1 should always return this month. 

There's a `DateHelper` class that has a class attribute that defines the current time. Each instance of the datehelper will use the original now value first set when the first DateHelper was created. My guess is that there were gunicorn threads with a now value from August and some with a now value in September, hence the API altering between last/current month when hit. 
Now should be defined for each instance, not at class level

A quick example to show what was happening. Note that the `now` value doesn't change

```
>>> import datetime
>>>
>>> class ClassAttributeExample:
...     now = datetime.datetime.utcnow()
...     def __init__(self):
...         print(f'Starting at {datetime.datetime.utcnow()} with a now value of {self.now}')
...
>>> thing1 = ClassAttributeExample()
Starting at 2018-09-04 14:56:32.850678 with a now value of 2018-09-04 14:56:24.409948
>>> thing2 = ClassAttributeExample()
Starting at 2018-09-04 14:56:40.666543 with a now value of 2018-09-04 14:56:24.409948
>>> thing3 = ClassAttributeExample()
Starting at 2018-09-04 14:56:47.361401 with a now value of 2018-09-04 14:56:24.409948