### PR TITLE
add site caching settings

### DIFF
--- a/koku/koku/settings.py
+++ b/koku/koku/settings.py
@@ -113,13 +113,18 @@ MIDDLEWARE = [
     'corsheaders.middleware.CorsMiddleware',
     'koku.middleware.DisableCSRF',
     'django.middleware.security.SecurityMiddleware',
+    'django.middleware.cache.UpdateCacheMiddleware',
     'django.middleware.common.CommonMiddleware',
+    'django.middleware.cache.FetchFromCacheMiddleware',
     'koku.middleware.IdentityHeaderMiddleware',
     'koku.middleware.KokuTenantMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'django_prometheus.middleware.PrometheusAfterMiddleware',
 ]
+
+CACHE_MIDDLEWARE_ALIAS = 'default'
+CACHE_MIDDLEWARE_SECONDS = ENVIRONMENT.get_value('CACHE_TIMEOUT', default=3600)
 
 DEVELOPMENT = ENVIRONMENT.bool('DEVELOPMENT', default=False)
 if DEVELOPMENT:
@@ -176,7 +181,8 @@ else:
             "LOCATION": "redis://{}:{}/1".format(REDIS_HOST, REDIS_PORT),
             "OPTIONS": {
                 "CLIENT_CLASS": "django_redis.client.DefaultClient",
-                "IGNORE_EXCEPTIONS": True
+                "IGNORE_EXCEPTIONS": True,
+                "MAX_ENTRIES": 1000,
             },
         },
         "rbac": {
@@ -184,7 +190,8 @@ else:
             "LOCATION": "redis://{}:{}/1".format(REDIS_HOST, REDIS_PORT),
             "OPTIONS": {
                 "CLIENT_CLASS": "django_redis.client.DefaultClient",
-                "IGNORE_EXCEPTIONS": True
+                "IGNORE_EXCEPTIONS": True,
+                "MAX_ENTRIES": 1000,
             },
         }
     }

--- a/koku/koku/settings.py
+++ b/koku/koku/settings.py
@@ -108,20 +108,29 @@ TENANT_APPS = (
 
 DEFAULT_FILE_STORAGE = 'tenant_schemas.storage.TenantFileSystemStorage'
 
+### Middleware setup
 MIDDLEWARE = [
     'django_prometheus.middleware.PrometheusBeforeMiddleware',
     'corsheaders.middleware.CorsMiddleware',
     'koku.middleware.DisableCSRF',
     'django.middleware.security.SecurityMiddleware',
-    'django.middleware.cache.UpdateCacheMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    'django.middleware.cache.FetchFromCacheMiddleware',
+]
+if 'test' in sys.argv:
+    MIDDLEWARE.append('django.middleware.common.CommonMiddleware')
+else:
+    MIDDLEWARE.extend([
+        'django.middleware.cache.UpdateCacheMiddleware',
+        'django.middleware.common.CommonMiddleware',
+        'django.middleware.cache.FetchFromCacheMiddleware',
+    ])
+MIDDLEWARE.extend([
     'koku.middleware.IdentityHeaderMiddleware',
     'koku.middleware.KokuTenantMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'django_prometheus.middleware.PrometheusAfterMiddleware',
-]
+])
+### End Middleware
 
 CACHE_MIDDLEWARE_ALIAS = 'default'
 CACHE_MIDDLEWARE_SECONDS = ENVIRONMENT.get_value('CACHE_TIMEOUT', default=3600)
@@ -391,7 +400,7 @@ CORS_ALLOW_HEADERS = default_headers + (
 APPEND_SLASH = False
 
 # disable log messages less than CRITICAL when running unit tests.
-if len(sys.argv) > 1 and sys.argv[1] == 'test':
+if len(sys.argv) > 1 and sys.argv[1] == 'test' and not DEBUG:
     logging.disable(logging.CRITICAL)
 
 # Masu API Endpoints


### PR DESCRIPTION
This addresses #1049 

This adds site-wide caching using Django's built-in caching framework and our pre-existing Redis configuration. (See: https://docs.djangoproject.com/en/2.2/topics/cache/ )

I kept the configuration fairly simple to start with. If we need more granularity in what we cache, we can modify the configuration in the future.

Query times for the initial uncached response:
```
real	0m0.683s
user	0m0.070s
sys	0m0.023s
```
Query times for the cached response:
```
real	0m0.074s
user	0m0.057s
sys	0m0.018s
```
The redis server's view of two GET requests for the same URL:
```
 blentz▌~▌$ oc rsh $(oc-pod-lookup koku-redis)
$ redis-cli
127.0.0.1:6379> dbsize
(integer) 0
127.0.0.1:6379> monitor
OK
1568832764.651807 [1 172.17.0.5:50334] "GET" ":1:views.decorators.cache.cache_header..43a6fefee13975e3608d99992f1863f2.en-us.UTC"
1568832765.050780 [1 172.17.0.5:50334] "GET" ":1:5fe8762a-add0-4a2b-a7f5-0f53c19c750b"
1568832765.051103 [1 172.17.0.5:50334] "SET" ":1:5fe8762a-add0-4a2b-a7f5-0f53c19c750b" "\x80\x04\x95\x02\x00\x00\x00\x00\x00\x00\x00N." "PX" "30000"
1568832766.152537 [1 172.17.0.5:50334] "SET" ":1:views.decorators.cache.cache_header..43a6fefee13975e3608d99992f1863f2.en-us.UTC" "\x80\x04\x95\x12\x00\x00\x00\x00\x00\x00\x00]\x94\x8c\x0bHTTP_ACCEPT\x94a." "PX" "3600000"
1568832766.153033 [1 172.17.0.5:50334] "SET" ":1:views.decorators.cache.cache_page..GET.43a6fefee13975e3608d99992f1863f2.65330eb47d0175f264fdb29633829c0b.en-us.UTC" "\x80\x04\x95/\b\x00\x00\x00\x00\x00\x00\x8c\x17rest_framework.response\x94\x8c\bResponse\x94\x93\x94)\x81\x94}\x94(\x8c\x05using\x94N\x8c\b_request\x94N\x8c\b_headers\x94}\x94(\x8c\x0ccontent-type\x94\x8c\x0cContent-Type\x94\x8c\x10application/json\x94\x86\x94\x8c\x04vary\x94\x8c\x04Vary\x94\x8c\x06Accept\x94\x86\x94\x8c\x05allow\x94\x8c\x05Allow\x94\x8c\x12GET, HEAD, OPTIONS\x94\x86\x94\x8c\x0fx-frame-options\x94\x8c\x0fX-Frame-Options\x94\x8c\nSAMEORIGIN\x94\x86\x94\x8c\x0econtent-length\x94\x8c\x0eContent-Length\x94\x8c\x03730\x94\x86\x94\x8c\aexpires\x94\x8c\aExpires\x94\x8c\x1dWed, 18 Sep 2019 19:52:46 GMT\x94\x86\x94\x8c\rcache-control\x94\x8c\rCache-Control\x94\x8c\x0cmax-age=3600\x94\x86\x94u\x8c\x11_closable_objects\x94]\x94\x8c\x0e_handler_class\x94N\x8c\acookies\x94\x8c\x0chttp.cookies\x94\x8c\x0cSimpleCookie\x94\x93\x94)\x81\x94\x8c\x06closed\x94\x89\x8c\x0e_reason_phrase\x94N\x8c\b_charset\x94N\x8c\n_container\x94]\x94B\xda\x02\x00\x00{\"meta\":{\"count\":10,\"limit\":2,\"delta\":{\"value\":0.0,\"percent\":null},\"filter\":{\"instance_type\":[\"Standard_A0\"],\"time_scope_value\":\"-10\",\"time_scope_units\":\"day\",\"resolution\":\"daily\"},\"total\":{\"infrastructure_cost\":{\"value\":0,\"units\":\"USD\"},\"derived_cost\":{\"value\":0,\"units\":\"USD\"},\"cost\":{\"value\":0,\"units\":\"USD\"}}},\"links\":{\"first\":\"/api/v1/reports/azure/costs/?delta=cost&filter%5Binstance_type%5D=Standard_A0&limit=2&offset=0\",\"next\":\"/api/v1/reports/azure/costs/?delta=cost&filter%5Binstance_type%5D=Standard_A0&limit=2&offset=2\",\"previous\":null,\"last\":\"/api/v1/reports/azure/costs/?delta=cost&filter%5Binstance_type%5D=Standard_A0&limit=2&offset=8\"},\"data\":[{\"date\":\"2019-09-09\",\"values\":[]},{\"date\":\"2019-09-10\",\"values\":[]}]}\x94a\x8c\x0c_is_rendered\x94\x88\x8c\x04data\x94}\x94(\x8c\x04meta\x94}\x94(\x8c\x05count\x94K\n\x8c\x05limit\x94K\x02\x8c\x05delta\x94}\x94(\x8c\x05value\x94\x8c\adecimal\x94\x8c\aDecimal\x94\x93\x94\x8c\x010\x94\x85\x94R\x94\x8c\apercent\x94Nu\x8c\x06filter\x94\x8c\x0bcollections\x94\x8c\x0bOrderedDict\x94\x93\x94)R\x94(\x8c\rinstance_type\x94]\x94\x8c\x0bStandard_A0\x94a\x8c\x10time_scope_value\x94\x8c\x03-10\x94\x8c\x10time_scope_units\x94\x8c\x03day\x94\x8c\nresolution\x94\x8c\x05daily\x94u\x8c\x05total\x94}\x94(\x8c\x13infrastructure_cost\x94}\x94(h<K\x00\x8c\x05units\x94\x8c\x03USD\x94u\x8c\x0cderived_cost\x94}\x94(h<K\x00hVhWu\x8c\x04cost\x94}\x94(h<K\x00hVhWuuu\x8c\x05links\x94}\x94(\x8c\x05first\x94\x8c^/api/v1/reports/azure/costs/?delta=cost&filter%5Binstance_type%5D=Standard_A0&limit=2&offset=0\x94\x8c\x04next\x94\x8c^/api/v1/reports/azure/costs/?delta=cost&filter%5Binstance_type%5D=Standard_A0&limit=2&offset=2\x94\x8c\bprevious\x94N\x8c\x04last\x94\x8c^/api/v1/reports/azure/costs/?delta=cost&filter%5Binstance_type%5D=Standard_A0&limit=2&offset=8\x94uh4]\x94(}\x94(\x8c\x04date\x94\x8c\n2019-09-09\x94\x8c\x06values\x94]\x94u}\x94(hg\x8c\n2019-09-10\x94hi]\x94ueu\x8c\texception\x94\x89\x8c\x0ccontent_type\x94N\x8c\x13accepted_media_type\x94h\x0bub." "PX" "3600000"
1568832767.083460 [1 172.17.0.5:50244] "GET" ":1:views.decorators.cache.cache_header..17859deb3b688dab7a9582798b3554c5.en-us.UTC"
1568832767.085380 [1 172.17.0.5:50244] "GET" ":1:views.decorators.cache.cache_page..GET.17859deb3b688dab7a9582798b3554c5.d41d8cd98f00b204e9800998ecf8427e.en-us.UTC"
1568832770.808343 [1 172.17.0.5:50334] "GET" ":1:views.decorators.cache.cache_header..17859deb3b688dab7a9582798b3554c5.en-us.UTC"
1568832770.808727 [1 172.17.0.5:50334] "GET" ":1:views.decorators.cache.cache_page..GET.17859deb3b688dab7a9582798b3554c5.d41d8cd98f00b204e9800998ecf8427e.en-us.UTC"
1568832774.168945 [1 172.17.0.5:50244] "GET" ":1:views.decorators.cache.cache_header..43a6fefee13975e3608d99992f1863f2.en-us.UTC"
1568832774.169539 [1 172.17.0.5:50244] "GET" ":1:views.decorators.cache.cache_page..GET.43a6fefee13975e3608d99992f1863f2.65330eb47d0175f264fdb29633829c0b.en-us.UTC"
1568832777.080483 [1 172.17.0.5:50244] "GET" ":1:views.decorators.cache.cache_header..17859deb3b688dab7a9582798b3554c5.en-us.UTC"
1568832777.080764 [1 172.17.0.5:50244] "GET" ":1:views.decorators.cache.cache_page..GET.17859deb3b688dab7a9582798b3554c5.d41d8cd98f00b204e9800998ecf8427e.en-us.UTC"
1568832780.815636 [1 172.17.0.5:50334] "GET" ":1:views.decorators.cache.cache_header..17859deb3b688dab7a9582798b3554c5.en-us.UTC"
1568832780.816968 [1 172.17.0.5:50334] "GET" ":1:views.decorators.cache.cache_page..GET.17859deb3b688dab7a9582798b3554c5.d41d8cd98f00b204e9800998ecf8427e.en-us.UTC"
^C
```