### PR TITLE
Fixing OpenShift on AWS queries when filtering by project

### DIFF
--- a/koku/api/report/ocp_aws/ocp_aws_query_handler.py
+++ b/koku/api/report/ocp_aws/ocp_aws_query_handler.py
@@ -47,7 +47,8 @@ class OCPAWSReportQueryHandler(AWSReportQueryHandler):
 
         # Update which field is used to calculate cost by group by param.
         group_by = self._get_group_by()
-        if group_by and group_by[0] == 'project':
+        if (group_by and group_by[0] == 'project') or \
+            'project' in self.query_parameters.get('filter', {}).keys():
             self._report_type = self._report_type + '_by_project'
             self._mapper = ProviderMap(provider=provider,
                                        report_type=self._report_type)

--- a/koku/api/report/ocp_aws/ocp_aws_query_handler.py
+++ b/koku/api/report/ocp_aws/ocp_aws_query_handler.py
@@ -48,7 +48,7 @@ class OCPAWSReportQueryHandler(AWSReportQueryHandler):
         # Update which field is used to calculate cost by group by param.
         group_by = self._get_group_by()
         if (group_by and group_by[0] == 'project') or \
-            'project' in self.query_parameters.get('filter', {}).keys():
+                'project' in self.query_parameters.get('filter', {}).keys():
             self._report_type = self._report_type + '_by_project'
             self._mapper = ProviderMap(provider=provider,
                                        report_type=self._report_type)


### PR DESCRIPTION
Addresses #750 
The incorrect annotations were being used for `filter[project]` on OCP on AWS queries.

**Testing**
1.  Ingest OCP and AWS data such that OCP is running on AWS
2. Verify that reports/openshift/infrastructures/aws/instance-types query param group_by[project]=* is the same as filter[project]=*

**Test Results**
[koku_750_ut.txt](https://github.com/project-koku/koku/files/3040082/koku_750_ut.txt)

Also ran and updated QE tests that were failing due to this issue.  PR is open for these changes.