### PR TITLE
Use case-insensitive ordering for non-numeric fields.

### DIFF
--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -574,6 +574,7 @@ class ReportQueryHandler(QueryHandler):
             (list): The sorted/ordered list
 
         """
+        numeric_ordering = ['date', 'rank', 'delta', 'delta_percent', 'total', 'charge', 'usage']
         sorted_data = data
         for field in reversed(order_fields):
             reverse = False
@@ -581,8 +582,12 @@ class ReportQueryHandler(QueryHandler):
             if '-' in field:
                 reverse = True
                 field = field.replace('-', '')
-            sorted_data = sorted(sorted_data, key=lambda entry: entry[field],
-                                 reverse=reverse)
+            if field in numeric_ordering:
+                sorted_data = sorted(sorted_data, key=lambda entry: entry[field],
+                                     reverse=reverse)
+            else:
+                sorted_data = sorted(sorted_data, key=lambda entry: entry[field].lower(),
+                                     reverse=reverse)
         return sorted_data
 
     def _percent_delta(self, a, b):


### PR DESCRIPTION

*GET* `/api/v1/reports/charges/ocp/?delta=charge&filter[time_scope_units]=month&filter[time_scope_value]=-2&filter[resolution]=monthly&group_by[project]=*&order_by[project]=asc`

```
{
    "group_by": {
        "project": [
            "*"
        ]
    },
    "delta": {
        "value": -36435.807778,
        "percent": -53.70278127120017
    },
    "order_by": {
        "project": "asc"
    },
    "filter": {
        "resolution": "monthly",
        "time_scope_value": "-2",
        "time_scope_units": "month"
    },
    "data": [
        {
            "date": "2018-12",
            "projects": [
                {
                    "project": "administration_prod",
                    "values": [
                        {
                            "date": "2018-12",
                            "project": "administration_prod",
                            "charge": 7.144184,
                            "units": "USD",
                            "delta_value": 7.144184,
                            "delta_percent": null
                        }
                    ]
                },
...
                {
                    "project": "lose_prod",
                    "values": [
                        {
                            "date": "2018-12",
                            "project": "lose_prod",
                            "charge": 2330.186506,
                            "units": "USD",
                            "delta_value": 2330.186506,
                            "delta_percent": null
                        }
                    ]
                },
                {
                    "project": "marriage_qa",
                    "values": [
                        {
                            "date": "2018-12",
                            "project": "marriage_qa",
                            "charge": 56.753062,
                            "units": "USD",
                            "delta_value": 56.753062,
                            "delta_percent": null
                        }
                    ]
                },
                {
                    "project": "Mrs_prod",
                    "values": [
                        {
                            "date": "2018-12",
                            "project": "Mrs_prod",
                            "charge": 340.091752,
                            "units": "USD",
                            "delta_value": 340.091752,
                            "delta_percent": null
                        }
                    ]
                },
                {
                    "project": "no_staging",
                    "values": [
                        {
                            "date": "2018-12",
                            "project": "no_staging",
                            "charge": 20.413243,
                            "units": "USD",
                            "delta_value": 20.413243,
                            "delta_percent": null
                        }
                    ]
                },
...
    ],
    "total": {
        "charge": 31411.344484,
        "units": "USD"
    }
}
```