### PR TITLE
Revert "Let's run tests in parallel (#1008)"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -404,16 +404,13 @@ oc-up-db: oc-up oc-create-db
 docker-down:
 	docker-compose down
 
-docker-down-db:
-	docker-compose stop db
-
 docker-logs:
 	docker-compose logs -f
 
 docker-rabbit:
 	docker-compose up -d rabbit
 
-docker-reinitdb: docker-down-db remove-db docker-up-db
+docker-reinitdb: docker-down remove-db docker-up-db
 	sleep 5
 	$(MAKE) run-migrations
 	$(MAKE) create-test-customer

--- a/koku/koku/koku_test_runner.py
+++ b/koku/koku/koku_test_runner.py
@@ -18,9 +18,8 @@
 """Koku Test Runner."""
 import logging
 
-from django.db import connections
 from django.test.runner import DiscoverRunner
-from django.test.utils import get_unique_databases_and_mirrors
+from django.test.utils import setup_databases
 
 from api.models import Tenant
 
@@ -37,59 +36,10 @@ class KokuTestRunner(DiscoverRunner):
         """Set up database tenant schema."""
         main_db = setup_databases(
             self.verbosity, self.interactive, self.keepdb, self.debug_sql,
-            self.parallel, **kwargs
+            **kwargs
         )
 
+        tenant = Tenant.objects.get_or_create(schema_name=KokuTestRunner.schema)[0]
+        tenant.save()
+
         return main_db
-
-
-# Disable pylint to keep the Django function in tact as written
-# pylint: disable=C0301,R0913,R0914,R1704,W0613
-def setup_databases(verbosity, interactive, keepdb=False, debug_sql=False, parallel=0, aliases=None, **kwargs):
-    """Create the test databases.
-
-    This function is a copy of the Django setup_databases with one addition.
-    A Tenant object is created and saved when setting up the database.
-    """
-    test_databases, mirrored_aliases = get_unique_databases_and_mirrors(aliases)
-
-    old_names = []
-
-    for db_name, aliases in test_databases.values():
-        first_alias = None
-        for alias in aliases:
-            connection = connections[alias]
-            old_names.append((connection, db_name, first_alias is None))
-
-            # Actually create the database for the first connection
-            if first_alias is None:
-                first_alias = alias
-                connection.creation.create_test_db(
-                    verbosity=verbosity,
-                    autoclobber=not interactive,
-                    keepdb=keepdb,
-                    serialize=connection.settings_dict.get('TEST', {}).get('SERIALIZE', True),
-                )
-                tenant = Tenant.objects.get_or_create(schema_name=KokuTestRunner.schema)[0]
-                tenant.save()
-                if parallel > 1:
-                    for index in range(parallel):
-                        connection.creation.clone_test_db(
-                            suffix=str(index + 1),
-                            verbosity=verbosity,
-                            keepdb=keepdb,
-                        )
-            # Configure all other connections as mirrors of the first one
-            else:
-                connections[alias].creation.set_as_test_mirror(connections[first_alias].settings_dict)
-
-    # Configure the test mirrors.
-    for alias, mirror_alias in mirrored_aliases.items():
-        connections[alias].creation.set_as_test_mirror(
-            connections[mirror_alias].settings_dict)
-
-    if debug_sql:
-        for alias in connections:
-            connections[alias].force_debug_cursor = True
-
-    return old_names

--- a/tox.ini
+++ b/tox.ini
@@ -41,8 +41,7 @@ commands =
   /bin/sh {toxinidir}/scripts/check_postgres_running.sh
   /bin/sh {toxinidir}/scripts/create_test_db_user.sh
   pipenv install --dev --ignore-pipfile
-  coverage run --parallel-mode --concurrency=multiprocessing {toxinidir}/koku/manage.py test --noinput --parallel -v 2 {posargs: koku/}
-  coverage combine
+  coverage run {toxinidir}/koku/manage.py test --noinput -v 2 {posargs: koku/}
   coverage report --show-missing
 
 [testenv:masu]
@@ -64,7 +63,7 @@ commands =
   /bin/sh {toxinidir}/scripts/create_test_db_user.sh {env:DATABASE_USER} {env:DATABASE_ADMIN}
   pipenv run pip install pip==18.0
   pipenv install --dev  --ignore-pipfile
-  coverage run --parallel-mode --concurrency=multiprocessing {toxinidir}/koku/manage.py test --noinput --parallel -v 2 {posargs: koku/masu/}
+  coverage run {toxinidir}/koku/manage.py test -v 2 {posargs: koku/masu/}
   coverage report --show-missing
 
 [testenv:lint]
@@ -82,4 +81,4 @@ commands =
   flake8 koku
   pipenv install --dev --ignore-pipfile
   ; R0801 = Similar lines of code.
-  pylint -j 0 --ignore=test --disable=R0801 --load-plugins=pylint_django koku/koku koku/masu/database
+  pylint --ignore=test --disable=R0801 --load-plugins=pylint_django koku/koku koku/masu/database


### PR DESCRIPTION
This reverts commit 3005eebcdbd286e05ce8fdb65e9c961578f0d8fe.

After discussing with @blentz, I'm reverting this feature because when (some? all? only sometimes?) tests fail and parallel is enabled, the test runner crashes out without giving useful information. For example, a recent run:

```
TypeError: can't pickle traceback objects

ERROR: InvocationError for command /home/travis/build/project-koku/koku/.tox/py36/bin/coverage run --parallel-mode --concurrency=multiprocessing koku/manage.py test --noinput --parallel -v 2 koku/ (exited with code 1)
```

It might also be related to a seemingly random/intermittent error I saw that results in databases being dropped too early:

```
setUpClass (api.provider.test.tests_serializers.AdminProviderSerializerTest) failed:

    OperationalError('FATAL:  database "test_koku_test_1" does not

    exist\nDETAIL:  It seems to have just been dropped or renamed.\n',)
```