### PR TITLE
Set provider name filter lookup expression to contain

### DIFF
--- a/koku/api/provider/test/tests_views.py
+++ b/koku/api/provider/test/tests_views.py
@@ -189,6 +189,40 @@ class ProviderViewTest(IamTestCase):
         self.assertEqual(json_result.get('stats'), {})
         self.assertEqual(json_result.get('infrastructure'), 'Unknown')
 
+    def test_filter_providers_by_name_contains(self):
+        """Test that providers that contain name appear."""
+        iam_arn = 'arn:aws:s3:::my_s3_bucket'
+        bucket_name = 'my_s3_bucket'
+        create_response = self.create_provider(bucket_name, iam_arn, )
+        provider_result = create_response.json()
+        provider_uuid = provider_result.get('uuid')
+        self.assertIsNotNone(provider_uuid)
+        url = '%s?mame=provider' % reverse('provider-list')
+        client = APIClient()
+        response = client.get(url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        json_result = response.json()
+        results = json_result.get('data')
+        self.assertIsNotNone(results)
+        self.assertEqual(len(results), 1)
+
+    def test_filter_providers_by_name_not_contain(self):
+        """Test that all providers that do not contain name will not appear."""
+        iam_arn = 'arn:aws:s3:::my_s3_bucket'
+        bucket_name = 'my_s3_bucket'
+        create_response = self.create_provider(bucket_name, iam_arn, )
+        provider_result = create_response.json()
+        provider_uuid = provider_result.get('uuid')
+        self.assertIsNotNone(provider_uuid)
+        url = '%s?name=blabla' % reverse('provider-list')
+        client = APIClient()
+        response = client.get(url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        json_result = response.json()
+        results = json_result.get('data')
+        self.assertIsNotNone(results)
+        self.assertEqual(len(results), 0)
+
     def test_get_provider_other_customer(self):
         """Test get a provider for another customer should fail."""
         iam_arn = 'arn:aws:s3:::my_s3_bucket'

--- a/koku/api/provider/view.py
+++ b/koku/api/provider/view.py
@@ -37,6 +37,16 @@ from .provider_manager import ProviderManager
 LOG = logging.getLogger(__name__)
 
 
+class ProviderFilter(filters.FilterSet):
+    """Provider custom filters."""
+
+    name = filters.CharFilter(lookup_expr='icontains')
+
+    class Meta:
+        model = Provider
+        fields = ['type']
+
+
 class ProviderDeleteException(APIException):
     """Provider deletion custom internal error exception."""
 
@@ -63,7 +73,7 @@ class ProviderViewSet(mixins.CreateModelMixin,
     queryset = Provider.objects.all()
     permission_classes = (AllowAny,)
     filter_backends = (filters.DjangoFilterBackend,)
-    filterset_fields = ('type', 'name')
+    filterset_class = ProviderFilter
 
     def get_serializer_class(self):
         """Return the appropriate serializer depending on user."""


### PR DESCRIPTION
fixes #781 

This is going to filter providers that their names contain the `name` parameter passed in the request.
