### PR TITLE
Update ordering for totals response.

### DIFF
--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -262,8 +262,8 @@ class ProviderMap(object):
                         'aggregates': {
                             'usage': Sum('pod_usage_cpu_core_hours'),
                             'request': Sum('pod_request_cpu_core_hours'),
-                            'charge': Sum('pod_charge_cpu_core_hours'),
-                            'limit': Sum('pod_limit_cpu_core_hours')
+                            'limit': Sum('pod_limit_cpu_core_hours'),
+                            'charge': Sum('pod_charge_cpu_core_hours')
                         },
                         'capacity_aggregate': {
                             'capacity': Max('cluster_capacity_cpu_core_hours')
@@ -290,8 +290,8 @@ class ProviderMap(object):
                         'aggregates': {
                             'usage': Sum('pod_usage_memory_gigabyte_hours'),
                             'request': Sum('pod_request_memory_gigabyte_hours'),
-                            'charge': Sum('pod_charge_memory_gigabyte_hours'),
-                            'limit': Sum('pod_limit_memory_gigabyte_hours')
+                            'limit': Sum('pod_limit_memory_gigabyte_hours'),
+                            'charge': Sum('pod_charge_memory_gigabyte_hours')
                         },
                         'capacity_aggregate': {
                             'capacity': Max('cluster_capacity_memory_gigabyte_hours')
@@ -301,8 +301,8 @@ class ProviderMap(object):
                             'usage': Sum('pod_usage_memory_gigabyte_hours'),
                             'request': Sum('pod_request_memory_gigabyte_hours'),
                             'capacity': Max('cluster_capacity_memory_gigabyte_hours'),
-                            'charge': Sum('pod_charge_memory_gigabyte_hours'),
                             'limit': Sum('pod_limit_memory_gigabyte_hours'),
+                            'charge': Sum('pod_charge_memory_gigabyte_hours'),
                             'units': Value('GB-Hours', output_field=CharField())
                         },
                         'delta_key': {


### PR DESCRIPTION
GET `http://127.0.0.1:8000/api/v1/reports/inventory/ocp/cpu/?filter[time_scope_value]=-2&filter[resolution]=monthly&filter[time_scope_units]=month&group_by[project]=*&delta=usage__capacity&filter[limit]=5`

Response:
```
{
    "group_by": {
        "project": [
            "*"
        ]
    },
    "filter": {
        "resolution": "monthly",
        "time_scope_value": "-2",
        "time_scope_units": "month",
        "limit": 5
    },
    "delta": {
        "value": 2789.804022,
        "percent": 598.2979326009739
    },
    "data": [
        {
            "date": "2018-11",
            "projects": [
                {
                    "project": "monitoring",
                    "values": [
                        {
                            "date": "2018-11",
                            "project": "monitoring",
                            "usage": 1639.927512,
                            "request": 3799.255248,
                            "limit": 4384.368,
                            "capacity": 96,
                            "charge": 771.330528,
                            "units": "Core-Hours",
                            "delta_value": 1543.927512,
                            "delta_percent": 1708.257825
                        }
                    ]
                },
                {
                    "project": "metering-koku",
                    "values": [
                        {
                            "date": "2018-11",
                            "project": "metering-koku",
                            "usage": 1049.763456,
                            "request": 23555.04012,
                            "limit": 30358.8,
                            "capacity": 96,
                            "charge": 4718.356344,
                            "units": "Core-Hours",
                            "delta_value": 953.763456,
                            "delta_percent": 1093.5036
                        }
                    ]
                },
                {
                    "project": "metering-hccm",
                    "values": [
                        {
                            "date": "2018-11",
                            "project": "metering-hccm",
                            "usage": 659.97972,
                            "request": 3271.139928,
                            "limit": 349.860024,
                            "capacity": 95.933333,
                            "charge": 658.847808,
                            "units": "Core-Hours",
                            "delta_value": 564.046387,
                            "delta_percent": 687.9566250450196
                        }
                    ]
                }
            ]
        }
    ],
    "total": {
        "usage": 3349.670688,
        "request": 30625.435296,
        "limit": 35093.028024,
        "charge": 6148.53468,
        "capacity": 559.866666,
        "units": "Core-Hours"
    }
}
```