### PR TITLE
Order by infra derived costs

### DIFF
--- a/koku/api/report/aws/serializers.py
+++ b/koku/api/report/aws/serializers.py
@@ -82,6 +82,10 @@ class OrderBySerializer(serializers.Serializer):
     ORDER_CHOICES = (('asc', 'asc'), ('desc', 'desc'))
     cost = serializers.ChoiceField(choices=ORDER_CHOICES,
                                    required=False)
+    infrastructure_cost = serializers.ChoiceField(choices=ORDER_CHOICES,
+                                                  required=False)
+    derived_cost = serializers.ChoiceField(choices=ORDER_CHOICES,
+                                           required=False)
     usage = serializers.ChoiceField(choices=ORDER_CHOICES,
                                     required=False)
     delta = serializers.ChoiceField(choices=ORDER_CHOICES,

--- a/koku/api/report/ocp/serializers.py
+++ b/koku/api/report/ocp/serializers.py
@@ -73,6 +73,10 @@ class OrderBySerializer(serializers.Serializer):
 
     cost = serializers.ChoiceField(choices=ORDER_CHOICES,
                                    required=False)
+    infrastructure_cost = serializers.ChoiceField(choices=ORDER_CHOICES,
+                                                  required=False)
+    derived_cost = serializers.ChoiceField(choices=ORDER_CHOICES,
+                                           required=False)
     cluster = serializers.ChoiceField(choices=ORDER_CHOICES,
                                       required=False)
     project = serializers.ChoiceField(choices=ORDER_CHOICES,

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -1359,7 +1359,7 @@ class ReportQueryHandler(QueryHandler):
                 reverse = True
                 field = field.replace('-', '')
             if field in numeric_ordering:
-                sorted_data = sorted(sorted_data, key=lambda entry: entry[field],
+                sorted_data = sorted(sorted_data, key=lambda entry: (entry[field] is None, entry[field]),
                                      reverse=reverse)
             else:
                 sorted_data = sorted(sorted_data, key=lambda entry: entry[field].lower(),
@@ -1610,7 +1610,7 @@ class ReportQueryHandler(QueryHandler):
         if self.order_field == 'delta':
             reverse = True if self.order_direction == 'desc' else False
             query_data = sorted(list(query_data),
-                                key=lambda x: x['delta_percent'],
+                                key=lambda x: (x['delta_percent'] is None, x['delta_percent']),
                                 reverse=reverse)
         return query_data
 

--- a/koku/api/report/test/ocp/tests_views.py
+++ b/koku/api/report/test/ocp/tests_views.py
@@ -1172,7 +1172,8 @@ class OCPReportViewTest(IamTestCase):
 
     def test_execute_query_with_group_by_order_by_and_limit(self):
         """Test that data is grouped by and limited on order by."""
-        order_by_options = ['cost', 'usage', 'request', 'limit']
+        order_by_options = ['cost', 'derived_cost', 'infrastructure_cost',
+                            'usage', 'request', 'limit']
         for option in order_by_options:
             url = reverse('reports-openshift-cpu')
             client = APIClient()
@@ -1197,6 +1198,25 @@ class OCPReportViewTest(IamTestCase):
                 current_value = entry.get('values', [])[0].get(option, {}).get('value')
                 self.assertTrue(current_value <= previous_value)
                 previous_value = current_value
+
+    def test_execute_query_with_order_by(self):
+        """Test that the possible order by options work."""
+        order_by_options = ['cost', 'derived_cost', 'infrastructure_cost',
+                            'usage', 'request', 'limit']
+        for option in order_by_options:
+            url = reverse('reports-openshift-cpu')
+            client = APIClient()
+            order_by_dict_key = 'order_by[{}]'.format(option)
+            params = {
+                'filter[resolution]': 'monthly',
+                'filter[time_scope_value]': '-1',
+                'filter[time_scope_units]': 'month',
+                order_by_dict_key: 'desc',
+            }
+
+            url = url + '?' + urlencode(params, quote_via=quote_plus)
+            response = client.get(url, **self.headers)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_execute_query_with_order_by_delta_and_limit(self):
         """Test that data is grouped and limited by order by delta."""


### PR DESCRIPTION
## Summary
This adds the ability to order by infrastructure_cost and derived_cost in the reporting APIs. The serializers just needed the fields added. Adding new tests to cover order by revealed and issue with order_by delta where None values couldn't be properly sorted. The lambda function for key in our order by functions was changed to accommodate `None` values.