### PR TITLE
update logic to check for markup and rates for non-ocp provider

### DIFF
--- a/koku/cost_models/serializers.py
+++ b/koku/cost_models/serializers.py
@@ -288,7 +288,10 @@ class CostModelSerializer(serializers.Serializer):
 
     def validate(self, data):
         """Validate that the source type is acceptable."""
-        if data.get('markup') and data['source_type'] in SOURCE_TYPE_MAP.keys():
+        if data.get('markup') \
+            and not data.get('rates') \
+            and data['source_type'] in SOURCE_TYPE_MAP.keys() \
+            and data['source_type'] != 'OCP':
             return data
         if data['source_type'] not in self.metric_map.keys():
             raise serializers.ValidationError('{} is not a valid source.'.format(data['source_type']))

--- a/koku/cost_models/serializers.py
+++ b/koku/cost_models/serializers.py
@@ -288,6 +288,7 @@ class CostModelSerializer(serializers.Serializer):
 
     def validate(self, data):
         """Validate that the source type is acceptable."""
+        # The cost model has markup, no rates, and is for a valid non-OpenShift source type
         if (data.get('markup') and not data.get('rates') and data['source_type'] != 'OCP'
                 and data['source_type'] in SOURCE_TYPE_MAP.keys()):
             return data

--- a/koku/cost_models/serializers.py
+++ b/koku/cost_models/serializers.py
@@ -288,10 +288,8 @@ class CostModelSerializer(serializers.Serializer):
 
     def validate(self, data):
         """Validate that the source type is acceptable."""
-        if data.get('markup') \
-            and not data.get('rates') \
-            and data['source_type'] in SOURCE_TYPE_MAP.keys() \
-            and data['source_type'] != 'OCP':
+        if (data.get('markup') and not data.get('rates') and data['source_type'] != 'OCP'
+                and data['source_type'] in SOURCE_TYPE_MAP.keys()):
             return data
         if data['source_type'] not in self.metric_map.keys():
             raise serializers.ValidationError('{} is not a valid source.'.format(data['source_type']))

--- a/koku/cost_models/test/tests_serializers.py
+++ b/koku/cost_models/test/tests_serializers.py
@@ -113,6 +113,7 @@ class CostModelSerializerTest(IamTestCase):
     def test_not_OCP_source_type_with_markup(self):
         """Test that a source type is valid if it has markup."""
         self.ocp_data['source_type'] = 'AWS'
+        self.ocp_data['rates'] = []
 
         with tenant_context(self.tenant):
             instance = None
@@ -136,6 +137,16 @@ class CostModelSerializerTest(IamTestCase):
         """Test error when non OCP source is added without markup."""
         self.ocp_data['source_type'] = 'AWS'
         self.ocp_data['markup'] = {}
+        with tenant_context(self.tenant):
+            serializer = CostModelSerializer(data=self.ocp_data)
+            with self.assertRaises(serializers.ValidationError):
+                if serializer.is_valid(raise_exception=True):
+                    serializer.save()
+
+    def test_error_on_nonOCP_source_type_with_markup_and_rates(self):
+        """Test error when non OCP source is added with markup and rates."""
+        self.ocp_data['source_type'] = 'AWS'
+
         with tenant_context(self.tenant):
             serializer = CostModelSerializer(data=self.ocp_data)
             with self.assertRaises(serializers.ValidationError):


### PR DESCRIPTION
fixes #1178 

POST:
```
{
    "name": "Test Cost Model",
    "description": "test",
    "source_type": "AWS",
    "provider_uuids": [],
    "rates": [
        {"metric": {"name": "cpu_core_request_per_hour"},
        "tiered_rates": [{"unit": "USD", "value": 0.10}]
        }
    ],
    "markup": {
        "value": 10,
        "unit": "percent"
    }
}
```

See Error:
```
{
    "errors": [
        {
            "detail": "AWS is not a valid source.",
            "source": "non_field_errors",
            "status": 400
        }
    ]
}
```