### PR TITLE
Ocp tag prefix

### DIFF
--- a/koku/api/report/ocp/view.py
+++ b/koku/api/report/ocp/view.py
@@ -34,7 +34,9 @@ def get_tag_keys(request):
     """Get a list of tag keys to validate filters."""
     tenant = get_tenant(request.user)
     handler = OCPTagQueryHandler('', {}, tenant)
-    return handler.get_tag_keys(filters=False)
+    tags = handler.get_tag_keys(filters=False)
+    tags = [':'.join(['tag', tag]) for tag in tags]
+    return tags
 
 
 @api_view(http_method_names=['GET'])

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -35,6 +35,11 @@ from reporting.models import (AWSCostEntryLineItemAggregates,
 LOG = logging.getLogger(__name__)
 
 
+def strip_tag_prefix(tag):
+        """Remove the query tag prefix from a tag key."""
+        return tag.replace('tag:', '')
+
+
 class ProviderMap(object):
     """Data structure mapping between API params and DB Model names.
 
@@ -366,6 +371,7 @@ class ReportQueryHandler(QueryHandler):
         tag_group_by = self.get_tag_group_by_keys()
         tag_filters.extend(tag_group_by)
         for tag in tag_filters:
+            tag = strip_tag_prefix(tag)
             # Update the filter to use the label column name
             tag_db_name = tag_column + '__' + tag
             filt = {
@@ -420,6 +426,7 @@ class ReportQueryHandler(QueryHandler):
         tag_group_by = self.get_tag_group_by_keys()
         if tag_group_by:
             for tag in tag_group_by:
+                tag = strip_tag_prefix(tag)
                 tag_db_name = tag_column + '__' + tag
                 filt = {
                     'field': tag_db_name,
@@ -457,6 +464,7 @@ class ReportQueryHandler(QueryHandler):
         tag_column = self._mapper._provider_map.get('tag_column')
         tag_groups = self.get_tag_group_by_keys()
         for tag in tag_groups:
+            tag = strip_tag_prefix(tag)
             tag_db_name = tag_column + '__' + tag
             group_data = self.get_query_param_data('group_by', tag)
             if group_data:

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -371,9 +371,8 @@ class ReportQueryHandler(QueryHandler):
         tag_group_by = self.get_tag_group_by_keys()
         tag_filters.extend(tag_group_by)
         for tag in tag_filters:
-            tag = strip_tag_prefix(tag)
             # Update the filter to use the label column name
-            tag_db_name = tag_column + '__' + tag
+            tag_db_name = tag_column + '__' + strip_tag_prefix(tag)
             filt = {
                 'field': tag_db_name,
                 'operation': 'icontains'
@@ -390,7 +389,8 @@ class ReportQueryHandler(QueryHandler):
                     'field': tag_column,
                     'operation': 'has_key'
                 }
-                q_filter = QueryFilter(parameter=tag, **wild_card_filt)
+                q_filter = QueryFilter(parameter=strip_tag_prefix(tag),
+                                       **wild_card_filt)
                 filters.add(q_filter)
         return filters
 
@@ -426,8 +426,7 @@ class ReportQueryHandler(QueryHandler):
         tag_group_by = self.get_tag_group_by_keys()
         if tag_group_by:
             for tag in tag_group_by:
-                tag = strip_tag_prefix(tag)
-                tag_db_name = tag_column + '__' + tag
+                tag_db_name = tag_column + '__' + strip_tag_prefix(tag)
                 filt = {
                     'field': tag_db_name,
                     'operation': 'isnull',
@@ -464,8 +463,7 @@ class ReportQueryHandler(QueryHandler):
         tag_column = self._mapper._provider_map.get('tag_column')
         tag_groups = self.get_tag_group_by_keys()
         for tag in tag_groups:
-            tag = strip_tag_prefix(tag)
-            tag_db_name = tag_column + '__' + tag
+            tag_db_name = tag_column + '__' + strip_tag_prefix(tag)
             group_data = self.get_query_param_data('group_by', tag)
             if group_data:
                 tag = quote_plus(tag)

--- a/koku/api/report/test/ocp/tests_views.py
+++ b/koku/api/report/test/ocp/tests_views.py
@@ -803,7 +803,7 @@ class OCPReportViewTest(IamTestCase):
 
         url = reverse('reports-ocp-cpu')
         client = APIClient()
-        params = {f'filter[{filter_key}]': filter_value}
+        params = {f'filter[tag:{filter_key}]': filter_value}
 
         url = url + '?' + urlencode(params, quote_via=quote_plus)
         response = client.get(url, **self.headers)
@@ -837,7 +837,7 @@ class OCPReportViewTest(IamTestCase):
 
         url = reverse('reports-ocp-cpu')
         client = APIClient()
-        params = {f'filter[{filter_key}]': '*'}
+        params = {f'filter[tag:{filter_key}]': '*'}
 
         url = url + '?' + urlencode(params, quote_via=quote_plus)
         response = client.get(url, **self.headers)
@@ -858,7 +858,7 @@ class OCPReportViewTest(IamTestCase):
 
         url = reverse('reports-ocp-cpu')
         client = APIClient()
-        params = {f'group_by[{group_by_key}]': '*'}
+        params = {f'group_by[tag:{group_by_key}]': '*'}
 
         url = url + '?' + urlencode(params, quote_via=quote_plus)
         response = client.get(url, **self.headers)

--- a/koku/api/report/test/tests_queries.py
+++ b/koku/api/report/test/tests_queries.py
@@ -31,6 +31,7 @@ from tenant_schemas.utils import tenant_context
 
 from api.iam.test.iam_test_case import IamTestCase
 from api.report.aws.aws_query_handler import AWSReportQueryHandler
+from api.report.queries import strip_tag_prefix
 from api.utils import DateHelper
 from reporting.models import (AWSAccountAlias,
                               AWSCostEntry,
@@ -1850,3 +1851,11 @@ class ReportQueryTest(IamTestCase):
 
         ordered_data = handler.order_by(unordered_data, order_fields)
         self.assertEqual(ordered_data, expected)
+
+    def test_strip_tag_prefix(self):
+        """Verify that our tag prefix is stripped from a string."""
+        tag_str = 'tag:project'
+
+        result = strip_tag_prefix(tag_str)
+
+        self.assertEqual(result, tag_str.replace('tag:', ''))


### PR DESCRIPTION
## Summary
This adds the `tag:` prefix to filters and group bys that use tag keys for OCP report APIs. 

## Examples

`http://localhost:8000/api/v1/reports/inventory/ocp/cpu/?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&group_by[tag:project]=institution`

```
HTTP 200 OK
Allow: GET, OPTIONS
Content-Type: application/json
Vary: Accept

{
    "group_by": {
        "tag:project": [
            "institution"
        ]
    },
    "filter": {
        "resolution": "monthly",
        "time_scope_value": "-1",
        "time_scope_units": "month"
    },
    "data": [
        {
            "date": "2019-01",
            "projects": [
                {
                    "project": "institution",
                    "values": [
                        {
                            "project": "institution",
                            "date": "2019-01",
                            "usage": 2.788974,
                            "request": 6.445987,
                            "limit": 7.665694,
                            "capacity": 1440.0,
                            "charge": 0.0,
                            "units": "Core-Hours"
                        }
                    ]
                }
            ]
        }
    ],
    "total": {
        "usage": 2.788974,
        "request": 6.445987,
        "limit": 7.665694,
        "capacity": 1440.0,
        "charge": 0.0,
        "units": "Core-Hours"
    }
}
```