### PR TITLE
Update test data to go for 11 days for new -10 assumption in APIs

### DIFF
--- a/koku/api/report/test/ocp/helpers.py
+++ b/koku/api/report/test/ocp/helpers.py
@@ -79,8 +79,8 @@ class OCPReportDataGenerator:
             ]
 
             self.report_ranges = [
-                (self.one_month_ago - relativedelta(days=i) for i in range(10)),
-                (self.today - relativedelta(days=i) for i in range(10)),
+                (self.one_month_ago - relativedelta(days=i) for i in range(11)),
+                (self.today - relativedelta(days=i) for i in range(11)),
             ]
 
     def create_manifest_entry(self, billing_period_start, provider_id):

--- a/koku/api/report/test/ocp/tests_views.py
+++ b/koku/api/report/test/ocp/tests_views.py
@@ -47,7 +47,7 @@ class OCPReportViewTest(IamTestCase):
         """Set up the test class."""
         super().setUpClass()
         cls.dh = DateHelper()
-        cls.ten_days_ago = cls.dh.n_days_ago(cls.dh._now, 9)
+        cls.ten_days_ago = cls.dh.n_days_ago(cls.dh._now, 10)
 
     def setUp(self):
         """Set up the customer view tests."""

--- a/koku/api/report/test/ocp_aws/helpers.py
+++ b/koku/api/report/test/ocp_aws/helpers.py
@@ -51,8 +51,8 @@ class OCPAWSReportDataGenerator:
         ]
 
         self.report_ranges = [
-            (self.one_month_ago - relativedelta(days=i) for i in range(10)),
-            (self.today - relativedelta(days=i) for i in range(10)),
+            (self.one_month_ago - relativedelta(days=i) for i in range(11)),
+            (self.today - relativedelta(days=i) for i in range(11)),
         ]
 
     def add_data_to_tenant(self):


### PR DESCRIPTION
## Summary
The report APIs return 11 days for  `-10` and the test data needed to be updated to created 11 days of data.