### PR TITLE
Fix OCP reports default ordering and travis tox lint.

### DIFF
--- a/koku/api/report/ocp/ocp_query_handler.py
+++ b/koku/api/report/ocp/ocp_query_handler.py
@@ -172,6 +172,7 @@ class OCPReportQueryHandler(ReportQueryHandler):
         tag_column = self._mapper._provider_map.get('tag_column')
         rank_orders = []
         rank_field = group_by_value.pop()
+        default_ordering = self._mapper._report_type_map.get('default_ordering')
 
         if self.order_field == 'delta' and '__' in self._delta:
             delta_field_one, delta_field_two = self._delta.split('__')
@@ -181,7 +182,7 @@ class OCPReportQueryHandler(ReportQueryHandler):
                     self.order_direction
                 )()
             )
-        elif self.query_parameters.get('order_by'):
+        elif self.query_parameters.get('order_by', default_ordering):
             rank_orders.append(
                 getattr(F(self.order_field), self.order_direction)()
             )

--- a/koku/reporting/provider/ocp/models.py
+++ b/koku/reporting/provider/ocp/models.py
@@ -768,6 +768,7 @@ class OCPAWSCostLineItemDailySummary(models.Model):
         null=True
     )
 
+
 class OCPStorageLineItem(models.Model):
     """Raw report storage data for OpenShift pods."""
 
@@ -821,6 +822,7 @@ class OCPStorageLineItem(models.Model):
 
     persistentvolume_labels = JSONField(null=True)
     persistentvolumeclaim_labels = JSONField(null=True)
+
 
 class OCPUStorageLineItemDaily(models.Model):
     """A daily aggregation of storage line items.
@@ -881,6 +883,7 @@ class OCPUStorageLineItemDaily(models.Model):
 
     persistentvolume_labels = JSONField(null=True)
     persistentvolumeclaim_labels = JSONField(null=True)
+
 
 class OCPStorageLineItemDailySummary(models.Model):
     """A daily aggregation of storage line items.

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,11 @@
 envlist = py37, py36, lint
 skipsdist = True
 
+[travis]
+python =
+  3.6: py36, lint
+  3.7: py37, lint
+
 [flake8]
 ; D106 = Missing docstring in public nested class
 ; D212 = Multi-line docstring summary should start at the first line


### PR DESCRIPTION
_Before:_
*GET* `/r/insights/platform/cost-management/api/v1/reports/charges/ocp/?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[limit]=5&group_by[project]=*`
```
{
	"group_by": {
		"project": ["*"]
	},
	"filter": {
		"resolution": "monthly",
		"time_scope_value": "-1",
		"time_scope_units": "month",
		"limit": 5
	},
	"data": [{
		"date": "2019-02",
		"projects": [{
			"project": "monitoring",
			"values": [{
				"date": "2019-02",
				"project": "monitoring",
				"charge": 30.720664,
				"units": "USD"
			}]
		}, {
			"project": "metering-hccm",
			"values": [{
				"date": "2019-02",
				"project": "metering-hccm",
				"charge": 108.975383,
				"units": "USD"
			}]
		}]
	}],
	"total": {
		"charge": 139.696047,
		"units": "USD"
	}
}
```

_After:_
*GET* `/r/insights/platform/cost-management/api/v1/reports/charges/ocp/?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[limit]=5&group_by[project]=*`
```
{
    "group_by": {
        "project": [
            "*"
        ]
    },
    "filter": {
        "resolution": "monthly",
        "time_scope_value": "-1",
        "time_scope_units": "month",
        "limit": 5
    },
    "data": [
        {
            "date": "2019-02",
            "projects": [
                {
                    "project": "metering-hccm",
                    "values": [
                        {
                            "date": "2019-02",
                            "project": "metering-hccm",
                            "charge": 108.302105,
                            "units": "USD"
                        }
                    ]
                },
                {
                    "project": "monitoring",
                    "values": [
                        {
                            "date": "2019-02",
                            "project": "monitoring",
                            "charge": 30.532298,
                            "units": "USD"
                        }
                    ]
                }
            ]
        }
    ],
    "total": {
        "charge": 138.834403,
        "units": "USD"
    }
}
```