### PR TITLE
changes for pylint update

### DIFF
--- a/koku/koku/middleware.py
+++ b/koku/koku/middleware.py
@@ -199,8 +199,11 @@ class IdentityHeaderMiddleware(MiddlewareMixin):  # pylint: disable=R0903
             query_string = ''
             if request.META['QUERY_STRING']:
                 query_string = '?{}'.format(request.META['QUERY_STRING'])
-            logger.info(f'API: {request.path}{query_string}'  # pylint: disable=W1203
-                        f' -- ACCOUNT: {account} USER: {username}')
+            stmt = (
+                f'API: {request.path}{query_string}'
+                f' -- ACCOUNT: {account} USER: {username}'
+            )
+            logger.info(stmt)
             try:
                 customer = Customer.objects.filter(account_id=account).get()
             except Customer.DoesNotExist:

--- a/koku/koku/tests_middleware.py
+++ b/koku/koku/tests_middleware.py
@@ -17,6 +17,7 @@
 """Test the project middleware."""
 from unittest.mock import Mock, patch
 
+from django.core.cache import caches
 from django.core.exceptions import PermissionDenied
 
 from api.iam.models import Customer, Tenant, User
@@ -158,7 +159,6 @@ class IdentityHeaderMiddlewareTest(IamTestCase):
         middleware.process_request(mock_request)
 
         user_uuid = mock_request.user.uuid
-        from django.core.cache import caches
         cache = caches['rbac']
         self.assertEqual(cache.get(user_uuid), mock_access)
 


### PR DESCRIPTION
An update to pylint is causing some lint failures in the [depency update](https://travis-ci.org/project-koku/koku/jobs/600906059) travis build:


```
************* Module koku.middleware
koku/koku/middleware.py:202:0: E0012: Bad option value 'W1203' (bad-option-value)
koku/koku/middleware.py:202:12: W1202: Use % formatting in logging functions and pass the % parameters as arguments (logging-format-interpolation)
************* Module koku.tests_middleware
koku/koku/tests_middleware.py:161:8: C0415: Import outside toplevel (django.core.cache) (import-outside-toplevel)
```

This PR fixes these linting failures.