### PR TITLE
Checking for None from db query on provider stats

### DIFF
--- a/koku/api/provider/provider_manager.py
+++ b/koku/api/provider/provider_manager.py
@@ -79,8 +79,9 @@ class ProviderManager:
                 query = AWSCostEntryBill.objects.filter(provider_id=provider.id,
                                                         billing_period_start=period_start).first()
 
-        if query:
+        if query and query.summary_data_creation_datetime:
             stats['summary_data_creation_datetime'] = query.summary_data_creation_datetime.strftime(DATE_TIME_FORMAT)
+        if query and query.summary_data_updated_datetime:
             stats['summary_data_updated_datetime'] = query.summary_data_updated_datetime.strftime(DATE_TIME_FORMAT)
 
         return stats


### PR DESCRIPTION
Fix for
```
Traceback (most recent call last):
  File "/opt/app-root/lib/python3.6/site-packages/django/core/handlers/exception.py", line 34, in inner
    response = get_response(request)
  File "/opt/app-root/lib/python3.6/site-packages/django/core/handlers/base.py", line 126, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/opt/app-root/lib/python3.6/site-packages/django/core/handlers/base.py", line 124, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/opt/app-root/lib/python3.6/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
    return view_func(*args, **kwargs)
  File "/opt/app-root/lib/python3.6/site-packages/rest_framework/viewsets.py", line 116, in view
    return self.dispatch(request, *args, **kwargs)
  File "/opt/app-root/lib/python3.6/site-packages/rest_framework/views.py", line 495, in dispatch
    response = self.handle_exception(exc)
  File "/opt/app-root/lib/python3.6/site-packages/rest_framework/views.py", line 455, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/opt/app-root/lib/python3.6/site-packages/rest_framework/views.py", line 492, in dispatch
    response = handler(request, *args, **kwargs)
  File "/opt/app-root/src/koku/api/provider/view.py", line 219, in list
    provider_stats = manager.provider_statistics(tenant)
  File "/opt/app-root/src/koku/api/provider/provider_manager.py", line 124, in provider_statistics
    schema_stats = self._get_tenant_provider_stats(provider_manifest.provider, tenant, month)
  File "/opt/app-root/src/koku/api/provider/provider_manager.py", line 83, in _get_tenant_provider_stats
    stats['summary_data_creation_datetime'] = query.summary_data_creation_datetime.strftime(DATE_TIME_FORMAT)
AttributeError: 'NoneType' object has no attribute 'strftime'
```