### PR TITLE
Switch to using DRF Status for tests

### DIFF
--- a/koku/api/openapi/tests_openapi.py
+++ b/koku/api/openapi/tests_openapi.py
@@ -22,6 +22,7 @@ from unittest.mock import patch
 
 from django.test import TestCase
 from django.urls import reverse
+from rest_framework import status
 
 from api.openapi.view import get_api_json
 
@@ -39,7 +40,7 @@ class OpenAPIViewTest(TestCase):
         """Test the openapi endpoint."""
         url = reverse('openapi')
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         mock_get_json.assert_called_once()
 
     @patch('api.openapi.view.get_api_json', side_effect=get_api_json_error)
@@ -47,7 +48,7 @@ class OpenAPIViewTest(TestCase):
         """Test the openapi endpoint."""
         url = reverse('openapi')
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
         mock_get_json.assert_called_once()
 
     def test_get_api_json(self):

--- a/koku/api/provider/test/tests_views.py
+++ b/koku/api/provider/test/tests_views.py
@@ -105,7 +105,7 @@ class ProviderViewTest(IamTestCase):
         iam_arn = 'arn:aws:s3:::my_s3_bucket'
         bucket_name = 'my_s3_bucket'
         response = self.create_provider(bucket_name, iam_arn)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         json_result = response.json()
         self.assertIsNotNone(json_result.get('uuid'))
         self.assertIsNotNone(json_result.get('customer'))

--- a/koku/api/report/test/ocp/tests_views.py
+++ b/koku/api/report/test/ocp/tests_views.py
@@ -23,6 +23,7 @@ from dateutil import relativedelta
 from django.db.models import Count, F, Sum
 from django.http import HttpRequest, QueryDict
 from django.urls import reverse
+from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.test import APIClient
@@ -226,7 +227,7 @@ class OCPReportViewTest(IamTestCase):
         response = _generic_report(request, report='cpu', provider='ocp')
         self.assertIsInstance(response, Response)
         # FIXME
-        # self.assertEqual(response.status_code, 200)
+        # self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     @patch('api.report.ocp.ocp_query_handler.OCPReportQueryHandler')
     def test_generic_report_ocp_mem_success(self, mock_handler):
@@ -252,7 +253,7 @@ class OCPReportViewTest(IamTestCase):
         response = _generic_report(request, report='memory', provider='ocp')
         self.assertIsInstance(response, Response)
         # FIXME
-        # self.assertEqual(response.status_code, 200)
+        # self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_execute_query_ocp_cpu(self):
         """Test that OCP CPU endpoint works."""
@@ -262,7 +263,7 @@ class OCPReportViewTest(IamTestCase):
 
         expected_end_date = self.dh.today.date().strftime('%Y-%m-%d')
         expected_start_date = self.ten_days_ago.strftime('%Y-%m-%d')
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
         dates = sorted([item.get('date') for item in data.get('data')])
         self.assertEqual(dates[0], expected_start_date)
@@ -343,7 +344,7 @@ class OCPReportViewTest(IamTestCase):
         expected_start_date = self.dh.n_days_ago(expected_end_date, 29)
         expected_end_date = str(expected_end_date.date())
         expected_start_date = str(expected_start_date.date())
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
         dates = sorted([item.get('date') for item in data.get('data')])
         self.assertEqual(dates[0], expected_start_date)
@@ -370,7 +371,7 @@ class OCPReportViewTest(IamTestCase):
 
         expected_date = self.dh.today.strftime('%Y-%m')
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
         dates = sorted([item.get('date') for item in data.get('data')])
         self.assertEqual(dates[0], expected_date)
@@ -395,7 +396,7 @@ class OCPReportViewTest(IamTestCase):
         expected_start_date = self.dh.this_month_start.strftime('%Y-%m-%d')
         expected_end_date = self.dh.today.strftime('%Y-%m-%d')
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
         dates = sorted([item.get('date') for item in data.get('data')])
         self.assertEqual(dates[0], expected_start_date)
@@ -422,7 +423,7 @@ class OCPReportViewTest(IamTestCase):
 
         expected_date = self.dh.last_month_start.strftime('%Y-%m')
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
         dates = sorted([item.get('date') for item in data.get('data')])
         self.assertEqual(dates[0], expected_date)
@@ -447,7 +448,7 @@ class OCPReportViewTest(IamTestCase):
         expected_start_date = self.dh.last_month_start.strftime('%Y-%m-%d')
         expected_end_date = self.dh.last_month_end.strftime('%Y-%m-%d')
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
         dates = sorted([item.get('date') for item in data.get('data')])
         self.assertEqual(dates[0], expected_start_date)
@@ -465,7 +466,7 @@ class OCPReportViewTest(IamTestCase):
         url = reverse('reports-openshift-memory')
         client = APIClient()
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_execute_query_ocp_memory_group_by_limit(self):
         """Test that OCP Mem endpoint works with limits."""
@@ -510,7 +511,7 @@ class OCPReportViewTest(IamTestCase):
         url = reverse('reports-openshift-costs')
         client = APIClient()
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_execute_query_ocp_costs_group_by_cluster(self):
         """Test that the costs endpoint is reachable."""
@@ -521,7 +522,7 @@ class OCPReportViewTest(IamTestCase):
         }
         url = url + '?' + urlencode(params, quote_via=quote_plus)
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_execute_query_ocp_costs_group_by_node(self):
         """Test that the costs endpoint is reachable."""
@@ -532,7 +533,7 @@ class OCPReportViewTest(IamTestCase):
         }
         url = url + '?' + urlencode(params, quote_via=quote_plus)
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_execute_query_ocp_costs_group_by_project(self):
         """Test that the costs endpoint is reachable."""
@@ -546,7 +547,7 @@ class OCPReportViewTest(IamTestCase):
         }
         url = url + '?' + urlencode(params, quote_via=quote_plus)
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         # Using .data instead of .json() retains the Decimal types for
         # direct value and type comparisons
@@ -579,7 +580,7 @@ class OCPReportViewTest(IamTestCase):
         }
         url = url + '?' + urlencode(params, quote_via=quote_plus)
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.data
         this_month_start = self.dh.this_month_start
         last_month_start = self.dh.last_month_start
@@ -660,12 +661,12 @@ class OCPReportViewTest(IamTestCase):
         params = {'delta': 'usage'}
         url = url + '?' + urlencode(params, quote_via=quote_plus)
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
         params = {'delta': 'request'}
         url = url + '?' + urlencode(params, quote_via=quote_plus)
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_execute_query_ocp_cpu_with_delta_cost(self):
         """Test that cost deltas work for CPU."""
@@ -676,7 +677,7 @@ class OCPReportViewTest(IamTestCase):
         }
         url = url + '?' + urlencode(params, quote_via=quote_plus)
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_execute_query_ocp_cpu_with_delta_usage(self):
         """Test that usage deltas work for CPU."""
@@ -687,7 +688,7 @@ class OCPReportViewTest(IamTestCase):
         }
         url = url + '?' + urlencode(params, quote_via=quote_plus)
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_execute_query_ocp_cpu_with_delta_request(self):
         """Test that request deltas work for CPU."""
@@ -698,7 +699,7 @@ class OCPReportViewTest(IamTestCase):
         }
         url = url + '?' + urlencode(params, quote_via=quote_plus)
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_execute_query_ocp_memory_with_delta(self):
         """Test that deltas work for CPU."""
@@ -707,7 +708,7 @@ class OCPReportViewTest(IamTestCase):
         params = {'delta': 'request'}
         url = url + '?' + urlencode(params, quote_via=quote_plus)
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_execute_query_ocp_cpu_with_delta_usage__capacity(self):
         """Test that usage v capacity deltas work."""
@@ -719,7 +720,7 @@ class OCPReportViewTest(IamTestCase):
         }
         url = url + '?' + urlencode(params, quote_via=quote_plus)
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         delta_one, delta_two = delta.split('__')
         data = response.data
@@ -740,7 +741,7 @@ class OCPReportViewTest(IamTestCase):
         }
         url = url + '?' + urlencode(params, quote_via=quote_plus)
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         delta_one, delta_two = delta.split('__')
         data = response.data
@@ -761,7 +762,7 @@ class OCPReportViewTest(IamTestCase):
         }
         url = url + '?' + urlencode(params, quote_via=quote_plus)
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         delta_one, delta_two = delta.split('__')
         data = response.json()
@@ -788,7 +789,7 @@ class OCPReportViewTest(IamTestCase):
 
         url = url + '?' + urlencode(params, quote_via=quote_plus)
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         data = response.json()
         for entry in data.get('data', []):
@@ -814,7 +815,7 @@ class OCPReportViewTest(IamTestCase):
 
         url = url + '?' + urlencode(params, quote_via=quote_plus)
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         data = response.json()
         for entry in data.get('data', []):
@@ -840,7 +841,7 @@ class OCPReportViewTest(IamTestCase):
 
         url = url + '?' + urlencode(params, quote_via=quote_plus)
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         data = response.json()
         for entry in data.get('data', []):
@@ -867,7 +868,7 @@ class OCPReportViewTest(IamTestCase):
 
         url = url + '?' + urlencode(params, quote_via=quote_plus)
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         data = response.json()
         for entry in data.get('data', []):
@@ -882,7 +883,7 @@ class OCPReportViewTest(IamTestCase):
 
         url = url + '?' + urlencode(params, quote_via=quote_plus)
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_execute_query_group_by_node(self):
         """Test that grouping by node filters data."""
@@ -902,7 +903,7 @@ class OCPReportViewTest(IamTestCase):
 
         url = url + '?' + urlencode(params, quote_via=quote_plus)
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         data = response.json()
         for entry in data.get('data', []):
@@ -923,7 +924,7 @@ class OCPReportViewTest(IamTestCase):
 
         url = url + '?' + urlencode(params, quote_via=quote_plus)
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         data = response.json()
         for entry in data.get('data', []):
@@ -949,7 +950,7 @@ class OCPReportViewTest(IamTestCase):
 
         url = url + '?' + urlencode(params, quote_via=quote_plus)
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         data = response.json()
         for entry in data.get('data', []):
@@ -992,7 +993,7 @@ class OCPReportViewTest(IamTestCase):
 
         url = url + '?' + urlencode(params, quote_via=quote_plus)
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         data = response.data
         data_totals = data.get('meta', {}).get('total', {})
@@ -1036,7 +1037,7 @@ class OCPReportViewTest(IamTestCase):
 
         url = url + '?' + urlencode(params, quote_via=quote_plus)
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         data = response.data
         data_totals = data.get('meta', {}).get('total', {})
@@ -1075,7 +1076,7 @@ class OCPReportViewTest(IamTestCase):
 
         url = url + '?' + urlencode(params, quote_via=quote_plus)
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         data = response.data
         data_totals = data.get('meta', {}).get('total', {})
@@ -1096,7 +1097,7 @@ class OCPReportViewTest(IamTestCase):
 
         url = url + '?' + urlencode(params, quote_via=quote_plus)
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         data = response.json()
         data = data.get('data', [])
@@ -1116,7 +1117,7 @@ class OCPReportViewTest(IamTestCase):
 
         url = url + '?' + urlencode(params, quote_via=quote_plus)
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         data = response.json()
         data = data.get('data', [])
@@ -1141,7 +1142,7 @@ class OCPReportViewTest(IamTestCase):
         }
         url = url + '?' + urlencode(params, quote_via=quote_plus)
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         data = response.json()
         data = data.get('data', [])
@@ -1163,7 +1164,7 @@ class OCPReportViewTest(IamTestCase):
         }
         url = url + '?' + urlencode(params, quote_via=quote_plus)
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         data = response.json()
         data = data.get('data', [])
@@ -1189,7 +1190,7 @@ class OCPReportViewTest(IamTestCase):
 
             url = url + '?' + urlencode(params, quote_via=quote_plus)
             response = client.get(url, **self.headers)
-            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
 
             data = response.json()
             data = data.get('data', [])
@@ -1214,7 +1215,7 @@ class OCPReportViewTest(IamTestCase):
         }
         url = url + '?' + urlencode(params, quote_via=quote_plus)
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         data = response.json()
         data = data.get('data', [])
@@ -1241,7 +1242,7 @@ class OCPReportViewTest(IamTestCase):
         }
         url = url + '?' + urlencode(params, quote_via=quote_plus)
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         data = response.json()
         values = data.get('data')[0].get('values')[0]
@@ -1261,7 +1262,7 @@ class OCPReportViewTest(IamTestCase):
         }
         url = url + '?' + urlencode(params, quote_via=quote_plus)
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         response_data = response.json()
         data = response_data.get('data', [])
@@ -1288,7 +1289,7 @@ class OCPReportViewTest(IamTestCase):
         }
         url = url + '?' + urlencode(params, quote_via=quote_plus)
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         response_data = response.json()
         data = response_data.get('data', [])
@@ -1324,7 +1325,7 @@ class OCPReportViewTest(IamTestCase):
         }
         url = url + '?' + urlencode(params, quote_via=quote_plus)
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         response_data = response.json()
         data = response_data.get('data', [])
@@ -1359,7 +1360,7 @@ class OCPReportViewTest(IamTestCase):
         }
         url = url + '?' + urlencode(params, quote_via=quote_plus)
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         response_data = response.json()
         data = response_data.get('data', [])
@@ -1394,7 +1395,7 @@ class OCPReportViewTest(IamTestCase):
         }
         url = url + '?' + urlencode(params, quote_via=quote_plus)
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         response_data = response.json()
         data = response_data.get('data', [])

--- a/koku/api/report/test/ocp_aws/tests_views.py
+++ b/koku/api/report/test/ocp_aws/tests_views.py
@@ -700,7 +700,7 @@ class OCPAWSReportViewTest(IamTestCase):
         }
         url = url + '?' + urlencode(params, quote_via=quote_plus)
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         response_data = response.json()
         data = response_data.get('data', [])
@@ -727,7 +727,7 @@ class OCPAWSReportViewTest(IamTestCase):
         }
         url = url + '?' + urlencode(params, quote_via=quote_plus)
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         response_data = response.json()
         data = response_data.get('data', [])
@@ -763,7 +763,7 @@ class OCPAWSReportViewTest(IamTestCase):
         }
         url = url + '?' + urlencode(params, quote_via=quote_plus)
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         response_data = response.json()
         data = response_data.get('data', [])
@@ -798,7 +798,7 @@ class OCPAWSReportViewTest(IamTestCase):
         }
         url = url + '?' + urlencode(params, quote_via=quote_plus)
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         response_data = response.json()
         data = response_data.get('data', [])
@@ -833,7 +833,7 @@ class OCPAWSReportViewTest(IamTestCase):
         }
         url = url + '?' + urlencode(params, quote_via=quote_plus)
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         response_data = response.json()
         data = response_data.get('data', [])

--- a/koku/api/report/test/tests_views.py
+++ b/koku/api/report/test/tests_views.py
@@ -19,6 +19,7 @@ from unittest.mock import patch
 
 from django.http import HttpRequest, QueryDict
 from django.urls import reverse
+from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.test import APIClient
@@ -132,7 +133,7 @@ class ReportViewTest(IamTestCase):
         url = reverse('reports-aws-costs')
         client = APIClient()
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         json_result = response.json()
         self.assertIsNotNone(json_result.get('data'))
         self.assertIsInstance(json_result.get('data'), list)
@@ -143,7 +144,7 @@ class ReportViewTest(IamTestCase):
         url = reverse('reports-aws-instance-type')
         client = APIClient()
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         json_result = response.json()
         self.assertIsNotNone(json_result.get('data'))
         self.assertIsInstance(json_result.get('data'), list)
@@ -154,7 +155,7 @@ class ReportViewTest(IamTestCase):
         url = reverse('reports-aws-storage')
         client = APIClient()
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         json_result = response.json()
         self.assertIsNotNone(json_result.get('data'))
         self.assertIsInstance(json_result.get('data'), list)
@@ -200,7 +201,7 @@ class ReportViewTest(IamTestCase):
         url = reverse('reports-aws-costs') + '?' + qs
         client = APIClient()
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_get_instance_usage_invalid_query_param(self):
         """Test instance usage reports runs with an invalid query param."""
@@ -208,7 +209,7 @@ class ReportViewTest(IamTestCase):
         url = reverse('reports-aws-instance-type') + '?' + qs
         client = APIClient()
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_get_storage_usage_invalid_query_param(self):
         """Test storage usage reports runs with an invalid query param."""
@@ -216,7 +217,7 @@ class ReportViewTest(IamTestCase):
         url = reverse('reports-aws-storage') + '?' + qs
         client = APIClient()
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_get_costs_csv(self):
         """Test CSV output of costs reports."""
@@ -226,7 +227,7 @@ class ReportViewTest(IamTestCase):
         response = client.get(url, **self.headers)
         response.render()
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.accepted_media_type, 'text/csv')
         self.assertIsInstance(response.accepted_renderer, CSVRenderer)
 
@@ -237,7 +238,7 @@ class ReportViewTest(IamTestCase):
         response = client.get(url, content_type='text/csv', **self.headers)
         response.render()
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.accepted_media_type, 'text/csv')
         self.assertIsInstance(response.accepted_renderer, CSVRenderer)
 
@@ -248,7 +249,7 @@ class ReportViewTest(IamTestCase):
         response = client.get(url, content_type='text/csv', **self.headers)
         response.render()
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.accepted_media_type, 'text/csv')
         self.assertIsInstance(response.accepted_renderer, CSVRenderer)
 
@@ -372,7 +373,7 @@ class ReportViewTest(IamTestCase):
         url = reverse('reports-aws-costs') + '?' + qs
         client = APIClient()
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_execute_query_w_delta_bad_choice(self):
         """Test invalid delta value."""
@@ -383,7 +384,7 @@ class ReportViewTest(IamTestCase):
         client = APIClient()
         response = client.get(url, **self.headers)
         result = str(response.data.get('delta')[0])
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(result, expected)
 
     def test_get_paginator_default(self):

--- a/koku/api/status/tests_status.py
+++ b/koku/api/status/tests_status.py
@@ -22,6 +22,7 @@ from unittest.mock import ANY, Mock, PropertyMock, patch
 
 from django.test import TestCase
 from django.urls import reverse
+from rest_framework import status
 
 from api.iam.models import Tenant
 from api.status.models import Status
@@ -122,6 +123,6 @@ class StatusViewTest(TestCase):
         """Test the status endpoint."""
         url = reverse('server-status')
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         # json_result = response.json()
         # self.assertEqual(json_result['api_version'], 1)

--- a/koku/api/tags/test/aws/tests_view.py
+++ b/koku/api/tags/test/aws/tests_view.py
@@ -20,6 +20,7 @@ from urllib.parse import quote_plus, urlencode
 
 from dateutil.relativedelta import relativedelta
 from django.urls import reverse
+from rest_framework import status
 from rest_framework.test import APIClient
 
 from api.iam.serializers import UserSerializer
@@ -78,7 +79,7 @@ class AWSTagsViewTest(IamTestCase):
             url = url + '?' + urlencode(params, quote_via=quote_plus)
             response = client.get(url, **self.headers)
 
-            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
             data = response.json()
             start_range, end_range = self._calculate_expected_range(case.get('value'), case.get('unit'))
 
@@ -103,7 +104,7 @@ class AWSTagsViewTest(IamTestCase):
             }
             url = url + '?' + urlencode(params, quote_via=quote_plus)
             response = client.get(url, **self.headers)
-            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
             data = response.json()
             start_range, end_range = self._calculate_expected_range(case.get('value'), case.get('unit'))
 

--- a/koku/api/tags/test/ocp/tests_view.py
+++ b/koku/api/tags/test/ocp/tests_view.py
@@ -21,6 +21,7 @@ from urllib.parse import quote_plus, urlencode
 
 from dateutil.relativedelta import relativedelta
 from django.urls import reverse
+from rest_framework import status
 from rest_framework.test import APIClient
 
 from api.iam.serializers import UserSerializer
@@ -82,7 +83,7 @@ class OCPTagsViewTest(IamTestCase):
             url = url + '?' + urlencode(params, quote_via=quote_plus)
             response = client.get(url, **self.headers)
 
-            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
             data = response.json()
             start_range, end_range = self._calculate_expected_range(case.get('value'), case.get('unit'))
 
@@ -112,7 +113,7 @@ class OCPTagsViewTest(IamTestCase):
             }
             url = url + '?' + urlencode(params, quote_via=quote_plus)
             response = client.get(url, **self.headers)
-            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
             data = response.json()
             start_range, end_range = self._calculate_expected_range(case.get('value'), case.get('unit'))
 
@@ -145,7 +146,7 @@ class OCPTagsViewTest(IamTestCase):
             }
             url = url + '?' + urlencode(params, quote_via=quote_plus)
             response = client.get(url, **self.headers)
-            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
             data = response.json()
             start_range, end_range = self._calculate_expected_range(case.get('value'), case.get('unit'))
 

--- a/koku/koku/tests_rbac.py
+++ b/koku/koku/tests_rbac.py
@@ -18,6 +18,7 @@
 from unittest.mock import Mock, patch
 
 from django.test import TestCase
+from rest_framework import status
 
 from koku.rbac import RbacService, _apply_access, _get_operation, _process_acls
 
@@ -55,29 +56,29 @@ class MockResponse:  # pylint: disable=too-few-public-methods
 def mocked_requests_get_404_json(*args, **kwargs):  # pylint: disable=unused-argument
     """Mock invalid response that returns json."""
     json_response = {'details': 'Invalid path.'}
-    return MockResponse(json_response, 404)
+    return MockResponse(json_response, status.HTTP_404_NOT_FOUND)
 
 
 def mocked_requests_get_404_text(*args, **kwargs):  # pylint: disable=unused-argument
     """Mock invalid response that returns non-json."""
     json_response = 'Not JSON'
-    return MockResponse(json_response, 404)
+    return MockResponse(json_response, status.HTTP_404_NOT_FOUND)
 
 
 def mocked_requests_get_404_except(*args, **kwargs):  # pylint: disable=unused-argument
     """Mock invalid response that returns non-json."""
-    return MockResponse(None, 404, ValueError('JSON Problem'))
+    return MockResponse(None, status.HTTP_404_NOT_FOUND, ValueError('JSON Problem'))
 
 
 def mocked_requests_get_200_text(*args, **kwargs):  # pylint: disable=unused-argument
     """Mock valid status response that returns non-json."""
     json_response = 'Not JSON'
-    return MockResponse(json_response, 200)
+    return MockResponse(json_response, status.HTTP_200_OK)
 
 
 def mocked_requests_get_200_except(*args, **kwargs):  # pylint: disable=unused-argument
     """Mock valid status response that raises an excecption."""
-    return MockResponse(None, 200, ValueError('Decode Problem'))
+    return MockResponse(None, status.HTTP_200_OK, ValueError('Decode Problem'))
 
 
 def mocked_requests_get_200_no_next(*args, **kwargs):  # pylint: disable=unused-argument
@@ -88,7 +89,7 @@ def mocked_requests_get_200_no_next(*args, **kwargs):  # pylint: disable=unused-
         },
         'data': [LIMITED_AWS_ACCESS]
     }
-    return MockResponse(json_response, 200)
+    return MockResponse(json_response, status.HTTP_200_OK)
 
 
 def mocked_requests_get_200_next(*args, **kwargs):  # pylint: disable=unused-argument
@@ -102,7 +103,7 @@ def mocked_requests_get_200_next(*args, **kwargs):  # pylint: disable=unused-arg
     if 'limit' in args[0]:
         json_response['links']['next'] = None
 
-    return MockResponse(json_response, 200)
+    return MockResponse(json_response, status.HTTP_200_OK)
 
 
 def mocked_get_operation(access_item, res_type):  # pylint: disable=unused-argument


### PR DESCRIPTION
## Summary
Use the status constants consistently in koku tests.