### PR TITLE
Check for optional organization access and log. Add back setup documenation.

### DIFF
--- a/docs/source/providers/aws.rst
+++ b/docs/source/providers/aws.rst
@@ -1,7 +1,7 @@
 Adding an AWS Account
 #####################
 
-This section describes how to configure your AWS account to allow Koku access.  Configuring your account involves configuring three AWS services. Setting up the AWS account for cost and usage reporting to an S3 bucket to make the cost and usage data available. Creating an Identity Access Management (IAM) Policy and Role to be utilized by Koku to process the cost and usage data. AWS simple notification service (SNS) setup in order to trigger processing of cost and usage data when created or updated (optional).
+This section describes how to configure your AWS account to allow Koku access.  Configuring your account involves configuring three AWS services. Setting up the AWS account for cost and usage reporting to an S3 bucket to make the cost and usage data available. Creating an Identity Access Management (IAM) Policy and Role to be utilized by Koku to process the cost and usage data. AWS organization setup in order to capture member account names when using consolidated billing (optional).
 
 Configuring an Amazon Account for Cost & Usage Reporting
 ********************************************************
@@ -30,6 +30,7 @@ Creating an IAM Policy
 #. Choose *Create Policy*.
 #. Select the *JSON* tab and paste the following JSON policy into the editor replacing *bucket_name* with the S3 bucket that was configured in the `Configuring an Amazon Account for Cost & Usage Reporting`_ section.
 #. Including Action `iam:ListAccountAliases` will allow Koku to display the AWS account alias rather than the account id.
+#. Including Actions `organization:List*` and `organizations:Describe*` will allow Koku to obtain the display names of AWS member accounts if you are using consolidated billing rather than the account id.
 
 
 ::
@@ -52,7 +53,9 @@ Creating an IAM Policy
           {
               "Sid": "VisualEditor1",
               "Effect": "Allow",
-              "Action": [
+              "Action": [   
+                  "organizations:List*",
+                  "organizations:Describe*",
                   "s3:ListAllMyBuckets",
                   "iam:ListAccountAliases",
                   "s3:HeadBucket",
@@ -76,70 +79,6 @@ Creating an IAM Role
 #. Choose the *Review* button and complete the creation fo the role by naming the role ``CostManagement``.
 #. Select the newly created role ``CostManagement`` to view the summary.
 #. Capture the *Role ARN* as it will be used in the provider creation.
-
-Enabling AWS Notifications
-**************************
-In order to make data available as early as possible AWS can send a notification to Koku when it writes or updates cost and usage data. In order to enable the notification capability you will need to create an SNS topic, alter the topic policy, and create a subscription then update the S3 bucket created above to generate events when changes occur.
-
-Creating an SNS Topic
----------------------
-
-#. Sign in to the AWS Management Console as an administrator of the account you wish to add, and open the SNS console at `https://console.aws.amazon.com/sns/ <https://console.aws.amazon.com/sns/>`_.
-#. Select the region in the management console that matches where the S3 bucket was created.
-#. Choose the *Create topic* action.
-#. Provide a topic name and display name.
-
-    - **Topic name:** koku-cost
-    - **Display name:** koku-cost
-
-Alter SNS Topic Policy
-----------------------
-
-#. Select *Edit topic policy* from the *Other topic actions* drop down menu.
-#. Select the *Advanced view* tab.
-#. Change the *Condition* portion of the JSON policy to include a reference to the S3 bucket created above, replacing ``bucket_name``, and select the *Update policy* button.
-
-**Before:**
-::
-
-    "Condition": {
-        "StringEquals": {
-            "AWS:SourceOwner": "AccountID"
-        }
-    }
-
-**After:**
-::
-
-    "Condition": {
-      "ArnLike": {
-        "aws:SourceArn": "arn:aws:s3:*:*:bucket_name"
-      }
-    }
-
-
-Create SNS Topic Subscription
------------------------------
-
-#. Select the *Create subscription* button for the topic.
-#. Choose **HTTPS** from the *Protocol* drop down menu.
-#. Provide ``https://`` in the *Endpoint* field.
-#. Select the *Create subscription* button to save the configuration.
-
-Set S3 Bucket to Generate Events
---------------------------------
-
-#. Sign in to the AWS Management Console as an administrator of the account you wish to add, and open the S3 console at `https://console.aws.amazon.com/s3/ <https://console.aws.amazon.com/s3/>`_.
-#. Select the S3 bucket created in the section above.
-#. Choose the *Properties* tab.
-#. From *Advanced Settings* select *Events*.
-#. Choose *Add notification*.
-#. Provide a name for the notification (e.g. koku)
-#. Select the *ObjectCreate (All)* checkbox.
-#. Leave *Prefix* blank.
-#. Leave *Suffix* blank.
-#. From the *Send to* drop down menu choose the SNS topic created earlier (i.e. koku-cost)
-#. Choose *Save* to enable event generation for the S3 bucket.
 
 Create an AWS Account Provider
 ******************************

--- a/koku/providers/test/aws/tests_aws_provider.py
+++ b/koku/providers/test/aws/tests_aws_provider.py
@@ -210,11 +210,13 @@ class AWSProviderTestCase(TestCase):
                              aws_secret_access_key=FAKE.md5(),
                              aws_session_token=FAKE.md5()))
     @patch('providers.aws.aws_provider._check_s3_access', return_value=True)
+    @patch('providers.aws.aws_provider._check_org_access', return_value=True)
     @patch('providers.aws.aws_provider._check_cost_report_access', return_value=True)
     @patch('providers.aws.aws_provider._get_configured_sns_topics', return_value=['t1'])
     def test_cost_usage_source_is_reachable(self,
                                             mock_get_sts_access,
                                             mock_check_s3_access,
+                                            mock_check_org_access,
                                             mock_check_cost_report_access,
                                             mock_get_configured_sns_topics):
         """Verify that the cost usage source is authenticated and created."""
@@ -257,9 +259,11 @@ class AWSProviderTestCase(TestCase):
                              aws_secret_access_key=FAKE.md5(),
                              aws_session_token=FAKE.md5()))
     @patch('providers.aws.aws_provider._check_s3_access', return_value=False)
+    @patch('providers.aws.aws_provider._check_org_access', return_value=True)
     def test_cost_usage_source_is_reachable_no_bucket_exists(self,
                                                              mock_get_sts_access,
-                                                             mock_check_s3_access):
+                                                             mock_check_s3_access,
+                                                             mock_check_org_access):
         """Verify that the cost usage source is authenticated and created."""
         provider_interface = AWSProvider()
         with self.assertRaises(ValidationError):


### PR DESCRIPTION
This adds back the check and documentation around AWS organizations access. Instead of being used for cost visibility it will be used to obtain the alias names of member accounts optionally if customers use consolidated billing.