### PR TITLE
Update tests to create tenant + schema only when necessary

### DIFF
--- a/koku/api/iam/test/iam_test_case.py
+++ b/koku/api/iam/test/iam_test_case.py
@@ -51,6 +51,7 @@ class IamTestCase(TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        """Tear down the class."""
         connection.set_schema_to_public()
         cls.tenant.delete()
         super().tearDownClass()

--- a/koku/api/iam/test/tests_user_preference_view.py
+++ b/koku/api/iam/test/tests_user_preference_view.py
@@ -33,11 +33,6 @@ class UserPreferenceViewTest(IamTestCase):
     def setUp(self):
         """Set up the user view tests."""
         super().setUp()
-        self.user_data = self._create_user_data()
-        self.customer = self._create_customer_data()
-        self.request_context = self._create_request_context(self.customer,
-                                                            self.user_data)
-        self.headers = self.request_context['request'].META
         serializer = UserSerializer(data=self.user_data, context=self.request_context)
         if serializer.is_valid(raise_exception=True):
             serializer.save()
@@ -77,7 +72,7 @@ class UserPreferenceViewTest(IamTestCase):
     def test_get_preference_detail_auth_other(self):
         """Test that an authed non-owner cannot retrieve preference details."""
         a_user_dict = self._create_user_data()
-        request_context = self._create_request_context(self.customer,
+        request_context = self._create_request_context(self.customer_data,
                                                        a_user_dict, False)
         serializer = UserSerializer(data=a_user_dict, context=request_context)
         if serializer.is_valid(raise_exception=True):
@@ -142,7 +137,7 @@ class UserPreferenceViewTest(IamTestCase):
     def test_delete_preference_auth_other(self):
         """Test that an authed non-owner cannot delete unowned preferences."""
         a_user_dict = self._create_user_data()
-        request_context = self._create_request_context(self.customer,
+        request_context = self._create_request_context(self.customer_data,
                                                        a_user_dict, False)
         serializer = UserSerializer(data=a_user_dict, context=request_context)
         if serializer.is_valid(raise_exception=True):

--- a/koku/api/provider/test/test_provider_manager.py
+++ b/koku/api/provider/test/test_provider_manager.py
@@ -28,12 +28,10 @@ class ProviderManagerTest(IamTestCase):
     def setUp(self):
         """Set up the provider manager tests."""
         super().setUp()
-        self.user_data = self._create_user_data()
-        self.current_customer_data = self._create_customer_data()
-        self.request_context = self._create_request_context(self.current_customer_data,
-                                                            self.user_data)
-        self.customer = Customer.objects.get(account_id=self.current_customer_data['account_id'],
-                                             org_id=self.current_customer_data['org_id'])
+        self.customer = Customer.objects.get(
+            account_id=self.customer_data['account_id'],
+            org_id=self.customer_data['org_id']
+        )
         serializer = UserSerializer(data=self.user_data, context=self.request_context)
         if serializer.is_valid(raise_exception=True):
             self.user = serializer.save()
@@ -121,7 +119,7 @@ class ProviderManagerTest(IamTestCase):
         provider_uuid = provider.uuid
 
         new_user_dict = self._create_user_data()
-        request_context = self._create_request_context(self.current_customer_data,
+        request_context = self._create_request_context(self.customer_data,
                                                        new_user_dict, False)
         user_serializer = UserSerializer(data=new_user_dict, context=request_context)
         other_user = None
@@ -144,7 +142,7 @@ class ProviderManagerTest(IamTestCase):
         provider_uuid = provider.uuid
 
         new_user_dict = self._create_user_data()
-        request_context = self._create_request_context(self.current_customer_data,
+        request_context = self._create_request_context(self.customer_data,
                                                        new_user_dict, False)
         user_serializer = UserSerializer(data=new_user_dict, context=request_context)
         other_user = None

--- a/koku/api/provider/test/tests_serializers.py
+++ b/koku/api/provider/test/tests_serializers.py
@@ -35,22 +35,11 @@ class ProviderSerializerTest(IamTestCase):
     def setUp(self):
         """Create test case objects."""
         super().setUp()
-        self.user_data = self._create_user_data()
-        self.customer = self._create_customer_data()
-        self.request_context = self._create_request_context(self.customer,
-                                                            self.user_data)
         request = self.request_context['request']
         serializer = UserSerializer(data=self.user_data, context=self.request_context)
         if serializer.is_valid(raise_exception=True):
             user = serializer.save()
             request.user = user
-
-    def tearDown(self):
-        """Tear down the serializer tests."""
-        super().tearDown()
-        User.objects.all().delete()
-        Customer.objects.all().delete()
-        Provider.objects.all().delete()
 
     def test_create_provider_fails_user(self):
         """Test creating a provider fails with no user."""

--- a/koku/api/provider/test/tests_serializers.py
+++ b/koku/api/provider/test/tests_serializers.py
@@ -21,7 +21,6 @@ from unittest.mock import patch
 from providers.provider_access import ProviderAccessor
 from rest_framework import serializers
 
-from api.iam.models import (Customer, User)
 from api.iam.serializers import (UserSerializer,
                                  create_schema_name)
 from api.iam.test.iam_test_case import IamTestCase

--- a/koku/api/provider/test/tests_views.py
+++ b/koku/api/provider/test/tests_views.py
@@ -23,7 +23,6 @@ from rest_framework.test import APIClient
 
 from api.iam.serializers import UserSerializer
 from api.iam.test.iam_test_case import IamTestCase
-from api.models import Customer, User
 from api.provider.models import Provider
 from api.provider.provider_manager import ProviderManager
 

--- a/koku/api/provider/test/tests_views.py
+++ b/koku/api/provider/test/tests_views.py
@@ -34,20 +34,9 @@ class ProviderViewTest(IamTestCase):
     def setUp(self):
         """Set up the customer view tests."""
         super().setUp()
-        self.user_data = self._create_user_data()
-        self.customer = self._create_customer_data()
-        self.request_context = self._create_request_context(self.customer,
-                                                            self.user_data)
-        self.headers = self.request_context['request'].META
         serializer = UserSerializer(data=self.user_data, context=self.request_context)
         if serializer.is_valid(raise_exception=True):
             serializer.save()
-
-    def tearDown(self):
-        """Tear down user tests."""
-        super().tearDown()
-        Customer.objects.all().delete()
-        User.objects.all().delete()
 
     def create_provider(self, bucket_name, iam_arn, headers=None):
         """Create a provider and return response."""
@@ -77,7 +66,7 @@ class ProviderViewTest(IamTestCase):
         self.assertIsNotNone(json_result.get('uuid'))
         self.assertIsNotNone(json_result.get('customer'))
         self.assertEqual(json_result.get('customer').get('account_id'),
-                         self.customer.get('account_id'))
+                         self.customer_data.get('account_id'))
         self.assertIsNotNone(json_result.get('created_by'))
         self.assertEqual(json_result.get('created_by').get('username'),
                          self.user_data.get('username'))
@@ -157,7 +146,7 @@ class ProviderViewTest(IamTestCase):
         self.assertIsNotNone(json_result.get('uuid'))
         self.assertIsNotNone(json_result.get('customer'))
         self.assertEqual(json_result.get('customer').get('account_id'),
-                         self.customer.get('account_id'))
+                         self.customer_data.get('account_id'))
         self.assertIsNotNone(json_result.get('created_by'))
         self.assertEqual(json_result.get('created_by').get('username'),
                          self.user_data['username'])
@@ -181,7 +170,7 @@ class ProviderViewTest(IamTestCase):
         self.assertIsNotNone(json_result.get('uuid'))
         self.assertIsNotNone(json_result.get('customer'))
         self.assertEqual(json_result.get('customer').get('account_id'),
-                         self.customer.get('account_id'))
+                         self.customer_data.get('account_id'))
         self.assertIsNotNone(json_result.get('created_by'))
         self.assertEqual(json_result.get('created_by').get('username'),
                          self.user_data.get('username'))

--- a/koku/api/report/test/tests_queries.py
+++ b/koku/api/report/test/tests_queries.py
@@ -259,12 +259,6 @@ class ReportQueryTest(IamTestCase):
         """Set up the customer view tests."""
         super().setUp()
         self.current_month_total = Decimal(0)
-
-        customer = self._create_customer_data()
-        new_customer = self._create_customer(customer['account_id'],
-                                             customer['org_id'],
-                                             create_tenant=True)
-        self.tenant = Tenant.objects.get(schema_name=new_customer.schema_name)
         self.add_data_to_tenant()
 
     def create_hourly_instance_usage(self, payer_account_id, bill,
@@ -895,7 +889,7 @@ class ReportQueryTest(IamTestCase):
 
     def test_execute_query_curr_month_by_account_w_limit(self):
         """Test execute_query for current month on monthly breakdown by account with limit."""
-        for _ in range(0, random.randint(3, 10)):
+        for _ in range(3):
             self.add_data_to_tenant()
 
         query_params = {'filter':
@@ -1337,7 +1331,7 @@ class ReportQueryTest(IamTestCase):
                   'data_start': dh.last_month_start,
                   'data_end': dh.last_month_start + timedelta(days=1)}
 
-        for _ in range(0, random.randint(3, 5)):
+        for _ in range(0, 3):
             # add some current data.
             self.add_data_to_tenant(account_id=account_id,
                                     account_alias=account_alias)
@@ -1397,7 +1391,7 @@ class ReportQueryTest(IamTestCase):
         expected_delta_percent = Decimal(0)
 
         query_params = {
-            'filter': {'time_scope_value': -10},
+            'filter': {'time_scope_value': -1},
             'delta': True
         }
 
@@ -1426,7 +1420,7 @@ class ReportQueryTest(IamTestCase):
                   'data_start': DateHelper().last_month_start,
                   'data_end': DateHelper().last_month_start + timedelta(days=1)}
 
-        for _ in range(0, random.randint(3, 5)):
+        for _ in range(0, 3):
             # add some current data.
             self.add_data_to_tenant(rate=Decimal(random.random()),
                                     account_id=account_id)
@@ -1501,7 +1495,7 @@ class ReportQueryTest(IamTestCase):
         """Test execute_query when account alias is avaiable."""
         # generate test data
         expected = {self.account_alias: self.payer_account_id}
-        for _ in range(0, random.randint(3, 5)):
+        for _ in range(0, 3):
             account_id = self.fake.ean(length=13)
             account_alias = self.fake.company()
             expected[account_alias] = account_id

--- a/koku/api/report/test/tests_queries.py
+++ b/koku/api/report/test/tests_queries.py
@@ -28,7 +28,6 @@ from faker import Faker
 from tenant_schemas.utils import tenant_context
 
 from api.iam.test.iam_test_case import IamTestCase
-from api.models import Tenant
 from api.report.queries import QueryFilter, QueryFilterCollection, ReportQueryHandler
 from api.utils import DateHelper
 from reporting.models import (AWSAccountAlias,

--- a/koku/api/report/test/tests_views.py
+++ b/koku/api/report/test/tests_views.py
@@ -27,7 +27,7 @@ from rest_framework_csv.renderers import CSVRenderer
 
 from api.iam.serializers import UserSerializer
 from api.iam.test.iam_test_case import IamTestCase
-from api.models import Customer, User
+from api.models import User
 from api.report.view import (_convert_units,
                              _fill_in_missing_units,
                              _find_unit,

--- a/koku/api/report/test/tests_views.py
+++ b/koku/api/report/test/tests_views.py
@@ -42,12 +42,6 @@ class ReportViewTest(IamTestCase):
     def setUp(self):
         """Set up the customer view tests."""
         super().setUp()
-        self.user_data = self._create_user_data()
-        self.customer = self._create_customer_data()
-        self.request_context = self._create_request_context(self.customer,
-                                                            self.user_data,
-                                                            create_tenant=True)
-        self.headers = self.request_context['request'].META
         serializer = UserSerializer(data=self.user_data, context=self.request_context)
         if serializer.is_valid(raise_exception=True):
             serializer.save()
@@ -129,12 +123,6 @@ class ReportViewTest(IamTestCase):
                 'units': 'GB-Mo'
             }
         }
-
-    def tearDown(self):
-        """Tear down user tests."""
-        super().tearDown()
-        Customer.objects.all().delete()
-        User.objects.all().delete()
 
     def test_get_costs_customer_owner(self):
         """Test costs reports runs with a customer owner."""

--- a/koku/providers/test/aws/tests_aws_provider.py
+++ b/koku/providers/test/aws/tests_aws_provider.py
@@ -37,14 +37,6 @@ def _mock_boto3_exception():
 class AWSProviderTestCase(TestCase):
     """Parent Class for AWSProvider test cases."""
 
-    def setup(self):
-        """Create test case objects."""
-        pass
-
-    def tearDown(self):
-        """Tear down test case objects."""
-        pass
-
     def test_get_name(self):
         """Get name of provider."""
         provider = AWSProvider()

--- a/koku/providers/test/aws_local/test_aws_local_provider.py
+++ b/koku/providers/test/aws_local/test_aws_local_provider.py
@@ -35,6 +35,7 @@ class AWSLocalProviderTestCase(TestCase):
     def tearDown(self):
         """Tear down test case objects."""
         os.rmdir(self.cur_source)
+        super().tearDown()
 
     def test_get_name(self):
         """Get name of provider."""


### PR DESCRIPTION
## Summary
This should speed up testing in Koku. A full run of the unit test suite using tox took approx. 2 minutes on my local machine.
* In iam_test_case.py, now customer and tenant creation happens at the test class level, so a new tenant is not created for every test. 
* In addition there are now many common shared objects at the test class level that can acceptably be recycled between tests.
* Minor cleanup in a few test files.