### PR TITLE
Add filter by name capability in to providers as intended.

### DIFF
--- a/koku/api/provider/view.py
+++ b/koku/api/provider/view.py
@@ -44,7 +44,7 @@ class ProviderFilter(filters.FilterSet):
 
     class Meta:
         model = Provider
-        fields = ['type']
+        fields = ['type', 'name']
 
 
 class ProviderDeleteException(APIException):


### PR DESCRIPTION
Base set, no filter:
*GET* `/api/cost-management/v1/providers/`
```
{
    "meta": {
        "count": 2
    },
    "links": {
        "first": "/api/cost-management/v1/providers/?limit=10&offset=0",
        "next": null,
        "previous": null,
        "last": "/api/cost-management/v1/providers/?limit=10&offset=0"
    },
    "data": [
        {
            "uuid": "3c6e687e-1a09-4a05-970c-2ccf44b0952e",
            "name": "OCP Test Provider",
            "type": "OCP",
            "authentication": {
                "uuid": "5e421052-8e16-4f66-93d4-27223c4673f2",
                "provider_resource_name": "my-ocp-cluster-1"
            },
            "billing_source": null,
            "customer": {
                "uuid": "96a98ab8-ebf0-46c1-a94e-48a68fcb0ab9",
                "account_id": "1460290",
                "date_created": "2019-05-02T11:48:29.276297Z"
            },
            "created_by": {
                "uuid": "db97dbce-e6c7-410c-a3a5-419b2cb0ccc9",
                "username": "jalberts@redhat.com",
                "email": "jalberts+qa@redhat.com"
            },
            "stats": {},
            "infrastructure": "Unknown"
        },
        {
            "uuid": "6e212746-484a-40cd-bba0-09a19d132d64",
            "name": "Test Provider",
            "type": "AWS",
            "authentication": {
                "uuid": "7e4ec31b-7ced-4a17-9f7e-f77e9efa8fd6",
                "provider_resource_name": "arn:aws:iam::111111111111:role/CostManagement"
            },
            "billing_source": {
                "uuid": "75b17096-319a-45ec-92c1-18dbd5e78f94",
                "bucket": "test-bucket"
            },
            "customer": {
                "uuid": "96a98ab8-ebf0-46c1-a94e-48a68fcb0ab9",
                "account_id": "1460290",
                "date_created": "2019-05-02T11:48:29.276297Z"
            },
            "created_by": {
                "uuid": "db97dbce-e6c7-410c-a3a5-419b2cb0ccc9",
                "username": "jalberts@redhat.com",
                "email": "jalberts+qa@redhat.com"
            },
            "stats": {},
            "infrastructure": "Unknown"
        }
    ]
}
```

ANDed filter:
*GET* `/api/cost-management/v1/providers/`
```
{
    "meta": {
        "count": 1
    },
    "links": {
        "first": "/api/cost-management/v1/providers/?limit=10&name=Provider%2COCP&offset=0",
        "next": null,
        "previous": null,
        "last": "/api/cost-management/v1/providers/?limit=10&name=Provider%2COCP&offset=0"
    },
    "data": [
        {
            "uuid": "3c6e687e-1a09-4a05-970c-2ccf44b0952e",
            "name": "OCP Test Provider",
            "type": "OCP",
            "authentication": {
                "uuid": "5e421052-8e16-4f66-93d4-27223c4673f2",
                "provider_resource_name": "my-ocp-cluster-1"
            },
            "billing_source": null,
            "customer": {
                "uuid": "96a98ab8-ebf0-46c1-a94e-48a68fcb0ab9",
                "account_id": "1460290",
                "date_created": "2019-05-02T11:48:29.276297Z"
            },
            "created_by": {
                "uuid": "db97dbce-e6c7-410c-a3a5-419b2cb0ccc9",
                "username": "jalberts@redhat.com",
                "email": "jalberts+qa@redhat.com"
            },
            "stats": {},
            "infrastructure": "Unknown"
        }
    ]
}
```

No match to ANDed filter:
*GET* `/api/cost-management/v1/providers/?name=Provider,Foo`
```
{
    "meta": {
        "count": 0
    },
    "links": {
        "first": "/api/cost-management/v1/providers/?limit=10&name=Provider%2CFoo&offset=0",
        "next": null,
        "previous": null,
        "last": "/api/cost-management/v1/providers/?limit=10&name=Provider%2CFoo&offset=0"
    },
    "data": []
}
```