### PR TITLE
rate metrics put look for metrics duplicates

### DIFF
--- a/koku/rates/rate_manager.py
+++ b/koku/rates/rate_manager.py
@@ -97,6 +97,7 @@ class RateManager:
 
     def update_metric(self, metric):
         """Update rate with new metric value."""
+        self._check_for_duplicate_metrics(metric, self.get_provider_uuids())
         self._model.metric = metric
         self._model.save()
 

--- a/koku/rates/rate_manager.py
+++ b/koku/rates/rate_manager.py
@@ -97,9 +97,10 @@ class RateManager:
 
     def update_metric(self, metric):
         """Update rate with new metric value."""
-        self._check_for_duplicate_metrics(metric, self.get_provider_uuids())
-        self._model.metric = metric
-        self._model.save()
+        if self._model.metric != metric:
+            self._check_for_duplicate_metrics(metric, self.get_provider_uuids())
+            self._model.metric = metric
+            self._model.save()
 
     def update_rates(self, rates):
         """Update rate with new tiered rate structure."""

--- a/koku/rates/serializers.py
+++ b/koku/rates/serializers.py
@@ -264,10 +264,11 @@ class RateSerializer(serializers.ModelSerializer):
         manager = RateManager(rate_uuid=instance.uuid)
         try:
             manager.update_provider_uuids(new_providers_for_instance)
+            manager.update_metric(metric)
+
         except RateManagerError as create_error:
             raise serializers.ValidationError(create_error.message)
 
-        manager.update_metric(metric)
         manager.update_rates(validated_data)
         return manager.instance
 

--- a/koku/rates/test/tests_view.py
+++ b/koku/rates/test/tests_view.py
@@ -238,6 +238,21 @@ class RateViewTests(IamTestCase):
         response = client.put(url, test_data, format='json', **self.headers)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+        # Attempt to update again but now remove the provider and it should be successful
+        test_data = {'provider_uuids': [],
+                     'metric': Rate.METRIC_CPU_CORE_USAGE_HOUR,
+                     'tiered_rate': [{
+                         'value': round(Decimal(random.random()), 6),
+                         'unit': 'USD',
+                         'usage_start': None,
+                         'usage_end': None
+                     }]
+                     }
+
+        url = reverse('rates-detail', kwargs={'uuid': rate_3_uuid})
+        response = client.put(url, test_data, format='json', **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
     def test_patch_failure(self):
         """Test that PATCH throws exception."""
         test_data = self.fake_data


### PR DESCRIPTION
Need to also check for metric duplicates when updating with `PUT`

rates
```
GET /r/insights/platform/cost-management/v1/rates/
HTTP 200 OK
Allow: GET, POST, HEAD, OPTIONS
Content-Type: application/json
Vary: Accept

{
    "meta": {
        "count": 2
    },
    "links": {
        "first": "/r/insights/platform/cost-management/v1/rates/?limit=10&offset=0",
        "next": null,
        "previous": null,
        "last": "/r/insights/platform/cost-management/v1/rates/?limit=10&offset=0"
    },
    "data": [
        {
            "uuid": "a087dc14-e544-4a5f-b89b-f4755dab8cab",
            "provider_uuids": [
                "b53db7c9-8a7a-48d7-9b79-bb82ea1c4246"
            ],
            "metric": {
                "name": "cpu_core_request_per_hour",
                "unit": "core-hours",
                "display_name": "Compute request rate"
            },
            "tiered_rate": [
                {
                    "unit": "USD",
                    "value": 0.6,
                    "usage": {
                        "usage_start": null,
                        "usage_end": 10.0,
                        "unit": "core-hours"
                    }
                },
                {
                    "unit": "USD",
                    "value": 5.3,
                    "usage": {
                        "usage_start": 10.0,
                        "usage_end": null,
                        "unit": "core-hours"
                    }
                }
            ]
        },
        {
            "uuid": "34dfcba8-cb71-4015-a160-e144bac7adfa",
            "provider_uuids": [
                "b53db7c9-8a7a-48d7-9b79-bb82ea1c4246"
            ],
            "metric": {
                "name": "cpu_core_usage_per_hour",
                "unit": "core-hours",
                "display_name": "Compute usage rate"
            },
            "tiered_rate": [
                {
                    "unit": "USD",
                    "value": 0.6,
                    "usage": {
                        "usage_start": null,
                        "usage_end": 10.0,
                        "unit": "core-hours"
                    }
                },
                {
                    "unit": "USD",
                    "value": 5.3,
                    "usage": {
                        "usage_start": 10.0,
                        "usage_end": null,
                        "unit": "core-hours"
                    }
                }
            ]
        }
    ]
}
```
```
PUT http://localhost:8000/r/insights/platform/cost-management/v1/rates/a087dc14-e544-4a5f-b89b-f4755dab8cab/
{
    "metric": "cpu_core_usage_per_hour",
    "provider_uuids": ["b53db7c9-8a7a-48d7-9b79-bb82ea1c4246"],
    "tiered_rate": [{
        "unit": "USD",
        "value": 0.60,
        "usage_start": null,
        "usage_end": 10
    }, {
        "unit": "USD",
        "value": 5.3,
        "usage_start": 10,
        "usage_end": null
    }]	
}
```

Response
```
{
    "errors": [
        {
            "detail": "Dupicate metrics found for the following providers: uuid: b53db7c9-8a7a-48d7-9b79-bb82ea1c4246, metric: cpu_core_usage_per_hour",
            "source": null,
            "status": 400
        }
    ]
}
```