### PR TITLE
exclude cluster and cluster_alias from others, fixes #774

### DIFF
--- a/koku/api/report/ocp/ocp_query_handler.py
+++ b/koku/api/report/ocp/ocp_query_handler.py
@@ -142,8 +142,7 @@ class OCPReportQueryHandler(ReportQueryHandler):
                 rank_by_total = self.get_rank_window_function(group_by_value)
                 query_data = query_data.annotate(rank=rank_by_total)
                 query_order_by.insert(1, 'rank')
-                query_data = self._ranked_list(query_data,
-                                               exclusions=['cluster_alias', 'cluster'])
+                query_data = self._ranked_list(query_data)
 
             # Populate the 'total' section of the API response
             if query.exists():
@@ -167,8 +166,7 @@ class OCPReportQueryHandler(ReportQueryHandler):
 
             if is_csv_output:
                 if self._limit:
-                    data = self._ranked_list(list(query_data),
-                                             exclusions=['cluster_alias', 'cluster'])
+                    data = self._ranked_list(list(query_data))
                 else:
                     data = list(query_data)
             else:

--- a/koku/api/report/ocp/ocp_query_handler.py
+++ b/koku/api/report/ocp/ocp_query_handler.py
@@ -142,7 +142,8 @@ class OCPReportQueryHandler(ReportQueryHandler):
                 rank_by_total = self.get_rank_window_function(group_by_value)
                 query_data = query_data.annotate(rank=rank_by_total)
                 query_order_by.insert(1, 'rank')
-                query_data = self._ranked_list(query_data)
+                query_data = self._ranked_list(query_data,
+                                               exclusions=['cluster_alias', 'cluster'])
 
             # Populate the 'total' section of the API response
             if query.exists():
@@ -166,7 +167,8 @@ class OCPReportQueryHandler(ReportQueryHandler):
 
             if is_csv_output:
                 if self._limit:
-                    data = self._ranked_list(list(query_data))
+                    data = self._ranked_list(list(query_data),
+                                             exclusions=['cluster_alias', 'cluster'])
                 else:
                     data = list(query_data)
             else:

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -1344,11 +1344,12 @@ class ReportQueryHandler(QueryHandler):
         except (DivisionByZero, ZeroDivisionError, InvalidOperation):
             return None
 
-    def _ranked_list(self, data_list):
+    def _ranked_list(self, data_list, exclusions=[]):
         """Get list of ranked items less than top.
 
         Args:
             data_list (List(Dict)): List of ranked data points from the same bucket
+            exclusions (List): A list of column names to exclude from the "others"
         Returns:
             List(Dict): List of data points meeting the rank criteria
         """
@@ -1361,12 +1362,13 @@ class ReportQueryHandler(QueryHandler):
         for date in date_grouped_data:
             ranked_list = self._perform_rank_summation(
                 date_grouped_data[date],
-                is_offset)
+                is_offset,
+                exclusions)
             rank_limited_data[date] = ranked_list
 
         return self.unpack_date_grouped_data(rank_limited_data)
 
-    def _perform_rank_summation(self, entry, is_offset):
+    def _perform_rank_summation(self, entry, is_offset, exclusions):
         """Do the actual rank limiting for rank_list."""
         other = None
         ranked_list = []
@@ -1396,9 +1398,7 @@ class ReportQueryHandler(QueryHandler):
             if 'account' in group_by:
                 other['account_alias'] = others_label
 
-            # don't include these in the "others" data.
-            not_others = ['cluster_alias', 'cluster']
-            for exclude in not_others:
+            for exclude in exclusions:
                 if exclude in other:
                     del other[exclude]
 

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -1368,7 +1368,8 @@ class ReportQueryHandler(QueryHandler):
 
         return self.unpack_date_grouped_data(rank_limited_data)
 
-    def _perform_rank_summation(self, entry, is_offset, exclusions):
+    # needs refactoring, but disabling pylint's complexity check for now.
+    def _perform_rank_summation(self, entry, is_offset, exclusions):    # noqa: C901
         """Do the actual rank limiting for rank_list."""
         other = None
         ranked_list = []

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -1395,6 +1395,8 @@ class ReportQueryHandler(QueryHandler):
                 other[group] = others_label
             if 'account' in group_by:
                 other['account_alias'] = others_label
+            if 'cluster_alias' in other:
+                del other['cluster_alias']
             ranked_list.append(other)
 
         return ranked_list

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -1349,7 +1349,6 @@ class ReportQueryHandler(QueryHandler):
 
         Args:
             data_list (List(Dict)): List of ranked data points from the same bucket
-            exclusions (List): A list of column names to exclude from the "others"
         Returns:
             List(Dict): List of data points meeting the rank criteria
         """
@@ -1407,6 +1406,8 @@ class ReportQueryHandler(QueryHandler):
                 other['cluster_alias'] = others_label
                 exclusions = []
             else:
+                # delete these labels from the Others category if we're not
+                # grouping by cluster.
                 exclusions = ['cluster', 'cluster_alias']
 
             for exclude in exclusions:

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -1361,8 +1361,7 @@ class ReportQueryHandler(QueryHandler):
         for date in date_grouped_data:
             ranked_list = self._perform_rank_summation(
                 date_grouped_data[date],
-                is_offset,
-                exclusions)
+                is_offset)
             rank_limited_data[date] = ranked_list
 
         return self.unpack_date_grouped_data(rank_limited_data)

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -1344,7 +1344,7 @@ class ReportQueryHandler(QueryHandler):
         except (DivisionByZero, ZeroDivisionError, InvalidOperation):
             return None
 
-    def _ranked_list(self, data_list, exclusions=[]):
+    def _ranked_list(self, data_list):
         """Get list of ranked items less than top.
 
         Args:
@@ -1369,7 +1369,7 @@ class ReportQueryHandler(QueryHandler):
         return self.unpack_date_grouped_data(rank_limited_data)
 
     # needs refactoring, but disabling pylint's complexity check for now.
-    def _perform_rank_summation(self, entry, is_offset, exclusions):    # noqa: C901
+    def _perform_rank_summation(self, entry, is_offset):    # noqa: C901
         """Do the actual rank limiting for rank_list."""
         other = None
         ranked_list = []
@@ -1389,15 +1389,25 @@ class ReportQueryHandler(QueryHandler):
         if other is not None and others_list and not is_offset:
             num_others = len(others_list)
             others_label = '{} Others'.format(num_others)
+
             if num_others == 1:
                 others_label = '{} Other'.format(num_others)
+
             other.update(other_sums)
             other['rank'] = self._limit + 1
             group_by = self._get_group_by()
+
             for group in group_by:
                 other[group] = others_label
+
             if 'account' in group_by:
                 other['account_alias'] = others_label
+
+            if 'cluster' in group_by:
+                other['cluster_alias'] = others_label
+                exclusions = []
+            else:
+                exclusions = ['cluster', 'cluster_alias']
 
             for exclude in exclusions:
                 if exclude in other:

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -1395,8 +1395,13 @@ class ReportQueryHandler(QueryHandler):
                 other[group] = others_label
             if 'account' in group_by:
                 other['account_alias'] = others_label
-            if 'cluster_alias' in other:
-                del other['cluster_alias']
+
+            # don't include these in the "others" data.
+            not_others = ['cluster_alias', 'cluster']
+            for exclude in not_others:
+                if exclude in other:
+                    del other[exclude]
+
             ranked_list.append(other)
 
         return ranked_list

--- a/koku/api/report/test/tests_queries.py
+++ b/koku/api/report/test/tests_queries.py
@@ -2100,11 +2100,13 @@ class ReportQueryTest(IamTestCase):
 
         query_params = {'filter': {'resolution': 'monthly',
                                    'time_scope_value': -1,
-                                   'time_scope_units': 'month'},
+                                   'time_scope_units': 'month',
+                                   'limit': 3},
                         'group_by': {'cluster': ['*']}}
         query_string = '?filter[resolution]=monthly&' + \
                        'filter[time_scope_value]=-1&' + \
                        'filter[time_scope_units]=month&' + \
+                       'filter[limit]=3&' + \
                        'group_by[cluster]=*'
 
         handler = OCPReportQueryHandler(

--- a/koku/api/report/test/tests_queries.py
+++ b/koku/api/report/test/tests_queries.py
@@ -33,8 +33,9 @@ from tenant_schemas.utils import tenant_context
 
 from api.iam.test.iam_test_case import IamTestCase
 from api.report.aws.aws_query_handler import AWSReportQueryHandler
+from api.report.ocp.ocp_query_handler import OCPReportQueryHandler
 from api.report.queries import strip_tag_prefix
-# from api.report.view import get_tag_keys
+from api.report.test.ocp.helpers import OCPReportDataGenerator
 from api.tags.aws.aws_tag_query_handler import AWSTagQueryHandler
 from api.utils import DateHelper
 from reporting.models import (AWSAccountAlias,
@@ -45,7 +46,6 @@ from reporting.models import (AWSAccountAlias,
                               AWSCostEntryLineItemDailySummary,
                               AWSCostEntryPricing,
                               AWSCostEntryProduct)
-# from reporting.provider.aws.models import AWSTagsSummary
 
 
 class FakeAWSCostData(object):
@@ -2092,3 +2092,37 @@ class ReportQueryTest(IamTestCase):
         for key in totals:
             result = data_totals.get(key, {}).get('value')
             self.assertEqual(result, totals[key])
+
+    def test_ocp_cpu_query_group_by_cluster(self):
+        """Test that group by cluster includes cluster and cluster_alias."""
+        data_generator = OCPReportDataGenerator(self.tenant)
+        data_generator.add_data_to_tenant()
+
+        query_params = {'filter': {'resolution': 'monthly',
+                                   'time_scope_value': -1,
+                                   'time_scope_units': 'month'},
+                        'group_by': {'cluster': ['*']}}
+        query_string = '?filter[resolution]=monthly&' + \
+                       'filter[time_scope_value]=-1&' + \
+                       'filter[time_scope_units]=month&' + \
+                       'group_by[cluster]=*'
+
+
+        handler = OCPReportQueryHandler(
+            query_params,
+            query_string,
+            self.tenant,
+            **{'report_type': 'cpu'}
+        )
+
+        query_data = handler.execute_query()
+        for data in query_data.get('data'):
+            self.assertIn('clusters', data)
+            for cluster_data in data.get('clusters'):
+                self.assertIn('cluster', cluster_data)
+                self.assertIn('values', cluster_data)
+                for cluster_value in cluster_data.get('values'):
+                    self.assertIn('cluster', cluster_value)
+                    self.assertIn('cluster_alias', cluster_value)
+                    self.assertIsNotNone('cluster', cluster_value)
+                    self.assertIsNotNone('cluster_alias', cluster_value)

--- a/koku/api/report/test/tests_queries.py
+++ b/koku/api/report/test/tests_queries.py
@@ -2107,7 +2107,6 @@ class ReportQueryTest(IamTestCase):
                        'filter[time_scope_units]=month&' + \
                        'group_by[cluster]=*'
 
-
         handler = OCPReportQueryHandler(
             query_params,
             query_string,

--- a/koku/api/report/test/tests_queries.py
+++ b/koku/api/report/test/tests_queries.py
@@ -2095,8 +2095,8 @@ class ReportQueryTest(IamTestCase):
 
     def test_ocp_cpu_query_group_by_cluster(self):
         """Test that group by cluster includes cluster and cluster_alias."""
-        data_generator = OCPReportDataGenerator(self.tenant)
-        data_generator.add_data_to_tenant()
+        for _ in range(1, 5):
+            OCPReportDataGenerator(self.tenant).add_data_to_tenant()
 
         query_params = {'filter': {'resolution': 'monthly',
                                    'time_scope_value': -1,


### PR DESCRIPTION
This removes `cluster` and `cluster_alias` from the "others" collection when querying with a limit. This also sets up a facility for enabling any future exclusions we may need.

Old Behavior:
```
                {
                    "project": "67 Others",
                    "values": [
                        {
                            "cluster_alias": "OCP Test Provider",
                            "date": "2019-04",
                            "cluster": "my-ocp-cluster-2",
                            "project": "67 Others",
                            "usage": {
                                "value": 223988.018558,
                                "units": "GB-Hours"
                            },
                            "request": {
                                "value": 442268.847481,
                                "units": "GB-Hours"
                            },
                            "limit": {
                                "value": 559314.843564,
                                "units": "GB-Hours"
                            },
                            "capacity": {
                                "value": 1501,
                                "units": "GB-Hours"
                            },
                            "infrastructure_cost": {
                                "value": 0,
                                "units": "USD"
                            },
                            "derived_cost": {
                                "value": 0,
                                "units": "USD"
                            },
                            "cost": {
                                "value": 0,
                                "units": "USD"
                            },
                            "delta_value": 223988.018558,
                            "delta_percent": null
                        }
                    ]
                }
```

New Behavior:
``` 
               {
                    "project": "67 Others",
                    "values": [
                        {
                            "date": "2019-04",
                            "project": "67 Others",
                            "usage": {
                                "value": 223988.018558,
                                "units": "GB-Hours"
                            },
                            "request": {
                                "value": 442268.847481,
                                "units": "GB-Hours"
                            },
                            "limit": {
                                "value": 559314.843564,
                                "units": "GB-Hours"
                            },
                            "capacity": {
                                "value": 3423,
                                "units": "GB-Hours"
                            },
                            "infrastructure_cost": {
                                "value": 0,
                                "units": "USD"
                            },
                            "derived_cost": {
                                "value": 0,
                                "units": "USD"
                            },
                            "cost": {
                                "value": 0,
                                "units": "USD"
                            },
                            "delta_value": 223988.018558,
                            "delta_percent": null
                        }
                    ]
                }
```