### PR TITLE
bugfix OCP-AWS OrderBy Serializer (fixes #741)

### DIFF
--- a/koku/api/query_handler.py
+++ b/koku/api/query_handler.py
@@ -111,7 +111,6 @@ class QueryHandler(object):
         The default is 'total'
         """
         order_by = self.query_parameters.get('order_by', self.default_ordering)
-        LOG.info('XXX: %s', list(order_by.keys()))
         return list(order_by.keys()).pop()
 
     @property
@@ -123,7 +122,6 @@ class QueryHandler(object):
 
         """
         order_by = self.query_parameters.get('order_by', self.default_ordering)
-        LOG.info('XXX: %s', list(order_by.values()))
         return list(order_by.values()).pop()
 
     @property

--- a/koku/api/query_handler.py
+++ b/koku/api/query_handler.py
@@ -111,6 +111,7 @@ class QueryHandler(object):
         The default is 'total'
         """
         order_by = self.query_parameters.get('order_by', self.default_ordering)
+        LOG.info('XXX: %s', list(order_by.keys()))
         return list(order_by.keys()).pop()
 
     @property
@@ -122,6 +123,7 @@ class QueryHandler(object):
 
         """
         order_by = self.query_parameters.get('order_by', self.default_ordering)
+        LOG.info('XXX: %s', list(order_by.values()))
         return list(order_by.values()).pop()
 
     @property

--- a/koku/api/report/ocp_aws/serializers.py
+++ b/koku/api/report/ocp_aws/serializers.py
@@ -39,12 +39,13 @@ class OCPAWSGroupBySerializer(GroupBySerializer):
 class OCPAWSOrderBySerializer(OrderBySerializer):
     """Serializer for handling query parameter order_by."""
 
-    project = StringOrListField(child=serializers.CharField(),
-                                required=False)
-    cluster = StringOrListField(child=serializers.CharField(),
-                                required=False)
-    node = StringOrListField(child=serializers.CharField(),
-                             required=False)
+    ORDER_CHOICES = (('asc', 'asc'), ('desc', 'desc'))
+    project = serializers.ChoiceField(choices=ORDER_CHOICES,
+                                   required=False)
+    cluster = serializers.ChoiceField(choices=ORDER_CHOICES,
+                                   required=False)
+    node = serializers.ChoiceField(choices=ORDER_CHOICES,
+                                   required=False)
 
 
 class OCPAWSFilterSerializer(FilterSerializer):

--- a/koku/api/report/ocp_aws/serializers.py
+++ b/koku/api/report/ocp_aws/serializers.py
@@ -41,9 +41,9 @@ class OCPAWSOrderBySerializer(OrderBySerializer):
 
     ORDER_CHOICES = (('asc', 'asc'), ('desc', 'desc'))
     project = serializers.ChoiceField(choices=ORDER_CHOICES,
-                                   required=False)
+                                      required=False)
     cluster = serializers.ChoiceField(choices=ORDER_CHOICES,
-                                   required=False)
+                                      required=False)
     node = serializers.ChoiceField(choices=ORDER_CHOICES,
                                    required=False)
 


### PR DESCRIPTION
This fixes the bug identified in #741 . The root cause was an improper field type in the Serializer was causing query params to be a list instead of a string.

Bug:
```
[2019-03-19 19:02:20,227] DEBUG: Query Params: {'delta': 'cost', 'group_by': OrderedDict([('project', ['*'])]), 'order_by': OrderedDict([('project', ['asc'])]), 'filter': OrderedDict([('resolution', 'monthly'), ('time_scope_value', '-1'), ('time_scope_units', 'month'), ('limit', 10)])}
```

Fixed:
```
[2019-03-19 19:22:43,568] DEBUG: Query Params: {'delta': 'cost', 'group_by': OrderedDict([('project', ['*'])]), 'order_by': OrderedDict([('project', 'asc')]), 'filter': OrderedDict([('resolution', 'monthly'), ('time_scope_value', '-1'), ('time_scope_units', 'month'), ('limit', 10)])}
```