### PR TITLE
1221 bugfix provider type 500

### DIFF
--- a/koku/api/provider/serializers.py
+++ b/koku/api/provider/serializers.py
@@ -30,6 +30,7 @@ from api.provider.models import (Provider,
                                  ProviderBillingSource,
                                  Sources)
 
+PROVIDER_CHOICE_LIST = [provider[0].lower() for provider in Provider.PROVIDER_CHOICES]
 
 def error_obj(key, message):
     """Create an error object."""
@@ -203,6 +204,11 @@ class ProviderSerializer(serializers.ModelSerializer):
         provider_type = None
         if data and data != empty:
             provider_type = data.get('type')
+
+        if provider_type and provider_type.lower() not in PROVIDER_CHOICE_LIST:
+            key = 'type'
+            message = f'{provider_type} is not a valid source type.'
+            raise serializers.ValidationError(error_obj(key, message))
 
         if provider_type:
             self.fields['authentication'] = AUTHENTICATION_SERIALIZERS.get(provider_type)()

--- a/koku/api/provider/serializers.py
+++ b/koku/api/provider/serializers.py
@@ -32,6 +32,7 @@ from api.provider.models import (Provider,
 
 PROVIDER_CHOICE_LIST = [provider[0].lower() for provider in Provider.PROVIDER_CHOICES]
 
+
 def error_obj(key, message):
     """Create an error object."""
     error = {

--- a/koku/api/provider/test/tests_serializers.py
+++ b/koku/api/provider/test/tests_serializers.py
@@ -355,6 +355,26 @@ class ProviderSerializerTest(IamTestCase):
                 if serializer.is_valid(raise_exception=True):
                     serializer.save()
 
+    def test_create_provider_invalid_type(self):
+        """Test that an invalid provider type is not validated."""
+        iam_arn = 'arn:aws:s3:::my_s3_bucket'
+        bucket_name = 'my_s3_bucket'
+        provider = {'name': 'test_provider',
+                    'type': 'Bad',
+                    'authentication': {
+                        'provider_resource_name': iam_arn
+                    },
+                    'billing_source': {
+                        'bucket': bucket_name
+                    }}
+        instance = None
+
+        with patch.object(ProviderAccessor, 'cost_usage_source_ready', returns=True):
+            with self.assertRaises(ValidationError):
+                serializer = ProviderSerializer(data=provider, context=self.request_context)
+                if serializer.is_valid(raise_exception=True):
+                    instance = serializer.save()
+
 
 class AdminProviderSerializerTest(IamTestCase):
     """Tests for the admin customer serializer."""

--- a/koku/api/provider/test/tests_serializers.py
+++ b/koku/api/provider/test/tests_serializers.py
@@ -367,13 +367,12 @@ class ProviderSerializerTest(IamTestCase):
                     'billing_source': {
                         'bucket': bucket_name
                     }}
-        instance = None
 
         with patch.object(ProviderAccessor, 'cost_usage_source_ready', returns=True):
             with self.assertRaises(ValidationError):
                 serializer = ProviderSerializer(data=provider, context=self.request_context)
                 if serializer.is_valid(raise_exception=True):
-                    instance = serializer.save()
+                    serializer.save()
 
 
 class AdminProviderSerializerTest(IamTestCase):


### PR DESCRIPTION
## Summary
Invalid provider types were causing a traceback and 500. This introduces a validation error with a 400 instead.

## Testing

```
POST /api/cost-management/v1/providers/
HTTP 400 Bad Request
Allow: GET, POST, HEAD, OPTIONS
Content-Type: application/json
Vary: Accept

{
    "errors": [
        {
            "detail": "BAD is not a valid source type.",
            "source": "type",
            "status": 400
        }
    ]
}
```

using
```
{
    "name": "",
    "type": "BAD",
    "authentication": {
        "provider_resource_name": "",
        "credentials": null
    },
    "billing_source": {
        "bucket": "",
        "data_source": null
    }
}
```