### PR TITLE
Remove duplicate tag keys

### DIFF
--- a/koku/api/report/test/ocp/tests_views.py
+++ b/koku/api/report/test/ocp/tests_views.py
@@ -778,13 +778,17 @@ class OCPReportViewTest(IamTestCase):
 
     def test_execute_query_with_tag_filter(self):
         """Test that data is filtered by tag key."""
+        handler = OCPTagQueryHandler('?type=pod', {'type': 'pod'}, self.tenant)
+        tag_keys = handler.get_tag_keys()
+        filter_key = tag_keys[0]
+
         with tenant_context(self.tenant):
             labels = OCPUsageLineItemDailySummary.objects\
-                .filter(usage_start__date__gte=self.ten_days_ago)\
+                .filter(usage_start__gte=self.ten_days_ago)\
+                .filter(pod_labels__has_key=filter_key)\
                 .values(*['pod_labels'])\
                 .all()
             label_of_interest = labels[0]
-            filter_key = list(label_of_interest.get('pod_labels', {}).keys())[0]
             filter_value = label_of_interest.get('pod_labels', {}).get(filter_key)
 
             totals = OCPUsageLineItemDailySummary.objects\
@@ -816,16 +820,13 @@ class OCPReportViewTest(IamTestCase):
 
     def test_execute_query_with_wildcard_tag_filter(self):
         """Test that data is filtered to include entries with tag key."""
-        with tenant_context(self.tenant):
-            labels = OCPUsageLineItemDailySummary.objects\
-                .filter(usage_start__date__gte=self.ten_days_ago)\
-                .values(*['pod_labels'])\
-                .all()
-            label_of_interest = labels[0]
-            filter_key = list(label_of_interest.get('pod_labels', {}).keys())[0]
+        handler = OCPTagQueryHandler('?type=pod', {'type': 'pod'}, self.tenant)
+        tag_keys = handler.get_tag_keys()
+        filter_key = tag_keys[0]
 
+        with tenant_context(self.tenant):
             totals = OCPUsageLineItemDailySummary.objects\
-                .filter(usage_start__date__gte=self.ten_days_ago)\
+                .filter(usage_start__gte=self.ten_days_ago)\
                 .filter(**{'pod_labels__has_key': filter_key})\
                 .aggregate(
                     **{
@@ -853,7 +854,7 @@ class OCPReportViewTest(IamTestCase):
 
     def test_execute_query_with_tag_group_by(self):
         """Test that data is grouped by tag key."""
-        handler = OCPTagQueryHandler('', {}, self.tenant)
+        handler = OCPTagQueryHandler('?type=pod', {'type': 'pod'}, self.tenant)
         tag_keys = handler.get_tag_keys()
         group_by_key = tag_keys[0]
 

--- a/koku/api/report/test/ocp/tests_views.py
+++ b/koku/api/report/test/ocp/tests_views.py
@@ -778,7 +778,7 @@ class OCPReportViewTest(IamTestCase):
 
     def test_execute_query_with_tag_filter(self):
         """Test that data is filtered by tag key."""
-        handler = OCPTagQueryHandler('?type=pod', {'type': 'pod'}, self.tenant)
+        handler = OCPTagQueryHandler({'filter': {'type': 'pod'}}, '?filter[type]=pod', self.tenant)
         tag_keys = handler.get_tag_keys()
         filter_key = tag_keys[0]
 
@@ -820,7 +820,7 @@ class OCPReportViewTest(IamTestCase):
 
     def test_execute_query_with_wildcard_tag_filter(self):
         """Test that data is filtered to include entries with tag key."""
-        handler = OCPTagQueryHandler('?type=pod', {'type': 'pod'}, self.tenant)
+        handler = OCPTagQueryHandler({'filter': {'type': 'pod'}}, '?filter[type]=pod', self.tenant)
         tag_keys = handler.get_tag_keys()
         filter_key = tag_keys[0]
 
@@ -854,7 +854,7 @@ class OCPReportViewTest(IamTestCase):
 
     def test_execute_query_with_tag_group_by(self):
         """Test that data is grouped by tag key."""
-        handler = OCPTagQueryHandler('?type=pod', {'type': 'pod'}, self.tenant)
+        handler = OCPTagQueryHandler({'filter': {'type': 'pod'}}, '?filter[type]=pod', self.tenant)
         tag_keys = handler.get_tag_keys()
         group_by_key = tag_keys[0]
 

--- a/koku/api/report/test/ocp/tests_views.py
+++ b/koku/api/report/test/ocp/tests_views.py
@@ -778,17 +778,13 @@ class OCPReportViewTest(IamTestCase):
 
     def test_execute_query_with_tag_filter(self):
         """Test that data is filtered by tag key."""
-        handler = OCPTagQueryHandler('', {}, self.tenant)
-        tag_keys = handler.get_tag_keys()
-        filter_key = tag_keys[0]
-
         with tenant_context(self.tenant):
             labels = OCPUsageLineItemDailySummary.objects\
-                .filter(usage_start__gte=self.ten_days_ago)\
-                .filter(pod_labels__has_key=filter_key)\
+                .filter(usage_start__date__gte=self.ten_days_ago)\
                 .values(*['pod_labels'])\
                 .all()
             label_of_interest = labels[0]
+            filter_key = list(label_of_interest.get('pod_labels', {}).keys())[0]
             filter_value = label_of_interest.get('pod_labels', {}).get(filter_key)
 
             totals = OCPUsageLineItemDailySummary.objects\
@@ -820,13 +816,16 @@ class OCPReportViewTest(IamTestCase):
 
     def test_execute_query_with_wildcard_tag_filter(self):
         """Test that data is filtered to include entries with tag key."""
-        handler = OCPTagQueryHandler('', {}, self.tenant)
-        tag_keys = handler.get_tag_keys()
-        filter_key = tag_keys[0]
-
         with tenant_context(self.tenant):
+            labels = OCPUsageLineItemDailySummary.objects\
+                .filter(usage_start__date__gte=self.ten_days_ago)\
+                .values(*['pod_labels'])\
+                .all()
+            label_of_interest = labels[0]
+            filter_key = list(label_of_interest.get('pod_labels', {}).keys())[0]
+
             totals = OCPUsageLineItemDailySummary.objects\
-                .filter(usage_start__gte=self.ten_days_ago)\
+                .filter(usage_start__date__gte=self.ten_days_ago)\
                 .filter(**{'pod_labels__has_key': filter_key})\
                 .aggregate(
                     **{

--- a/koku/api/tags/queries.py
+++ b/koku/api/tags/queries.py
@@ -125,7 +125,7 @@ class TagQueryHandler(QueryHandler):
                 for tag_key in tag_keys_query:
                     tag_keys.append(tag_key)
 
-        return tag_keys
+        return list(set(tag_keys))
 
     @staticmethod
     def _get_dictionary_for_key(dictionary_list, key):

--- a/koku/api/tags/test/ocp/test_ocp_tag_query_handler.py
+++ b/koku/api/tags/test/ocp/test_ocp_tag_query_handler.py
@@ -222,7 +222,7 @@ class OCPTagQueryHandlerTest(IamTestCase):
                 .annotate(tag_count=Count('tag_keys'))\
                 .all()
             storage_tag_keys = [tag.get('tag_keys') for tag in storage_tag_keys]
-            tag_keys = usage_tag_keys + storage_tag_keys
+            tag_keys = list(set(usage_tag_keys + storage_tag_keys))
 
         result = handler.get_tag_keys(filters=True)
         self.assertNotEqual(sorted(result), sorted(tag_keys))
@@ -255,7 +255,7 @@ class OCPTagQueryHandlerTest(IamTestCase):
                 .annotate(tag_count=Count('tag_keys'))\
                 .all()
             storage_tag_keys = [tag.get('tag_keys') for tag in storage_tag_keys]
-            tag_keys = usage_tag_keys + storage_tag_keys
+            tag_keys = list(set(usage_tag_keys + storage_tag_keys))
 
         result = handler.get_tag_keys(filters=False)
         self.assertEqual(sorted(result), sorted(tag_keys))


### PR DESCRIPTION
## Summary
Filter out duplicate keys when multiple sources contribute to the key list

## Testing

Before: 

```
GET /local/v1/tags/openshift/?filter[time_scope_value]=-2&key_only=true
HTTP 200 OK
Allow: OPTIONS, GET
Content-Type: application/json
Vary: Accept

{
    "meta": {
        "count": 9,
        "filter": {
            "time_scope_value": "-2"
        },
        "key_only": true
    },
    "links": {
        "first": "/local/v1/tags/openshift/?filter%5Btime_scope_value%5D=-2&key_only=true&limit=100&offset=0",
        "next": null,
        "previous": null,
        "last": "/local/v1/tags/openshift/?filter%5Btime_scope_value%5D=-2&key_only=true&limit=100&offset=0"
    },
    "data": [
        "key1",
        "key2",
        "key3",
        "key3",
        "key4",
        "key4",
        "storageclass",
        "vc_key2",
        "vc_key3"
    ]
}
```

After:

```
GET /local/v1/tags/openshift/?filter[time_scope_value]=-2&key_only=true
HTTP 200 OK
Allow: OPTIONS, GET
Content-Type: application/json
Vary: Accept

{
    "filter": {
        "time_scope_value": "-2"
    },
    "key_only": true,
    "data": [
        "key1",
        "key2",
        "key3",
        "key4",
        "storageclass",
        "vc_key2",
        "vc_key3"
    ]
}
```