### PR TITLE
finish implementing RBAC for Azure.

### DIFF
--- a/koku/api/common/permissions/azure_access.py
+++ b/koku/api/common/permissions/azure_access.py
@@ -22,7 +22,7 @@ from rest_framework import permissions
 class AzureAccessPermission(permissions.BasePermission):
     """Determines if a user can view Azure data."""
 
-    resource_type = 'azure.account'
+    resource_type = 'azure.subscription_guid'
 
     def has_permission(self, request, view):
         """Check permission to view Azure data."""

--- a/koku/api/common/permissions/test/tests_azure_access.py
+++ b/koku/api/common/permissions/test/tests_azure_access.py
@@ -45,7 +45,7 @@ class AzureAccessPermissionTest(TestCase):
 
     def test_has_perm_with_access_on_get(self):
         """Test that a user with access can execute."""
-        access = {'azure.account': {'read': ['*']}}
+        access = {'azure.subscription_guid': {'read': ['*']}}
         user = Mock(spec=User, access=access, admin=False)
         req = Mock(user=user, method='GET')
         access_perm = AzureAccessPermission()
@@ -54,7 +54,7 @@ class AzureAccessPermissionTest(TestCase):
 
     def test_has_perm_with_access_on_put(self):
         """Test that a user with access can execute."""
-        access = {'azure.account': {'read': ['*']}}
+        access = {'azure.subscription_guid': {'read': ['*']}}
         user = Mock(spec=User, access=access, admin=False)
         req = Mock(user=user, method='PUT')
         access_perm = AzureAccessPermission()

--- a/koku/api/query_handler.py
+++ b/koku/api/query_handler.py
@@ -194,7 +194,9 @@ class QueryHandler:
         if self.resolution:
             return self.resolution
 
-        self.resolution = self.get_query_param_data('filter', 'resolution')
+        self.resolution = self.get_query_param_data('filter',
+                                                    'resolution',
+                                                    default='daily')
 
         if self.resolution == 'monthly':
             self.date_to_string = lambda dt: dt.strftime('%Y-%m')
@@ -248,8 +250,9 @@ class QueryHandler:
         if self.time_scope_units:
             return self.time_scope_units
 
-        time_scope_units = self.get_query_param_data('filter', 'time_scope_units')
-
+        time_scope_units = self.get_query_param_data('filter',
+                                                     'time_scope_units',
+                                                     default='day')
         self.time_scope_units = time_scope_units
         return self.time_scope_units
 
@@ -263,8 +266,9 @@ class QueryHandler:
         if self.time_scope_value:
             return self.time_scope_value
 
-        time_scope_value = self.get_query_param_data('filter', 'time_scope_value')
-
+        time_scope_value = self.get_query_param_data('filter',
+                                                     'time_scope_value',
+                                                     default=-10)
         self.time_scope_value = int(time_scope_value)
         return self.time_scope_value
 

--- a/koku/api/report/access_utils.py
+++ b/koku/api/report/access_utils.py
@@ -68,6 +68,11 @@ def update_query_parameters_for_aws(query_parameters, access):
     return _update_query_parameters(query_parameters, 'account', access, 'aws.account')
 
 
+def update_query_parameters_for_azure(query_parameters, access):
+    """Alter query parameters based on user access."""
+    return _update_query_parameters(query_parameters, 'account', access, 'azure.subscription_guid')
+
+
 def update_query_parameters_for_openshift(query_parameters, access):
     """Alter query parameters based on user access."""
     query_parameters = _update_query_parameters(query_parameters, 'cluster',

--- a/koku/api/report/access_utils.py
+++ b/koku/api/report/access_utils.py
@@ -70,7 +70,7 @@ def update_query_parameters_for_aws(query_parameters, access):
 
 def update_query_parameters_for_azure(query_parameters, access):
     """Alter query parameters based on user access."""
-    return _update_query_parameters(query_parameters, 'account', access, 'azure.subscription_guid')
+    return _update_query_parameters(query_parameters, 'subscription_guid', access, 'azure.subscription_guid')
 
 
 def update_query_parameters_for_openshift(query_parameters, access):

--- a/koku/api/report/azure/query_handler.py
+++ b/koku/api/report/azure/query_handler.py
@@ -22,6 +22,7 @@ from django.db.models import (F, Value, Window)
 from django.db.models.functions import Coalesce, Concat, RowNumber
 from tenant_schemas.utils import tenant_context
 
+from api.report.access_utils import update_query_parameters_for_azure
 from api.report.azure.provider_map import AzureProviderMap
 from api.report.queries import ReportQueryHandler
 
@@ -45,6 +46,10 @@ class AzureReportQueryHandler(ReportQueryHandler):
         provider = 'AZURE'
 
         self._initialize_kwargs(kwargs)
+
+        if kwargs.get('access'):
+            query_parameters = update_query_parameters_for_azure(query_parameters,
+                                                                 kwargs.get('access'))
 
         # do not override mapper if its already set
         try:

--- a/koku/api/report/test/azure/tests_azure_query_handler.py
+++ b/koku/api/report/test/azure/tests_azure_query_handler.py
@@ -18,6 +18,7 @@
 
 import random
 from decimal import Decimal, ROUND_HALF_UP
+from unittest.mock import patch
 from urllib.parse import quote_plus
 from uuid import UUID
 
@@ -1378,3 +1379,10 @@ class AzureReportQueryHandlerTest(IamTestCase):
         for key in totals:
             result = data_totals.get(key, {}).get('value')
             self.assertEqual(result, totals[key])
+
+    @patch('api.report.azure.query_handler.update_query_parameters_for_azure')
+    def test_access_param(self, mocked):
+        """Test that query params are updated when access param is present."""
+        AzureReportQueryHandler({}, '', self.tenant, report_type='costs',
+                                access='my fake access')
+        mocked.assert_called()

--- a/koku/api/report/test/tests_access_utils.py
+++ b/koku/api/report/test/tests_access_utils.py
@@ -15,10 +15,13 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 """Test the AWS Query Handler."""
+from uuid import uuid4
+
 from django.core.exceptions import PermissionDenied
 from django.test import TestCase
 
 from api.report.access_utils import (update_query_parameters_for_aws,
+                                     update_query_parameters_for_azure,
                                      update_query_parameters_for_openshift)
 
 
@@ -112,6 +115,107 @@ class AwsAccessUtilsTest(TestCase):
         out = update_query_parameters_for_aws(query_parameters, access)
         expected = {
             'filter': {'account': ['account1'], 'region': ['*']}
+        }
+        self.assertEqual(expected, out)
+
+
+class AzureAccessUtilsTest(TestCase):
+    """Test the azure access utils functions."""
+
+    def setUp(self):
+        super().setUp()
+        self.guid1 = uuid4()
+        self.guid2 = uuid4()
+        self.guid3 = uuid4()
+        self.guid4 = uuid4()
+
+    def test_update_query_parameters_with_wildcard(self):
+        """Test wildcard doesn't update query parameters."""
+        query_parameters = {
+            'group_by': {'subscription_guid': ['*'], 'resource_location': ['*']}
+        }
+        access = {
+            'azure.subscription_guid': {'read': ['*']}
+        }
+        out = update_query_parameters_for_azure(query_parameters, access)
+        self.assertEqual(query_parameters, out)
+
+    def test_update_query_parameters_replace_wildcard(self):
+        """Test that a group by subscription_guid wildcard is replaced with only the subset of subscription_guids."""
+        query_parameters = {
+            'group_by': {'subscription_guid': ['*'], 'resource_location': ['*']}
+        }
+        access = {
+            'azure.subscription_guid': {'read': [self.guid1, self.guid2]}
+        }
+        out = update_query_parameters_for_azure(query_parameters, access)
+        expected = {
+            'group_by': {'subscription_guid': [self.guid1, self.guid2], 'resource_location': ['*']}
+        }
+        self.assertEqual(expected, out)
+
+    def test_update_query_parameters_gb_filtered_intersection(self):
+        """Test that a group by subscription_guid filtered list is replaced with only the intersection of subscription_guids."""
+        query_parameters = {
+            'group_by': {'subscription_guid': [self.guid1, self.guid2], 'resource_location': ['*']}
+        }
+        access = {
+            'azure.subscription_guid': {'read': [self.guid1, self.guid3]}
+        }
+        out = update_query_parameters_for_azure(query_parameters, access)
+        expected = {
+            'group_by': {'subscription_guid': [self.guid1], 'resource_location': ['*']}
+        }
+        self.assertEqual(expected, out)
+
+    def test_update_query_parameters_empty_intersection(self):
+        """Test that a group by subscription_guid filtered list causes 403 when empty intersection of subscription_guids."""
+        query_parameters = {
+            'group_by': {'subscription_guid': [self.guid1, self.guid3], 'resource_location': ['*']}
+        }
+        access = {
+            'azure.subscription_guid': {'read': [self.guid2, self.guid4]}
+        }
+        with self.assertRaises(PermissionDenied):
+            update_query_parameters_for_azure(query_parameters, access)
+
+    def test_update_query_parameters_add_subscription_guid_filter(self):
+        """Test that if no group_by or filter is present a filter of subscription_guids is added."""
+        query_parameters = {
+            'filter': {'resource_location': ['*']}
+        }
+        access = {
+            'azure.subscription_guid': {'read': [self.guid1, self.guid2]}
+        }
+        out = update_query_parameters_for_azure(query_parameters, access)
+        expected = {
+            'filter': {'subscription_guid': [self.guid1, self.guid2], 'resource_location': ['*']}
+        }
+        self.assertEqual(expected, out)
+
+    def test_update_query_parameters_add_subscription_guid_filter_obj(self):
+        """Test that if no group_by or filter is present a filter of subscription_guids is added."""
+        query_parameters = {}
+        access = {
+            'azure.subscription_guid': {'read': [self.guid1, self.guid2]}
+        }
+        out = update_query_parameters_for_azure(query_parameters, access)
+        expected = {
+            'filter': {'subscription_guid': [self.guid1, self.guid2]}
+        }
+        self.assertEqual(expected, out)
+
+    def test_update_query_parameters_filtered_intersection(self):
+        """Test that a filter by subscription_guid filtered list is replaced with only the intersection of subscription_guids."""
+        query_parameters = {
+            'filter': {'subscription_guid': [self.guid1, self.guid2], 'resource_location': ['*']}
+        }
+        access = {
+            'azure.subscription_guid': {'read': [self.guid1, self.guid3]}
+        }
+        out = update_query_parameters_for_azure(query_parameters, access)
+        expected = {
+            'filter': {'subscription_guid': [self.guid1], 'resource_location': ['*']}
         }
         self.assertEqual(expected, out)
 

--- a/koku/api/report/test/tests_access_utils.py
+++ b/koku/api/report/test/tests_access_utils.py
@@ -123,6 +123,7 @@ class AzureAccessUtilsTest(TestCase):
     """Test the azure access utils functions."""
 
     def setUp(self):
+        """Test setup."""
         super().setUp()
         self.guid1 = uuid4()
         self.guid2 = uuid4()
@@ -141,7 +142,7 @@ class AzureAccessUtilsTest(TestCase):
         self.assertEqual(query_parameters, out)
 
     def test_update_query_parameters_replace_wildcard(self):
-        """Test that a group by subscription_guid wildcard is replaced with only the subset of subscription_guids."""
+        """Test that a group by guid wildcard is replaced with only the subset of guids."""
         query_parameters = {
             'group_by': {'subscription_guid': ['*'], 'resource_location': ['*']}
         }
@@ -155,7 +156,7 @@ class AzureAccessUtilsTest(TestCase):
         self.assertEqual(expected, out)
 
     def test_update_query_parameters_gb_filtered_intersection(self):
-        """Test that a group by subscription_guid filtered list is replaced with only the intersection of subscription_guids."""
+        """Test that a group by guid filtered list is replaced with only intersection of guids."""
         query_parameters = {
             'group_by': {'subscription_guid': [self.guid1, self.guid2], 'resource_location': ['*']}
         }
@@ -169,7 +170,7 @@ class AzureAccessUtilsTest(TestCase):
         self.assertEqual(expected, out)
 
     def test_update_query_parameters_empty_intersection(self):
-        """Test that a group by subscription_guid filtered list causes 403 when empty intersection of subscription_guids."""
+        """Test that a group by guid filtered list causes 403 when empty intersection of guids."""
         query_parameters = {
             'group_by': {'subscription_guid': [self.guid1, self.guid3], 'resource_location': ['*']}
         }
@@ -206,7 +207,7 @@ class AzureAccessUtilsTest(TestCase):
         self.assertEqual(expected, out)
 
     def test_update_query_parameters_filtered_intersection(self):
-        """Test that a filter by subscription_guid filtered list is replaced with only the intersection of subscription_guids."""
+        """Test that a filter by guid filtered list is replaced with only intersection of guids."""
         query_parameters = {
             'filter': {'subscription_guid': [self.guid1, self.guid2], 'resource_location': ['*']}
         }

--- a/koku/koku/rbac.py
+++ b/koku/koku/rbac.py
@@ -31,6 +31,7 @@ PORT = 'port'
 PATH = 'path'
 RESOURCE_TYPES = {
     'aws.account': ['read'],
+    'azure.subscription_guid': ['read'],
     'openshift.cluster': ['read'],
     'openshift.node': ['read'],
     'openshift.project': ['read'],

--- a/koku/koku/tests_rbac.py
+++ b/koku/koku/tests_rbac.py
@@ -363,7 +363,7 @@ class RbacServiceTest(TestCase):
             'provider': rw_access,
             'rate': rw_access,
             'aws.account': op_access,
-            'azure.subscription_guid': op_access,
+            'azure.subscription_guid': no_access,
             'openshift.cluster': no_access,
             'openshift.node': no_access,
             'openshift.project': no_access

--- a/koku/koku/tests_rbac.py
+++ b/koku/koku/tests_rbac.py
@@ -288,6 +288,7 @@ class RbacServiceTest(TestCase):
             'provider': rw_access,
             'rate': rw_access,
             'aws.account': read_access,
+            'azure.subscription_guid': read_access,
             'openshift.cluster': read_access,
             'openshift.node': read_access,
             'openshift.project': read_access

--- a/koku/koku/tests_rbac.py
+++ b/koku/koku/tests_rbac.py
@@ -249,6 +249,7 @@ class RbacServiceTest(TestCase):
             'provider': rw_access,
             'rate': rw_access,
             'aws.account': read_access,
+            'azure.subscription_guid': read_access,
             'openshift.cluster': read_access,
             'openshift.node': read_access,
             'openshift.project': read_access
@@ -265,6 +266,7 @@ class RbacServiceTest(TestCase):
             'provider': rw_access,
             'rate': rw_access,
             'aws.account': read_access,
+            'azure.subscription_guid': read_access,
             'openshift.cluster': read_access,
             'openshift.node': read_access,
             'openshift.project': read_access
@@ -311,6 +313,7 @@ class RbacServiceTest(TestCase):
             'provider': rw_access,
             'rate': rw_access,
             'aws.account': read_access,
+            'azure.subscription_guid': read_access,
             'openshift.cluster': read_access,
             'openshift.node': read_access,
             'openshift.project': read_access
@@ -337,6 +340,7 @@ class RbacServiceTest(TestCase):
             'provider': op_access,
             'rate': no_rw_access,
             'aws.account': no_access,
+            'azure.subscription_guid': no_access,
             'openshift.cluster': no_access,
             'openshift.node': no_access,
             'openshift.project': no_access
@@ -358,6 +362,7 @@ class RbacServiceTest(TestCase):
             'provider': rw_access,
             'rate': rw_access,
             'aws.account': op_access,
+            'azure.subscription_guid': op_access,
             'openshift.cluster': no_access,
             'openshift.node': no_access,
             'openshift.project': no_access
@@ -385,6 +390,7 @@ class RbacServiceTest(TestCase):
             'provider': {'write': [], 'read': []},
             'rate': {'write': [], 'read': []},
             'aws.account': {'read': ['123456']},
+            'azure.subscription_guid': {'read': []},
             'openshift.cluster': {'read': []},
             'openshift.node': {'read': []},
             'openshift.project': {'read': []}


### PR DESCRIPTION
This finishes off the RBAC implementation for Azure. fixes #1110 