### PR TITLE
Update exiting pagination results to use new platform guidelines.

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -1803,10 +1803,10 @@
                     "$ref": "#/components/schemas/ListPagination"
                 }],
                 "required": [
-                    "results"
+                    "data"
                 ],
                 "properties": {
-                    "results": {
+                    "data": {
                         "type": "array",
                         "items": {
                             "$ref": "#/components/schemas/ProviderOut"
@@ -1853,10 +1853,10 @@
                     "$ref": "#/components/schemas/ListPagination"
                 }],
                 "required": [
-                    "results"
+                    "data"
                 ],
                 "properties": {
-                    "results": {
+                    "data": {
                         "type": "array",
                         "items": {
                             "$ref": "#/components/schemas/RateOut"
@@ -3084,10 +3084,10 @@
                     "$ref": "#/components/schemas/ListPagination"
                 }],
                 "required": [
-                    "results"
+                    "data"
                 ],
                 "properties": {
-                    "results": {
+                    "data": {
                         "type": "array",
                         "items": {
                             "$ref": "#/components/schemas/UserPreferenceOut"

--- a/koku/api/iam/test/tests_user_preference_view.py
+++ b/koku/api/iam/test/tests_user_preference_view.py
@@ -48,7 +48,7 @@ class UserPreferenceViewTest(IamTestCase):
         client = APIClient()
         url = reverse('preferences-list')
         response = client.get(url, **self.headers)
-        results = response.json().get('results')
+        results = response.json().get('data')
         self.assertEqual(len(results), 3)
 
         from django.conf import settings
@@ -130,7 +130,7 @@ class UserPreferenceViewTest(IamTestCase):
         # validate the pref isn't listed
         url = reverse('preferences-list')
         response = client.get(url, **self.headers)
-        results = response.json().get('results')
+        results = response.json().get('data')
         results_prefs = [r['preference'] for r in results]
         self.assertNotIn(pref.preference, results_prefs)
 

--- a/koku/api/iam/view/user_preference.py
+++ b/koku/api/iam/view/user_preference.py
@@ -130,17 +130,22 @@ class UserPreferenceViewSet(mixins.CreateModelMixin,
 
         @apiParam (Query) {String} name Filter by preference name.
 
-        @apiSuccess {Number} count The number of preferences.
-        @apiSuccess {String} previous  The uri of the previous page of results.
-        @apiSuccess {String} next  The uri of the next page of results.
-        @apiSuccess {Object[]} results  The array of preference results.
+        @apiSuccess {Object} meta The metadata for pagination.
+        @apiSuccess {Object} links  The object containing links of results.
+        @apiSuccess {Object[]} data  The array of results.
         @apiSuccessExample {json} Success-Response:
             HTTP/1.1 200 OK
             {
-                'count': 3,
-                'next': None,
-                'previous': None,
-                'results': [
+                'meta': {
+                    'count': 3
+                }
+                'links': {
+                    'first': /api/v1/preferences/?page=1,
+                    'next': None,
+                    'previous': None,
+                    'last': /api/v1/preferences/?page=1
+                },
+                'data': [
                                 {
                                     'uuid': '7f273d8a-50cb-4a3a-a4c0-6b7fae0bfd61',
                                     'preference': {'currency': 'USD'},

--- a/koku/api/provider/test/tests_views.py
+++ b/koku/api/provider/test/tests_views.py
@@ -162,7 +162,7 @@ class ProviderViewTest(IamTestCase):
         response = client.get(url, **self.headers)
         self.assertEqual(response.status_code, 200)
         json_result = response.json()
-        results = json_result.get('results')
+        results = json_result.get('data')
         self.assertIsNotNone(results)
         self.assertEqual(len(results), 1)
 

--- a/koku/api/provider/view.py
+++ b/koku/api/provider/view.py
@@ -213,7 +213,7 @@ class ProviderViewSet(mixins.CreateModelMixin,
             }
         """
         response = super().list(request=request, args=args, kwargs=kwargs)
-        for provider in response.data['results']:
+        for provider in response.data['data']:
             manager = ProviderManager(provider['uuid'])
             tenant = get_tenant(request.user)
             provider_stats = manager.provider_statistics(tenant)

--- a/koku/rates/test/tests_view.py
+++ b/koku/rates/test/tests_view.py
@@ -185,12 +185,12 @@ class RateViewTests(IamTestCase):
         response = client.get(url, **self.headers)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        for keyname in ['count', 'next', 'previous', 'results']:
+        for keyname in ['meta', 'links', 'data']:
             self.assertIn(keyname, response.data)
-        self.assertIsInstance(response.data.get('results'), list)
-        self.assertEqual(len(response.data.get('results')), 1)
+        self.assertIsInstance(response.data.get('data'), list)
+        self.assertEqual(len(response.data.get('data')), 1)
 
-        rate = response.data.get('results')[0]
+        rate = response.data.get('data')[0]
         self.assertIsNotNone(rate.get('uuid'))
         self.assertIsNotNone(rate.get('uuid'))
         self.assertIsNotNone(rate.get('provider_uuid'))

--- a/koku/rates/view.py
+++ b/koku/rates/view.py
@@ -104,18 +104,23 @@ class RateViewSet(mixins.CreateModelMixin,
 
         @apiParam (Query) {String} name Filter by rate name.
 
-        @apiSuccess {Number} count The number of rates.
-        @apiSuccess {String} previous  The uri of the previous page of results.
-        @apiSuccess {String} next  The uri of the next page of results.
-        @apiSuccess {Object[]} results  The array of rate results.
+        @apiSuccess {Object} meta The metadata for pagination.
+        @apiSuccess {Object} links  The object containing links of results.
+        @apiSuccess {Object[]} data  The array of results.
 
         @apiSuccessExample {json} Success-Response:
             HTTP/1.1 200 OK
             {
-                'count': 2,
-                'next': None,
-                'previous': None,
-                'results': [
+                'meta': {
+                    'count': 2
+                }
+                'links': {
+                    'first': /api/v1/rates/?page=1,
+                    'next': None,
+                    'previous': None,
+                    'last': /api/v1/rates/?page=1
+                },
+                'data': [
                                 {
                                     "uuid": "16fd2706-8baf-433b-82eb-8c7fada847da",
                                     "provider_uuid": "a1de6812-0c26-4b33-acdb-3bad8b1ef295",


### PR DESCRIPTION
Example of update paginated format:
```
{
	"meta": {
		"count": 1
	},
	"links": {
		"first": "/r/insights/platform/cost-management/api/v1/providers/?page=1",
		"next": null,
		"previous": null,
		"last": "/r/insights/platform/cost-management/api/v1/providers/?page=1"
	},
	"data": [{
		"uuid": "1a9bbeee-3873-45ba-bb8d-ef8b72832680",
		"name": "test9999",
		"type": "OCP",
		"authentication": {
			"uuid": "dd2bd80f-5023-410a-badb-6133c3ef3d7d",
			"provider_resource_name": "test99999"
		},
		"billing_source": {
			"uuid": "dfe4692f-3a83-436f-b022-dab5383d55ca",
			"bucket": ""
		},
		"customer": {
			"uuid": "b2b41ac5-3850-499d-9290-ad6eed7408d1",
			"account_id": "11111111",
			"date_created": "2018-10-22T18:56:45.647027Z"
		},
		"created_by": {
			"uuid": "b74eac0b-9f39-4848-96dc-2118b802db0d",
			"username": "user_dev",
			"email": "user_dev@redhat.com"
		},
		"stats": {}
	}]
}
```