### PR TITLE
Add capability for filtering providers by type and by name (exact match).

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -120,15 +120,12 @@
                 "summary": "List the user's preferences",
                 "operationId": "listUserPreferences",
                 "parameters": [{
-                    "name": "uuid",
-                    "in": "path",
-                    "description": "ID of user to get",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "uuid"
+                        "$ref": "#/components/parameters/QueryPageSize"
+                    },
+                    {
+                        "$ref": "#/components/parameters/QueryPageNumber"
                     }
-                }],
+                ],
                 "responses": {
                     "200": {
                         "description": "A paginated list of preference objects",
@@ -376,6 +373,31 @@
                 ],
                 "summary": "List the providers",
                 "operationId": "listProviders",
+                "parameters": [{
+                        "name": "type",
+                        "in": "query",
+                        "description": "The type of provider to filter for.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "name",
+                        "in": "query",
+                        "description": "The name of the provider to filter for.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/QueryPageSize"
+                    },
+                    {
+                        "$ref": "#/components/parameters/QueryPageNumber"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "A paginated list of provider objects",
@@ -575,15 +597,12 @@
                 "summary": "List the rates",
                 "operationId": "listRates",
                 "parameters": [{
-                    "name": "rate_id",
-                    "in": "path",
-                    "description": "ID of rate to get",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "uuid"
+                        "$ref": "#/components/parameters/QueryPageSize"
+                    },
+                    {
+                        "$ref": "#/components/parameters/QueryPageNumber"
                     }
-                }],
+                ],
                 "responses": {
                     "200": {
                         "description": "A paginated list of rate objects",
@@ -1599,6 +1618,31 @@
         "url": "/r/insights/platform/cost-management/api/v1"
     }],
     "components": {
+        "parameters": {
+            "QueryPageNumber": {
+                "in": "query",
+                "name": "page",
+                "required": false,
+                "description": "Parameter for selecting the page of data.",
+                "schema": {
+                    "type": "integer",
+                    "default": 1,
+                    "minimum": 1
+                }
+            },
+            "QueryPageSize": {
+                "in": "query",
+                "name": "page_size",
+                "required": false,
+                "description": "Parameter for selecting the amount of data in a page.",
+                "schema": {
+                    "type": "integer",
+                    "default": 10,
+                    "minimum": 1,
+                    "maximum": 1000
+                }
+            }
+        },
         "securitySchemes": {
             "api_key": {
                 "type": "apiKey",

--- a/koku/api/provider/view.py
+++ b/koku/api/provider/view.py
@@ -19,6 +19,7 @@
 import logging
 
 from django.utils.encoding import force_text
+from django_filters import rest_framework as filters
 from rest_framework import mixins, status, viewsets
 from rest_framework.exceptions import APIException, PermissionDenied
 from rest_framework.permissions import AllowAny
@@ -59,6 +60,8 @@ class ProviderViewSet(mixins.CreateModelMixin,
     lookup_field = 'uuid'
     queryset = Provider.objects.all()
     permission_classes = (AllowAny,)
+    filter_backends = (filters.DjangoFilterBackend,)
+    filterset_fields = ('type', 'name')
 
     def get_serializer_class(self):
         """Return the appropriate serializer depending on user."""


### PR DESCRIPTION
- Also documented pagination query parameters while adding query parameters for filtering.

All providers:
*GET* `/r/insights/platform/cost-management/api/v1/providers/`
```
{
    "meta": {
        "count": 2
    },
    "links": {
        "first": "/r/insights/platform/cost-management/api/v1/providers/?page=1",
        "next": null,
        "previous": null,
        "last": "/r/insights/platform/cost-management/api/v1/providers/?page=1"
    },
    "data": [
        {
            "uuid": "3c6e687e-1a09-4a05-970c-2ccf44b0952e",
            "name": "OCP Test Provider",
            "type": "OCP",
            "authentication": {
                "uuid": "5e421052-8e16-4f66-93d4-27223c4673f2",
                "provider_resource_name": "my-ocp-cluster-1"
            },
            "billing_source": null,
            "customer": {
                "uuid": "b57363a1-2221-4cd4-b13d-76ab3b18ab61",
                "account_id": "10001",
                "date_created": "2019-02-21T20:15:20.218648Z"
            },
            "created_by": {
                "uuid": "a4cf856c-e876-4b7d-b79f-6d770a5d21ae",
                "username": "user_dev",
                "email": "user_dev@foo.com"
            },
            "stats": {}
        },
        {
            "uuid": "6e212746-484a-40cd-bba0-09a19d132d64",
            "name": "Test Provider",
            "type": "AWS",
            "authentication": {
                "uuid": "7e4ec31b-7ced-4a17-9f7e-f77e9efa8fd6",
                "provider_resource_name": "arn:aws:iam::111111111111:role/CostManagement"
            },
            "billing_source": {
                "uuid": "75b17096-319a-45ec-92c1-18dbd5e78f94",
                "bucket": "test-bucket"
            },
            "customer": {
                "uuid": "b57363a1-2221-4cd4-b13d-76ab3b18ab61",
                "account_id": "10001",
                "date_created": "2019-02-21T20:15:20.218648Z"
            },
            "created_by": {
                "uuid": "a4cf856c-e876-4b7d-b79f-6d770a5d21ae",
                "username": "user_dev",
                "email": "user_dev@foo.com"
            },
            "stats": {}
        }
    ]
}
```

Filter by type:
*GET* `/r/insights/platform/cost-management/api/v1/providers/?type=AWS`
```
{
    "meta": {
        "count": 1
    },
    "links": {
        "first": "/r/insights/platform/cost-management/api/v1/providers/?page=1&type=AWS",
        "next": null,
        "previous": null,
        "last": "/r/insights/platform/cost-management/api/v1/providers/?page=1&type=AWS"
    },
    "data": [
        {
            "uuid": "6e212746-484a-40cd-bba0-09a19d132d64",
            "name": "Test Provider",
            "type": "AWS",
            "authentication": {
                "uuid": "7e4ec31b-7ced-4a17-9f7e-f77e9efa8fd6",
                "provider_resource_name": "arn:aws:iam::111111111111:role/CostManagement"
            },
            "billing_source": {
                "uuid": "75b17096-319a-45ec-92c1-18dbd5e78f94",
                "bucket": "test-bucket"
            },
            "customer": {
                "uuid": "b57363a1-2221-4cd4-b13d-76ab3b18ab61",
                "account_id": "10001",
                "date_created": "2019-02-21T20:15:20.218648Z"
            },
            "created_by": {
                "uuid": "a4cf856c-e876-4b7d-b79f-6d770a5d21ae",
                "username": "user_dev",
                "email": "user_dev@foo.com"
            },
            "stats": {}
        }
    ]
}
```

Filter by name (exact match):
*GET* `/r/insights/platform/cost-management/api/v1/providers/?name=OCP%20Test%20Provider`
```
{
    "meta": {
        "count": 1
    },
    "links": {
        "first": "/r/insights/platform/cost-management/api/v1/providers/?name=OCP+Test+Provider&page=1",
        "next": null,
        "previous": null,
        "last": "/r/insights/platform/cost-management/api/v1/providers/?name=OCP+Test+Provider&page=1"
    },
    "data": [
        {
            "uuid": "3c6e687e-1a09-4a05-970c-2ccf44b0952e",
            "name": "OCP Test Provider",
            "type": "OCP",
            "authentication": {
                "uuid": "5e421052-8e16-4f66-93d4-27223c4673f2",
                "provider_resource_name": "my-ocp-cluster-1"
            },
            "billing_source": null,
            "customer": {
                "uuid": "b57363a1-2221-4cd4-b13d-76ab3b18ab61",
                "account_id": "10001",
                "date_created": "2019-02-21T20:15:20.218648Z"
            },
            "created_by": {
                "uuid": "a4cf856c-e876-4b7d-b79f-6d770a5d21ae",
                "username": "user_dev",
                "email": "user_dev@foo.com"
            },
            "stats": {}
        }
    ]
}
```

FYI @dlabrecq 