### PR TITLE
Bugfix for #499 that orders the total output by annotation order to match group order.

### DIFF
--- a/koku/api/report/aws/aws_query_handler.py
+++ b/koku/api/report/aws/aws_query_handler.py
@@ -149,7 +149,12 @@ class AWSReportQueryHandler(ReportQueryHandler):
                 data = self._apply_group_by(list(query_data))
                 data = self._transform_data(query_group_by, 0, data)
 
-        self.query_sum = query_sum
+        key_order = list(set(['units'] + list(annotations.keys())))
+        ordered_total = {total_key: query_sum[total_key]
+                         for total_key in key_order if total_key in query_sum}
+        ordered_total.update(query_sum)
+
+        self.query_sum = ordered_total
         self.query_data = data
         return self._format_query_response()
 

--- a/koku/api/report/ocp/ocp_query_handler.py
+++ b/koku/api/report/ocp/ocp_query_handler.py
@@ -149,7 +149,11 @@ class OCPReportQueryHandler(ReportQueryHandler):
 
         query_sum.update({'units': self._mapper.units_key})
 
-        self.query_sum = query_sum
+        ordered_total = {total_key: query_sum[total_key]
+                         for total_key in annotations.keys() if total_key in query_sum}
+        ordered_total.update(query_sum)
+
+        self.query_sum = ordered_total
         self.query_data = data
         return self._format_query_response()
 

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -74,8 +74,7 @@ class ProviderMap(object):
                 },
                 'report_type': {
                     'costs': {
-                        'aggregate': {'value': Sum('unblended_cost'),
-                                      'cost': Sum('unblended_cost')},
+                        'aggregate': {'value': Sum('unblended_cost')},
                         'aggregate_key': 'unblended_cost',
                         'annotations': {'total': Sum('unblended_cost'),
                                         'units': Max('currency_code')},
@@ -170,9 +169,9 @@ class ProviderMap(object):
                     },
                     'instance_type': {
                         'aggregate': {
-                            'value': Sum('usage_amount'),
                             'cost': Sum('unblended_cost'),
                             'count': Sum('resource_count '),
+                            'value': Sum('usage_amount'),
                         },
                         'aggregate_key': 'usage_amount',
                         'annotations': {'cost': Sum('unblended_cost'),
@@ -192,9 +191,9 @@ class ProviderMap(object):
                     },
                     'storage': {
                         'aggregate': {
-                            'value': Sum('usage_amount'),
                             'cost': Sum('unblended_cost'),
                             'count': Sum('resource_count'),
+                            'value': Sum('usage_amount'),
                         },
                         'aggregate_key': 'usage_amount',
                         'annotations': {'cost': Sum('unblended_cost'),
@@ -300,8 +299,8 @@ class ProviderMap(object):
                         'annotations': {
                             'usage': Sum('pod_usage_memory_gigabyte_hours'),
                             'request': Sum('pod_request_memory_gigabyte_hours'),
-                            'capacity': Max('cluster_capacity_memory_gigabyte_hours'),
                             'limit': Sum('pod_limit_memory_gigabyte_hours'),
+                            'capacity': Max('cluster_capacity_memory_gigabyte_hours'),
                             'charge': Sum('pod_charge_memory_gigabyte_hours'),
                             'units': Value('GB-Hours', output_field=CharField())
                         },


### PR DESCRIPTION
Fixes for both OCP & AWS.

GET `/api/v1/reports/inventory/aws/storage/?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=daily`
```
{
    "filter": {
        "resolution": "daily",
        "time_scope_value": "-1",
        "time_scope_units": "month"
    },
    "data": [
        {
            "date": "2018-12-01",
            "values": [
                {
                    "date": "2018-12-01",
                    "units": null,
                    "cost": 0,
                    "total": 1.584125571
                }
            ]
        },
        {
            "date": "2018-12-02",
            "values": [
                {
                    "date": "2018-12-02",
                    "units": null,
                    "cost": 0,
                    "total": 0.035367831
                }
            ]
        },
...
        {
            "date": "2018-12-31",
            "values": []
        }
    ],
    "total": {
        "units": null,
        "cost": 0.14784946,
        "value": 17.697224883
    }
}
```
GET `/api/v1/reports/inventory/aws/instance-type/?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=daily`
```
{
    "filter": {
        "resolution": "daily",
        "time_scope_value": "-1",
        "time_scope_units": "month"
    },
    "data": [
        {
            "date": "2018-12-01",
            "instance_types": [
                {
                    "instance_type": "t2.micro",
                    "values": [
                        {
                            "instance_type": "t2.micro",
                            "date": "2018-12-01",
                            "units": null,
                            "cost": 0,
                            "count": 0,
                            "total": 20
                        }
                    ]
                },
                {
                    "instance_type": "t2.small",
                    "values": [
                        {
                            "instance_type": "t2.small",
                            "date": "2018-12-01",
                            "units": "Hrs",
                            "cost": 0.94,
                            "count": 1,
                            "total": 20
                        }
                    ]
                },
                {
                    "instance_type": "db.t2.small",
                    "values": [
                        {
                            "instance_type": "db.t2.small",
                            "date": "2018-12-01",
                            "units": "Hrs",
                            "cost": 0.252,
                            "count": 1,
                            "total": 7
                        }
                    ]
                },
                {
                    "instance_type": "t2.xlarge",
                    "values": [
                        {
                            "instance_type": "t2.xlarge",
                            "date": "2018-12-01",
                            "units": "Hrs",
                            "cost": 1.7192,
                            "count": 1,
                            "total": 7
                        }
                    ]
                }
            ]
        },
        {
            "date": "2018-12-02",
            "instance_types": [
                {
                    "instance_type": "t2.small",
                    "values": [
                        {
                            "instance_type": "t2.small",
                            "date": "2018-12-02",
                            "units": "Hrs",
                            "cost": 0.069,
                            "count": 0,
                            "total": 3
                        }
                    ]
                },
                {
                    "instance_type": "t2.micro",
                    "values": [
                        {
                            "instance_type": "t2.micro",
                            "date": "2018-12-02",
                            "units": null,
                            "cost": 0,
                            "count": 0,
                            "total": 2
                        }
                    ]
                }
            ]
        },
        {
            "date": "2018-12-03",
            "instance_types": [
                {
                    "instance_type": "t2.small",
                    "values": [
                        {
                            "instance_type": "t2.small",
                            "date": "2018-12-03",
                            "units": "Hrs",
                            "cost": 1.106,
                            "count": 1,
                            "total": 22
                        }
                    ]
                },
                {
                    "instance_type": "t2.micro",
                    "values": [
                        {
                            "instance_type": "t2.micro",
                            "date": "2018-12-03",
                            "units": null,
                            "cost": 0,
                            "count": 0,
                            "total": 22
                        }
                    ]
                },
                {
                    "instance_type": "t2.xlarge",
                    "values": [
                        {
                            "instance_type": "t2.xlarge",
                            "date": "2018-12-03",
                            "units": "Hrs",
                            "cost": 1.9648,
                            "count": 1,
                            "total": 8
                        }
                    ]
                },
                {
                    "instance_type": "db.t2.small",
                    "values": [
                        {
                            "instance_type": "db.t2.small",
                            "date": "2018-12-03",
                            "units": "Hrs",
                            "cost": 0.288,
                            "count": 1,
                            "total": 8
                        }
                    ]
                }
            ]
        },
...
        {
            "date": "2018-12-31",
            "instance_types": []
        }
    ],
    "total": {
        "units": "Hrs",
        "cost": 33.9992,
        "count": 3,
        "value": 582
    }
}
```
GET `/api/v1/reports/inventory/ocp/memory/?filter[time_scope_value]=-2&filter[resolution]=monthly&filter[time_scope_units]=month&group_by[project]=*&delta=usage__capacity&filter[limit]=5`
```
{
    "group_by": {
        "project": [
            "*"
        ]
    },
    "filter": {
        "resolution": "monthly",
        "time_scope_value": "-2",
        "time_scope_units": "month",
        "limit": 5
    },
    "delta": {
        "value": 57497.053702,
        "percent": 2567.2477639558697
    },
    "data": [
        {
            "date": "2018-11",
            "projects": [
                {
                    "project": "monitoring",
                    "values": [
                        {
                            "date": "2018-11",
                            "project": "monitoring",
                            "usage": 18191.87433,
                            "request": 26417.82375,
                            "limit": 8085.77874,
                            "capacity": 399.78487,
                            "charge": 1484.61831,
                            "units": "GB-Hours",
                            "delta_value": 17792.08946,
                            "delta_percent": 4550.415909936762
                        }
                    ]
                },
                {
                    "project": "metering-koku",
                    "values": [
                        {
                            "date": "2018-11",
                            "project": "metering-koku",
                            "usage": 30161.89296,
                            "request": 37250.65584,
                            "limit": 51339.62115,
                            "capacity": 399.78487,
                            "charge": 2133.98964,
                            "units": "GB-Hours",
                            "delta_value": 29762.10809,
                            "delta_percent": 7544.5308773190945
                        }
                    ]
                },
                {
                    "project": "metering-hccm",
                    "values": [
                        {
                            "date": "2018-11",
                            "project": "metering-hccm",
                            "usage": 11473.69905,
                            "request": 12343.19958,
                            "limit": 834.19677,
                            "capacity": 399.507242,
                            "charge": 720.42327,
                            "units": "GB-Hours",
                            "delta_value": 11074.191808,
                            "delta_percent": 2871.9627190137394
                        }
                    ]
                }
            ]
        }
    ],
    "total": {
        "usage": 59827.46634,
        "request": 76011.67917,
        "limit": 60259.59666,
        "capacity": 2330.412638,
        "charge": 4339.03122,
        "units": "GB-Hours"
    }
}
```