### PR TITLE
cost model provider uuids type changed to string in openapi.json

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -2056,7 +2056,7 @@
                       "provider_uuids": {
                         "type": "array",
                         "items": {
-                          "type": "integer"
+                          "type": "string"
                         }
                       },
                       "rates": {


### PR DESCRIPTION
fixes #1053