### PR TITLE
Mount the ssl cert on the scheduler

### DIFF
--- a/openshift/celery-scheduler.yaml
+++ b/openshift/celery-scheduler.yaml
@@ -47,6 +47,10 @@ objects:
         containers:
         - name: ${NAME}-scheduler
           image: ${NAME}-scheduler
+          volumeMounts:
+          - name: ssl-cert
+            mountPath: /etc/ssl/certs
+            readOnly: true
           command:
             - /bin/bash
             - -c


### PR DESCRIPTION
## Summary
The celery scheduler needs this file mounted to work in production. 