### PR TITLE
removed required fields from authentication and billing source inputs

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -2457,10 +2457,6 @@
                 }
             },
             "ProviderAuthenticationIn": {
-                "required": [
-                    "provider_resource_name",
-                    "credentials"
-                ],
                 "properties": {
                     "provider_resource_name": {
                         "type": "string",
@@ -2478,10 +2474,6 @@
                 }
             },
             "ProviderBillingSourceIn": {
-                "required": [
-                    "bucket",
-                    "data_source"
-                ],
                 "properties": {
                     "bucket": {
                         "type": "string",


### PR DESCRIPTION
Declaring both `provider_resource_name` and `credentials` (or `bucket` and `data_source`) as required makes the autogenerated client raise exceptions on adding an AZURE provider. (We don't use `provider_resource_name` or `bucket` when doing so)

I was looking for a solution to make one of the fields required in the spec, but it looks like there's no way to do so (correct me if I'm wrong)

This PR will make the client work with all types of providers.