### PR TITLE
ensure serializer objects are instantiated correctly. fixes #857

### DIFF
--- a/koku/api/report/serializers.py
+++ b/koku/api/report/serializers.py
@@ -15,6 +15,8 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 """Common serializer logic."""
+import copy
+
 from django.utils.translation import ugettext as _
 from rest_framework import serializers
 
@@ -177,8 +179,13 @@ class BaseSerializer(serializers.Serializer):
         if fkwargs is None:
             fkwargs = {}
 
-        tag_fields = {key: field(*fargs, **fkwargs)
-                      for key in self.tag_keys}
+        tag_fields = {}
+        for key in self.tag_keys:
+            if len(self.tag_keys) > 1 and 'child' in fkwargs.keys():
+                # when there are multiple filters, each filter needs its own
+                # instantiated copy of the child field.
+                fkwargs['child'] = copy.deepcopy(fkwargs.get('child'))
+            tag_fields[key] = field(*fargs, **fkwargs)
 
         # Add tag keys to allowable fields
         for key, val in tag_fields.items():

--- a/koku/api/report/test/tests_serializers.py
+++ b/koku/api/report/test/tests_serializers.py
@@ -316,6 +316,13 @@ class GroupBySerializerTest(TestCase):
             serializer = GroupBySerializer(data=filter_param)
             self.assertTrue(serializer.is_valid())
 
+    def test_multiple_params(self):
+        """Test that multiple group_by parameters works."""
+        group_by_params = {'account': 'account1', 'project': 'project1'}
+        serializer = GroupBySerializer(data=group_by_params)
+        with self.assertRaises(serializers.ValidationError):
+            serializer.is_valid(raise_exception=True)
+
 
 class OrderBySerializerTest(TestCase):
     """Tests for the order_by serializer."""
@@ -396,5 +403,19 @@ class QueryParamSerializerTest(TestCase):
         query_params = {'delta': 'usage'}
         req = Mock(path='/api/cost-management/v1/reports/aws/costs/')
         serializer = QueryParamSerializer(data=query_params, context={'request': req})
+        with self.assertRaises(serializers.ValidationError):
+            serializer.is_valid(raise_exception=True)
+
+    def test_multiple_group_by(self):
+        """Test parse of query params with multiple group_bys."""
+        query_params = {'group_by': {'account': ['account1'],
+                                     'project': ['project1']},
+                        'order_by': {'cost': 'asc'},
+                        'filter': {'resolution': 'daily',
+                                   'time_scope_value': '-10',
+                                   'time_scope_units': 'day',
+                                   'resource_scope': []}
+                        }
+        serializer = QueryParamSerializer(data=query_params)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)

--- a/koku/api/report/test/tests_views.py
+++ b/koku/api/report/test/tests_views.py
@@ -407,3 +407,15 @@ class ReportViewTest(IamTestCase):
         paginator = get_paginator(params, 0)
 
         self.assertIsInstance(paginator, ReportRankedPagination)
+
+    def test_process_multiple_tag_query_params(self):
+        """Test that grouping by multiple tag keys returns a valid response."""
+        qs = f'group_by[tag:app]=*&group_by[tag:environment]=*&filter[limit]=2'
+        url = reverse('reports-aws-costs') + '?' + qs
+        client = APIClient()
+        response = client.get(url, **self.headers)
+        import logging
+        logging.disable(0)
+        log = logging.getLogger(__name__)
+        log.critical('XXX: %s', response.content)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/koku/api/report/test/tests_views.py
+++ b/koku/api/report/test/tests_views.py
@@ -407,15 +407,3 @@ class ReportViewTest(IamTestCase):
         paginator = get_paginator(params, 0)
 
         self.assertIsInstance(paginator, ReportRankedPagination)
-
-    def test_process_multiple_tag_query_params(self):
-        """Test that grouping by multiple tag keys returns a valid response."""
-        qs = f'group_by[tag:app]=*&group_by[tag:environment]=*&filter[limit]=2'
-        url = reverse('reports-aws-costs') + '?' + qs
-        client = APIClient()
-        response = client.get(url, **self.headers)
-        import logging
-        logging.disable(0)
-        log = logging.getLogger(__name__)
-        log.critical('XXX: %s', response.content)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)


### PR DESCRIPTION
This fixes bug #857. The problem was that multiple group_bys were trying to use the same instance of a `Charfield` child inside of a `StringOrListField`. This change ensures that each `StringOrListField` has its own copy of the `Charfield` child object.

Functional test:
```
COMMAND: curl -v -g -H 'HTTP_X_RH_IDENTITY: ImlkZW50aXR5Ijp7ImFjY291bnRfbnVtYmVyIjoiMTAwMDEiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsidXNlcm5hbWUiOiJ0ZXN0X2N1c3RvbWVyIiwiZW1haWwiOiJibGVudHoraGNjbS10ZXN0QHJlZGhhdC5jb20ifX0K' http://localhost:8000/api/v1/reports/openshift/costs/?group_by[tag:app]=*&group_by[tag:environment]=*&limit=2
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0* Could not resolve host: ImlkZW50aXR5Ijp7ImFjY291bnRfbnVtYmVyIjoiMTAwMDEiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsidXNlcm5hbWUiOiJ0ZXN0X2N1c3RvbWVyIiwiZW1haWwiOiJibGVudHoraGNjbS10ZXN0QHJlZGhhdC5jb20ifX0K'
* Closing connection 0
curl: (6) Could not resolve host: ImlkZW50aXR5Ijp7ImFjY291bnRfbnVtYmVyIjoiMTAwMDEiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsidXNlcm5hbWUiOiJ0ZXN0X2N1c3RvbWVyIiwiZW1haWwiOiJibGVudHoraGNjbS10ZXN0QHJlZGhhdC5jb20ifX0K'
*   Trying ::1...
* TCP_NODELAY set
* connect to ::1 port 8000 failed: Connection refused
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8000 (#1)
> GET /api/v1/reports/openshift/costs/?group_by[tag:app]=*&group_by[tag:environment]=*&limit=2 HTTP/1.1
> Host: localhost:8000
> User-Agent: curl/7.64.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Date: Mon, 03 Jun 2019 19:32:15 GMT
< Server: WSGIServer/0.2 CPython/3.7.3
< Content-Type: application/json
< Vary: Accept, Origin
< Allow: GET, OPTIONS
< X-Frame-Options: SAMEORIGIN
< Content-Length: 3351
< 
{ [3351 bytes data]
100  3351  100  3351    0     0   4584      0 --:--:-- --:--:-- --:--:--  4584
* Connection #1 to host localhost left intact


{
  "meta": {
    "count": 10,
    "limit": 2,
    "group_by": {
      "tag:environment": [
        "*"
      ],
      "tag:app": [
        "*"
      ]
    },
    "filter": {
      "time_scope_value": "-10",
      "time_scope_units": "day",
      "resolution": "daily"
    },
    "total": {
      "infrastructure_cost": {
        "value": 1448.505668,
        "units": "USD"
      },
      "derived_cost": {
        "value": 0,
        "units": "USD"
      },
      "cost": {
        "value": 1448.505668,
        "units": "USD"
      }
    }
  },
  "links": {
    "first": "/api/v1/reports/openshift/costs/?group_by%5Btag%3Aapp%5D=%2A&group_by%5Btag%3Aenvironment%5D=%2A&limit=2&offset=0",
    "next": "/api/v1/reports/openshift/costs/?group_by%5Btag%3Aapp%5D=%2A&group_by%5Btag%3Aenvironment%5D=%2A&limit=2&offset=2",
    "previous": null,
    "last": "/api/v1/reports/openshift/costs/?group_by%5Btag%3Aapp%5D=%2A&group_by%5Btag%3Aenvironment%5D=%2A&limit=2&offset=8"
  },
  "data": [
    {
      "date": "2019-05-25",
      "apps": [
        {
          "app": "catalog",
          "environments": [
            {
              "environment": "dev",
              "values": [
                {
                  "app": "catalog",
                  "environment": "dev",
                  "date": "2019-05-25",
                  "infrastructure_cost": {
                    "value": 2.643256,
                    "units": "USD"
                  },
                  "derived_cost": {
                    "value": 0,
                    "units": "USD"
                  },
                  "cost": {
                    "value": 2.643256,
                    "units": "USD"
                  }
                }
              ]
            }
          ]
        },
        {
          "app": "analytics",
          "environments": [
            {
              "environment": "prod",
              "values": [
                {
                  "app": "analytics",
                  "environment": "prod",
                  "date": "2019-05-25",
                  "infrastructure_cost": {
                    "value": 2.539574,
                    "units": "USD"
                  },
                  "derived_cost": {
                    "value": 0,
                    "units": "USD"
                  },
                  "cost": {
                    "value": 2.539574,
                    "units": "USD"
                  }
                }
              ]
            }
          ]
        },
        {
          "app": "cost",
          "environments": [
            {
              "environment": "qe",
              "values": [
                {
                  "app": "cost",
                  "environment": "qe",
                  "date": "2019-05-25",
                  "infrastructure_cost": {
                    "value": 2.452151,
                    "units": "USD"
                  },
                  "derived_cost": {
                    "value": 0,
                    "units": "USD"
                  },
                  "cost": {
                    "value": 2.452151,
                    "units": "USD"
                  }
                }
              ]
            }
          ]
        },
        {
          "app": "master",
          "environments": [
            {
              "environment": "dev",
              "values": [
                {
                  "app": "master",
                  "environment": "dev",
                  "date": "2019-05-25",
                  "infrastructure_cost": {
                    "value": 1.169484,
                    "units": "USD"
                  },
                  "derived_cost": {
                    "value": 0,
                    "units": "USD"
                  },
                  "cost": {
                    "value": 1.169484,
                    "units": "USD"
                  }
                }
              ]
            },
            {
              "environment": "prod",
              "values": [
                {
                  "app": "master",
                  "environment": "prod",
                  "date": "2019-05-25",
                  "infrastructure_cost": {
                    "value": 1.169484,
                    "units": "USD"
                  },
                  "derived_cost": {
                    "value": 0,
                    "units": "USD"
                  },
                  "cost": {
                    "value": 1.169484,
                    "units": "USD"
                  }
                }
              ]
            }
          ]
        }
      ]
    },
    {
      "date": "2019-05-26",
      "apps": [
        {
          "app": "catalog",
          "environments": [
            {
              "environment": "dev",
              "values": [
                {
                  "app": "catalog",
                  "environment": "dev",
                  "date": "2019-05-26",
                  "infrastructure_cost": {
                    "value": 2.572988,
                    "units": "USD"
                  },
                  "derived_cost": {
                    "value": 0,
                    "units": "USD"
                  },
                  "cost": {
                    "value": 2.572988,
                    "units": "USD"
                  }
                }
              ]
            }
          ]
        },
        {
          "app": "analytics",
          "environments": [
            {
              "environment": "prod",
              "values": [
                {
                  "app": "analytics",
                  "environment": "prod",
                  "date": "2019-05-26",
                  "infrastructure_cost": {
                    "value": 2.482821,
                    "units": "USD"
                  },
                  "derived_cost": {
                    "value": 0,
                    "units": "USD"
                  },
                  "cost": {
                    "value": 2.482821,
                    "units": "USD"
                  }
                }
              ]
            }
          ]
        },
        {
          "app": "cost",
          "environments": [
            {
              "environment": "qe",
              "values": [
                {
                  "app": "cost",
                  "environment": "qe",
                  "date": "2019-05-26",
                  "infrastructure_cost": {
                    "value": 2.457527,
                    "units": "USD"
                  },
                  "derived_cost": {
                    "value": 0,
                    "units": "USD"
                  },
                  "cost": {
                    "value": 2.457527,
                    "units": "USD"
                  }
                }
              ]
            }
          ]
        },
        {
          "app": "master",
          "environments": [
            {
              "environment": "dev",
              "values": [
                {
                  "app": "master",
                  "environment": "dev",
                  "date": "2019-05-26",
                  "infrastructure_cost": {
                    "value": 1.188773,
                    "units": "USD"
                  },
                  "derived_cost": {
                    "value": 0,
                    "units": "USD"
                  },
                  "cost": {
                    "value": 1.188773,
                    "units": "USD"
                  }
                }
              ]
            },
            {
              "environment": "prod",
              "values": [
                {
                  "app": "master",
                  "environment": "prod",
                  "date": "2019-05-26",
                  "infrastructure_cost": {
                    "value": 1.188773,
                    "units": "USD"
                  },
                  "derived_cost": {
                    "value": 0,
                    "units": "USD"
                  },
                  "cost": {
                    "value": 1.188773,
                    "units": "USD"
                  }
                }
              ]
            }
          ]
        }
      ]
    }
  ]
}

```