### PR TITLE
add local provider support to create_test_customer script

### DIFF
--- a/scripts/create_test_customer.py
+++ b/scripts/create_test_customer.py
@@ -87,7 +87,7 @@ class KokuCustomerOnboarder:
 
         data = {
             'name': self.customer.get('provider_name'),
-            'type': 'AWS',
+            'type': self.customer.get('provider_type'),
             'authentication': {
                 'provider_resource_name': self.customer.get('provider_resource_name')
             },

--- a/scripts/test_customer.yaml
+++ b/scripts/test_customer.yaml
@@ -7,6 +7,7 @@ customer:
   password: str0ng!P@ss
   provider_name: Test Provider
   provider_resource_name: arn:aws:iam::111111111111:role/CostManagement
+  provider_type: 'AWS'
 koku:
   host: localhost
   port: 8000


### PR DESCRIPTION
This allows you to pass in a provider definition to the script, so that you can choose between supported providers.