### PR TITLE
add region and service to order-by serializer

### DIFF
--- a/docs/source/specs/openapi.yml
+++ b/docs/source/specs/openapi.yml
@@ -670,6 +670,16 @@ definitions:
         enum:
           - asc
           - desc
+      region:
+        type: string
+        enum:
+          - asc
+          - desc
+      service:
+        type: string
+        enum:
+          - asc
+          - desc
     example: { 'total': 'asc' }
     description: The ordering to apply to the report. Default is ascending order for the data.
   ReportDelta:

--- a/koku/api/report/serializers.py
+++ b/koku/api/report/serializers.py
@@ -121,9 +121,12 @@ class OrderBySerializer(serializers.Serializer):
                                     required=False)
     inventory = serializers.ChoiceField(choices=ORDER_CHOICES,
                                         required=False)
-
     account_alias = serializers.ChoiceField(choices=ORDER_CHOICES,
                                             required=False)
+    region = serializers.ChoiceField(choices=ORDER_CHOICES,
+                                     required=False)
+    service = serializers.ChoiceField(choices=ORDER_CHOICES,
+                                      required=False)
 
     def validate(self, data):
         """Validate incoming data."""


### PR DESCRIPTION
This enables support for ordering-by region and service.

Order-by Region Example:
```
GET /api/v1/reports/inventory/instance-type/?filter[time_scope_value]=-1&filter[resolution]=daily&group_by[region]=*&order_by[region]=asc
HTTP 200 OK
Allow: GET, OPTIONS
Content-Type: application/json
Vary: Accept

{
    "group_by": {
        "region": [
            "*"
        ]
    },
    "order_by": {
        "region": "asc"
    },
    "filter": {
        "resolution": "daily",
        "time_scope_value": "-1"
    },
    "data": [
        {
            "date": "2018-10-01",
            "regions": [
                {
                    "region": "us-east-1",
                    "instance_types": [
                        {
                            "instance_type": "t2.micro",
                            "values": [
                                {
                                    "region": "us-east-1",
                                    "instance_type": "t2.micro",
                                    "date": "2018-10-01",
                                    "units": null,
                                    "total": 2484.0,
                                    "account_alias": "redhat-hccm",
                                    "count": 16
                                }
                            ]
                        }
                    ]
                },
                {
                    "region": "us-east-2",
                    "instance_types": [
                        {
                            "instance_type": "t2.small",
                            "values": [
                                {
                                    "region": "us-east-2",
                                    "instance_type": "t2.small",
                                    "date": "2018-10-01",
                                    "units": "Hrs",
                                    "total": 852.0,
                                    "account_alias": "256293412812",
                                    "count": 10
                                }
                            ]
                        }
                    ]
                },
                {
                    "region": "us-west-2",
                    "instance_types": [
                        {
                            "instance_type": "t2.small",
                            "values": [
                                {
                                    "region": "us-west-2",
                                    "instance_type": "t2.small",
                                    "date": "2018-10-01",
                                    "units": "Hrs",
                                    "total": 1350.0,
                                    "account_alias": "redhat-hccm",
                                    "count": 8
                                }
                            ]
                        }
                    ]
                },
                {
                    "region": null,
                    "instance_types": [
                        {
                            "instance_type": "c4.xlarge",
                            "values": [
                                {
                                    "region": null,
                                    "instance_type": "c4.xlarge",
                                    "date": "2018-10-01",
                                    "units": "Hrs",
                                    "total": 9147.0,
                                    "account_alias": null,
                                    "count": 1682
                                }
                            ]
                        },
                        {
                            "instance_type": "c5d.2xlarge",
                            "values": [
                                {
                                    "region": null,
                                    "instance_type": "c5d.2xlarge",
                                    "date": "2018-10-01",
                                    "units": "Hrs",
                                    "total": 8955.0,
                                    "account_alias": null,
                                    "count": 1659
                                }
                            ]
                        },
                        {
                            "instance_type": "m5.large",
                            "values": [
                                {
                                    "region": null,
                                    "instance_type": "m5.large",
                                    "date": "2018-10-01",
                                    "units": "Hrs",
                                    "total": 9252.0,
                                    "account_alias": null,
                                    "count": 1725
                                }
                            ]
                        },
                        {
                            "instance_type": "r4.large",
                            "values": [
                                {
                                    "region": null,
                                    "instance_type": "r4.large",
                                    "date": "2018-10-01",
                                    "units": "Hrs",
                                    "total": 10467.0,
                                    "account_alias": null,
                                    "count": 1935
                                }
                            ]
                        }
                    ]
                }
            ]
        },
        {
            "date": "2018-10-02",
            "regions": [
                {
                    "region": "us-east-1",
                    "instance_types": [
                        {
                            "instance_type": "t2.micro",
                            "values": [
                                {
                                    "region": "us-east-1",
                                    "instance_type": "t2.micro",
                                    "date": "2018-10-02",
                                    "units": null,
                                    "total": 26.0,
                                    "account_alias": "redhat-hccm",
                                    "count": 2
                                }
                            ]
                        }
                    ]
                },
                {
                    "region": "us-east-2",
                    "instance_types": [
                        {
                            "instance_type": "t2.small",
                            "values": [
                                {
                                    "region": "us-east-2",
                                    "instance_type": "t2.small",
                                    "date": "2018-10-02",
                                    "units": "Hrs",
                                    "total": 4.0,
                                    "account_alias": "256293412812",
                                    "count": 1
                                }
                            ]
                        }
                    ]
                },
                {
                    "region": "us-west-2",
                    "instance_types": [
                        {
                            "instance_type": "t2.small",
                            "values": [
                                {
                                    "region": "us-west-2",
                                    "instance_type": "t2.small",
                                    "date": "2018-10-02",
                                    "units": "Hrs",
                                    "total": 18.0,
                                    "account_alias": "redhat-hccm",
                                    "count": 1
                                }
                            ]
                        }
                    ]
                }
            ]
        },
        {
            "date": "2018-10-03",
            "regions": []
        },
        {
            "date": "2018-10-04",
            "regions": []
        },
        {
            "date": "2018-10-05",
            "regions": []
        },
        {
            "date": "2018-10-06",
            "regions": []
        },
        {
            "date": "2018-10-07",
            "regions": []
        },
        {
            "date": "2018-10-08",
            "regions": []
        },
        {
            "date": "2018-10-09",
            "regions": []
        },
        {
            "date": "2018-10-10",
            "regions": []
        },
        {
            "date": "2018-10-11",
            "regions": []
        },
        {
            "date": "2018-10-12",
            "regions": []
        },
        {
            "date": "2018-10-13",
            "regions": []
        },
        {
            "date": "2018-10-14",
            "regions": []
        },
        {
            "date": "2018-10-15",
            "regions": []
        },
        {
            "date": "2018-10-16",
            "regions": []
        },
        {
            "date": "2018-10-17",
            "regions": []
        },
        {
            "date": "2018-10-18",
            "regions": []
        },
        {
            "date": "2018-10-19",
            "regions": []
        },
        {
            "date": "2018-10-20",
            "regions": []
        },
        {
            "date": "2018-10-21",
            "regions": []
        },
        {
            "date": "2018-10-22",
            "regions": []
        },
        {
            "date": "2018-10-23",
            "regions": []
        },
        {
            "date": "2018-10-24",
            "regions": []
        },
        {
            "date": "2018-10-25",
            "regions": []
        },
        {
            "date": "2018-10-26",
            "regions": []
        },
        {
            "date": "2018-10-27",
            "regions": []
        },
        {
            "date": "2018-10-28",
            "regions": []
        },
        {
            "date": "2018-10-29",
            "regions": []
        },
        {
            "date": "2018-10-30",
            "regions": []
        },
        {
            "date": "2018-10-31",
            "regions": []
        }
    ],
    "total": {
        "value": 8183.0,
        "count": 725,
        "units": "Hrs"
    }
}
```

Order-by Service Example:
```
GET /api/v1/reports/inventory/instance-type/?filter[time_scope_value]=-1&filter[resolution]=daily&group_by[service]=*&order_by[service]=asc
HTTP 200 OK
Allow: GET, OPTIONS
Content-Type: application/json
Vary: Accept

{
    "group_by": {
        "service": [
            "*"
        ]
    },
    "order_by": {
        "service": "asc"
    },
    "filter": {
        "resolution": "daily",
        "time_scope_value": "-1"
    },
    "data": [
        {
            "date": "2018-10-01",
            "services": [
                {
                    "service": "AmazonEC2",
                    "instance_types": [
                        {
                            "instance_type": "c4.xlarge",
                            "values": [
                                {
                                    "instance_type": "c4.xlarge",
                                    "date": "2018-10-01",
                                    "units": "Hrs",
                                    "service": "AmazonEC2",
                                    "total": 9147.0,
                                    "account_alias": null,
                                    "count": 1682
                                }
                            ]
                        },
                        {
                            "instance_type": "c5d.2xlarge",
                            "values": [
                                {
                                    "instance_type": "c5d.2xlarge",
                                    "date": "2018-10-01",
                                    "units": "Hrs",
                                    "service": "AmazonEC2",
                                    "total": 8955.0,
                                    "account_alias": null,
                                    "count": 1659
                                }
                            ]
                        },
                        {
                            "instance_type": "m5.large",
                            "values": [
                                {
                                    "instance_type": "m5.large",
                                    "date": "2018-10-01",
                                    "units": "Hrs",
                                    "service": "AmazonEC2",
                                    "total": 9252.0,
                                    "account_alias": null,
                                    "count": 1725
                                }
                            ]
                        },
                        {
                            "instance_type": "r4.large",
                            "values": [
                                {
                                    "instance_type": "r4.large",
                                    "date": "2018-10-01",
                                    "units": "Hrs",
                                    "service": "AmazonEC2",
                                    "total": 10467.0,
                                    "account_alias": null,
                                    "count": 1935
                                }
                            ]
                        },
                        {
                            "instance_type": "t2.micro",
                            "values": [
                                {
                                    "instance_type": "t2.micro",
                                    "date": "2018-10-01",
                                    "units": null,
                                    "service": "AmazonEC2",
                                    "total": 2484.0,
                                    "account_alias": "redhat-hccm",
                                    "count": 16
                                }
                            ]
                        },
                        {
                            "instance_type": "t2.small",
                            "values": [
                                {
                                    "instance_type": "t2.small",
                                    "date": "2018-10-01",
                                    "units": "Hrs",
                                    "service": "AmazonEC2",
                                    "total": 852.0,
                                    "account_alias": "256293412812",
                                    "count": 10
                                },
                                {
                                    "instance_type": "t2.small",
                                    "date": "2018-10-01",
                                    "units": "Hrs",
                                    "service": "AmazonEC2",
                                    "total": 1350.0,
                                    "account_alias": "redhat-hccm",
                                    "count": 8
                                }
                            ]
                        }
                    ]
                }
            ]
        },
        {
            "date": "2018-10-02",
            "services": [
                {
                    "service": "AmazonEC2",
                    "instance_types": [
                        {
                            "instance_type": "t2.micro",
                            "values": [
                                {
                                    "instance_type": "t2.micro",
                                    "date": "2018-10-02",
                                    "units": null,
                                    "service": "AmazonEC2",
                                    "total": 26.0,
                                    "account_alias": "redhat-hccm",
                                    "count": 2
                                }
                            ]
                        },
                        {
                            "instance_type": "t2.small",
                            "values": [
                                {
                                    "instance_type": "t2.small",
                                    "date": "2018-10-02",
                                    "units": "Hrs",
                                    "service": "AmazonEC2",
                                    "total": 4.0,
                                    "account_alias": "256293412812",
                                    "count": 1
                                },
                                {
                                    "instance_type": "t2.small",
                                    "date": "2018-10-02",
                                    "units": "Hrs",
                                    "service": "AmazonEC2",
                                    "total": 18.0,
                                    "account_alias": "redhat-hccm",
                                    "count": 1
                                }
                            ]
                        }
                    ]
                }
            ]
        },
        {
            "date": "2018-10-03",
            "services": []
        },
        {
            "date": "2018-10-04",
            "services": []
        },
        {
            "date": "2018-10-05",
            "services": []
        },
        {
            "date": "2018-10-06",
            "services": []
        },
        {
            "date": "2018-10-07",
            "services": []
        },
        {
            "date": "2018-10-08",
            "services": []
        },
        {
            "date": "2018-10-09",
            "services": []
        },
        {
            "date": "2018-10-10",
            "services": []
        },
        {
            "date": "2018-10-11",
            "services": []
        },
        {
            "date": "2018-10-12",
            "services": []
        },
        {
            "date": "2018-10-13",
            "services": []
        },
        {
            "date": "2018-10-14",
            "services": []
        },
        {
            "date": "2018-10-15",
            "services": []
        },
        {
            "date": "2018-10-16",
            "services": []
        },
        {
            "date": "2018-10-17",
            "services": []
        },
        {
            "date": "2018-10-18",
            "services": []
        },
        {
            "date": "2018-10-19",
            "services": []
        },
        {
            "date": "2018-10-20",
            "services": []
        },
        {
            "date": "2018-10-21",
            "services": []
        },
        {
            "date": "2018-10-22",
            "services": []
        },
        {
            "date": "2018-10-23",
            "services": []
        },
        {
            "date": "2018-10-24",
            "services": []
        },
        {
            "date": "2018-10-25",
            "services": []
        },
        {
            "date": "2018-10-26",
            "services": []
        },
        {
            "date": "2018-10-27",
            "services": []
        },
        {
            "date": "2018-10-28",
            "services": []
        },
        {
            "date": "2018-10-29",
            "services": []
        },
        {
            "date": "2018-10-30",
            "services": []
        },
        {
            "date": "2018-10-31",
            "services": []
        }
    ],
    "total": {
        "value": 8183.0,
        "count": 725,
        "units": "Hrs"
    }
}
```