### PR TITLE
 cluster_alias annotation doesn't blow up when group by cluster

### DIFF
--- a/koku/api/query_handler.py
+++ b/koku/api/query_handler.py
@@ -353,7 +353,7 @@ class QueryHandler(object):
 
         for value in self.query_parameters.get('filter', {}).keys():
             if value in ('project', 'node') and 'cluster_id' not in clustered_group_by:
-                clustered_group_by.extend(['cluster_id', 'cluster_alias'])
+                clustered_group_by.extend(['cluster', 'cluster_alias'])
                 break
 
         return clustered_group_by

--- a/koku/api/query_handler.py
+++ b/koku/api/query_handler.py
@@ -342,11 +342,13 @@ class QueryHandler(object):
         # here to do the actual grouping, but kepe the original
         # unaltered so as to keep the final API result grouped by
         # the specified group by value
+        if 'cluster' in group_by:
+            return group_by
         clustered_group_by = copy.copy(group_by)
 
         for value in group_by:
             if value in ('project', 'node'):
-                clustered_group_by.extend(['cluster_id', 'cluster_alias'])
+                clustered_group_by.extend(['cluster', 'cluster_alias'])
                 break
 
         for value in self.query_parameters.get('filter', {}).keys():

--- a/koku/api/report/test/ocp/tests_views.py
+++ b/koku/api/report/test/ocp/tests_views.py
@@ -799,7 +799,6 @@ class OCPReportViewTest(IamTestCase):
                 for value in values:
                     self.assertIn('cluster', value)
                     self.assertIn('cluster_alias', value)
-                print(project)
 
     def test_execute_query_group_by_project_duplicate_projects(self):
         """Test that same-named projects across clusters are accounted for."""

--- a/koku/api/report/test/ocp/tests_views.py
+++ b/koku/api/report/test/ocp/tests_views.py
@@ -797,7 +797,7 @@ class OCPReportViewTest(IamTestCase):
                 self.assertEqual(project.get('project'), project_of_interest)
                 values = project.get('values', [])
                 for value in values:
-                    self.assertIn('cluster_id', value)
+                    self.assertIn('cluster', value)
                     self.assertIn('cluster_alias', value)
                 print(project)
 
@@ -823,7 +823,7 @@ class OCPReportViewTest(IamTestCase):
                 values = project.get('values', [])
                 self.assertEqual(len(values), 2)
                 for value in values:
-                    self.assertIn('cluster_id', value)
+                    self.assertIn('cluster', value)
                     self.assertIn('cluster_alias', value)
 
     def test_execute_query_filter_by_project_duplicate_projects(self):
@@ -847,7 +847,7 @@ class OCPReportViewTest(IamTestCase):
             values = entry.get('values', [])
             self.assertEqual(len(values), 2)
             for value in values:
-                self.assertIn('cluster_id', value)
+                self.assertIn('cluster', value)
                 self.assertIn('cluster_alias', value)
 
     def test_execute_query_group_by_cluster(self):
@@ -932,7 +932,7 @@ class OCPReportViewTest(IamTestCase):
                 values = node.get('values', [])
                 self.assertEqual(len(values), 2)
                 for value in values:
-                    self.assertIn('cluster_id', value)
+                    self.assertIn('cluster', value)
                     self.assertIn('cluster_alias', value)
 
     def test_execute_query_filter_by_node_duplicate_projects(self):
@@ -956,7 +956,7 @@ class OCPReportViewTest(IamTestCase):
             values = entry.get('values', [])
             self.assertEqual(len(values), 2)
             for value in values:
-                self.assertIn('cluster_id', value)
+                self.assertIn('cluster', value)
                 self.assertIn('cluster_alias', value)
 
     def test_execute_query_with_tag_filter(self):


### PR DESCRIPTION
## Summary
The recent change to implicitly group by cluster broke the cluster_alias annotation when doing a group by cluster.