### PR TITLE
upgrade pip to latest during build

### DIFF
--- a/openshift/koku.yaml
+++ b/openshift/koku.yaml
@@ -83,6 +83,8 @@ objects:
             value: ${PIPENV_PYPI_MIRROR}
           - name: ENABLE_PIPENV
             value: "true"
+          - name: UPGRADE_PIP_TO_LATEST
+            value: "true"
           - name: APP_CONFIG
             valueFrom:
               configMapKeyRef:


### PR DESCRIPTION
Since we recently added `google-cloud-python` as a dependency, the build step has started failing as in #1149. This is because we have old versions of `pip` and `setuptools` in the base build image.

This change enables a feature in our build image to upgrade to the latest `pip`, `setuptools`, and `wheel` _before_ `pipenv` starts its own environment installation process.

See also: https://github.com/googleapis/google-cloud-python/issues/2990 and https://github.com/pypa/setuptools/issues/885