### PR TITLE
Use the cluster alias when available in OCP on AWS

### DIFF
--- a/koku/api/report/ocp_aws/ocp_aws_query_handler.py
+++ b/koku/api/report/ocp_aws/ocp_aws_query_handler.py
@@ -80,7 +80,6 @@ class OCPAWSReportQueryHandler(AWSReportQueryHandler):
                 query_data = query_data.annotate(cluster_alias=Coalesce('cluster_alias',
                                                                         'cluster_id'))
 
-
             if self._limit:
                 rank_order = getattr(F(self.order_field), self.order_direction)()
                 rank_by_total = Window(

--- a/koku/api/report/ocp_aws/ocp_aws_query_handler.py
+++ b/koku/api/report/ocp_aws/ocp_aws_query_handler.py
@@ -76,6 +76,10 @@ class OCPAWSReportQueryHandler(AWSReportQueryHandler):
             if 'account' in query_group_by:
                 query_data = query_data.annotate(account_alias=Coalesce(
                     F(self._mapper._provider_map.get('alias')), 'usage_account_id'))
+            elif 'cluster' in query_group_by or 'cluster' in self.query_filter:
+                query_data = query_data.annotate(cluster_alias=Coalesce('cluster_alias',
+                                                                        'cluster_id'))
+
 
             if self._limit:
                 rank_order = getattr(F(self.order_field), self.order_direction)()


### PR DESCRIPTION
## Summary
Add in the cluster alias when grouping by cluster.