### PR TITLE
Provide cluster_alias for cluster related output to make interaction more user friendly

### DIFF
--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -142,7 +142,7 @@ class ProviderMap(object):
         'filters': {
             'project': {'field': 'namespace',
                         'operation': 'icontains'},
-            'cluster': {'field': 'cluster_id',
+            'cluster': {'field': 'cluster_alias',
                         'operation': 'icontains'},
             'pod': {'field': 'pod',
                     'operation': 'icontains'},


### PR DESCRIPTION
Queries with cluster will now return a _cluster_alias_ which is the provider name that was setup.

*GET* `api/v1/reports/inventory/ocp/memory/?filter[time_scope_value]=-1&filter[resolution]=monthly&filter[time_scope_units]=month&group_by[cluster]=hccm&delta=usage__capacity&filter[limit]=5`
```
{
    "group_by": {
        "cluster": [
            "hccm"
        ]
    },
    "delta": {
        "value": -4652.568689,
        "percent": 30.51694302767339
    },
    "filter": {
        "resolution": "monthly",
        "time_scope_value": "-1",
        "time_scope_units": "month",
        "limit": 5
    },
    "data": [
        {
            "date": "2018-12",
            "clusters": [
                {
                    "cluster": "3de10d3e-4a16-51f2-a51d-90366553d530",
                    "values": [
                        {
                            "date": "2018-12",
                            "cluster": "3de10d3e-4a16-51f2-a51d-90366553d530",
                            "usage": 2043.407124,
                            "request": 2495.68073,
                            "limit": 2638.12566,
                            "capacity": 6695.975813,
                            "charge": 143.174703,
                            "units": "GB-Hours",
                            "cluster_alias": "hccm-vmware",
                            "delta_value": -4652.568689,
                            "delta_percent": 30.51694302767339
                        }
                    ]
                }
            ]
        }
    ],
    "total": {
        "usage": 2043.407124,
        "request": 2495.68073,
        "limit": 2638.12566,
        "capacity": 6695.975813,
        "charge": 143.174703,
        "units": "GB-Hours"
    }
}
```


FYI:
@dlabrecq @boaz1337