### PR TITLE
add optional postgres exporter container

### DIFF
--- a/openshift/postgresql-exporter/Dockerfile
+++ b/openshift/postgresql-exporter/Dockerfile
@@ -1,0 +1,20 @@
+FROM centos/go-toolset-7-centos7
+
+USER root
+
+RUN yum -y update && \
+    yum clean all
+
+RUN mkdir -p /opt/app-root/{src,bin,etc}
+
+ENV LC_ALL=en_US.UTF-8 \
+    LANG=en_US.UTF-8 \
+    GOPATH=/opt/app-root \
+    BASH_ENV=/opt/rh/go-toolset-7/enable \
+    ENV=/opt/rh/go-toolset-7/enable \
+    PROMPT_COMMAND=". /opt/rh/go-toolset-7/enable"
+
+RUN scl enable go-toolset-7 -- go get -u github.com/wrouesnel/postgres_exporter/cmd/postgres_exporter
+
+EXPOSE      9187
+ENTRYPOINT  [ "/opt/app-root/bin/postgres_exporter" ]

--- a/openshift/postgresql-exporter/README.rst
+++ b/openshift/postgresql-exporter/README.rst
@@ -1,0 +1,31 @@
+============
+PostgreSQL Exporter
+============
+
+Upstream
+--------
+
+https://github.com/wrouesnel/postgres_exporter
+
+Requirements
+============
+
+Running PostgreSQL Exporter
+--------------------
+
+The OpenShift template contains a secret object that defines the environment variables required to connect to the DB.
+
+DATA_SOURCE_NAME - connection info; see upstream docs for details.
+
+Example:::
+
+    $ oc new-app --template postgresql-exporter-template \
+                 --param 'DATA_SOURCE_NAME=postgresql://username:password@hostname.projectname.svc.cluster.local:5432/dbname?sslmode=disable'
+
+Deploying to OpenShift
+======================
+
+$ oc new-project postgresql-exporter
+$ oc create istag go-toolset-7-centos7:latest --from-image=centos/go-toolset-7-centos7
+$ oc apply -f postgresql-exporter.yaml
+$ oc new-app --template postgresql-exporter-template [--param]

--- a/openshift/postgresql-exporter/postgresql-exporter.yaml
+++ b/openshift/postgresql-exporter/postgresql-exporter.yaml
@@ -166,7 +166,7 @@ parameters:
   name: CONTEXT_DIR
   value: openshift/postgresql-exporter
 - description: PostgreSQL connection string
-  displayName: Data source URI
+  displayName: Data source name
   from: ${DATA_SOURCE_NAME}
   name: DATA_SOURCE_NAME
 - description: Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.

--- a/openshift/postgresql-exporter/postgresql-exporter.yaml
+++ b/openshift/postgresql-exporter/postgresql-exporter.yaml
@@ -1,0 +1,176 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: postgresql-exporter-template
+  annotations:
+    openshift.io/display-name: 'PostgreSQL Exporter'
+    openshift.io/description: 'Prometheus exporter for PostgreSQL'
+    openshift.io/long-description: 'This template defines resources to export monitoring and metrics data from a PostgreSQL database to Prometheus.'
+labels:
+  app: postgresql-exporter
+  template: postgresql-exporter-template
+objects:
+- apiVersion: apps.openshift.io/v1
+  kind: DeploymentConfig
+  metadata:
+    labels:
+      app: postgresql-exporter
+      template: postgresql-exporter-template
+    name: ${NAME}
+  spec:
+    replicas: 1
+    revisionHistoryLimit: 10
+    selector:
+      app: ${NAME}
+      deploymentconfig: ${NAME}
+    strategy:
+      activeDeadlineSeconds: 21600
+      rollingParams:
+        intervalSeconds: 1
+        maxSurge: 25%
+        maxUnavailable: 25%
+        timeoutSeconds: 300
+        updatePeriodSeconds: 1
+      type: Rolling
+    template:
+      metadata:
+        labels:
+          app: ${NAME}
+          deploymentconfig: ${NAME}
+      spec:
+        containers:
+        - env:
+          - name: DATA_SOURCE_NAME
+            valueFrom:
+              secretKeyRef:
+                key: data-source-name
+                name: ${NAME}
+          image: ${NAMESPACE}/${NAME}:latest
+          imagePullPolicy: Always
+          name: postgresql-exporter
+          ports:
+          - containerPort: 9187
+            protocol: TCP
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        schedulerName: default-scheduler
+        terminationGracePeriodSeconds: 30
+    test: false
+    triggers:
+    - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - ${NAME}
+        from:
+          kind: ImageStreamTag
+          name: ${NAME}:latest
+          namespace: ${NAMESPACE}
+      type: ImageChange
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      prometheus.io/path: /metrics
+      prometheus.io/port: "9187"
+      prometheus.io/scrape: "true"
+    labels:
+      app: postgresql-exporter
+      template: postgresql-exporter-template
+    name: ${NAME}
+  spec:
+    ports:
+    - name: 9187-tcp
+      port: 9187
+      protocol: TCP
+      targetPort: 9187
+    selector:
+      app: ${NAME}
+      deploymentconfig: ${NAME}
+- apiVersion: build.openshift.io/v1
+  kind: BuildConfig
+  metadata:
+    labels:
+      app: postgresql-exporter
+      template: postgresql-exporter-template
+    name: ${NAME}
+  spec:
+    failedBuildsHistoryLimit: 5
+    output:
+      to:
+        kind: ImageStreamTag
+        name: ${NAME}:latest
+    runPolicy: Serial
+    source:
+      contextDir: ${CONTEXT_DIR}
+      git:
+        ref: ${SOURCE_REPOSITORY_REF}
+        uri: ${SOURCE_REPOSITORY_URL}
+      type: Git
+    strategy:
+      dockerStrategy:
+        from:
+          kind: ImageStreamTag
+          name: go-toolset-7-centos7:latest
+          namespace: ${NAMESPACE}
+      type: Docker
+    successfulBuildsHistoryLimit: 5
+    triggers:
+    - github:
+        secret: ${GITHUB_WEBHOOK_SECRET}
+      type: GitHub
+    - type: ConfigChange
+    - imageChange: {}
+      type: ImageChange
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    labels:
+      app: postgresql-exporter
+      template: postgresql-exporter-template
+    name: ${NAME}
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    labels:
+      app: postgresql-exporter
+      template: postgresql-exporter-template
+    name: ${NAME}
+  stringData:
+    data-source-name: ${DATA_SOURCE_NAME}
+parameters:
+- description: The name assigned to all objects defined in this template.
+  displayName: Name
+  name: NAME
+  required: true
+  value: postgresql-exporter
+- description: The OpenShift Namespace where the ImageStream resides.
+  displayName: Namespace
+  name: NAMESPACE
+  required: true
+  value: postgresql-exporter
+- description: The URL of the repository with your application source code.
+  displayName: Git Repository URL
+  name: SOURCE_REPOSITORY_URL
+  required: true
+  value: https://github.com/project-koku/koku.git
+- description: Set this to a branch name, tag or other ref of your repository if you
+    are not using the default branch.
+  displayName: Git Reference
+  name: SOURCE_REPOSITORY_REF
+- description: Set this to the relative path to your project if it is not in the root
+    of your repository.
+  displayName: Context Directory
+  name: CONTEXT_DIR
+  value: openshift/postgresql-exporter
+- description: PostgreSQL connection string
+  displayName: Data source URI
+  from: ${DATA_SOURCE_NAME}
+  name: DATA_SOURCE_NAME
+- description: Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.
+  displayName: GitHub Webhook Secret
+  from: '[a-zA-Z0-9]{40}'
+  generate: expression
+  name: GITHUB_WEBHOOK_SECRET


### PR DESCRIPTION
This adds an optional container running postgresql-exporter. The exporter exposes data about postgresql for Prometheus to scrape for monitoring/alerting.

![Screenshot from 2019-03-25 11-09-47](https://user-images.githubusercontent.com/17390/54931095-cbce7900-4eee-11e9-9284-3d8bcfd31855.png)
