### PR TITLE
Add our swagger file to the set of static files hosted by our server.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,7 @@ create-test-db-file: run-migrations
 gen-apidoc:
 	rm -fr $(PYDIR)/staticfiles/
 	apidoc -i $(PYDIR) -o $(APIDOC)
+	cp docs/source/specs/openapi.yml $(APIDOC)/
 
 collect-static:
 	$(PYTHON) $(PYDIR)/manage.py collectstatic --no-input


### PR DESCRIPTION
This just adds our swagger file to our existing collection of api doc files.