### PR TITLE
Openshift 4 provider documentation update

### DIFF
--- a/docs/source/providers/ocp.rst
+++ b/docs/source/providers/ocp.rst
@@ -1,12 +1,12 @@
 Adding an OCP Provider
 #######################
 
-This section describes how to configure your Openshift Container Platform (OCP) cluster to provide Koku operator metering usage data.  Configuring your OCP cluster involves configuring four setup steps. Obtaining a login token for your metering-operator service account. Downloading our Ansible playbook and performing the setup step to configure connectivity to the OCP cluster and generate report resources. Create a cron job that will collect the operator metering usage data on an interval and send this data to our upload service. Create an OCP provider in Koku.
+This section describes how to configure your Openshift Container Platform (OCP) cluster to provide Koku operator metering usage data.  Configuring your OCP cluster involves configuring four setup steps. Obtaining a login token for your reporting-operator service account. Downloading our Ansible playbook and performing the setup step to configure connectivity to the OCP cluster and generate report resources. Create a cron job that will collect the operator metering usage data on an interval and send this data to our upload service. Create an OCP provider in Koku.
 
 Dependencies
 ************
 
-We require the following dependencies in order to obtain the OCP operator metering usage data. 
+We require the following dependencies in order to obtain the OCP operator metering usage data.
 
 - You must be running OCP version 3.11 or newer.
 - You must `install Operator Metering <https://github.com/operator-framework/operator-metering/blob/master/Documentation/install-metering.md>`_ on your OCP cluster.
@@ -18,7 +18,7 @@ We require the following dependencies in order to obtain the OCP operator meteri
 Obtaining login credentials
 ***************************
 
-During the installation process for Operator Metering a service account, `metering-operator`, is created in the Operator Metering namespace. Login to your OCP cluster with a user that has access to the Operator Metering namespace (e.g. `metering`), like a sysadmin.
+During the installation process for Operator Metering a service account, `reporting-operator`, is created in the Operator Metering namespace. Login to your OCP cluster with a user that has access to the Operator Metering namespace (e.g. `metering`), like a sysadmin.
 
 
 ::
@@ -27,12 +27,12 @@ During the installation process for Operator Metering a service account, `meteri
 
   # oc project metering
 
-After logging into the cluster you can obtain the login token for the `metering-operator` service account with the following command which will place the token into a file, `ocp_usage_token`::
+After logging into the cluster you can obtain the login token for the `reporting-operator` service account with the following command which will place the token into a file, `ocp_usage_token`::
 
-  
-  # oc serviceaccounts get-token metering-operator > ocp_usage_token
 
-The token for the `metering-operator` service account does not expire, as such the token file should be placed on file system with limited access to maintain security This service account token will be used to obtain metering data on a scheduled basis using a cron job.
+  # oc serviceaccounts get-token reporting-operator > ocp_usage_token
+
+The token for the `reporting-operator` service account does not expire, as such the token file should be placed on file system with limited access to maintain security This service account token will be used to obtain metering data on a scheduled basis using a cron job.
 
 Download and Configure OCP Usage Collector (Korekuta)
 *****************************************************
@@ -54,7 +54,7 @@ Once download you can unzip the tool and open the created directory::
 In the directory you will find the `ocp_usage.sh` script, this script will be used to run both phases of the OCP Usage Collector. In order to configure the tool you need to the following information:
 
 - OCP API endpoint (i.e. https://api.openshift-prod.mycompany.com)
-- OCP `metering-operator` token file path 
+- OCP `reporting-operator` token file path
 - OCP Operator Metering namespace (i.e. metering)
 - Sudo password for installing dependencies
 
@@ -83,7 +83,7 @@ The command above would perform a one time extraction of usage data based on the
 
   # crontab -u <username> -e
 
-Note: The crontab user must have access to the file with `metering-operator` token.
+Note: The crontab user must have access to the file with `reporting-operator` token.
 
 Create an entry to run the OCP Usage collector every 45 minutes::
 

--- a/docs/source/providers/ocp.rst
+++ b/docs/source/providers/ocp.rst
@@ -54,9 +54,10 @@ Once download you can unzip the tool and open the created directory::
 
 In the directory you will find the `ocp_usage.sh` script, this script will be used to run both phases of the OCP Usage Collector. In order to configure the tool you need to the following information:
 
-- OCP API endpoint (i.e. https://api.openshift-prod.mycompany.com)
+- OCP API endpoint (e.g. https://api.openshift-prod.mycompany.com)
 - OCP `reporting-operator` token file path
-- OCP Operator Metering namespace (i.e. metering)
+- OCP Operator Metering namespace (e.g. metering)
+- The URL of the route exposed for the reporting operator in the Operator Metering namespace (e.g. https://metering.metering.api.ocp.com)
 - Sudo password for installing dependencies
 
 Now you can trigger the setup of the tool providing the above data as seen in the example below::

--- a/docs/source/providers/ocp.rst
+++ b/docs/source/providers/ocp.rst
@@ -10,6 +10,7 @@ We require the following dependencies in order to obtain the OCP operator meteri
 
 - You must be running OCP version 3.11 or newer.
 - You must `install Operator Metering <https://github.com/operator-framework/operator-metering/blob/master/Documentation/install-metering.md>`_ on your OCP cluster.
+- The Operator Metering installation must `expose a route <https://github.com/operator-framework/operator-metering/blob/master/Documentation/configuring-reporting-operator.md#openshift-route>`_ for the reporting operator.
 - You must install and configure the `Red Hat Insights Client <https://access.redhat.com/products/red-hat-insights/#getstarted>`_ on a system with network access to you OCP cluster.
 - You must install `Ansible <https://docs.ansible.com/ansible/2.7/installation_guide/intro_installation.html>`_ and the `EPEL repository <https://fedoraproject.org/wiki/EPEL#Quickstart>`_ on the system where the Red Hat Insight Client is installed.
 - You must `install the OCP commandline, oc <https://docs.openshift.com/container-platform/3.3/cli_reference/get_started_cli.html#cli-linux>`_, on the system where the Red Hat Insighs Client is installed.
@@ -60,7 +61,7 @@ In the directory you will find the `ocp_usage.sh` script, this script will be us
 
 Now you can trigger the setup of the tool providing the above data as seen in the example below::
 
-  # ./ocp_usage.sh --setup -e OCP_API="https://api.openshift-prod.mycompany.com"  -e OCP_METERING_NAMESPACE="metering" -e OCP_TOKEN_PATH="/path/to/ocp_usage_token"
+  # ./ocp_usage.sh --setup -e OCP_API="https://api.openshift-prod.mycompany.com"  -e OCP_METERING_NAMESPACE="metering" -e OCP_TOKEN_PATH="/path/to/ocp_usage_token" -e METERING_API="https://metering.metering.api.ocp.com"
 
 You will be prompted for your sudo password and the Ansible playbook will execute to capture the configuration information and create the usage reports on your OCP cluster. When complete you will see the following message::
 


### PR DESCRIPTION
## Summary 
This is a documentation update to reflect changes for Openshift 4 and the most recent Operator Metering version. We now access the operator metering API through an OpenShift route. 

I apologize for the whitespace changes caused automatically by my editor, there are several lines in the diff that are not actual changes.