### PR TITLE
Validate AWS delta value support based on path.

### DIFF
--- a/koku/api/report/aws/serializers.py
+++ b/koku/api/report/aws/serializers.py
@@ -304,3 +304,14 @@ class QueryParamSerializer(serializers.Serializer):
             raise serializers.ValidationError(error)
 
         return value
+
+    def validate_delta(self, value):
+        """Validate incoming delta value based on path."""
+        valid_delta = 'usage'
+        request = self.context.get('request')
+        if request and 'costs' in request.path:
+            valid_delta = 'cost'
+        if value != valid_delta:
+            error = {'delta': f'"{value}" is not a valid choice.'}
+            raise serializers.ValidationError(error)
+        return value

--- a/koku/api/report/test/tests_serializers.py
+++ b/koku/api/report/test/tests_serializers.py
@@ -16,6 +16,7 @@
 #
 """Test the Report serializers."""
 from unittest import TestCase
+from unittest.mock import Mock
 
 from rest_framework import serializers
 
@@ -212,3 +213,33 @@ class QueryParamSerializerTest(TestCase):
         serializer = QueryParamSerializer(data=query_params)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
+
+    def test_invalid_delta(self):
+        """Test failure while handling invalid delta for different requests."""
+        query_params = {'delta': 'cost'}
+        req = Mock(path='/api/cost-management/v1/reports/aws/storage/')
+        serializer = QueryParamSerializer(data=query_params, context={'request': req})
+        with self.assertRaises(serializers.ValidationError):
+            serializer.is_valid(raise_exception=True)
+
+        query_params = {'delta': 'usage'}
+        req = Mock(path='/api/cost-management/v1/reports/aws/costs/')
+        serializer = QueryParamSerializer(data=query_params, context={'request': req})
+        with self.assertRaises(serializers.ValidationError):
+            serializer.is_valid(raise_exception=True)
+
+        query_params = {'delta': 'usage'}
+        req = Mock(path='/api/cost-management/v1/reports/aws/storage/')
+        serializer = QueryParamSerializer(data=query_params, context={'request': req})
+        try:
+            serializer.is_valid(raise_exception=True)
+        except serializers.ValidationError:
+            self.fail('Serizalizer raised error for valid delta')
+
+        query_params = {'delta': 'cost'}
+        req = Mock(path='/api/cost-management/v1/reports/aws/costs/')
+        serializer = QueryParamSerializer(data=query_params, context={'request': req})
+        try:
+            serializer.is_valid(raise_exception=True)
+        except serializers.ValidationError:
+            self.fail('Serizalizer raised error for valid delta')

--- a/koku/api/report/view.py
+++ b/koku/api/report/view.py
@@ -175,7 +175,7 @@ def get_tag_keys(request, summary_model):
     return tags
 
 
-def process_query_parameters(url_data, provider_serializer, tag_keys=None):
+def process_query_parameters(url_data, provider_serializer, tag_keys=None, **kwargs):
     """Process query parameters and raise any validation errors.
 
     Args:
@@ -193,9 +193,9 @@ def process_query_parameters(url_data, provider_serializer, tag_keys=None):
         raise ValidationError(error)
     if tag_keys:
         tag_keys = process_tag_query_params(query_params, tag_keys)
-        qps = provider_serializer(data=query_params, tag_keys=tag_keys)
+        qps = provider_serializer(data=query_params, tag_keys=tag_keys, context=kwargs)
     else:
-        qps = provider_serializer(data=query_params)
+        qps = provider_serializer(data=query_params, context=kwargs)
     validation = qps.is_valid()
     if not validation:
         output = qps.errors
@@ -364,7 +364,8 @@ def _generic_report(request, provider, report):
     validation, params = process_query_parameters(
         url_data,
         provider_parameter_serializer,
-        tag_keys
+        tag_keys,
+        **{'request': request}
     )
 
     if not validation:


### PR DESCRIPTION
Now provides expected output:

*GET* `/api/cost-management/v1/reports/aws/storage/?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&delta=cost`

```
{
    "delta": {
        "delta": "\"cost\" is not a valid choice."
    }
}
```