### PR TITLE
Add fix for default time_scope_value if none provided.

### DIFF
--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -981,7 +981,7 @@ class ReportQueryHandler(object):
         total_filter['time_scope_value'] = self.get_query_param_data(
             'filter',
             'time_scope_value',
-            0
+            -10
         )
         total_filter['report_type'] = self._report_type
         total_query = AWSCostEntryLineItemAggregates.objects.filter(

--- a/koku/api/report/test/tests_queries.py
+++ b/koku/api/report/test/tests_queries.py
@@ -667,6 +667,17 @@ class ReportQueryTest(IamTestCase):
         self.assertIsInstance(interval, list)
         self.assertTrue(len(interval) == 31)
 
+    def test_execute_take_defaults(self):
+        """Test execute_query for current month on daily breakdown."""
+        query_params = {}
+        handler = ReportQueryHandler(query_params, '', self.tenant, 'unblended_cost',
+                                     'currency_code', **{'report_type': 'costs'})
+        query_output = handler.execute_query()
+        self.assertIsNotNone(query_output.get('data'))
+        self.assertIsNotNone(query_output.get('total'))
+        total = query_output.get('total')
+        self.assertIsNotNone(total.get('value'))
+
     def test_execute_query_current_month_daily(self):
         """Test execute_query for current month on daily breakdown."""
         query_params = {'filter':


### PR DESCRIPTION
Fix for https://github.com/project-koku/koku/issues/389.

`time_scope_value` was not being properly defaulted when calculating the total.

*GET* `/api/v1/reports/costs/`
```
{
    "data": [
        {
            "date": "2018-09-25",
            "values": [
                {
                    "date": "2018-09-25",
                    "units": "USD",
                    "total": 3070.866990552
                }
            ]
        },
        {
            "date": "2018-09-26",
            "values": [
                {
                    "date": "2018-09-26",
                    "units": "USD",
                    "total": 3755.887344702
                }
            ]
        },
        {
            "date": "2018-09-27",
            "values": [
                {
                    "date": "2018-09-27",
                    "units": "USD",
                    "total": 2749.900786962
                }
            ]
        },
        {
            "date": "2018-09-28",
            "values": [
                {
                    "date": "2018-09-28",
                    "units": "USD",
                    "total": 3398.80045235
                }
            ]
        },
        {
            "date": "2018-09-29",
            "values": [
                {
                    "date": "2018-09-29",
                    "units": "USD",
                    "total": 3453.492498618
                }
            ]
        },
        {
            "date": "2018-09-30",
            "values": [
                {
                    "date": "2018-09-30",
                    "units": "USD",
                    "total": 0.567666666
                }
            ]
        },
        {
            "date": "2018-10-01",
            "values": [
                {
                    "date": "2018-10-01",
                    "units": "USD",
                    "total": 1596638.547039876
                }
            ]
        },
        {
            "date": "2018-10-02",
            "values": [
                {
                    "date": "2018-10-02",
                    "units": "USD",
                    "total": 3.102189086
                }
            ]
        },
        {
            "date": "2018-10-03",
            "values": [
                {
                    "date": "2018-10-03",
                    "units": "USD",
                    "total": 3.102189086
                }
            ]
        },
        {
            "date": "2018-10-04",
            "values": [
                {
                    "date": "2018-10-04",
                    "units": "USD",
                    "total": 3.102189086
                }
            ]
        },
        {
            "date": "2018-10-05",
            "values": [
                {
                    "date": "2018-10-05",
                    "units": "USD",
                    "total": 0.59
                }
            ]
        }
    ],
    "total": {
        "value": 117559.350016364,
        "units": "USD"
    }
}
```