### PR TITLE
Openshift project node name collisions

### DIFF
--- a/koku/api/provider/test/test_provider_manager.py
+++ b/koku/api/provider/test/test_provider_manager.py
@@ -275,7 +275,7 @@ class ProviderManagerTest(IamTestCase):
                                            authentication=provider_authentication,)
 
         data_generator = OCPReportDataGenerator(self.tenant)
-        data_generator.add_data_to_tenant(provider.id)
+        data_generator.add_data_to_tenant(**{'provider_id': provider.id})
 
         provider_uuid = provider.uuid
         manager = ProviderManager(provider_uuid)
@@ -328,7 +328,7 @@ class ProviderManagerTest(IamTestCase):
                                            authentication=provider_authentication,)
 
         data_generator = OCPReportDataGenerator(self.tenant)
-        data_generator.add_data_to_tenant(provider.id)
+        data_generator.add_data_to_tenant(**{'provider_id': provider.id})
 
         provider_uuid = provider.uuid
         manager = ProviderManager(provider_uuid)

--- a/koku/api/query_handler.py
+++ b/koku/api/query_handler.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 """Query Handling for all APIs."""
+import copy
 import datetime
 import logging
 
@@ -325,3 +326,32 @@ class QueryHandler(object):
         filters.add(query_filter=end_filter)
 
         return filters
+
+    def _get_cluster_group_by(self, group_by):
+        """Determine if a GROUP BY list requires implicit group by cluster.
+
+        Args:
+            group_by (list): The list of group by params
+
+        Returns:
+            (list): A new group by list with cluster if needed
+
+        """
+        # To avoid namespace/node name collisions we implicitly
+        # group by cluster as well. We make a copy of the group_by
+        # here to do the actual grouping, but kepe the original
+        # unaltered so as to keep the final API result grouped by
+        # the specified group by value
+        clustered_group_by = copy.copy(group_by)
+
+        for value in group_by:
+            if value in ('project', 'node'):
+                clustered_group_by.extend(['cluster_id', 'cluster_alias'])
+                break
+
+        for value in self.query_parameters.get('filter', {}).keys():
+            if value in ('project', 'node') and 'cluster_id' not in clustered_group_by:
+                clustered_group_by.extend(['cluster_id', 'cluster_alias'])
+                break
+
+        return clustered_group_by

--- a/koku/api/report/ocp/ocp_query_handler.py
+++ b/koku/api/report/ocp/ocp_query_handler.py
@@ -125,8 +125,9 @@ class OCPReportQueryHandler(ReportQueryHandler):
             query_group_by = ['date'] + group_by_value
             query_order_by = ['-date']
             query_order_by.extend([self.order])
+            clustered_group_by = self._get_cluster_group_by(query_group_by)
 
-            query_data = query_data.values(*query_group_by).annotate(**self.report_annotations)
+            query_data = query_data.values(*clustered_group_by).annotate(**self.report_annotations)
 
             if 'cluster' in query_group_by or 'cluster' in self.query_filter:
                 query_data = query_data.annotate(cluster_alias=Coalesce('cluster_alias',

--- a/koku/api/report/ocp_aws/ocp_aws_query_handler.py
+++ b/koku/api/report/ocp_aws/ocp_aws_query_handler.py
@@ -66,12 +66,14 @@ class OCPAWSReportQueryHandler(AWSReportQueryHandler):
         with tenant_context(self.tenant):
             query = q_table.objects.filter(self.query_filter)
             query_data = query.annotate(**self.annotations)
-            query_group_by = ['date'] + self._get_group_by()
+            group_by_value = self._get_group_by()
+            query_group_by = ['date'] + group_by_value
             query_order_by = ['-date', ]
             query_order_by.extend([self.order])
+            clustered_group_by = self._get_cluster_group_by(query_group_by)
 
             annotations = self._mapper.report_type_map.get('annotations')
-            query_data = query_data.values(*query_group_by).annotate(**annotations)
+            query_data = query_data.values(*clustered_group_by).annotate(**annotations)
 
             if 'account' in query_group_by:
                 query_data = query_data.annotate(account_alias=Coalesce(

--- a/koku/api/report/test/ocp/helpers.py
+++ b/koku/api/report/test/ocp/helpers.py
@@ -115,13 +115,20 @@ class OCPReportDataGenerator:
         status_entry.save()
         return status_entry
 
-    def add_data_to_tenant(self, provider_id=None):
+    def add_data_to_tenant(self, **kwargs):
         """Populate tenant with data."""
         words = list(set([self.fake.word() for _ in range(10)]))
+        provider_id = kwargs.get('provider_id')
         self.cluster_id = random.choice(words)
         self.cluster_alias = random.choice(words)
-        self.namespaces = random.sample(words, k=2)
-        self.nodes = random.sample(words, k=2)
+        if kwargs.get('namespaces'):
+            self.namespaces = kwargs['namespaces']
+        else:
+            self.namespaces = random.sample(words, k=2)
+        if kwargs.get('nodes'):
+            self.nodes = kwargs['nodes']
+        else:
+            self.nodes = random.sample(words, k=2)
         self.pods = random.sample(words, k=2)
         self.storage_classes = ['gp2', 'standard', 'magnetic']
         self.line_items = [

--- a/koku/api/report/test/ocp/tests_views.py
+++ b/koku/api/report/test/ocp/tests_views.py
@@ -794,6 +794,61 @@ class OCPReportViewTest(IamTestCase):
         for entry in data.get('data', []):
             for project in entry.get('projects', []):
                 self.assertEqual(project.get('project'), project_of_interest)
+                values = project.get('values', [])
+                for value in values:
+                    self.assertIn('cluster_id', value)
+                    self.assertIn('cluster_alias', value)
+                print(project)
+
+    def test_execute_query_group_by_project_duplicate_projects(self):
+        """Test that same-named projects across clusters are accounted for."""
+        data_config = {'namespaces': ['project_one', 'project_two']}
+        project_of_interest = data_config['namespaces'][0]
+        data_generator = OCPReportDataGenerator(self.tenant)
+        data_generator.add_data_to_tenant(**data_config)
+        data_generator.add_data_to_tenant(**data_config)
+
+        url = reverse('reports-openshift-cpu')
+        client = APIClient()
+        params = {'group_by[project]': project_of_interest}
+
+        url = url + '?' + urlencode(params, quote_via=quote_plus)
+        response = client.get(url, **self.headers)
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+        for entry in data.get('data', []):
+            for project in entry.get('projects', []):
+                self.assertEqual(project.get('project'), project_of_interest)
+                values = project.get('values', [])
+                self.assertEqual(len(values), 2)
+                for value in values:
+                    self.assertIn('cluster_id', value)
+                    self.assertIn('cluster_alias', value)
+
+    def test_execute_query_filter_by_project_duplicate_projects(self):
+        """Test that same-named projects across clusters are accounted for."""
+        data_config = {'namespaces': ['project_one', 'project_two']}
+        project_of_interest = data_config['namespaces'][0]
+        data_generator = OCPReportDataGenerator(self.tenant)
+        data_generator.add_data_to_tenant(**data_config)
+        data_generator.add_data_to_tenant(**data_config)
+
+        url = reverse('reports-openshift-cpu')
+        client = APIClient()
+        params = {'filter[project]': project_of_interest}
+
+        url = url + '?' + urlencode(params, quote_via=quote_plus)
+        response = client.get(url, **self.headers)
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+        for entry in data.get('data', []):
+            values = entry.get('values', [])
+            self.assertEqual(len(values), 2)
+            for value in values:
+                self.assertIn('cluster_id', value)
+                self.assertIn('cluster_alias', value)
 
     def test_execute_query_group_by_cluster(self):
         """Test that grouping by cluster filters data."""
@@ -853,6 +908,56 @@ class OCPReportViewTest(IamTestCase):
         for entry in data.get('data', []):
             for node in entry.get('nodes', []):
                 self.assertEqual(node.get('node'), node_of_interest)
+
+    def test_execute_query_group_by_node_duplicate_projects(self):
+        """Test that same-named nodes across clusters are accounted for."""
+        data_config = {'nodes': ['node_one', 'node_two']}
+        node_of_interest = data_config['nodes'][0]
+        data_generator = OCPReportDataGenerator(self.tenant)
+        data_generator.add_data_to_tenant(**data_config)
+        data_generator.add_data_to_tenant(**data_config)
+
+        url = reverse('reports-openshift-cpu')
+        client = APIClient()
+        params = {'group_by[node]': node_of_interest}
+
+        url = url + '?' + urlencode(params, quote_via=quote_plus)
+        response = client.get(url, **self.headers)
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+        for entry in data.get('data', []):
+            for node in entry.get('nodes', []):
+                self.assertEqual(node.get('node'), node_of_interest)
+                values = node.get('values', [])
+                self.assertEqual(len(values), 2)
+                for value in values:
+                    self.assertIn('cluster_id', value)
+                    self.assertIn('cluster_alias', value)
+
+    def test_execute_query_filter_by_node_duplicate_projects(self):
+        """Test that same-named nodes across clusters are accounted for."""
+        data_config = {'nodes': ['node_one', 'node_two']}
+        node_of_interest = data_config['nodes'][0]
+        data_generator = OCPReportDataGenerator(self.tenant)
+        data_generator.add_data_to_tenant(**data_config)
+        data_generator.add_data_to_tenant(**data_config)
+
+        url = reverse('reports-openshift-cpu')
+        client = APIClient()
+        params = {'filter[node]': node_of_interest}
+
+        url = url + '?' + urlencode(params, quote_via=quote_plus)
+        response = client.get(url, **self.headers)
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+        for entry in data.get('data', []):
+            values = entry.get('values', [])
+            self.assertEqual(len(values), 2)
+            for value in values:
+                self.assertIn('cluster_id', value)
+                self.assertIn('cluster_alias', value)
 
     def test_execute_query_with_tag_filter(self):
         """Test that data is filtered by tag key."""


### PR DESCRIPTION
## Summary
When grouping or filtering by OpenShift project/node we now add an implicit group by cluster so that same-named projects on different clusters come out as separate values in the API response.

## Examples

OpenShift using a group by

```
GET /local/v1/reports/openshift/compute/?filter[resolution]=monthly&filter[time_scope_units]=month&filter[time_scope_value]=-1&group_by[project]=*
HTTP 200 OK
Allow: GET, OPTIONS
Content-Type: application/json
Vary: Accept

{
    "meta": {
        "count": 1,
        "group_by": {
            "project": [
                "*"
            ]
        },
        "filter": {
            "resolution": "monthly",
            "time_scope_value": "-1",
            "time_scope_units": "month"
        },
        "total": {
            "usage": {
                "value": 1400.0,
                "units": "Core-Hours"
            },
            "request": {
                "value": 7000.0,
                "units": "Core-Hours"
            },
            "limit": {
                "value": 7000.0,
                "units": "Core-Hours"
            },
            "capacity": {
                "value": 5600.0,
                "units": "Core-Hours"
            },
            "infrastructure_cost": {
                "value": 0.0,
                "units": "USD"
            },
            "derived_cost": {
                "value": 0.0,
                "units": "USD"
            },
            "cost": {
                "value": 0.0,
                "units": "USD"
            }
        }
    },
    "links": {
        "first": "/local/v1/reports/openshift/compute/?filter%5Bresolution%5D=monthly&filter%5Btime_scope_units%5D=month&filter%5Btime_scope_value%5D=-1&group_by%5Bproject%5D=%2A&limit=100&offset=0",
        "next": null,
        "previous": null,
        "last": "/local/v1/reports/openshift/compute/?filter%5Bresolution%5D=monthly&filter%5Btime_scope_units%5D=month&filter%5Btime_scope_value%5D=-1&group_by%5Bproject%5D=%2A&limit=100&offset=0"
    },
    "data": [
        {
            "date": "2019-03",
            "projects": [
                {
                    "project": "namespace_ci",
                    "values": [
                        {
                            "cluster_id": "nise",
                            "cluster_alias": "OCP Test Provider",
                            "date": "2019-03",
                            "project": "namespace_ci",
                            "usage": {
                                "value": 253.0,
                                "units": "Core-Hours"
                            },
                            "request": {
                                "value": 1265.0,
                                "units": "Core-Hours"
                            },
                            "limit": {
                                "value": 1265.0,
                                "units": "Core-Hours"
                            },
                            "capacity": {
                                "value": 5600.0,
                                "units": "Core-Hours"
                            },
                            "infrastructure_cost": {
                                "value": 0.0,
                                "units": "USD"
                            },
                            "derived_cost": {
                                "value": 0.0,
                                "units": "USD"
                            },
                            "cost": {
                                "value": 0.0,
                                "units": "USD"
                            }
                        },
                        {
                            "cluster_id": "cmaas",
                            "cluster_alias": "OCP Provider 2",
                            "date": "2019-03",
                            "project": "namespace_ci",
                            "usage": {
                                "value": 447.0,
                                "units": "Core-Hours"
                            },
                            "request": {
                                "value": 2235.0,
                                "units": "Core-Hours"
                            },
                            "limit": {
                                "value": 2235.0,
                                "units": "Core-Hours"
                            },
                            "capacity": {
                                "value": 5600.0,
                                "units": "Core-Hours"
                            },
                            "infrastructure_cost": {
                                "value": 0.0,
                                "units": "USD"
                            },
                            "derived_cost": {
                                "value": 0.0,
                                "units": "USD"
                            },
                            "cost": {
                                "value": 0.0,
                                "units": "USD"
                            }
                        }
                    ]
                },
                {
                    "project": "namespace_hyper",
                    "values": [
                        {
                            "cluster_id": "cmaas",
                            "cluster_alias": "OCP Provider 2",
                            "date": "2019-03",
                            "project": "namespace_hyper",
                            "usage": {
                                "value": 447.0,
                                "units": "Core-Hours"
                            },
                            "request": {
                                "value": 2235.0,
                                "units": "Core-Hours"
                            },
                            "limit": {
                                "value": 2235.0,
                                "units": "Core-Hours"
                            },
                            "capacity": {
                                "value": 5600.0,
                                "units": "Core-Hours"
                            },
                            "infrastructure_cost": {
                                "value": 0.0,
                                "units": "USD"
                            },
                            "derived_cost": {
                                "value": 0.0,
                                "units": "USD"
                            },
                            "cost": {
                                "value": 0.0,
                                "units": "USD"
                            }
                        },
                        {
                            "cluster_id": "nise",
                            "cluster_alias": "OCP Test Provider",
                            "date": "2019-03",
                            "project": "namespace_hyper",
                            "usage": {
                                "value": 253.0,
                                "units": "Core-Hours"
                            },
                            "request": {
                                "value": 1265.0,
                                "units": "Core-Hours"
                            },
                            "limit": {
                                "value": 1265.0,
                                "units": "Core-Hours"
                            },
                            "capacity": {
                                "value": 5600.0,
                                "units": "Core-Hours"
                            },
                            "infrastructure_cost": {
                                "value": 0.0,
                                "units": "USD"
                            },
                            "derived_cost": {
                                "value": 0.0,
                                "units": "USD"
                            },
                            "cost": {
                                "value": 0.0,
                                "units": "USD"
                            }
                        }
                    ]
                }
            ]
        }
    ]
}
```

OpenShift using a filter

```
GET /local/v1/reports/openshift/compute/?filter[resolution]=monthly&filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[project]=*
HTTP 200 OK
Allow: GET, OPTIONS
Content-Type: application/json
Vary: Accept

{
    "meta": {
        "count": 1,
        "filter": {
            "resolution": "monthly",
            "time_scope_value": "-1",
            "time_scope_units": "month",
            "project": [
                "*"
            ]
        },
        "total": {
            "usage": {
                "value": 1400.0,
                "units": "Core-Hours"
            },
            "request": {
                "value": 7000.0,
                "units": "Core-Hours"
            },
            "limit": {
                "value": 7000.0,
                "units": "Core-Hours"
            },
            "capacity": {
                "value": 5600.0,
                "units": "Core-Hours"
            },
            "infrastructure_cost": {
                "value": 0.0,
                "units": "USD"
            },
            "derived_cost": {
                "value": 0.0,
                "units": "USD"
            },
            "cost": {
                "value": 0.0,
                "units": "USD"
            }
        }
    },
    "links": {
        "first": "/local/v1/reports/openshift/compute/?filter%5Bproject%5D=%2A&filter%5Bresolution%5D=monthly&filter%5Btime_scope_units%5D=month&filter%5Btime_scope_value%5D=-1&limit=100&offset=0",
        "next": null,
        "previous": null,
        "last": "/local/v1/reports/openshift/compute/?filter%5Bproject%5D=%2A&filter%5Bresolution%5D=monthly&filter%5Btime_scope_units%5D=month&filter%5Btime_scope_value%5D=-1&limit=100&offset=0"
    },
    "data": [
        {
            "date": "2019-03",
            "values": [
                {
                    "cluster_id": "cmaas",
                    "cluster_alias": "OCP Provider 2",
                    "date": "2019-03",
                    "usage": {
                        "value": 894.0,
                        "units": "Core-Hours"
                    },
                    "request": {
                        "value": 4470.0,
                        "units": "Core-Hours"
                    },
                    "limit": {
                        "value": 4470.0,
                        "units": "Core-Hours"
                    },
                    "capacity": {
                        "value": 5600.0,
                        "units": "Core-Hours"
                    },
                    "infrastructure_cost": {
                        "value": 0.0,
                        "units": "USD"
                    },
                    "derived_cost": {
                        "value": 0.0,
                        "units": "USD"
                    },
                    "cost": {
                        "value": 0.0,
                        "units": "USD"
                    }
                },
                {
                    "cluster_id": "nise",
                    "cluster_alias": "OCP Test Provider",
                    "date": "2019-03",
                    "usage": {
                        "value": 506.0,
                        "units": "Core-Hours"
                    },
                    "request": {
                        "value": 2530.0,
                        "units": "Core-Hours"
                    },
                    "limit": {
                        "value": 2530.0,
                        "units": "Core-Hours"
                    },
                    "capacity": {
                        "value": 5600.0,
                        "units": "Core-Hours"
                    },
                    "infrastructure_cost": {
                        "value": 0.0,
                        "units": "USD"
                    },
                    "derived_cost": {
                        "value": 0.0,
                        "units": "USD"
                    },
                    "cost": {
                        "value": 0.0,
                        "units": "USD"
                    }
                }
            ]
        }
    ]
}
```

OpenShift on AWS 

```
GET /local/v1/reports/openshift/infrastructures/aws/instance-types/?filter[resolution]=monthly&filter[time_scope_units]=month&filter[time_scope_value]=-2&filter[project]=namespace_ci
HTTP 200 OK
Allow: GET, OPTIONS
Content-Type: application/json
Vary: Accept

{
    "meta": {
        "count": 1,
        "filter": {
            "resolution": "monthly",
            "time_scope_value": "-2",
            "time_scope_units": "month",
            "project": [
                "namespace_ci"
            ]
        },
        "total": {
            "infrastructure_cost": {
                "value": 1344.0,
                "units": "USD"
            },
            "derived_cost": {
                "value": 0.0,
                "units": "USD"
            },
            "cost": {
                "value": 1344.0,
                "units": "USD"
            },
            "count": {
                "value": 1,
                "units": "instances"
            },
            "usage": {
                "value": 1344.0,
                "units": "Hrs"
            }
        }
    },
    "links": {
        "first": "/local/v1/reports/openshift/infrastructures/aws/instance-types/?filter%5Bproject%5D=namespace_ci&filter%5Bresolution%5D=monthly&filter%5Btime_scope_units%5D=month&filter%5Btime_scope_value%5D=-2&limit=100&offset=0",
        "next": null,
        "previous": null,
        "last": "/local/v1/reports/openshift/infrastructures/aws/instance-types/?filter%5Bproject%5D=namespace_ci&filter%5Bresolution%5D=monthly&filter%5Btime_scope_units%5D=month&filter%5Btime_scope_value%5D=-2&limit=100&offset=0"
    },
    "data": [
        {
            "date": "2019-02",
            "instance_types": [
                {
                    "instance_type": "m5.large",
                    "values": [
                        {
                            "instance_type": "m5.large",
                            "cluster_id": "cmaas",
                            "cluster_alias": "OCP Provider 2",
                            "date": "2019-02",
                            "infrastructure_cost": {
                                "value": 672.0,
                                "units": "USD"
                            },
                            "derived_cost": {
                                "value": 0.0,
                                "units": "USD"
                            },
                            "cost": {
                                "value": 672.0,
                                "units": "USD"
                            },
                            "count": {
                                "value": 1,
                                "units": "instances"
                            },
                            "usage": {
                                "value": 672.0,
                                "units": "Hrs"
                            }
                        },
                        {
                            "instance_type": "m5.large",
                            "cluster_id": "nise",
                            "cluster_alias": "OCP Test Provider",
                            "date": "2019-02",
                            "infrastructure_cost": {
                                "value": 672.0,
                                "units": "USD"
                            },
                            "derived_cost": {
                                "value": 0.0,
                                "units": "USD"
                            },
                            "cost": {
                                "value": 672.0,
                                "units": "USD"
                            },
                            "count": {
                                "value": 1,
                                "units": "instances"
                            },
                            "usage": {
                                "value": 672.0,
                                "units": "Hrs"
                            }
                        }
                    ]
                }
            ]
        }
    ]
}
```