### PR TITLE
Add support for swagger spec consumption via bravado_core.

### DIFF
--- a/docs/source/specs/openapi.yml
+++ b/docs/source/specs/openapi.yml
@@ -30,11 +30,11 @@ paths:
       produces:
       - 'application/json'
       responses:
-        200:
+        '200':
           description: An object describing the server status
           schema:
             $ref: '#/definitions/Status'
-        500:
+        '500':
           description: Unexpected Error
           schema:
             $ref: '#/definitions/Error'
@@ -54,15 +54,15 @@ paths:
         description: Preference to add to a Preference
         required: true
         schema:
-          $ref: '#/definitions/UserPreferenceIn'
+          $ref: '#/definitions/UserPreference'
       responses:
-        201:
+        '201':
           description: An object describing the user
           schema:
             $ref: '#/definitions/UserPreferenceOut'
-        401:
+        '401':
           description: Unauthorized
-        500:
+        '500':
           description: Unexpected Error
           schema:
             $ref: '#/definitions/Error'
@@ -83,13 +83,13 @@ paths:
         type: 'string'
         format: 'uuid'
       responses:
-        200:
+        '200':
           description: A paginated list of preference objects
           schema:
             $ref: '#/definitions/UserPreferencePagination'
-        401:
+        '401':
           description: Unauthorized
-        500:
+        '500':
           description: Unexpected Error
           schema:
             $ref: '#/definitions/Error'
@@ -111,17 +111,17 @@ paths:
         type: 'string'
         format: 'uuid'
       responses:
-        200:
+        '200':
           description: A UserPreference object
           schema:
             $ref: '#/definitions/UserPreferenceOut'
-        401:
+        '401':
           description: Unauthorized
-        404:
+        '404':
           description: Not Found
           schema:
             $ref: '#/definitions/Error'
-        500:
+        '500':
           description: Unexpected Error
           schema:
             $ref: '#/definitions/Error'
@@ -142,15 +142,15 @@ paths:
         type: 'string'
         format: 'uuid'
       responses:
-        204:
+        '204':
           description: User deleted
-        401:
+        '401':
           description: Unauthorized
-        404:
+        '404':
           description: Not Found
           schema:
             $ref: '#/definitions/Error'
-        500:
+        '500':
           description: Unexpected Error
           schema:
             $ref: '#/definitions/Error'
@@ -177,17 +177,17 @@ paths:
         description: Update to a Preference
         required: true
         schema:
-          $ref: '#/definitions/UserPreferenceIn'
+          $ref: '#/definitions/UserPreference'
       responses:
-        200:
+        '200':
           description: Preference updated
-        401:
+        '401':
           description: Unauthorized
-        404:
+        '404':
           description: Not Found
           schema:
             $ref: '#/definitions/Error'
-        500:
+        '500':
           description: Unexpected Error
           schema:
             $ref: '#/definitions/Error'
@@ -211,13 +211,13 @@ paths:
         schema:
           $ref: '#/definitions/ProviderIn'
       responses:
-        201:
+        '201':
           description: An object describing the provider
           schema:
             $ref: '#/definitions/ProviderOut'
-        401:
+        '401':
           description: Unauthorized
-        500:
+        '500':
           description: Unexpected Error
           schema:
             $ref: '#/definitions/Error'
@@ -231,13 +231,13 @@ paths:
       produces:
       - 'application/json'
       responses:
-        200:
+        '200':
           description: A paginated list of provider objects
           schema:
             $ref: '#/definitions/ProviderPagination'
-        401:
+        '401':
           description: Unauthorized
-        500:
+        '500':
           description: Unexpected Error
           schema:
             $ref: '#/definitions/Error'
@@ -256,19 +256,19 @@ paths:
         type: 'string'
         format: 'uuid'
       responses:
-        204:
+        '204':
           description: Provider deleted
-        401:
+        '401':
           description: Unauthorized
-        403:
+        '403':
           description: Insufficent permissions to delete provider
           schema:
             $ref: '#/definitions/Error'
-        404:
+        '404':
           description: Not Found
           schema:
             $ref: '#/definitions/Error'
-        500:
+        '500':
           description: Unexpected Error
           schema:
             $ref: '#/definitions/Error'
@@ -290,17 +290,17 @@ paths:
         type: 'string'
         format: 'uuid'
       responses:
-        200:
+        '200':
           description: A Provider object
           schema:
             $ref: '#/definitions/ProviderOut'
-        401:
+        '401':
           description: Unauthorized
-        404:
+        '404':
           description: Not Found
           schema:
             $ref: '#/definitions/Error'
-        500:
+        '500':
           description: Unexpected Error
           schema:
             $ref: '#/definitions/Error'
@@ -324,13 +324,13 @@ paths:
         schema:
           $ref: '#/definitions/RateIn'
       responses:
-        201:
+        '201':
           description: An object describing the rate
           schema:
             $ref: '#/definitions/RateOut'
-        401:
+        '401':
           description: Unauthorized
-        500:
+        '500':
           description: Unexpected Error
           schema:
             $ref: '#/definitions/Error'
@@ -351,13 +351,13 @@ paths:
         type: 'string'
         format: 'uuid'
       responses:
-        200:
+        '200':
           description: A paginated list of rate objects
           schema:
             $ref: '#/definitions/RatePagination'
-        401:
+        '401':
           description: Unauthorized
-        500:
+        '500':
           description: Unexpected Error
           schema:
             $ref: '#/definitions/Error'
@@ -379,17 +379,17 @@ paths:
         type: 'string'
         format: 'uuid'
       responses:
-        200:
+        '200':
           description: A Rate object
           schema:
             $ref: '#/definitions/RateOut'
-        401:
+        '401':
           description: Unauthorized
-        404:
+        '404':
           description: Not Found
           schema:
             $ref: '#/definitions/Error'
-        500:
+        '500':
           description: Unexpected Error
           schema:
             $ref: '#/definitions/Error'
@@ -410,15 +410,15 @@ paths:
         type: 'string'
         format: 'integer'
       responses:
-        204:
+        '204':
           description: Rate deleted
-        401:
+        '401':
           description: Unauthorized
-        404:
+        '404':
           description: Not Found
           schema:
             $ref: '#/definitions/Error'
-        500:
+        '500':
           description: Unexpected Error
           schema:
             $ref: '#/definitions/Error'
@@ -447,15 +447,15 @@ paths:
         schema:
           $ref: '#/definitions/RateIn'
       responses:
-        200:
+        '200':
           description: Rate updated
-        401:
+        '401':
           description: Unauthorized
-        404:
+        '404':
           description: Not Found
           schema:
             $ref: '#/definitions/Error'
-        500:
+        '500':
           description: Unexpected Error
           schema:
             $ref: '#/definitions/Error'
@@ -495,13 +495,13 @@ paths:
           - sum
           - none
       responses:
-        200:
+        '200':
           description: A report object
           schema:
             $ref: '#/definitions/ReportCost'
-        401:
+        '401':
           description: Unauthorized
-        500:
+        '500':
           description: Unexpected Error
           schema:
             $ref: '#/definitions/Error'
@@ -541,13 +541,13 @@ paths:
           - sum
           - none
       responses:
-        200:
+        '200':
           description: A report object
           schema:
             $ref: '#/definitions/ReportCharge'
-        401:
+        '401':
           description: Unauthorized
-        500:
+        '500':
           description: Unexpected Error
           schema:
             $ref: '#/definitions/Error'
@@ -587,13 +587,13 @@ paths:
           - sum
           - none
       responses:
-        200:
+        '200':
           description: A report object
           schema:
             $ref: '#/definitions/ReportInstanceInventory'
-        401:
+        '401':
           description: Unauthorized
-        500:
+        '500':
           description: Unexpected Error
           schema:
             $ref: '#/definitions/Error'
@@ -633,13 +633,13 @@ paths:
           - sum
           - none
       responses:
-        200:
+        '200':
           description: A report object
           schema:
             $ref: '#/definitions/ReportStorageInventory'
-        401:
+        '401':
           description: Unauthorized
-        500:
+        '500':
           description: Unexpected Error
           schema:
             $ref: '#/definitions/Error'
@@ -668,13 +668,13 @@ paths:
         description: 'The ordering to apply to the report as a URL encoded dictionary.'
         type: 'string'
       responses:
-        200:
+        '200':
           description: A report object
           schema:
             $ref: '#/definitions/ReportOCPCpu'
-        401:
+        '401':
           description: Unauthorized
-        500:
+        '500':
           description: Unexpected Error
           schema:
             $ref: '#/definitions/Error'
@@ -703,13 +703,13 @@ paths:
         description: 'The ordering to apply to the report as a URL encoded dictionary.'
         type: 'string'
       responses:
-        200:
+        '200':
           description: A report object
           schema:
             $ref: '#/definitions/ReportOCPmemory'
-        401:
+        '401':
           description: Unauthorized
-        500:
+        '500':
           description: Unexpected Error
           schema:
             $ref: '#/definitions/Error'
@@ -735,9 +735,9 @@ definitions:
   CustomerOut:
     allOf:
       - $ref: '#/definitions/Customer'
-      - required:
-          - uuid
-          - date_created
+    required:
+      - uuid
+      - date_created
     properties:
       uuid:
         type: string
@@ -766,8 +766,6 @@ definitions:
         type: string
         format: uri
         example: /api/v1/(resources)/?page=4
-      results:
-        type: object
   ProviderAuthenticationIn:
     required:
       - provider_resource_name
@@ -796,9 +794,8 @@ definitions:
   ProviderIn:
     allOf:
       - $ref: '#/definitions/Provider'
-      - required:
-          - authentication
-          - billing_source
+    required:
+      - authentication
     properties:
       authentication:
         $ref: '#/definitions/ProviderAuthenticationIn'
@@ -807,8 +804,8 @@ definitions:
   ProviderAuthenticationOut:
     allOf:
       - $ref: '#/definitions/ProviderAuthenticationIn'
-      - required:
-          - uuid
+    required:
+      - uuid
     properties:
       uuid:
         type: string
@@ -817,8 +814,8 @@ definitions:
   ProviderBillingSourceOut:
     allOf:
       - $ref: '#/definitions/ProviderBillingSourceIn'
-      - required:
-          - uuid
+    required:
+      - uuid
     properties:
       uuid:
         type: string
@@ -827,12 +824,12 @@ definitions:
   ProviderOut:
     allOf:
       - $ref: '#/definitions/Provider'
-      - required:
-          - uuid
-          - authentication
-          - billing_source
-          - customer
-          - created_by
+    required:
+      - uuid
+      - authentication
+      - billing_source
+      - customer
+      - created_by
     properties:
       uuid:
         type: string
@@ -849,8 +846,8 @@ definitions:
   ProviderPagination:
     allOf:
       - $ref: '#/definitions/ListPagination'
-      - required:
-          - results
+    required:
+      - results
     properties:
       results:
         type: array
@@ -873,14 +870,14 @@ definitions:
   RateIn:
     allOf:
       - $ref: '#/definitions/Rate'
-      - required:
-        - provider_uuid
-        - metric
+    required:
+      - provider_uuid
+      - metric
   RatePagination:
     allOf:
       - $ref: '#/definitions/ListPagination'
-      - required:
-          - results
+    required:
+      - results
     properties:
       results:
         type: array
@@ -889,10 +886,10 @@ definitions:
   RateOut:
     allOf:
       - $ref: '#/definitions/Rate'
-      - required:
-        - uuid
-        - provider_uuid
-        - metric
+    required:
+      - uuid
+      - provider_uuid
+      - metric
     properties:
       uuid:
         type: string
@@ -1249,8 +1246,8 @@ definitions:
   ReportCost:
     allOf:
       - $ref: '#/definitions/Report'
-      - required:
-          - data
+    required:
+      - data
     properties:
       data:
         type: array
@@ -1299,8 +1296,8 @@ definitions:
   ReportCharge:
     allOf:
       - $ref: '#/definitions/Report'
-      - required:
-          - data
+    required:
+      - data
     properties:
       data:
         type: array
@@ -1336,8 +1333,8 @@ definitions:
   ReportInstanceInventory:
     allOf:
       - $ref: '#/definitions/Report'
-      - required:
-          - data
+    required:
+      - data
     properties:
       data:
         type: array
@@ -1379,8 +1376,8 @@ definitions:
   ReportStorageInventory:
     allOf:
       - $ref: '#/definitions/Report'
-      - required:
-          - data
+    required:
+      - data
     properties:
       data:
         type: array
@@ -1453,8 +1450,8 @@ definitions:
   ReportOCPCpu:
     allOf:
       - $ref: '#/definitions/Report'
-      - required:
-          - data
+    required:
+      - data
     properties:
       data:
         type: array
@@ -1489,8 +1486,8 @@ definitions:
   ReportOCPMemory:
     allOf:
       - $ref: '#/definitions/Report'
-      - required:
-          - data
+    required:
+      - data
     properties:
       data:
         type: array
@@ -1523,7 +1520,6 @@ definitions:
   Status:
     required:
       - api_version
-      - name
     properties:
       api_version:
         type: integer
@@ -1591,35 +1587,18 @@ definitions:
   UserOut:
     allOf:
       - $ref: '#/definitions/User'
-      - required:
-          - uuid
+    required:
+      - uuid
     properties:
       uuid:
         type: string
         format: uuid
         example: 57e60f90-8c0c-4bd1-87a0-2143759aae1c
-  UserPreferenceIn:
-    allOf:
-      - $ref: '#/definitions/UserPreference'
-      - required:
-          - name
-          - preference
-    properties:
-      name:
-        type: string
-        example: my-preference-name
-      preference:
-        type: object
-        format: json
-        example: {'currency': 'USD'}
-      description:
-        type: string
-        example: my long preference description
   UserPreferencePagination:
     allOf:
       - $ref: '#/definitions/ListPagination'
-      - required:
-          - results
+    required:
+      - results
     properties:
       results:
         type: array
@@ -1628,9 +1607,9 @@ definitions:
   UserPreferenceOut:
     allOf:
       - $ref: '#/definitions/UserPreference'
-      - required:
-          - uuid
-          - user
+    required:
+      - uuid
+      - user
     properties:
       uuid:
         type: string


### PR DESCRIPTION

Support bravado_core consuming `openapi.yml`
```
from bravado_core.spec import Spec
import yaml

spec_dict = yaml.load(open('/path/to/file/openapi.yml', 'r').read())

config = {
    'validate_requests': False,
    'use_models': False,
}

swagger_spec = Spec.from_dict(spec_dict, config=config)
```