### PR TITLE
Support alias or ID based filtering via composition_key.

### DIFF
--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -62,8 +62,12 @@ class ProviderMap(object):
                         'avail_zone': 'availability_zone'},
         'end_date': 'usage_end',
         'filters': {
-            'account': {'field': 'account_alias__account_alias',
-                        'operation': 'icontains'},
+            'account': [{'field': 'account_alias__account_alias',
+                        'operation': 'icontains',
+                        'composition_key': 'account_filter'},
+                        {'field': 'usage_account_id',
+                        'operation': 'icontains',
+                        'composition_key': 'account_filter'}],
             'service': {'field': 'product_code',
                         'operation': 'icontains'},
             'avail_zone': {'field': 'availability_zone',
@@ -147,8 +151,12 @@ class ProviderMap(object):
         'filters': {
             'project': {'field': 'namespace',
                         'operation': 'icontains'},
-            'cluster': {'field': 'cluster_alias',
-                        'operation': 'icontains'},
+            'cluster': [{'field': 'cluster_alias',
+                        'operation': 'icontains',
+                        'composition_key': 'cluster_filter'},
+                        {'field': 'cluster_id',
+                        'operation': 'icontains',
+                        'composition_key': 'cluster_filter'}],
             'pod': {'field': 'pod',
                     'operation': 'icontains'},
             'node': {'field': 'node',
@@ -354,9 +362,15 @@ class ReportQueryHandler(QueryHandler):
             filter_ = self.get_query_param_data('filter', q_param, list())
             list_ = list(set(group_by + filter_))    # uniquify the list
             if list_ and not ReportQueryHandler.has_wildcard(list_):
-                for item in list_:
-                    q_filter = QueryFilter(parameter=item, **filt)
-                    filters.add(q_filter)
+                if isinstance(filt, list):
+                    for _filt in filt:
+                        for item in list_:
+                            q_filter = QueryFilter(parameter=item, **_filt)
+                            filters.add(q_filter)
+                else:
+                    for item in list_:
+                        q_filter = QueryFilter(parameter=item, **filt)
+                        filters.add(q_filter)
 
         # Update filters with tag filters
         filters = self._set_tag_filters(filters)


### PR DESCRIPTION
You can now filter using the alias or id for account and cluster.

## Account
*GET* `api/v1/reports/inventory/aws/instance-type/?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[limit]=5&group_by[account]=hccm`
```
{
    "group_by": {
        "account": [
            "hccm"
        ]
    },
    "filter": {
        "resolution": "monthly",
        "time_scope_value": "-1",
        "time_scope_units": "month",
        "limit": 5
    },
    "data": [
        {
            "date": "2019-01",
            "accounts": [
                {
                    "account": "589173575009",
                    "instance_types": [
                        {
                            "instance_type": "t2.micro",
                            "values": [
                                {
                                    "instance_type": "t2.micro",
                                    "date": "2019-01",
                                    "units": "Hrs",
                                    "account": "589173575009",
                                    "cost": 0.0,
                                    "count": 0,
                                    "total": 104.0,
                                    "account_alias": "hccm-alias"
                                }
                            ]
                        },
                        {
                            "instance_type": "t2.small",
                            "values": [
                                {
                                    "instance_type": "t2.small",
                                    "date": "2019-01",
                                    "units": "Hrs",
                                    "account": "589173575009",
                                    "cost": 1.449,
                                    "count": 0,
                                    "total": 63.0,
                                    "account_alias": "hccm-alias"
                                }
                            ]
                        }
                    ]
                }
            ]
        }
    ],
    "total": {
        "units": "Hrs",
        "cost": 1.449,
        "count": 0,
        "value": 167.0
    }
}
```
*GET* `api/v1/reports/inventory/aws/instance-type/?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[limit]=5&group_by[account]=589173`
```
{
    "group_by": {
        "account": [
            "589173"
        ]
    },
    "filter": {
        "resolution": "monthly",
        "time_scope_value": "-1",
        "time_scope_units": "month",
        "limit": 5
    },
    "data": [
        {
            "date": "2019-01",
            "accounts": [
                {
                    "account": "589173575009",
                    "instance_types": [
                        {
                            "instance_type": "t2.micro",
                            "values": [
                                {
                                    "instance_type": "t2.micro",
                                    "date": "2019-01",
                                    "units": "Hrs",
                                    "account": "589173575009",
                                    "cost": 0.0,
                                    "count": 0,
                                    "total": 104.0,
                                    "account_alias": "hccm-alias"
                                }
                            ]
                        },
                        {
                            "instance_type": "t2.small",
                            "values": [
                                {
                                    "instance_type": "t2.small",
                                    "date": "2019-01",
                                    "units": "Hrs",
                                    "account": "589173575009",
                                    "cost": 1.449,
                                    "count": 0,
                                    "total": 63.0,
                                    "account_alias": "hccm-alias"
                                }
                            ]
                        }
                    ]
                }
            ]
        }
    ],
    "total": {
        "units": "Hrs",
        "cost": 1.449,
        "count": 0,
        "value": 167.0
    }
}
```

## Cluster

*GET* `api/v1/reports/inventory/ocp/cpu/?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&group_by[cluster]=3de10d3e`
```
{
    "group_by": {
        "cluster": [
            "3de10d3e"
        ]
    },
    "filter": {
        "resolution": "monthly",
        "time_scope_value": "-1",
        "time_scope_units": "month"
    },
    "data": [
        {
            "date": "2019-01",
            "clusters": [
                {
                    "cluster": "3de10d3e-4a16-51f2-a51d-90366553d530",
                    "values": [
                        {
                            "date": "2019-01",
                            "cluster": "3de10d3e-4a16-51f2-a51d-90366553d530",
                            "usage": 73.283258,
                            "request": 463.7724,
                            "limit": 613.216504,
                            "capacity": 510.866667,
                            "charge": 93.267465,
                            "units": "Core-Hours",
                            "cluster_alias": "hccm-vmware"
                        }
                    ]
                }
            ]
        }
    ],
    "total": {
        "usage": 73.283258,
        "request": 463.7724,
        "limit": 613.216504,
        "capacity": 510.866667,
        "charge": 93.267465,
        "units": "Core-Hours"
    }
}
```

*GET* `api/v1/reports/inventory/ocp/cpu/?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&group_by[cluster]=hccm`
```
{
    "group_by": {
        "cluster": [
            "hccm"
        ]
    },
    "filter": {
        "resolution": "monthly",
        "time_scope_value": "-1",
        "time_scope_units": "month"
    },
    "data": [
        {
            "date": "2019-01",
            "clusters": [
                {
                    "cluster": "3de10d3e-4a16-51f2-a51d-90366553d530",
                    "values": [
                        {
                            "date": "2019-01",
                            "cluster": "3de10d3e-4a16-51f2-a51d-90366553d530",
                            "usage": 73.283258,
                            "request": 463.7724,
                            "limit": 613.216504,
                            "capacity": 510.866667,
                            "charge": 93.267465,
                            "units": "Core-Hours",
                            "cluster_alias": "hccm-vmware"
                        }
                    ]
                }
            ]
        }
    ],
    "total": {
        "usage": 73.283258,
        "request": 463.7724,
        "limit": 613.216504,
        "capacity": 510.866667,
        "charge": 93.267465,
        "units": "Core-Hours"
    }
}
```