### PR TITLE
removing ocp cost summary update from charge task

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -154,6 +154,7 @@ services:
         # - '~/aws_local_1:/tmp/local_bucket_1'
         # - '~/aws_local_2:/tmp/local_bucket_2'
         # - '~/aws_local_3:/tmp/local_bucket_3'
+        # - '~/aws_local_4:/tmp/local_bucket_4'
         # - '~/insights_local:/var/tmp/insights_local'
       links:
           - koku-rabbit

--- a/koku/masu/processor/ocp/ocp_report_charge_updater.py
+++ b/koku/masu/processor/ocp/ocp_report_charge_updater.py
@@ -275,11 +275,6 @@ class OCPReportChargeUpdater:
         self._update_storage_charge()
 
         with OCPReportDBAccessor(self._schema, self._column_map) as accessor:
-            LOG.info('Updating OpenShift on Cloud cost summary for schema: %s and provider: %s',
-                     self._schema, self._provider_uuid)
-            accessor.populate_cost_summary_table(self._cluster_id,
-                                                 start_date=start_date,
-                                                 end_date=end_date)
             report_periods = accessor.report_periods_for_provider_id(self._provider_id, start_date)
             with schema_context(self._schema):
                 for period in report_periods:

--- a/koku/masu/test/processor/ocp/test_ocp_report_charge_updater.py
+++ b/koku/masu/test/processor/ocp/test_ocp_report_charge_updater.py
@@ -594,7 +594,6 @@ class OCPReportChargeUpdaterTest(MasuTestCase):
 
         self.accessor.populate_line_item_daily_table(start_date, end_date, self.cluster_id)
         self.accessor.populate_line_item_daily_summary_table(start_date, end_date, self.cluster_id)
-        self.accessor.populate_cost_summary_table(self.cluster_id, start_date, end_date)
         self.updater.update_summary_charge_info()
 
         table_name = OCP_REPORT_TABLE_MAP['line_item_daily_summary']
@@ -632,7 +631,6 @@ class OCPReportChargeUpdaterTest(MasuTestCase):
 
         self.accessor.populate_line_item_daily_table(start_date, end_date, self.cluster_id)
         self.accessor.populate_line_item_daily_summary_table(start_date, end_date, self.cluster_id)
-        self.accessor.populate_cost_summary_table(self.cluster_id, start_date, end_date)
         self.updater.update_summary_charge_info()
 
         table_name = OCP_REPORT_TABLE_MAP['line_item_daily_summary']
@@ -664,7 +662,6 @@ class OCPReportChargeUpdaterTest(MasuTestCase):
 
         self.accessor.populate_line_item_daily_table(start_date, end_date, self.cluster_id)
         self.accessor.populate_line_item_daily_summary_table(start_date, end_date, self.cluster_id)
-        self.accessor.populate_cost_summary_table(self.cluster_id, start_date, end_date)
         self.updater.update_summary_charge_info()
 
         table_name = OCP_REPORT_TABLE_MAP['line_item_daily_summary']
@@ -699,7 +696,6 @@ class OCPReportChargeUpdaterTest(MasuTestCase):
         self.accessor.populate_line_item_daily_summary_table(start_date, end_date, self.cluster_id)
         self.accessor.populate_storage_line_item_daily_table(start_date, end_date, self.cluster_id)
         self.accessor.populate_storage_line_item_daily_summary_table(start_date, end_date, self.cluster_id)
-        self.accessor.populate_cost_summary_table(self.cluster_id, start_date, end_date)
         self.updater.update_summary_charge_info()
 
         table_name = OCP_REPORT_TABLE_MAP['storage_line_item_daily_summary']
@@ -763,7 +759,6 @@ class OCPReportChargeUpdaterTest(MasuTestCase):
 
         self.accessor.populate_line_item_daily_table(start_date, end_date, self.cluster_id)
         self.accessor.populate_line_item_daily_summary_table(start_date, end_date, self.cluster_id)
-        self.accessor.populate_cost_summary_table(self.cluster_id, start_date, end_date)
         self.updater.update_summary_charge_info()
 
         table_name = OCP_REPORT_TABLE_MAP['line_item_daily_summary']
@@ -823,7 +818,6 @@ class OCPReportChargeUpdaterTest(MasuTestCase):
 
         self.accessor.populate_line_item_daily_table(start_date, end_date, self.cluster_id)
         self.accessor.populate_line_item_daily_summary_table(start_date, end_date, self.cluster_id)
-        self.accessor.populate_cost_summary_table(self.cluster_id, start_date, end_date)
         self.updater.update_summary_charge_info()
 
         table_name = OCP_REPORT_TABLE_MAP['line_item_daily_summary']
@@ -852,7 +846,6 @@ class OCPReportChargeUpdaterTest(MasuTestCase):
 
         self.accessor.populate_line_item_daily_table(start_date, end_date, self.cluster_id)
         self.accessor.populate_line_item_daily_summary_table(start_date, end_date, self.cluster_id)
-        self.accessor.populate_cost_summary_table(self.cluster_id, start_date, end_date)
         self.updater.update_summary_charge_info()
 
         with OCPReportDBAccessor(schema='acct10001', column_map=self.column_map) as accessor:


### PR DESCRIPTION
With #1004 it is no longer necessary to update OCP cost table at the end of OCP Charge Updater

*Testing*
Ran all QE API tests