### PR TITLE
Don't allow order by delta without a delta param

### DIFF
--- a/koku/api/report/ocp/serializers.py
+++ b/koku/api/report/ocp/serializers.py
@@ -237,6 +237,11 @@ class OCPQueryParamSerializer(serializers.Serializer):
         Raises:
             (ValidationError): if field inputs are invalid
         """
+        error = {}
+        if 'delta' in data.get('order_by', {}) and 'delta' not in data:
+            error['order_by'] = _('Cannot order by delta without a delta param')
+            raise serializers.ValidationError(error)
+
         handle_invalid_fields(self, data)
         return data
 

--- a/koku/api/report/test/ocp/tests_serializers.py
+++ b/koku/api/report/test/ocp/tests_serializers.py
@@ -270,6 +270,22 @@ class OCPInventoryQueryParamSerializerTest(TestCase):
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
+    def test_order_by_delta_with_delta(self):
+        """Test that order_by[delta] works with a delta param."""
+        query_params = {
+            'delta': 'usage__request',
+            'order_by': {'delta': 'asc'}
+        }
+        serializer = OCPInventoryQueryParamSerializer(data=query_params)
+        self.assertTrue(serializer.is_valid())
+
+    def test_order_by_delta_without_delta(self):
+        """Test that order_by[delta] does not work without a delta param."""
+        query_params = {'order_by': {'delta': 'asc'}}
+        serializer = OCPInventoryQueryParamSerializer(data=query_params)
+        with self.assertRaises(serializers.ValidationError):
+            serializer.is_valid(raise_exception=True)
+
 
 class OCPChargeQueryParamSerializerTest(TestCase):
     """Tests for the handling charge query parameter parsing serializer."""


### PR DESCRIPTION
## Summary
order_by[delta] is now blocked at the serializer level when a delta param is not specified