### PR TITLE
OpenShift report filter by infrastructures=aws

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -2241,6 +2241,12 @@
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "infrastructures": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             },

--- a/koku/api/provider/view.py
+++ b/koku/api/provider/view.py
@@ -221,6 +221,7 @@ class ProviderViewSet(mixins.CreateModelMixin,
                                 }
                             ]
                         }
+                        "infrastructure": "Unknown"
                     }
               ]
             }
@@ -294,7 +295,8 @@ class ProviderViewSet(mixins.CreateModelMixin,
                             "summary_data_updated_datetime": "2019-01-07 21:51:32"
                         }
                     ]
-                }
+                },
+                "infrastructure": "Unknown"
             }
         """
         response = super().retrieve(request=request, args=args, kwargs=kwargs)

--- a/koku/api/query_filter.py
+++ b/koku/api/query_filter.py
@@ -30,7 +30,7 @@ class QueryFilter(UserDict):
     parameter = None
     composition_key = None
 
-    def __init__(self, table=None, field=None, operation=None, parameter=None, composition_key=None):
+    def __init__(self, table=None, field=None, operation=None, parameter=None, composition_key=None, custom=None):
         """Constructor.
 
         Args:

--- a/koku/api/query_handler.py
+++ b/koku/api/query_handler.py
@@ -176,6 +176,7 @@ class QueryHandler(object):
             (Boolean): True if they keys given appear in given query parameters.
 
         """
+        # import pdb; pdb.set_trace()
         return (self.query_parameters and key in self.query_parameters and  # noqa: W504
                 in_key in self.query_parameters.get(key))
 

--- a/koku/api/query_handler.py
+++ b/koku/api/query_handler.py
@@ -176,7 +176,6 @@ class QueryHandler(object):
             (Boolean): True if they keys given appear in given query parameters.
 
         """
-        # import pdb; pdb.set_trace()
         return (self.query_parameters and key in self.query_parameters and  # noqa: W504
                 in_key in self.query_parameters.get(key))
 

--- a/koku/api/report/ocp/serializers.py
+++ b/koku/api/report/ocp/serializers.py
@@ -169,6 +169,10 @@ class FilterSerializer(serializers.Serializer):
         ('month', 'month'),
     )
 
+    INFRASTRUCTURE_CHOICES = (
+        ('aws', 'aws'),
+    )
+
     resolution = serializers.ChoiceField(choices=RESOLUTION_CHOICES,
                                          required=False)
     time_scope_value = serializers.ChoiceField(choices=TIME_CHOICES,
@@ -187,6 +191,8 @@ class FilterSerializer(serializers.Serializer):
                             required=False)
     node = StringOrListField(child=serializers.CharField(),
                              required=False)
+    infrastructures = serializers.ChoiceField(choices=INFRASTRUCTURE_CHOICES,
+                                              required=False)
 
     def __init__(self, *args, **kwargs):
         """Initialize the FilterSerializer."""
@@ -216,6 +222,10 @@ class FilterSerializer(serializers.Serializer):
         resolution = data.get('resolution')
         time_scope_value = data.get('time_scope_value')
         time_scope_units = data.get('time_scope_units')
+
+        if data.get('infrastructures'):
+            infra_value = data['infrastructures']
+            data['infrastructures'] = [infra_value.upper()]
 
         if time_scope_units and time_scope_value:
             msg = 'Valid values are {} when time_scope_units is {}'

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -17,6 +17,8 @@
 """Query Handling for Reports."""
 import copy
 import logging
+import random
+import string
 from collections import OrderedDict, defaultdict
 from decimal import Decimal, DivisionByZero, InvalidOperation
 from itertools import groupby
@@ -952,11 +954,15 @@ class ReportQueryHandler(QueryHandler):
                 tag_groups.append(filt)
         return tag_groups
 
-    def _build_custom_filter_list(self, type, method, filter_list):
+    def _build_custom_filter_list(self, filter_type, method, filter_list):
         """Replace filter list items from custom method."""
-        if type == 'infrastructures' and method:
+        if filter_type == 'infrastructures' and method:
             for item in filter_list:
                 custom_list = method(item, self.tenant)
+                if not custom_list:
+                    random_name = ''.join(random.choices(string.ascii_lowercase + string.digits,
+                                          k=5))
+                    custom_list = [random_name]
                 filter_list.remove(item)
                 filter_list = list(set(filter_list + custom_list))
         return filter_list

--- a/koku/api/report/test/ocp/tests_serializers.py
+++ b/koku/api/report/test/ocp/tests_serializers.py
@@ -110,6 +110,18 @@ class OCPFilterSerializerTest(TestCase):
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
+    def test_infrastructure_field_validation_success(self):
+        """Test that infrastructure filter are validated for aws."""
+        query_params = {'infrastructures': 'aws'}
+        serializer = FilterSerializer(data=query_params)
+        self.assertTrue(serializer.is_valid())
+
+    def test_infrastructure_field_validation_failure(self):
+        """Test that infrastructure filter are validated for non-aws."""
+        query_params = {'infrastructures': 'notaws'}
+        serializer = FilterSerializer(data=query_params)
+        self.assertFalse(serializer.is_valid())
+
 
 class OCPGroupBySerializerTest(TestCase):
     """Tests for the group_by serializer."""

--- a/koku/providers/aws/aws_provider.py
+++ b/koku/providers/aws/aws_provider.py
@@ -183,3 +183,7 @@ class AWSProvider(ProviderInterface):
     def infra_type_implementation(self, provider_uuid, tenant):
         """Return infrastructure type."""
         return None
+
+    def infra_key_list_implementation(self, infrastructure_type, schema_name):
+        """Return a list of cluster ids on the given infrastructure type."""
+        return []

--- a/koku/providers/ocp/ocp_provider.py
+++ b/koku/providers/ocp/ocp_provider.py
@@ -72,13 +72,11 @@ class OCPProvider(ProviderInterface):
 
     def _is_on_aws(self, tenant, resource_name):
         """Determine if provider is running on AWS."""
-        with tenant_context(tenant):
-            objects = OCPAWSCostLineItemDailySummary.objects.all()
-            clusters = list(objects.values('cluster_id').distinct())
-            for cluster in clusters:
-                for key, cluster_id in cluster.items():
-                    if resource_name == cluster_id:
-                        return True
+        clusters = self._aws_clusters(tenant)
+        for cluster in clusters:
+            for key, cluster_id in cluster.items():
+                if resource_name == cluster_id:
+                    return True
 
         return False
 
@@ -94,3 +92,17 @@ class OCPProvider(ProviderInterface):
             return Provider.PROVIDER_AWS
 
         return None
+
+    def _aws_clusters(self, tenant):
+        """Return a list of OCP clusters running on AWS."""
+        with tenant_context(tenant):
+            objects = OCPAWSCostLineItemDailySummary.objects.all()
+            clusters = list(objects.values('cluster_id').distinct())
+        return clusters
+
+    def infra_key_list_implementation(self, infrastructure_type, schema_name):
+        """Return a list of cluster ids on the given infrastructure type."""
+        clusters = []
+        if infrastructure_type == Provider.PROVIDER_AWS:
+            clusters = self._aws_clusters(schema_name)
+        return clusters

--- a/koku/providers/ocp/ocp_provider.py
+++ b/koku/providers/ocp/ocp_provider.py
@@ -73,10 +73,9 @@ class OCPProvider(ProviderInterface):
     def _is_on_aws(self, tenant, resource_name):
         """Determine if provider is running on AWS."""
         clusters = self._aws_clusters(tenant)
-        for cluster in clusters:
-            for key, cluster_id in cluster.items():
-                if resource_name == cluster_id:
-                    return True
+        for cluster_id in clusters:
+            if resource_name == cluster_id:
+                return True
 
         return False
 
@@ -96,8 +95,8 @@ class OCPProvider(ProviderInterface):
     def _aws_clusters(self, tenant):
         """Return a list of OCP clusters running on AWS."""
         with tenant_context(tenant):
-            objects = OCPAWSCostLineItemDailySummary.objects.all()
-            clusters = list(objects.values('cluster_id').distinct())
+            objects = OCPAWSCostLineItemDailySummary.objects.values_list('cluster_id', flat=True)
+            clusters = list(objects.distinct())
         return clusters
 
     def infra_key_list_implementation(self, infrastructure_type, schema_name):

--- a/koku/providers/provider_access.py
+++ b/koku/providers/provider_access.py
@@ -130,3 +130,24 @@ class ProviderAccessor:
             raise ProviderAccessorError(str(error))
 
         return infrastructure_type if infrastructure_type else 'Unknown'
+
+    def infrastructure_key_list(self, infrastructure_type, schema_name):
+        """
+        Return the name of the infrastructure that the provider is running on.
+
+        Args:
+            infrastructure_type (String): Provider type
+            schema_name (String): Database schema name
+
+        Returns:
+            (String) : Name of Service
+                       example: "AWS"
+
+        """
+        keys = []
+        try:
+            keys = self.service.infra_key_list_implementation(infrastructure_type, schema_name)
+        except Exception as error:
+            raise ProviderAccessorError(str(error))
+
+        return keys

--- a/koku/providers/provider_access.py
+++ b/koku/providers/provider_access.py
@@ -133,15 +133,15 @@ class ProviderAccessor:
 
     def infrastructure_key_list(self, infrastructure_type, schema_name):
         """
-        Return the name of the infrastructure that the provider is running on.
+        Return a list of keys identifying the provider running on specified infrastructure type.
 
         Args:
             infrastructure_type (String): Provider type
             schema_name (String): Database schema name
 
         Returns:
-            (String) : Name of Service
-                       example: "AWS"
+            (List) : List of strings
+                       example: ['ocp-cluster-on-aws-1', 'ocp-cluster-on-aws-2']
 
         """
         keys = []

--- a/koku/providers/provider_interface.py
+++ b/koku/providers/provider_interface.py
@@ -75,7 +75,26 @@ class ProviderInterface(ABC):
             None
 
         Raises:
-            ValidationError: Error string
+            ProviderAccessorError: Error string
+
+        """
+        pass
+
+    @abstractmethod
+    def infra_key_list_implementation(self, infrastructure_type, schema_name):
+        """
+        Return a list of key values to identify resources running on provided infrastructure type.
+
+        Args:
+            infrastructure_type (String): Provider type
+            schema_name (String): Database schema name
+
+        Returns:
+            (List) : List of strings
+                       example: ['ocp-cluster-on-aws-1', 'ocp-cluster-on-aws-2']
+
+        Raises:
+            ProviderAccessorError: Error string
 
         """
         pass

--- a/koku/providers/test/tests_provider_access.py
+++ b/koku/providers/test/tests_provider_access.py
@@ -101,3 +101,11 @@ class ProviderAccessorTestCase(TestCase):
         with self.assertRaises(ProviderAccessorError):
             with patch.object(OCPProvider, 'infra_type_implementation', side_effect=Exception('test')):
                 interface.infrastructure_type(None, None)
+
+    def test_get_infrastructure_key_list_exception(self):
+        """Get infrastructure key list with exception."""
+        provider = OCPProvider()
+        interface = ProviderAccessor(provider.name())
+        with self.assertRaises(ProviderAccessorError):
+            with patch.object(OCPProvider, 'infra_key_list_implementation', side_effect=Exception('test')):
+                interface.infrastructure_type(None, None)


### PR DESCRIPTION
Addresses #749 

New OpenShift filter option for `infrastructures` today the only valid option is `aws`.

**Testing**
1.  Add OCP and AWS providers with 2 OCP providers on AWS and 1 not on AWS
2. Execute a reports/openshift/compute query that filters on only the clusters running on aws (my-ocp-cluster-1, my-ocp-cluster-2) and verify it matches filter for infrastructure=aws
3. Repeat the step #2 for memory and volumes queries, verify the API responses match
4.  Verify 400 is returned for non-aws infrastructures filter queries
5. Run compute query for OCP cluster not on AWS (my-ocp-cluster-3).  Verify infrastructure=aws + ocp-cluster-3 query matches no filter query

**Testing Results**
[koku_749_ut.txt](https://github.com/project-koku/koku/files/2994771/koku_749_ut.txt)

