### PR TITLE
adding redis.conf for OpenShift

### DIFF
--- a/openshift/koku-template.yaml
+++ b/openshift/koku-template.yaml
@@ -93,6 +93,14 @@ objects:
     aws-access-key-id: ${AWS_ACCESS_KEY_ID}
     aws-secret-access-key: ${AWS_SECRET_ACCESS_KEY}
 - apiVersion: v1
+  data:
+    redis.conf: |
+      dir /var/lib/redis/data
+  kind: ConfigMap
+  metadata:
+    name: redis-config
+    namespace: ${NAMESPACE}
+- apiVersion: v1
   kind: ConfigMap
   metadata:
     name: koku-env
@@ -597,6 +605,10 @@ objects:
         containers:
         - env:
           image: redis:5.0.4
+          command:
+            - "redis-server"
+          args:
+            - "/etc/redis/redis.conf"
           imagePullPolicy: IfNotPresent
           name: ${NAME}-redis
           ports:
@@ -605,10 +617,15 @@ objects:
           volumeMounts:
           - mountPath: /var/lib/redis/data
             name: ${NAME}-redis-data
+          - mountPath: /etc/redis/
+            name: ${NAME}-redis-config
         volumes:
-        - name: ${NAME}-redis-data
-          persistentVolumeClaim:
-            claimName: ${NAME}-redis
+          - name: ${NAME}-redis-data
+            persistentVolumeClaim:
+              claimName: ${NAME}-redis
+          - name: ${NAME}-redis-config
+            configMap:
+              name: redis-config
     triggers:
     - imageChangeParams:
         automatic: true


### PR DESCRIPTION
The Redis data directory needs to be in a location that has the same permissions as the Redis pod.  We have a persistent volume for this at `/var/lib/redis/data`.  In order for Redis to use this directory instead of `/data` the directory must be set in redis.conf file.

The contents of this file is added as a configMap and a volume mount is used for the Redis deployment to use this configuration when running `redis-server`

**Testing**
Verify that the configMap has contents of `redis.conf`:
```
(koku_fork) ➜  koku_fork git:(redis_conf) ✗ oc get configmap redis-config -o yaml
apiVersion: v1
data:
  redis.conf: |
    dir /var/lib/redis/data
kind: ConfigMap
metadata:
  annotations:
    openshift.io/generated-by: OpenShiftNewApp
  creationTimestamp: 2019-04-11T02:50:05Z
  labels:
    app: koku
    template: koku-template
  name: redis-config
  namespace: myproject
  resourceVersion: "132863"
  selfLink: /api/v1/namespaces/myproject/configmaps/redis-config
  uid: 82f9abb1-5c04-11e9-91c4-1e324a88a218
(koku_fork) ➜  koku_fork git:(redis_conf) ✗
```
Verify that the config is updated on the Redis pod
```
# redis-cli
127.0.0.1:6379> config get dir
1) "dir"
2) "/var/lib/redis/data"
127.0.0.1:6379>
```

