### PR TITLE
Provide fallback for Openshift on AWS instance types group by project count units.

### DIFF
--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -725,6 +725,7 @@ class ProviderMap(object):
                     'cost_units_fallback': 'USD',
                     'usage_units_key': 'unit',
                     'usage_units_fallback': 'Hrs',
+                    'count_units_fallback': 'instances',
                     'sum_columns': ['usage', 'cost', 'infrastructure_cost', 'derived_cost', 'count'],
                     'default_ordering': {'usage': 'desc'},
                 },


### PR DESCRIPTION
Associated with #695.

*GET* `/r/insights/platform/cost-management/v1/reports/openshift/infrastructures/aws/instance-types/?group_by[project]=*`
```
{
    "group_by": {
        "project": [
            "*"
        ]
    },
    "data": [
        {
            "date": "2019-02-25",
            "projects": []
        },
        {
            "date": "2019-02-26",
            "projects": []
        },
        {
            "date": "2019-02-27",
            "projects": []
        },
        {
            "date": "2019-02-28",
            "projects": []
        },
        {
            "date": "2019-03-01",
            "projects": []
        },
        {
            "date": "2019-03-02",
            "projects": []
        },
        {
            "date": "2019-03-03",
            "projects": []
        },
        {
            "date": "2019-03-04",
            "projects": []
        },
        {
            "date": "2019-03-05",
            "projects": []
        },
        {
            "date": "2019-03-06",
            "projects": []
        }
    ],
    "total": {
        "infrastructure_cost": {
            "value": 0,
            "units": "USD"
        },
        "derived_cost": {
            "value": 0,
            "units": "USD"
        },
        "cost": {
            "value": 0,
            "units": "USD"
        },
        "count": {
            "value": 0,
            "units": "instances"
        },
        "usage": {
            "value": 0,
            "units": "Hrs"
        }
    }
}
```