### PR TITLE
538 rewrite pagination - partial urls

### DIFF
--- a/koku/api/common/pagination.py
+++ b/koku/api/common/pagination.py
@@ -20,7 +20,6 @@ import logging
 
 from rest_framework.pagination import PageNumberPagination
 
-HTTP_REFERER = 'HTTP_REFERER'
 PATH_INFO = 'PATH_INFO'
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -34,7 +33,7 @@ class StandardResultsSetPagination(PageNumberPagination):
 
     @staticmethod
     def link_rewrite(request, link):
-        """Rewrite the link based on the referer header."""
+        """Rewrite the link based on the path header to only provide partial url."""
         url = link
         if PATH_INFO in request.META:
             try:
@@ -43,30 +42,20 @@ class StandardResultsSetPagination(PageNumberPagination):
                 path_api_index = path.index('api/')
                 path_link = '{}{}'
                 url = path_link.format(path[:path_api_index],
-                                          link[local_api_index:])
+                                       link[local_api_index:])
             except ValueError:
                 logger.warning('Unable to rewrite link as "api" was not found.')
-        # if HTTP_REFERER in request.META:
-        #     try:
-        #         http_referer = request.META.get(HTTP_REFERER)
-        #         local_api_index = link.index('api/')
-        #         referer_api_index = http_referer.index('api/')
-        #         referer_link = '{}{}'
-        #         url = referer_link.format(http_referer[:referer_api_index],
-        #                                   link[local_api_index:])
-        #     except ValueError:
-        #         logger.warning('Unable to rewrite link as "api" was not found.')
         return url
 
     def get_next_link(self):
-        """Create next link with referer rewrite."""
+        """Create next link with partial url rewrite."""
         next_link = super().get_next_link()
         if next_link is None:
             return next_link
         return StandardResultsSetPagination.link_rewrite(self.request, next_link)
 
     def get_previous_link(self):
-        """Create previous link with referer rewrite."""
+        """Create previous link with partial url rewrite."""
         previous_link = super().get_previous_link()
         if previous_link is None:
             return previous_link

--- a/koku/api/common/pagination.py
+++ b/koku/api/common/pagination.py
@@ -21,6 +21,7 @@ import logging
 from rest_framework.pagination import PageNumberPagination
 
 HTTP_REFERER = 'HTTP_REFERER'
+PATH_INFO = 'PATH_INFO'
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
@@ -35,16 +36,26 @@ class StandardResultsSetPagination(PageNumberPagination):
     def link_rewrite(request, link):
         """Rewrite the link based on the referer header."""
         url = link
-        if HTTP_REFERER in request.META:
+        if PATH_INFO in request.META:
             try:
-                http_referer = request.META.get(HTTP_REFERER)
                 local_api_index = link.index('api/')
-                referer_api_index = http_referer.index('api/')
-                referer_link = '{}{}'
-                url = referer_link.format(http_referer[:referer_api_index],
+                path = request.META.get(PATH_INFO)
+                path_api_index = path.index('api/')
+                path_link = '{}{}'
+                url = path_link.format(path[:path_api_index],
                                           link[local_api_index:])
             except ValueError:
                 logger.warning('Unable to rewrite link as "api" was not found.')
+        # if HTTP_REFERER in request.META:
+        #     try:
+        #         http_referer = request.META.get(HTTP_REFERER)
+        #         local_api_index = link.index('api/')
+        #         referer_api_index = http_referer.index('api/')
+        #         referer_link = '{}{}'
+        #         url = referer_link.format(http_referer[:referer_api_index],
+        #                                   link[local_api_index:])
+        #     except ValueError:
+        #         logger.warning('Unable to rewrite link as "api" was not found.')
         return url
 
     def get_next_link(self):

--- a/koku/api/common/pagination.py
+++ b/koku/api/common/pagination.py
@@ -37,6 +37,15 @@ class StandardResultsSetPagination(PageNumberPagination):
             http_referer = request.META.get(HTTP_REFERER)
             referer_link = '{}{}'
             url = referer_link.format(http_referer, link[api_index:])
+            print('#' * 90)
+            print('http_referer=' + http_referer)
+            print('link[api_index:]=' + link[api_index:])
+            print('url=' + url)
+            print('#' * 90)
+        else:
+            print('*' * 90)
+            print('No Referer header')
+            print('*' * 90)
         return url
 
     def get_next_link(self):

--- a/koku/api/common/pagination.py
+++ b/koku/api/common/pagination.py
@@ -16,9 +16,12 @@
 #
 
 """Common pagination class."""
+import logging
+
 from rest_framework.pagination import PageNumberPagination
 
 HTTP_REFERER = 'HTTP_REFERER'
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
 class StandardResultsSetPagination(PageNumberPagination):
@@ -33,19 +36,15 @@ class StandardResultsSetPagination(PageNumberPagination):
         """Rewrite the link based on the referer header."""
         url = link
         if HTTP_REFERER in request.META:
-            api_index = link.index('api')
-            http_referer = request.META.get(HTTP_REFERER)
-            referer_link = '{}{}'
-            url = referer_link.format(http_referer, link[api_index:])
-            print('#' * 90)
-            print('http_referer=' + http_referer)
-            print('link[api_index:]=' + link[api_index:])
-            print('url=' + url)
-            print('#' * 90)
-        else:
-            print('*' * 90)
-            print('No Referer header')
-            print('*' * 90)
+            try:
+                http_referer = request.META.get(HTTP_REFERER)
+                local_api_index = link.index('api/')
+                referer_api_index = http_referer.index('api/')
+                referer_link = '{}{}'
+                url = referer_link.format(http_referer[:referer_api_index],
+                                          link[local_api_index:])
+            except ValueError:
+                logger.warning('Unable to rewrite link as "api" was not found.')
         return url
 
     def get_next_link(self):

--- a/koku/api/common/tests_pagination.py
+++ b/koku/api/common/tests_pagination.py
@@ -19,7 +19,7 @@ from unittest.mock import Mock, patch
 
 from django.test import TestCase
 
-from .pagination import HTTP_REFERER, StandardResultsSetPagination
+from .pagination import PATH_INFO, StandardResultsSetPagination
 
 
 class PaginationTest(TestCase):
@@ -28,16 +28,16 @@ class PaginationTest(TestCase):
     def test_link_rewrite(self):
         """Test the link rewrite."""
         request = Mock()
-        request.META = {HTTP_REFERER: 'https://api.koku.com/api/v1/providers/'}
+        request.META = {PATH_INFO: '/api/v1/providers/'}
         link = 'http://localhost:8000/api/v1/providers/?page=2'
-        expected = 'https://api.koku.com/api/v1/providers/?page=2'
+        expected = '/api/v1/providers/?page=2'
         result = StandardResultsSetPagination.link_rewrite(request, link)
         self.assertEqual(expected, result)
 
     def test_link_rewrite_err(self):
         """Test the link rewrite."""
         request = Mock()
-        request.META = {HTTP_REFERER: 'https://api.koku.com/v1/providers/'}
+        request.META = {PATH_INFO: 'https://api.koku.com/v1/providers/'}
         link = 'http://localhost:8000/api/v1/providers/?page=2'
         result = StandardResultsSetPagination.link_rewrite(request, link)
         self.assertEqual(link, result)
@@ -53,6 +53,7 @@ class PaginationTest(TestCase):
     @patch('api.common.pagination.PageNumberPagination.get_next_link',
            return_value=None)
     def test_get_next_link_none(self, mock_super):
+        """Test the get next link method when super returns none."""
         paginator = StandardResultsSetPagination()
         link = paginator.get_next_link()
         self.assertIsNone(link)
@@ -60,12 +61,14 @@ class PaginationTest(TestCase):
     @patch('api.common.pagination.PageNumberPagination.get_previous_link',
            return_value=None)
     def test_get_previous_link_none(self, mock_super):
+        """Test the get previous link method when super returns none."""
         paginator = StandardResultsSetPagination()
         link = paginator.get_previous_link()
         self.assertIsNone(link)
 
     @patch('api.common.pagination.PageNumberPagination.get_next_link')
     def test_get_next_link_value(self, mock_super):
+        """Test the get next link method when super returns a value."""
         expected = 'http://localhost:8000/api/v1/providers/?page=2'
         mock_super.return_value = expected
         paginator = StandardResultsSetPagination()
@@ -76,6 +79,7 @@ class PaginationTest(TestCase):
 
     @patch('api.common.pagination.PageNumberPagination.get_previous_link')
     def test_get_previous_link_value(self, mock_super):
+        """Test the get previous link method when super returns a value."""
         expected = 'http://localhost:8000/api/v1/providers/?page=2'
         mock_super.return_value = expected
         paginator = StandardResultsSetPagination()

--- a/koku/api/common/tests_pagination.py
+++ b/koku/api/common/tests_pagination.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 """Test the API pagination module."""
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from django.test import TestCase
 
@@ -28,11 +28,19 @@ class PaginationTest(TestCase):
     def test_link_rewrite(self):
         """Test the link rewrite."""
         request = Mock()
-        request.META = {HTTP_REFERER: 'https://api.koku.com/'}
+        request.META = {HTTP_REFERER: 'https://api.koku.com/api/v1/providers/'}
         link = 'http://localhost:8000/api/v1/providers/?page=2'
         expected = 'https://api.koku.com/api/v1/providers/?page=2'
         result = StandardResultsSetPagination.link_rewrite(request, link)
         self.assertEqual(expected, result)
+
+    def test_link_rewrite_err(self):
+        """Test the link rewrite."""
+        request = Mock()
+        request.META = {HTTP_REFERER: 'https://api.koku.com/v1/providers/'}
+        link = 'http://localhost:8000/api/v1/providers/?page=2'
+        result = StandardResultsSetPagination.link_rewrite(request, link)
+        self.assertEqual(link, result)
 
     def test_link_now_rewrite(self):
         """Test the no link rewrite."""
@@ -41,3 +49,37 @@ class PaginationTest(TestCase):
         link = 'http://localhost:8000/api/v1/providers/?page=2'
         result = StandardResultsSetPagination.link_rewrite(request, link)
         self.assertEqual(link, result)
+
+    @patch('api.common.pagination.PageNumberPagination.get_next_link',
+           return_value=None)
+    def test_get_next_link_none(self, mock_super):
+        paginator = StandardResultsSetPagination()
+        link = paginator.get_next_link()
+        self.assertIsNone(link)
+
+    @patch('api.common.pagination.PageNumberPagination.get_previous_link',
+           return_value=None)
+    def test_get_previous_link_none(self, mock_super):
+        paginator = StandardResultsSetPagination()
+        link = paginator.get_previous_link()
+        self.assertIsNone(link)
+
+    @patch('api.common.pagination.PageNumberPagination.get_next_link')
+    def test_get_next_link_value(self, mock_super):
+        expected = 'http://localhost:8000/api/v1/providers/?page=2'
+        mock_super.return_value = expected
+        paginator = StandardResultsSetPagination()
+        paginator.request = Mock
+        paginator.request.META = {}
+        link = paginator.get_next_link()
+        self.assertEqual(link, expected)
+
+    @patch('api.common.pagination.PageNumberPagination.get_previous_link')
+    def test_get_previous_link_value(self, mock_super):
+        expected = 'http://localhost:8000/api/v1/providers/?page=2'
+        mock_super.return_value = expected
+        paginator = StandardResultsSetPagination()
+        paginator.request = Mock
+        paginator.request.META = {}
+        link = paginator.get_previous_link()
+        self.assertEqual(link, expected)

--- a/koku/koku/middleware.py
+++ b/koku/koku/middleware.py
@@ -167,6 +167,7 @@ class IdentityHeaderMiddleware(MiddlewareMixin):  # pylint: disable=R0903
                 query_string = '?{}'.format(request.META['QUERY_STRING'])
             logger.info(f'API: {request.path}{query_string}'  # pylint: disable=W1203
                         f' -- ACCOUNT: {account} USER: {username}')
+            logger.info(f'META: {request.META}')
             try:
                 customer = Customer.objects.filter(account_id=account).get()
             except Customer.DoesNotExist:

--- a/koku/koku/middleware.py
+++ b/koku/koku/middleware.py
@@ -167,7 +167,6 @@ class IdentityHeaderMiddleware(MiddlewareMixin):  # pylint: disable=R0903
                 query_string = '?{}'.format(request.META['QUERY_STRING'])
             logger.info(f'API: {request.path}{query_string}'  # pylint: disable=W1203
                         f' -- ACCOUNT: {account} USER: {username}')
-            logger.info(f'META: {request.META}')
             try:
                 customer = Customer.objects.filter(account_id=account).get()
             except Customer.DoesNotExist:


### PR DESCRIPTION
3scale was passing a longer path than I had originally seen.
Fixed that plus any case where api is not found in the path_info or locally.
Also figured out how to properly patch the super, so 100% coverage.

pagination links are now partial urls, but validated the pagination buttons still work!