### PR TITLE
Remove bad date logic around start of month in OCP data gen

### DIFF
--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -951,11 +951,15 @@ class ReportQueryHandler(object):
         else:
             current_total_sum = Decimal(query_sum.get('value') or 0)
         delta_field = self._mapper._report_type_map.get('delta_key').get(self._delta)
-        dates = [entry.get('date') for entry in query_data]
-        prev_total_filters = self._get_previous_totals_filter(dates)
-        prev_total_sum = previous_query\
-            .filter(prev_total_filters)\
-            .aggregate(value=delta_field)
+        prev_total_sum = previous_query.aggregate(value=delta_field)
+        if self.resolution == 'daily':
+            dates = [entry.get('date') for entry in query_data]
+            prev_total_filters = self._get_previous_totals_filter(dates)
+            if prev_total_filters:
+                prev_total_sum = previous_query\
+                    .filter(prev_total_filters)\
+                    .aggregate(value=delta_field)
+
         prev_total_sum = Decimal(prev_total_sum.get('value') or 0)
 
         total_delta = current_total_sum - prev_total_sum

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -23,7 +23,7 @@ from decimal import Decimal, DivisionByZero, InvalidOperation
 from itertools import groupby
 
 from dateutil import relativedelta
-from django.db.models import CharField, Count, F, Max, Sum, Value
+from django.db.models import CharField, Count, F, Max, Q, Sum, Value
 from django.db.models.functions import TruncDay, TruncMonth
 
 from api.report.query_filter import QueryFilter, QueryFilterCollection
@@ -894,6 +894,34 @@ class ReportQueryHandler(object):
 
         return previous_dict
 
+    def _get_previous_totals_filter(self, filter_dates):
+        """Filter previous time range to exlude days from the current range.
+
+        Specifically this covers days in the current range that have not yet
+        happened, but that data exists for in the previous range.
+
+        Args:
+            filter_dates (list) A list of date strings of dates to filter
+
+        Returns:
+            (django.db.models.query_utils.Q) The OR date filter
+
+        """
+        date_delta = self._get_date_delta()
+        prev_total_filters = None
+
+        for i in range(len(filter_dates)):
+            date = self.string_to_date(filter_dates[i])
+            date = date - date_delta
+            filter_dates[i] = self.date_to_string(date)
+
+        for date in filter_dates:
+            if prev_total_filters:
+                prev_total_filters = prev_total_filters | Q(usage_start=date)
+            else:
+                prev_total_filters = Q(usage_start=date)
+        return prev_total_filters
+
     def add_deltas(self, query_data, query_sum):
         """Calculate and add cost deltas to a result set.
 
@@ -923,7 +951,11 @@ class ReportQueryHandler(object):
         else:
             current_total_sum = Decimal(query_sum.get('value') or 0)
         delta_field = self._mapper._report_type_map.get('delta_key').get(self._delta)
-        prev_total_sum = previous_query.aggregate(value=delta_field)
+        dates = [entry.get('date') for entry in query_data]
+        prev_total_filters = self._get_previous_totals_filter(dates)
+        prev_total_sum = previous_query\
+            .filter(prev_total_filters)\
+            .aggregate(value=delta_field)
         prev_total_sum = Decimal(prev_total_sum.get('value') or 0)
 
         total_delta = current_total_sum - prev_total_sum

--- a/koku/api/report/test/ocp/helpers.py
+++ b/koku/api/report/test/ocp/helpers.py
@@ -52,22 +52,10 @@ class OCPReportDataGenerator:
             (self.dh.this_month_start, self.dh.this_month_end),
         ]
 
-        if self.one_month_ago.day >= 10:
-            self.report_ranges = [
+        self.report_ranges = [
                 (self.one_month_ago - relativedelta(days=i) for i in range(11)),
                 (self.today - relativedelta(days=i) for i in range(11)),
             ]
-        else:
-            self.report_ranges = [
-                (self.one_month_ago - relativedelta(days=i) for i in range(11)),
-                (self.today + relativedelta(days=i) for i in range(11)),
-            ]
-
-        self.this_month_filter = {'usage_start__gte': self.dh.this_month_start}
-        self.ten_day_filter = {'usage_start__gte': self.dh.n_days_ago(self.dh.today, 10)}
-        self.thirty_day_filter = {'usage_start__gte': self.dh.n_days_ago(self.dh.today, 30)}
-        self.last_month_filter = {'usage_start__gte': self.dh.last_month_start,
-                                  'usage_end__lte': self.dh.last_month_end}
 
     def add_data_to_tenant(self):
         """Populate tenant with data."""

--- a/koku/api/report/test/ocp/helpers.py
+++ b/koku/api/report/test/ocp/helpers.py
@@ -53,8 +53,8 @@ class OCPReportDataGenerator:
         ]
 
         self.report_ranges = [
-                (self.one_month_ago - relativedelta(days=i) for i in range(11)),
-                (self.today - relativedelta(days=i) for i in range(11)),
+                (self.one_month_ago - relativedelta(days=i) for i in range(10)),
+                (self.today - relativedelta(days=i) for i in range(10)),
             ]
 
     def add_data_to_tenant(self):

--- a/koku/api/report/test/ocp/helpers.py
+++ b/koku/api/report/test/ocp/helpers.py
@@ -53,9 +53,9 @@ class OCPReportDataGenerator:
         ]
 
         self.report_ranges = [
-                (self.one_month_ago - relativedelta(days=i) for i in range(10)),
-                (self.today - relativedelta(days=i) for i in range(10)),
-            ]
+            (self.one_month_ago - relativedelta(days=i) for i in range(10)),
+            (self.today - relativedelta(days=i) for i in range(10)),
+        ]
 
     def add_data_to_tenant(self):
         """Populate tenant with data."""

--- a/koku/api/report/test/ocp/tests_views.py
+++ b/koku/api/report/test/ocp/tests_views.py
@@ -533,14 +533,7 @@ class OCPReportViewTest(IamTestCase):
             current_total = OCPUsageLineItemDailySummary.objects\
                 .filter(usage_start__gte=this_month_start)\
                 .aggregate(total=Sum(F('pod_charge_cpu_cores') + F('pod_charge_memory_gigabytes'))).get('total')
-
-            prev_total = OCPUsageLineItemDailySummary.objects\
-                .filter(usage_start__gte=last_month_start)\
-                .filter(usage_start__lt=this_month_start)\
-                .aggregate(total=Sum(F('pod_charge_cpu_cores') + F('pod_charge_memory_gigabytes'))).get('total')
-
             current_total = current_total if current_total is not None else 0
-            prev_total = prev_total if prev_total is not None else 0
 
             current_totals = OCPUsageLineItemDailySummary.objects\
                 .filter(usage_start__gte=this_month_start)\
@@ -558,7 +551,12 @@ class OCPReportViewTest(IamTestCase):
         current_totals = {total.get('date'): total.get('total')
                           for total in current_totals}
         prev_totals = {date_to_string(string_to_date(total.get('date')) + date_delta): total.get('total')
-                       for total in prev_totals}
+                       for total in prev_totals
+                       if date_to_string(string_to_date(total.get('date')) + date_delta) in current_totals}
+
+        prev_total = sum(prev_totals.values())
+        prev_total = prev_total if prev_total is not None else 0
+
         expected_delta = current_total - prev_total
         delta = data.get('delta').get('value')
         self.assertEqual(round(delta, 3), round(float(expected_delta), 3))
@@ -569,7 +567,6 @@ class OCPReportViewTest(IamTestCase):
             delta_value = 0
             if values:
                 delta_value = values[0].get('delta_value')
-
             self.assertEqual(round(delta_value, 3), round(float(expected_delta), 3))
 
     def test_execute_query_ocp_charge_with_invalid_delta(self):

--- a/koku/api/report/test/tests_views.py
+++ b/koku/api/report/test/tests_views.py
@@ -375,7 +375,7 @@ class ReportViewTest(IamTestCase):
         self.assertEqual(result.get('units'), expected_unit)
 
     def test_execute_query_w_delta_total(self):
-        """Test that delta=True returns deltas."""
+        """Test that delta=total returns deltas."""
         qs = 'delta=total'
         url = reverse('reports-costs') + '?' + qs
         client = APIClient()


### PR DESCRIPTION
## Summary
This fixes some bad test data creation assumptions around the beginning of the month. 
It also highlighted issues with our delta calculations when resolution is daily. The delta totals were using all days in the previous time period, but our daily deltas only show for days we have data in the current date range. This filters out results from the previous date range for days in the current range that have not happened yet.