### PR TITLE
Fix account_alias issue and pin pip to 18.0

### DIFF
--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -647,6 +647,7 @@ class ReportQueryHandler(object):
             group_by = self._get_group_by()
             for group in group_by:
                 other[group] = 'Other'
+            if 'account' in group_by:
                 other['account_alias'] = 'Other'
             ranked_list.append(other)
 
@@ -744,8 +745,10 @@ class ReportQueryHandler(object):
 
             query_data = query_data.values(*query_group_by)\
                 .annotate(total=Sum(self.aggregate_key))\
-                .annotate(units=Max(self.units_key))\
-                .annotate(account_alias=F('account_alias__account_alias'))
+                .annotate(units=Max(self.units_key))
+
+            if 'account' in query_group_by:
+                query_data = query_data.annotate(account_alias=F('account_alias__account_alias'))
 
             if self.count:
                 # This is a sum because the summary table already

--- a/openshift/s2i/bin/assemble
+++ b/openshift/s2i/bin/assemble
@@ -51,8 +51,10 @@ if [[ ! -z "$ENABLE_PIPENV" ]]; then
   install_pipenv
   echo "---> Installing dependencies via pipenv ..."
   if [[ -f Pipfile ]]; then
+    pipenv run pip install pip==18.0
     pipenv install --deploy --ignore-pipfile --verbose
   elif [[ -f requirements.txt ]]; then
+    pipenv run pip install pip==18.0
     pipenv install -r requirements.txt --verbose
   fi
   # pipenv check

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,7 @@ deps =
   pipenv
   codecov
 commands =
+  pipenv run pip install pip==18.0
   pipenv install --dev --ignore-pipfile
   coverage run {toxinidir}/koku/manage.py test -v 2 {posargs: koku/}
   coverage report --show-missing
@@ -47,5 +48,6 @@ setenv =
   PYTHONPATH={toxinidir}
 commands =
   flake8 koku
+  pipenv run pip install pip==18.0
   pipenv install --dev --ignore-pipfile
   pylint --load-plugins=pylint_django koku/koku


### PR DESCRIPTION
Fixing below where account_alias shouldn't be there:
**GET** `/api/v1/reports/costs/?filter[time_scope_value]=-1&filter[time_scope_units]=month&filter[resolution]=monthly&group_by[service]=eC2`
```
{
    "group_by": {
        "service": [
            "eC2"
        ]
    },
    "filter": {
        "resolution": "monthly",
        "time_scope_value": "-1",
        "time_scope_units": "month"
    },
    "data": [
        {
            "date": "2018-10",
            "services": [
                {
                    "service": "AmazonEC2",
                    "values": [
                        {
                            "date": "2018-10",
                            "units": "USD",
                            "service": "AmazonEC2",
                            "total": 805093.898081718,
                            "account_alias": null
                        },
                        {
                            "date": "2018-10",
                            "units": "USD",
                            "service": "AmazonEC2",
                            "total": 409.356,
                            "account_alias": "256293412812"
                        },
                        {
                            "date": "2018-10",
                            "units": "USD",
                            "service": "AmazonEC2",
                            "total": 210.634,
                            "account_alias": "redhat-hccm"
                        }
                    ]
                }
            ]
        }
    ],
    "total": {
        "value": 71338.870655968,
        "units": "USD"
    }
}
```

**GET** `/api/v1/reports/costs/?filter[time_scope_value]=-1&filter[time_scope_units]=month&filter[resolution]=monthly&group_by[service]=eC2`
```
{
    "group_by": {
        "service": [
            "eC2"
        ]
    },
    "filter": {
        "resolution": "monthly",
        "time_scope_value": "-1",
        "time_scope_units": "month"
    },
    "data": [
        {
            "date": "2018-10",
            "services": [
                {
                    "service": "AmazonEC2",
                    "values": [
                        {
                            "date": "2018-10",
                            "units": "USD",
                            "service": "AmazonEC2",
                            "total": 1397716.075099878
                        }
                    ]
                }
            ]
        }
    ],
    "total": {
        "value": 94509.936762564,
        "units": "USD"
    }
}
```