### PR TITLE
looking up source type name based on id

### DIFF
--- a/koku/sources/kafka_listener.py
+++ b/koku/sources/kafka_listener.py
@@ -42,9 +42,9 @@ KAFKA_APPLICATION_DESTROY = 'Application.destroy'
 KAFKA_SOURCE_DESTROY = 'Source.destroy'
 KAFKA_HDR_RH_IDENTITY = 'x-rh-identity'
 KAFKA_HDR_EVENT_TYPE = 'event_type'
-SOURCES_OCP_SOURCE_TYPE = 1
-SOURCES_AWS_SOURCE_TYPE = 2
-SOURCES_AZURE_SOURCE_TYPE = 3
+SOURCES_OCP_SOURCE_NAME = 'openshift'
+SOURCES_AWS_SOURCE_NAME = 'amazon'
+SOURCES_AZURE_SOURCE_NAME = 'azure'
 
 
 class SourcesIntegrationError(Exception):
@@ -167,14 +167,15 @@ def sources_network_info(source_id, auth_header):
         return
     source_name = source_details.get('name')
     source_type_id = int(source_details.get('source_type_id'))
+    source_type_name = sources_network.get_source_type_name(source_type_id)
 
-    if source_type_id == SOURCES_OCP_SOURCE_TYPE:
+    if source_type_name == SOURCES_OCP_SOURCE_NAME:
         source_type = 'OCP'
         authentication = {'resource_name': source_details.get('uid')}
-    elif source_type_id == SOURCES_AWS_SOURCE_TYPE:
+    elif source_type_name == SOURCES_AWS_SOURCE_NAME:
         source_type = 'AWS'
         authentication = {'resource_name': sources_network.get_aws_role_arn()}
-    elif source_type_id == SOURCES_AZURE_SOURCE_TYPE:
+    elif source_type_name == SOURCES_AZURE_SOURCE_NAME:
         source_type = 'AZURE'
         authentication = {'credentials': sources_network.get_azure_credentials()}
     else:

--- a/koku/sources/sources_http_client.py
+++ b/koku/sources/sources_http_client.py
@@ -64,6 +64,22 @@ class SourcesHTTPClient:
         application_type_id = endpoint_response.get('data')[0].get('id')
         return int(application_type_id)
 
+    def get_source_type_name(self, type_id):
+        """Get the source name for a give type id."""
+        application_type_url = '{}/source_types?filter[id]={}'.format(
+            self._base_url, type_id)
+        try:
+            r = requests.get(application_type_url, headers=self._identity_header)
+        except RequestException as conn_error:
+            raise SourcesHTTPClientError('Unable to get source name. Reason: ', str(conn_error))
+
+        if r.status_code != 200:
+            raise SourcesHTTPClientError(f'Status Code: {r.status_code}. Response: {r.text}')
+
+        endpoint_response = r.json()
+        source_name = endpoint_response.get('data')[0].get('name')
+        return source_name
+
     def get_aws_role_arn(self):
         """Get the roleARN from Sources Authentication service."""
         endpoint_url = '{}/endpoints?filter[source_id]={}'.format(self._base_url, str(self._source_id))

--- a/koku/sources/test/test_kafka_listener.py
+++ b/koku/sources/test/test_kafka_listener.py
@@ -249,12 +249,15 @@ class SourcesKafkaMsgHandlerTest(TestCase):
                              auth_header=test_auth_header,
                              offset=1)
         aws_source.save()
-
+        source_type_id = 1
+        mock_source_name = 'amazon'
         resource_id = 2
         authentication_id = 3
         with requests_mock.mock() as m:
             m.get(f'http://www.sources.com/api/v1.0/sources/{test_source_id}',
-                  status_code=200, json={'name': source_name, 'source_type_id': test_source_id, 'uid': source_uid})
+                  status_code=200, json={'name': source_name, 'source_type_id': source_type_id, 'uid': source_uid})
+            m.get(f'http://www.sources.com/api/v1.0/source_types?filter[id]={source_type_id}',
+                  status_code=200, json={'data': [{'name': mock_source_name}]})
             m.get(f'http://www.sources.com/api/v1.0/endpoints?filter[source_id]={test_source_id}',
                   status_code=200, json={'data': [{'id': resource_id}]})
             m.get((f'http://www.sources.com/api/v1.0/authentications?filter[resource_type]=Endpoint'
@@ -282,11 +285,13 @@ class SourcesKafkaMsgHandlerTest(TestCase):
                              auth_header=test_auth_header,
                              offset=1)
         ocp_source.save()
-
+        source_type_id = 3
+        mock_source_name = 'openshift'
         with requests_mock.mock() as m:
             m.get(f'http://www.sources.com/api/v1.0/sources/{test_source_id}',
-                  status_code=200, json={'name': source_name, 'source_type_id': test_source_id, 'uid': source_uid})
-
+                  status_code=200, json={'name': source_name, 'source_type_id': source_type_id, 'uid': source_uid})
+            m.get(f'http://www.sources.com/api/v1.0/source_types?filter[id]={source_type_id}',
+                  status_code=200, json={'data': [{'name': mock_source_name}]})
             source_integration.sources_network_info(test_source_id, test_auth_header)
 
         source_obj = Sources.objects.get(source_id=test_source_id)
@@ -308,14 +313,17 @@ class SourcesKafkaMsgHandlerTest(TestCase):
                                auth_header=test_auth_header,
                                offset=1)
         azure_source.save()
-
+        source_type_id = 2
+        mock_source_name = 'azure'
         resource_id = 3
         authentication_id = 4
         authentications_response = {'id': authentication_id, 'username': username,
                                     'extra': {'azure': {'tenant_id': tenent_id}}}
         with requests_mock.mock() as m:
             m.get(f'http://www.sources.com/api/v1.0/sources/{test_source_id}',
-                  status_code=200, json={'name': source_name, 'source_type_id': test_source_id, 'uid': source_uid})
+                  status_code=200, json={'name': source_name, 'source_type_id': source_type_id, 'uid': source_uid})
+            m.get(f'http://www.sources.com/api/v1.0/source_types?filter[id]={source_type_id}',
+                  status_code=200, json={'data': [{'name': mock_source_name}]})
             m.get(f'http://www.sources.com/api/v1.0/endpoints?filter[source_id]={test_source_id}',
                   status_code=200, json={'data': [{'id': resource_id}]})
             m.get((f'http://www.sources.com/api/v1.0/authentications?filter[resource_type]=Endpoint'

--- a/koku/sources/test/test_sources_http_client.py
+++ b/koku/sources/test/test_sources_http_client.py
@@ -89,6 +89,41 @@ class SourcesHTTPClientTest(TestCase):
                 client.get_cost_management_application_type_id()
 
     @patch.object(Config, 'SOURCES_API_URL', 'http://www.sources.com')
+    def test_get_source_type_name(self):
+        """Test to get source type name from type id."""
+        source_type_id = 3
+        mock_source_name = 'fakesource'
+        client = SourcesHTTPClient(auth_header=Config.SOURCES_FAKE_HEADER)
+        with requests_mock.mock() as m:
+            m.get(f'http://www.sources.com/api/v1.0/source_types?filter[id]={source_type_id}',
+                  status_code=200, json={'data': [{'name': mock_source_name}]})
+            response = client.get_source_type_name(source_type_id)
+            self.assertEqual(response, mock_source_name)
+
+    @patch.object(Config, 'SOURCES_API_URL', 'http://www.sources.com')
+    def test_get_source_type_name_error(self):
+        """Test to get source type name from type id with error."""
+        source_type_id = 3
+        client = SourcesHTTPClient(auth_header=Config.SOURCES_FAKE_HEADER)
+        with requests_mock.mock() as m:
+            m.get(f'http://www.sources.com/api/v1.0/source_types?filter[id]={source_type_id}',
+                  exc=requests.exceptions.RequestException)
+            with self.assertRaises(SourcesHTTPClientError):
+                client.get_source_type_name(source_type_id)
+
+    @patch.object(Config, 'SOURCES_API_URL', 'http://www.sources.com')
+    def test_get_source_type_name_non_200(self):
+        """Test to get source type name from type id with bad response."""
+        source_type_id = 3
+        mock_source_name = 'fakesource'
+        client = SourcesHTTPClient(auth_header=Config.SOURCES_FAKE_HEADER)
+        with requests_mock.mock() as m:
+            m.get(f'http://www.sources.com/api/v1.0/source_types?filter[id]={source_type_id}',
+                  status_code=404, json={'data': [{'name': mock_source_name}]})
+            with self.assertRaises(SourcesHTTPClientError):
+                client.get_source_type_name(source_type_id)
+
+    @patch.object(Config, 'SOURCES_API_URL', 'http://www.sources.com')
     def test_get_aws_role_arn(self):
         """Test to get AWS Role ARN from authentication service."""
         resource_id = 2

--- a/scripts/create_sources.py
+++ b/scripts/create_sources.py
@@ -150,7 +150,7 @@ class SourcesDataGenerator:
                      'status_details': 'Details Here', 'username': 'username', 'resource_type': 'Endpoint',
                      'resource_id': str(resource_id)}
 
-        url = '{}/{}'.format(self._base_url, 'authentication')
+        url = '{}/{}'.format(self._base_url, 'authentications')
         r = requests.post(url, headers=self._identity_header, json=json_data)
         response = r.json()
         return response.get('id')


### PR DESCRIPTION
While testing Sources Client in CI I noticed that the Source Type IDs are different between local and CI deployments.  Verified with the Sources team that we need to be looking up the source name (which will not change) for a given source type id.

**Testing**
Regression tested all providers.  Verified AWS, OCP, and Azure providers could be created.