### PR TITLE
use RHSCL image for redis

### DIFF
--- a/openshift/imagestream.yaml
+++ b/openshift/imagestream.yaml
@@ -63,6 +63,9 @@ objects:
     name: redis
     namespace: ${NAMESPACE}
   spec:
+    dockerImageRepository: registry.access.redhat.com/rhscl/redis-5-rhel7
+    lookupPolicy:
+      local: false
     tags:
     - from:
         kind: DockerImage

--- a/openshift/koku-auth-cache.yaml
+++ b/openshift/koku-auth-cache.yaml
@@ -44,7 +44,7 @@ objects:
       spec:
         containers:
         - env:
-          image: redis:5.0.4
+          image: redis:latest
           command:
             - "redis-server"
           args:
@@ -73,7 +73,7 @@ objects:
         - ${NAME}-redis
         from:
           kind: ImageStreamTag
-          name: redis:5.0.4
+          name: redis:latest
           namespace: ${NAMESPACE}
       type: ImageChange
 


### PR DESCRIPTION
This should resolve UnresolvedImageErrors that I'm seeing in `hccm-build` by pointing at the RHCL redis image.