### PR TITLE
968 - download last report of month

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,6 @@ scripts/aws_pricing/
 # Editors
 .vscode/
 .idea/
+
+# Mac OSX
+.DS_Store

--- a/koku/masu/external/report_downloader.py
+++ b/koku/masu/external/report_downloader.py
@@ -97,7 +97,7 @@ class ReportDownloader:
 
         return None
 
-    def get_reports(self, number_of_months=1):
+    def get_reports(self, number_of_months=2):
         """
         Download cost usage reports.
 

--- a/koku/masu/processor/_tasks/download.py
+++ b/koku/masu/processor/_tasks/download.py
@@ -66,7 +66,7 @@ def _get_report_files(customer_name,
     if Config.INGEST_OVERRIDE or not reports_processed:
         number_of_months = Config.INITIAL_INGEST_NUM_MONTHS
     else:
-        number_of_months = 1
+        number_of_months = 2
 
     stmt = ('Downloading report for'
             ' credential: {},'

--- a/koku/masu/test/processor/test_tasks.py
+++ b/koku/masu/test/processor/test_tasks.py
@@ -187,6 +187,32 @@ class GetReportFileTests(MasuTestCase):
         Config.INGEST_OVERRIDE = False
         Config.INITIAL_INGEST_NUM_MONTHS = 2
 
+    @patch(
+        'masu.processor._tasks.download.ReportDownloader._set_downloader',
+        return_value=FakeDownloader,
+    )
+    @patch(
+        'masu.database.provider_db_accessor.ProviderDBAccessor.get_setup_complete',
+        return_value=True,
+    )
+    def test_get_report_without_override(self, fake_accessor, fake_report_files):
+        """Test _get_report_files for two months."""
+        initial_month_qty = 2
+
+        account = fake_arn(service='iam', generate_account_id=True)
+        with patch.object(ReportDownloader, 'get_reports') as download_call:
+            _get_report_files(
+                customer_name=self.fake.word(),
+                authentication=account,
+                provider_type='AWS',
+                report_name=self.fake.word(),
+                provider_uuid=self.aws_test_provider_uuid,
+                billing_source=self.fake.word(),
+            )
+
+            download_call.assert_called_with(initial_month_qty)
+
+
     @patch('masu.processor._tasks.download.ProviderStatus.set_error')
     @patch(
         'masu.processor._tasks.download.ReportDownloader._set_downloader',


### PR DESCRIPTION
AWS report downloader gets last update of the month

Testing
1. Created an AWS Provider
2. Set the setup_complete flag to True (This was so that only 1 month would be downloaded without this change)
3. Ran the masu `/download/` endpoint to trigger downloading and processing of the AWS provider
4. Confirmed that 2 months were downloaded and processed successfully