### PR TITLE
Change openshift tag query to use distinct instead of count to remove aggregation.

### DIFF
--- a/koku/api/tags/queries.py
+++ b/koku/api/tags/queries.py
@@ -18,7 +18,7 @@
 import copy
 import logging
 
-from django.db.models import Count, Q
+from django.db.models import Q
 from tenant_schemas.utils import tenant_context
 
 from api.functions import JSONBObjectKeys
@@ -160,7 +160,7 @@ class TagQueryHandler(QueryHandler):
 
                 tag_keys_query = tag_keys_query.annotate(tag_keys=JSONBObjectKeys(source.get('db_column')))\
                     .values('tag_keys')\
-                    .annotate(tag_count=Count('tag_keys'))\
+                    .distinct()\
                     .all()
                 tag_keys_query = [tag.get('tag_keys') for tag in tag_keys_query]
                 for tag_key in tag_keys_query:

--- a/koku/api/tags/test/ocp/test_ocp_tag_query_handler.py
+++ b/koku/api/tags/test/ocp/test_ocp_tag_query_handler.py
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 """Test the Report Queries."""
-from django.db.models import Count
 from tenant_schemas.utils import tenant_context
 
 from api.functions import JSONBObjectKeys
@@ -213,7 +212,7 @@ class OCPTagQueryHandlerTest(IamTestCase):
             usage_tag_keys = OCPUsageLineItemDailySummary.objects\
                 .annotate(tag_keys=JSONBObjectKeys('pod_labels'))\
                 .values('tag_keys')\
-                .annotate(tag_count=Count('tag_keys'))\
+                .distinct()\
                 .all()
 
             usage_tag_keys = [tag.get('tag_keys') for tag in usage_tag_keys]
@@ -221,7 +220,7 @@ class OCPTagQueryHandlerTest(IamTestCase):
             storage_tag_keys = OCPStorageLineItemDailySummary.objects\
                 .annotate(tag_keys=JSONBObjectKeys('volume_labels'))\
                 .values('tag_keys')\
-                .annotate(tag_count=Count('tag_keys'))\
+                .distinct()\
                 .all()
             storage_tag_keys = [tag.get('tag_keys') for tag in storage_tag_keys]
             tag_keys = list(set(usage_tag_keys + storage_tag_keys))
@@ -249,7 +248,7 @@ class OCPTagQueryHandlerTest(IamTestCase):
             usage_tag_keys = OCPUsageLineItemDailySummary.objects\
                 .annotate(tag_keys=JSONBObjectKeys('pod_labels'))\
                 .values('tag_keys')\
-                .annotate(tag_count=Count('tag_keys'))\
+                .distinct()\
                 .all()
 
             usage_tag_keys = [tag.get('tag_keys') for tag in usage_tag_keys]
@@ -257,7 +256,7 @@ class OCPTagQueryHandlerTest(IamTestCase):
             storage_tag_keys = OCPStorageLineItemDailySummary.objects\
                 .annotate(tag_keys=JSONBObjectKeys('volume_labels'))\
                 .values('tag_keys')\
-                .annotate(tag_count=Count('tag_keys'))\
+                .distinct()\
                 .all()
             storage_tag_keys = [tag.get('tag_keys') for tag in storage_tag_keys]
             tag_keys = list(set(usage_tag_keys + storage_tag_keys))
@@ -287,7 +286,7 @@ class OCPTagQueryHandlerTest(IamTestCase):
             usage_tag_keys = OCPUsageLineItemDailySummary.objects\
                 .annotate(tag_keys=JSONBObjectKeys('pod_labels'))\
                 .values('tag_keys')\
-                .annotate(tag_count=Count('tag_keys'))\
+                .distinct()\
                 .all()
 
             usage_tag_keys = [tag.get('tag_keys') for tag in usage_tag_keys]
@@ -318,7 +317,7 @@ class OCPTagQueryHandlerTest(IamTestCase):
             storage_tag_keys = OCPStorageLineItemDailySummary.objects\
                 .annotate(tag_keys=JSONBObjectKeys('volume_labels'))\
                 .values('tag_keys')\
-                .annotate(tag_count=Count('tag_keys'))\
+                .distinct()\
                 .all()
             storage_tag_keys = [tag.get('tag_keys') for tag in storage_tag_keys]
             tag_keys = storage_tag_keys


### PR DESCRIPTION
Functionality is the same after change:
*GET* `/api/cost-management/v1/tags/openshift/?filter[resolution]=monthly&filter[time_scope_units]=month&filter[time_scope_value]=-1&key_only=true`
```
{
    "meta": {
        "count": 14,
        "filter": {
            "resolution": "monthly",
            "time_scope_value": "-1",
            "time_scope_units": "month"
        },
        "key_only": true
    },
    "links": {
        "first": "/api/cost-management/v1/tags/openshift/?filter%5Bresolution%5D=monthly&filter%5Btime_scope_units%5D=month&filter%5Btime_scope_value%5D=-1&key_only=true&limit=100&offset=0",
        "next": null,
        "previous": null,
        "last": "/api/cost-management/v1/tags/openshift/?filter%5Bresolution%5D=monthly&filter%5Btime_scope_units%5D=month&filter%5Btime_scope_value%5D=-1&key_only=true&limit=100&offset=0"
    },
    "data": [
        "alertmanager",
        "app",
        "component",
        "controller_revision_hash",
        "hive",
        "openshift_io_component",
        "pod_template_generation",
        "pod_template_hash",
        "presto",
        "prometheus",
        "statefulset_kubernetes_io_pod_name",
        "template",
        "template_openshift_io_template_instance_owner",
        "type"
    ]
}
```