### PR TITLE
URL adjustments to align OCP and AWS end points

### DIFF
--- a/docs/source/specs/openapi.yml
+++ b/docs/source/specs/openapi.yml
@@ -461,7 +461,7 @@ paths:
             $ref: '#/definitions/Error'
       security:
       - api_key: []
-  /reports/costs/:
+  /reports/costs/aws/:
     get:
       tags:
         - Report
@@ -507,7 +507,7 @@ paths:
             $ref: '#/definitions/Error'
       security:
       - api_key: []
-  /reports/inventory/instance-type/:
+  /reports/inventory/aws/instance-type/:
     get:
       tags:
         - Report
@@ -553,7 +553,7 @@ paths:
             $ref: '#/definitions/Error'
       security:
       - api_key: []
-  /reports/inventory/storage/:
+  /reports/inventory/aws/storage/:
     get:
       tags:
         - Report

--- a/docs/source/users.rst
+++ b/docs/source/users.rst
@@ -42,4 +42,4 @@ This is an example for making authenticated HTTP requests to the Koku API when `
    #!/bin/bash
    HOST='localhost'
    IDENTITY=$(echo '"identity":{"org_id":"20001","account_number":"10001","username":"test_customer","email":"koku-dev@example.com"}' | base64 | tr -d '\n')
-   curl -g -H "HTTP_X_RH_IDENTITY: ${IDENTITY}" 'http://'${HOST}'/api/v1/reports/inventory/instance-type/'
+   curl -g -H "HTTP_X_RH_IDENTITY: ${IDENTITY}" 'http://'${HOST}'/api/v1/reports/inventory/aws/instance-type/'

--- a/koku/api/report/aws/view.py
+++ b/koku/api/report/aws/view.py
@@ -36,7 +36,7 @@ from api.report.view import _generic_report
 def costs(request):
     """Get cost data.
 
-    @api {get} /api/v1/reports/costs/ Get cost data
+    @api {get} /api/v1/reports/costs/aws/ Get cost data
     @apiName getCostData
     @apiGroup Report
     @apiVersion 1.0.0
@@ -128,7 +128,7 @@ def costs(request):
 def instance_type(request):
     """Get inventory data.
 
-    @api {get} /api/v1/reports/inventory/instance-type/ Get inventory instance type data
+    @api {get} /api/v1/reports/inventory/aws/instance-type/ Get inventory instance type data
     @apiName getInventoryInstanceTypeData
     @apiGroup Report
     @apiVersion 1.0.0
@@ -259,7 +259,7 @@ def instance_type(request):
 def storage(request):
     """Get inventory storage data.
 
-    @api {get} /api/v1/reports/inventory/storage Get inventory storage data
+    @api {get} /api/v1/reports/inventory/aws/storage Get inventory storage data
     @apiName getInventoryStorageData
     @apiGroup Report
     @apiVersion 1.0.0

--- a/koku/api/urls.py
+++ b/koku/api/urls.py
@@ -35,9 +35,9 @@ ROUTER.register(r'rates', RateViewSet, base_name='rates')
 # pylint: disable=invalid-name
 urlpatterns = [
     url(r'^status/$', status, name='server-status'),
-    url(r'^reports/costs/$', costs, name='reports-costs'),
-    url(r'^reports/inventory/instance-type/$', instance_type, name='reports-instance-type'),
-    url(r'^reports/inventory/storage/$', storage, name='reports-storage'),
+    url(r'^reports/costs/aws/$', costs, name='reports-costs'),
+    url(r'^reports/inventory/aws/instance-type/$', instance_type, name='reports-instance-type'),
+    url(r'^reports/inventory/aws/storage/$', storage, name='reports-storage'),
     url(r'^reports/inventory/ocp/memory/$', memory, name='reports-ocp-memory'),
     url(r'^reports/inventory/ocp/cpu/$', cpu, name='reports-ocp-cpu'),
     url(r'^', include(ROUTER.urls)),

--- a/scripts/create_test_customer.py
+++ b/scripts/create_test_customer.py
@@ -69,7 +69,7 @@ class KokuCustomerOnboarder:
     def create_customer(self):
         """Create Koku Customer."""
         # Customer, User, and Tenant schema are lazy initialized on any API request
-        response = requests.get(self.endpoint_base + 'reports/costs/',
+        response = requests.get(self.endpoint_base + 'reports/costs/aws/',
                                  headers=self.get_headers(self.auth_token))
         print(response.text)
 


### PR DESCRIPTION
Provider API changes to align OCP and AWS.

Final end points
```
/reports/inventory/ocp/cpu/
/reports/inventory/ocp/memory/
/reports/inventory/aws/instance-type/
/reports/inventory/aws/storage/
/reports/costs/aws/
/reports/charge/ocp/ <<<<<<<<<<< Not implemented yet
```

**Testing**
1. Verify costs API
2. Verify inventory API
3. Verify storage API

**Test Results**
[koku_api_alignment_ut.txt](https://github.com/project-koku/koku/files/2576538/koku_api_alignment_ut.txt)

Closes #461 
