### PR TITLE
Update default request/limit for OpenShift

### DIFF
--- a/openshift/celery-flower.yaml
+++ b/openshift/celery-flower.yaml
@@ -292,22 +292,22 @@ parameters:
   displayName: Celery Flower Memory Resource Request
   name: MEMORY_REQUEST
   required: true
-  value: 512Mi
+  value: 256Mi
 - description: Maximum amount of memory the Flower container can use.
   displayName: Celery Flower Memory Resource Limit
   name: MEMORY_LIMIT
   required: true
-  value: 1Gi
+  value: 512Mi
 - description: Initial amount of CPU the Flower container will request.
   displayName: Celery Flower CPU Resource Request
   name: CPU_REQUEST
   required: true
-  value: 500m
+  value: 100m
 - description: Maximum amount of CPU the Flower container can use.
   displayName: Celery Flower CPU Resource Limit
   name: CPU_LIMIT
   required: true
-  value: '1'
+  value: 250m
 - description: Initial amount of memory the build container will request.
   displayName: Build Memory Resource Request
   name: BUILD_MEMORY_REQUEST

--- a/openshift/celery-worker.yaml
+++ b/openshift/celery-worker.yaml
@@ -295,17 +295,17 @@ parameters:
   displayName: Celery Worker Memory Limit
   name: MEMORY_LIMIT
   required: true
-  value: 1Gi
+  value: 2Gi
 - description: Initial amount of CPU the Flower container will request.
   displayName: Celery Worker CPU Request
   name: CPU_REQUEST
   required: true
-  value: '500m'
+  value: 100m
 - description: Maximum amount of CPU the Flower container can use.
   displayName: Celery Worker CPU Limit
   name: CPU_LIMIT
   required: true
-  value: '1'
+  value: 300m
 - displayName: Volume Capacity
   description: Volume space available for shared files, e.g. 512Mi, 2Gi
   name: VOLUME_CAPACITY

--- a/openshift/koku-database.yaml
+++ b/openshift/koku-database.yaml
@@ -162,7 +162,7 @@ parameters:
   displayName: Memory Limit
   name: MEMORY_LIMIT
   required: true
-  value: 1Gi
+  value: 2Gi
 - displayName: Database Name
   name: DATABASE_NAME
   required: true

--- a/openshift/koku.yaml
+++ b/openshift/koku.yaml
@@ -472,12 +472,12 @@ parameters:
   displayName: Memory Limit
   name: MEMORY_LIMIT
   required: true
-  value: 1Gi
+  value: 2Gi
 - description: Initial amount of cpu the Django container will request.
   displayName: CPU Request
   name: CPU_REQUEST
   required: true
-  value: 200m
+  value: 100m
 - description: Maximum amount of cpu the Django container can use.
   displayName: CPU Limit
   name: CPU_LIMIT

--- a/openshift/masu-flask.yaml
+++ b/openshift/masu-flask.yaml
@@ -389,12 +389,12 @@ parameters:
   displayName: Masu CPU Limit
   name: CPU_REQUEST
   required: true
-  value: '500m'
+  value: 100m
 - description: Maximum amount of CPU the Flower container can use.
   displayName: Masu CPU Limit
   name: CPU_LIMIT
   required: true
-  value: '1'
+  value: 300m
 - description: Initial amount of memory the build container will request.
   displayName: Build Memory Request
   name: BUILD_MEMORY_REQUEST

--- a/openshift/masu-listener.yaml
+++ b/openshift/masu-listener.yaml
@@ -237,17 +237,17 @@ parameters:
   displayName: Masu Listener Memory Limit
   name: MEMORY_LIMIT
   required: true
-  value: 1Gi
+  value: 2Gi
 - description: Initial amount of CPU the listener container will request.
   displayName: Masu Listener CPU Request
   name: CPU_REQUEST
   required: true
-  value: '500m'
+  value: 100m
 - description: Maximum amount of CPU the listener container can use.
   displayName: Masu Listener CPU Limit
   name: CPU_LIMIT
   required: true
-  value: '1'
+  value: 250m
 - displayName: Volume Capacity
   description: Volume space available for shared files, e.g. 512Mi, 2Gi
   name: VOLUME_CAPACITY

--- a/openshift/rabbitmq.yaml
+++ b/openshift/rabbitmq.yaml
@@ -237,12 +237,12 @@ parameters:
   displayName: CPU Request
   name: CPU_REQUEST
   required: true
-  value: '500m'
+  value: 100m
 - description: Maximum amount of CPU the app container can use.
   displayName: CPU Limit
   name: CPU_LIMIT
   required: true
-  value: '1'
+  value: 300m
 - displayName: Volume Capacity
   description: Volume space available for shared files, e.g. 512Mi, 2Gi
   name: VOLUME_CAPACITY


### PR DESCRIPTION
## Summary
I'd like to get our resource usage to a place where we can deploy multiple instances of the koku API and celery worker without bumping into our quota limits. This lowers default values down. Looking at the OpenShift monitoring, we just don't use CPU, so freeing that up will give us significant leeway to deploy replicas. 