### PR TITLE
Get tests working for today, will break tomorrow.

### DIFF
--- a/koku/api/report/test/ocp/helpers.py
+++ b/koku/api/report/test/ocp/helpers.py
@@ -79,8 +79,8 @@ class OCPReportDataGenerator:
             ]
 
             self.report_ranges = [
-                (self.one_month_ago - relativedelta(days=i) for i in range(11)),
-                (self.today - relativedelta(days=i) for i in range(11)),
+                (self.one_month_ago - relativedelta(days=i) for i in range(12)),
+                (self.today - relativedelta(days=i) for i in range(12)),
             ]
 
     def create_manifest_entry(self, billing_period_start, provider_id):

--- a/koku/api/report/test/ocp/tests_views.py
+++ b/koku/api/report/test/ocp/tests_views.py
@@ -476,7 +476,7 @@ class OCPReportViewTest(IamTestCase):
 
         with tenant_context(self.tenant):
             totals = OCPUsageLineItemDailySummary.objects\
-                .filter(usage_start__gte=self.ten_days_ago)\
+                .filter(usage_start__gte=self.dh.this_month_start)\
                 .values(*['usage_start'])\
                 .annotate(usage=Sum('pod_usage_memory_gigabyte_hours'))
 

--- a/koku/api/report/test/ocp_aws/helpers.py
+++ b/koku/api/report/test/ocp_aws/helpers.py
@@ -51,8 +51,8 @@ class OCPAWSReportDataGenerator:
         ]
 
         self.report_ranges = [
-            (self.one_month_ago - relativedelta(days=i) for i in range(11)),
-            (self.today - relativedelta(days=i) for i in range(11)),
+            (self.one_month_ago - relativedelta(days=i) for i in range(12)),
+            (self.today - relativedelta(days=i) for i in range(12)),
         ]
 
     def add_data_to_tenant(self):

--- a/koku/api/report/test/ocp_aws/tests_views.py
+++ b/koku/api/report/test/ocp_aws/tests_views.py
@@ -210,7 +210,7 @@ class OCPAWSReportViewTest(IamTestCase):
 
         with tenant_context(self.tenant):
             totals = OCPAWSCostLineItemDailySummary.objects\
-                .filter(usage_start__gte=self.ten_days_ago)\
+                .filter(usage_start__gte=self.dh.this_month_start)\
                 .filter(product_family__contains='Storage')\
                 .values(*['usage_start'])\
                 .annotate(usage=Sum('usage_amount'))


### PR DESCRIPTION
## Summary
Because of the current defaults we are by default returning daily data from the start of the month until the current day. Our tests data is not produced that way. This is the simplest change to unblock today. Several other attempts caused more unit tests to fail. 