### PR TITLE
turn off automatic redeploys after image change

### DIFF
--- a/openshift/celery-exporter.yaml
+++ b/openshift/celery-exporter.yaml
@@ -97,7 +97,7 @@ objects:
     triggers:
     - type: ConfigChange
     - imageChangeParams:
-        automatic: true
+        automatic: false
         containerNames:
           - ${NAME}-celery-exporter
         from:

--- a/openshift/celery-flower.yaml
+++ b/openshift/celery-flower.yaml
@@ -255,7 +255,7 @@ objects:
     triggers:
     - type: ConfigChange
     - imageChangeParams:
-        automatic: true
+        automatic: false
         containerNames:
           - ${NAME}-flower
         from:

--- a/openshift/celery-scheduler.yaml
+++ b/openshift/celery-scheduler.yaml
@@ -178,7 +178,7 @@ objects:
     triggers:
     - type: ConfigChange
     - imageChangeParams:
-        automatic: true
+        automatic: false
         containerNames:
           - ${NAME}-scheduler
         from:

--- a/openshift/celery-worker.yaml
+++ b/openshift/celery-worker.yaml
@@ -261,7 +261,7 @@ objects:
     triggers:
     - type: ConfigChange
     - imageChangeParams:
-        automatic: true
+        automatic: false
         containerNames:
           - ${NAME}-worker
         from:

--- a/openshift/koku-auth-cache.yaml
+++ b/openshift/koku-auth-cache.yaml
@@ -68,7 +68,7 @@ objects:
               name: ${NAME}-redis-config
     triggers:
     - imageChangeParams:
-        automatic: true
+        automatic: false
         containerNames:
         - ${NAME}-redis
         from:

--- a/openshift/koku-database.yaml
+++ b/openshift/koku-database.yaml
@@ -106,7 +106,7 @@ objects:
             claimName: ${NAME}-db
     triggers:
     - imageChangeParams:
-        automatic: true
+        automatic: false
         containerNames:
         - ${NAME}-db
         from:

--- a/openshift/koku.yaml
+++ b/openshift/koku.yaml
@@ -433,7 +433,7 @@ objects:
     triggers:
     - type: ConfigChange
     - imageChangeParams:
-        automatic: true
+        automatic: false
         containerNames:
           - ${NAME}
         from:

--- a/openshift/masu-flask.yaml
+++ b/openshift/masu-flask.yaml
@@ -333,7 +333,7 @@ objects:
     triggers:
     - type: ConfigChange
     - imageChangeParams:
-        automatic: true
+        automatic: false
         containerNames:
           - ${NAME}-masu-flask
         from:

--- a/openshift/masu-listener.yaml
+++ b/openshift/masu-listener.yaml
@@ -203,7 +203,7 @@ objects:
     triggers:
     - type: ConfigChange
     - imageChangeParams:
-        automatic: true
+        automatic: false
         containerNames:
           - ${NAME}-listener
         from:


### PR DESCRIPTION
This turns off automatically deploying a newly built image. Builds will automatically be triggered in the buildconfig, but will require a manual deployment.