### PR TITLE
Correcting the ProviderMap parameters for group_by/filter projects

### DIFF
--- a/koku/api/report/ocp/query_handler.py
+++ b/koku/api/report/ocp/query_handler.py
@@ -55,7 +55,7 @@ class OCPReportQueryHandler(ReportQueryHandler):
                 and parameters.report_type == 'costs':
             self._report_type = parameters.report_type + '_by_project'
             self._mapper = OCPProviderMap(provider=self.provider,
-                                          report_type=parameters.report_type)
+                                          report_type=self._report_type)
 
     @property
     def annotations(self):

--- a/koku/api/report/ocp_aws/query_handler.py
+++ b/koku/api/report/ocp_aws/query_handler.py
@@ -52,7 +52,7 @@ class OCPAWSReportQueryHandler(AWSReportQueryHandler):
                 'project' in self.parameters.get('filter', {}).keys():
             self._report_type = parameters.report_type + '_by_project'
             self._mapper = OCPAWSProviderMap(provider=self.provider,
-                                             report_type=parameters.report_type)
+                                             report_type=self._report_type)
 
     def execute_query(self):  # noqa: C901
         """Execute query and return provided data.


### PR DESCRIPTION
Addresses #1303 

The wrong report type is being passed into `OCPAWSProviderMap` and `OCPProviderMap` when a group_by or filter on project is done.  The problem seen in CI is explained by the discrepancy in `OCPAWSProviderMap`.

I tried adding a cost model to an OCP source but the `/v1/reports/openshift/costs/?group_by[project]=` query remained unchanged.  So it seems that the annotations match between report_type = costs and report_type costs_by_project.

**Testing**
1.  Add accounts for OCP and AWS such that OCP is running on AWS.  Verify that ocp-on-aws instance-types API returns group_by and filter correctly
2. Running QE API tests

**Test Results.**

[issue_1303_ut.txt](https://github.com/project-koku/koku/files/3768801/issue_1303_ut.txt)
