### PR TITLE
Set primary tox mode to serial, add parallel opt

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,7 @@ commands =
   coverage report --show-missing
 
 
-# The same tests as testens, just without parallel
+# The same tests as testenv, but run in parallel
 [testenv:parallel]
 passenv = CI TRAVIS TRAVIS_* LDFLAGS CPPFLAGS
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -41,6 +41,30 @@ commands =
   /bin/sh {toxinidir}/scripts/check_postgres_running.sh
   /bin/sh {toxinidir}/scripts/create_test_db_user.sh
   pipenv install --dev --ignore-pipfile
+  coverage run {toxinidir}/koku/manage.py test --noinput -v 2 {posargs: koku/}
+  coverage report --show-missing
+
+
+# The same tests as testens, just without parallel
+[testenv:parallel]
+passenv = CI TRAVIS TRAVIS_* LDFLAGS CPPFLAGS
+setenv =
+  DATABASE_SERVICE_NAME={env:DATABASE_SERVICE_NAME:POSTGRES_SQL}
+  DATABASE_ENGINE={env:DATABASE_ENGINE:postgresql}
+  DATABASE_NAME={env:DATABASE_NAME:koku_test}
+  POSTGRES_SQL_SERVICE_HOST={env:POSTGRES_SQL_SERVICE_HOST:localhost}
+  POSTGRES_SQL_SERVICE_PORT={env:POSTGRES_SQL_SERVICE_PORT:15432}
+  DATABASE_ADMIN={env:DATABASE_ADMIN:postgres}
+  DATABASE_USER=koku_tester
+  DATABASE_PASSWORD={env:DATABASE_PASSWORD:''}
+  prometheus_multiproc_dir=/tmp
+deps =
+  pipenv
+  codecov
+commands =
+  /bin/sh {toxinidir}/scripts/check_postgres_running.sh
+  /bin/sh {toxinidir}/scripts/create_test_db_user.sh
+  pipenv install --dev --ignore-pipfile
   coverage run --parallel-mode --concurrency=multiprocessing {toxinidir}/koku/manage.py test --noinput --parallel -v 2 {posargs: koku/}
   coverage combine
   coverage report --show-missing


### PR DESCRIPTION
## Summary
Instead of completely disabling the ability to run tests in parallel, let's just reset the primary tox run to be in serial.