### PR TITLE
Refactor query filtering; clarify behavior, remove unnecessary functions.

### DIFF
--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -17,8 +17,9 @@
 """Query Handling for Reports."""
 import copy
 import datetime
+import logging
 import re
-from collections import OrderedDict
+from collections import OrderedDict, UserDict
 from decimal import Decimal, DivisionByZero
 from itertools import groupby
 
@@ -38,6 +39,7 @@ from reporting.models import (AWSCostEntryLineItem,
                               AWSCostEntryLineItemDailySummary)
 
 
+LOG = logging.getLogger(__name__)
 WILDCARD = '*'
 OPERATION_SUM = 'sum'
 OPERATION_NONE = 'none'
@@ -71,6 +73,120 @@ class TruncMonthString(TruncMonth):
         return value.strftime('%Y-%m')
 
 
+class QueryFilter(UserDict):
+    """Dict-like object representing a single query filter."""
+
+    SEP = '__'    # separator
+    table = None
+    field = None
+    operation = None
+    parameter = None
+
+    def __init__(self, table=None, field=None, operation=None, parameter=None):
+        """Constructor."""
+        super().__init__(table=table, field=field, operation=operation,
+                         parameter=parameter)
+        self.table = table
+        self.field = field
+        self.operation = operation
+        self.parameter = parameter
+
+    def composed_query_string(self):
+        """Return compiled query string."""
+        composed = ''
+        for el in [self.table, self.field, self.operation]:
+            if el:
+                composed += f'{el}{self.SEP}'
+        return composed.strip(self.SEP)
+
+    def composed_dict(self):
+        """Return a dict formatted for Django's ORM."""
+        return {self.composed_query_string(): self.parameter}
+
+    def from_string(self, query_string):
+        """Parse a string representing a filter.
+
+        Returns:
+            QueryFilter instance.
+
+        Args:
+            query_string (str) A string representing a query filter.
+
+        Example:
+            QueryFilter().from_string('mytable__myfield__contains')
+
+        """
+        parts = query_string.split(self.SEP)
+        if len(parts) == 3:
+            self.table, self.field, self.operation = parts
+        elif len(parts) == 2:
+            self.table, self.operation = parts
+        else:
+            message = 'Insufficient parts in query string. ' + \
+                'Missing table, field, or operation.'
+            raise TypeError(message)
+        return self
+
+    def __repr__(self):
+        """Return string representation."""
+        return str(self.composed_dict())
+
+
+class QueryFilterCollection(object):
+    """Object representing a set of filters for a query."""
+
+    def __init__(self, filters=None):
+        """Constructor."""
+        if filters is None:
+            self._filters = list()    # a list of QueryFilter objects
+        else:
+            for item in filters:
+                assert isinstance(item, QueryFilter), \
+                    'Filters list must be instances of QueryFilter.'
+            self._filters = filters
+
+    def add(self, query_filter=None, table=None, field=None, operation=None, parameter=None):
+        """Add a query filter to the collection.
+
+        Args:
+            query_filter (QueryFilter) a QueryFilter object
+
+            - or -
+
+            table (str)  db table name
+            field (str)  db field/row name
+            operation (str) db operation
+            parameter (object) query object
+
+        """
+        if query_filter:
+            assert not (table or field or operation or parameter), \
+                'query_filter can not be defined with other parameters'
+            self._filters.append(query_filter)
+
+        if (table or field or operation or parameter):
+            assert not query_filter, \
+                'query_filter can not be defined with other parameters'
+            qf = QueryFilter(table=table, field=field, operation=operation,
+                             parameter=parameter)
+            self._filters.append(qf)
+
+    def compose(self):
+        """Compose filters into a dict for submitting to Django's ORM."""
+        out = {}
+        for filt in self._filters:
+            if filt.parameter is not None:
+                out.update(filt.composed_dict())
+        return out
+
+    def __repr__(self):
+        """Return string representation."""
+        out = f'{self.__class__}: '
+        for filt in self._filters:
+            out += filt.__repr__() + ', '
+        return out
+
+
 class ReportQueryHandler(object):
     """Handles report queries and responses."""
 
@@ -88,6 +204,8 @@ class ReportQueryHandler(object):
             units_key   (String): the key defining the units
             kwargs    (Dict): A dictionary for internal query alteration based on path
         """
+        LOG.debug(f'Query Params: {query_parameters}')
+
         self._accept_type = None
         self._annotations = None
         self._count = None
@@ -121,6 +239,8 @@ class ReportQueryHandler(object):
             # don't override the property by using setattr
             if 'count' in kwargs:
                 self.count = kwargs['count']
+
+        self.query_filter = self._get_filter()
 
         assert getattr(self, '_report_type'), \
             'kwargs["report_type"] is missing!'
@@ -158,15 +278,6 @@ class ReportQueryHandler(object):
         self._count = value
         if self.is_sum:
             self._count = 'resource_count'
-
-    @property
-    def join_tables(self):
-        """List the foreign tables line items join to."""
-        return [
-            'cost_entry_product',
-            'cost_entry_pricing',
-            'cost_entry_reservation'
-        ]
 
     @staticmethod
     def has_wildcard(in_list):
@@ -370,56 +481,51 @@ class ReportQueryHandler(object):
             (Dict): query filter dictionary
 
         """
-        filter_dict = {
-            'usage_start__gte': self.start_datetime,
-            'usage_end__lte': self.end_datetime,
-        }
+        filters = QueryFilterCollection()
+
+        if self._filter:
+            for key, value in self._filter.items():
+                filt = QueryFilter().from_string(key)
+                if value is not None:
+                    filt.parameter = value
+                filters.add(filt)
+
         if self.is_sum:
             # Summary table is already wrapped up at the date level
-            filter_dict = {
-                'usage_start__gte': self.start_datetime.date(),
-                'usage_start__lte': self.end_datetime.date(),
-            }
-        if self._filter:
-            filter_dict.update(self._filter)
+            start_filter = QueryFilter(table='usage_start', operation='gte',
+                                       parameter=self.start_datetime.date())
+            end_filter = QueryFilter(table='usage_start', operation='lte',
+                                     parameter=self.end_datetime.date())
+            # the summary table has a region field, otherwise we need to specify the table
+            region_filter = QueryFilter(field='region', operation='in')
+        else:
+            start_filter = QueryFilter(table='usage_start', operation='gte',
+                                       parameter=self.start_datetime)
+            end_filter = QueryFilter(table='usage_end', operation='lte',
+                                     parameter=self.end_datetime)
+            region_filter = QueryFilter(table='cost_entry_product', field='region',
+                                        operation='in')
 
-        # { query_param: database_field_name }
-        fields = {'account': 'usage_account_id',
-                  'service': 'product_code',
-                  'region': 'cost_entry_product__region',
-                  'avail_zone': 'availability_zone'}
-        if self.is_sum:
-            # Use the summary table that has region built in
-            fields.update({'region': 'region'})
-        # db query operation
-        op = 'in'
-        for q_param, db_field in fields.items():
+        filters.add(query_filter=start_filter)
+        filters.add(query_filter=end_filter)
+
+        # define filter parameters using API query params.
+        fields = {'account': QueryFilter(field='usage_account_id',
+                                         operation='in'),
+                  'service': QueryFilter(field='product_code', operation='in'),
+                  'region': region_filter,
+                  'avail_zone': QueryFilter(field='availability_zone',
+                                            operation='in')}
+        for q_param, filt in fields.items():
             group_by = self.get_query_param_data('group_by', q_param, list())
             filter_ = self.get_query_param_data('filter', q_param, list())
             list_ = list(set(group_by + filter_))    # uniquify the list
             if list_ and not ReportQueryHandler.has_wildcard(list_):
-                filter_dict[f'{db_field}__{op}'] = list_
+                filt.parameter = list_
+            filters.add(filt)
 
-        return filter_dict
-
-    def _strip_table_references(self, filters):
-        """Remove the foreign table reference from a Django query string.
-
-        Args:
-            filter (dict): The Django query filter dict
-
-        Returns:
-            (dict): The query filter with the table reference stripped
-
-        """
-        filters = copy.deepcopy(filters)
-        for key in filters:
-            for table_name in self.join_tables:
-                if table_name in key:
-                    new_key = key.replace(f'{table_name}__', '')
-                    filters[new_key] = filters[key]
-                    filters.pop(key, None)
-        return filters
+        LOG.debug(f'Filters: {filters.compose()}')
+        return filters.compose()
 
     def _get_group_by(self):
         """Create list for group_by parameters."""
@@ -603,8 +709,8 @@ class ReportQueryHandler(object):
 
         return out_data
 
-    def execute_query(self):    # noqa: C901
-        """Execute query and return provided data.
+    def execute_sum_query(self):
+        """Execute query and return provided data when self.is_sum == True.
 
         Returns:
             (Dict): Dictionary response of query params, data, and total
@@ -614,37 +720,24 @@ class ReportQueryHandler(object):
         data = []
 
         with tenant_context(self.tenant):
-            query_filter = self._get_filter()
-            query_group_by = self._get_group_by()
-            query_annotations = self._get_annotations()
-            query_order_by = ('-date',)
+            query = AWSCostEntryLineItemDailySummary.objects.filter(**self.query_filter)
 
-            if self.is_sum:
-                query_filter = self._strip_table_references(query_filter)
-                query = AWSCostEntryLineItemDailySummary.objects.filter(
-                    **query_filter
-                )
-            else:
-                query = AWSCostEntryLineItem.objects.filter(
-                    **query_filter
-                )
+            query_annotations = self._get_annotations()
             query_data = query.annotate(**query_annotations)
-            query_group_by = ['date'] + query_group_by
+
+            query_group_by = ['date'] + self._get_group_by()
             query_group_by_with_units = query_group_by + ['units']
 
-            if self.is_sum:
-                query_order_by += (self.order,)
-                query_data = query_data.values(*query_group_by_with_units)\
-                    .annotate(total=Sum(self.aggregate_key))
+            query_order_by = ('-date', self.order)
+            query_data = query_data.values(*query_group_by_with_units)\
+                .annotate(total=Sum(self.aggregate_key))
 
-            if self.count and self.is_sum:
+            if self.count:
                 # This is a sum because the summary table already
                 # has already performed counts
-                query_data = query_data.annotate(
-                    count=Sum(self.count)
-                )
+                query_data = query_data.annotate(count=Sum(self.count))
 
-            if self._limit and self.is_sum:
+            if self._limit:
                 rank_order = getattr(F(self.order_field), self.order_direction)()
                 dense_rank_by_total = Window(
                     expression=DenseRank(),
@@ -655,19 +748,16 @@ class ReportQueryHandler(object):
                 query_order_by = query_order_by + ('rank',)
 
             query_data = query_data.order_by(*query_order_by)
+
             is_csv_output = self._accept_type and 'text/csv' in self._accept_type
-            if self.is_sum and not is_csv_output:
-                data = self._apply_group_by(list(query_data))
-                data = self._transform_data(query_group_by, 0, data)
-            elif is_csv_output and self.is_sum:
-                values_out = query_group_by_with_units + ['total']
+            if is_csv_output:
                 if self._limit:
                     data = self._ranked_list(list(query_data))
                 else:
                     data = list(query_data)
             else:
-                values_out = query_group_by_with_units + EXPORT_COLUMNS
-                data = list(query_data.values(*values_out))
+                data = self._apply_group_by(list(query_data))
+                data = self._transform_data(query_group_by, 0, data)
 
             if query.exists():
                 units_value = query.values(self.units_key).first().get(self.units_key)
@@ -677,7 +767,47 @@ class ReportQueryHandler(object):
                 self.query_delta = self.calculate_delta(self._delta,
                                                         query,
                                                         query_sum,
-                                                        **query_filter)
+                                                        **self.query_filter)
+        self.query_sum = query_sum
+        self.query_data = data
+        return self._format_query_response()
+
+    def execute_query(self):
+        """Execute query and return provided data.
+
+        Returns:
+            (Dict): Dictionary response of query params, data, and total
+
+        """
+        if self.is_sum:
+            return self.execute_sum_query()
+
+        query_sum = {'value': 0}
+        data = []
+
+        with tenant_context(self.tenant):
+            query = AWSCostEntryLineItem.objects.filter(**self.query_filter)
+
+            query_annotations = self._get_annotations()
+            query_data = query.annotate(**query_annotations)
+
+            query_group_by = ['date'] + self._get_group_by()
+            query_group_by_with_units = query_group_by + ['units']
+
+            query_order_by = ('-date',)
+            query_data = query_data.order_by(*query_order_by)
+            values_out = query_group_by_with_units + EXPORT_COLUMNS
+            data = list(query_data.values(*values_out))
+
+            if query.exists():
+                units_value = query.values(self.units_key).first().get(self.units_key)
+                query_sum = self.calculate_total(units_value)
+
+            if self._delta:
+                self.query_delta = self.calculate_delta(self._delta,
+                                                        query,
+                                                        query_sum,
+                                                        **self.query_filter)
 
         self.query_sum = query_sum
         self.query_data = data
@@ -760,11 +890,10 @@ class ReportQueryHandler(object):
             'product_code'
         ]
         total_filter = {}
-        query_filter = self._get_filter()
 
         for field in filter_fields:
             total_filter.update(
-                {key: value for key, value in query_filter.items()
+                {key: value for key, value in self.query_filter.items()
                  if re.match(field, key)}
             )
 

--- a/koku/api/report/test/tests_queries.py
+++ b/koku/api/report/test/tests_queries.py
@@ -145,7 +145,7 @@ class QueryFilterCollectionTest(TestCase):
         """Test the constructor using invalid values."""
         bad_list = [self.fake.word(), self.fake.word()]
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(TypeError):
             QueryFilterCollection(bad_list)
 
     def test_add_filter(self):
@@ -176,7 +176,7 @@ class QueryFilterCollectionTest(TestCase):
         """Test the add() method using invalid values."""
         qf_coll = QueryFilterCollection()
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(AttributeError):
             qf_coll.add(self.fake.word(), self.fake.word(), self.fake.word())
 
     def test_compose(self):

--- a/koku/api/report/view.py
+++ b/koku/api/report/view.py
@@ -442,11 +442,9 @@ def instance_type(request):
         8133889256380,2018-08-04,r4.large,10.0,Hrs
 
     """
-    filter_scope = {'instance_type__isnull': False}
     annotations = {'instance_type':
                    Concat('cost_entry_product__instance_type', Value(''))}
-    extras = {'filter': filter_scope,
-              'annotations': annotations,
+    extras = {'annotations': annotations,
               'group_by': ['instance_type'],
               'count': 'resource_id',
               'report_type': 'instance_type'}
@@ -576,9 +574,7 @@ def storage(request):
         2415722664993,2018-08,2599.75765963921,GB-Mo
 
     """
-    filter_scope = {'product_family__contains': 'Storage'}
-    extras = {'filter': filter_scope,
-              'report_type': 'storage'}
+    extras = {'report_type': 'storage'}
     return _generic_report(request,
                            'usage_amount',
                            'cost_entry_pricing__unit',

--- a/koku/api/report/view.py
+++ b/koku/api/report/view.py
@@ -442,7 +442,7 @@ def instance_type(request):
         8133889256380,2018-08-04,r4.large,10.0,Hrs
 
     """
-    filter_scope = {'cost_entry_product__instance_type__isnull': False}
+    filter_scope = {'instance_type__isnull': False}
     annotations = {'instance_type':
                    Concat('cost_entry_product__instance_type', Value(''))}
     extras = {'filter': filter_scope,
@@ -576,7 +576,7 @@ def storage(request):
         2415722664993,2018-08,2599.75765963921,GB-Mo
 
     """
-    filter_scope = {'cost_entry_product__product_family__contains': 'Storage'}
+    filter_scope = {'product_family__contains': 'Storage'}
     extras = {'filter': filter_scope,
               'report_type': 'storage'}
     return _generic_report(request,


### PR DESCRIPTION
PR #340 is a pre-requisite for this change.

Changes:
* This reworks filter processing to ensure the translation from API query params to backend DB query filters is consistent.  There are two new classes, `QueryFilter` and `QueryFilterCollection` that handle arranging query filters into a unique list of filters ready for consumption by the Django ORM. This should eliminate the need to second-guess the contents of the query filters and make functions like `_strip_table_references()` unnecessary.

* I've also split `execute_query()` into two functions due to the large number of `if self.is_sum` checks indicating that use case is distinct enough to merit its own code path. I'm expecting this to allow future cleanups and refactoring now that it's clearer what each code branch is trying to accomplish.

Thoughts about the future:

Once this is merged, I'm hoping to apply a similar pattern for handling other elements of query processing, so that eventually the ordering and time_scope functions are also clearer.