### PR TITLE
1226 Create OCP/AWS providers with missing params raises 500

### DIFF
--- a/koku/api/provider/serializers.py
+++ b/koku/api/provider/serializers.py
@@ -65,6 +65,8 @@ class ProviderAuthenticationSerializer(serializers.ModelSerializer):
 
     def validate(self, data):
         """Validate authentication parameters."""
+        if not data.get('credentials'):
+            data['credentials'] = data.get('credentials', {})
         if data.get('provider_resource_name') and not data.get('credentials'):
             data['credentials'] = {'provider_resource_name': data.get('provider_resource_name')}
         if data.get('credentials').get('provider_resource_name'):
@@ -124,6 +126,8 @@ class ProviderBillingSourceSerializer(serializers.ModelSerializer):
 
     def validate(self, data):
         """Validate billing source."""
+        if not data.get('data_source'):
+            data['data_source'] = data.get('data_source', {})
         if (data.get('bucket') or data.get('bucket') == '') and not data.get('data_source'):
             data['data_source'] = {'bucket': data.get('bucket')}
         if data.get('data_source').get('bucket'):

--- a/koku/api/provider/test/tests_views.py
+++ b/koku/api/provider/test/tests_views.py
@@ -21,6 +21,7 @@ from uuid import uuid4
 from django.urls import reverse
 from providers.provider_access import ProviderAccessor
 from rest_framework import status
+from rest_framework.exceptions import ValidationError
 from rest_framework.test import APIClient
 
 from api.iam.serializers import UserSerializer
@@ -110,6 +111,39 @@ class ProviderViewTest(IamTestCase):
         with patch.object(ProviderAccessor, 'cost_usage_source_ready', returns=True):
             client = APIClient()
             return client.post(url, data=provider, format='json', **req_headers), provider
+
+    def test_create_aws_with_no_provider_resource_name(self):
+        """Test missing provider_resource_name returns 400."""
+        req_headers = self.headers
+        provider = {'name': 'test_provider',
+                    'type': Provider.PROVIDER_AWS,
+                    'authentication': {
+                        'provider_resource_name': ''
+                    },
+                    'billing_source': {
+                        'bucket': ''
+                    }}
+        url = reverse('provider-list')
+        client = APIClient()
+        response = client.post(url, data=provider, format='json', **req_headers)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    @patch('providers.aws.provider._get_sts_access', return_value={'empty': 'dict'})
+    def test_create_aws_with_no_bucket_name(self, mock_sts_return):
+        """Test missing bucket returns 400."""
+        req_headers = self.headers
+        provider = {'name': 'test_provider',
+                    'type': Provider.PROVIDER_AWS,
+                    'authentication': {
+                        'provider_resource_name': 'arn:aws:s3:::my_s3_bucket'
+                    },
+                    'billing_source': {
+                        'bucket': ''
+                    }}
+        url = reverse('provider-list')
+        client = APIClient()
+        response = client.post(url, data=provider, format='json', **req_headers)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_create_provider(self):
         """Test create a provider."""

--- a/koku/api/provider/test/tests_views.py
+++ b/koku/api/provider/test/tests_views.py
@@ -21,7 +21,6 @@ from uuid import uuid4
 from django.urls import reverse
 from providers.provider_access import ProviderAccessor
 from rest_framework import status
-from rest_framework.exceptions import ValidationError
 from rest_framework.test import APIClient
 
 from api.iam.serializers import UserSerializer


### PR DESCRIPTION
#1226 

1. Create AWS or OCP provider with missing provider_resource_name _or_ bucket.
```
{
    "name": "provider",
    "type": "AWS",
    "authentication": {
        "provider_resource_name": "arn:aws:iam::000000000000:role/CostManagement"
    },
    "billing_source": {
        "bucket": ""
    }
}
```
or
```
{
    "name": "provider",
    "type": "AWS",
    "authentication": {
        "provider_resource_name": ""
    },
    "billing_source": {
        "bucket": ""
    }
}
```
or
```
{
    "name": "provider",
    "type": "OCP",
    "authentication": {
        "provider_resource_name": ""
    },
    "billing_source": {
        "bucket": ""
    }
}
```
2. See 400 Bad Request
```
{
    "errors": [
        {
            "detail": "Bucket is a required parameter for AWS and must not be blank.",
            "source": "billing_source.bucket",
            "status": 400
        }
    ]
}
```
or
```
{
    "errors": [
        {
            "detail": "Provider resource name is a required parameter for AWS and must not be blank.",
            "source": "authentication.provider_resource_name",
            "status": 400
        }
    ]
}
```
or
```
{
    "errors": [
        {
            "detail": "Provider resource name is a required parameter for OCP.",
            "source": "authentication.provider_resource_name",
            "status": 400
        }
    ]
}
```