### PR TITLE
Fixing monthly delta calculations

### DIFF
--- a/koku/api/query_handler.py
+++ b/koku/api/query_handler.py
@@ -240,7 +240,7 @@ class QueryHandler(object):
             if time_scope_value == -1:
                 # get current month
                 start = dh.this_month_start
-                end = dh.this_month_end
+                end = dh.now
             else:
                 # get previous month
                 start = dh.last_month_start

--- a/koku/api/report/test/ocp/tests_views.py
+++ b/koku/api/report/test/ocp/tests_views.py
@@ -388,7 +388,7 @@ class OCPReportViewTest(IamTestCase):
         response = client.get(url, **self.headers)
 
         expected_start_date = self.dh.this_month_start.strftime('%Y-%m-%d')
-        expected_end_date = self.dh.this_month_end.strftime('%Y-%m-%d')
+        expected_end_date = self.dh.now.strftime('%Y-%m-%d')
 
         self.assertEqual(response.status_code, 200)
         data = response.json()

--- a/koku/api/report/test/ocp_aws/tests_views.py
+++ b/koku/api/report/test/ocp_aws/tests_views.py
@@ -138,7 +138,7 @@ class OCPAWSReportViewTest(IamTestCase):
         response = client.get(url, **self.headers)
 
         expected_start_date = self.dh.this_month_start.strftime('%Y-%m-%d')
-        expected_end_date = self.dh.this_month_end.strftime('%Y-%m-%d')
+        expected_end_date = self.dh.now.strftime('%Y-%m-%d')
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()

--- a/koku/api/report/test/tests_queries.py
+++ b/koku/api/report/test/tests_queries.py
@@ -805,9 +805,9 @@ class ReportQueryTest(IamTestCase):
         end = handler.end_datetime
         interval = handler.time_interval
         self.assertEqual(start, DateHelper().this_month_start)
-        self.assertEqual(end, DateHelper().this_month_end)
+        self.assertEqual(end.date(), DateHelper().now.date())
         self.assertIsInstance(interval, list)
-        self.assertTrue(len(interval) >= 28)
+        self.assertEqual(len(interval), DateHelper().now.day)
 
     def test_get_time_frame_filter_previous_month(self):
         """Test _get_time_frame_filter for previous month."""

--- a/koku/api/utils.py
+++ b/koku/api/utils.py
@@ -33,6 +33,11 @@ class DateHelper():
         self._now = timezone.now()
 
     @property
+    def now(self):
+        """Datetime as of now."""
+        return self._now
+
+    @property
     def one_day(self):
         """Timedelta of one day."""
         return datetime.timedelta(days=1)


### PR DESCRIPTION
Addresses #615 

Monthly delta queries were working as followed:

Current Day: 2/20/19

Last Month Data: 1/1/19 - 1/28/19
Current Month Data: 2/1/19 - 2/28/19

This was incorrect because it should have only been accounting for last month's data from 1/1/19 - 1/20/19.

The way I addressed this was to make the QueryHandler's query_filter have an end date of today.  That way the delta calculation would always iterate over data up to the current day instead of to the end of the month (future dates don't have any data)

One API response impact of this change is that daily resolution queries will have days up to the current day instead of the last day of the month.

*Testing*
Used Nise to generate Data for a single EC2 instance from 1/1/19 - 1/31/19 and for 2/1/19 - 2/20/19.  A new local AWS provider was added so both months of data was ingested.

The `/api/v1/reports/costs/aws/?delta=total&filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&group_by[account]=*&order_by[total]=desc` API call was used to show the problem

Before Fix
```
GET /api/v1/reports/costs/aws/?delta=total&filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&group_by[account]=*&order_by[total]=desc
HTTP 200 OK
Allow: OPTIONS, GET
Content-Type: application/json
Vary: Accept

{
    "delta": {
        "value": -192.0,
        "percent": -28.571428571428573
    },
    "group_by": {
        "account": [
            "*"
        ]
    },
    "order_by": {
        "total": "desc"
    },
    "filter": {
        "resolution": "monthly",
        "time_scope_value": "-1",
        "time_scope_units": "month"
    },
    "data": [
        {
            "date": "2019-02",
            "accounts": [
                {
                    "account": "9999999999999",
                    "values": [
                        {
                            "date": "2019-02",
                            "units": "USD",
                            "account": "9999999999999",
                            "total": 480.0,
                            "account_alias": "9999999999999",
                            "delta_value": -192.0,
                            "delta_percent": -28.571428571428573
                        }
                    ]
                }
            ]
        }
    ],
    "total": {
        "units": "USD",
        "value": 480.0
    }
}
```

After Fix:
```
GET /api/v1/reports/costs/aws/?delta=total&filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&group_by[account]=*&order_by[total]=desc
HTTP 200 OK
Allow: OPTIONS, GET
Content-Type: application/json
Vary: Accept

{
    "delta": {
        "value": 0.0,
        "percent": 0.0
    },
    "group_by": {
        "account": [
            "*"
        ]
    },
    "order_by": {
        "total": "desc"
    },
    "filter": {
        "resolution": "monthly",
        "time_scope_value": "-1",
        "time_scope_units": "month"
    },
    "data": [
        {
            "date": "2019-02",
            "accounts": [
                {
                    "account": "9999999999999",
                    "values": [
                        {
                            "date": "2019-02",
                            "units": "USD",
                            "account": "9999999999999",
                            "total": 480.0,
                            "account_alias": "9999999999999",
                            "delta_value": 0.0,
                            "delta_percent": 0.0
                        }
                    ]
                }
            ]
        }
    ],
    "total": {
        "units": "USD",
        "value": 480.0
    }
}
```

[issue_koku_615_repo_2.txt](https://github.com/project-koku/koku/files/2886480/issue_koku_615_repo_2.txt)


