### PR TITLE
Fixed the ordering in the AWS total by annotation.

### DIFF
--- a/koku/api/report/aws/aws_query_handler.py
+++ b/koku/api/report/aws/aws_query_handler.py
@@ -67,7 +67,7 @@ class AWSReportQueryHandler(ReportQueryHandler):
         units_fallback = self._mapper._report_type_map.get('units_fallback')
         annotations = {
             'date': self.date_trunc('usage_start'),
-            'units': Coalesce(Concat(self._mapper.units_key, Value('')), Value(units_fallback))
+            'units': Coalesce(self._mapper.units_key, Value(units_fallback))
         }
 
         # { query_param: database_field_name }
@@ -132,8 +132,7 @@ class AWSReportQueryHandler(ReportQueryHandler):
             if query.exists():
                 units_fallback = self._mapper._report_type_map.get('units_fallback')
                 sum_annotations = {
-                    'units': Coalesce(Value(units_fallback),
-                                      Concat(self._mapper.units_key, Value('')))
+                    'units': Coalesce(self._mapper.units_key, Value(units_fallback))
                 }
                 sum_query = query.annotate(**sum_annotations)
                 units_value = sum_query.values('units').first().get('units')

--- a/koku/api/report/aws/aws_query_handler.py
+++ b/koku/api/report/aws/aws_query_handler.py
@@ -67,7 +67,7 @@ class AWSReportQueryHandler(ReportQueryHandler):
         units_fallback = self._mapper._report_type_map.get('units_fallback')
         annotations = {
             'date': self.date_trunc('usage_start'),
-            'units': Coalesce(Value(units_fallback), Concat(self._mapper.units_key, Value('')))
+            'units': Coalesce(Concat(self._mapper.units_key, Value('')), Value(units_fallback))
         }
 
         # { query_param: database_field_name }

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -24,7 +24,7 @@ from itertools import groupby
 
 from dateutil import relativedelta
 from django.db.models import CharField, Count, F, Max, Q, Sum, Value
-from django.db.models.functions import TruncDay, TruncMonth
+from django.db.models.functions import Coalesce, TruncDay, TruncMonth
 
 from api.report.query_filter import QueryFilter, QueryFilterCollection
 from api.utils import DateHelper
@@ -77,11 +77,14 @@ class ProviderMap(object):
                         'aggregate': {'value': Sum('unblended_cost')},
                         'aggregate_key': 'unblended_cost',
                         'annotations': {'total': Sum('unblended_cost'),
-                                        'units': Max('currency_code')},
+                                        'units': Coalesce(Max('currency_code'),
+                                        Value('USD'))
+                        },
                         'count': None,
                         'delta_key': {'total': Sum('unblended_cost')},
                         'filter': {},
                         'units_key': 'currency_code',
+                        'units_fallback': 'USD',
                         'sum_columns': ['total'],
                         'default_ordering': {'total': 'desc'},
                     },
@@ -96,7 +99,8 @@ class ProviderMap(object):
                                         # The summary table already already has counts
                                         'count': Sum('resource_count'),
                                         'total': Sum('usage_amount'),
-                                        'units': Max('unit')},
+                                        'units': Coalesce(Max('unit'),
+                                        Value('Hrs'))},
                         'count': 'resource_count',
                         'delta_key': {'total': Sum('usage_amount')},
                         'filter': {
@@ -105,6 +109,7 @@ class ProviderMap(object):
                             'parameter': False
                         },
                         'units_key': 'unit',
+                        'units_fallback': 'Hrs',
                         'sum_columns': ['total'],
                         'default_ordering': {'total': 'desc'},
                     },
@@ -116,7 +121,8 @@ class ProviderMap(object):
                         'aggregate_key': 'usage_amount',
                         'annotations': {'cost': Sum('unblended_cost'),
                                         'total': Sum('usage_amount'),
-                                        'units': Max('unit')},
+                                        'units': Coalesce(Max('unit'),
+                                        Value('GB-Mo'))},
                         'count': None,
                         'delta_key': {'total': Sum('usage_amount')},
                         'filter': {
@@ -125,6 +131,7 @@ class ProviderMap(object):
                             'parameter': 'Storage'
                         },
                         'units_key': 'unit',
+                        'units_fallback': 'GB-Mo',
                         'sum_columns': ['total'],
                         'default_ordering': {'total': 'desc'},
                     },
@@ -160,11 +167,13 @@ class ProviderMap(object):
                         },
                         'aggregate_key': 'unblended_cost',
                         'annotations': {'total': Sum('unblended_cost'),
-                                        'units': Max('currency_code')},
+                                        'units': Coalesce(Max('currency_code'),
+                                        Value('USD'))},
                         'count': None,
                         'delta_key': {'total': Sum('unblended_cost')},
                         'filter': {},
                         'units_key': 'currency_code',
+                        'units_fallback': 'USD',
                         'sum_columns': ['total'],
                     },
                     'instance_type': {
@@ -177,7 +186,8 @@ class ProviderMap(object):
                         'annotations': {'cost': Sum('unblended_cost'),
                                         'count': Count('resource_id', distinct=True),
                                         'total': Sum('usage_amount'),
-                                        'units': Max('cost_entry_pricing__unit')},
+                                        'units': Coalesce(Max('cost_entry_pricing__unit'),
+                                        Value('Hrs'))},
                         'count': 'resource_id',
                         'delta_key': {'total': Sum('usage_amount')},
                         'filter': {
@@ -187,6 +197,7 @@ class ProviderMap(object):
                             'parameter': False
                         },
                         'units_key': 'cost_entry_pricing__unit',
+                        'units_fallback': 'Hrs',
                         'sum_columns': ['total'],
                     },
                     'storage': {
@@ -199,7 +210,8 @@ class ProviderMap(object):
                         'annotations': {'cost': Sum('unblended_cost'),
                                         'count': Count('resource_id', distinct=True),
                                         'total': Sum('usage_amount'),
-                                        'units': Max('cost_entry_pricing__unit')},
+                                        'units': Coalesce(Max('cost_entry_pricing__unit'),
+                                        Value('GB-Mo'))},
                         'count': 'resource_id',
                         'delta_key': {'total': Sum('usage_amount')},
                         'filter': {
@@ -209,6 +221,7 @@ class ProviderMap(object):
                             'parameter': 'Storage'
                         },
                         'units_key': 'cost_entry_pricing__unit',
+                        'units_fallback': 'GB-Mo',
                         'sum_columns': ['total'],
                     },
                 },

--- a/koku/api/report/view.py
+++ b/koku/api/report/view.py
@@ -165,8 +165,6 @@ def _generic_report(request, provider_parameter_serializer, provider_query_hdlr,
         (Response): The report in a Response object
 
     """
-    LOG.info(f'API: {request.path} USER: {request.user.username}')
-
     url_data = request.GET.urlencode()
     validation, params = process_query_parameters(url_data, provider_parameter_serializer)
     if not validation:

--- a/koku/koku/middleware.py
+++ b/koku/koku/middleware.py
@@ -157,6 +157,8 @@ class IdentityHeaderMiddleware(MiddlewareMixin):  # pylint: disable=R0903
             return
         if (username and email and account and org):
             # Check for customer creation & user creation
+            logger.info(f'API: {request.path}?{request.META["QUERY_STRING"]}'  # pylint: disable=W1203
+                        ' -- ACCOUNT: {account} USER: {username}')
             try:
                 customer = Customer.objects.filter(account_id=account, org_id=org).get()
             except Customer.DoesNotExist:

--- a/koku/koku/settings.py
+++ b/koku/koku/settings.py
@@ -268,6 +268,10 @@ LOGGING = {
             'handlers': LOGGING_HANDLERS,
             'level': KOKU_LOGGING_LEVEL,
         },
+        'koku': {
+            'handlers': LOGGING_HANDLERS,
+            'level': KOKU_LOGGING_LEVEL,
+        },
         'providers': {
             'handlers': LOGGING_HANDLERS,
             'level': KOKU_LOGGING_LEVEL,

--- a/koku/koku/tests_middleware.py
+++ b/koku/koku/tests_middleware.py
@@ -83,6 +83,7 @@ class IdentityHeaderMiddlewareTest(IamTestCase):
                                                             create_customer=False)
         self.request = self.request_context['request']
         self.request.path = '/api/v1/providers/'
+        self.request.META['QUERY_STRING'] = ''
 
     def test_process_status(self):
         """Test that the request gets a user."""


### PR DESCRIPTION
- Bug was because I was creating a set and this caused the order to vary.
- Added logging into middleware to capture Path+Querystring and Account and Username
- Added fallback units to AWS values