### PR TITLE
Fix batching for azure report processing.

### DIFF
--- a/koku/masu/processor/azure/azure_report_processor.py
+++ b/koku/masu/processor/azure/azure_report_processor.py
@@ -300,19 +300,19 @@ class AzureReportProcessor(ReportProcessorBase):
                 reader = csv.DictReader(f)
                 for row in reader:
                     _ = self.create_cost_entry_objects(row, report_db)
-                if len(self.processed_report.line_items) >= self._batch_size:
-                    self._save_to_db(temp_table, report_db)
-                    report_db.merge_temp_table(
-                        self.table_name._meta.db_table,
-                        temp_table,
-                        self.line_item_columns,
-                        self.line_item_conflict_columns
-                    )
-                    LOG.info('Saving report rows %d to %d for %s', row_count,
-                             row_count + len(self.processed_report.line_items),
-                             self._report_name)
-                    row_count += len(self.processed_report.line_items)
-                    self._update_mappings()
+                    if len(self.processed_report.line_items) >= self._batch_size:
+                        self._save_to_db(temp_table, report_db)
+                        report_db.merge_temp_table(
+                            self.table_name._meta.db_table,
+                            temp_table,
+                            self.line_item_columns,
+                            self.line_item_conflict_columns
+                        )
+                        LOG.info('Saving report rows %d to %d for %s', row_count,
+                                 row_count + len(self.processed_report.line_items),
+                                 self._report_name)
+                        row_count += len(self.processed_report.line_items)
+                        self._update_mappings()
 
                 if self.processed_report.line_items:
                     self._save_to_db(temp_table, report_db)


### PR DESCRIPTION
If the check for batch size is outside of the for loop, reports aren't actually processed in batches (just one big batch at the end). 