### PR TITLE
Check that user is entitled before processing request.

### DIFF
--- a/koku/api/iam/test/iam_test_case.py
+++ b/koku/api/iam/test/iam_test_case.py
@@ -94,7 +94,8 @@ class IamTestCase(TestCase):
 
     @classmethod
     def _create_request_context(cls, customer_data, user_data,
-                                create_customer=True, create_tenant=False, is_admin=True):
+                                create_customer=True, create_tenant=False,
+                                is_admin=True, is_hybrid_cloud=True):
         """Create the request context for a user."""
         customer = customer_data
         account = customer.get('account_id')
@@ -112,6 +113,9 @@ class IamTestCase(TestCase):
                     'email': user_data['email'],
                     'is_org_admin': is_admin
                 }
+            },
+            'entitlements': {
+                'hybrid_cloud': {'is_entitled': is_hybrid_cloud}
             }
         }
         json_identity = json_dumps(identity)

--- a/koku/koku/dev_middleware.py
+++ b/koku/koku/dev_middleware.py
@@ -46,6 +46,9 @@ class DevelopmentIdentityHeaderMiddleware(MiddlewareMixin):  # pylint: disable=t
                                        'email': 'user_dev@foo.com',
                                        'is_org_admin': True
                                    }
+                               },
+                               'entitlements': {
+                                   'hybrid_cloud': {'is_entitled': True}
                                }
                                }
             json_identity = json_dumps(identity_header)

--- a/koku/koku/middleware.py
+++ b/koku/koku/middleware.py
@@ -184,6 +184,10 @@ class IdentityHeaderMiddleware(MiddlewareMixin):  # pylint: disable=R0903
             email = json_rh_auth.get('identity', {}).get('user', {}).get('email')
             account = json_rh_auth.get('identity', {}).get('account_number')
             is_admin = json_rh_auth.get('identity', {}).get('user', {}).get('is_org_admin')
+            is_hybrid_cloud = json_rh_auth.get(
+                'entitlements', {}).get('hybrid_cloud', {}).get('is_entitled', False)
+            if not is_hybrid_cloud:
+                raise PermissionDenied()
         except (KeyError, JSONDecodeError):
             logger.warning('Could not obtain identity on request.')
             return


### PR DESCRIPTION
The entitlements service is called as part of the 3scale authorization layer and the x-rh-identity header now includes and `entitlements` object, example below:

```
{
	"entitlements": {
		"insights": {
			"is_entitled": true
		},
		"openshift": {
			"is_entitled": true
		},
		"smart_management": {
			"is_entitled": true
		},
		"hybrid_cloud": {
			"is_entitled": true
		}
	},
	"identity": {
		"account_number": "1111111",
		"user": {
			"first_name": "First",
			"last_name": "Last",
			"is_org_admin": false,
			"username": "user1",
			"email": "user1@company.com"
		},
		"type": "User"
	}
}
```

The API layer is now checking that the user is entitled to `hybrid_cloud` otherwise a 403 is raised.