### PR TITLE
set koku-db deploymentConfig to recreate strategy

### DIFF
--- a/openshift/koku-database.yaml
+++ b/openshift/koku-database.yaml
@@ -34,13 +34,7 @@ objects:
       limits:
         memory: ${MEMORY_LIMIT}
     strategy:
-      type: Rolling
-      rollingParams:
-        updatePeriodSeconds: 20
-        intervalSeconds: 120
-        timeoutSeconds: 600
-        maxSurge: 25%
-        maxUnavailable: 25%
+      type: Recreate
     template:
       metadata:
         name: ${NAME}-db


### PR DESCRIPTION
This sets the deployment strategy for the koku-database pod to `Recreate`. This is to improve deployment reliability by removing the competition for the pod's PVC. 

In our current environments, only one pod can mount the PVC at a time, so we have to bring down the current pod before a new pod can be redeployed successfully.