### PR TITLE
safer sql AWS_report_db_accessor.py

### DIFF
--- a/koku/masu/database/aws_report_db_accessor.py
+++ b/koku/masu/database/aws_report_db_accessor.py
@@ -235,15 +235,11 @@ class AWSReportDBAccessor(ReportDBAccessorBase):
             'sql/reporting_awscostentrylineitem_daily_summary.sql'
         )
         summary_sql = summary_sql.decode('utf-8')
-        bill_id_where_clause = ''
-        if bill_ids:
-            ids = ','.join(bill_ids)
-            bill_id_where_clause = f'AND cost_entry_bill_id IN ({ids})'
         summary_sql_params = {
             'uuid': str(uuid.uuid4()).replace('-', '_'),
             'start_date': start_date,
             'end_date': end_date,
-            'bill_id_where_clause': bill_id_where_clause,
+            'bill_ids': bill_ids,
             'schema': self.schema
         }
         summary_sql, summary_sql_params = self.jinja_sql.prepare_query(

--- a/koku/masu/database/sql/reporting_awscostentrylineitem_daily_summary.sql
+++ b/koku/masu/database/sql/reporting_awscostentrylineitem_daily_summary.sql
@@ -33,7 +33,12 @@ CREATE TEMPORARY TABLE reporting_awscostentrylineitem_daily_summary_{{uuid | sql
         ON li.usage_account_id = aa.account_id
     WHERE date(li.usage_start) >= {{start_date}}
         AND date(li.usage_start) <= {{end_date}}
-        {{bill_id_where_clause | sqlsafe}}
+        {% if bill_ids %}
+        AND cost_entry_bill_id IN (
+            {%- for bill_id in bill_ids  -%}
+                {{bill_id}}{% if not loop.last %},{% endif %}
+            {%- endfor -%})
+        {% endif %}
     GROUP BY li.cost_entry_bill_id,
         li.usage_start,
         li.usage_end,
@@ -52,7 +57,12 @@ CREATE TEMPORARY TABLE reporting_awscostentrylineitem_daily_summary_{{uuid | sql
 DELETE FROM {{schema | sqlsafe}}.reporting_awscostentrylineitem_daily_summary AS li
 WHERE li.usage_start >= {{start_date}}
     AND li.usage_start <= {{end_date}}
-    {{bill_id_where_clause | sqlsafe}}
+    {% if bill_ids %}
+    AND cost_entry_bill_id IN (
+        {%- for bill_id in bill_ids  -%}
+            {{bill_id}}{% if not loop.last %},{% endif %}
+        {%- endfor -%})
+    {% endif %}
 ;
 
 -- Populate the daily aggregate line item data


### PR DESCRIPTION
This PR replaces the Python formatting in the aws_report_db_accessor.py in exchange for Jinja2 templating to make the SQL more safe by using Bind params instead of string substitution in the SQL.