### PR TITLE
Handle others with matching rank.

### DIFF
--- a/koku/api/report/aws/aws_query_handler.py
+++ b/koku/api/report/aws/aws_query_handler.py
@@ -29,7 +29,7 @@ from django.db.models import (F,
                               Window)
 from django.db.models.functions import (Coalesce,
                                         Concat,
-                                        DenseRank)
+                                        RowNumber)
 from tenant_schemas.utils import tenant_context
 
 from api.report.queries import ReportQueryHandler
@@ -230,12 +230,12 @@ class AWSReportQueryHandler(ReportQueryHandler):
 
             if self._limit:
                 rank_order = getattr(F(self.order_field), self.order_direction)()
-                dense_rank_by_total = Window(
-                    expression=DenseRank(),
+                rank_by_total = Window(
+                    expression=RowNumber(),
                     partition_by=F('date'),
                     order_by=rank_order
                 )
-                query_data = query_data.annotate(rank=dense_rank_by_total)
+                query_data = query_data.annotate(rank=rank_by_total)
                 query_order_by = query_order_by + ('rank',)
 
             if self.order_field != 'delta':

--- a/koku/api/report/ocp/ocp_query_handler.py
+++ b/koku/api/report/ocp/ocp_query_handler.py
@@ -23,7 +23,7 @@ from django.db.models import (F,
                               Value,
                               Window)
 from django.db.models.functions import Concat
-from django.db.models.functions import DenseRank
+from django.db.models.functions import RowNumber
 from tenant_schemas.utils import tenant_context
 
 from api.report.queries import ReportQueryHandler
@@ -151,12 +151,12 @@ class OCPReportQueryHandler(ReportQueryHandler):
 
             if self._limit and group_by_value:
                 rank_order = getattr(F(group_by_value.pop()), self.order_direction)()
-                dense_rank_by_total = Window(
-                    expression=DenseRank(),
+                rank_by_total = Window(
+                    expression=RowNumber(),
                     partition_by=F('date'),
                     order_by=rank_order
                 )
-                query_data = query_data.annotate(rank=dense_rank_by_total)
+                query_data = query_data.annotate(rank=rank_by_total)
                 query_order_by = query_order_by + ('rank',)
 
             if self.order_field != 'delta':

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -757,7 +757,6 @@ class ReportQueryHandler(object):
         Returns:
             List(Dict): List of data points meeting the rank criteria
         """
-        ranked_dict = {}
         ranked_list = []
         others_list = []
         other = None
@@ -766,15 +765,14 @@ class ReportQueryHandler(object):
             if other is None:
                 other = copy.deepcopy(data)
             rank = data.get('rank')
-            if rank <= self._limit and ranked_dict.get(rank) is None:
+            if rank <= self._limit:
                 del data['rank']
-                ranked_dict[rank] = data
+                ranked_list.append(data)
             else:
                 others_list.append(data)
                 for column in self._mapper.sum_columns:
                     other_sums[column] += data.get(column) if data.get(column) else 0
 
-        ranked_list = list(ranked_dict.values())
         if other is not None and others_list:
             num_others = len(others_list)
             others_label = '{} Others'.format(num_others)

--- a/koku/api/report/test/ocp/tests_views.py
+++ b/koku/api/report/test/ocp/tests_views.py
@@ -419,4 +419,4 @@ class OCPReportViewTest(IamTestCase):
                 projects = item.get('nodes')
                 print(projects)
                 self.assertEqual(len(projects), 2)
-                self.assertEqual(projects[1].get('node'), 'Other')
+                self.assertEqual(projects[1].get('node'), '1 Other')

--- a/koku/api/report/test/tests_queries.py
+++ b/koku/api/report/test/tests_queries.py
@@ -1669,7 +1669,7 @@ class ReportQueryTest(IamTestCase):
         expected = [
             {'account': '1', 'account_alias': '1', 'total': 5},
             {'account': '2', 'account_alias': '2', 'total': 4},
-            {'account': 'Other', 'account_alias': 'Other', 'total': 5}
+            {'account': '2 Others', 'account_alias': '2 Others', 'total': 5}
         ]
         ranked_list = handler._ranked_list(data_list)
         self.assertEqual(ranked_list, expected)
@@ -1692,7 +1692,7 @@ class ReportQueryTest(IamTestCase):
         expected = [
             {'service': '1', 'total': 5},
             {'service': '2', 'total': 4},
-            {'service': 'Other', 'total': 5}
+            {'service': '2 Others', 'total': 5}
         ]
         ranked_list = handler._ranked_list(data_list)
         self.assertEqual(ranked_list, expected)


### PR DESCRIPTION
**GET** `/api/v1/reports/costs/?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[limit]=2&group_by[account]=*`

```
{
    "group_by": {
        "account": [
            "*"
        ]
    },
    "filter": {
        "resolution": "monthly",
        "time_scope_value": "-1",
        "time_scope_units": "month",
        "limit": 2
    },
    "data": [
        {
            "date": "2018-11",
            "accounts": [
                {
                    "account": "9513809867510",
                    "values": [
                        {
                            "date": "2018-11",
                            "units": "USD",
                            "account": "9513809867510",
                            "total": 5708.09125736,
                            "account_alias": "9513809867510"
                        }
                    ]
                },
                {
                    "account": "3827551307245",
                    "values": [
                        {
                            "date": "2018-11",
                            "units": "USD",
                            "account": "3827551307245",
                            "total": 5290.19343164,
                            "account_alias": "3827551307245"
                        }
                    ]
                },
                {
                    "account": "3 Others",
                    "values": [
                        {
                            "date": "2018-11",
                            "units": "USD",
                            "account": "3 Others",
                            "total": 12801.32307403,
                            "account_alias": "3 Others"
                        }
                    ]
                }
            ]
        }
    ],
    "total": {
        "value": 23799.60776303,
        "units": "USD"
    }
}
```