### PR TITLE
 Remap null group value content to no-{group_type}.

### DIFF
--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -796,7 +796,14 @@ class ReportQueryHandler(QueryHandler):
             label = groups[next_group_index] + 's'
 
         for group, group_value in data.items():
-            cur = {group_type: group,
+            group_label = group
+            if group is None:
+                group_label = 'no-{}'.format(group_type)
+                if isinstance(group_value, list):
+                    for group_item in group_value:
+                        if group_item.get(group_type) is None:
+                            group_item[group_type] = group_label
+            cur = {group_type: group_label,
                    label: self._transform_data(groups, next_group_index,
                                                group_value)}
             out_data.append(cur)

--- a/koku/api/report/test/ocp/tests_views.py
+++ b/koku/api/report/test/ocp/tests_views.py
@@ -689,7 +689,7 @@ class OCPReportViewTest(IamTestCase):
             values = entry.get('values', {})[0]
             delta_percent = (values.get(delta_one) /  # noqa: W504
                              values.get(delta_two) * 100) if values.get(delta_two) else 0
-            self.assertEqual(round(values.get('delta_percent'), 3), round(delta_percent, 3))
+            self.assertAlmostEqual(values.get('delta_percent'), delta_percent)
 
     def test_execute_query_group_by_project(self):
         """Test that grouping by project filters data."""

--- a/koku/api/report/test/tests_queries.py
+++ b/koku/api/report/test/tests_queries.py
@@ -636,6 +636,16 @@ class ReportQueryTest(IamTestCase):
         out_data = handler._transform_data(groups, group_index, data)
         self.assertEqual(expected, out_data)
 
+        data = {'us-east': [{'region': 'us-east', 'units': 'USD'}]}
+        expected = [{'region': 'us-east', 'values': [{'region': 'us-east', 'units': 'USD'}]}]
+        out_data = handler._transform_data(groups, group_index, data)
+        self.assertEqual(expected, out_data)
+
+        data = {None: {'region': None, 'units': 'USD'}}
+        expected = [{'region': 'no-region', 'values': {'region': None, 'units': 'USD'}}]
+        out_data = handler._transform_data(groups, group_index, data)
+        self.assertEqual(expected, out_data)
+
     def test_has_filter_no_filter(self):
         """Test the has_filter method with no filter in the query params."""
         handler = AWSReportQueryHandler({}, '', self.tenant,

--- a/koku/api/report/test/tests_queries.py
+++ b/koku/api/report/test/tests_queries.py
@@ -625,6 +625,17 @@ class ReportQueryTest(IamTestCase):
             self._populate_daily_summary_table()
             self._populate_aggregates_table()
 
+    def test_transform_null_group(self):
+        """Test transform data with null group value."""
+        handler = AWSReportQueryHandler({}, '', self.tenant,
+                                        **{'report_type': 'costs'})
+        groups = ['region']
+        group_index = 0
+        data = {None: [{'region': None, 'units': 'USD'}]}
+        expected = [{'region': 'no-region', 'values': [{'region': 'no-region', 'units': 'USD'}]}]
+        out_data = handler._transform_data(groups, group_index, data)
+        self.assertEqual(expected, out_data)
+
     def test_has_filter_no_filter(self):
         """Test the has_filter method with no filter in the query params."""
         handler = AWSReportQueryHandler({}, '', self.tenant,


### PR DESCRIPTION
Results with CI data:
[test_no-regions.txt](https://github.com/project-koku/koku/files/2869948/test_no-regions.txt)
