### PR TITLE
handling EOFError in listener

### DIFF
--- a/koku/masu/external/kafka_msg_handler.py
+++ b/koku/masu/external/kafka_msg_handler.py
@@ -115,7 +115,7 @@ def extract_payload(url):
         mytar.extractall(path=temp_dir)
         files = mytar.getnames()
         manifest_path = [manifest for manifest in files if 'manifest.json' in manifest]
-    except ReadError as error:
+    except (ReadError, EOFError) as error:
         LOG.error('Unable to untar file. Reason: %s', str(error))
         shutil.rmtree(temp_dir)
         raise KafkaMsgHandlerError('Extraction failure.')
@@ -231,6 +231,7 @@ def handle_message(msg):
     if msg.topic == HCCM_TOPIC:
         value = json.loads(msg.value.decode('utf-8'))
         try:
+            LOG.info(f'Extracting Payload for msg: {str(msg)}')
             report_meta = extract_payload(value['url'])
             return SUCCESS_CONFIRM_STATUS, report_meta
         except KafkaMsgHandlerError as error:


### PR DESCRIPTION
The following backtrace was seen on production.  It's not clear what the root cause is but for now I want to at least handle this exception while we continue to investigate.

Additionally we were not logging the Kafka request_id until we validate the message back to the ingress service.  Unfortunately that was being done *after* extraction so we don't have any request_id for this case to try and retrieve the offending payload from the ingress service.  Adding a log message to correct that.

```
Task exception was never retrieved
future: <Task finished coro=<process_messages() done, defined at /opt/app-root/src/koku/masu/external/kafka_msg_handler.py:304> exception=EOFError('Compressed file ended before the end-of-stream marker was reached',)>
Traceback (most recent call last):
  File "/opt/app-root/src/koku/masu/external/kafka_msg_handler.py", line 317, in process_messages
    status, report_meta = handle_message(msg)
  File "/opt/app-root/src/koku/masu/external/kafka_msg_handler.py", line 234, in handle_message
    report_meta = extract_payload(value['url'])
  File "/opt/app-root/src/koku/masu/external/kafka_msg_handler.py", line 115, in extract_payload
    mytar.extractall(path=temp_dir)
  File "/opt/app-root/lib64/python3.6/tarfile.py", line 2007, in extractall
    numeric_owner=numeric_owner)
  File "/opt/app-root/lib64/python3.6/tarfile.py", line 2049, in extract
    numeric_owner=numeric_owner)
  File "/opt/app-root/lib64/python3.6/tarfile.py", line 2119, in _extract_member
    self.makefile(tarinfo, targetpath)
  File "/opt/app-root/lib64/python3.6/tarfile.py", line 2168, in makefile
    copyfileobj(source, target, tarinfo.size, ReadError, bufsize)
  File "/opt/app-root/lib64/python3.6/tarfile.py", line 248, in copyfileobj
    buf = src.read(bufsize)
  File "/opt/rh/rh-python36/root/usr/lib64/python3.6/gzip.py", line 276, in read
    return self._buffer.read(size)
  File "/opt/rh/rh-python36/root/usr/lib64/python3.6/_compression.py", line 68, in readinto
    data = self.read(len(byte_view))
  File "/opt/rh/rh-python36/root/usr/lib64/python3.6/gzip.py", line 482, in read
    raise EOFError("Compressed file ended before the "
EOFError: Compressed file ended before the end-of-stream marker was reached
```

**Testing**
Attempted to reproduce the EOFError by corrupting tar.gz files but was unsuccessful.  Here's an example of the log message:
```
koku_listener     | [2019-10-09 17:21:44,428] INFO: Starting Kafka handler
koku_listener     | [2019-10-09 17:21:47,510] INFO: Listener started.  Waiting for messages...
koku_listener     | [2019-10-09 17:21:56,894] INFO: Extracting Payload for msg: ConsumerRecord(topic='platform.upload.hccm', partition=0, offset=1, timestamp=1570641716890, timestamp_type=0, key=None, value=b'{"account": "12345", "rh_account": "12345", "principal": "54321", "request_id": "52df9f748eabcfea", "payload_id": "52df9f748eabcfea", "size": 1127, "service": "hccm", "category": "tar", "b64_identity": "eyJpZGVudGl0eSI6IHsiYWNjb3VudF9udW1iZXIiOiAiMTIzNDUiLCAiaW50ZXJuYWwiOiB7Im9yZ19pZCI6ICI1NDMyMSJ9fX0=", "url": "https://insights-perm.s3.amazonaws.com/52df9f748eabcfea?AWSAccessKeyId=AKIAYSLL3JVQ225QH362&Signature=5aMq3xLBnz21NoGsOtoPRu2VOs0%3D&Expires=1570728116"}', checksum=None, serialized_key_size=-1, serialized_value_size=467, headers=())
koku_listener     | [2019-10-09 17:21:57,084] INFO: Successfully extracted OCP for my-ocp-cluster-1/20191001-20191101
koku_listener     | [2019-10-09 17:21:57,115] INFO: Validating message: b'{"request_id": "52df9f748eabcfea", "validation": "success"}'
koku_listener     | [2019-10-09 17:21:57,148] INFO: Validating message complete.
koku_listener     | [2019-10-09 17:21:57,183] ERROR: Could not find provider_uuid for cluster_id: my-ocp-cluster-1
koku_listener     | [2019-10-09 17:21:57,183] INFO: Processing: {'files': ['c2f41484-672e-499b-9747-139b6d2a8407_October-2019-my-ocp-cluster-1-ocp_pod_usage.csv', 'c2f41484-672e-499b-9747-139b6d2a8407_October-2019-my-ocp-cluster-1-ocp_storage_usage.csv'], 'date': datetime.datetime(2019, 10, 9, 11, 33, 8, 548260), 'uuid': 'c2f41484-672e-499b-9747-139b6d2a8407', 'cluster_id': 'my-ocp-cluster-1', 'manifest_path': '/var/tmp/masu/tmpga8lesj0/manifest.json'} complete.
```