### PR TITLE
Use projected volume to map ssl cert file.

### DIFF
--- a/koku/koku/database.py
+++ b/koku/koku/database.py
@@ -16,7 +16,6 @@
 #
 """Django database settings."""
 import os
-from tempfile import NamedTemporaryFile
 
 from django.conf import settings
 

--- a/koku/koku/database.py
+++ b/koku/koku/database.py
@@ -33,13 +33,11 @@ engines = {
 def _cert_config(db_config, database_cert):
     """Add certificate configuration as needed."""
     if database_cert:
-        temp_cert_file = NamedTemporaryFile(delete=False, mode='w', suffix='pem')
-        with open(temp_cert_file.name, mode='w') as cert_file:
-            cert_file.write(database_cert)
+        cert_file = '/etc/ssl/certs/server.pem'
         db_options = {
             'OPTIONS': {
                 'sslmode': 'verify-full',
-                'sslrootcert': temp_cert_file.name
+                'sslrootcert': cert_file
             }
         }
         db_config.update(db_options)

--- a/openshift/koku.yaml
+++ b/openshift/koku.yaml
@@ -162,6 +162,10 @@ objects:
         containers:
         - name: ${NAME}
           image: ${NAME}
+          volumeMounts:
+          - name: ssl-cert
+            mountPath: /etc/ssl/certs
+            readOnly: true
           env:
             - name: DATABASE_USER
               valueFrom:
@@ -417,6 +421,15 @@ objects:
             limits:
               cpu: ${CPU_LIMIT}
               memory: ${MEMORY_LIMIT}
+        volumes:
+        - name: ssl-cert
+          projected:
+            sources:
+            - secret:
+                name: ${NAME}-db
+                items:
+                  - key: database-client-cert
+                    path: server.pem
     triggers:
     - type: ConfigChange
     - imageChangeParams:


### PR DESCRIPTION
This alters the flow of database configuration to rely on obtaining the SSL certificate file using a projected volume instead of reading the environment variable in and writing it to a temporary file.

Here you see that the `server.pem` file exists in the defined projected volume.
<img width="686" alt="Screen Shot 2019-07-25 at 11 43 06 AM" src="https://user-images.githubusercontent.com/29379759/61889161-e29fcf00-aed2-11e9-9a76-bdc5460a463f.png">

Here you can see the contents of the `server.pem` file when the secret is populated:
<img width="628" alt="Screen Shot 2019-07-25 at 11 49 46 AM" src="https://user-images.githubusercontent.com/29379759/61889183-f64b3580-aed2-11e9-8b9e-fe6a2b00fbf5.png">

