### PR TITLE
Allow case insensitive filtering on account_alias, service, region, avail_zone.

### DIFF
--- a/koku/api/iam/test/iam_test_case.py
+++ b/koku/api/iam/test/iam_test_case.py
@@ -73,8 +73,8 @@ class IamTestCase(TestCase):
                                 create_customer=True, create_tenant=False):
         """Create the request context for a user."""
         customer = customer_data
-        account = customer['account_id']
-        org = customer['org_id']
+        account = customer.get('account_id')
+        org = customer.get('org_id')
         if create_customer:
             self._create_customer(account, org, create_tenant=create_tenant)
         identity = {

--- a/koku/koku/dev_middleware.py
+++ b/koku/koku/dev_middleware.py
@@ -40,7 +40,7 @@ class DevelopmentIdentityHeaderMiddleware(MiddlewareMixin):  # pylint: disable=t
             identity_header = {'identity':
                                {
                                    'account_number': '10001',
-                                   'org_id': '20002',
+                                   'org_id': '20001',
                                    'username': 'user_dev',
                                    'email': 'user_dev@foo.com'
                                }

--- a/koku/koku/middleware.py
+++ b/koku/koku/middleware.py
@@ -148,7 +148,7 @@ class IdentityHeaderMiddleware(MiddlewareMixin):  # pylint: disable=R0903
         except (KeyError, JSONDecodeError):
             logger.warning('Could not obtain identity on request.')
             return
-        if username:
+        if (username and email and account and org):
             # Check for customer creation & user creation
             try:
                 customer = Customer.objects.filter(account_id=account, org_id=org).get()


### PR DESCRIPTION
- Also catches bug with missing required customer and user data
- Dev middleware uses the same organization as the UI default

**GET** `/api/v1/reports/costs/?filter[time_scope_value]=-1&filter[time_scope_units]=month&filter[resolution]=monthly&group_by[account]=redhat`
```
{
    "group_by": {
        "account": [
            "redhat"
        ]
    },
    "filter": {
        "resolution": "monthly",
        "time_scope_value": "-1",
        "time_scope_units": "month"
    },
    "data": [
        {
            "date": "2018-10",
            "accounts": [
                {
                    "account": "589173575009",
                    "values": [
                        {
                            "date": "2018-10",
                            "units": "USD",
                            "account": "589173575009",
                            "total": 211.59330833,
                            "account_alias": "redhat-hccm"
                        }
                    ]
                }
            ]
        }
    ],
    "total": {
        "value": 71338.988248602,
        "units": "USD"
    }
}
```

**GET** `/api/v1/reports/costs/?filter[time_scope_value]=-1&filter[time_scope_units]=month&filter[resolution]=monthly&group_by[service]=eC2`
```
{
    "group_by": {
        "service": [
            "eC2"
        ]
    },
    "filter": {
        "resolution": "monthly",
        "time_scope_value": "-1",
        "time_scope_units": "month"
    },
    "data": [
        {
            "date": "2018-10",
            "services": [
                {
                    "service": "AmazonEC2",
                    "values": [
                        {
                            "date": "2018-10",
                            "units": "USD",
                            "service": "AmazonEC2",
                            "total": 805093.898081718,
                            "account_alias": null
                        },
                        {
                            "date": "2018-10",
                            "units": "USD",
                            "service": "AmazonEC2",
                            "total": 409.356,
                            "account_alias": "256293412812"
                        },
                        {
                            "date": "2018-10",
                            "units": "USD",
                            "service": "AmazonEC2",
                            "total": 210.634,
                            "account_alias": "redhat-hccm"
                        }
                    ]
                }
            ]
        }
    ],
    "total": {
        "value": 71338.870655968,
        "units": "USD"
    }
}
```


FYI @dlabrecq ^