### PR TITLE
Handle 5xx errors

### DIFF
--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -713,8 +713,8 @@ class ReportQueryHandler(QueryHandler):
                                                      delta_group_by)
         for row in query_data:
             key = tuple((row[key] for key in delta_group_by))
-            previous_total = previous_dict.get(key, 0)
-            current_total = row.get(self._delta, 0)
+            previous_total = previous_dict.get(key) or 0
+            current_total = row.get(self._delta) or 0
             row['delta_value'] = current_total - previous_total
             row['delta_percent'] = self._percent_delta(current_total, previous_total)
         # Calculate the delta on the total aggregate


### PR DESCRIPTION
I looked at a number of errors in the past that occurred in prod, most have been resolved in one form or another earlier, but this one has not.

Here is a relevant stack trace.
```
[2019-10-23 10:15:32,346] ERROR: Internal Server Error: /api/cost-management/v1/reports/aws/costs/
Traceback (most recent call last):
  File "/opt/app-root/lib/python3.6/site-packages/django/core/handlers/exception.py", line 34, in inner
    response = get_response(request)
  File "/opt/app-root/lib/python3.6/site-packages/django/core/handlers/base.py", line 115, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/opt/app-root/lib/python3.6/site-packages/django/core/handlers/base.py", line 113, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/opt/app-root/lib/python3.6/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
    return view_func(*args, **kwargs)
  File "/opt/app-root/lib/python3.6/site-packages/django/views/generic/base.py", line 71, in view
    return self.dispatch(request, *args, **kwargs)
  File "/opt/app-root/lib/python3.6/site-packages/rest_framework/views.py", line 505, in dispatch
    response = self.handle_exception(exc)
  File "/opt/app-root/lib/python3.6/site-packages/rest_framework/views.py", line 465, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/opt/app-root/lib/python3.6/site-packages/rest_framework/views.py", line 476, in raise_uncaught_exception
    raise exc
  File "/opt/app-root/lib/python3.6/site-packages/rest_framework/views.py", line 502, in dispatch
    response = handler(request, *args, **kwargs)
  File "/opt/app-root/lib/python3.6/site-packages/django/views/decorators/vary.py", line 20, in inner_func
    response = func(*args, **kwargs)
  File "/opt/app-root/src/koku/api/report/view.py", line 157, in get
    output = handler.execute_query()
  File "/opt/app-root/src/koku/api/report/aws/query_handler.py", line 174, in execute_query
    query_data = self.add_deltas(query_data, query_sum)
  File "/opt/app-root/src/koku/api/report/queries.py", line 718, in add_deltas
    row['delta_value'] = current_total - previous_total
TypeError: unsupported operand type(s) for -: 'decimal.Decimal' and 'NoneType'
```