### PR TITLE
Temporarily blocking tiered OCP storage rates

### DIFF
--- a/koku/rates/serializers.py
+++ b/koku/rates/serializers.py
@@ -158,6 +158,10 @@ class RateSerializer(serializers.ModelSerializer):
             tiered_rate = data.get('tiered_rate')
             if tiered_rate is not None:
                 RateSerializer._validate_continuouse_tiers(tiered_rate)
+                storage_rates = (Rate.METRIC_STORAGE_GB_REQUEST_MONTH,
+                                 Rate.METRIC_STORAGE_GB_USAGE_MONTH)
+                if len(tiered_rate) > 1 and data.get('metric') in storage_rates:
+                    raise serializers.ValidationError('Storage rates do not support tiers.')
             return data
         else:
             rate_keys_str = ', '.join(str(rate_key) for rate_key in rate_keys)


### PR DESCRIPTION
Tiered OCP storage rates will be supported in the future.  For now we are blocking their creation.

Adding storage rate with tiers
```
POST /api/v1/rates/
{
    "provider_uuid": "a59f3509-7f8e-40a3-afe3-5f5f0180be71",
    "metric": "storage_gb_request_per_month",
    "tiered_rate": [{
        "unit": "USD",
        "value": 0.25,
        "usage_start": null,
        "usage_end": 10
    },
    {
    	"unit": "USD",
        "value": 0.50,
        "usage_start": 10,
        "usage_end": null

    }]
}
```

Response
```
{
    "non_field_errors": [
        "Storage rates do not support tiers."
    ]
}
```

No tiers
```
POST /api/v1/rates/

{
    "provider_uuid": "a59f3509-7f8e-40a3-afe3-5f5f0180be71",
    "metric": "storage_gb_request_per_month",
    "tiered_rate": [{
        "unit": "USD",
        "value": 0.25,
        "usage_start": null,
        "usage_end": null
    }]
}
```

Response
```
{
    "uuid": "a864c6ff-6165-4353-9004-cb380d887785",
    "provider_uuid": "a59f3509-7f8e-40a3-afe3-5f5f0180be71",
    "metric": "storage_gb_request_per_month",
    "tiered_rate": [
        {
            "value": 0.25,
            "usage_start": null,
            "usage_end": null,
            "unit": "USD"
        }
    ]
}
```