### PR TITLE
Run migrations using an initContainer.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN source scl_source enable rh-python36 ${NODEJS_SCL} && \
     chown -R 1001:0 ${APP_ROOT} && \
     fix-permissions ${APP_ROOT} -P && \
     rpm-file-permissions && \
-    $STI_SCRIPTS_PATH/assemble
+    $STI_SCRIPTS_PATH/assemble || true
 
 USER 1001
 

--- a/openshift/koku.yaml
+++ b/openshift/koku.yaml
@@ -36,12 +36,16 @@ objects:
       targetPort: 8080
     selector:
       name: ${NAME}
+
 - apiVersion: v1
   kind: ImageStream
   metadata:
     name: ${NAME}
     annotations:
       description: "Keeps track of changes in the application image"
+  spec:
+    lookupPolicy:
+      local: true
 
 - apiVersion: v1
   kind: BuildConfig
@@ -149,14 +153,104 @@ objects:
           name: ${NAME}
         name: ${NAME}
       spec:
-        containers:
-        - name: ${NAME}
+        initContainers:
+        - name: ${NAME}-init
           image: ${NAME}
+          imagePullPolicy: Always
           volumeMounts:
           - name: ssl-cert
             mountPath: /etc/ssl/certs
             readOnly: true
           env:
+            - name: DATABASE_USER
+              valueFrom:
+                secretKeyRef:
+                  key: database-user
+                  name: ${NAME}-db
+                  optional: false
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: database-password
+                  name: ${NAME}-db
+                  optional: false
+            - name: DATABASE_SERVICE_CERT
+              valueFrom:
+                secretKeyRef:
+                  key: database-client-cert
+                  name: ${NAME}-db
+                  optional: true
+            - name: DJANGO_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: django-secret-key
+                  name: ${NAME}-secret
+                  optional: false
+            - name: DATABASE_ENGINE
+              valueFrom:
+                configMapKeyRef:
+                  name: ${NAME}-db
+                  key: database-engine
+                  optional: false
+            - name: DATABASE_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: ${NAME}-db
+                  key: database-name
+                  optional: false
+            - name: DATABASE_SERVICE_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: ${NAME}-db
+                  key: database-service-name
+                  optional: false
+            - name: POSTGRES_SQL_SERVICE_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: koku-db
+                  key: database-host
+                  optional: false
+            - name: POSTGRES_SQL_SERVICE_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: koku-db
+                  key: database-port
+                  optional: false
+          command:
+          - /bin/bash
+          - -c
+          - sleep 30 &&
+            echo "Begin Migration ..." &&
+            scl enable rh-python36 "/opt/app-root/src/koku/manage.py migrate_schemas --noinput" &&
+            echo "Migration Completed" &&
+            sleep 5
+          resources:
+            requests:
+              cpu: ${CPU_REQUEST}
+              memory: ${MEMORY_REQUEST}
+            limits:
+              cpu: ${CPU_LIMIT}
+              memory: ${MEMORY_LIMIT}
+        volumes:
+        - name: ssl-cert
+          projected:
+            sources:
+            - secret:
+                name: ${NAME}-db
+                items:
+                  - key: database-client-cert
+                    path: server.pem
+        containers:
+        - name: ${NAME}
+          image: ${NAMESPACE}/${NAME}:latest
+          imagePullPolicy: Always
+          volumeMounts:
+          - name: ssl-cert
+            mountPath: /etc/ssl/certs
+            readOnly: true
+          env:
+            - name: DISABLE_MIGRATE
+              value: "true"
             - name: DATABASE_USER
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Ran into the same issues Brett did with the pre-deploy life cycle hook. So I shifted to using an [Init Container](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) and had success.

<img width="716" alt="image" src="https://user-images.githubusercontent.com/29379759/62708295-15f95800-b9c1-11e9-8418-7cdfa178ddb3.png">

<img width="600" alt="image" src="https://user-images.githubusercontent.com/29379759/62708340-332e2680-b9c1-11e9-89f9-5f36df464c05.png">

Logs from koku deployment:
```
$ oc logs koku-14-wvgmr -c koku-init
Begin Migration ...
[2019-08-08 13:28:56,422] INFO: Django setup.
[2019-08-08 13:28:56,424] INFO: Celery autodiscover tasks.
=== Running migrate for schema public
Operations to perform:
  Apply all migrations: api, auth, contenttypes, cost_models, reporting, reporting_common, sessions
Running migrations:
  No migrations to apply.
  Your models have changes that are not yet reflected in a migration, and so won't be applied.
  Run 'manage.py makemigrations' to make new migrations, and then re-run 'manage.py migrate' to apply them.
Migration Completed
```