### PR TITLE
Removing operations

### DIFF
--- a/koku/api/report/aws/aws_query_handler.py
+++ b/koku/api/report/aws/aws_query_handler.py
@@ -170,33 +170,7 @@ class AWSReportQueryHandler(ReportQueryHandler):
             (Dict): Dictionary response of query params, data, and total
 
         """
-        if self.is_sum:
-            return self.execute_sum_query()
-
-        query_sum = {'value': 0}
-        data = []
-
-        q_table = self._mapper._operation_map.get('tables').get('query')
-        with tenant_context(self.tenant):
-            query = q_table.objects.filter(self.query_filter)
-            query_data = query.annotate(**self.annotations)
-
-            query_group_by = ['date'] + self._get_group_by()
-            query_group_by_with_units = query_group_by + ['units']
-
-            query_order_by = ('-date',)
-            query_data = query_data.order_by(*query_order_by)
-            values_out = query_group_by_with_units + EXPORT_COLUMNS
-            data = list(query_data.values(*values_out))
-
-            if query.exists():
-                units_key = self._mapper.units_key
-                units_value = query.values(units_key).first().get(units_key)
-                query_sum = self.calculate_total(units_value)
-
-        self.query_sum = query_sum
-        self.query_data = data
-        return self._format_query_response()
+        return self.execute_sum_query()
 
     def calculate_total(self, units_value):
         """Calculate aggregated totals for the query.

--- a/koku/api/report/aws/aws_query_handler.py
+++ b/koku/api/report/aws/aws_query_handler.py
@@ -71,7 +71,7 @@ class AWSReportQueryHandler(ReportQueryHandler):
         }
 
         # { query_param: database_field_name }
-        fields = self._mapper._operation_map.get('annotations')
+        fields = self._mapper._provider_map.get('annotations')
         for q_param, db_field in fields.items():
             annotations[q_param] = Concat(db_field, Value(''))
 
@@ -103,7 +103,7 @@ class AWSReportQueryHandler(ReportQueryHandler):
         query_sum = {'value': 0}
         data = []
 
-        q_table = self._mapper._operation_map.get('tables').get('query')
+        q_table = self._mapper._provider_map.get('tables').get('query')
         with tenant_context(self.tenant):
             query = q_table.objects.filter(self.query_filter)
             query_data = query.annotate(**self.annotations)
@@ -116,7 +116,7 @@ class AWSReportQueryHandler(ReportQueryHandler):
 
             if 'account' in query_group_by:
                 query_data = query_data.annotate(account_alias=Coalesce(
-                    F(self._mapper._operation_map.get('alias')), 'usage_account_id'))
+                    F(self._mapper._provider_map.get('alias')), 'usage_account_id'))
 
             if self._limit:
                 rank_order = getattr(F(self.order_field), self.order_direction)()
@@ -196,7 +196,7 @@ class AWSReportQueryHandler(ReportQueryHandler):
         else:
             total_filter = total_filter & time_and_report_filter
 
-        q_table = self._mapper._operation_map.get('tables').get('total')
+        q_table = self._mapper._provider_map.get('tables').get('total')
         aggregates = self._mapper._report_type_map.get('aggregate')
         total_query = q_table.objects.filter(total_filter).aggregate(**aggregates)
         total_query['units'] = units_value

--- a/koku/api/report/aws/serializers.py
+++ b/koku/api/report/aws/serializers.py
@@ -155,7 +155,6 @@ class QueryParamSerializer(serializers.Serializer):
     # Tuples are (key, display_name)
     OPERATION_CHOICES = (
         ('sum', 'sum'),
-        ('none', 'none'),
     )
 
     DELTA_CHOICES = (

--- a/koku/api/report/aws/serializers.py
+++ b/koku/api/report/aws/serializers.py
@@ -153,10 +153,6 @@ class QueryParamSerializer(serializers.Serializer):
     """Serializer for handling query parameters."""
 
     # Tuples are (key, display_name)
-    OPERATION_CHOICES = (
-        ('sum', 'sum'),
-    )
-
     DELTA_CHOICES = (
         ('total', 'total')
     )
@@ -166,8 +162,6 @@ class QueryParamSerializer(serializers.Serializer):
     order_by = OrderBySerializer(required=False)
     filter = FilterSerializer(required=False)
     units = serializers.CharField(required=False)
-    operation = serializers.ChoiceField(choices=OPERATION_CHOICES,
-                                        required=False)
 
     def validate(self, data):
         """Validate incoming data.

--- a/koku/api/report/ocp/ocp_query_handler.py
+++ b/koku/api/report/ocp/ocp_query_handler.py
@@ -59,7 +59,7 @@ class OCPReportQueryHandler(ReportQueryHandler):
         annotations = {'date': self.date_trunc('usage_start')}
 
         # { query_param: database_field_name }
-        fields = self._mapper._operation_map.get('annotations')
+        fields = self._mapper._provider_map.get('annotations')
         for q_param, db_field in fields.items():
             annotations[q_param] = Concat(db_field, Value(''))
 
@@ -91,7 +91,7 @@ class OCPReportQueryHandler(ReportQueryHandler):
         query_sum = {'value': 0}
         data = []
 
-        q_table = self._mapper._operation_map.get('tables').get('query')
+        q_table = self._mapper._provider_map.get('tables').get('query')
         with tenant_context(self.tenant):
             query = q_table.objects.filter(self.query_filter)
             query_data = query.annotate(**self.annotations)
@@ -174,7 +174,7 @@ class OCPReportQueryHandler(ReportQueryHandler):
 
         cap_key = list(annotations.keys())[0]
         total_capacity = Decimal(0)
-        q_table = self._mapper._operation_map.get('tables').get('query')
+        q_table = self._mapper._provider_map.get('tables').get('query')
         query = q_table.objects.filter(self.query_filter)
         query_group_by = ['usage_start']
 

--- a/koku/api/report/ocp/ocp_query_handler.py
+++ b/koku/api/report/ocp/ocp_query_handler.py
@@ -82,7 +82,7 @@ class OCPReportQueryHandler(ReportQueryHandler):
         return output
 
     def execute_sum_query(self):
-        """Execute query and return provided data when self.is_sum == True.
+        """Execute query and return provided data.
 
         Returns:
             (Dict): Dictionary response of query params, data, and total

--- a/koku/api/report/ocp/serializers.py
+++ b/koku/api/report/ocp/serializers.py
@@ -216,15 +216,9 @@ class OCPQueryParamSerializer(serializers.Serializer):
     """Serializer for handling query parameters."""
 
     # Tuples are (key, display_name)
-    OPERATION_CHOICES = (
-        ('sum', 'sum'),
-    )
-
     group_by = GroupBySerializer(required=False)
     filter = FilterSerializer(required=False)
     units = serializers.CharField(required=False)
-    operation = serializers.ChoiceField(choices=OPERATION_CHOICES,
-                                        required=False)
 
     def validate(self, data):
         """Validate incoming data.

--- a/koku/api/report/ocp/serializers.py
+++ b/koku/api/report/ocp/serializers.py
@@ -218,7 +218,6 @@ class OCPQueryParamSerializer(serializers.Serializer):
     # Tuples are (key, display_name)
     OPERATION_CHOICES = (
         ('sum', 'sum'),
-        ('none', 'none'),
     )
 
     group_by = GroupBySerializer(required=False)

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -21,13 +21,12 @@ from collections import OrderedDict, defaultdict
 from decimal import Decimal, DivisionByZero, InvalidOperation
 from itertools import groupby
 
-from django.db.models import CharField, Count, F, Max, Q, Sum, Value
+from django.db.models import CharField, F, Max, Q, Sum, Value
 from django.db.models.functions import Coalesce
 
 from api.query_filter import QueryFilter
 from api.query_handler import QueryHandler
-from reporting.models import (AWSCostEntryLineItem,
-                              AWSCostEntryLineItemAggregates,
+from reporting.models import (AWSCostEntryLineItemAggregates,
                               AWSCostEntryLineItemDailySummary,
                               OCPUsageLineItemAggregates,
                               OCPUsageLineItemDailySummary)
@@ -35,7 +34,6 @@ from reporting.models import (AWSCostEntryLineItem,
 LOG = logging.getLogger(__name__)
 WILDCARD = '*'
 OPERATION_SUM = 'sum'
-OPERATION_NONE = 'none'
 
 
 class ProviderMap(object):
@@ -139,95 +137,6 @@ class ProviderMap(object):
                            'query': AWSCostEntryLineItemDailySummary,
                            'total': AWSCostEntryLineItemAggregates},
             },
-            OPERATION_NONE: {
-                'alias': 'account_alias__account_alias',
-                'annotations': {'account': 'usage_account_id',
-                                'service': 'product_code',
-                                'avail_zone': 'availability_zone',
-                                'region': 'cost_entry_product__region'},
-                'end_date': 'usage_end',
-                'filters': {
-                    'account': {'field': 'account_alias__account_alias',
-                                'operation': 'icontains'},
-                    'service': {'field': 'product_code',
-                                'operation': 'icontains'},
-                    'avail_zone': {'field': 'availability_zone',
-                                   'operation': 'icontains'},
-                    'region': {'field': 'availability_zone',
-                               'operation': 'icontains',
-                               'table': 'cost_entry_product'}
-                },
-                'report_type': {
-                    'costs': {
-                        'aggregate': {
-                            'value': Sum('unblended_cost'),
-                            'cost': Sum('unblended_cost')
-                        },
-                        'aggregate_key': 'unblended_cost',
-                        'annotations': {'total': Sum('unblended_cost'),
-                                        'units': Coalesce(Max('currency_code'),
-                                        Value('USD'))},
-                        'count': None,
-                        'delta_key': {'total': Sum('unblended_cost')},
-                        'filter': {},
-                        'units_key': 'currency_code',
-                        'units_fallback': 'USD',
-                        'sum_columns': ['total'],
-                    },
-                    'instance_type': {
-                        'aggregate': {
-                            'cost': Sum('unblended_cost'),
-                            'count': Sum('resource_count '),
-                            'value': Sum('usage_amount'),
-                        },
-                        'aggregate_key': 'usage_amount',
-                        'annotations': {'cost': Sum('unblended_cost'),
-                                        'count': Count('resource_id', distinct=True),
-                                        'total': Sum('usage_amount'),
-                                        'units': Coalesce(Max('cost_entry_pricing__unit'),
-                                        Value('Hrs'))},
-                        'count': 'resource_id',
-                        'delta_key': {'total': Sum('usage_amount')},
-                        'filter': {
-                            'field': 'instance_type',
-                            'table': 'cost_entry_product',
-                            'operation': 'isnull',
-                            'parameter': False
-                        },
-                        'units_key': 'cost_entry_pricing__unit',
-                        'units_fallback': 'Hrs',
-                        'sum_columns': ['total'],
-                    },
-                    'storage': {
-                        'aggregate': {
-                            'cost': Sum('unblended_cost'),
-                            'count': Sum('resource_count'),
-                            'value': Sum('usage_amount'),
-                        },
-                        'aggregate_key': 'usage_amount',
-                        'annotations': {'cost': Sum('unblended_cost'),
-                                        'count': Count('resource_id', distinct=True),
-                                        'total': Sum('usage_amount'),
-                                        'units': Coalesce(Max('cost_entry_pricing__unit'),
-                                        Value('GB-Mo'))},
-                        'count': 'resource_id',
-                        'delta_key': {'total': Sum('usage_amount')},
-                        'filter': {
-                            'field': 'product_family',
-                            'table': 'cost_entry_product',
-                            'operation': 'contains',
-                            'parameter': 'Storage'
-                        },
-                        'units_key': 'cost_entry_pricing__unit',
-                        'units_fallback': 'GB-Mo',
-                        'sum_columns': ['total'],
-                    },
-                },
-                'start_date': 'usage_start',
-                'tables': {'query': AWSCostEntryLineItem,
-                           'previous_query': AWSCostEntryLineItem,
-                           'total': AWSCostEntryLineItemAggregates},
-            }
         },
     }, {
         'provider': 'OCP',

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -261,16 +261,16 @@ class ProviderMap(object):
         op_data = ProviderMap.operation_data(operation, provider)
         return op_data.get('report_type').get(report_type)
 
-    def __init__(self, provider, operation, report_type):
+    def __init__(self, provider, report_type):
         """Constructor."""
         self._provider = provider
-        self._operation = operation
+        self._operation = OPERATION_SUM
         self._report_type = report_type
 
         self._map = ProviderMap.mapping
         self._provider_map = ProviderMap.provider_data(provider)
-        self._operation_map = ProviderMap.operation_data(operation, provider)
-        self._report_type_map = ProviderMap.report_type_data(report_type, operation, provider)
+        self._operation_map = ProviderMap.operation_data(OPERATION_SUM, provider)
+        self._report_type_map = ProviderMap.report_type_data(report_type, OPERATION_SUM, provider)
 
     @property
     def count(self):
@@ -314,9 +314,7 @@ class ReportQueryHandler(QueryHandler):
 
         assert getattr(self, '_report_type'), \
             'kwargs["report_type"] is missing!'
-        self.operation = query_parameters.get('operation', OPERATION_SUM)
         self._mapper = ProviderMap(provider=kwargs.get('provider'),
-                                   operation=self.operation,
                                    report_type=self._report_type)
         default_ordering = self._mapper._report_type_map.get('default_ordering')
 
@@ -330,16 +328,6 @@ class ReportQueryHandler(QueryHandler):
         self.query_delta = {'value': None, 'percent': None}
 
         self.query_filter = self._get_filter()
-
-    @property
-    def is_sum(self):
-        """Determine the type of API call this is.
-
-        is_sum == True -> API Summary data
-        is_sum == False -> Full data download
-
-        """
-        return self.operation == OPERATION_SUM
 
     @staticmethod
     def has_wildcard(in_list):

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -33,7 +33,6 @@ from reporting.models import (AWSCostEntryLineItemAggregates,
 
 LOG = logging.getLogger(__name__)
 WILDCARD = '*'
-OPERATION_SUM = 'sum'
 
 
 class ProviderMap(object):
@@ -51,191 +50,187 @@ class ProviderMap(object):
     # this data should be considered static and read-only.
     mapping = [{
         'provider': 'AWS',
-        'maps': {
-            'alias': 'account_alias__account_alias',
-            'annotations': {'account': 'usage_account_id',
-                            'service': 'product_code',
-                            'avail_zone': 'availability_zone'},
-            'end_date': 'usage_end',
-            'filters': {
-                'account': {'field': 'account_alias__account_alias',
+        'alias': 'account_alias__account_alias',
+        'annotations': {'account': 'usage_account_id',
+                        'service': 'product_code',
+                        'avail_zone': 'availability_zone'},
+        'end_date': 'usage_end',
+        'filters': {
+            'account': {'field': 'account_alias__account_alias',
+                        'operation': 'icontains'},
+            'service': {'field': 'product_code',
+                        'operation': 'icontains'},
+            'avail_zone': {'field': 'availability_zone',
                             'operation': 'icontains'},
-                'service': {'field': 'product_code',
-                            'operation': 'icontains'},
-                'avail_zone': {'field': 'availability_zone',
-                                'operation': 'icontains'},
-                'region': {'field': 'availability_zone',
-                            'operation': 'icontains'}
-            },
-            'report_type': {
-                'costs': {
-                    'aggregate': {'value': Sum('unblended_cost')},
-                    'aggregate_key': 'unblended_cost',
-                    'annotations': {'total': Sum('unblended_cost'),
-                                    'units': Coalesce(Max('currency_code'),
-                                    Value('USD'))
-                    },
-                    'count': None,
-                    'delta_key': {'total': Sum('unblended_cost')},
-                    'filter': {},
-                    'units_key': 'currency_code',
-                    'units_fallback': 'USD',
-                    'sum_columns': ['total'],
-                    'default_ordering': {'total': 'desc'},
-                },
-                'instance_type': {
-                    'aggregate': {
-                        'cost': Sum('unblended_cost'),
-                        'count': Sum('resource_count'),
-                        'value': Sum('usage_amount'),
-                    },
-                    'aggregate_key': 'usage_amount',
-                    'annotations': {'cost': Sum('unblended_cost'),
-                                    # The summary table already already has counts
-                                    'count': Sum('resource_count'),
-                                    'total': Sum('usage_amount'),
-                                    'units': Coalesce(Max('unit'),
-                                    Value('Hrs'))},
-                    'count': 'resource_count',
-                    'delta_key': {'total': Sum('usage_amount')},
-                    'filter': {
-                        'field': 'instance_type',
-                        'operation': 'isnull',
-                        'parameter': False
-                    },
-                    'units_key': 'unit',
-                    'units_fallback': 'Hrs',
-                    'sum_columns': ['total'],
-                    'default_ordering': {'total': 'desc'},
-                },
-                'storage': {
-                    'aggregate': {
-                        'value': Sum('usage_amount'),
-                        'cost': Sum('unblended_cost')
-                    },
-                    'aggregate_key': 'usage_amount',
-                    'annotations': {'cost': Sum('unblended_cost'),
-                                    'total': Sum('usage_amount'),
-                                    'units': Coalesce(Max('unit'),
-                                    Value('GB-Mo'))},
-                    'count': None,
-                    'delta_key': {'total': Sum('usage_amount')},
-                    'filter': {
-                        'field': 'product_family',
-                        'operation': 'contains',
-                        'parameter': 'Storage'
-                    },
-                    'units_key': 'unit',
-                    'units_fallback': 'GB-Mo',
-                    'sum_columns': ['total'],
-                    'default_ordering': {'total': 'desc'},
-                },
-            },
-            'start_date': 'usage_start',
-            'tables': {'previous_query': AWSCostEntryLineItemDailySummary,
-                        'query': AWSCostEntryLineItemDailySummary,
-                        'total': AWSCostEntryLineItemAggregates},
+            'region': {'field': 'availability_zone',
+                        'operation': 'icontains'}
         },
+        'report_type': {
+            'costs': {
+                'aggregate': {'value': Sum('unblended_cost')},
+                'aggregate_key': 'unblended_cost',
+                'annotations': {'total': Sum('unblended_cost'),
+                                'units': Coalesce(Max('currency_code'),
+                                Value('USD'))
+                },
+                'count': None,
+                'delta_key': {'total': Sum('unblended_cost')},
+                'filter': {},
+                'units_key': 'currency_code',
+                'units_fallback': 'USD',
+                'sum_columns': ['total'],
+                'default_ordering': {'total': 'desc'},
+            },
+            'instance_type': {
+                'aggregate': {
+                    'cost': Sum('unblended_cost'),
+                    'count': Sum('resource_count'),
+                    'value': Sum('usage_amount'),
+                },
+                'aggregate_key': 'usage_amount',
+                'annotations': {'cost': Sum('unblended_cost'),
+                                # The summary table already already has counts
+                                'count': Sum('resource_count'),
+                                'total': Sum('usage_amount'),
+                                'units': Coalesce(Max('unit'),
+                                Value('Hrs'))},
+                'count': 'resource_count',
+                'delta_key': {'total': Sum('usage_amount')},
+                'filter': {
+                    'field': 'instance_type',
+                    'operation': 'isnull',
+                    'parameter': False
+                },
+                'units_key': 'unit',
+                'units_fallback': 'Hrs',
+                'sum_columns': ['total'],
+                'default_ordering': {'total': 'desc'},
+            },
+            'storage': {
+                'aggregate': {
+                    'value': Sum('usage_amount'),
+                    'cost': Sum('unblended_cost')
+                },
+                'aggregate_key': 'usage_amount',
+                'annotations': {'cost': Sum('unblended_cost'),
+                                'total': Sum('usage_amount'),
+                                'units': Coalesce(Max('unit'),
+                                Value('GB-Mo'))},
+                'count': None,
+                'delta_key': {'total': Sum('usage_amount')},
+                'filter': {
+                    'field': 'product_family',
+                    'operation': 'contains',
+                    'parameter': 'Storage'
+                },
+                'units_key': 'unit',
+                'units_fallback': 'GB-Mo',
+                'sum_columns': ['total'],
+                'default_ordering': {'total': 'desc'},
+            },
+        },
+        'start_date': 'usage_start',
+        'tables': {'previous_query': AWSCostEntryLineItemDailySummary,
+                    'query': AWSCostEntryLineItemDailySummary,
+                    'total': AWSCostEntryLineItemAggregates},
     }, {
         'provider': 'OCP',
-        'maps': {
-            'annotations': {'cluster': 'cluster_id',
-                            'project': 'namespace'},
-            'end_date': 'usage_end',
-            'filters': {
-                'project': {'field': 'namespace',
-                            'operation': 'icontains'},
-                'cluster': {'field': 'cluster_id',
-                            'operation': 'icontains'},
-                'pod': {'field': 'pod',
+        'annotations': {'cluster': 'cluster_id',
+                        'project': 'namespace'},
+        'end_date': 'usage_end',
+        'filters': {
+            'project': {'field': 'namespace',
                         'operation': 'icontains'},
-                'node': {'field': 'node',
-                            'operation': 'icontains'},
-            },
-            'report_type': {
-                'charge': {
-                    'aggregates': {
-                        'charge': Sum(F('pod_charge_cpu_core_hours') + F('pod_charge_memory_gigabyte_hours'))
-                    },
-                    'default_ordering': {'charge': 'desc'},
-                    'annotations': {
-
-                        'charge': Sum(F('pod_charge_cpu_core_hours') + F('pod_charge_memory_gigabyte_hours')),
-                        'units': Value('USD', output_field=CharField())
-                    },
-                    'capacity_aggregate': {},
-                    'delta_key': {
-                        'charge': Sum(
-                            F('pod_charge_cpu_core_hours') +  # noqa: W504
-                            F('pod_charge_memory_gigabyte_hours')
-                        )
-                    },
-                    'filter': {},
-                    'units_key': 'USD',
-                    'sum_columns': ['charge'],
-                },
-                'cpu': {
-                    'aggregates': {
-                        'usage': Sum('pod_usage_cpu_core_hours'),
-                        'request': Sum('pod_request_cpu_core_hours'),
-                        'limit': Sum('pod_limit_cpu_core_hours'),
-                        'charge': Sum('pod_charge_cpu_core_hours')
-                    },
-                    'capacity_aggregate': {
-                        'capacity': Max('cluster_capacity_cpu_core_hours')
-                    },
-                    'default_ordering': {'usage': 'desc'},
-                    'annotations': {
-                        'usage': Sum('pod_usage_cpu_core_hours'),
-                        'request': Sum('pod_request_cpu_core_hours'),
-                        'limit': Sum('pod_limit_cpu_core_hours'),
-                        'capacity': Max('cluster_capacity_cpu_core_hours'),
-                        'charge': Sum('pod_charge_cpu_core_hours'),
-                        'units': Value('Core-Hours', output_field=CharField())
-                    },
-                    'delta_key': {
-                        'usage': Sum('pod_usage_cpu_core_hours'),
-                        'request': Sum('pod_request_cpu_core_hours'),
-                        'charge': Sum('pod_charge_cpu_core_hours')
-                    },
-                    'filter': {},
-                    'units_key': 'Core-Hours',
-                    'sum_columns': ['usage', 'request', 'limit', 'charge'],
-                },
-                'mem': {
-                    'aggregates': {
-                        'usage': Sum('pod_usage_memory_gigabyte_hours'),
-                        'request': Sum('pod_request_memory_gigabyte_hours'),
-                        'limit': Sum('pod_limit_memory_gigabyte_hours'),
-                        'charge': Sum('pod_charge_memory_gigabyte_hours')
-                    },
-                    'capacity_aggregate': {
-                        'capacity': Max('cluster_capacity_memory_gigabyte_hours')
-                    },
-                    'default_ordering': {'usage': 'desc'},
-                    'annotations': {
-                        'usage': Sum('pod_usage_memory_gigabyte_hours'),
-                        'request': Sum('pod_request_memory_gigabyte_hours'),
-                        'limit': Sum('pod_limit_memory_gigabyte_hours'),
-                        'capacity': Max('cluster_capacity_memory_gigabyte_hours'),
-                        'charge': Sum('pod_charge_memory_gigabyte_hours'),
-                        'units': Value('GB-Hours', output_field=CharField())
-                    },
-                    'delta_key': {
-                        'usage': Sum('pod_usage_memory_gigabyte_hours'),
-                        'request': Sum('pod_request_memory_gigabyte_hours'),
-                        'charge': Sum('pod_charge_memory_gigabyte_hours')
-                    },
-                    'filter': {},
-                    'units_key': 'GB-Hours',
-                    'sum_columns': ['usage', 'request', 'limit', 'charge'],
-                }
-            },
-            'start_date': 'usage_start',
-            'tables': {'previous_query': OCPUsageLineItemDailySummary,
-                        'query': OCPUsageLineItemDailySummary,
-                        'total': OCPUsageLineItemAggregates},
+            'cluster': {'field': 'cluster_id',
+                        'operation': 'icontains'},
+            'pod': {'field': 'pod',
+                    'operation': 'icontains'},
+            'node': {'field': 'node',
+                        'operation': 'icontains'},
         },
+        'report_type': {
+            'charge': {
+                'aggregates': {
+                    'charge': Sum(F('pod_charge_cpu_core_hours') + F('pod_charge_memory_gigabyte_hours'))
+                },
+                'default_ordering': {'charge': 'desc'},
+                'annotations': {
+
+                    'charge': Sum(F('pod_charge_cpu_core_hours') + F('pod_charge_memory_gigabyte_hours')),
+                    'units': Value('USD', output_field=CharField())
+                },
+                'capacity_aggregate': {},
+                'delta_key': {
+                    'charge': Sum(
+                        F('pod_charge_cpu_core_hours') +  # noqa: W504
+                        F('pod_charge_memory_gigabyte_hours')
+                    )
+                },
+                'filter': {},
+                'units_key': 'USD',
+                'sum_columns': ['charge'],
+            },
+            'cpu': {
+                'aggregates': {
+                    'usage': Sum('pod_usage_cpu_core_hours'),
+                    'request': Sum('pod_request_cpu_core_hours'),
+                    'limit': Sum('pod_limit_cpu_core_hours'),
+                    'charge': Sum('pod_charge_cpu_core_hours')
+                },
+                'capacity_aggregate': {
+                    'capacity': Max('cluster_capacity_cpu_core_hours')
+                },
+                'default_ordering': {'usage': 'desc'},
+                'annotations': {
+                    'usage': Sum('pod_usage_cpu_core_hours'),
+                    'request': Sum('pod_request_cpu_core_hours'),
+                    'limit': Sum('pod_limit_cpu_core_hours'),
+                    'capacity': Max('cluster_capacity_cpu_core_hours'),
+                    'charge': Sum('pod_charge_cpu_core_hours'),
+                    'units': Value('Core-Hours', output_field=CharField())
+                },
+                'delta_key': {
+                    'usage': Sum('pod_usage_cpu_core_hours'),
+                    'request': Sum('pod_request_cpu_core_hours'),
+                    'charge': Sum('pod_charge_cpu_core_hours')
+                },
+                'filter': {},
+                'units_key': 'Core-Hours',
+                'sum_columns': ['usage', 'request', 'limit', 'charge'],
+            },
+            'mem': {
+                'aggregates': {
+                    'usage': Sum('pod_usage_memory_gigabyte_hours'),
+                    'request': Sum('pod_request_memory_gigabyte_hours'),
+                    'limit': Sum('pod_limit_memory_gigabyte_hours'),
+                    'charge': Sum('pod_charge_memory_gigabyte_hours')
+                },
+                'capacity_aggregate': {
+                    'capacity': Max('cluster_capacity_memory_gigabyte_hours')
+                },
+                'default_ordering': {'usage': 'desc'},
+                'annotations': {
+                    'usage': Sum('pod_usage_memory_gigabyte_hours'),
+                    'request': Sum('pod_request_memory_gigabyte_hours'),
+                    'limit': Sum('pod_limit_memory_gigabyte_hours'),
+                    'capacity': Max('cluster_capacity_memory_gigabyte_hours'),
+                    'charge': Sum('pod_charge_memory_gigabyte_hours'),
+                    'units': Value('GB-Hours', output_field=CharField())
+                },
+                'delta_key': {
+                    'usage': Sum('pod_usage_memory_gigabyte_hours'),
+                    'request': Sum('pod_request_memory_gigabyte_hours'),
+                    'charge': Sum('pod_charge_memory_gigabyte_hours')
+                },
+                'filter': {},
+                'units_key': 'GB-Hours',
+                'sum_columns': ['usage', 'request', 'limit', 'charge'],
+            }
+        },
+        'start_date': 'usage_start',
+        'tables': {'previous_query': OCPUsageLineItemDailySummary,
+                    'query': OCPUsageLineItemDailySummary,
+                    'total': OCPUsageLineItemAggregates},
     }]
 
     @staticmethod
@@ -246,28 +241,19 @@ class ProviderMap(object):
                 return item
 
     @staticmethod
-    def operation_data(provider):
-        """Return operation portion of map structure."""
-        prov = ProviderMap.provider_data(provider)
-        return prov.get('maps')
-
-    @staticmethod
-    def report_type_data(report_type, operation, provider):
+    def report_type_data(report_type, provider):
         """Return report_type portion of map structure."""
         prov = ProviderMap.provider_data(provider)
-        maps = prov.get('maps')
-        return maps.get('report_type').get(report_type)
+        return prov.get('report_type').get(report_type)
 
     def __init__(self, provider, report_type):
         """Constructor."""
         self._provider = provider
-        self._operation = OPERATION_SUM
         self._report_type = report_type
 
         self._map = ProviderMap.mapping
         self._provider_map = ProviderMap.provider_data(provider)
-        self._operation_map = ProviderMap.operation_data(provider)
-        self._report_type_map = ProviderMap.report_type_data(report_type, OPERATION_SUM, provider)
+        self._report_type_map = ProviderMap.report_type_data(report_type, provider)
 
     @property
     def count(self):
@@ -348,7 +334,7 @@ class ReportQueryHandler(QueryHandler):
             (QueryFilterCollection): populated collection of query filters
         """
         # define filter parameters using API query params.
-        fields = self._mapper._operation_map.get('filters')
+        fields = self._mapper._provider_map.get('filters')
         for q_param, filt in fields.items():
             group_by = self.get_query_param_data('group_by', q_param, list())
             filter_ = self.get_query_param_data('filter', q_param, list())
@@ -664,7 +650,7 @@ class ReportQueryHandler(QueryHandler):
         """
         delta_group_by = ['date'] + self._get_group_by()
         delta_filter = self._get_filter(delta=True)
-        q_table = self._mapper._operation_map.get('tables').get('previous_query')
+        q_table = self._mapper._provider_map.get('tables').get('previous_query')
         previous_query = q_table.objects.filter(delta_filter)
         previous_dict = self._create_previous_totals(previous_query,
                                                      delta_group_by)

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -51,194 +51,190 @@ class ProviderMap(object):
     # this data should be considered static and read-only.
     mapping = [{
         'provider': 'AWS',
-        'operation': {
-            OPERATION_SUM: {
-                'alias': 'account_alias__account_alias',
-                'annotations': {'account': 'usage_account_id',
-                                'service': 'product_code',
-                                'avail_zone': 'availability_zone'},
-                'end_date': 'usage_end',
-                'filters': {
-                    'account': {'field': 'account_alias__account_alias',
+        'maps': {
+            'alias': 'account_alias__account_alias',
+            'annotations': {'account': 'usage_account_id',
+                            'service': 'product_code',
+                            'avail_zone': 'availability_zone'},
+            'end_date': 'usage_end',
+            'filters': {
+                'account': {'field': 'account_alias__account_alias',
+                            'operation': 'icontains'},
+                'service': {'field': 'product_code',
+                            'operation': 'icontains'},
+                'avail_zone': {'field': 'availability_zone',
                                 'operation': 'icontains'},
-                    'service': {'field': 'product_code',
-                                'operation': 'icontains'},
-                    'avail_zone': {'field': 'availability_zone',
-                                   'operation': 'icontains'},
-                    'region': {'field': 'availability_zone',
-                               'operation': 'icontains'}
-                },
-                'report_type': {
-                    'costs': {
-                        'aggregate': {'value': Sum('unblended_cost')},
-                        'aggregate_key': 'unblended_cost',
-                        'annotations': {'total': Sum('unblended_cost'),
-                                        'units': Coalesce(Max('currency_code'),
-                                        Value('USD'))
-                        },
-                        'count': None,
-                        'delta_key': {'total': Sum('unblended_cost')},
-                        'filter': {},
-                        'units_key': 'currency_code',
-                        'units_fallback': 'USD',
-                        'sum_columns': ['total'],
-                        'default_ordering': {'total': 'desc'},
-                    },
-                    'instance_type': {
-                        'aggregate': {
-                            'cost': Sum('unblended_cost'),
-                            'count': Sum('resource_count'),
-                            'value': Sum('usage_amount'),
-                        },
-                        'aggregate_key': 'usage_amount',
-                        'annotations': {'cost': Sum('unblended_cost'),
-                                        # The summary table already already has counts
-                                        'count': Sum('resource_count'),
-                                        'total': Sum('usage_amount'),
-                                        'units': Coalesce(Max('unit'),
-                                        Value('Hrs'))},
-                        'count': 'resource_count',
-                        'delta_key': {'total': Sum('usage_amount')},
-                        'filter': {
-                            'field': 'instance_type',
-                            'operation': 'isnull',
-                            'parameter': False
-                        },
-                        'units_key': 'unit',
-                        'units_fallback': 'Hrs',
-                        'sum_columns': ['total'],
-                        'default_ordering': {'total': 'desc'},
-                    },
-                    'storage': {
-                        'aggregate': {
-                            'value': Sum('usage_amount'),
-                            'cost': Sum('unblended_cost')
-                        },
-                        'aggregate_key': 'usage_amount',
-                        'annotations': {'cost': Sum('unblended_cost'),
-                                        'total': Sum('usage_amount'),
-                                        'units': Coalesce(Max('unit'),
-                                        Value('GB-Mo'))},
-                        'count': None,
-                        'delta_key': {'total': Sum('usage_amount')},
-                        'filter': {
-                            'field': 'product_family',
-                            'operation': 'contains',
-                            'parameter': 'Storage'
-                        },
-                        'units_key': 'unit',
-                        'units_fallback': 'GB-Mo',
-                        'sum_columns': ['total'],
-                        'default_ordering': {'total': 'desc'},
-                    },
-                },
-                'start_date': 'usage_start',
-                'tables': {'previous_query': AWSCostEntryLineItemDailySummary,
-                           'query': AWSCostEntryLineItemDailySummary,
-                           'total': AWSCostEntryLineItemAggregates},
+                'region': {'field': 'availability_zone',
+                            'operation': 'icontains'}
             },
+            'report_type': {
+                'costs': {
+                    'aggregate': {'value': Sum('unblended_cost')},
+                    'aggregate_key': 'unblended_cost',
+                    'annotations': {'total': Sum('unblended_cost'),
+                                    'units': Coalesce(Max('currency_code'),
+                                    Value('USD'))
+                    },
+                    'count': None,
+                    'delta_key': {'total': Sum('unblended_cost')},
+                    'filter': {},
+                    'units_key': 'currency_code',
+                    'units_fallback': 'USD',
+                    'sum_columns': ['total'],
+                    'default_ordering': {'total': 'desc'},
+                },
+                'instance_type': {
+                    'aggregate': {
+                        'cost': Sum('unblended_cost'),
+                        'count': Sum('resource_count'),
+                        'value': Sum('usage_amount'),
+                    },
+                    'aggregate_key': 'usage_amount',
+                    'annotations': {'cost': Sum('unblended_cost'),
+                                    # The summary table already already has counts
+                                    'count': Sum('resource_count'),
+                                    'total': Sum('usage_amount'),
+                                    'units': Coalesce(Max('unit'),
+                                    Value('Hrs'))},
+                    'count': 'resource_count',
+                    'delta_key': {'total': Sum('usage_amount')},
+                    'filter': {
+                        'field': 'instance_type',
+                        'operation': 'isnull',
+                        'parameter': False
+                    },
+                    'units_key': 'unit',
+                    'units_fallback': 'Hrs',
+                    'sum_columns': ['total'],
+                    'default_ordering': {'total': 'desc'},
+                },
+                'storage': {
+                    'aggregate': {
+                        'value': Sum('usage_amount'),
+                        'cost': Sum('unblended_cost')
+                    },
+                    'aggregate_key': 'usage_amount',
+                    'annotations': {'cost': Sum('unblended_cost'),
+                                    'total': Sum('usage_amount'),
+                                    'units': Coalesce(Max('unit'),
+                                    Value('GB-Mo'))},
+                    'count': None,
+                    'delta_key': {'total': Sum('usage_amount')},
+                    'filter': {
+                        'field': 'product_family',
+                        'operation': 'contains',
+                        'parameter': 'Storage'
+                    },
+                    'units_key': 'unit',
+                    'units_fallback': 'GB-Mo',
+                    'sum_columns': ['total'],
+                    'default_ordering': {'total': 'desc'},
+                },
+            },
+            'start_date': 'usage_start',
+            'tables': {'previous_query': AWSCostEntryLineItemDailySummary,
+                        'query': AWSCostEntryLineItemDailySummary,
+                        'total': AWSCostEntryLineItemAggregates},
         },
     }, {
         'provider': 'OCP',
-        'operation': {
-            OPERATION_SUM: {
-                'annotations': {'cluster': 'cluster_id',
-                                'project': 'namespace'},
-                'end_date': 'usage_end',
-                'filters': {
-                    'project': {'field': 'namespace',
-                                'operation': 'icontains'},
-                    'cluster': {'field': 'cluster_id',
-                                'operation': 'icontains'},
-                    'pod': {'field': 'pod',
+        'maps': {
+            'annotations': {'cluster': 'cluster_id',
+                            'project': 'namespace'},
+            'end_date': 'usage_end',
+            'filters': {
+                'project': {'field': 'namespace',
                             'operation': 'icontains'},
-                    'node': {'field': 'node',
-                             'operation': 'icontains'},
-                },
-                'report_type': {
-                    'charge': {
-                        'aggregates': {
-                            'charge': Sum(F('pod_charge_cpu_core_hours') + F('pod_charge_memory_gigabyte_hours'))
-                        },
-                        'default_ordering': {'charge': 'desc'},
-                        'annotations': {
-
-                            'charge': Sum(F('pod_charge_cpu_core_hours') + F('pod_charge_memory_gigabyte_hours')),
-                            'units': Value('USD', output_field=CharField())
-                        },
-                        'capacity_aggregate': {},
-                        'delta_key': {
-                            'charge': Sum(
-                                F('pod_charge_cpu_core_hours') +  # noqa: W504
-                                F('pod_charge_memory_gigabyte_hours')
-                            )
-                        },
-                        'filter': {},
-                        'units_key': 'USD',
-                        'sum_columns': ['charge'],
-                    },
-                    'cpu': {
-                        'aggregates': {
-                            'usage': Sum('pod_usage_cpu_core_hours'),
-                            'request': Sum('pod_request_cpu_core_hours'),
-                            'limit': Sum('pod_limit_cpu_core_hours'),
-                            'charge': Sum('pod_charge_cpu_core_hours')
-                        },
-                        'capacity_aggregate': {
-                            'capacity': Max('cluster_capacity_cpu_core_hours')
-                        },
-                        'default_ordering': {'usage': 'desc'},
-                        'annotations': {
-                            'usage': Sum('pod_usage_cpu_core_hours'),
-                            'request': Sum('pod_request_cpu_core_hours'),
-                            'limit': Sum('pod_limit_cpu_core_hours'),
-                            'capacity': Max('cluster_capacity_cpu_core_hours'),
-                            'charge': Sum('pod_charge_cpu_core_hours'),
-                            'units': Value('Core-Hours', output_field=CharField())
-                        },
-                        'delta_key': {
-                            'usage': Sum('pod_usage_cpu_core_hours'),
-                            'request': Sum('pod_request_cpu_core_hours'),
-                            'charge': Sum('pod_charge_cpu_core_hours')
-                        },
-                        'filter': {},
-                        'units_key': 'Core-Hours',
-                        'sum_columns': ['usage', 'request', 'limit', 'charge'],
-                    },
-                    'mem': {
-                        'aggregates': {
-                            'usage': Sum('pod_usage_memory_gigabyte_hours'),
-                            'request': Sum('pod_request_memory_gigabyte_hours'),
-                            'limit': Sum('pod_limit_memory_gigabyte_hours'),
-                            'charge': Sum('pod_charge_memory_gigabyte_hours')
-                        },
-                        'capacity_aggregate': {
-                            'capacity': Max('cluster_capacity_memory_gigabyte_hours')
-                        },
-                        'default_ordering': {'usage': 'desc'},
-                        'annotations': {
-                            'usage': Sum('pod_usage_memory_gigabyte_hours'),
-                            'request': Sum('pod_request_memory_gigabyte_hours'),
-                            'limit': Sum('pod_limit_memory_gigabyte_hours'),
-                            'capacity': Max('cluster_capacity_memory_gigabyte_hours'),
-                            'charge': Sum('pod_charge_memory_gigabyte_hours'),
-                            'units': Value('GB-Hours', output_field=CharField())
-                        },
-                        'delta_key': {
-                            'usage': Sum('pod_usage_memory_gigabyte_hours'),
-                            'request': Sum('pod_request_memory_gigabyte_hours'),
-                            'charge': Sum('pod_charge_memory_gigabyte_hours')
-                        },
-                        'filter': {},
-                        'units_key': 'GB-Hours',
-                        'sum_columns': ['usage', 'request', 'limit', 'charge'],
-                    }
-                },
-                'start_date': 'usage_start',
-                'tables': {'previous_query': OCPUsageLineItemDailySummary,
-                           'query': OCPUsageLineItemDailySummary,
-                           'total': OCPUsageLineItemAggregates},
+                'cluster': {'field': 'cluster_id',
+                            'operation': 'icontains'},
+                'pod': {'field': 'pod',
+                        'operation': 'icontains'},
+                'node': {'field': 'node',
+                            'operation': 'icontains'},
             },
+            'report_type': {
+                'charge': {
+                    'aggregates': {
+                        'charge': Sum(F('pod_charge_cpu_core_hours') + F('pod_charge_memory_gigabyte_hours'))
+                    },
+                    'default_ordering': {'charge': 'desc'},
+                    'annotations': {
+
+                        'charge': Sum(F('pod_charge_cpu_core_hours') + F('pod_charge_memory_gigabyte_hours')),
+                        'units': Value('USD', output_field=CharField())
+                    },
+                    'capacity_aggregate': {},
+                    'delta_key': {
+                        'charge': Sum(
+                            F('pod_charge_cpu_core_hours') +  # noqa: W504
+                            F('pod_charge_memory_gigabyte_hours')
+                        )
+                    },
+                    'filter': {},
+                    'units_key': 'USD',
+                    'sum_columns': ['charge'],
+                },
+                'cpu': {
+                    'aggregates': {
+                        'usage': Sum('pod_usage_cpu_core_hours'),
+                        'request': Sum('pod_request_cpu_core_hours'),
+                        'limit': Sum('pod_limit_cpu_core_hours'),
+                        'charge': Sum('pod_charge_cpu_core_hours')
+                    },
+                    'capacity_aggregate': {
+                        'capacity': Max('cluster_capacity_cpu_core_hours')
+                    },
+                    'default_ordering': {'usage': 'desc'},
+                    'annotations': {
+                        'usage': Sum('pod_usage_cpu_core_hours'),
+                        'request': Sum('pod_request_cpu_core_hours'),
+                        'limit': Sum('pod_limit_cpu_core_hours'),
+                        'capacity': Max('cluster_capacity_cpu_core_hours'),
+                        'charge': Sum('pod_charge_cpu_core_hours'),
+                        'units': Value('Core-Hours', output_field=CharField())
+                    },
+                    'delta_key': {
+                        'usage': Sum('pod_usage_cpu_core_hours'),
+                        'request': Sum('pod_request_cpu_core_hours'),
+                        'charge': Sum('pod_charge_cpu_core_hours')
+                    },
+                    'filter': {},
+                    'units_key': 'Core-Hours',
+                    'sum_columns': ['usage', 'request', 'limit', 'charge'],
+                },
+                'mem': {
+                    'aggregates': {
+                        'usage': Sum('pod_usage_memory_gigabyte_hours'),
+                        'request': Sum('pod_request_memory_gigabyte_hours'),
+                        'limit': Sum('pod_limit_memory_gigabyte_hours'),
+                        'charge': Sum('pod_charge_memory_gigabyte_hours')
+                    },
+                    'capacity_aggregate': {
+                        'capacity': Max('cluster_capacity_memory_gigabyte_hours')
+                    },
+                    'default_ordering': {'usage': 'desc'},
+                    'annotations': {
+                        'usage': Sum('pod_usage_memory_gigabyte_hours'),
+                        'request': Sum('pod_request_memory_gigabyte_hours'),
+                        'limit': Sum('pod_limit_memory_gigabyte_hours'),
+                        'capacity': Max('cluster_capacity_memory_gigabyte_hours'),
+                        'charge': Sum('pod_charge_memory_gigabyte_hours'),
+                        'units': Value('GB-Hours', output_field=CharField())
+                    },
+                    'delta_key': {
+                        'usage': Sum('pod_usage_memory_gigabyte_hours'),
+                        'request': Sum('pod_request_memory_gigabyte_hours'),
+                        'charge': Sum('pod_charge_memory_gigabyte_hours')
+                    },
+                    'filter': {},
+                    'units_key': 'GB-Hours',
+                    'sum_columns': ['usage', 'request', 'limit', 'charge'],
+                }
+            },
+            'start_date': 'usage_start',
+            'tables': {'previous_query': OCPUsageLineItemDailySummary,
+                        'query': OCPUsageLineItemDailySummary,
+                        'total': OCPUsageLineItemAggregates},
         },
     }]
 
@@ -250,16 +246,17 @@ class ProviderMap(object):
                 return item
 
     @staticmethod
-    def operation_data(operation, provider):
+    def operation_data(provider):
         """Return operation portion of map structure."""
         prov = ProviderMap.provider_data(provider)
-        return prov.get('operation').get(operation)
+        return prov.get('maps')
 
     @staticmethod
     def report_type_data(report_type, operation, provider):
         """Return report_type portion of map structure."""
-        op_data = ProviderMap.operation_data(operation, provider)
-        return op_data.get('report_type').get(report_type)
+        prov = ProviderMap.provider_data(provider)
+        maps = prov.get('maps')
+        return maps.get('report_type').get(report_type)
 
     def __init__(self, provider, report_type):
         """Constructor."""
@@ -269,7 +266,7 @@ class ProviderMap(object):
 
         self._map = ProviderMap.mapping
         self._provider_map = ProviderMap.provider_data(provider)
-        self._operation_map = ProviderMap.operation_data(OPERATION_SUM, provider)
+        self._operation_map = ProviderMap.operation_data(provider)
         self._report_type_map = ProviderMap.report_type_data(report_type, OPERATION_SUM, provider)
 
     @property

--- a/koku/api/report/test/ocp/test_ocp_query_handler.py
+++ b/koku/api/report/test/ocp/test_ocp_query_handler.py
@@ -193,7 +193,7 @@ class OCPReportQueryHandlerTest(IamTestCase):
         )
         handler._delta = 'usage__request'
 
-        q_table = handler._mapper._operation_map.get('tables').get('query')
+        q_table = handler._mapper._provider_map.get('tables').get('query')
         with tenant_context(self.tenant):
             query = q_table.objects.filter(handler.query_filter)
             query_data = query.annotate(**handler.annotations)
@@ -247,7 +247,7 @@ class OCPReportQueryHandlerTest(IamTestCase):
         )
         handler._delta = 'usage__request'
 
-        q_table = handler._mapper._operation_map.get('tables').get('query')
+        q_table = handler._mapper._provider_map.get('tables').get('query')
         with tenant_context(self.tenant):
             query = q_table.objects.filter(handler.query_filter)
             query_data = query.annotate(**handler.annotations)
@@ -290,7 +290,7 @@ class OCPReportQueryHandlerTest(IamTestCase):
         )
         handler._delta = 'usage__foo'
 
-        q_table = handler._mapper._operation_map.get('tables').get('query')
+        q_table = handler._mapper._provider_map.get('tables').get('query')
         with tenant_context(self.tenant):
             query = q_table.objects.filter(handler.query_filter)
             query_data = query.annotate(**handler.annotations)

--- a/koku/api/report/test/tests_queries.py
+++ b/koku/api/report/test/tests_queries.py
@@ -700,6 +700,7 @@ class ReportQueryTest(IamTestCase):
     def test_get_time_scope_value_empty_default(self):
         """Test get_time_scope_value returns default when query params are empty."""
         query_params = {}
+        import pdb; pdb.set_trace()
         handler = AWSReportQueryHandler(query_params, '', self.tenant,
                                         **{'report_type': 'costs'})
         self.assertEqual(handler.get_time_scope_value(), -10)

--- a/koku/api/report/test/tests_queries.py
+++ b/koku/api/report/test/tests_queries.py
@@ -1350,57 +1350,6 @@ class ReportQueryTest(IamTestCase):
             month_val = data_item.get('date')
             self.assertEqual(month_val, cmonth_str)
 
-    def test_execute_query_current_month_export_json(self):
-        """Test execute_query for current month on monthly export raw json data."""
-        query_params = {'filter':
-                        {'resolution': 'monthly', 'time_scope_value': -1,
-                         'time_scope_units': 'month'},
-                        'operation': 'none'}
-        handler = AWSReportQueryHandler(query_params, '',
-                                        self.tenant,
-                                        **{'report_type': 'costs'})
-        query_output = handler.execute_query()
-
-        data = query_output.get('data')
-        self.assertIsNotNone(data)
-        self.assertIsNotNone(query_output.get('total'))
-
-        total = query_output.get('total')
-        self.assertIsNotNone(total.get('value'))
-        self.assertEqual(total.get('value'), self.current_month_total)
-
-        cmonth_str = DateHelper().this_month_start.strftime('%Y-%m')
-        self.assertEqual(len(data), 24)
-        for data_item in data:
-            month = data_item.get('date')
-            self.assertEqual(month, cmonth_str)
-
-    def test_execute_query_current_month_export_csv(self):
-        """Test execute_query for current month on monthly export raw csv data."""
-        query_params = {'filter':
-                        {'resolution': 'monthly', 'time_scope_value': -1,
-                         'time_scope_units': 'month'},
-                        'operation': 'none'}
-        handler = AWSReportQueryHandler(query_params, '',
-                                        self.tenant,
-                                        **{'accept_type': 'text/csv',
-                                            'report_type': 'costs'})
-        query_output = handler.execute_query()
-
-        data = query_output.get('data')
-        self.assertIsNotNone(data)
-        self.assertIsNotNone(query_output.get('total'))
-
-        total = query_output.get('total')
-        self.assertIsNotNone(total.get('value'))
-        self.assertEqual(total.get('value'), self.current_month_total)
-
-        cmonth_str = DateHelper().this_month_start.strftime('%Y-%m')
-        self.assertEqual(len(data), 24)
-        for data_item in data:
-            month = data_item.get('date')
-            self.assertEqual(month, cmonth_str)
-
     def test_execute_query_curr_month_by_account_w_limit_csv(self):
         """Test execute_query for current month on monthly by account with limt as csv."""
         for _ in range(5):

--- a/koku/api/report/test/tests_queries.py
+++ b/koku/api/report/test/tests_queries.py
@@ -700,7 +700,6 @@ class ReportQueryTest(IamTestCase):
     def test_get_time_scope_value_empty_default(self):
         """Test get_time_scope_value returns default when query params are empty."""
         query_params = {}
-        import pdb; pdb.set_trace()
         handler = AWSReportQueryHandler(query_params, '', self.tenant,
                                         **{'report_type': 'costs'})
         self.assertEqual(handler.get_time_scope_value(), -10)

--- a/tox.ini
+++ b/tox.ini
@@ -31,8 +31,8 @@ deps =
 commands =
   /bin/sh {toxinidir}/scripts/create_test_db_user.sh {env:DATABASE_USER}
   pipenv run pip install pip==18.0
-  ;pipenv install --dev --ignore-pipfile
-  coverage run {toxinidir}/koku/manage.py test api.report.test.tests_queries
+  pipenv install --dev --ignore-pipfile
+  coverage run {toxinidir}/koku/manage.py test -v 2 {posargs: koku/}
   coverage report --show-missing
   /bin/sh {toxinidir}/scripts/drop_test_db_user.sh {env:DATABASE_USER}
 

--- a/tox.ini
+++ b/tox.ini
@@ -31,8 +31,8 @@ deps =
 commands =
   /bin/sh {toxinidir}/scripts/create_test_db_user.sh {env:DATABASE_USER}
   pipenv run pip install pip==18.0
-  pipenv install --dev --ignore-pipfile
-  coverage run {toxinidir}/koku/manage.py test -v 2 {posargs: koku/}
+  ;pipenv install --dev --ignore-pipfile
+  coverage run {toxinidir}/koku/manage.py test api.report.test.tests_queries
   coverage report --show-missing
   /bin/sh {toxinidir}/scripts/drop_test_db_user.sh {env:DATABASE_USER}
 


### PR DESCRIPTION
Closes #501 

Now that we no long require raw csv data to be exported, the operation None query parameter can be removed.  Since that leaves us with only a single operation (OPERATION_SUM) I am removing all notion of operations from the koku API with this change.

Testing
Sanity test with OCP and AWS data.