### PR TITLE
removing tags__ prefix from AWS group_by response

### DIFF
--- a/koku/api/report/aws/aws_query_handler.py
+++ b/koku/api/report/aws/aws_query_handler.py
@@ -142,6 +142,10 @@ class AWSReportQueryHandler(ReportQueryHandler):
 
             is_csv_output = self._accept_type and 'text/csv' in self._accept_type
 
+            query_data, query_group_by = self.strip_label_column_name(
+                query_data,
+                query_group_by
+            )
             query_data = self.order_by(query_data, query_order_by)
 
             if is_csv_output:

--- a/koku/api/report/ocp/ocp_query_handler.py
+++ b/koku/api/report/ocp/ocp_query_handler.py
@@ -273,21 +273,3 @@ class OCPReportQueryHandler(ReportQueryHandler):
         }
 
         return query_data
-
-    def strip_label_column_name(self, data, group_by):
-        """Remove the column name from tags."""
-        tag_column = self._mapper._provider_map.get('tag_column')
-        val_to_strip = tag_column + '__'
-        new_data = []
-        for entry in data:
-            new_entry = {}
-            for key, value in entry.items():
-                key = key.replace(val_to_strip, '')
-                new_entry[key] = value
-
-            new_data.append(new_entry)
-
-        for i, group in enumerate(group_by):
-            group_by[i] = group.replace(val_to_strip, '')
-
-        return new_data, group_by

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -834,3 +834,21 @@ class ReportQueryHandler(QueryHandler):
                                 key=lambda x: x['delta_percent'],
                                 reverse=reverse)
         return query_data
+
+    def strip_label_column_name(self, data, group_by):
+        """Remove the column name from tags."""
+        tag_column = self._mapper._provider_map.get('tag_column')
+        val_to_strip = tag_column + '__'
+        new_data = []
+        for entry in data:
+            new_entry = {}
+            for key, value in entry.items():
+                key = key.replace(val_to_strip, '')
+                new_entry[key] = value
+
+            new_data.append(new_entry)
+
+        for i, group in enumerate(group_by):
+            group_by[i] = group.replace(val_to_strip, '')
+
+        return new_data, group_by


### PR DESCRIPTION

```
GET /api/v1/reports/inventory/aws/instance-type/?group_by[tag:environment]=*
HTTP 200 OK
Allow: OPTIONS, GET
Content-Type: application/json
Vary: Accept

{
    "group_by": {
        "tag:environment": [
            "*"
        ]
    },
    "data": [
        {
            "date": "2019-01-26",
            "environments": []
        },
        {
            "date": "2019-01-27",
            "environments": []
        },
        {
            "date": "2019-01-28",
            "environments": []
        },
        {
            "date": "2019-01-29",
            "environments": []
        },
        {
            "date": "2019-01-30",
            "environments": []
        },
        {
            "date": "2019-01-31",
            "environments": []
        },
        {
            "date": "2019-02-01",
            "environments": [
                {
                    "environment": null,
                    "instance_types": [
                        {
                            "instance_type": "m5.large",
                            "values": [
                                {
                                    "environment": "dev",
                                    "instance_type": "m5.large",
                                    "date": "2019-02-01",
                                    "units": "Hrs",
                                    "cost": 48.0,
                                    "count": 2,
                                    "total": 48.0
                                }
                            ]
                        }
                    ]
                }
            ]
        },
        {
            "date": "2019-02-02",
            "environments": [
                {
                    "environment": null,
                    "instance_types": [
                        {
                            "instance_type": "m5.large",
                            "values": [
                                {
                                    "environment": "dev",
                                    "instance_type": "m5.large",
                                    "date": "2019-02-02",
                                    "units": "Hrs",
                                    "cost": 48.0,
                                    "count": 2,
                                    "total": 48.0
                                }
                            ]
                        }
                    ]
                }
            ]
        },
        {
            "date": "2019-02-03",
            "environments": [
                {
                    "environment": null,
                    "instance_types": [
                        {
                            "instance_type": "m5.large",
                            "values": [
                                {
                                    "environment": "dev",
                                    "instance_type": "m5.large",
                                    "date": "2019-02-03",
                                    "units": "Hrs",
                                    "cost": 24.0,
                                    "count": 1,
                                    "total": 24.0
                                }
                            ]
                        }
                    ]
                }
            ]
        },
        {
            "date": "2019-02-04",
            "environments": []
        }
    ],
    "total": {
        "units": "Hrs",
        "cost": 120.0,
        "count": 2,
        "value": 120.0
    }
}
```