### PR TITLE
Display default filter parameters in API response

### DIFF
--- a/koku/api/query_handler.py
+++ b/koku/api/query_handler.py
@@ -19,6 +19,8 @@ import copy
 import datetime
 import logging
 
+from querystring_parser import parser
+
 from dateutil import relativedelta
 from django.db.models.functions import TruncDay, TruncMonth
 
@@ -62,7 +64,11 @@ class QueryHandler(object):
             kwargs    (Dict): A dictionary for internal query alteration based on path
         """
         LOG.debug(f'Query Params: {query_parameters}')
-        self.query_parameters = query_parameters
+        default_query = self.query_parameters = parser.parse('filter[time_scope_units]=day&filter[time_scope_value]=-10&filter[resolution]=daily')
+        if not query_parameters:
+            self.query_parameters = default_query
+        else:
+            self.query_parameters = query_parameters
         self.url_data = url_data
         self.tenant = tenant
         self.default_ordering = default_ordering

--- a/koku/api/query_handler.py
+++ b/koku/api/query_handler.py
@@ -194,11 +194,6 @@ class QueryHandler(object):
             return self.resolution
 
         self.resolution = self.get_query_param_data('filter', 'resolution')
-        time_scope_value = self.get_time_scope_value()
-        if not self.resolution:
-            self.resolution = 'daily'
-            if int(time_scope_value) in [-1, -2]:
-                self.resolution = 'monthly'
 
         if self.resolution == 'monthly':
             self.date_to_string = lambda dt: dt.strftime('%Y-%m')
@@ -252,11 +247,6 @@ class QueryHandler(object):
             return self.time_scope_units
 
         time_scope_units = self.get_query_param_data('filter', 'time_scope_units')
-        time_scope_value = self.get_query_param_data('filter', 'time_scope_value')
-        if not time_scope_units:
-            time_scope_units = 'day'
-            if time_scope_value and int(time_scope_value) in [-1, -2]:
-                time_scope_units = 'month'
 
         self.time_scope_units = time_scope_units
         return self.time_scope_units
@@ -271,13 +261,7 @@ class QueryHandler(object):
         if self.time_scope_value:
             return self.time_scope_value
 
-        time_scope_units = self.get_query_param_data('filter', 'time_scope_units')
         time_scope_value = self.get_query_param_data('filter', 'time_scope_value')
-
-        if not time_scope_value:
-            time_scope_value = -10
-            if time_scope_units == 'month':
-                time_scope_value = -1
 
         self.time_scope_value = int(time_scope_value)
         return self.time_scope_value

--- a/koku/api/query_handler.py
+++ b/koku/api/query_handler.py
@@ -64,11 +64,8 @@ class QueryHandler(object):
             kwargs    (Dict): A dictionary for internal query alteration based on path
         """
         LOG.debug(f'Query Params: {query_parameters}')
-        default_query = self.query_parameters = parser.parse('filter[time_scope_units]=day&filter[time_scope_value]=-10&filter[resolution]=daily')
-        if not query_parameters:
-            self.query_parameters = default_query
-        else:
-            self.query_parameters = query_parameters
+
+        self.query_parameters = query_parameters
         self.url_data = url_data
         self.tenant = tenant
         self.default_ordering = default_ordering
@@ -82,6 +79,47 @@ class QueryHandler(object):
         self._max_rank = 0
 
         self._get_timeframe()
+
+    @property
+    def query_parameters(self):
+        return self._query_parameters
+
+    @query_parameters.setter
+    def query_parameters(self, new_value):
+        if not new_value:
+            default_query = ('filter[time_scope_units]=day&'
+                             'filter[time_scope_value]=-10&'
+                             'filter[resolution]=daily')
+            new_value = parser.parse(default_query)
+        else:
+            default_query = ''
+            time_scope_units = new_value.get('filter').get('time_scope_units')
+            time_scope_value = new_value.get('filter').get('time_scope_value')
+            resolution = new_value.get('filter').get('resolution')
+            import pdb; pdb.set_trace()
+
+            if not time_scope_value:
+                if time_scope_units is 'month':
+                    time_scope_value = -1
+                else:
+                    time_scope_value = -10
+
+            if not time_scope_units:
+                if int(time_scope_value) in [-1, -2]:
+                    time_scope_units = 'month'
+                else:
+                    time_scope_units = 'day'
+
+            if not resolution:
+                if int(time_scope_value) in [-1, -2]:
+                    resolution = 'monthly'
+                else:
+                    resolution = 'daily'
+            
+            default_query = 'filter[time_scope_units]={}&filter[time_scope_value]={}&filter[resolution]={}'.format(str(time_scope_units), time_scope_value, resolution)
+            new_value = parser.parse(default_query)
+
+        self._query_parameters = new_value
 
     @staticmethod
     def has_wildcard(in_list):

--- a/koku/api/report/test/tests_queries.py
+++ b/koku/api/report/test/tests_queries.py
@@ -663,10 +663,15 @@ class ReportQueryTest(IamTestCase):
         self.assertEqual(expected, out_data)
 
     def test_has_filter_no_filter(self):
-        """Test the has_filter method with no filter in the query params."""
+        """Test the default filter query parameters."""
         handler = AWSReportQueryHandler({}, '', self.tenant,
                                         **{'report_type': 'costs'})
-        self.assertFalse(handler.check_query_params('filter', 'time_scope_value'))
+        self.assertTrue(handler.check_query_params('filter', 'time_scope_units'))
+        self.assertTrue(handler.check_query_params('filter', 'time_scope_value'))
+        self.assertTrue(handler.check_query_params('filter', 'resolution'))
+        self.assertEqual(handler.query_parameters.get('filter').get('time_scope_units'), 'day')
+        self.assertEqual(handler.query_parameters.get('filter').get('time_scope_value'), '-10')
+        self.assertEqual(handler.query_parameters.get('filter').get('resolution'), 'daily')
 
     def test_has_filter_with_filter(self):
         """Test the has_filter method with filter in the query params."""


### PR DESCRIPTION
Addresses #696 

By ensuring that `self.query_parameters` includes the default query, they will be returned on the report API responses.

**Testing**
1.  Add OCP and AWS data
2.  Run report endpoints with no parameters.  Verify filter parameters are in API repsonse
3. Query for time_scope_value = -1, -2, -10, and -30 and veirfy that time_scope_units and resolution are correct
4. Query for time_scope_units = month and veirfy that time_scope_units and resolution are correct
5.  Add a group_by and verify that the default filters are still visible and works

Also ran QE API tests comparing results to `master`. No regressions found, but the change actually fixes some failing csv output related tests 🍾 

**Test Results**
[koku_696_ut.txt](https://github.com/project-koku/koku/files/3044277/koku_696_ut.txt)
