### PR TITLE
1257 scrape logs

### DIFF
--- a/koku/koku/settings.py
+++ b/koku/koku/settings.py
@@ -341,7 +341,6 @@ LOGGING = {
         'api': {
             'handlers': LOGGING_HANDLERS,
             'level': KOKU_LOGGING_LEVEL,
-            'propagate': False,
         },
         'celery': {
             'handlers': LOGGING_HANDLERS,
@@ -355,17 +354,14 @@ LOGGING = {
         'providers': {
             'handlers': LOGGING_HANDLERS,
             'level': KOKU_LOGGING_LEVEL,
-            'propagate': False,
         },
         'reporting': {
             'handlers': LOGGING_HANDLERS,
             'level': KOKU_LOGGING_LEVEL,
-            'propagate': False,
         },
         'reporting_common': {
             'handlers': LOGGING_HANDLERS,
             'level': KOKU_LOGGING_LEVEL,
-            'propagate': False,
         },
         'masu': {
             'handlers': LOGGING_HANDLERS,
@@ -375,7 +371,6 @@ LOGGING = {
         'sources': {
             'handlers': LOGGING_HANDLERS,
             'level': KOKU_LOGGING_LEVEL,
-            'propagate': False,
         },
     },
 }

--- a/koku/koku/settings.py
+++ b/koku/koku/settings.py
@@ -318,6 +318,10 @@ LOGGING = {
         },
     },
     'handlers': {
+        'celery': {
+            'class': 'logging.StreamHandler',
+            'formatter': LOGGING_FORMATTER
+        },
         'console': {
             'class': 'logging.StreamHandler',
             'formatter': LOGGING_FORMATTER
@@ -337,6 +341,12 @@ LOGGING = {
         'api': {
             'handlers': LOGGING_HANDLERS,
             'level': KOKU_LOGGING_LEVEL,
+            'propagate': False,
+        },
+        'celery': {
+            'handlers': LOGGING_HANDLERS,
+            'level': KOKU_LOGGING_LEVEL,
+            'propagate': False,
         },
         'koku': {
             'handlers': LOGGING_HANDLERS,
@@ -345,22 +355,27 @@ LOGGING = {
         'providers': {
             'handlers': LOGGING_HANDLERS,
             'level': KOKU_LOGGING_LEVEL,
+            'propagate': False,
         },
         'reporting': {
             'handlers': LOGGING_HANDLERS,
             'level': KOKU_LOGGING_LEVEL,
+            'propagate': False,
         },
         'reporting_common': {
             'handlers': LOGGING_HANDLERS,
             'level': KOKU_LOGGING_LEVEL,
+            'propagate': False,
         },
         'masu': {
             'handlers': LOGGING_HANDLERS,
             'level': KOKU_LOGGING_LEVEL,
+            'propagate': False,
         },
         'sources': {
             'handlers': LOGGING_HANDLERS,
             'level': KOKU_LOGGING_LEVEL,
+            'propagate': False,
         },
     },
 }

--- a/koku/masu/external/accounts_accessor.py
+++ b/koku/masu/external/accounts_accessor.py
@@ -84,13 +84,19 @@ class AccountsAccessor:
         """
         poll = False
         if utils.ingest_method_for_provider(account.get('provider_type')) == POLL_INGEST:
-            LOG.info('Polling for account type: %s, uuid: %s',
-                     account.get('provider_type'), account.get('provider_uuid'))
+            log_statement = (f'Polling for\n'
+                             f' schema_name: {account.get("schema_name")}\n'
+                             f' provider: {account.get("provider_type")}\n'
+                             f' account (provider uuid): {account.get("provider_uuid")}')
+            LOG.info(log_statement)
             poll = True
         else:
             if ocp_utils.poll_ingest_override_for_provider(account.get('provider_uuid')):
-                LOG.info('Polling override for account type: %s, uuid: %s',
-                         account.get('provider_type'), account.get('provider_uuid'))
+                log_statement = (f'Polling for'
+                                 f' schema_name: {account.get("schema_name")}\n'
+                                 f' provider: {account.get("provider_type")}\n'
+                                 f' account (provider uuid): {account.get("provider_uuid")}')
+                LOG.info(log_statement)
                 poll = True
         return poll
 

--- a/koku/masu/external/downloader/aws/aws_report_downloader.py
+++ b/koku/masu/external/downloader/aws/aws_report_downloader.py
@@ -282,13 +282,10 @@ class AWSReportDownloader(ReportDownloaderBase, DownloaderInterface):
 
         if not should_download:
             manifest_id = self._get_existing_manifest_db_id(manifest_dict.get('assembly_id'))
-            stmt = ('This manifest has already been downloaded and processed:\n'
-                    ' customer: {},\n'
-                    ' provider_id: {},\n'
-                    ' manifest_id: {}')
-            stmt = stmt.format(self.customer_name,
-                               self._provider_id,
-                               manifest_id)
+            stmt = (f'This manifest has already been downloaded and processed:\n'
+                    f' schema_name: {self.customer_name},\n'
+                    f' provider_id: {self._provider_id},\n'
+                    f' manifest_id: {manifest_id}')
             LOG.info(stmt)
             return report_dict
 

--- a/koku/masu/external/downloader/aws/aws_report_downloader.py
+++ b/koku/masu/external/downloader/aws/aws_report_downloader.py
@@ -282,10 +282,12 @@ class AWSReportDownloader(ReportDownloaderBase, DownloaderInterface):
 
         if not should_download:
             manifest_id = self._get_existing_manifest_db_id(manifest_dict.get('assembly_id'))
-            stmt = (f'This manifest has already been downloaded and processed:\n'
-                    f' schema_name: {self.customer_name},\n'
-                    f' provider_id: {self._provider_id},\n'
-                    f' manifest_id: {manifest_id}')
+            stmt = (
+                f'This manifest has already been downloaded and processed:\n'
+                f' schema_name: {self.customer_name},\n'
+                f' provider_id: {self._provider_id},\n'
+                f' manifest_id: {manifest_id}'
+            )
             LOG.info(stmt)
             return report_dict
 

--- a/koku/masu/external/downloader/azure/azure_report_downloader.py
+++ b/koku/masu/external/downloader/azure/azure_report_downloader.py
@@ -172,10 +172,12 @@ class AzureReportDownloader(ReportDownloaderBase, DownloaderInterface):
 
         if not should_download:
             manifest_id = self._get_existing_manifest_db_id(manifest_dict.get('assembly_id'))
-            stmt = (f'This manifest has already been downloaded and processed:\n'
-                    f' schema_name: {self.customer_name},\n'
-                    f' provider_id: {self._provider_id},\n'
-                    f' manifest_id: {manifest_id}')
+            stmt = (
+                f'This manifest has already been downloaded and processed:\n'
+                f' schema_name: {self.customer_name},\n'
+                f' provider_id: {self._provider_id},\n'
+                f' manifest_id: {manifest_id}'
+            )
             LOG.info(stmt)
             return report_dict
 

--- a/koku/masu/external/downloader/azure/azure_report_downloader.py
+++ b/koku/masu/external/downloader/azure/azure_report_downloader.py
@@ -172,13 +172,10 @@ class AzureReportDownloader(ReportDownloaderBase, DownloaderInterface):
 
         if not should_download:
             manifest_id = self._get_existing_manifest_db_id(manifest_dict.get('assembly_id'))
-            stmt = ('This manifest has already been downloaded and processed:\n'
-                    ' customer: {},\n'
-                    ' provider_id: {},\n'
-                    ' manifest_id: {}')
-            stmt = stmt.format(self.customer_name,
-                               self._provider_id,
-                               manifest_id)
+            stmt = (f'This manifest has already been downloaded and processed:\n'
+                    f' schema_name: {self.customer_name},\n'
+                    f' provider_id: {self._provider_id},\n'
+                    f' manifest_id: {manifest_id}')
             LOG.info(stmt)
             return report_dict
 

--- a/koku/masu/external/downloader/gcp/gcp_report_downloader.py
+++ b/koku/masu/external/downloader/gcp/gcp_report_downloader.py
@@ -89,32 +89,24 @@ class GCPReportDownloader(ReportDownloaderBase, DownloaderInterface):
             manifest_id = self._get_existing_manifest_db_id(
                 manifest_data['assembly_id']
             )
-            LOG.info(
-                'This manifest has already been downloaded and processed:\n'
-                ' customer: "%(customer)s",\n'
-                ' provider_id: %(provider_id)s,\n'
-                ' manifest_id: %(manifest_id)s',
-                {
-                    'customer': self.customer_name,
-                    'provider_id': self._provider_id,
-                    'manifest_id': manifest_id,
-                },
+            stmt = (
+                f'This manifest has already been downloaded and processed:\n'
+                f' schema_name: {self.customer_name}\n'
+                f' provider_id: {self._provider_id}\n'
+                f' manifest_id: {manifest_id}'
             )
+            LOG.info(stmt)
             return {}
 
         file_names_count = len(manifest_data['file_names'])
         if not file_names_count:
-            LOG.info(
-                'No relevant files found for month starting on %(start_date)s '
-                ' for customer "%(customer_name)s", provider_id %(provider_id)s, '
-                ' and bucket_name: %(bucket_name)s',
-                {
-                    'start_date': manifest_data['start_date'],
-                    'customer_name': self.customer_name,
-                    'provider_id': self._provider_id,
-                    'bucket_name': self.bucket_name,
-                },
+            stmt = (
+                f'No relevant files found for month starting {manifest_data["start_date"]}'
+                f' for customer "{self.customer_name}",'
+                f' provider_id {self._provider_id},'
+                f' and bucket_name: {self.bucket_name}'
             )
+            LOG.info(stmt)
             return {}
 
         manifest_id = self._process_manifest_db_record(

--- a/koku/masu/processor/_tasks/download.py
+++ b/koku/masu/processor/_tasks/download.py
@@ -68,24 +68,19 @@ def _get_report_files(customer_name,
     else:
         number_of_months = 2
 
-    stmt = ('Downloading report for'
-            ' credential: {},'
-            ' source: {},'
-            ' customer_name: {},'
-            ' provider: {},'
-            ' number_of_months: {}')
-    log_statement = stmt.format(str(authentication),
-                                str(billing_source),
-                                customer_name,
-                                provider_type,
-                                number_of_months)
+    log_statement = (f'Downloading report for:\n'
+                     f' schema_name: {customer_name}\n'
+                     f' provider: {provider_type}\n'
+                     f' account (provider uuid): {provider_uuid}\n'
+                     f' number_of_months: {number_of_months}')
     LOG.info(log_statement)
     try:
         disk = psutil.disk_usage(Config.PVC_DIR)
-        disk_msg = 'Available disk space: {} bytes ({}%)'.format(disk.free, 100 - disk.percent)
+        disk_msg = f'Available disk space: {disk.free} bytes ({100 - disk.percent}%)'
+        LOG.info(disk_msg)
     except OSError:
-        disk_msg = 'Unable to find available disk space. {} does not exist'.format(Config.PVC_DIR)
-    LOG.info(disk_msg)
+        disk_msg = f'Unable to find available disk space. {Config.PVC_DIR} does not exist'
+        LOG.error(disk_msg)
 
     reports = None
     try:

--- a/koku/masu/processor/_tasks/download.py
+++ b/koku/masu/processor/_tasks/download.py
@@ -77,10 +77,9 @@ def _get_report_files(customer_name,
     try:
         disk = psutil.disk_usage(Config.PVC_DIR)
         disk_msg = f'Available disk space: {disk.free} bytes ({100 - disk.percent}%)'
-        LOG.info(disk_msg)
     except OSError:
         disk_msg = f'Unable to find available disk space. {Config.PVC_DIR} does not exist'
-        LOG.error(disk_msg)
+    LOG.info(disk_msg)
 
     reports = None
     try:

--- a/koku/masu/processor/_tasks/process.py
+++ b/koku/masu/processor/_tasks/process.py
@@ -49,20 +49,16 @@ def _process_report_file(schema_name, provider, provider_uuid, report_dict):
     compression = report_dict.get('compression')
     manifest_id = report_dict.get('manifest_id')
     provider_id = report_dict.get('provider_id')
-    stmt = ('Processing Report:'
-            ' schema_name: {},'
-            ' report_path: {},'
-            ' compression: {},'
-            ' provider: {},'
-            ' start_date: {}')
-    log_statement = stmt.format(schema_name,
-                                report_path,
-                                compression,
-                                provider,
-                                start_date)
+    log_statement = (f'Processing Report:\n'
+                     f' schema_name: {schema_name}\n'
+                     f' provider: {provider}\n'
+                     f' provider_uuid: {provider_uuid}\n'
+                     f' file: {report_path}\n'
+                     f' compression: {compression}\n'
+                     f' start_date: {start_date}')
     LOG.info(log_statement)
     mem = psutil.virtual_memory()
-    mem_msg = 'Avaiable memory: {} bytes ({}%)'.format(mem.free, mem.percent)
+    mem_msg = f'Avaiable memory: {mem.free} bytes ({mem.percent}%)'
     LOG.info(mem_msg)
 
     file_name = report_path.split('/')[-1]

--- a/koku/masu/processor/_tasks/remove_expired.py
+++ b/koku/masu/processor/_tasks/remove_expired.py
@@ -36,16 +36,15 @@ def _remove_expired_data(schema_name, provider, simulate, provider_id=None):
         None
 
     """
-    stmt = ('Remove expired data:'
-            ' schema_name: {},'
-            ' simulate: {}')
-    log_statement = stmt.format(schema_name,
-                                simulate)
+    log_statement = (f'Remove expired data:\n'
+                     f' schema_name: {schema_name}\n'
+                     f' provider: {provider}\n'
+                     f' simulate: {simulate}')
     LOG.info(log_statement)
 
     remover = ExpiredDataRemover(schema_name, provider)
     removed_data = remover.remove(simulate=simulate, provider_id=provider_id)
 
     status_msg = 'Expired Data' if simulate else 'Removed Data'
-    result_msg = '{}: {}'.format(status_msg, str(removed_data))
+    result_msg = f'{status_msg}:\n {str(removed_data)}'
     LOG.info(result_msg)

--- a/koku/masu/processor/aws/aws_report_processor.py
+++ b/koku/masu/processor/aws/aws_report_processor.py
@@ -108,8 +108,13 @@ class AWSReportProcessor(ReportProcessorBase):
 
         self.line_item_columns = None
 
-        LOG.info('Initialized report processor for file: %s and schema: %s',
-                 self._report_name, self._schema_name)
+        stmt = (
+            f'Initialized report processor for:\n'
+            f' schema_name: {self._schema_name}\n'
+            f' provider_id: {provider_id}\n'
+            f' file: {self._report_name}'
+        )
+        LOG.info(stmt)
 
     def process(self):
         """Process CUR file.
@@ -185,8 +190,13 @@ class AWSReportProcessor(ReportProcessorBase):
             bill_date = manifest.billing_period_start_datetime.date()
             provider_id = manifest.provider_id
 
-        LOG.info('Deleting data for schema: %s and bill date: %s',
-                 self._schema_name, str(bill_date))
+        stmt = (
+            f'Deleting data for:\n'
+            f' schema_name: {self._schema_name}'
+            f' provider_id: {provider_id}'
+            f' bill date: {str(bill_date)}'
+        )
+        LOG.info(stmt)
 
         with AWSReportDBAccessor(self._schema_name, self.column_map) as accessor:
             bills = accessor.get_cost_entry_bills_query_by_provider(provider_id)

--- a/koku/masu/processor/aws/aws_report_processor.py
+++ b/koku/masu/processor/aws/aws_report_processor.py
@@ -192,8 +192,8 @@ class AWSReportProcessor(ReportProcessorBase):
 
         stmt = (
             f'Deleting data for:\n'
-            f' schema_name: {self._schema_name}'
-            f' provider_id: {provider_id}'
+            f' schema_name: {self._schema_name}\n'
+            f' provider_id: {provider_id}\n'
             f' bill date: {str(bill_date)}'
         )
         LOG.info(stmt)

--- a/koku/masu/processor/azure/azure_report_processor.py
+++ b/koku/masu/processor/azure/azure_report_processor.py
@@ -100,8 +100,13 @@ class AzureReportProcessor(ReportProcessorBase):
 
         self.line_item_columns = None
 
-        LOG.info('Initialized report processor for file: %s and schema: %s',
-                 report_path, self._schema_name)
+        stmt = (
+            f'Initialized report processor for:\n'
+            f' schema_name: {self._schema_name}\n'
+            f' provider_id: {provider_id}\n'
+            f' file: {report_path}'
+        )
+        LOG.info(stmt)
 
     def _create_cost_entry_bill(self, row, report_db_accessor):
         """Create a cost entry bill object.

--- a/koku/masu/processor/ocp/ocp_report_processor.py
+++ b/koku/masu/processor/ocp/ocp_report_processor.py
@@ -370,8 +370,13 @@ class OCPCpuMemReportProcessor(OCPReportProcessorBase):
             provider_id=provider_id
         )
         self.table_name = OCPUsageLineItem()
-        LOG.info('Initialized report processor for file: %s and schema: %s',
-                 self._report_path, self._schema_name)
+        stmt = (
+            f'Initialized report processor for:\n'
+            f' schema_name: {self._schema_name}\n'
+            f' provider_id: {provider_id}\n'
+            f' file: {self._report_path}'
+        )
+        LOG.info(stmt)
 
     def _create_usage_report_line_item(self,
                                        row,
@@ -440,8 +445,13 @@ class OCPStorageProcessor(OCPReportProcessorBase):
             provider_id=provider_id
         )
         self.table_name = OCPStorageLineItem()
-        LOG.info('Initialized report processor for file: %s and schema: %s',
-                 self._report_path, self._schema_name)
+        stmt = (
+            f'Initialized report processor for:\n'
+            f' schema_name: {self._schema_name}\n'
+            f' provider_id: {provider_id}\n'
+            f' file: {self._report_path}'
+        )
+        LOG.info(stmt)
 
     def _create_usage_report_line_item(self,
                                        row,

--- a/koku/masu/processor/orchestrator.py
+++ b/koku/masu/processor/orchestrator.py
@@ -96,14 +96,15 @@ class Orchestrator():
         """
         async_result = None
         for account in self._polling_accounts:
-            provider_status = ProviderStatus(account.get('provider_uuid'))
+            provider_uuid = account.get('provider_uuid')
+            provider_status = ProviderStatus(provider_uuid)
             if provider_status.is_valid() and not provider_status.is_backing_off():
-                LOG.info('Getting report files for account: %s', account)
+                LOG.info('Getting report files for account (provider uuid): %s', provider_uuid)
                 async_result = (get_report_files.s(**account) | summarize_reports.s()).\
                     apply_async()
 
-                LOG.info('Download queued - customer: %s, Task ID: %s',
-                         account.get('customer_name'),
+                LOG.info('Download queued - schema_name: %s, Task ID: %s',
+                         account.get('schema_name'),
                          str(async_result))
 
                 # update labels
@@ -137,8 +138,8 @@ class Orchestrator():
             async_result = remove_expired_data.delay(schema_name=account.get('schema_name'),
                                                      provider=account.get('provider_type'),
                                                      simulate=simulate)
-            LOG.info('Expired data removal queued - customer: %s, Task ID: %s',
-                     account.get('customer_name'),
+            LOG.info('Expired data removal queued - schema_name: %s, Task ID: %s',
+                     account.get('schema_name'),
                      str(async_result))
             async_results.append({'customer': account.get('customer_name'),
                                   'async_id': str(async_result)})

--- a/koku/masu/processor/tasks.py
+++ b/koku/masu/processor/tasks.py
@@ -74,7 +74,15 @@ def get_report_files(customer_name,
                                 provider_uuid)
 
     try:
-        LOG.info('Reports to be processed: %s', str(reports))
+        stmt = (
+            f'Reports to be processed:\n'
+            f' schema_name: {customer_name}\n'
+            f' provider: {provider_type}\n'
+            f' provider_uuid: {provider_uuid}\n'
+        )
+        for report in reports:
+            stmt += ' file: ' + str(report['file']) + '\n'
+        LOG.info(stmt[:-1]) # -1 removes the last new line
         reports_to_summarize = []
         for report_dict in reports:
             manifest_id = report_dict.get('manifest_id')
@@ -97,8 +105,14 @@ def get_report_files(customer_name,
                          file_name, str(started_date), str(completed_date))
                 continue
 
-            LOG.info('Processing starting - schema_name: %s, provider_uuid: %s, File: %s',
-                     schema_name, provider_uuid, report_dict.get('file'))
+            stmt = (
+                f'Processing starting:\n'
+                f' schema_name: {customer_name}\n'
+                f' provider: {provider_type}\n'
+                f' provider_uuid: {provider_uuid}\n'
+                f' file: {report_dict.get("file")}'
+            )
+            LOG.info(stmt)
             worker_stats.PROCESS_REPORT_ATTEMPTS_COUNTER.labels(provider_type=provider_type).inc()
             _process_report_file(schema_name,
                                  provider_type,

--- a/koku/masu/processor/tasks.py
+++ b/koku/masu/processor/tasks.py
@@ -82,7 +82,7 @@ def get_report_files(customer_name,
         )
         for report in reports:
             stmt += ' file: ' + str(report['file']) + '\n'
-        LOG.info(stmt[:-1]) # -1 removes the last new line
+        LOG.info(stmt[:-1])
         reports_to_summarize = []
         for report_dict in reports:
             manifest_id = report_dict.get('manifest_id')

--- a/koku/masu/test/processor/aws/test_aws_report_processor.py
+++ b/koku/masu/test/processor/aws/test_aws_report_processor.py
@@ -174,7 +174,7 @@ class AWSReportProcessorTest(MasuTestCase):
 
         bill_date = self.manifest.billing_period_start_datetime.date()
         expected = (
-            f'INFO:masu.processor.aws.aws_report_processor:Deleting data for\n'
+            f'INFO:masu.processor.aws.aws_report_processor:Deleting data for:\n'
             f' schema_name: acct10001\n'
             f' provider_id: {self.aws_provider.id}\n'
             f' bill date: {bill_date}'

--- a/koku/masu/test/processor/aws/test_aws_report_processor.py
+++ b/koku/masu/test/processor/aws/test_aws_report_processor.py
@@ -176,7 +176,7 @@ class AWSReportProcessorTest(MasuTestCase):
         expected = (
             f'INFO:masu.processor.aws.aws_report_processor:Deleting data for\n'
             f' schema_name: acct10001\n'
-            f' provider_id: {self.aws_provider.id}'
+            f' provider_id: {self.aws_provider.id}\n'
             f' bill date: {bill_date}'
         )
         logging.disable(

--- a/koku/masu/test/processor/aws/test_aws_report_processor.py
+++ b/koku/masu/test/processor/aws/test_aws_report_processor.py
@@ -173,7 +173,12 @@ class AWSReportProcessorTest(MasuTestCase):
             counts[table_name] = count
 
         bill_date = self.manifest.billing_period_start_datetime.date()
-        expected = f'INFO:masu.processor.aws.aws_report_processor:Deleting data for schema: acct10001 and bill date: {bill_date}'
+        expected = (
+            f'INFO:masu.processor.aws.aws_report_processor:Deleting data for\n'
+            f' schema_name: acct10001\n'
+            f' provider_id: {self.aws_provider.id}'
+            f' bill date: {bill_date}'
+        )
         logging.disable(
             logging.NOTSET
         )  # We are currently disabling all logging below CRITICAL in masu/__init__.py

--- a/koku/masu/test/processor/test_orchestrator.py
+++ b/koku/masu/test/processor/test_orchestrator.py
@@ -184,7 +184,7 @@ class OrchestratorTest(MasuTestCase):
         ]
         mock_remover.return_value = expected_results
 
-        expected = 'INFO:masu.processor.orchestrator:Expired data removal queued - customer: acct10001, Task ID: {}'
+        expected = 'INFO:masu.processor.orchestrator:Expired data removal queued - schema_name: acct10001, Task ID: {}'
         # unset disabling all logging below CRITICAL from masu/__init__.py
         logging.disable(logging.NOTSET)
         with self.assertLogs('masu.processor.orchestrator', level='INFO') as logger:

--- a/koku/masu/test/processor/test_tasks.py
+++ b/koku/masu/test/processor/test_tasks.py
@@ -601,7 +601,7 @@ class TestRemoveExpiredDataTasks(MasuTestCase):
         ]
         fake_remover.return_value = expected_results
 
-        expected = 'INFO:masu.processor._tasks.remove_expired:Expired Data: {}'
+        expected = 'INFO:masu.processor._tasks.remove_expired:Expired Data:\n {}'
 
         # disable logging override set in masu/__init__.py
         logging.disable(logging.NOTSET)


### PR DESCRIPTION
#1257 

This PR does a few things:
- Removes provider/source secrets from logs
- Make _some_ logging more consistent
- Turned off logging propagation for masu and celery so we aren't double logging messages
- convert several string statements to f-strings

example worker logs when adding azure and ingesting data:
```
koku_server       | [2019-10-17 20:34:11,082] INFO: "POST /api/cost-management/v1/providers/ HTTP/1.1" 201 839
masu_server       | [2019-10-17 20:34:13,190] INFO: "GET /api/cost-management/v1/download/ HTTP/1.1" 200 67
koku_worker       | [2019-10-17 20:34:13,204] INFO: Polling for
koku_worker       |  schema_name: acct10001
koku_worker       |  provider: AZURE
koku_worker       |  account (provider uuid): c83c3e28-e81c-43a6-9465-c8d28012362e
koku_worker       | [2019-10-17 20:34:13,216] INFO: Getting report files for account (provider uuid): c83c3e28-e81c-43a6-9465-c8d28012362e
koku_worker       | [2019-10-17 20:34:13,246] INFO: Download queued - schema_name: acct10001, Task ID: 79c48464-43a2-4df8-bcf6-1eb286030777
koku_worker       | [2019-10-17 20:34:13,266: INFO/ForkPoolWorker-2] masu.processor.tasks.get_report_files[d1f706ce-10a6-446b-a077-bd03a8d794fc]: Downloading report for:
koku_worker       |  schema_name: acct10001
koku_worker       |  provider: AZURE
koku_worker       |  account (provider uuid): c83c3e28-e81c-43a6-9465-c8d28012362e
koku_worker       |  number_of_months: 2
koku_worker       | [2019-10-17 20:34:13,268: INFO/ForkPoolWorker-2] masu.processor.tasks.get_report_files[d1f706ce-10a6-446b-a077-bd03a8d794fc]: Available disk space: 367985336320 bytes (74.2%)
koku_worker       | [2019-10-17 20:34:15,200] INFO: Attempting to get AZURE manifest for 2019-09-01 20:34:01.000001+00:00...
koku_worker       | [2019-10-17 20:34:15,654] INFO: Inserting manifest database record for assembly_id: f0c2978e-6ce4-43e1-bd4a-fc1a34eb4caa
koku_worker       | [2019-10-17 20:34:15,657] INFO: No manifest entry found.  Adding for bill period start: 2019-09-01 00:00:00
koku_worker       | [2019-10-17 20:34:15,806] INFO: Downloading cost/costreport/20190901-20190930/costreport_f0c2978e-6ce4-43e1-bd4a-fc1a34eb4caa.csv to /testing/pvc_dir/processing/acct10001/azure/output/costreport_f0c2978e-6ce4-43e1-bd4a-fc1a34eb4caa.csv
koku_worker       | [2019-10-17 20:34:16,072] INFO: Returning full_file_path: /testing/pvc_dir/processing/acct10001/azure/output/costreport_f0c2978e-6ce4-43e1-bd4a-fc1a34eb4caa.csv, etag: 0x8D74844057F727F
koku_worker       | [2019-10-17 20:34:16,075] INFO: Attempting to get AZURE manifest for 2019-10-01 20:34:01.000001+00:00...
koku_worker       | [2019-10-17 20:34:16,235] INFO: Inserting manifest database record for assembly_id: e8c1692f-d1e9-483f-8ab5-cbb0a7525b57
koku_worker       | [2019-10-17 20:34:16,237] INFO: No manifest entry found.  Adding for bill period start: 2019-10-01 00:00:00
koku_worker       | [2019-10-17 20:34:16,390] INFO: Downloading cost/costreport/20191001-20191031/costreport_e8c1692f-d1e9-483f-8ab5-cbb0a7525b57.csv to /testing/pvc_dir/processing/acct10001/azure/output/costreport_e8c1692f-d1e9-483f-8ab5-cbb0a7525b57.csv
koku_worker       | [2019-10-17 20:34:16,757] INFO: Returning full_file_path: /testing/pvc_dir/processing/acct10001/azure/output/costreport_e8c1692f-d1e9-483f-8ab5-cbb0a7525b57.csv, etag: 0x8D7527AE39A6C0A
koku_worker       | [2019-10-17 20:34:16,770: INFO/ForkPoolWorker-2] masu.processor.tasks.get_report_files[d1f706ce-10a6-446b-a077-bd03a8d794fc]: Reports to be processed:
koku_worker       |  schema_name: acct10001
koku_worker       |  provider: AZURE
koku_worker       |  provider_uuid: c83c3e28-e81c-43a6-9465-c8d28012362e
koku_worker       |  file: /testing/pvc_dir/processing/acct10001/azure/output/costreport_f0c2978e-6ce4-43e1-bd4a-fc1a34eb4caa.csv
koku_worker       |  file: /testing/pvc_dir/processing/acct10001/azure/output/costreport_e8c1692f-d1e9-483f-8ab5-cbb0a7525b57.csv
koku_worker       | [2019-10-17 20:34:16,775: INFO/ForkPoolWorker-2] masu.processor.tasks.get_report_files[d1f706ce-10a6-446b-a077-bd03a8d794fc]: Processing starting:
koku_worker       |  schema_name: acct10001
koku_worker       |  provider: AZURE
koku_worker       |  provider_uuid: c83c3e28-e81c-43a6-9465-c8d28012362e
koku_worker       |  file: /testing/pvc_dir/processing/acct10001/azure/output/costreport_f0c2978e-6ce4-43e1-bd4a-fc1a34eb4caa.csv
koku_worker       | [2019-10-17 20:34:16,776: INFO/ForkPoolWorker-2] masu.processor.tasks.get_report_files[d1f706ce-10a6-446b-a077-bd03a8d794fc]: Processing Report:
koku_worker       |  schema_name: acct10001
koku_worker       |  provider: AZURE
koku_worker       |  provider_uuid: c83c3e28-e81c-43a6-9465-c8d28012362e
koku_worker       |  file: /testing/pvc_dir/processing/acct10001/azure/output/costreport_f0c2978e-6ce4-43e1-bd4a-fc1a34eb4caa.csv
koku_worker       |  compression: PLAIN
koku_worker       |  start_date: 2019-09-01 20:34:01.000001+00:00
koku_worker       | [2019-10-17 20:34:16,776: INFO/ForkPoolWorker-2] masu.processor.tasks.get_report_files[d1f706ce-10a6-446b-a077-bd03a8d794fc]: Avaiable memory: 93478912 bytes (67.9%)
koku_worker       | [2019-10-17 20:34:16,792] INFO: Initialized report processor for:
koku_worker       |  schema_name: acct10001
koku_worker       |  provider_id: 1
koku_worker       |  file: /testing/pvc_dir/processing/acct10001/azure/output/costreport_f0c2978e-6ce4-43e1-bd4a-fc1a34eb4caa.csv