### PR TITLE
Report cluster capacity actually by cluster

### DIFF
--- a/koku/api/report/test/ocp/test_ocp_query_handler.py
+++ b/koku/api/report/test/ocp/test_ocp_query_handler.py
@@ -16,12 +16,14 @@
 #
 """Test the Report Queries."""
 import copy
+from collections import defaultdict
 from decimal import Decimal
 from unittest.mock import patch
 from urllib.parse import quote_plus, urlencode
 
 from tenant_schemas.utils import tenant_context
 
+from django.db.models import Max
 from api.iam.test.iam_test_case import IamTestCase
 from api.query_filter import QueryFilterCollection
 from api.report.ocp.ocp_query_handler import OCPReportQueryHandler
@@ -126,6 +128,56 @@ class OCPReportQueryHandlerTest(IamTestCase):
         self.assertTrue('capacity' in query_data[0])
         self.assertEqual(query_data[0].get('capacity'),
                          total_capacity.get('capacity'))
+
+    def test_get_cluster_capacity_monthly_resolution_multiple_clusters(self):
+        """Test that cluster capacity returns capacity by cluster."""
+        # Add data for a second cluster
+        OCPReportDataGenerator(self.tenant).add_data_to_tenant()
+
+        query_params = {'filter': {'resolution': 'monthly',
+                                   'time_scope_value': -1,
+                                   'time_scope_units': 'month'},
+                        'group_by': {'cluster': ['*']},
+                        }
+        query_string = '?filter[resolution]=monthly&' + \
+                       'filter[time_scope_value]=-1&' + \
+                       'filter[time_scope_units]=month&' + \
+                       'group_by[cluster]=*'
+
+        handler = OCPReportQueryHandler(
+            query_params,
+            query_string,
+            self.tenant,
+            **{'report_type': 'cpu'}
+        )
+
+        query_data = handler.execute_query()
+
+        capacity_by_cluster = defaultdict(Decimal)
+        total_capacity = Decimal(0)
+        query_filter = handler.query_filter
+        query_group_by = ['usage_start', 'cluster_id']
+        annotations = {'capacity': Max('cluster_capacity_cpu_core_hours')}
+        cap_key = list(annotations.keys())[0]
+
+        q_table = handler._mapper._provider_map.get('tables').get('query')
+        query = q_table.objects.filter(query_filter)
+
+        with tenant_context(self.tenant):
+            cap_data = query.values(*query_group_by).annotate(**annotations)
+            for entry in cap_data:
+                cluster_id = entry.get('cluster_id', '')
+                capacity_by_cluster[cluster_id] += entry.get(cap_key, 0)
+                total_capacity += entry.get(cap_key, 0)
+
+        for entry in query_data.get('data', []):
+            for cluster in entry.get('clusters', []):
+                cluster_name = cluster.get('cluster', '')
+                capacity = cluster.get('values')[0].get('capacity')
+                self.assertEqual(capacity, capacity_by_cluster[cluster_name])
+
+        self.assertEqual(query_data.get('total', {}).get('capacity'),
+                         total_capacity)
 
     def test_get_cluster_capacity_daily_resolution(self):
         """Test that cluster capacity is unaltered for daily resolution."""

--- a/koku/api/report/test/ocp/test_ocp_query_handler.py
+++ b/koku/api/report/test/ocp/test_ocp_query_handler.py
@@ -21,9 +21,9 @@ from decimal import Decimal
 from unittest.mock import patch
 from urllib.parse import quote_plus, urlencode
 
+from django.db.models import Max
 from tenant_schemas.utils import tenant_context
 
-from django.db.models import Max
 from api.iam.test.iam_test_case import IamTestCase
 from api.query_filter import QueryFilterCollection
 from api.report.ocp.ocp_query_handler import OCPReportQueryHandler


### PR DESCRIPTION
## Summary 
Cluster capacity was being reported without considering that multiple clusters might be reported. This adds cluster_id to the group by and uses the proper cluster's total capacity when group by cluster is used as a param

`GET /api/v1/reports/inventory/ocp/cpu/?group_by[cluster]=*&filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly`

```
HTTP 200 OK
Allow: GET, OPTIONS
Content-Type: application/json
Vary: Accept

{
    "group_by": {
        "cluster": [
            "*"
        ]
    },
    "filter": {
        "resolution": "monthly",
        "time_scope_value": "-1",
        "time_scope_units": "month"
    },
    "data": [
        {
            "date": "2019-01",
            "clusters": [
                {
                    "cluster": "my-ocp-cluster-1",
                    "values": [
                        {
                            "date": "2019-01",
                            "cluster": "my-ocp-cluster-1",
                            "usage": 685.485241,
                            "request": 1316.86914,
                            "limit": 2000.158608,
                            "capacity": 1440.0,
                            "charge": 0.0,
                            "units": "Core-Hours",
                            "cluster_alias": "OCP Test Provider"
                        }
                    ]
                },
                {
                    "cluster": "nise",
                    "values": [
                        {
                            "date": "2019-01",
                            "cluster": "nise",
                            "usage": 459.616675,
                            "request": 878.952278,
                            "limit": 1269.619299,
                            "capacity": 1225.0,
                            "charge": 0.0,
                            "units": "Core-Hours",
                            "cluster_alias": "Test Provider"
                        }
                    ]
                },
                {
                    "cluster": "my-ocp-cluster-2",
                    "values": [
                        {
                            "date": "2019-01",
                            "cluster": "my-ocp-cluster-2",
                            "usage": 271.161308,
                            "request": 518.946453,
                            "limit": 756.305947,
                            "capacity": 800.0,
                            "charge": 0.0,
                            "units": "Core-Hours",
                            "cluster_alias": "my-ocp-cluster-2"
                        }
                    ]
                }
            ]
        }
    ],
    "total": {
        "usage": 1416.263224,
        "request": 2714.767871,
        "limit": 4026.083854,
        "capacity": 3465.0,
        "charge": 0.0,
        "units": "Core-Hours"
    }
}
```