### PR TITLE
API response for daily, time_scope_values queries returns correct number of days

### DIFF
--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -487,11 +487,11 @@ class ReportQueryHandler(object):
         else:
             if time_scope_value == -10:
                 # get last 10 days
-                start = dh.n_days_ago(dh.this_hour, 10)
+                start = dh.n_days_ago(dh.this_hour, 9)
                 end = dh.this_hour
             else:
                 # get last 30 days
-                start = dh.n_days_ago(dh.this_hour, 30)
+                start = dh.n_days_ago(dh.this_hour, 29)
                 end = dh.this_hour
 
         self.start_datetime = start

--- a/koku/api/report/test/tests_queries.py
+++ b/koku/api/report/test/tests_queries.py
@@ -744,14 +744,14 @@ class ReportQueryTest(IamTestCase):
         handler = ReportQueryHandler(query_params, '', self.tenant,
                                      **{'report_type': 'costs'})
         dh = DateHelper()
-        ten_days_ago = dh.n_days_ago(dh.today, 10)
+        nine_days_ago = dh.n_days_ago(dh.today, 9)
         start = handler.start_datetime.replace(hour=0, minute=0, second=0, microsecond=0)
         end = handler.end_datetime.replace(hour=0, minute=0, second=0, microsecond=0)
         interval = handler.time_interval
-        self.assertEqual(start, ten_days_ago)
+        self.assertEqual(start, nine_days_ago)
         self.assertEqual(end, dh.today)
         self.assertIsInstance(interval, list)
-        self.assertTrue(len(interval) == 11)
+        self.assertTrue(len(interval) == 10)
 
     def test_get_time_frame_filter_last_thirty(self):
         """Test _get_time_frame_filter for last thirty days."""
@@ -762,14 +762,14 @@ class ReportQueryTest(IamTestCase):
         handler = ReportQueryHandler(query_params, '', self.tenant,
                                      **{'report_type': 'costs'})
         dh = DateHelper()
-        thirty_days_ago = dh.n_days_ago(dh.today, 30)
+        twenty_nine_days_ago = dh.n_days_ago(dh.today, 29)
         start = handler.start_datetime.replace(hour=0, minute=0, second=0, microsecond=0)
         end = handler.end_datetime.replace(hour=0, minute=0, second=0, microsecond=0)
         interval = handler.time_interval
-        self.assertEqual(start, thirty_days_ago)
+        self.assertEqual(start, twenty_nine_days_ago)
         self.assertEqual(end, dh.today)
         self.assertIsInstance(interval, list)
-        self.assertTrue(len(interval) == 31)
+        self.assertTrue(len(interval) == 30)
 
     def test_execute_take_defaults(self):
         """Test execute_query for current month on daily breakdown."""


### PR DESCRIPTION
`filter[resolution]=daily&filter[time_scope_value]=-10` incorrectly returns 11 days
`filter[resolution]=daily&filter[time_scope_value]=-30` incorrectly returns 31 days


Test Results:
```
GET /api/v1/reports/costs/?filter[resolution]=daily&filter[time_scope_value]=-10&filter[time_scope_units]=day
HTTP 200 OK
Allow: OPTIONS, GET
Content-Type: application/json
Vary: Accept

{
    "filter": {
        "resolution": "daily",
        "time_scope_value": "-10",
        "time_scope_units": "day"
    },
    "data": [
        {
            "date": "2018-10-23",
            "values": [
                {
                    "date": "2018-10-23",
                    "units": "USD",
                    "total": 0.836514169
                }
            ]
        },
        {
            "date": "2018-10-24",
            "values": [
                {
                    "date": "2018-10-24",
                    "units": "USD",
                    "total": 0.836514169
                }
            ]
        },
        {
            "date": "2018-10-25",
            "values": [
                {
                    "date": "2018-10-25",
                    "units": "USD",
                    "total": 0.836514169
                }
            ]
        },
        {
            "date": "2018-10-26",
            "values": [
                {
                    "date": "2018-10-26",
                    "units": "USD",
                    "total": 0.836549169
                }
            ]
        },
        {
            "date": "2018-10-27",
            "values": [
                {
                    "date": "2018-10-27",
                    "units": "USD",
                    "total": 0.836784169
                }
            ]
        },
        {
            "date": "2018-10-28",
            "values": [
                {
                    "date": "2018-10-28",
                    "units": "USD",
                    "total": 0.837064169
                }
            ]
        },
        {
            "date": "2018-10-29",
            "values": [
                {
                    "date": "2018-10-29",
                    "units": "USD",
                    "total": 0.836694169
                }
            ]
        },
        {
            "date": "2018-10-30",
            "values": [
                {
                    "date": "2018-10-30",
                    "units": "USD",
                    "total": 0.836834169
                }
            ]
        },
        {
            "date": "2018-10-31",
            "values": [
                {
                    "date": "2018-10-31",
                    "units": "USD",
                    "total": 0.703654917
                }
            ]
        },
        {
            "date": "2018-11-01",
            "values": []
        }
    ],
    "total": {
        "value": 8.233637438,
        "units": "USD"
    }
}
```
Repeated same test for -30.  30 days are in response

Thanks for spotting this @lcouzens 