### PR TITLE
configure cache-control headers for all views.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ DJANGO_MANAGE = DJANGO_READ_DOT_ENV_FILE=True $(PYTHON) $(PYDIR)/manage.py
 # required OpenShift template parameters
 # if a value is defined in a parameter file, we try to use that.
 # otherwise, we use a default value
-NAME = $(or $(shell grep -h '^[^\#]*NAME=' openshift/parameters/* 2>/dev/null | uniq | awk -F= '{print $$2}'), koku)
+NAME = $(or $(shell grep -h '^NAME=' openshift/parameters/* 2>/dev/null | uniq | awk -F= '{print $$2}'), koku)
 NAMESPACE = $(or $(shell grep -h '^[^\#]*NAMESPACE=' openshift/parameters/* 2>/dev/null | uniq | awk -F= '{print $$2}'), koku)
 
 OC_TEMPLATE_DIR = $(TOPDIR)/openshift

--- a/koku/api/iam/view/user_preference.py
+++ b/koku/api/iam/view/user_preference.py
@@ -24,8 +24,8 @@ from rest_framework.permissions import AllowAny
 
 import api.iam.models as models
 import api.iam.serializers as serializers
-from api.common.permissions.object_owner import IsObjectOwner
 from api.common import RH_IDENTITY_HEADER
+from api.common.permissions.object_owner import IsObjectOwner
 
 
 class UserPreferenceViewSet(mixins.CreateModelMixin,

--- a/koku/api/iam/view/user_preference.py
+++ b/koku/api/iam/view/user_preference.py
@@ -16,15 +16,13 @@
 #
 
 """View for User Preferences."""
-from django.views.decorators.cache import cache_control, never_cache
-from django.views.decorators.vary import vary_on_headers
+from django.views.decorators.cache import never_cache
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import exceptions, mixins, viewsets
 from rest_framework.permissions import AllowAny
 
 import api.iam.models as models
 import api.iam.serializers as serializers
-from api.common import RH_IDENTITY_HEADER
 from api.common.permissions.object_owner import IsObjectOwner
 
 
@@ -119,8 +117,7 @@ class UserPreferenceViewSet(mixins.CreateModelMixin,
 
         return super().create(request=request, args=args, kwargs=kwargs)
 
-    @cache_control(private=True)
-    @vary_on_headers(RH_IDENTITY_HEADER)
+    @never_cache
     def list(self, request, *args, **kwargs):
         """Obtain the list of preferences for the user.
 
@@ -176,8 +173,7 @@ class UserPreferenceViewSet(mixins.CreateModelMixin,
         """
         return super().list(request=request, args=args, kwargs=kwargs)
 
-    @cache_control(private=True)
-    @vary_on_headers(RH_IDENTITY_HEADER)
+    @never_cache
     def retrieve(self, request, *args, **kwargs):
         """Get a user preference.
 

--- a/koku/api/iam/view/user_preference.py
+++ b/koku/api/iam/view/user_preference.py
@@ -25,6 +25,7 @@ from rest_framework.permissions import AllowAny
 import api.iam.models as models
 import api.iam.serializers as serializers
 from api.common.permissions.object_owner import IsObjectOwner
+from api.common import RH_IDENTITY_HEADER
 
 
 class UserPreferenceViewSet(mixins.CreateModelMixin,
@@ -119,7 +120,7 @@ class UserPreferenceViewSet(mixins.CreateModelMixin,
         return super().create(request=request, args=args, kwargs=kwargs)
 
     @cache_control(private=True)
-    @vary_on_headers('User-Agent', 'Cookie')
+    @vary_on_headers(RH_IDENTITY_HEADER)
     def list(self, request, *args, **kwargs):
         """Obtain the list of preferences for the user.
 
@@ -176,7 +177,7 @@ class UserPreferenceViewSet(mixins.CreateModelMixin,
         return super().list(request=request, args=args, kwargs=kwargs)
 
     @cache_control(private=True)
-    @vary_on_headers('User-Agent', 'Cookie')
+    @vary_on_headers(RH_IDENTITY_HEADER)
     def retrieve(self, request, *args, **kwargs):
         """Get a user preference.
 

--- a/koku/api/iam/view/user_preference.py
+++ b/koku/api/iam/view/user_preference.py
@@ -16,6 +16,8 @@
 #
 
 """View for User Preferences."""
+from django.views.decorators.cache import cache_control, never_cache
+from django.views.decorators.vary import vary_on_headers
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import exceptions, mixins, viewsets
 from rest_framework.permissions import AllowAny
@@ -66,6 +68,7 @@ class UserPreferenceViewSet(mixins.CreateModelMixin,
         user_b = models.User.objects.get(uuid=uuid)
         return user_a == user_b
 
+    @never_cache
     def create(self, request, *args, **kwargs):
         """Create a user preference.
 
@@ -115,6 +118,8 @@ class UserPreferenceViewSet(mixins.CreateModelMixin,
 
         return super().create(request=request, args=args, kwargs=kwargs)
 
+    @cache_control(private=True)
+    @vary_on_headers('User-Agent', 'Cookie')
     def list(self, request, *args, **kwargs):
         """Obtain the list of preferences for the user.
 
@@ -170,6 +175,8 @@ class UserPreferenceViewSet(mixins.CreateModelMixin,
         """
         return super().list(request=request, args=args, kwargs=kwargs)
 
+    @cache_control(private=True)
+    @vary_on_headers('User-Agent', 'Cookie')
     def retrieve(self, request, *args, **kwargs):
         """Get a user preference.
 
@@ -200,6 +207,7 @@ class UserPreferenceViewSet(mixins.CreateModelMixin,
         """
         return super().retrieve(request=request, args=args, kwargs=kwargs)
 
+    @never_cache
     def destroy(self, request, *args, **kwargs):
         """Delete a user preference.
 
@@ -218,6 +226,7 @@ class UserPreferenceViewSet(mixins.CreateModelMixin,
         """
         return super().destroy(request=request, args=args, kwargs=kwargs)
 
+    @never_cache
     def update(self, request, *args, **kwargs):
         """Update a user preference.
 

--- a/koku/api/metrics/views.py
+++ b/koku/api/metrics/views.py
@@ -22,6 +22,7 @@ from django.views.decorators.vary import vary_on_headers
 from rest_framework import mixins, viewsets
 from rest_framework.permissions import AllowAny
 
+from api.common import RH_IDENTITY_HEADER
 from api.metrics.models import CostModelMetricsMap
 from api.metrics.serializers import CostModelMetricMapSerializer
 
@@ -51,7 +52,7 @@ class CostModelMetricsMapViewSet(mixins.ListModelMixin, viewsets.GenericViewSet)
 
         return queryset
 
-    @vary_on_headers('User-Agent', 'Cookie')
+    @vary_on_headers(RH_IDENTITY_HEADER)
     def list(self, request, *args, **kwargs):
         """Obtain the list of CostModelMetrics for the tenant."""
         return super().list(request=request, args=args, kwargs=kwargs)

--- a/koku/api/metrics/views.py
+++ b/koku/api/metrics/views.py
@@ -18,6 +18,7 @@
 """Views for CostModelMetricsMap."""
 import logging
 
+from django.views.decorators.vary import vary_on_headers
 from rest_framework import mixins, viewsets
 from rest_framework.permissions import AllowAny
 
@@ -49,3 +50,8 @@ class CostModelMetricsMapViewSet(mixins.ListModelMixin, viewsets.GenericViewSet)
             queryset = queryset.filter(source_type=source_type)
 
         return queryset
+
+    @vary_on_headers('User-Agent', 'Cookie')
+    def list(self, request, *args, **kwargs):
+        """Obtain the list of CostModelMetrics for the tenant."""
+        return super().list(request=request, args=args, kwargs=kwargs)

--- a/koku/api/provider/view.py
+++ b/koku/api/provider/view.py
@@ -34,6 +34,7 @@ from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.serializers import UUIDField
 
+from api.common import RH_IDENTITY_HEADER
 from api.iam.models import Customer
 from api.provider import serializers
 from api.provider.models import Provider
@@ -123,7 +124,7 @@ class ProviderViewSet(mixins.CreateModelMixin,
         return super().create(request=request, args=args, kwargs=kwargs)
 
     @cache_control(private=True)
-    @vary_on_headers('User-Agent', 'Cookie')
+    @vary_on_headers(RH_IDENTITY_HEADER)
     def list(self, request, *args, **kwargs):
         """Obtain the list of providers."""
         response = super().list(request=request, args=args, kwargs=kwargs)
@@ -135,7 +136,7 @@ class ProviderViewSet(mixins.CreateModelMixin,
         return response
 
     @cache_control(private=True)
-    @vary_on_headers('User-Agent', 'Cookie')
+    @vary_on_headers(RH_IDENTITY_HEADER)
     def retrieve(self, request, *args, **kwargs):
         """Get a provider."""
         response = super().retrieve(request=request, args=args, kwargs=kwargs)

--- a/koku/api/provider/view.py
+++ b/koku/api/provider/view.py
@@ -23,8 +23,7 @@ from operator import and_
 from django.db.models import Q
 from django.shortcuts import get_object_or_404
 from django.utils.encoding import force_text
-from django.views.decorators.cache import cache_control, never_cache
-from django.views.decorators.vary import vary_on_headers
+from django.views.decorators.cache import never_cache
 from django_filters import CharFilter, FilterSet
 from django_filters.filters import BaseCSVFilter
 from django_filters.rest_framework import DjangoFilterBackend
@@ -34,7 +33,6 @@ from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.serializers import UUIDField
 
-from api.common import RH_IDENTITY_HEADER
 from api.iam.models import Customer
 from api.provider import serializers
 from api.provider.models import Provider
@@ -123,8 +121,7 @@ class ProviderViewSet(mixins.CreateModelMixin,
         """Create a Provider."""
         return super().create(request=request, args=args, kwargs=kwargs)
 
-    @cache_control(private=True)
-    @vary_on_headers(RH_IDENTITY_HEADER)
+    @never_cache
     def list(self, request, *args, **kwargs):
         """Obtain the list of providers."""
         response = super().list(request=request, args=args, kwargs=kwargs)
@@ -135,8 +132,7 @@ class ProviderViewSet(mixins.CreateModelMixin,
             provider['infrastructure'] = manager.get_infrastructure_name(tenant)
         return response
 
-    @cache_control(private=True)
-    @vary_on_headers(RH_IDENTITY_HEADER)
+    @never_cache
     def retrieve(self, request, *args, **kwargs):
         """Get a provider."""
         response = super().retrieve(request=request, args=args, kwargs=kwargs)

--- a/koku/api/provider/view.py
+++ b/koku/api/provider/view.py
@@ -23,6 +23,8 @@ from operator import and_
 from django.db.models import Q
 from django.shortcuts import get_object_or_404
 from django.utils.encoding import force_text
+from django.views.decorators.cache import cache_control, never_cache
+from django.views.decorators.vary import vary_on_headers
 from django_filters import CharFilter, FilterSet
 from django_filters.filters import BaseCSVFilter
 from django_filters.rest_framework import DjangoFilterBackend
@@ -115,10 +117,13 @@ class ProviderViewSet(mixins.CreateModelMixin,
                 LOG.error('No customer found for user %s.', user)
         return queryset
 
+    @never_cache
     def create(self, request, *args, **kwargs):
         """Create a Provider."""
         return super().create(request=request, args=args, kwargs=kwargs)
 
+    @cache_control(private=True)
+    @vary_on_headers('User-Agent', 'Cookie')
     def list(self, request, *args, **kwargs):
         """Obtain the list of providers."""
         response = super().list(request=request, args=args, kwargs=kwargs)
@@ -129,6 +134,8 @@ class ProviderViewSet(mixins.CreateModelMixin,
             provider['infrastructure'] = manager.get_infrastructure_name(tenant)
         return response
 
+    @cache_control(private=True)
+    @vary_on_headers('User-Agent', 'Cookie')
     def retrieve(self, request, *args, **kwargs):
         """Get a provider."""
         response = super().retrieve(request=request, args=args, kwargs=kwargs)
@@ -138,6 +145,7 @@ class ProviderViewSet(mixins.CreateModelMixin,
         response.data['stats'] = manager.provider_statistics(tenant)
         return response
 
+    @never_cache
     def destroy(self, request, *args, **kwargs):
         """Delete a provider."""
         # throws ValidationError if pk is not a valid UUID

--- a/koku/api/report/view.py
+++ b/koku/api/report/view.py
@@ -28,6 +28,7 @@ from rest_framework.serializers import ValidationError
 from rest_framework.views import APIView
 from tenant_schemas.utils import tenant_context
 
+from api.common import RH_IDENTITY_HEADER
 from api.common.pagination import ReportPagination, ReportRankedPagination
 from api.models import Tenant, User
 from api.report.aws.query_handler import AWSReportQueryHandler
@@ -460,7 +461,7 @@ class ReportView(APIView):
     It providers one GET endpoint for the reports.
     """
 
-    @vary_on_headers('User-Agent', 'Cookie')
+    @vary_on_headers(RH_IDENTITY_HEADER)
     def get(self, request):
         """Get Report Data."""
         return _generic_report(request,

--- a/koku/api/report/view.py
+++ b/koku/api/report/view.py
@@ -18,6 +18,7 @@
 """View for Reports."""
 import logging
 
+from django.views.decorators.vary import vary_on_headers
 from django.utils.translation import ugettext as _
 from pint.errors import DimensionalityError, UndefinedUnitError
 from querystring_parser import parser
@@ -459,6 +460,7 @@ class ReportView(APIView):
     It providers one GET endpoint for the reports.
     """
 
+    @vary_on_headers('User-Agent', 'Cookie')
     def get(self, request):
         """Get Report Data."""
         return _generic_report(request,

--- a/koku/api/report/view.py
+++ b/koku/api/report/view.py
@@ -18,8 +18,8 @@
 """View for Reports."""
 import logging
 
-from django.views.decorators.vary import vary_on_headers
 from django.utils.translation import ugettext as _
+from django.views.decorators.vary import vary_on_headers
 from pint.errors import DimensionalityError, UndefinedUnitError
 from querystring_parser import parser
 from rest_framework import status

--- a/koku/api/status/views.py
+++ b/koku/api/status/views.py
@@ -16,6 +16,7 @@
 #
 
 """View for server status."""
+from django.views.decorators.cache import never_cache
 from rest_framework import permissions
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -73,6 +74,7 @@ class StatusView(APIView):
     permission_classes = [permissions.AllowAny]
     serializer_class = StatusSerializer
 
+    @never_cache
     def get(self, request):
         """Return the server status."""
         status_info = Status()

--- a/koku/cost_models/view.py
+++ b/koku/cost_models/view.py
@@ -23,6 +23,8 @@ from operator import and_
 from django.core.exceptions import FieldError, ValidationError
 from django.db.models import Q
 from django.utils.encoding import force_text
+from django.views.decorators.cache import never_cache
+from django.views.decorators.vary import vary_on_headers
 from django_filters import CharFilter, FilterSet, UUIDFilter
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import mixins, status, viewsets
@@ -142,10 +144,12 @@ class CostModelViewSet(mixins.CreateModelMixin,
                     LOG.error(queryset_error)
         return queryset
 
+    @never_cache
     def create(self, request, *args, **kwargs):
         """Create a rate."""
         return super().create(request=request, args=args, kwargs=kwargs)
 
+    @vary_on_headers('User-Agent', 'Cookie')
     def list(self, request, *args, **kwargs):
         """Obtain the list of rates for the tenant."""
         try:
@@ -155,14 +159,17 @@ class CostModelViewSet(mixins.CreateModelMixin,
 
         return response
 
+    @vary_on_headers('User-Agent', 'Cookie')
     def retrieve(self, request, *args, **kwargs):
         """Get a rate."""
         return super().retrieve(request=request, args=args, kwargs=kwargs)
 
+    @never_cache
     def destroy(self, request, *args, **kwargs):
         """Delete a rate."""
         return super().destroy(request=request, args=args, kwargs=kwargs)
 
+    @never_cache
     def update(self, request, *args, **kwargs):
         """Update a rate."""
         if request.method == 'PATCH':

--- a/koku/cost_models/view.py
+++ b/koku/cost_models/view.py
@@ -24,13 +24,11 @@ from django.core.exceptions import FieldError, ValidationError
 from django.db.models import Q
 from django.utils.encoding import force_text
 from django.views.decorators.cache import never_cache
-from django.views.decorators.vary import vary_on_headers
 from django_filters import CharFilter, FilterSet, UUIDFilter
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import mixins, status, viewsets
 from rest_framework.exceptions import APIException
 
-from api.common import RH_IDENTITY_HEADER
 from api.common.permissions.cost_models_access import CostModelsAccessPermission
 from cost_models.models import CostModel
 from cost_models.serializers import CostModelSerializer
@@ -150,7 +148,7 @@ class CostModelViewSet(mixins.CreateModelMixin,
         """Create a rate."""
         return super().create(request=request, args=args, kwargs=kwargs)
 
-    @vary_on_headers(RH_IDENTITY_HEADER)
+    @never_cache
     def list(self, request, *args, **kwargs):
         """Obtain the list of rates for the tenant."""
         try:
@@ -160,7 +158,7 @@ class CostModelViewSet(mixins.CreateModelMixin,
 
         return response
 
-    @vary_on_headers(RH_IDENTITY_HEADER)
+    @never_cache
     def retrieve(self, request, *args, **kwargs):
         """Get a rate."""
         return super().retrieve(request=request, args=args, kwargs=kwargs)

--- a/koku/cost_models/view.py
+++ b/koku/cost_models/view.py
@@ -30,6 +30,7 @@ from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import mixins, status, viewsets
 from rest_framework.exceptions import APIException
 
+from api.common import RH_IDENTITY_HEADER
 from api.common.permissions.cost_models_access import CostModelsAccessPermission
 from cost_models.models import CostModel
 from cost_models.serializers import CostModelSerializer
@@ -149,7 +150,7 @@ class CostModelViewSet(mixins.CreateModelMixin,
         """Create a rate."""
         return super().create(request=request, args=args, kwargs=kwargs)
 
-    @vary_on_headers('User-Agent', 'Cookie')
+    @vary_on_headers(RH_IDENTITY_HEADER)
     def list(self, request, *args, **kwargs):
         """Obtain the list of rates for the tenant."""
         try:
@@ -159,7 +160,7 @@ class CostModelViewSet(mixins.CreateModelMixin,
 
         return response
 
-    @vary_on_headers('User-Agent', 'Cookie')
+    @vary_on_headers(RH_IDENTITY_HEADER)
     def retrieve(self, request, *args, **kwargs):
         """Get a rate."""
         return super().retrieve(request=request, args=args, kwargs=kwargs)

--- a/koku/masu/api/download.py
+++ b/koku/masu/api/download.py
@@ -19,6 +19,7 @@
 
 import logging
 
+from django.views.decorators.cache import never_cache
 from rest_framework.decorators import (api_view,
                                        permission_classes,
                                        renderer_classes)
@@ -31,6 +32,7 @@ from masu.celery.tasks import check_report_updates
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
+@never_cache
 @api_view(http_method_names=['GET'])
 @permission_classes((AllowAny,))
 @renderer_classes(tuple(api_settings.DEFAULT_RENDERER_CLASSES))

--- a/koku/masu/api/expired_data.py
+++ b/koku/masu/api/expired_data.py
@@ -19,6 +19,7 @@
 
 import logging
 
+from django.views.decorators.cache import never_cache
 from rest_framework.decorators import (api_view,
                                        permission_classes,
                                        renderer_classes)
@@ -32,6 +33,7 @@ from masu.processor.orchestrator import Orchestrator
 LOG = logging.getLogger(__name__)
 
 
+@never_cache
 @api_view(http_method_names=['GET', 'DELETE'])
 @permission_classes((AllowAny,))
 @renderer_classes(tuple(api_settings.DEFAULT_RENDERER_CLASSES))

--- a/koku/masu/api/notification.py
+++ b/koku/masu/api/notification.py
@@ -19,6 +19,7 @@
 
 import logging
 
+from django.views.decorators.cache import never_cache
 from rest_framework.decorators import api_view, permission_classes, renderer_classes
 from rest_framework.permissions import AllowAny
 from rest_framework.settings import api_settings
@@ -33,6 +34,7 @@ from masu.processor.orchestrator import Orchestrator
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
+@never_cache
 @api_view(http_method_names=['GET'])
 @permission_classes((AllowAny,))
 @renderer_classes(tuple(api_settings.DEFAULT_RENDERER_CLASSES))

--- a/koku/masu/api/region_map.py
+++ b/koku/masu/api/region_map.py
@@ -17,15 +17,16 @@
 
 """View endpoint for updating region mapping."""
 
+from django.views.decorators.cache import never_cache
 from rest_framework.decorators import api_view, permission_classes, renderer_classes
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.settings import api_settings
 
-
 from masu.util.aws.region_map import update_region_mapping
 
 
+@never_cache
 @api_view(http_method_names=['GET'])
 @permission_classes((AllowAny,))
 @renderer_classes(tuple(api_settings.DEFAULT_RENDERER_CLASSES))

--- a/koku/masu/api/report_data.py
+++ b/koku/masu/api/report_data.py
@@ -21,6 +21,7 @@
 
 import logging
 
+from django.views.decorators.cache import never_cache
 from rest_framework import status
 from rest_framework.decorators import api_view, permission_classes, renderer_classes
 from rest_framework.permissions import AllowAny
@@ -38,6 +39,7 @@ LOG = logging.getLogger(__name__)
 REPORT_DATA_KEY = "Report Data Task ID"
 
 
+@never_cache
 @api_view(http_method_names=["GET", "DELETE"])
 @permission_classes((AllowAny,))
 @renderer_classes(tuple(api_settings.DEFAULT_RENDERER_CLASSES))

--- a/koku/masu/api/status.py
+++ b/koku/masu/api/status.py
@@ -29,6 +29,7 @@ from django.db import (InterfaceError,
                        OperationalError,
                        ProgrammingError,
                        connection)
+from django.views.decorators.cache import never_cache
 from rest_framework.decorators import (api_view,
                                        permission_classes,
                                        renderer_classes)
@@ -47,6 +48,7 @@ BROKER_CONNECTION_ERROR = 'Unable to establish connection with broker.'
 CELERY_WORKER_NOT_FOUND = 'No running Celery workers were found.'
 
 
+@never_cache
 @api_view(http_method_names=['GET'])
 @permission_classes((AllowAny,))
 @renderer_classes(tuple(api_settings.DEFAULT_RENDERER_CLASSES))

--- a/koku/masu/api/update_charge.py
+++ b/koku/masu/api/update_charge.py
@@ -19,6 +19,7 @@
 
 import logging
 
+from django.views.decorators.cache import never_cache
 from rest_framework import status
 from rest_framework.decorators import (api_view,
                                        permission_classes,
@@ -32,6 +33,7 @@ from masu.processor.tasks import update_charge_info
 LOG = logging.getLogger(__name__)
 
 
+@never_cache
 @api_view(http_method_names=['GET', 'DELETE'])
 @permission_classes((AllowAny,))
 @renderer_classes(tuple(api_settings.DEFAULT_RENDERER_CLASSES))

--- a/koku/sources/api/billing_source.py
+++ b/koku/sources/api/billing_source.py
@@ -17,6 +17,7 @@
 
 """View for Sources AWS billing source endpoint."""
 
+from django.views.decorators.cache import never_cache
 from rest_framework import status
 from rest_framework.decorators import (api_view,
                                        permission_classes,
@@ -27,6 +28,7 @@ from rest_framework.settings import api_settings
 from sources.storage import SourcesStorageError, add_provider_billing_source
 
 
+@never_cache
 @api_view(http_method_names=['POST'])
 @permission_classes((AllowAny,))
 @renderer_classes(tuple(api_settings.DEFAULT_RENDERER_CLASSES))


### PR DESCRIPTION
This configures cache-control headers for each view to ensure we are not caching things that shouldn't be cached and that we are maintaining privacy of critical user data.