### PR TITLE
Filter AWS tags by account or account alias.

### DIFF
--- a/koku/api/report/test/ocp/tests_views.py
+++ b/koku/api/report/test/ocp/tests_views.py
@@ -891,11 +891,13 @@ class OCPReportViewTest(IamTestCase):
 
         data = response.json()
         data = data.get('data', [])
-        previous_tag = data[0].get('app_labels', [])[0].get('app_label')
-
+        # default ordered by usage
+        previous_tag_usage = data[0].get('app_labels', [])[0].get('values', [{}])[0].get('usage', 0)
         for entry in data[0].get('app_labels', []):
-            current_tag = entry.get('app_label')
-            self.assertTrue(current_tag <= previous_tag)
+            current_tag_usage = entry.get('values', [{}])[0].get('usage', 0)
+            if 'Other' not in entry.get('app_label'):
+                self.assertTrue(current_tag_usage <= previous_tag_usage)
+                previous_tag_usage = current_tag_usage
 
     def test_execute_query_with_group_by_and_limit(self):
         """Test that data is grouped by and limited."""

--- a/koku/api/tags/aws/view.py
+++ b/koku/api/tags/aws/view.py
@@ -25,7 +25,7 @@ from rest_framework.settings import api_settings
 
 from api.report.view import _generic_report
 from api.tags.aws.aws_tag_query_handler import AWSTagQueryHandler
-from api.tags.serializers import TagsQueryParamSerializer
+from api.tags.serializers import AWSTagsQueryParamSerializer
 
 
 @api_view(http_method_names=['GET'])
@@ -65,5 +65,5 @@ def aws_tags(request):
 
     """
     extras = {}
-    return _generic_report(request, TagsQueryParamSerializer,
+    return _generic_report(request, AWSTagsQueryParamSerializer,
                            AWSTagQueryHandler, **extras)

--- a/koku/api/tags/ocp/view.py
+++ b/koku/api/tags/ocp/view.py
@@ -25,7 +25,7 @@ from rest_framework.settings import api_settings
 
 from api.report.view import _generic_report
 from api.tags.ocp.ocp_tag_query_handler import OCPTagQueryHandler
-from api.tags.serializers import TagsQueryParamSerializer
+from api.tags.serializers import OCPTagsQueryParamSerializer
 
 
 @api_view(http_method_names=['GET'])
@@ -65,5 +65,5 @@ def ocp_tags(request):
 
     """
     extras = {}
-    return _generic_report(request, TagsQueryParamSerializer,
+    return _generic_report(request, OCPTagsQueryParamSerializer,
                            OCPTagQueryHandler, **extras)

--- a/koku/api/tags/serializers.py
+++ b/koku/api/tags/serializers.py
@@ -103,9 +103,6 @@ class FilterSerializer(serializers.Serializer):
     time_scope_units = serializers.ChoiceField(choices=TIME_UNIT_CHOICES,
                                                required=False)
 
-    project = StringOrListField(child=serializers.CharField(),
-                                required=False)
-
     def validate(self, data):
         """Validate incoming data.
 
@@ -144,6 +141,20 @@ class FilterSerializer(serializers.Serializer):
         return data
 
 
+class OCPFilterSerializer(FilterSerializer):
+    """Serializer for handling tag query parameter filter."""
+
+    project = StringOrListField(child=serializers.CharField(),
+                                required=False)
+
+
+class AWSFilterSerializer(FilterSerializer):
+    """Serializer for handling tag query parameter filter."""
+
+    account = StringOrListField(child=serializers.CharField(),
+                                required=False)
+
+
 class TagsQueryParamSerializer(serializers.Serializer):
     """Serializer for handling query parameters."""
 
@@ -173,5 +184,17 @@ class TagsQueryParamSerializer(serializers.Serializer):
         Raises:
             (ValidationError): if filter field inputs are invalid
         """
-        validate_field(self, 'filter', FilterSerializer, value)
+        validate_field(self, 'filter', OCPFilterSerializer, value)
         return value
+
+
+class OCPTagsQueryParamSerializer(TagsQueryParamSerializer):
+    """Serializer for handling OCP tag query parameters."""
+
+    filter = OCPFilterSerializer(required=False)
+
+
+class AWSTagsQueryParamSerializer(TagsQueryParamSerializer):
+    """Serializer for handling AWS tag query parameters."""
+
+    filter = AWSFilterSerializer(required=False)

--- a/koku/api/tags/test/aws/test_aws_tag_query_handler.py
+++ b/koku/api/tags/test/aws/test_aws_tag_query_handler.py
@@ -150,3 +150,28 @@ class AWSTagQueryHandlerTest(IamTestCase):
         self.assertIsNotNone(query_output.get('data'))
         self.assertEqual(handler.time_scope_units, 'month')
         self.assertEqual(handler.time_scope_value, -2)
+
+    def test_execute_query_for_account(self):
+        """Test that the execute query runs properly with account query."""
+        account = IamTestCase.fake.ean8()
+        query_params = {'filter': {'resolution': 'daily',
+                                   'time_scope_value': -10,
+                                   'time_scope_units': 'day',
+                                   'account': account},
+                        }
+        query_string = '?filter[resolution]=daily&' + \
+                       'filter[time_scope_value]=-10&' + \
+                       'filter[time_scope_units]=day&' + \
+                       'filter[account]={}'.format(account)
+
+        handler = AWSTagQueryHandler(
+            query_params,
+            query_string,
+            self.tenant,
+            **{}
+        )
+
+        query_output = handler.execute_query()
+        self.assertIsNotNone(query_output.get('data'))
+        self.assertEqual(handler.time_scope_units, 'day')
+        self.assertEqual(handler.time_scope_value, -10)

--- a/koku/api/tags/test/ocp/test_ocp_tag_query_handler.py
+++ b/koku/api/tags/test/ocp/test_ocp_tag_query_handler.py
@@ -163,7 +163,7 @@ class OCPTagQueryHandlerTest(IamTestCase):
         self.assertEqual(handler.time_scope_value, -2)
 
     def test_execute_query_for_project(self):
-        """Test that the execute query runs properly with 10 day query."""
+        """Test that the execute query runs properly with project query."""
         namespace = None
         with tenant_context(self.tenant):
             namespace_obj = OCPUsageLineItemDailySummary.objects\

--- a/koku/api/tags/test/tests_serializers.py
+++ b/koku/api/tags/test/tests_serializers.py
@@ -19,7 +19,9 @@ from unittest import TestCase
 
 from rest_framework import serializers
 
-from api.tags.serializers import (FilterSerializer,
+from api.tags.serializers import (AWSFilterSerializer,
+                                  FilterSerializer,
+                                  OCPFilterSerializer,
                                   TagsQueryParamSerializer)
 
 
@@ -33,24 +35,6 @@ class FilterSerializerTest(TestCase):
                          'time_scope_units': 'day'}
         serializer = FilterSerializer(data=filter_params)
         self.assertTrue(serializer.is_valid())
-
-    def test_parse_filter_params_w_project_success(self):
-        """Test parse of a filter param with project successfully."""
-        filter_params = {'resolution': 'daily',
-                         'time_scope_value': '-10',
-                         'time_scope_units': 'day',
-                         'project': 'myproject'}
-        serializer = FilterSerializer(data=filter_params)
-        self.assertTrue(serializer.is_valid())
-
-    def test_parse_filter_params_w_project_failure(self):
-        """Test parse of a filter param with an invalid project."""
-        filter_params = {'resolution': 'daily',
-                         'time_scope_value': '-10',
-                         'time_scope_units': 'day',
-                         'project': 3}
-        serializer = FilterSerializer(data=filter_params)
-        self.assertFalse(serializer.is_valid())
 
     def test_parse_filter_no_params_success(self):
         """Test parse of a filter param successfully."""
@@ -94,6 +78,50 @@ class FilterSerializerTest(TestCase):
         serializer = FilterSerializer(data=filter_params)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
+
+
+class AWSFilterSerializerTest(TestCase):
+    """Tests for the AWS filter serializer."""
+
+    def test_parse_filter_params_w_project_success(self):
+        """Test parse of a filter param with project successfully."""
+        filter_params = {'resolution': 'daily',
+                         'time_scope_value': '-10',
+                         'time_scope_units': 'day',
+                         'account': 'myaccount'}
+        serializer = AWSFilterSerializer(data=filter_params)
+        self.assertTrue(serializer.is_valid())
+
+    def test_parse_filter_params_w_project_failure(self):
+        """Test parse of a filter param with an invalid project."""
+        filter_params = {'resolution': 'daily',
+                         'time_scope_value': '-10',
+                         'time_scope_units': 'day',
+                         'account': 3}
+        serializer = AWSFilterSerializer(data=filter_params)
+        self.assertFalse(serializer.is_valid())
+
+
+class OCPFilterSerializerTest(TestCase):
+    """Tests for the OCP filter serializer."""
+
+    def test_parse_filter_params_w_project_success(self):
+        """Test parse of a filter param with project successfully."""
+        filter_params = {'resolution': 'daily',
+                         'time_scope_value': '-10',
+                         'time_scope_units': 'day',
+                         'project': 'myproject'}
+        serializer = OCPFilterSerializer(data=filter_params)
+        self.assertTrue(serializer.is_valid())
+
+    def test_parse_filter_params_w_project_failure(self):
+        """Test parse of a filter param with an invalid project."""
+        filter_params = {'resolution': 'daily',
+                         'time_scope_value': '-10',
+                         'time_scope_units': 'day',
+                         'project': 3}
+        serializer = OCPFilterSerializer(data=filter_params)
+        self.assertFalse(serializer.is_valid())
 
 
 class TagsQueryParamSerializerTest(TestCase):


### PR DESCRIPTION
*GET* `/r/insights/platform/cost-management/api/v1/tags/aws/?filter[time_scope_units]=month&filter[time_scope_value]=-2&filter[resolution]=monthly&filter[account]=hccm-alias`
```
{
    "filter": {
        "resolution": "monthly",
        "time_scope_value": "-2",
        "time_scope_units": "month",
        "account": [
            "hccm-alias"
        ]
    },
    "key_only": false,
    "data": [
        {
            "key": "5dc_key",
            "values": [
                "5dc_value"
            ]
        },
        {
            "key": "c25_key",
            "values": [
                "c25_value"
            ]
        }
    ]
}
```

*GET* `/r/insights/platform/cost-management/api/v1/tags/ocp/?filter[time_scope_units]=month&filter[time_scope_value]=-2&filter[resolution]=monthly&filter[project]=metering-hccm`
```
{
    "filter": {
        "resolution": "monthly",
        "time_scope_value": "-2",
        "time_scope_units": "month",
        "project": [
            "metering-hccm"
        ]
    },
    "key_only": false,
    "data": [
        {
            "key": "app",
            "values": [
                "hdfs-datanode",
                "hdfs-namenode",
                "hive",
                "metering-operator",
                "presto",
                "reporting-operator"
            ]
        },
        {
            "key": "controller_revision_hash",
            "values": [
                "hdfs-datanode-5c646f475f",
                "hdfs-namenode-76f697fd9d",
                "hive-metastore-58d54d97b4",
                "hive-server-7c795464cf"
            ]
        },
        {
            "key": "hive",
            "values": [
                "metastore",
                "server"
            ]
        },
        {
            "key": "pod_template_hash",
            "values": [
                "1801501740",
                "21764925",
                "3197520876"
            ]
        },
        {
            "key": "presto",
            "values": [
                "coordinator"
            ]
        },
        {
            "key": "statefulset_kubernetes_io_pod_name",
            "values": [
                "hdfs-datanode-0",
                "hdfs-namenode-0",
                "hive-metastore-0",
                "hive-server-0"
            ]
        }
    ]
}
```