### PR TITLE
Ocp units

### DIFF
--- a/koku/api/iam/serializers.py
+++ b/koku/api/iam/serializers.py
@@ -207,7 +207,7 @@ class UserPreferenceSerializer(serializers.ModelSerializer):
             None
 
         """
-        if data.get('name') is not field:
+        if data.get('name') != field:
             return
 
         pref = data.get('preference', dict).get(field)

--- a/koku/api/report/ocp/ocp_query_handler.py
+++ b/koku/api/report/ocp/ocp_query_handler.py
@@ -136,6 +136,9 @@ class OCPReportQueryHandler(ReportQueryHandler):
             else:
                 data = self._apply_group_by(list(query_data))
                 data = self._transform_data(query_group_by, 0, data)
+
+        query_sum.update({'units': self._mapper.units_key})
+
         self.query_sum = query_sum
         self.query_data = data
         return self._format_query_response()

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -23,7 +23,7 @@ from decimal import Decimal, DivisionByZero, InvalidOperation
 from itertools import groupby
 
 from dateutil import relativedelta
-from django.db.models import Count, F, Max, Sum
+from django.db.models import CharField, Count, F, Max, Sum, Value
 from django.db.models.functions import TruncDay, TruncMonth
 
 from api.report.query_filter import QueryFilter, QueryFilterCollection
@@ -242,6 +242,7 @@ class ProviderMap(object):
                         'default_ordering': {'charge': 'desc'},
                         'annotations': {
                             'charge': Sum(F('pod_charge_cpu_cores') + F('pod_charge_memory_gigabytes')),
+                            'units': Value('USD', output_field=CharField())
                         },
                         'delta_key': {'charge': Sum(F('pod_charge_cpu_cores') + F('pod_charge_memory_gigabytes'))},
                         'filter': {},
@@ -261,6 +262,7 @@ class ProviderMap(object):
                             'request': Sum('pod_request_cpu_core_hours'),
                             'limit': Sum('pod_limit_cpu_core_hours'),
                             'charge': Sum('pod_charge_cpu_cores'),
+                            'units': Value('Core-Hours', output_field=CharField())
                         },
                         'delta_key': {
                             'usage': Sum('pod_usage_cpu_core_hours'),
@@ -268,7 +270,7 @@ class ProviderMap(object):
                             'charge': Sum('pod_charge_cpu_cores')
                         },
                         'filter': {},
-                        'units_key': 'core_hours',
+                        'units_key': 'Core-Hours',
                         'sum_columns': ['usage', 'request', 'limit', 'charge'],
                     },
                     'mem': {
@@ -283,7 +285,8 @@ class ProviderMap(object):
                             'usage': Sum('pod_usage_memory_gigabytes'),
                             'request': Sum('pod_request_memory_gigabytes'),
                             'charge': Sum('pod_charge_memory_gigabytes'),
-                            'limit': Sum('pod_limit_memory_gigabytes')
+                            'limit': Sum('pod_limit_memory_gigabytes'),
+                            'units': Value('GB-Hours', output_field=CharField())
                         },
                         'delta_key': {
                             'usage': Sum('pod_usage_memory_gigabytes'),
@@ -291,7 +294,7 @@ class ProviderMap(object):
                             'charge': Sum('pod_charge_memory_gigabytes')
                         },
                         'filter': {},
-                        'units_key': 'GB',
+                        'units_key': 'GB-Hours',
                         'sum_columns': ['usage', 'request', 'limit', 'charge'],
                     }
                 },

--- a/koku/api/report/test/ocp/tests_views.py
+++ b/koku/api/report/test/ocp/tests_views.py
@@ -270,6 +270,63 @@ class OCPReportViewTest(IamTestCase):
                 self.assertTrue('usage' in values)
                 self.assertTrue('request' in values)
 
+    def test_charge_api_has_units(self):
+        """Test that the charge API returns units."""
+        url = reverse('reports-ocp-charges')
+        client = APIClient()
+        response = client.get(url, **self.headers)
+        response_json = response.json()
+
+        total = response_json.get('total', {})
+        data = response_json.get('data', {})
+        import pdb; pdb.set_trace()
+        self.assertTrue('units' in total)
+        self.assertEqual(total.get('units'), 'USD')
+
+        for item in data:
+            if item.get('values'):
+                values = item.get('values')[0]
+                self.assertTrue('units' in values)
+                self.assertEqual(values.get('units'), 'USD')
+
+    def test_cpu_api_has_units(self):
+        """Test that the CPU API returns units."""
+        url = reverse('reports-ocp-cpu')
+        client = APIClient()
+        response = client.get(url, **self.headers)
+        response_json = response.json()
+
+        total = response_json.get('total', {})
+        data = response_json.get('data', {})
+        import pdb; pdb.set_trace()
+        self.assertTrue('units' in total)
+        self.assertEqual(total.get('units'), 'Core-Hours')
+
+        for item in data:
+            if item.get('values'):
+                values = item.get('values')[0]
+                self.assertTrue('units' in values)
+                self.assertEqual(values.get('units'), 'Core-Hours')
+
+    def test_charge_api_has_units(self):
+        """Test that the charge API returns units."""
+        url = reverse('reports-ocp-memory')
+        client = APIClient()
+        response = client.get(url, **self.headers)
+        response_json = response.json()
+
+        total = response_json.get('total', {})
+        data = response_json.get('data', {})
+        import pdb; pdb.set_trace()
+        self.assertTrue('units' in total)
+        self.assertEqual(total.get('units'), 'GB-Hours')
+
+        for item in data:
+            if item.get('values'):
+                values = item.get('values')[0]
+                self.assertTrue('units' in values)
+                self.assertEqual(values.get('units'), 'GB-Hours')
+
     def test_execute_query_ocp_cpu_last_thirty_days(self):
         """Test that OCP CPU endpoint works."""
         url = reverse('reports-ocp-cpu')

--- a/koku/api/report/test/ocp/tests_views.py
+++ b/koku/api/report/test/ocp/tests_views.py
@@ -279,7 +279,6 @@ class OCPReportViewTest(IamTestCase):
 
         total = response_json.get('total', {})
         data = response_json.get('data', {})
-        import pdb; pdb.set_trace()
         self.assertTrue('units' in total)
         self.assertEqual(total.get('units'), 'USD')
 
@@ -298,7 +297,6 @@ class OCPReportViewTest(IamTestCase):
 
         total = response_json.get('total', {})
         data = response_json.get('data', {})
-        import pdb; pdb.set_trace()
         self.assertTrue('units' in total)
         self.assertEqual(total.get('units'), 'Core-Hours')
 
@@ -317,7 +315,6 @@ class OCPReportViewTest(IamTestCase):
 
         total = response_json.get('total', {})
         data = response_json.get('data', {})
-        import pdb; pdb.set_trace()
         self.assertTrue('units' in total)
         self.assertEqual(total.get('units'), 'GB-Hours')
 

--- a/koku/api/report/test/ocp/tests_views.py
+++ b/koku/api/report/test/ocp/tests_views.py
@@ -306,7 +306,7 @@ class OCPReportViewTest(IamTestCase):
                 self.assertTrue('units' in values)
                 self.assertEqual(values.get('units'), 'Core-Hours')
 
-    def test_charge_api_has_units(self):
+    def test_memory_api_has_units(self):
         """Test that the charge API returns units."""
         url = reverse('reports-ocp-memory')
         client = APIClient()


### PR DESCRIPTION
## Summary

A quick fix to get units reporting in OCP APIs. CPU and Memory are tightly coupled to the actual columns, so I think it's an okay approach there for units. I think it's sub-optimal for charge, but works for now while we are assuming USD. Once we have some sort of concept of different currencies this could be revisited.