### PR TITLE
using DateHelper.today instead of now

### DIFF
--- a/koku/api/query_handler.py
+++ b/koku/api/query_handler.py
@@ -240,7 +240,7 @@ class QueryHandler(object):
             if time_scope_value == -1:
                 # get current month
                 start = dh.this_month_start
-                end = dh.now
+                end = dh.today
             else:
                 # get previous month
                 start = dh.last_month_start

--- a/koku/api/report/test/ocp/tests_views.py
+++ b/koku/api/report/test/ocp/tests_views.py
@@ -388,7 +388,7 @@ class OCPReportViewTest(IamTestCase):
         response = client.get(url, **self.headers)
 
         expected_start_date = self.dh.this_month_start.strftime('%Y-%m-%d')
-        expected_end_date = self.dh.now.strftime('%Y-%m-%d')
+        expected_end_date = self.dh.today.strftime('%Y-%m-%d')
 
         self.assertEqual(response.status_code, 200)
         data = response.json()

--- a/koku/api/report/test/ocp_aws/tests_views.py
+++ b/koku/api/report/test/ocp_aws/tests_views.py
@@ -138,7 +138,7 @@ class OCPAWSReportViewTest(IamTestCase):
         response = client.get(url, **self.headers)
 
         expected_start_date = self.dh.this_month_start.strftime('%Y-%m-%d')
-        expected_end_date = self.dh.now.strftime('%Y-%m-%d')
+        expected_end_date = self.dh.today.strftime('%Y-%m-%d')
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()

--- a/koku/api/report/test/tests_queries.py
+++ b/koku/api/report/test/tests_queries.py
@@ -805,9 +805,9 @@ class ReportQueryTest(IamTestCase):
         end = handler.end_datetime
         interval = handler.time_interval
         self.assertEqual(start, DateHelper().this_month_start)
-        self.assertEqual(end.date(), DateHelper().now.date())
+        self.assertEqual(end.date(), DateHelper().today.date())
         self.assertIsInstance(interval, list)
-        self.assertEqual(len(interval), DateHelper().now.day)
+        self.assertEqual(len(interval), DateHelper().today.day)
 
     def test_get_time_frame_filter_previous_month(self):
         """Test _get_time_frame_filter for previous month."""

--- a/koku/api/utils.py
+++ b/koku/api/utils.py
@@ -33,11 +33,6 @@ class DateHelper():
         self._now = timezone.now()
 
     @property
-    def now(self):
-        """Datetime as of now."""
-        return self._now
-
-    @property
     def one_day(self):
         """Timedelta of one day."""
         return datetime.timedelta(days=1)


### PR DESCRIPTION
I just noticed that `DateHelper` already had a `today` property.  Reverting the `now` property that I added yesterday