### PR TITLE
Handle malformed query parameters with 400 response.

### DIFF
--- a/koku/api/report/test/tests_views.py
+++ b/koku/api/report/test/tests_views.py
@@ -22,6 +22,7 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
+from rest_framework.serializers import ValidationError
 from rest_framework.test import APIClient
 from rest_framework_csv.renderers import CSVRenderer
 
@@ -160,6 +161,12 @@ class ReportViewTest(IamTestCase):
         self.assertIsNotNone(json_result.get('data'))
         self.assertIsInstance(json_result.get('data'), list)
         self.assertTrue(len(json_result.get('data')) > 0)
+
+    def test_process_invalid_query_parameters_format(self):
+        """Test processing of invalid parameters format."""
+        qs = 'group_by%5Baccount%5D=account1&filter%5'
+        with self.assertRaises(ValidationError):
+            process_query_parameters(qs, QueryParamSerializer)
 
     def test_process_query_parameters(self):
         """Test processing of valid parameters."""

--- a/koku/api/report/view.py
+++ b/koku/api/report/view.py
@@ -185,7 +185,12 @@ def process_query_parameters(url_data, provider_serializer, tag_keys=None):
         (Dict): Dictionary parsed from query params string
     """
     output = None
-    query_params = parser.parse(url_data)
+    try:
+        query_params = parser.parse(url_data)
+    except parser.MalformedQueryStringError:
+        LOG.error('Invalid query parameter format %s.', url_data)
+        error = {'details': _(f'Invalid query parameter format.')}
+        raise ValidationError(error)
     if tag_keys:
         tag_keys = process_tag_query_params(query_params, tag_keys)
         qps = provider_serializer(data=query_params, tag_keys=tag_keys)


### PR DESCRIPTION
Example fix:
*GET* `/api/cost-management/v1/reports/openshift/volumes/?group_by[`
```
{
    "errors": [
        {
            "detail": "Invalid query parameter format.",
            "source": "details",
            "status": 400
        }
    ]
}
```