### PR TITLE
sorting by total instead of cost

### DIFF
--- a/docs/source/specs/openapi.yml
+++ b/docs/source/specs/openapi.yml
@@ -1016,7 +1016,7 @@ definitions:
   ReportOrdering:
     type: object
     properties:
-      cost:
+      total:
         type: string
         enum:
           - asc
@@ -1026,7 +1026,7 @@ definitions:
         enum:
           - asc
           - desc
-    example: { 'cost': 'asc' }
+    example: { 'total': 'asc' }
     description: The ordering to apply to the report. Default is ascending order for the data.
   ReportDelta:
     type: object

--- a/koku/api/report/serializers.py
+++ b/koku/api/report/serializers.py
@@ -115,8 +115,8 @@ class OrderBySerializer(serializers.Serializer):
     """Serializer for handling query parameter order_by."""
 
     ORDER_CHOICES = (('asc', 'asc'), ('desc', 'desc'))
-    cost = serializers.ChoiceField(choices=ORDER_CHOICES,
-                                   required=False)
+    total = serializers.ChoiceField(choices=ORDER_CHOICES,
+                                    required=False)
     delta = serializers.ChoiceField(choices=ORDER_CHOICES,
                                     required=False)
     inventory = serializers.ChoiceField(choices=ORDER_CHOICES,

--- a/koku/api/report/test/tests_serializers.py
+++ b/koku/api/report/test/tests_serializers.py
@@ -115,7 +115,7 @@ class OrderBySerializerTest(TestCase):
 
     def test_parse_order_by_params_success(self):
         """Test parse of a order_by param successfully."""
-        order_params = {'cost': 'asc'}
+        order_params = {'total': 'asc'}
         serializer = OrderBySerializer(data=order_params)
         self.assertTrue(serializer.is_valid())
 
@@ -135,7 +135,7 @@ class QueryParamSerializerTest(TestCase):
     def test_parse_query_params_success(self):
         """Test parse of a query params successfully."""
         query_params = {'group_by': {'account': ['account1']},
-                        'order_by': {'cost': 'asc'},
+                        'order_by': {'total': 'asc'},
                         'filter': {'resolution': 'daily',
                                    'time_scope_value': '-10',
                                    'time_scope_units': 'day',


### PR DESCRIPTION

Test Results from query in issue
```
GET /api/v1/reports/costs/?filter[time_scope_units]=month&filter[resolution]=monthly&filter[time_scope_value]=-1&group_by[account]=*&order_by[total]=asc
HTTP 200 OK
Allow: OPTIONS, GET
Content-Type: application/json
Vary: Accept

{
    "group_by": {
        "account": [
            "*"
        ]
    },
    "order_by": {
        "total": "asc"
    },
    "filter": {
        "resolution": "monthly",
        "time_scope_value": "-1",
        "time_scope_units": "month"
    },
    "data": [
        {
            "date": "2018-09",
            "accounts": [
                {
                    "account": "589173575009",
                    "values": [
                        {
                            "date": "2018-09",
                            "units": "USD",
                            "account": "589173575009",
                            "total": 35.5996488,
                            "account_alias": "redhat-hccm"
                        }
                    ]
                }
            ]
        }
    ],
    "total": {
        "value": 35.5996488,
        "units": "USD"
    }
}
```
Closes #375 