### PR TITLE
add validation for OCP order-by, fixes #795

### DIFF
--- a/koku/api/report/ocp/serializers.py
+++ b/koku/api/report/ocp/serializers.py
@@ -317,12 +317,16 @@ class OCPInventoryQueryParamSerializer(OCPQueryParamSerializer):
         """Validate incoming order_by data.
 
         Args:
-            data    (Dict): data to be validated
+            value    (Dict): data to be validated
         Returns:
             (Dict): Validated data
         Raises:
             (ValidationError): if order_by field inputs are invalid
         """
+        import logging
+        logging.disable(0)
+        LOG = logging.getLogger(__name__)
+        LOG.warning('XXX: %s', self.__dict__)
         validate_field(self, 'order_by', InventoryOrderBySerializer, value)
         return value
 

--- a/koku/api/report/test/ocp/tests_serializers.py
+++ b/koku/api/report/test/ocp/tests_serializers.py
@@ -391,7 +391,8 @@ class OCPInventoryQueryParamSerializerTest(TestCase):
             'order_by': {'node': 'asc'}
         }
         serializer = OCPInventoryQueryParamSerializer(data=query_params)
-        self.assertFalse(serializer.is_valid())
+        with self.assertRaises(serializers.ValidationError):
+            serializer.is_valid(raise_exception=True)
 
 
 class OCPCostQueryParamSerializerTest(TestCase):

--- a/koku/api/report/test/ocp/tests_serializers.py
+++ b/koku/api/report/test/ocp/tests_serializers.py
@@ -376,6 +376,23 @@ class OCPInventoryQueryParamSerializerTest(TestCase):
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
+    def test_order_by_node_with_groupby(self):
+        """Test that order_by[node] works with a matching group-by."""
+        query_params = {
+            'group_by': {'node': 'asc'},
+            'order_by': {'node': 'asc'}
+        }
+        serializer = OCPInventoryQueryParamSerializer(data=query_params)
+        self.assertFalse(serializer.is_valid())
+
+    def test_order_by_node_without_groupby(self):
+        """Test that order_by[node] fails without a matching group-by."""
+        query_params = {
+            'order_by': {'node': 'asc'}
+        }
+        serializer = OCPInventoryQueryParamSerializer(data=query_params)
+        self.assertFalse(serializer.is_valid())
+
 
 class OCPCostQueryParamSerializerTest(TestCase):
     """Tests for the handling charge query parameter parsing serializer."""

--- a/koku/api/report/test/ocp/tests_serializers.py
+++ b/koku/api/report/test/ocp/tests_serializers.py
@@ -383,7 +383,7 @@ class OCPInventoryQueryParamSerializerTest(TestCase):
             'order_by': {'node': 'asc'}
         }
         serializer = OCPInventoryQueryParamSerializer(data=query_params)
-        self.assertFalse(serializer.is_valid())
+        self.assertTrue(serializer.is_valid())
 
     def test_order_by_node_without_groupby(self):
         """Test that order_by[node] fails without a matching group-by."""


### PR DESCRIPTION
This adds validation to order-by parameters so that when a corresponding group-by is required, we throw a validation error when that requirement isn't met.

Example:

```
* Connected to koku-myproject.192.168.42.57.nip.io (192.168.42.57) port 80 (#1)
> GET /api/v1/reports/openshift/volumes/?order_by[project]=asc& HTTP/1.1
> Host: koku-myproject.192.168.42.57.nip.io
> User-Agent: curl/7.61.1
> Accept: */*
> 
< HTTP/1.1 400 Bad Request
< Server: gunicorn/19.9.0
< Date: Thu, 18 Apr 2019 19:20:09 GMT
< Content-Type: application/json
< Vary: Accept, Origin
< Allow: GET, OPTIONS
< X-Frame-Options: SAMEORIGIN
< Content-Length: 75
< Set-Cookie: d02bf7bff81a220d14ef9d513c8d6521=178e49b2a3373ed6b0358ab33ff44bfb; path=/; HttpOnly
< 
{ [75 bytes data]
100    75  100    75    0     0    431      0 --:--:-- --:--:-- --:--:--   431
* Connection #1 to host koku-myproject.192.168.42.57.nip.io left intact


{
  "order_by": {
    "project": "Order-by \"project\" requires matching Group-by."
  }
}


```