### PR TITLE
Migrationless test runner

### DIFF
--- a/koku/api/iam/test/iam_test_case.py
+++ b/koku/api/iam/test/iam_test_case.py
@@ -23,9 +23,9 @@ from django.db import connection
 from django.test import TestCase
 from faker import Faker
 
-from ..models import Customer, Tenant
-from ..serializers import create_schema_name
-from ...common import RH_IDENTITY_HEADER
+from api.common import RH_IDENTITY_HEADER
+from api.iam.serializers import create_schema_name
+from api.models import Customer, Tenant
 from koku.koku_test_runner import KokuTestRunner
 
 

--- a/koku/api/iam/test/iam_test_case.py
+++ b/koku/api/iam/test/iam_test_case.py
@@ -26,6 +26,7 @@ from faker import Faker
 from ..models import Customer, Tenant
 from ..serializers import create_schema_name
 from ...common import RH_IDENTITY_HEADER
+from koku.koku_test_runner import KokuTestRunner
 
 
 class IamTestCase(TestCase):
@@ -45,7 +46,7 @@ class IamTestCase(TestCase):
             cls.user_data
         )
         cls.schema_name = cls.customer_data.get('schema_name')
-        cls.tenant = Tenant(schema_name=cls.schema_name)
+        cls.tenant = Tenant.objects.get_or_create(schema_name=cls.schema_name)[0]
         cls.tenant.save()
         cls.headers = cls.request_context['request'].META
 
@@ -53,14 +54,14 @@ class IamTestCase(TestCase):
     def tearDownClass(cls):
         """Tear down the class."""
         connection.set_schema_to_public()
-        cls.tenant.delete()
+        # cls.tenant.delete()
         super().tearDownClass()
 
     @classmethod
     def _create_customer_data(cls):
         """Create customer data."""
-        account = cls.fake.ean8()
-        schema = f'acct{account}'
+        account = KokuTestRunner.account
+        schema = KokuTestRunner.schema
         customer = {'account_id': account,
                     'schema_name': schema}
         return customer
@@ -85,10 +86,10 @@ class IamTestCase(TestCase):
         """
         connection.set_schema_to_public()
         schema_name = create_schema_name(account)
-        customer = Customer(account_id=account, schema_name=schema_name)
+        customer = Customer.objects.get_or_create(account_id=account, schema_name=schema_name)[0]
         customer.save()
         if create_tenant:
-            tenant = Tenant(schema_name=schema_name)
+            tenant = Tenant.objects.get_or_create(schema_name=schema_name)[0]
             tenant.save()
         return customer
 
@@ -125,3 +126,11 @@ class IamTestCase(TestCase):
         request.user = user_data['username']
         request_context = {'request': request}
         return request_context
+
+    def create_mock_customer_data(self):
+        """Create randomized data for a customer test."""
+        account = self.fake.ean8()
+        schema = f'acct{account}'
+        customer = {'account_id': account,
+                    'schema_name': schema}
+        return customer

--- a/koku/api/iam/test/tests_serializers.py
+++ b/koku/api/iam/test/tests_serializers.py
@@ -123,10 +123,6 @@ class UserPreferenceSerializerTest(IamTestCase):
             {'currency': settings.KOKU_DEFAULT_CURRENCY},
             {'timezone': settings.KOKU_DEFAULT_TIMEZONE},
             {'locale': settings.KOKU_DEFAULT_LOCALE}]
-        # self.user_data = self._create_user_data()
-        # customer_data = self._create_customer_data()
-        # self.request_context = self._create_request_context(customer_data,
-        #                                                     self.user_data)
 
     def test_user_preference_defaults(self):
         """Test that defaults are set for new users."""

--- a/koku/api/iam/test/tests_serializers.py
+++ b/koku/api/iam/test/tests_serializers.py
@@ -39,7 +39,7 @@ class CustomerSerializerTest(IamTestCase):
     def test_create_customer(self):
         """Test creating a customer."""
         # create the customers
-        customer = self._create_customer_data()
+        customer = self.create_mock_customer_data()
         instance = None
         serializer = CustomerSerializer(data=customer)
         if serializer.is_valid(raise_exception=True):
@@ -58,7 +58,8 @@ class AdminCustomerSerializerTest(IamTestCase):
 
     def test_schema_name_present(self):
         """Test that the serializer contains schema_name."""
-        serializer = AdminCustomerSerializer(data=self._create_customer_data())
+        customer = self.create_mock_customer_data()
+        serializer = AdminCustomerSerializer(data=customer)
         serializer.is_valid()
         serializer.save()
         expected_schema_name = create_schema_name(serializer.data.get('account_id'))
@@ -122,10 +123,10 @@ class UserPreferenceSerializerTest(IamTestCase):
             {'currency': settings.KOKU_DEFAULT_CURRENCY},
             {'timezone': settings.KOKU_DEFAULT_TIMEZONE},
             {'locale': settings.KOKU_DEFAULT_LOCALE}]
-        self.user_data = self._create_user_data()
-        customer_data = self._create_customer_data()
-        self.request_context = self._create_request_context(customer_data,
-                                                            self.user_data)
+        # self.user_data = self._create_user_data()
+        # customer_data = self._create_customer_data()
+        # self.request_context = self._create_request_context(customer_data,
+        #                                                     self.user_data)
 
     def test_user_preference_defaults(self):
         """Test that defaults are set for new users."""

--- a/koku/api/provider/test/test_provider_manager.py
+++ b/koku/api/provider/test/test_provider_manager.py
@@ -112,7 +112,7 @@ class ProviderManagerTest(IamTestCase):
                                            customer=self.customer)
         provider_uuid = provider.uuid
         user_data = self._create_user_data()
-        request_context = self._create_request_context(self._create_customer_data(),
+        request_context = self._create_request_context(self.create_mock_customer_data(),
                                                        user_data)
         new_user = None
         serializer = UserSerializer(data=user_data, context=request_context)

--- a/koku/api/provider/test/tests_serializers.py
+++ b/koku/api/provider/test/tests_serializers.py
@@ -202,10 +202,6 @@ class AdminProviderSerializerTest(IamTestCase):
     def setUp(self):
         """Create test case objects."""
         super().setUp()
-        self.user_data = self._create_user_data()
-        self.customer = self._create_customer_data()
-        self.request_context = self._create_request_context(self.customer,
-                                                            self.user_data)
         request = self.request_context['request']
         serializer = UserSerializer(data=self.user_data, context=self.request_context)
         if serializer.is_valid(raise_exception=True):
@@ -232,7 +228,7 @@ class AdminProviderSerializerTest(IamTestCase):
             if serializer.is_valid(raise_exception=True):
                 serializer.save()
 
-        account = self.customer['account_id']
+        account = self.customer.account_id
         expected_schema_name = create_schema_name(account)
         schema_name = serializer.data['customer'].get('schema_name')
         self.assertIsNotNone(schema_name)

--- a/koku/api/provider/test/tests_views.py
+++ b/koku/api/provider/test/tests_views.py
@@ -155,7 +155,7 @@ class ProviderViewTest(IamTestCase):
         iam_arn2 = 'arn:aws:s3:::a_s3_bucket'
         bucket_name2 = 'a_s3_bucket'
         self.create_provider(bucket_name1, iam_arn1)
-        request_context = self._create_request_context(self._create_customer_data(),
+        request_context = self._create_request_context(self.create_mock_customer_data(),
                                                        self._create_user_data())
         headers = request_context['request'].META
         self.create_provider(bucket_name2, iam_arn2, headers)
@@ -232,7 +232,7 @@ class ProviderViewTest(IamTestCase):
         provider_uuid = provider_result.get('uuid')
         self.assertIsNotNone(provider_uuid)
         url = reverse('provider-detail', args=[provider_uuid])
-        request_context = self._create_request_context(self._create_customer_data(),
+        request_context = self._create_request_context(self.create_mock_customer_data(),
                                                        self._create_user_data())
         headers = request_context['request'].META
         client = APIClient()

--- a/koku/koku/koku_test_runner.py
+++ b/koku/koku/koku_test_runner.py
@@ -25,6 +25,7 @@ from api.models import Tenant
 
 LOG = logging.getLogger(__name__)
 
+
 class KokuTestRunner(DiscoverRunner):
     """Koku Test Runner for Unit Tests."""
 

--- a/koku/koku/koku_test_runner.py
+++ b/koku/koku/koku_test_runner.py
@@ -1,0 +1,44 @@
+#
+# Copyright 2019 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Koku Test Runner."""
+import logging
+
+from django.test.runner import DiscoverRunner
+from django.test.utils import setup_databases
+
+from api.models import Tenant
+
+LOG = logging.getLogger(__name__)
+
+class KokuTestRunner(DiscoverRunner):
+    """Koku Test Runner for Unit Tests."""
+
+    account = '10001'
+    schema = f'acct{account}'
+
+    def setup_databases(self, **kwargs):
+        """Setup the database with a tenant schema."""
+        main_db = setup_databases(
+            self.verbosity, self.interactive, self.keepdb, self.debug_sql,
+            **kwargs
+        )
+
+        tenant = Tenant.objects.get_or_create(schema_name=KokuTestRunner.schema)[0]
+        tenant.save()
+
+        return main_db

--- a/koku/koku/settings.py
+++ b/koku/koku/settings.py
@@ -153,6 +153,7 @@ WSGI_APPLICATION = 'koku.wsgi.application'
 REDIS_HOST = ENVIRONMENT.get_value('REDIS_HOST', default='redis')
 REDIS_PORT = ENVIRONMENT.get_value('REDIS_PORT', default='6379')
 if 'test' in sys.argv:
+    TEST_RUNNER ='koku.koku_test_runner.KokuTestRunner'
     CACHES = {
         "default": {
             'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',

--- a/koku/koku/settings.py
+++ b/koku/koku/settings.py
@@ -153,7 +153,7 @@ WSGI_APPLICATION = 'koku.wsgi.application'
 REDIS_HOST = ENVIRONMENT.get_value('REDIS_HOST', default='redis')
 REDIS_PORT = ENVIRONMENT.get_value('REDIS_PORT', default='6379')
 if 'test' in sys.argv:
-    TEST_RUNNER ='koku.koku_test_runner.KokuTestRunner'
+    TEST_RUNNER = 'koku.koku_test_runner.KokuTestRunner'
     CACHES = {
         "default": {
             'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',

--- a/koku/koku/tests_middleware.py
+++ b/koku/koku/tests_middleware.py
@@ -34,11 +34,6 @@ class KokuTenantMiddlewareTest(IamTestCase):
     def setUp(self):
         """Set up middleware tests."""
         super().setUp()
-        self.user_data = self._create_user_data()
-        self.customer = self._create_customer_data()
-        self.schema_name = create_schema_name(self.customer['account_id'])
-        self.request_context = self._create_request_context(self.customer,
-                                                            self.user_data)
         request = self.request_context['request']
         request.path = '/api/v1/providers/'
         serializer = UserSerializer(data=self.user_data, context=self.request_context)
@@ -75,12 +70,6 @@ class IdentityHeaderMiddlewareTest(IamTestCase):
     def setUp(self):
         """Set up middleware tests."""
         super().setUp()
-        self.user_data = self._create_user_data()
-        self.customer = self._create_customer_data()
-        self.schema_name = create_schema_name(self.customer['account_id'])
-        self.request_context = self._create_request_context(self.customer,
-                                                            self.user_data,
-                                                            create_customer=False)
         self.request = self.request_context['request']
         self.request.path = '/api/v1/providers/'
         self.request.META['QUERY_STRING'] = ''
@@ -98,7 +87,7 @@ class IdentityHeaderMiddlewareTest(IamTestCase):
         middleware = IdentityHeaderMiddleware()
         middleware.process_request(mock_request)
         self.assertTrue(hasattr(mock_request, 'user'))
-        customer = Customer.objects.get(account_id=self.customer['account_id'])
+        customer = Customer.objects.get(account_id=self.customer.account_id)
         self.assertIsNotNone(customer)
         user = User.objects.get(username=self.user_data['username'])
         self.assertIsNotNone(user)
@@ -108,7 +97,7 @@ class IdentityHeaderMiddlewareTest(IamTestCase):
     def test_process_no_customer(self):
         """Test that the customer, tenant and user are not created."""
         customer = self._create_customer_data()
-        account_id = customer['account_id']
+        account_id = '12345'
         del customer['account_id']
         request_context = self._create_request_context(customer,
                                                        self.user_data,
@@ -138,7 +127,7 @@ class IdentityHeaderMiddlewareTest(IamTestCase):
         middleware = IdentityHeaderMiddleware()
         middleware.process_request(mock_request)
         self.assertTrue(hasattr(mock_request, 'user'))
-        customer = Customer.objects.get(account_id=self.customer['account_id'])
+        customer = Customer.objects.get(account_id=self.customer.account_id)
         self.assertIsNotNone(customer)
         user = User.objects.get(username=self.user_data['username'])
         self.assertIsNotNone(user)

--- a/koku/koku/tests_middleware.py
+++ b/koku/koku/tests_middleware.py
@@ -20,8 +20,7 @@ from unittest.mock import Mock, patch
 from django.core.exceptions import PermissionDenied
 
 from api.iam.models import Customer, Tenant, User
-from api.iam.serializers import (UserSerializer,
-                                 create_schema_name)
+from api.iam.serializers import (UserSerializer)
 from api.iam.test.iam_test_case import IamTestCase
 from koku.middleware import (HttpResponseUnauthorizedRequest,
                              IdentityHeaderMiddleware,


### PR DESCRIPTION
## Summary
This subclasses the Django DiscoveryRunner and creates our tenant at database creation time, so it's already available for each test class. This means we don't have to run migrations for any tests that don't explicitly create a new tenant as part of the test. Should speed tests up some.