### PR TITLE
refactor report serializers into a common object hierarchy

### DIFF
--- a/koku/api/report/ocp_aws/serializers.py
+++ b/koku/api/report/ocp_aws/serializers.py
@@ -14,79 +14,42 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
-"""Report Serializers."""
-from rest_framework import serializers
+"""OCP-on-AWS Report Serializers."""
 
-from api.report.aws.serializers import (FilterSerializer,
-                                        GroupBySerializer,
-                                        OrderBySerializer,
-                                        QueryParamSerializer,
-                                        validate_field)
-from api.report.ocp.serializers import OP_FIELDS
-from api.report.serializers import StringOrListField, add_operator_specified_fields
+import api.report.aws.serializers as awsser
+import api.report.ocp.serializers as ocpser
+from api.report.serializers import validate_field
 
 
-class OCPAWSGroupBySerializer(GroupBySerializer):
+class OCPAWSGroupBySerializer(awsser.GroupBySerializer,
+                              ocpser.GroupBySerializer):
     """Serializer for handling query parameter group_by."""
 
-    project = StringOrListField(child=serializers.CharField(),
-                                required=False)
-    cluster = StringOrListField(child=serializers.CharField(),
-                                required=False)
-    node = StringOrListField(child=serializers.CharField(),
-                             required=False)
-
-    def __init__(self, *args, **kwargs):
-        """Initialize the OCPAWSGroupBySerializer."""
-        super().__init__(*args, **kwargs)
-        add_operator_specified_fields(self.fields, OP_FIELDS)
+    _opfields = ('account', 'az', 'instance_type', 'region',
+                 'service', 'storage_type', 'product_family',
+                 'project', 'cluster', 'node')
 
 
-class OCPAWSOrderBySerializer(OrderBySerializer):
+class OCPAWSOrderBySerializer(awsser.OrderBySerializer,
+                              ocpser.OrderBySerializer):
     """Serializer for handling query parameter order_by."""
 
-    ORDER_CHOICES = (('asc', 'asc'), ('desc', 'desc'))
-    project = serializers.ChoiceField(choices=ORDER_CHOICES,
-                                      required=False)
-    cluster = serializers.ChoiceField(choices=ORDER_CHOICES,
-                                      required=False)
-    node = serializers.ChoiceField(choices=ORDER_CHOICES,
-                                   required=False)
+    pass
 
 
-class OCPAWSFilterSerializer(FilterSerializer):
+class OCPAWSFilterSerializer(awsser.FilterSerializer,
+                             ocpser.FilterSerializer):
     """Serializer for handling query parameter filter."""
 
-    project = StringOrListField(child=serializers.CharField(),
-                                required=False)
-    cluster = StringOrListField(child=serializers.CharField(),
-                                required=False)
-    node = StringOrListField(child=serializers.CharField(),
-                             required=False)
-
-    def __init__(self, *args, **kwargs):
-        """Initialize the OCPAWSGroupBySerializer."""
-        super().__init__(*args, **kwargs)
-        add_operator_specified_fields(self.fields, OP_FIELDS)
+    pass
 
 
-class OCPAWSQueryParamSerializer(QueryParamSerializer):
+class OCPAWSQueryParamSerializer(awsser.QueryParamSerializer):
     """Serializer for handling query parameters."""
 
     group_by = OCPAWSGroupBySerializer(required=False)
     order_by = OCPAWSOrderBySerializer(required=False)
     filter = OCPAWSFilterSerializer(required=False)
-
-    def __init__(self, *args, **kwargs):
-        """Initialize the AWS query param serializer."""
-        super().__init__(*args, **kwargs)
-
-        tag_fields = {
-            'filter': OCPAWSFilterSerializer(required=False, tag_keys=self.tag_keys),
-            'group_by': OCPAWSGroupBySerializer(required=False, tag_keys=self.tag_keys)
-        }
-
-        self.fields.update(tag_fields)
 
     def validate_group_by(self, value):
         """Validate incoming group_by data.

--- a/koku/api/report/serializers.py
+++ b/koku/api/report/serializers.py
@@ -22,7 +22,11 @@ from rest_framework import serializers
 def handle_invalid_fields(this, data):
     """Validate incoming data.
 
+    The primary validation being done is ensuring the incoming data only
+    contains known fields.
+
     Args:
+        this    (Object): Serializer object
         data    (Dict): data to be validated
     Returns:
         (Dict): Validated data
@@ -32,6 +36,7 @@ def handle_invalid_fields(this, data):
     unknown_keys = None
     if hasattr(this, 'initial_data'):
         unknown_keys = set(this.initial_data.keys()) - set(this.fields.keys())
+
     if unknown_keys:
         error = {}
         for unknown_key in unknown_keys:
@@ -94,3 +99,148 @@ class StringOrListField(serializers.ListField):
             list_data = list_data.split(',')
 
         return super().to_internal_value(list_data)
+
+
+class BaseSerializer(serializers.Serializer):
+    """A common serializer base for all of our serializers."""
+
+    _opfields = None
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the FilterSerializer."""
+        tag_keys = kwargs.pop('tag_keys', None)
+        super().__init__(*args, **kwargs)
+
+        if tag_keys is not None:
+            tag_keys = {key: StringOrListField(child=serializers.CharField(),
+                                               required=False)
+                        for key in tag_keys}
+            # Add tag keys to allowable fields
+            self.fields.update(tag_keys)
+
+        if self._opfields:
+            add_operator_specified_fields(self.fields, self._opfields)
+
+    def validate(self, data):
+        """Validate incoming data."""
+        handle_invalid_fields(self, data)
+        return data
+
+
+class FilterSerializer(BaseSerializer):
+    """A base serializer for filter operations."""
+
+    RESOLUTION_CHOICES = (
+        ('daily', 'daily'),
+        ('monthly', 'monthly'),
+    )
+    TIME_CHOICES = (
+        ('-10', '-10'),
+        ('-30', '-30'),
+        ('-1', '1'),
+        ('-2', '-2'),
+    )
+    TIME_UNIT_CHOICES = (
+        ('day', 'day'),
+        ('month', 'month'),
+    )
+
+    resolution = serializers.ChoiceField(choices=RESOLUTION_CHOICES,
+                                         required=False)
+    time_scope_value = serializers.ChoiceField(choices=TIME_CHOICES,
+                                               required=False)
+    time_scope_units = serializers.ChoiceField(choices=TIME_UNIT_CHOICES,
+                                               required=False)
+    resource_scope = StringOrListField(child=serializers.CharField(),
+                                       required=False)
+    limit = serializers.IntegerField(required=False, min_value=1)
+    offset = serializers.IntegerField(required=False, min_value=0)
+
+    def validate(self, data):
+        """Validate incoming data.
+
+        Args:
+            data    (Dict): data to be validated
+        Returns:
+            (Dict): Validated data
+        Raises:
+            (ValidationError): if filter inputs are invalid
+        """
+        handle_invalid_fields(self, data)
+        resolution = data.get('resolution')
+        time_scope_value = data.get('time_scope_value')
+        time_scope_units = data.get('time_scope_units')
+
+        if time_scope_units and time_scope_value:
+            msg = 'Valid values are {} when time_scope_units is {}'
+            if (time_scope_units == 'day' and  # noqa: W504
+                    (time_scope_value == '-1' or time_scope_value == '-2')):
+                valid_values = ['-10', '-30']
+                valid_vals = ', '.join(valid_values)
+                error = {'time_scope_value': msg.format(valid_vals, 'day')}
+                raise serializers.ValidationError(error)
+            if (time_scope_units == 'day' and resolution == 'monthly'):
+                valid_values = ['daily']
+                valid_vals = ', '.join(valid_values)
+                error = {'resolution': msg.format(valid_vals, 'day')}
+                raise serializers.ValidationError(error)
+            if (time_scope_units == 'month' and  # noqa: W504
+                    (time_scope_value == '-10' or time_scope_value == '-30')):
+                valid_values = ['-1', '-2']
+                valid_vals = ', '.join(valid_values)
+                error = {'time_scope_value': msg.format(valid_vals, 'month')}
+                raise serializers.ValidationError(error)
+        return data
+
+
+class GroupSerializer(BaseSerializer):
+    """A base serializer for group-by operations."""
+
+    pass
+
+
+class OrderSerializer(BaseSerializer):
+    """A base serializer for order-by operations."""
+
+    ORDER_CHOICES = (('asc', 'asc'), ('desc', 'desc'))
+
+    cost = serializers.ChoiceField(choices=ORDER_CHOICES,
+                                   required=False)
+    infrastructure_cost = serializers.ChoiceField(choices=ORDER_CHOICES,
+                                                  required=False)
+    derived_cost = serializers.ChoiceField(choices=ORDER_CHOICES,
+                                           required=False)
+    delta = serializers.ChoiceField(choices=ORDER_CHOICES,
+                                    required=False)
+
+
+class ParamSerializer(BaseSerializer):
+    """A base serializer for query parameter operations."""
+
+    # Adding pagination fields to the serializer because we validate
+    # before running reports and paginating
+    limit = serializers.IntegerField(required=False)
+    offset = serializers.IntegerField(required=False)
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the query param serializer."""
+        if self.tag_keys and self.tag_fields:
+            inst = {}
+            for key, val in self.tag_fields.items():
+                # replace class references with instances of the class.
+                inst[key] = val(required=False, tag_keys=self.tag_keys)
+            self.fields.update(inst)
+        super().__init__(*args, **kwargs)
+
+    def validate(self, data):
+        """Validate incoming data.
+
+        Args:
+            data    (Dict): data to be validated
+        Returns:
+            (Dict): Validated data
+        Raises:
+            (ValidationError): if field inputs are invalid
+        """
+        handle_invalid_fields(self, data)
+        return data

--- a/koku/api/report/test/ocp/tests_serializers.py
+++ b/koku/api/report/test/ocp/tests_serializers.py
@@ -24,7 +24,6 @@ from api.report.ocp.serializers import (FilterSerializer,
                                         OCPCostQueryParamSerializer,
                                         OCPInventoryQueryParamSerializer,
                                         OCPQueryParamSerializer,
-                                        OP_FIELDS,
                                         OrderBySerializer)
 
 
@@ -125,12 +124,12 @@ class OCPFilterSerializerTest(TestCase):
 
     def test_all_filter_op_fields(self):
         """Test that the allowed fields pass."""
-        for field in OP_FIELDS:
+        for field in FilterSerializer._opfields:
             field = 'and:' + field
             filter_param = {field: ['1', '2']}
             serializer = FilterSerializer(data=filter_param)
             self.assertTrue(serializer.is_valid())
-        for field in OP_FIELDS:
+        for field in FilterSerializer._opfields:
             field = 'or:' + field
             filter_param = {field: ['1', '2']}
             serializer = FilterSerializer(data=filter_param)
@@ -182,12 +181,12 @@ class OCPGroupBySerializerTest(TestCase):
 
     def test_all_group_by_op_fields(self):
         """Test that the allowed fields pass."""
-        for field in OP_FIELDS:
+        for field in GroupBySerializer._opfields:
             field = 'and:' + field
             filter_param = {field: ['1', '2']}
             serializer = GroupBySerializer(data=filter_param)
             self.assertTrue(serializer.is_valid())
-        for field in OP_FIELDS:
+        for field in GroupBySerializer._opfields:
             field = 'or:' + field
             filter_param = {field: ['1', '2']}
             serializer = GroupBySerializer(data=filter_param)

--- a/koku/api/report/test/ocp/tests_views.py
+++ b/koku/api/report/test/ocp/tests_views.py
@@ -1233,10 +1233,6 @@ class OCPReportViewTest(IamTestCase):
         }
         url = url + '?' + urlencode(params, quote_via=quote_plus)
         response = client.get(url, **self.headers)
-        import logging
-        logging.disable(0)
-        log = logging.getLogger(__name__)
-        log.critical('XXX: %s', response.content)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         data = response.json()

--- a/koku/api/report/test/ocp/tests_views.py
+++ b/koku/api/report/test/ocp/tests_views.py
@@ -1233,6 +1233,10 @@ class OCPReportViewTest(IamTestCase):
         }
         url = url + '?' + urlencode(params, quote_via=quote_plus)
         response = client.get(url, **self.headers)
+        import logging
+        logging.disable(0)
+        log = logging.getLogger(__name__)
+        log.critical('XXX: %s', response.content)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         data = response.json()

--- a/koku/api/report/test/ocp_aws/tests_serializers.py
+++ b/koku/api/report/test/ocp_aws/tests_serializers.py
@@ -20,8 +20,7 @@ from unittest import TestCase
 from api.report.ocp_aws.serializers import (OCPAWSFilterSerializer,
                                             OCPAWSGroupBySerializer,
                                             OCPAWSOrderBySerializer,
-                                            OCPAWSQueryParamSerializer,
-                                            OP_FIELDS)
+                                            OCPAWSQueryParamSerializer)
 
 
 class OCPAWSFilterSerializerTest(TestCase):
@@ -56,12 +55,12 @@ class OCPAWSFilterSerializerTest(TestCase):
 
     def test_all_filter_op_fields(self):
         """Test that the allowed fields pass."""
-        for field in OP_FIELDS:
+        for field in OCPAWSFilterSerializer._opfields:
             field = 'and:' + field
             filter_param = {field: ['1', '2']}
             serializer = OCPAWSFilterSerializer(data=filter_param)
             self.assertTrue(serializer.is_valid())
-        for field in OP_FIELDS:
+        for field in OCPAWSFilterSerializer._opfields:
             field = 'or:' + field
             filter_param = {field: ['1', '2']}
             serializer = OCPAWSFilterSerializer(data=filter_param)
@@ -91,12 +90,12 @@ class OCPAWSGroupBySerializerTest(TestCase):
 
     def test_all_group_by_op_fields(self):
         """Test that the allowed fields pass."""
-        for field in OP_FIELDS:
+        for field in OCPAWSGroupBySerializer._opfields:
             field = 'and:' + field
             filter_param = {field: ['1', '2']}
             serializer = OCPAWSGroupBySerializer(data=filter_param)
             self.assertTrue(serializer.is_valid())
-        for field in OP_FIELDS:
+        for field in OCPAWSGroupBySerializer._opfields:
             field = 'or:' + field
             filter_param = {field: ['1', '2']}
             serializer = OCPAWSGroupBySerializer(data=filter_param)

--- a/koku/api/report/test/tests_serializers.py
+++ b/koku/api/report/test/tests_serializers.py
@@ -20,9 +20,7 @@ from unittest.mock import Mock
 
 from rest_framework import serializers
 
-from api.report.aws.serializers import (FILTER_OP_FIELDS,
-                                        FilterSerializer,
-                                        GROUP_BY_OP_FIELDS,
+from api.report.aws.serializers import (FilterSerializer,
                                         GroupBySerializer,
                                         OrderBySerializer,
                                         QueryParamSerializer)
@@ -195,12 +193,12 @@ class FilterSerializerTest(TestCase):
 
     def test_all_filter_op_fields(self):
         """Test that the allowed fields pass."""
-        for field in FILTER_OP_FIELDS:
+        for field in FilterSerializer._opfields:
             field = 'and:' + field
             filter_param = {field: ['1', '2']}
             serializer = FilterSerializer(data=filter_param)
             self.assertTrue(serializer.is_valid())
-        for field in FILTER_OP_FIELDS:
+        for field in FilterSerializer._opfields:
             field = 'or:' + field
             filter_param = {field: ['1', '2']}
             serializer = FilterSerializer(data=filter_param)
@@ -307,12 +305,12 @@ class GroupBySerializerTest(TestCase):
 
     def test_all_group_by_op_fields(self):
         """Test that the allowed fields pass."""
-        for field in GROUP_BY_OP_FIELDS:
+        for field in GroupBySerializer._opfields:
             field = 'and:' + field
             filter_param = {field: ['1', '2']}
             serializer = GroupBySerializer(data=filter_param)
             self.assertTrue(serializer.is_valid())
-        for field in GROUP_BY_OP_FIELDS:
+        for field in GroupBySerializer._opfields:
             field = 'or:' + field
             filter_param = {field: ['1', '2']}
             serializer = GroupBySerializer(data=filter_param)

--- a/koku/api/report/view.py
+++ b/koku/api/report/view.py
@@ -187,23 +187,26 @@ def process_query_parameters(url_data, provider_serializer, tag_keys=None, **kwa
         (Boolean): True if query params are valid, False otherwise
         (Dict): Dictionary parsed from query params string
     """
-    output = None
     try:
         query_params = parser.parse(url_data)
     except parser.MalformedQueryStringError:
         LOG.error('Invalid query parameter format %s.', url_data)
         error = {'details': _(f'Invalid query parameter format.')}
         raise ValidationError(error)
+
     if tag_keys:
         tag_keys = process_tag_query_params(query_params, tag_keys)
         qps = provider_serializer(data=query_params, tag_keys=tag_keys, context=kwargs)
     else:
         qps = provider_serializer(data=query_params, context=kwargs)
+
+    output = None
     validation = qps.is_valid()
     if not validation:
         output = qps.errors
     else:
         output = qps.data
+
     return (validation, output)
 
 
@@ -350,7 +353,7 @@ def _generic_report(request, provider, report):
         (Response): The report in a Response object
 
     """
-    LOG.info(f'API: {request.path} USER: {request.user.username}')
+    LOG.debug(f'API: {request.path} USER: {request.user.username}')
     tenant = get_tenant(request.user)
 
     cm = ClassMapper()
@@ -368,7 +371,7 @@ def _generic_report(request, provider, report):
         url_data,
         provider_parameter_serializer,
         tag_keys,
-        **{'request': request}
+        request=request
     )
 
     if not validation:


### PR DESCRIPTION
This is purely a reorganizing/refactoring PR. No behavior has changed.

For each of the reporting serializers, I've moved duplicate functions into a series of parent classes. This cuts down on code duplication and inconsistencies across report types.

This is also intended to set up for implementing ordering by tag. This helps me because with this PR I can do that implementation in the common base classes, rather than needing three distinct implementations across the AWS, OCP, and AWS+OCP serializers.

The Class hierarchy is now:
```
- BaseSerializer
    - FilterSerializer
        - aws.FilterSerializer
        - ocp.FilterSerializer
            - ocp_aws.OCPAWSFilterSerializer (inherits from both aws & ocp FilterSerializers)
    - OrderSerializer
        - aws.OrderBySerializer
        - ocp.OrderBySerializer
            - ocp.InventoryOrderBySerializer
            - ocp_aws.OCPAWSOrderBySerializer (inherits from both aws & ocp OrderBySerializers)
    - GroupSerializer
        - aws.GroupBySerializer
        - ocp.GroupBySerializer
            - ocp_aws.OCPAWSGroupBySerializer (inherits from both aws & ocp GroupBySerializers)
    - ParamSerializer
        - aws.QueryParamSerializer
            - ocp_aws.OCPAWSQueryParamSerializer
        - ocp.OCPQueryParamSerializer
            - ocp.OCPInventoryQueryParamSerializer
            - ocp.OCPCostQueryParamSerializer
```