### PR TITLE
add prometheus gauge to track postgresql tenant size

### DIFF
--- a/koku/api/status/views.py
+++ b/koku/api/status/views.py
@@ -23,6 +23,7 @@ from rest_framework.response import Response
 
 from api.status.models import Status
 from api.status.serializers import StatusSerializer
+from koku.metrics import DBSTATUS
 
 
 @api_view(['GET', 'HEAD'])
@@ -76,4 +77,5 @@ def status(request):
     serializer = StatusSerializer(status_info)
     server_info = serializer.data
     server_info['server_address'] = request.META.get('HTTP_HOST', 'localhost')
+    DBSTATUS.collect()    # trigger update to prometheus metrics
     return Response(server_info)

--- a/koku/koku/metrics.py
+++ b/koku/koku/metrics.py
@@ -1,0 +1,133 @@
+#
+# Copyright 2018 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Prometheus metrics."""
+
+import logging
+import time
+from datetime import datetime, timedelta
+
+import psycopg2
+from prometheus_client import Gauge
+
+from koku import database
+
+LOG = logging.getLogger(__name__)
+PGSQL_GAUGE = Gauge('postgresql_schema_size_bytes',
+                    'PostgreSQL DB Size (bytes)',
+                    ['schema'])
+
+
+class DatabaseStatus(object):
+    """Database status information."""
+
+    _last_result = None
+    _last_query = None
+
+    def __init__(self):
+        """Constructor."""
+        cfg = database.config()
+        if cfg.get('ENGINE') == 'tenant_schemas.postgresql_backend':
+            cfg['ENGINE'] = 'postgresql'
+        self.uri = '{ENGINE}://{USER}:{PASSWORD}@{HOST}:{PORT}/{NAME}'.format(**cfg)
+
+    def _query(self, query):
+        """Execute a SQL query, format the results.
+
+        Returns:
+            [
+                {col_1: <value>, col_2: value, ...},
+                {col_1: <value>, col_2: value, ...},
+                {col_1: <value>, col_2: value, ...},
+            ]
+
+        """
+        query_interval = datetime.now() - timedelta(minutes=5)
+        if self._last_query and \
+                self._last_query < query_interval:
+            return self._last_result
+
+        retries = 0
+        rows = None
+        while retries < 10:
+            try:
+                connection = psycopg2.connect(self.uri)
+                cursor = connection.cursor()
+                cursor.execute(query)
+                rows = cursor.fetchall()
+            except (psycopg2.OperationalError, psycopg2.InterfaceError) as exc:
+                LOG.warning(exc)
+                time.sleep(3)
+                continue
+            break
+
+        if not rows:
+            LOG.error("Query failed to return results.")
+            return []
+
+        # get column names
+        names = [desc[0] for desc in cursor.description]
+
+        # transform list-of-lists into list-of-dicts including column names.
+        result = [dict(zip(names, row)) for row in rows]
+
+        self._last_result = result
+        self._last_query = datetime.now()
+
+        connection.close()
+        return result
+
+    def collect(self):
+        """Collect stats and report using Prometheus objects."""
+        stats = self.schema_size()
+        for item in stats:
+            PGSQL_GAUGE.labels(schema=item.get('schema')).set(item.get('size'))
+
+    def schema_size(self):
+        """Show DB storage consumption.
+
+        Returns:
+            [
+                {schema: <string>, size: <bigint> },
+                {schema: <string>, size: <bigint> },
+                {schema: <string>, size: <bigint> },
+            ]
+
+        """
+        # sample query output:
+        #
+        #   schema   |   size
+        # -----------+----------
+        #  acct10001 | 51011584
+        #
+        query = """
+            SELECT schema_name as schema,
+                   sum(table_size)::bigint as size
+            FROM (
+              SELECT pg_catalog.pg_namespace.nspname as schema_name,
+                     pg_relation_size(pg_catalog.pg_class.oid) as table_size
+              FROM   pg_catalog.pg_class
+                 JOIN pg_catalog.pg_namespace ON relnamespace = pg_catalog.pg_namespace.oid
+              WHERE pg_catalog.pg_namespace.nspname NOT IN ('public', 'pg_catalog', 'pg_toast', 'information_schema')
+            ) t
+            GROUP BY schema_name
+            ORDER BY schema_name;
+        """
+        return self._query(query)
+
+
+DBSTATUS = DatabaseStatus()

--- a/koku/koku/metrics.py
+++ b/koku/koku/metrics.py
@@ -63,7 +63,7 @@ class DatabaseStatus(object):
 
         retries = 0
         rows = None
-        while retries < 10:
+        while retries < 3:
             try:
                 connection = psycopg2.connect(self.uri)
                 cursor = connection.cursor()
@@ -71,7 +71,8 @@ class DatabaseStatus(object):
                 rows = cursor.fetchall()
             except (psycopg2.OperationalError, psycopg2.InterfaceError) as exc:
                 LOG.warning(exc)
-                time.sleep(3)
+                retries += 1
+                time.sleep(2)
                 continue
             break
 

--- a/koku/koku/tests_metrics.py
+++ b/koku/koku/tests_metrics.py
@@ -1,0 +1,56 @@
+#
+# Copyright 2018 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""Test the prometheus metrics."""
+from unittest.mock import patch
+
+from api.iam.test.iam_test_case import IamTestCase
+from koku.metrics import DatabaseStatus
+
+
+class DatabaseStatusTest(IamTestCase):
+    """Test DatabaseStatus object."""
+
+    def test_constructor(self):
+        """Test DatabaseStatus constructor."""
+        dbs = DatabaseStatus()
+        self.assertIsNotNone(dbs.uri)
+        self.assertRegex(dbs.uri, r'\w+://\w+:[a-zA-Z0-9\']*@\w+:\d+/\w+')
+
+    @patch('koku.metrics.DatabaseStatus._query', return_value=True)
+    def test_schema_size(self, mock_status):
+        """Test schema_size()."""
+        dbs = DatabaseStatus()
+        result = dbs.schema_size()
+        assert mock_status.called
+        self.assertTrue(result)
+
+    @patch('koku.metrics.PGSQL_GAUGE.labels')
+    @patch('koku.metrics.DatabaseStatus._query', return_value=[{'schema': 'foo',
+                                                                'size': 10}])
+    def test_collect(self, mock_query, mock_gauge):
+        """Test collect()."""
+        dbs = DatabaseStatus()
+        dbs.collect()
+        assert mock_gauge.called
+
+    def test_query(self):
+        """Test _query()."""
+        test_query = 'SELECT count(*) from now()'
+        expected = [{'count': 1}]
+        dbs = DatabaseStatus()
+        result = dbs._query(test_query)
+        self.assertEqual(result, expected)


### PR DESCRIPTION
This adds a Gauge for tracking postgresql tenant schema size.  Each schema name is a label. 

Functional Screenshot:
![screenshot](https://user-images.githubusercontent.com/17390/51767954-d31f0500-20ac-11e9-99e5-5e4c170e78c7.png)
