### PR TITLE
Add support for aws glacier storage_class in the dataexport syncer.

### DIFF
--- a/koku/api/dataexport/models.py
+++ b/koku/api/dataexport/models.py
@@ -12,9 +12,11 @@ class DataExportRequest(models.Model):
 
     PENDING = 'pending'
     PROCESSING = 'processing'
+    WAITING = 'waiting'
     COMPLETE = 'complete'
     ERROR = 'error'
-    STATUS_CHOICES = ((PENDING, 'Pending'), (PROCESSING, 'Processing'), (COMPLETE, 'Complete'), (ERROR, 'Error'))
+    STATUS_CHOICES = ((PENDING, 'Pending'), (PROCESSING, 'Processing'), (WAITING, 'Waiting'),
+                      (COMPLETE, 'Complete'), (ERROR, 'Error'))
 
     uuid = models.UUIDField(default=uuid4, editable=False, unique=True, null=False)
     created_by = models.ForeignKey('User', null=False, on_delete=models.CASCADE)

--- a/koku/api/dataexport/syncer/tests_syncer.py
+++ b/koku/api/dataexport/syncer/tests_syncer.py
@@ -3,11 +3,12 @@ from datetime import date, timedelta
 from unittest.mock import Mock, patch
 
 import faker
+from botocore.exceptions import ClientError
 from dateutil.rrule import DAILY, MONTHLY, rrule
 from django.conf import settings
 from django.test import TestCase
 
-from api.dataexport.syncer import AwsS3Syncer
+from api.dataexport.syncer import AwsS3Syncer, SyncedFileInColdStorageError
 
 fake = faker.Faker()
 
@@ -132,3 +133,105 @@ class AwsS3SyncerTest(TestCase):
 
         mock_destination_object.assert_not_called()
         mock_copy_from.assert_not_called()
+
+    @patch('api.dataexport.syncer.boto3')
+    def test_sync_file_in_glacier(self, mock_boto3):
+        """Test syncing a file in glacier will call restore, and raise an exception."""
+        client_error_glacier = ClientError(
+            error_response={'Error': {'Code': 'InvalidObjectState'}},
+            operation_name=Mock(),
+        )
+        source_bucket_name = fake.slug()
+        destination_bucket_name = fake.slug()
+        account = fake.word()
+
+        start_date = date(2019, 1, 1)
+        end_date = date(2019, 3, 1)
+        date_range = (start_date, end_date)
+
+        source_object = Mock()
+        source_object.key = f'{settings.S3_BUCKET_PATH}/{account}{fake.file_path()}'
+        source_object.bucket_name = source_bucket_name
+        source_object.storage_class = 'GLACIER'
+
+        self.assertNotEqual(source_bucket_name, destination_bucket_name)
+
+        mock_resource = mock_boto3.resource
+        mock_buckets = mock_resource.return_value.Bucket
+        mock_filter = mock_buckets.return_value.objects.filter
+        mock_filter.return_value = (source_object,)
+        mock_destination_object = mock_buckets.return_value.Object
+        mock_copy_from = mock_destination_object.return_value.copy_from
+        mock_copy_from.side_effect = client_error_glacier
+        with self.assertRaises(SyncedFileInColdStorageError):
+            syncer = AwsS3Syncer(source_bucket_name)
+            syncer.sync_bucket(account, destination_bucket_name, date_range)
+        source_object.restore_object.assert_called()
+
+    @patch('api.dataexport.syncer.boto3')
+    def test_sync_glacier_file_restore_in_progress(self, mock_boto3):
+        """Test syncing a file that is currently being restored from glacier will raise an exception."""
+        restore_in_progress_error = ClientError(
+            error_response={'Error': {'Code': 'RestoreAlreadyInProgress'}},
+            operation_name=Mock(),
+        )
+        source_bucket_name = fake.slug()
+        destination_bucket_name = fake.slug()
+        account = fake.word()
+
+        start_date = date(2019, 1, 1)
+        end_date = date(2019, 3, 1)
+        date_range = (start_date, end_date)
+
+        source_object = Mock()
+        source_object.key = f'{settings.S3_BUCKET_PATH}/{account}{fake.file_path()}'
+        source_object.bucket_name = source_bucket_name
+        source_object.storage_class = 'GLACIER'
+
+        self.assertNotEqual(source_bucket_name, destination_bucket_name)
+
+        mock_resource = mock_boto3.resource
+        mock_buckets = mock_resource.return_value.Bucket
+        mock_filter = mock_buckets.return_value.objects.filter
+        mock_filter.return_value = (source_object,)
+        mock_destination_object = mock_buckets.return_value.Object
+        mock_copy_from = mock_destination_object.return_value.copy_from
+        mock_copy_from.side_effect = restore_in_progress_error
+
+        with self.assertRaises(SyncedFileInColdStorageError):
+            syncer = AwsS3Syncer(source_bucket_name)
+            syncer.sync_bucket(account, destination_bucket_name, date_range)
+        source_object.restore_object.assert_not_called()
+
+    @patch('api.dataexport.syncer.boto3')
+    def test_sync_fail_boto3_client_exception(self, mock_boto3):
+        """Test that if an client error, we raise that error."""
+        client_error = ClientError(
+            error_response={'Error': {'Code': fake.word()}},
+            operation_name=Mock(),
+        )
+        source_bucket_name = fake.slug()
+        destination_bucket_name = fake.slug()
+        account = fake.word()
+
+        start_date = date(2019, 1, 1)
+        end_date = date(2019, 3, 1)
+        date_range = (start_date, end_date)
+
+        source_object = Mock()
+        source_object.key = f'{settings.S3_BUCKET_PATH}/{account}{fake.file_path()}'
+        source_object.bucket_name = source_bucket_name
+        self.assertNotEqual(source_bucket_name, destination_bucket_name)
+
+        mock_resource = mock_boto3.resource
+        mock_buckets = mock_resource.return_value.Bucket
+        mock_filter = mock_buckets.return_value.objects.filter
+        mock_filter.return_value = (source_object,)
+        mock_destination_object = mock_buckets.return_value.Object
+        mock_copy_from = mock_destination_object.return_value.copy_from
+        mock_copy_from.side_effect = client_error
+
+        with self.assertRaises(ClientError):
+            syncer = AwsS3Syncer(source_bucket_name)
+            syncer.sync_bucket(account, destination_bucket_name, date_range)
+        source_object.restore_object.assert_not_called()

--- a/koku/koku/settings.py
+++ b/koku/koku/settings.py
@@ -429,3 +429,6 @@ S3_BUCKET_NAME = ENVIRONMENT.get_value('S3_BUCKET_NAME', default='koku-reports')
 S3_BUCKET_PATH = ENVIRONMENT.get_value('S3_BUCKET_PATH', default='data_archive')
 S3_REGION = ENVIRONMENT.get_value('S3_REGION', default='us-east-1')
 ENABLE_S3_ARCHIVING = ENVIRONMENT.get_value('ENABLE_S3_ARCHIVING', default=True)
+
+# Time to wait between cold storage retrieval for data export. Default is 3 hours
+COLD_STORAGE_RETRIVAL_WAIT_TIME = int(os.getenv('COLD_STORAGE_RETRIVAL_WAIT_TIME', default='10800'))

--- a/koku/masu/external/downloader/gcp/gcp_report_downloader.py
+++ b/koku/masu/external/downloader/gcp/gcp_report_downloader.py
@@ -305,6 +305,7 @@ class GCPReportDownloader(ReportDownloaderBase, DownloaderInterface):
     def _get_local_file_path(self, directory_path, key):
         """
         Get the local file path destination for a downloaded file.
+
         Args:
             directory_path (str): base local directory path
             key (str): name of the blob in the GCP storage bucket

--- a/koku/masu/test/celery/test_tasks.py
+++ b/koku/masu/test/celery/test_tasks.py
@@ -1,10 +1,13 @@
 """Tests for celery tasks."""
 from datetime import date, datetime
-from unittest.mock import call, patch
+from unittest.mock import call, patch, Mock
 
 import faker
 from botocore.exceptions import ClientError
+from celery.exceptions import Retry, MaxRetriesExceededError
 
+from api.dataexport.models import DataExportRequest as APIExportRequest
+from api.dataexport.syncer import SyncedFileInColdStorageError
 from masu.celery import tasks
 from masu.test import MasuTestCase
 
@@ -113,3 +116,32 @@ class TestCeleryTasks(MasuTestCase):
         mock_sync.assert_called_once()
         mock_sync.return_value.sync_bucket.assert_called_once()
         mock_log.exception.assert_called_once()
+
+    @patch('masu.celery.tasks.DataExportRequest.objects')
+    @patch('masu.celery.tasks.AwsS3Syncer')
+    def test_sync_data_to_customer_cold_storage_retry(self, mock_sync, mock_data_export_request):
+        """Test that the sync task retries syncer fails with a cold storage error."""
+        data_export_object = Mock()
+        data_export_object.uuid = fake.uuid4()
+        data_export_object.status = APIExportRequest.PENDING
+
+        mock_data_export_request.get.return_value = data_export_object
+        mock_sync.return_value.sync_bucket.side_effect = SyncedFileInColdStorageError()
+        with self.assertRaises(Retry):
+            tasks.sync_data_to_customer(data_export_object.uuid)
+        self.assertEquals(data_export_object.status, APIExportRequest.WAITING)
+
+    @patch('masu.celery.tasks.sync_data_to_customer.retry', side_effect=MaxRetriesExceededError())
+    @patch('masu.celery.tasks.DataExportRequest.objects')
+    @patch('masu.celery.tasks.AwsS3Syncer')
+    def test_sync_data_to_customer_max_retry(self, mock_sync, mock_data_export_request, mock_retry):
+        """Test that the sync task retries syncer fails with a cold storage error."""
+        data_export_object = Mock()
+        data_export_object.uuid = fake.uuid4()
+        data_export_object.status = APIExportRequest.PENDING
+
+        mock_data_export_request.get.return_value = data_export_object
+        mock_sync.return_value.sync_bucket.side_effect = SyncedFileInColdStorageError()
+
+        tasks.sync_data_to_customer(data_export_object.uuid)
+        self.assertEquals(data_export_object.status, APIExportRequest.ERROR)


### PR DESCRIPTION
- When the file being synced is in glacier storage, restore that file and try
  to sync again later.

- When the file being synced is in IA-Standard, it can be copied with the usual `copy_from`, no additional check is needed.