### PR TITLE
clean up ReportView hierarchy; set class parameters

### DIFF
--- a/koku/api/report/aws/view.py
+++ b/koku/api/report/aws/view.py
@@ -17,10 +17,23 @@
 #
 """AWS views."""
 from api.common.permissions.aws_access import AwsAccessPermission
+from api.report.aws.query_handler import AWSReportQueryHandler
+from api.report.aws.serializers import QueryParamSerializer
 from api.report.view import ReportView
+from reporting.provider.aws.models import AWSTagsSummary
 
 
-class AWSCostView(ReportView):
+class AWSView(ReportView):
+    """AWS Base View."""
+
+    permission_classes = [AwsAccessPermission]
+    provider = 'aws'
+    _serializer = QueryParamSerializer
+    _query_handler = AWSReportQueryHandler
+    _tag_handler = [AWSTagsSummary]
+
+
+class AWSCostView(AWSView):
     """Get cost data.
 
     @api {get} /cost-management/v1/reports/aws/costs/ Get cost data
@@ -106,12 +119,10 @@ class AWSCostView(ReportView):
 
     """
 
-    permission_classes = [AwsAccessPermission]
     report = 'costs'
-    provider = 'aws'
 
 
-class AWSInstanceTypeView(ReportView):
+class AWSInstanceTypeView(AWSView):
     """Get inventory data.
 
     @api {get} /cost-management/v1/reports/aws/instance-types/ Get inventory instance type data
@@ -232,12 +243,10 @@ class AWSInstanceTypeView(ReportView):
 
     """
 
-    permission_classes = [AwsAccessPermission]
     report = 'instance_type'
-    provider = 'aws'
 
 
-class AWSStorageView(ReportView):
+class AWSStorageView(AWSView):
     """Get inventory storage data.
 
     @api {get} /cost-management/v1/reports/aws/storage/ Get inventory storage data
@@ -350,6 +359,4 @@ class AWSStorageView(ReportView):
 
     """
 
-    permission_classes = [AwsAccessPermission]
     report = 'storage'
-    provider = 'aws'

--- a/koku/api/report/azure/view.py
+++ b/koku/api/report/azure/view.py
@@ -17,7 +17,10 @@
 """Azure views."""
 
 from api.common.permissions.azure_access import AzureAccessPermission
+from api.report.azure.query_handler import AzureReportQueryHandler
+from api.report.azure.serializers import AzureQueryParamSerializer
 from api.report.view import ReportView
+from reporting.provider.azure.models import AzureTagsSummary
 
 
 class AzureView(ReportView):
@@ -25,6 +28,9 @@ class AzureView(ReportView):
 
     permission_classes = [AzureAccessPermission]
     provider = 'azure'
+    _serializer = AzureQueryParamSerializer,
+    _query_handler = AzureReportQueryHandler,
+    _tag_handler = [AzureTagsSummary]
 
 
 class AzureCostView(AzureView):

--- a/koku/api/report/azure/view.py
+++ b/koku/api/report/azure/view.py
@@ -28,8 +28,8 @@ class AzureView(ReportView):
 
     permission_classes = [AzureAccessPermission]
     provider = 'azure'
-    _serializer = AzureQueryParamSerializer,
-    _query_handler = AzureReportQueryHandler,
+    _serializer = AzureQueryParamSerializer
+    _query_handler = AzureReportQueryHandler
     _tag_handler = [AzureTagsSummary]
 
 

--- a/koku/api/report/ocp/view.py
+++ b/koku/api/report/ocp/view.py
@@ -368,7 +368,7 @@ class OCPCostView(OCPView):
     _serializer = OCPCostQueryParamSerializer
 
 
-class OCPVolumeView(ReportView):
+class OCPVolumeView(OCPView):
     """Get OpenShift volume usage data.
 
     @api {get} /cost-management/v1/reports/openshift/volume/ Get volume usage data

--- a/koku/api/report/ocp/view.py
+++ b/koku/api/report/ocp/view.py
@@ -18,10 +18,28 @@
 """View for OpenShift Usage Reports."""
 
 from api.common.permissions.openshift_access import OpenShiftAccessPermission
+from api.report.ocp.query_handler import OCPReportQueryHandler
+from api.report.ocp.serializers import (OCPCostQueryParamSerializer,
+                                        OCPInventoryQueryParamSerializer)
 from api.report.view import ReportView
+from reporting.provider.ocp.models import (OCPStorageVolumeClaimLabelSummary,
+                                           OCPStorageVolumeLabelSummary,
+                                           OCPUsagePodLabelSummary)
 
 
-class OCPMemoryView(ReportView):
+class OCPView(ReportView):
+    """OCP Base View."""
+
+    permission_classes = [OpenShiftAccessPermission]
+    provider = 'ocp'
+    _serializer = OCPInventoryQueryParamSerializer
+    _query_handler = OCPReportQueryHandler
+    _tag_handler = [OCPUsagePodLabelSummary,
+                    OCPStorageVolumeClaimLabelSummary,
+                    OCPStorageVolumeLabelSummary]
+
+
+class OCPMemoryView(OCPView):
     """Get OpenShift memory usage data.
 
     @api {get} /cost-management/v1/reports/openshift/memory/ Get memory usage data
@@ -121,12 +139,10 @@ class OCPMemoryView(ReportView):
 
     """
 
-    permission_classes = [OpenShiftAccessPermission]
     report = 'memory'
-    provider = 'ocp'
 
 
-class OCPCpuView(ReportView):
+class OCPCpuView(OCPView):
     """Get OpenShift compute usage data.
 
     @api {get} /cost-management/v1/reports/openshift/compute/ Get compute usage data
@@ -230,12 +246,10 @@ class OCPCpuView(ReportView):
 
     """
 
-    permission_classes = [OpenShiftAccessPermission]
     report = 'cpu'
-    provider = 'ocp'
 
 
-class OCPCostView(ReportView):
+class OCPCostView(OCPView):
     """Get OpenShift cost data.
 
     @api {get} /cost-management/v1/reports/openshift/costs/ Get OpenShift costs data
@@ -350,9 +364,8 @@ class OCPCostView(ReportView):
 
     """
 
-    permission_classes = [OpenShiftAccessPermission]
     report = 'costs'
-    provider = 'ocp'
+    _serializer = OCPCostQueryParamSerializer
 
 
 class OCPVolumeView(ReportView):
@@ -428,6 +441,4 @@ class OCPVolumeView(ReportView):
 
     """
 
-    permission_classes = [OpenShiftAccessPermission]
     report = 'volume'
-    provider = 'ocp'

--- a/koku/api/report/ocp_aws/view.py
+++ b/koku/api/report/ocp_aws/view.py
@@ -19,10 +19,23 @@
 
 from api.common.permissions.aws_access import AwsAccessPermission
 from api.common.permissions.openshift_access import OpenShiftAccessPermission
+from api.report.ocp_aws.query_handler import OCPAWSReportQueryHandler
+from api.report.ocp_aws.serializers import OCPAWSQueryParamSerializer
 from api.report.view import ReportView
+from reporting.provider.aws.models import AWSTagsSummary
 
 
-class OCPAWSCostView(ReportView):
+class OCPAWSView(ReportView):
+    """OCP+AWS Base View."""
+
+    permission_classes = [AwsAccessPermission, OpenShiftAccessPermission]
+    provider = 'ocp_aws'
+    _serializer = OCPAWSQueryParamSerializer
+    _query_handler = OCPAWSReportQueryHandler
+    _tag_handler = [AWSTagsSummary]
+
+
+class OCPAWSCostView(OCPAWSView):
     """Get OpenShift on AWS cost usage data.
 
     @api {get} /cost-management/v1/reports/openshift/costs/ Get OpenShift cost data
@@ -46,12 +59,10 @@ class OCPAWSCostView(ReportView):
 
     """
 
-    permission_classes = [AwsAccessPermission, OpenShiftAccessPermission]
     report = 'costs'
-    provider = 'ocp_aws'
 
 
-class OCPAWSStorageView(ReportView):
+class OCPAWSStorageView(OCPAWSView):
     """Get OpenShift on AWS storage usage data.
 
     @api {get} /cost-management/v1/reports/openshift/infrastructures/aws/storage/ Get OpenShift on AWS storage usage.
@@ -121,12 +132,10 @@ class OCPAWSStorageView(ReportView):
 
     """
 
-    permission_classes = [AwsAccessPermission, OpenShiftAccessPermission]
     report = 'storage'
-    provider = 'ocp_aws'
 
 
-class OCPAWSInstanceTypeView(ReportView):
+class OCPAWSInstanceTypeView(OCPAWSView):
     """Get OpenShift on AWS instance usage data.
 
     @api {get} /cost-management/v1/reports/openshift/infrastructures/aws/instance-types/ Get instance data
@@ -224,6 +233,4 @@ class OCPAWSInstanceTypeView(ReportView):
 
     """
 
-    permission_classes = [AwsAccessPermission, OpenShiftAccessPermission]
     report = 'instance_type'
-    provider = 'ocp_aws'

--- a/koku/api/report/test/azure/tests_views.py
+++ b/koku/api/report/test/azure/tests_views.py
@@ -33,10 +33,10 @@ from api.iam.serializers import UserSerializer
 from api.iam.test.iam_test_case import IamTestCase
 from api.models import User
 from api.report.azure.serializers import AzureQueryParamSerializer
+from api.report.azure.view import AzureCostView
 from api.report.view import (_convert_units,
                              _fill_in_missing_units,
                              _find_unit,
-                             _generic_report,
                              get_paginator,
                              process_query_parameters,
                              )
@@ -289,8 +289,8 @@ class AzureReportViewTest(IamTestCase):
         self.assertEqual(report_total * 1E9, result_total)
 
     @patch('api.report.azure.query_handler.AzureReportQueryHandler')
-    def test_generic_report_with_units_success(self, mock_handler):
-        """Test unit conversion succeeds in generic report."""
+    def test_costview_with_units_success(self, mock_handler):
+        """Test unit conversion succeeds in AzureCostView."""
         mock_handler.return_value.execute_query.return_value = self.report
         params = {
             'group_by[subscription_guid]': '*',
@@ -311,7 +311,7 @@ class AzureReportViewTest(IamTestCase):
         request = Request(django_request)
         request.user = user
 
-        response = _generic_report(request, provider='azure', report='costs')
+        response = AzureCostView().get(request)
         self.assertIsInstance(response, Response)
 
     def test_find_unit_list(self):

--- a/koku/api/report/test/ocp/tests_views.py
+++ b/koku/api/report/test/ocp/tests_views.py
@@ -34,8 +34,8 @@ from api.iam.serializers import UserSerializer
 from api.iam.test.iam_test_case import IamTestCase
 from api.models import User
 from api.query_handler import TruncDayString
+from api.report.ocp.view import OCPCpuView, OCPMemoryView
 from api.report.test.ocp.helpers import OCPReportDataGenerator
-from api.report.view import _generic_report
 from api.tags.ocp.queries import OCPTagQueryHandler
 from api.utils import DateHelper
 from reporting.models import CostSummary, OCPUsageLineItemDailySummary
@@ -205,8 +205,8 @@ class OCPReportViewTest(IamTestCase):
         self.data_generator.remove_data_from_reporting_common()
 
     @patch('api.report.ocp.query_handler.OCPReportQueryHandler')
-    def test_generic_report_ocp_cpu_success(self, mock_handler):
-        """Test OCP cpu generic report."""
+    def test_ocpcpuview_success(self, mock_handler):
+        """Test OCP cpu view report."""
         mock_handler.return_value.execute_query.return_value = self.report_ocp_cpu
         params = {
             'group_by[node]': '*',
@@ -228,13 +228,13 @@ class OCPReportViewTest(IamTestCase):
         request = Request(django_request)
         request.user = user
 
-        response = _generic_report(request, report='cpu', provider='ocp')
+        response = OCPCpuView().get(request)
         self.assertIsInstance(response, Response)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     @patch('api.report.ocp.query_handler.OCPReportQueryHandler')
-    def test_generic_report_ocp_mem_success(self, mock_handler):
-        """Test OCP memory generic report."""
+    def test_ocpmemview_success(self, mock_handler):
+        """Test OCP memory view report."""
         mock_handler.return_value.execute_query.return_value = self.report_ocp_mem
         params = {
             'group_by[node]': '*',
@@ -256,7 +256,7 @@ class OCPReportViewTest(IamTestCase):
         request = Request(django_request)
         request.user = user
 
-        response = _generic_report(request, report='memory', provider='ocp')
+        response = OCPMemoryView().get(request)
         self.assertIsInstance(response, Response)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 

--- a/koku/api/report/test/tests_views.py
+++ b/koku/api/report/test/tests_views.py
@@ -31,10 +31,10 @@ from api.iam.serializers import UserSerializer
 from api.iam.test.iam_test_case import IamTestCase
 from api.models import User
 from api.report.aws.serializers import QueryParamSerializer
+from api.report.aws.view import AWSCostView
 from api.report.view import (_convert_units,
                              _fill_in_missing_units,
                              _find_unit,
-                             _generic_report,
                              get_paginator,
                              process_query_parameters,
                              process_tag_query_params)
@@ -305,8 +305,8 @@ class ReportViewTest(IamTestCase):
         self.assertEqual(report_total * 1E9, result_total)
 
     @patch('api.report.aws.query_handler.AWSReportQueryHandler')
-    def test_generic_report_with_units_success(self, mock_handler):
-        """Test unit conversion succeeds in generic report."""
+    def test_awsreportview_with_units_success(self, mock_handler):
+        """Test unit conversion succeeds in aws report."""
         mock_handler.return_value.execute_query.return_value = self.report
         params = {
             'group_by[account]': '*',
@@ -327,7 +327,7 @@ class ReportViewTest(IamTestCase):
         request = Request(django_request)
         request.user = user
 
-        response = _generic_report(request, provider='aws', report='costs')
+        response = AWSCostView().get(request)
         self.assertIsInstance(response, Response)
 
     def test_find_unit_list(self):

--- a/koku/api/report/view.py
+++ b/koku/api/report/view.py
@@ -238,8 +238,7 @@ class ReportView(APIView):
 
         tag_keys = []
         if self.report != 'tags':
-            tag_models = self._tag_handler(self.provider, self.report)
-            for tag_model in tag_models:
+            for tag_model in self._tag_handler:
                 tag_keys.extend(get_tag_keys(request, tag_model))
 
         url_data = request.GET.urlencode()

--- a/koku/api/tags/aws/view.py
+++ b/koku/api/tags/aws/view.py
@@ -17,12 +17,13 @@
 
 """View for AWS tags."""
 
-from rest_framework.permissions import AllowAny
+from api.tags.aws.queries import AWSTagQueryHandler
+from api.tags.serializers import AWSTagsQueryParamSerializer
+from api.tags.view import TagView
+from reporting.provider.aws.models import AWSTagsSummary
 
-from api.report.view import ReportView
 
-
-class AWSTagView(ReportView):
+class AWSTagView(TagView):
     """Get AWS tags.
 
     @api {get} /cost-management/v1/tags/aws/
@@ -56,6 +57,7 @@ class AWSTagView(ReportView):
 
     """
 
-    permission_classes = [AllowAny]
     provider = 'aws'
-    report = 'tags'
+    _serializer = AWSTagsQueryParamSerializer
+    _query_handler = AWSTagQueryHandler
+    _tag_handler = [AWSTagsSummary]

--- a/koku/api/tags/azure/view.py
+++ b/koku/api/tags/azure/view.py
@@ -16,12 +16,13 @@
 #
 """View for AWS tags."""
 
-from rest_framework.permissions import AllowAny
+from api.tags.azure.queries import AzureTagQueryHandler
+from api.tags.serializers import AzureTagsQueryParamSerializer
+from api.tags.view import TagView
+from reporting.provider.azure.models import AzureTagsSummary
 
-from api.report.view import ReportView
 
-
-class AzureTagView(ReportView):
+class AzureTagView(TagView):
     """Get Azure tags.
 
     @api {get} /cost-management/v1/tags/azure/
@@ -55,6 +56,7 @@ class AzureTagView(ReportView):
 
     """
 
-    permission_classes = [AllowAny]
     provider = 'azure'
-    report = 'tags'
+    _serializer = AzureTagsQueryParamSerializer
+    _query_handler = AzureTagQueryHandler
+    _tag_handler = [AzureTagsSummary]

--- a/koku/api/tags/ocp/view.py
+++ b/koku/api/tags/ocp/view.py
@@ -17,12 +17,15 @@
 
 """View for OpenShift tags."""
 
-from rest_framework.permissions import AllowAny
+from api.tags.ocp.queries import OCPTagQueryHandler
+from api.tags.serializers import OCPTagsQueryParamSerializer
+from api.tags.view import TagView
+from reporting.provider.ocp.models import (OCPStorageVolumeClaimLabelSummary,
+                                           OCPStorageVolumeLabelSummary,
+                                           OCPUsagePodLabelSummary)
 
-from api.report.view import ReportView
 
-
-class OCPTagView(ReportView):
+class OCPTagView(TagView):
     """Get OpenShift tags.
 
     @api {get} /cost-management/v1/tags/openshift/
@@ -56,6 +59,9 @@ class OCPTagView(ReportView):
 
     """
 
-    permission_classes = [AllowAny]
     provider = 'ocp'
-    report = 'tags'
+    _serializer = OCPTagsQueryParamSerializer
+    _query_handler = OCPTagQueryHandler
+    _tag_handler = [OCPUsagePodLabelSummary,
+                    OCPStorageVolumeClaimLabelSummary,
+                    OCPStorageVolumeLabelSummary]

--- a/koku/api/tags/ocp_aws/view.py
+++ b/koku/api/tags/ocp_aws/view.py
@@ -17,12 +17,13 @@
 
 """View for OCP-on-AWS tags."""
 
-from rest_framework.permissions import AllowAny
+from api.tags.ocp_aws.queries import OCPAWSTagQueryHandler
+from api.tags.serializers import OCPAWSTagsQueryParamSerializer
+from api.tags.view import TagView
+from reporting.provider.aws.models import AWSTagsSummary
 
-from api.report.view import ReportView
 
-
-class OCPAWSTagView(ReportView):
+class OCPAWSTagView(TagView):
     """Get OpenShift-on-AWS tags.
 
     @api {get} /cost-management/v1/tags/openshift/infrastructures/aws/
@@ -56,6 +57,7 @@ class OCPAWSTagView(ReportView):
 
     """
 
-    permission_classes = [AllowAny]
     provider = 'ocp_aws'
-    report = 'tags'
+    _serializer = OCPAWSTagsQueryParamSerializer
+    _query_handler = OCPAWSTagQueryHandler
+    _tag_handler = [AWSTagsSummary]

--- a/koku/api/tags/view.py
+++ b/koku/api/tags/view.py
@@ -1,0 +1,29 @@
+#
+# Copyright 2018 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""View for tags."""
+
+from rest_framework.permissions import AllowAny
+
+from api.report.view import ReportView
+
+
+class TagView(ReportView):
+    """Base Tag View."""
+
+    permission_classes = [AllowAny]
+    report = 'tags'

--- a/koku/api/views.py
+++ b/koku/api/views.py
@@ -40,4 +40,4 @@ from api.status.views import StatusView
 from api.tags.aws.view import AWSTagView
 from api.tags.azure.view import AzureTagView
 from api.tags.ocp.view import OCPTagView
-from api.tags.ocp_aws.views import OCPAWSTagView
+from api.tags.ocp_aws.view import OCPAWSTagView

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ import-order-style = pycharm
 application-import-names = koku, api, reporting, reporting_common, cost_models, masu
 
 [testenv]
-passenv = CI TRAVIS TRAVIS_* LDFLAGS CPPFLAGS CODECOV_TOKEN
+passenv = CI TRAVIS TRAVIS_* LDFLAGS CPPFLAGS CODECOV_TOKEN PIP_TRUSTED_HOST PIPENV_PYPI_MIRROR
 setenv =
   DATABASE_SERVICE_NAME={env:DATABASE_SERVICE_NAME:POSTGRES_SQL}
   DATABASE_ENGINE={env:DATABASE_ENGINE:postgresql}


### PR DESCRIPTION
This is the first in a series of clean-ups around the View->QueryHandler interfaces. These are related to issue #960 . 

This PR removes a mapping data structure in favor of defining class attributes. This takes advantage of the shift to class-based views to eliminate some unnecessary complexity.

There should be no functional change to the code.