### PR TITLE
make azure tags return array of values

### DIFF
--- a/koku/api/tags/azure/queries.py
+++ b/koku/api/tags/azure/queries.py
@@ -70,7 +70,9 @@ class AzureTagQueryHandler(TagQueryHandler):
                             LOG.warning('Bad value in tags: %s', item)
                             LOG.info('Tag keys: %s', tag_keys)
                             continue
-                        dikt = {'key': key, 'values': value}
+                        values = []
+                        values.append(value)
+                        dikt = {'key': key, 'values': values}
                         if dikt not in merged_data:
                             merged_data.append(dikt)
         return merged_data


### PR DESCRIPTION
#1140 

1. Go to v1/tags/azure/?filter[subscription_guid]=2639de71-ca37-4a17-a104-17665a50e7fc
2. See value returned

```
GET /api/cost-management/v1/tags/azure/?filter[subscription_guid]=2639de71-ca37-4a17-a104-17665a50e7fc
HTTP 200 OK
Allow: GET, HEAD, OPTIONS
Content-Type: application/json
Vary: HTTP_X_RH_IDENTITY, Accept

{
    "meta": {
        "count": 2,
        "filter": {
            "subscription_guid": [
                "2639de71-ca37-4a17-a104-17665a50e7fc"
            ],
            "time_scope_value": "-10",
            "time_scope_units": "day",
            "resolution": "daily"
        },
        "key_only": false
    },
    "links": {
        "first": "/api/cost-management/v1/tags/azure/?filter%5Bsubscription_guid%5D=2639de71-ca37-4a17-a104-17665a50e7fc&limit=100&offset=0",
        "next": null,
        "previous": null,
        "last": "/api/cost-management/v1/tags/azure/?filter%5Bsubscription_guid%5D=2639de71-ca37-4a17-a104-17665a50e7fc&limit=100&offset=0"
    },
    "data": [
        {
            "key": "cost",
            "values": [
                "management"
            ]
        },
        {
            "key": "project",
            "values": [
                "p1"
            ]
        }
    ]
}
```