### PR TITLE
fix koku template. small Makefile tweak.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -456,11 +456,11 @@ __oc-create-object: __oc-create-project
 		if [ -f $(OC_PARAM_DIR)/$(OC_PARAMETER_FILE) ]; then \
 			oc process -f $(OC_TEMPLATE_DIR)/$(OC_TEMPLATE_FILE) \
 				--param-file=$(OC_PARAM_DIR)/$(OC_PARAMETER_FILE) \
-			| oc create --save-config=True -n $(NAMESPACE) -f - 2>&1 | grep -v "already exists" || /usr/bin/true ;\
+			| oc create --save-config=True -n $(NAMESPACE) -f - 2>&1 || /usr/bin/true ;\
 		else \
 			oc process -f $(OC_TEMPLATE_DIR)/$(OC_TEMPLATE_FILE) \
 				$(foreach PARAM, $(OC_PARAMETERS), -p $(PARAM)) \
-			| oc create --save-config=True -n $(NAMESPACE) -f - 2>&1 | grep -v "already exists" || /usr/bin/true ;\
+			| oc create --save-config=True -n $(NAMESPACE) -f - 2>&1 || /usr/bin/true ;\
 		fi ;\
 	fi
 

--- a/openshift/koku.yaml
+++ b/openshift/koku.yaml
@@ -535,13 +535,13 @@ parameters:
   displayName: Git Reference
   name: SOURCE_REPOSITORY_REF
   required: false
-  - description: The minimum number of replicas to keep
+- description: The minimum number of replicas to keep
   displayName: Replica minimum
   name: MIN_REPLICAS
   required: true
-  value: 1
+  value: '1'
 - description: The maximum number of replicas to keep
   displayName: Replica maximum
   name: MAX_REPLICAS
   required: true
-  value: 10
+  value: '10'


### PR DESCRIPTION
This PR fixes a whitespacing issue in the Koku template that's causing the YAML->JSON conversion to fail. 

There's also a Makefile change that removes an unnecessary grep in here, too.