### PR TITLE
add optional rdsexporter container

### DIFF
--- a/openshift/rdsexporter/Dockerfile
+++ b/openshift/rdsexporter/Dockerfile
@@ -1,0 +1,24 @@
+FROM centos/go-toolset-7-centos7
+
+USER root
+
+RUN yum -y update && \
+    yum install -y PyYAML && \
+    yum clean all
+
+RUN mkdir -p /opt/app-root/{src,bin,etc}
+
+ENV LC_ALL=en_US.UTF-8 \
+    LANG=en_US.UTF-8 \
+    GOPATH=/opt/app-root \
+    BASH_ENV=/opt/rh/go-toolset-7/enable \
+    ENV=/opt/rh/go-toolset-7/enable \
+    PROMPT_COMMAND=". /opt/rh/go-toolset-7/enable"
+
+RUN scl enable go-toolset-7 -- go get -u github.com/percona/rds_exporter
+
+COPY deploy_config.py /opt/app-root
+RUN /opt/app-root/deploy_config.py
+
+EXPOSE      9042
+ENTRYPOINT  [ "/opt/app-root/bin/rds_exporter", "--config.file=/opt/app-root/etc/config.yml" ]

--- a/openshift/rdsexporter/README.rst
+++ b/openshift/rdsexporter/README.rst
@@ -1,0 +1,36 @@
+============
+RDS Exporter
+============
+
+Upstream
+--------
+
+https://github.com/percona/rds_exporter
+
+Requirements
+============
+
+Building RDS Exporter
+---------------------
+
+RDS_EXPORTER_CONFIG environment variable must be present in the build
+environment.
+
+RDS_EXPORTER_CONFIG should be JSON. It will be converted to YAML and
+deployed as the rdsexporter's "config.yaml".
+
+See upstream docs for config.yaml syntax.
+
+Running RDS Exporter
+--------------------
+
+AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables must be
+present in the running container.
+
+Deploying to OpenShift
+======================
+
+$ oc new-project rdsexporter
+$ oc create istag go-toolset-7-centos7:latest --from-image=centos/go-toolset-7-centos7
+$ oc apply -f rdsexporter.yaml
+$ oc new-app --template rdsexporter [--param]

--- a/openshift/rdsexporter/deploy_config.py
+++ b/openshift/rdsexporter/deploy_config.py
@@ -1,0 +1,34 @@
+#!/usr/bin/python
+#
+# Copyright 2018 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""RDS Exporter config file deployer."""
+
+import json
+import os
+import sys
+import yaml
+
+APP_ROOT = os.environ.get('APP_ROOT')
+CONFIG = os.environ.get('RDS_EXPORTER_CONFIG')
+
+if APP_ROOT and CONFIG:
+    FILENAME = '{}/etc/config.yml'.format(APP_ROOT)
+    with open(FILENAME, 'w') as fh:
+        yaml.safe_dump(json.loads(CONFIG), fh, default_flow_style=False)
+else:
+    print('Environment vars APP_ROOT and RDS_EXPORTER_CONFIG are required.')
+    sys.exit(-1)

--- a/openshift/rdsexporter/rdsexporter.yaml
+++ b/openshift/rdsexporter/rdsexporter.yaml
@@ -1,0 +1,228 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: rdsexporter-template
+  annotations:
+    openshift.io/display-name: 'RDS Exporter'
+    openshift.io/description: 'Prometheus exporter for AWS RDS'
+    openshift.io/long-description: 'This template defines resources to export monitoring and metrics data from AWS Cloudwatch about your RDS instances to Prometheus.'
+labels:
+  app: rdsexporter
+  template: rdsexporter-template
+objects:
+- apiVersion: apps.openshift.io/v1
+  kind: DeploymentConfig
+  metadata:
+    labels:
+      app: rdsexporter
+      template: rdsexporter-template
+    name: ${NAME}
+  spec:
+    replicas: 1
+    revisionHistoryLimit: 10
+    selector:
+      app: ${NAME}
+      deploymentconfig: ${NAME}
+    strategy:
+      activeDeadlineSeconds: 21600
+      rollingParams:
+        intervalSeconds: 1
+        maxSurge: 25%
+        maxUnavailable: 25%
+        timeoutSeconds: 300
+        updatePeriodSeconds: 1
+      type: Rolling
+    template:
+      metadata:
+        labels:
+          app: ${NAME}
+          deploymentconfig: ${NAME}
+      spec:
+        containers:
+        - env:
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                key: aws-access-key-id
+                name: ${NAME}
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                key: aws-secret-access-key
+                name: ${NAME}
+          image: ${NAMESPACE}/${NAME}:latest
+          imagePullPolicy: Always
+          name: rdsexporter
+          ports:
+          - containerPort: 9042
+            protocol: TCP
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        schedulerName: default-scheduler
+        terminationGracePeriodSeconds: 30
+    test: false
+    triggers:
+    - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - ${NAME}
+        from:
+          kind: ImageStreamTag
+          name: ${NAME}:latest
+          namespace: ${NAMESPACE}
+      type: ImageChange
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      prometheus.io/path: /basic
+      prometheus.io/port: "9041"
+      prometheus.io/scrape: "true"
+    labels:
+      app: rdsexporter
+      template: rdsexporter-template
+    name: ${NAME}-basic
+  spec:
+    ports:
+    - name: 9041-tcp
+      port: 9041
+      protocol: TCP
+      targetPort: 9042
+    selector:
+      app: ${NAME}
+      deploymentconfig: ${NAME}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      prometheus.io/path: /enhanced
+      prometheus.io/port: "9042"
+      prometheus.io/scrape: "true"
+    labels:
+      app: rdsexporter
+      template: rdsexporter-template
+    name: ${NAME}-enhanced
+  spec:
+    ports:
+    - name: 9042-tcp
+      port: 9042
+      protocol: TCP
+      targetPort: 9042
+    selector:
+      app: ${NAME}
+      deploymentconfig: ${NAME}
+- apiVersion: build.openshift.io/v1
+  kind: BuildConfig
+  metadata:
+    labels:
+      app: rdsexporter
+      template: rdsexporter-template
+    name: ${NAME}
+  spec:
+    failedBuildsHistoryLimit: 5
+    output:
+      to:
+        kind: ImageStreamTag
+        name: ${NAME}:latest
+    runPolicy: Serial
+    source:
+      contextDir: ${CONTEXT_DIR}
+      git:
+        ref: ${SOURCE_REPOSITORY_REF}
+        uri: ${SOURCE_REPOSITORY_URL}
+      type: Git
+    strategy:
+      dockerStrategy:
+        env:
+          - name: RDS_EXPORTER_CONFIG
+            valueFrom:
+              configMapKeyRef:
+                name: ${NAME}
+                key: rdsexporter-config
+                optional: false
+        from:
+          kind: ImageStreamTag
+          name: go-toolset-7-centos7:latest
+          namespace: ${NAMESPACE}
+      type: Docker
+    successfulBuildsHistoryLimit: 5
+    triggers:
+    - github:
+        secret: ${GITHUB_WEBHOOK_SECRET}
+      type: GitHub
+    - type: ConfigChange
+    - imageChange: {}
+      type: ImageChange
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    labels:
+      app: rdsexporter
+      template: rdsexporter-template
+    name: ${NAME}
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    labels:
+      app: rdsexporter
+      template: rdsexporter-template
+    annotations:
+      template.openshift.io/expose-aws_access_key_id: "{.data['aws-access-key-id']}"
+      template.openshift.io/expose-aws_secret_access_key: "{.data['aws-secret-access-key']}"
+    name: ${NAME}
+  stringData:
+    aws-access-key-id: ${AWS_ACCESS_KEY_ID}
+    aws-secret-access-key: ${AWS_SECRET_ACCESS_KEY}
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    labels:
+      app: rdsexporter
+      template: rdsexporter-template
+    name: ${NAME}
+  data:
+    rdsexporter-config: ${RDS_EXPORTER_CONFIG}
+parameters:
+- description: The name assigned to all frontend objects defined in this template.
+  displayName: Name
+  name: NAME
+  required: true
+  value: rdsexporter
+- description: The OpenShift Namespace where the ImageStream resides.
+  displayName: Namespace
+  name: NAMESPACE
+  required: true
+  value: rdsexporter
+- description: The URL of the repository with your application source code.
+  displayName: Git Repository URL
+  name: SOURCE_REPOSITORY_URL
+  required: true
+  value: https://github.com/project-koku/koku.git
+- description: Set this to a branch name, tag or other ref of your repository if you
+    are not using the default branch.
+  displayName: Git Reference
+  name: SOURCE_REPOSITORY_REF
+- description: Set this to the relative path to your project if it is not in the root
+    of your repository.
+  displayName: Context Directory
+  name: CONTEXT_DIR
+  value: openshift/rdsexporter
+- description: AWS Access Key ID
+  displayName: AWS Access Key ID
+  from: ${AWS_ACCESS_KEY_ID}
+  name: AWS_ACCESS_KEY_ID
+- description: AWS Secret Access Key
+  displayName: AWS Secret Access Key
+  from: ${AWS_SECRET_ACCESS_KEY}
+  name: AWS_SECRET_ACCESS_KEY
+- description: Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.
+  displayName: GitHub Webhook Secret
+  from: '[a-zA-Z0-9]{40}'
+  generate: expression
+  name: GITHUB_WEBHOOK_SECRET
+- description: JSON string representing config for rdsexporter. Deployed as config.yaml during build.
+  displayName: Config file JSON
+  name: RDS_EXPORTER_CONFIG


### PR DESCRIPTION
This adds an optional container to deploy Percona's rds-exporter. This enables us to collect metrics from CloudWatch for RDS and push them to a Prometheus instance.

This addresses Koku #737 .

Screenshot:
![Screenshot from 2019-03-22 14-22-10](https://user-images.githubusercontent.com/17390/54844985-950a2000-4cae-11e9-8a70-e6ff5e386714.png)
