### PR TITLE
fix docker-down-db failing if the container has already been removed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -406,7 +406,7 @@ docker-down:
 
 docker-down-db:
 	docker-compose stop db
-	docker container rm $(shell docker ps -a -f name=koku_db -q)
+	docker ps -a -f name=koku_db -q | xargs docker container rm
 
 docker-logs:
 	docker-compose logs -f


### PR DESCRIPTION
Previously, this would fail and cause any make targets that depend on it to fail if the koku_db container didn't already exist.