### PR TITLE
removing provider rates upon provider removal.

### DIFF
--- a/koku/api/provider/provider_manager.py
+++ b/koku/api/provider/provider_manager.py
@@ -25,6 +25,7 @@ from django.db import transaction
 from requests.exceptions import ConnectionError
 
 from api.provider.models import Provider
+from rates.models import Rate
 
 
 LOG = logging.getLogger(__name__)
@@ -68,6 +69,7 @@ class ProviderManager:
         if self.is_removable_by_user(current_user):
             authentication_model = self.model.authentication
             billing_source = self.model.billing_source
+            provider_rate_objs = Rate.objects.all().filter(provider_uuid=self._uuid)
 
             auth_count = Provider.objects.exclude(uuid=self._uuid)\
                 .filter(authentication=authentication_model).count()
@@ -80,6 +82,8 @@ class ProviderManager:
                 authentication_model.delete()
             if billing_source and billing_count == 0:
                 billing_source.delete()
+            if provider_rate_objs:
+                provider_rate_objs.delete()
             try:
                 self._delete_report_data()
             except ConnectionError as err:

--- a/koku/api/provider/test/test_provider_manager.py
+++ b/koku/api/provider/test/test_provider_manager.py
@@ -19,11 +19,14 @@ import json
 import logging
 from unittest.mock import patch
 
+from tenant_schemas.utils import tenant_context
+
 from api.iam.models import Customer
 from api.iam.serializers import UserSerializer
 from api.iam.test.iam_test_case import IamTestCase
 from api.provider.models import Provider, ProviderAuthentication, ProviderBillingSource
 from api.provider.provider_manager import ProviderManager, ProviderManagerError
+from rates.models import Rate
 
 
 class MockResponse:
@@ -144,8 +147,9 @@ class ProviderManagerTest(IamTestCase):
         if user_serializer.is_valid(raise_exception=True):
             other_user = user_serializer.save()
 
-        manager = ProviderManager(provider_uuid)
-        manager.remove(other_user)
+        with tenant_context(self.tenant):
+            manager = ProviderManager(provider_uuid)
+            manager.remove(other_user)
         provider_query = Provider.objects.all().filter(uuid=provider_uuid)
         auth_count = ProviderAuthentication.objects.count()
         billing_count = ProviderBillingSource.objects.count()
@@ -183,8 +187,9 @@ class ProviderManagerTest(IamTestCase):
         if user_serializer.is_valid(raise_exception=True):
             other_user = user_serializer.save()
 
-        manager = ProviderManager(provider_uuid)
-        manager.remove(other_user)
+        with tenant_context(self.tenant):
+            manager = ProviderManager(provider_uuid)
+            manager.remove(other_user)
         auth_count = ProviderAuthentication.objects.count()
         billing_count = ProviderBillingSource.objects.count()
         provider_query = Provider.objects.all().filter(uuid=provider_uuid)
@@ -212,8 +217,22 @@ class ProviderManagerTest(IamTestCase):
         if user_serializer.is_valid(raise_exception=True):
             other_user = user_serializer.save()
 
-        manager = ProviderManager(provider_uuid)
-        manager.remove(other_user)
+        with tenant_context(self.tenant):
+            rate = {'provider_uuid': provider.uuid,
+                    'metric': Rate.METRIC_CPU_CORE_HOUR,
+                    'rates': {'tiered_rate': [{
+                        'unit': 'USD',
+                        'value': 1.0,
+                        'usage_start': 10.0,
+                        'usage_end': 3.0
+                    }]}
+                    }
+
+            Rate.objects.create(**rate)
+            manager = ProviderManager(provider_uuid)
+            manager.remove(other_user)
+            rates_query = Rate.objects.all().filter(provider_uuid=provider_uuid)
+            self.assertFalse(rates_query)
         provider_query = Provider.objects.all().filter(uuid=provider_uuid)
         self.assertFalse(provider_query)
 


### PR DESCRIPTION
When a provider is removed the associated rates must also be removed.

**Testing**
1. Create two providers:
2.  Add rates to both providers
3. Remove one of the providers and verify that only the rates associated with that provider are removed
4. Remove the other provider and verify that no rates remain

**Testing Results**
[koku_rate_removal_provider_del_ut.txt](https://github.com/project-koku/koku/files/2601414/koku_rate_removal_provider_del_ut.txt)

Closes https://github.com/project-koku/masu/issues/266