### PR TITLE
 Add a mechanism to skip migrations in init container and reduce readiness/liveliness probe wait times.

### DIFF
--- a/openshift/koku.yaml
+++ b/openshift/koku.yaml
@@ -216,6 +216,18 @@ objects:
                   name: koku-db
                   key: database-port
                   optional: false
+            - name: APP_NAMESPACE
+              valueFrom:
+                configMapKeyRef:
+                  name: ${NAME}-app
+                  key: app-namespace
+                  optional: true
+            - name: API_PATH_PREFIX
+              valueFrom:
+                configMapKeyRef:
+                  name: ${NAME}-app
+                  key: api-path-prefix
+                  optional: false
           command:
           - /bin/bash
           - -c

--- a/openshift/koku.yaml
+++ b/openshift/koku.yaml
@@ -141,9 +141,9 @@ objects:
     strategy:
       type: Rolling
       rollingParams:
-        updatePeriodSeconds: 20
-        intervalSeconds: 120
-        timeoutSeconds: 600
+        updatePeriodSeconds: 5
+        intervalSeconds: 10
+        timeoutSeconds: 120
         maxSurge: 25%
         maxUnavailable: 25%
     template:
@@ -219,11 +219,7 @@ objects:
           command:
           - /bin/bash
           - -c
-          - sleep 30 &&
-            echo "Begin Migration ..." &&
-            scl enable rh-python36 "/opt/app-root/src/koku/manage.py migrate_schemas --noinput" &&
-            echo "Migration Completed" &&
-            sleep 5
+          - ${HOME}/scripts/run_migrations.sh
           resources:
             requests:
               cpu: ${CPU_REQUEST}
@@ -481,7 +477,7 @@ objects:
               path: ${API_PATH_PREFIX}/v1/status/
               port: 8080
               scheme: HTTP
-            initialDelaySeconds: 60
+            initialDelaySeconds: 15
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 3
@@ -493,7 +489,7 @@ objects:
               path: ${API_PATH_PREFIX}/v1/status/
               port: 8080
               scheme: HTTP
-            initialDelaySeconds: 50
+            initialDelaySeconds: 10
             periodSeconds: 10
             successThreshold: 1
             failureThreshold: 3

--- a/scripts/run_migrations.sh
+++ b/scripts/run_migrations.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+APP_NAME_DEFAULT="koku"
+APP_NAME="${1:-$APP_NAME_DEFAULT}"
+TARGET_DEFAULT="http://${APP_NAME}.${APP_NAMESPACE}.svc.cluster.local"
+TARGET="${2:-$TARGET_DEFAULT}"
+COMMIT=`curl  -X GET ${TARGET}${API_PATH_PREFIX}/v1/status/ | sed 's/{.*commit":"*\([0-9a-zA-Z]*\)"*,*.*}/\1/'`
+
+echo "COMMIT=$COMMIT"
+echo "OPENSHIFT_BUILD_COMMIT=$OPENSHIFT_BUILD_COMMIT"
+
+if [ "$COMMIT" = "$OPENSHIFT_BUILD_COMMIT" ]; then
+    echo "Migration already executed."
+else
+    scl enable rh-python36 "${APP_HOME}/manage.py migrate_schemas --noinput"
+fi

--- a/scripts/run_migrations.sh
+++ b/scripts/run_migrations.sh
@@ -2,7 +2,7 @@
 
 APP_NAME_DEFAULT="koku"
 APP_NAME="${1:-$APP_NAME_DEFAULT}"
-APP_PORT="${$KOKU_SERVICE_PORT:-'8080'}"
+APP_PORT="${KOKU_SERVICE_PORT:-'8080'}"
 TARGET_DEFAULT="http://${APP_NAME}.${APP_NAMESPACE}.svc.cluster.local:${APP_PORT}"
 TARGET="${2:-$TARGET_DEFAULT}"
 COMMIT=`curl  -X GET ${TARGET}${API_PATH_PREFIX}/v1/status/ | sed 's/{.*commit":"*\([0-9a-zA-Z]*\)"*,*.*}/\1/'`

--- a/scripts/run_migrations.sh
+++ b/scripts/run_migrations.sh
@@ -2,7 +2,8 @@
 
 APP_NAME_DEFAULT="koku"
 APP_NAME="${1:-$APP_NAME_DEFAULT}"
-TARGET_DEFAULT="http://${APP_NAME}.${APP_NAMESPACE}.svc.cluster.local"
+APP_PORT="${$KOKU_SERVICE_PORT:-'8080'}"
+TARGET_DEFAULT="http://${APP_NAME}.${APP_NAMESPACE}.svc.cluster.local:${APP_PORT}"
 TARGET="${2:-$TARGET_DEFAULT}"
 COMMIT=`curl  -X GET ${TARGET}${API_PATH_PREFIX}/v1/status/ | sed 's/{.*commit":"*\([0-9a-zA-Z]*\)"*,*.*}/\1/'`
 


### PR DESCRIPTION
> The init container runs to completion before the application container starts.

Unfortunately the above is per pod, which means the init container runs even as we scale out, so with our existing implementation we are still running the check for migrations on every new pod even though it has already been performed by the first pod.

I have updated our init container to now call a script that compares the current running commit. If it is the same then migrations are skipped.

Initial deploy:
```
$ oc logs koku-2-6srd5 -c koku-init
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:--  0:00:03 --:--:--     0curl: (7) Failed connect to koku.hccm-build.svc.cluster.local:80; No route to host
COMMIT=
OPENSHIFT_BUILD_COMMIT=a6b2dea0d28e13beda30c09afd371b4b9319e892
=== Running migrate for schema public
Operations to perform:
  Apply all migrations: api, auth, contenttypes, cost_models, reporting, reporting_common, sessions
Running migrations:
  No migrations to apply.
```

Scale Out:
```
$ oc logs koku-4-hxhxr -c koku-init
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2844  100  2844    0     0  68371      0 --:--:-- --:--:-- --:--:-- 69365
COMMIT=77e4b87a1ddb4b9b4b872e3b2e050ff16c260f82
OPENSHIFT_BUILD_COMMIT=77e4b87a1ddb4b9b4b872e3b2e050ff16c260f82
Migration already executed.

```

Next I reduced our readiness/liveliness probe timing.

Takes about 4 seconds to go through init container and start app container:
<img width="1185" alt="image" src="https://user-images.githubusercontent.com/29379759/62962361-c229ad00-bdcc-11e9-818b-738027a2c86f.png">


App is ready 12 seconds after startup.
```
---> Serving application with gunicorn (koku.wsgi) ...
--
  | [2019-08-13 16:56:45 +0000] [1] [INFO] Starting gunicorn 19.9.0
  | [2019-08-13 16:56:45 +0000] [1] [INFO] Listening at: http://0.0.0.0:8080  (1)
  | [2019-08-13 16:56:45 +0000] [1] [INFO] Using worker: threads
  | [2019-08-13 16:56:45 +0000] [36] [INFO] Booting worker with pid: 36
  | [2019-08-13 16:56:45 +0000] [37] [INFO] Booting worker with pid: 37
  | [2019-08-13 16:56:50,205] ERROR: Query failed to return results.
  | [2019-08-13 16:56:50,412] ERROR: Query failed to return results.
  | 10.129.16.1 - - [13/Aug/2019:16:57:03 +0000] "GET /api/cost-management/v1/status/ HTTP/1.1" 200 2823 "-" "kube-probe/1.11+"


```