### PR TITLE
Fix downloader retry bug (#1267)

### DIFF
--- a/koku/api/provider/models.py
+++ b/koku/api/provider/models.py
@@ -201,6 +201,7 @@ class ProviderStatus(models.Model):
     #
     STATES = ((0, 'New'),
               (1, 'Ready'),
+              (10, 'In Progress'),
               (33, 'Warning'),
               (98, 'Disabled: Error'),
               (99, 'Disabled: Admin'),)

--- a/koku/masu/celery/tasks.py
+++ b/koku/masu/celery/tasks.py
@@ -39,11 +39,11 @@ from masu.util.upload import query_and_upload_to_s3
 LOG = get_task_logger(__name__)
 
 
-@app.task(name='masu.celery.tasks.check_report_updates')
-def check_report_updates():
+@app.task(name='masu.celery.tasks.check_report_updates', bind=True)
+def check_report_updates(self):
     """Scheduled task to initiate scanning process on a regular interval."""
     orchestrator = Orchestrator()
-    orchestrator.prepare()
+    orchestrator.prepare(task=self)
 
 
 @app.task(name='masu.celery.tasks.remove_expired_data')

--- a/koku/masu/database/provider_status_accessor.py
+++ b/koku/masu/database/provider_status_accessor.py
@@ -37,9 +37,22 @@ class ProviderStatusCode(enum.IntEnum):
 
     NEW = 0
     READY = 1
+    IN_PROGRESS = 10
     WARNING = 33
     DISABLED_ERROR = 98
     DISABLED_ADMIN = 99
+
+
+class InProgressTimeoutActions(enum.IntEnum):
+    """Enum class of provider status timeout actions.
+
+    The values intentionally match ProviderStatusCode
+
+    """
+
+    DO_NOTHING = 10  # Using this value will cause an infinite loop. Beware.
+    SET_READY = 1
+    SET_DISABLED_ERROR = 98
 
 
 class ProviderStatusAccessor(KokuDBAccess):

--- a/koku/masu/processor/orchestrator.py
+++ b/koku/masu/processor/orchestrator.py
@@ -16,7 +16,10 @@
 #
 """Report Processing Orchestrator."""
 import logging
+from datetime import datetime
 
+from masu.database.provider_status_accessor import (InProgressTimeoutActions,
+                                                    ProviderStatusCode)
 from masu.external.account_label import AccountLabel
 from masu.external.accounts_accessor import (AccountsAccessor, AccountsAccessorError)
 from masu.processor.tasks import (get_report_files,
@@ -25,6 +28,13 @@ from masu.processor.tasks import (get_report_files,
 from masu.providers.status import ProviderStatus
 
 LOG = logging.getLogger(__name__)
+
+# The maximum amount of time a provider status can be IN_PROGRESS before
+# taking the INPROGRESS_TIMEOUT_ACTION
+MAX_INPROGRESS_TIMEOUT_SECONDS = 43200    # 12 hours
+
+# The behavior when a provider sits in-progress beyond the timeout value.
+INPROGRESS_TIMEOUT_ACTION = InProgressTimeoutActions.SET_READY
 
 
 # pylint: disable=too-few-public-methods
@@ -83,12 +93,12 @@ class Orchestrator():
 
         return all_accounts, polling_accounts
 
-    def prepare(self):
+    def prepare(self, task):
         """
         Prepare a processing request for each account.
 
         Args:
-            None
+            task           (Object): bound Celery task
 
         Returns:
             (celery.result.AsyncResult) Async result for download request.
@@ -98,8 +108,19 @@ class Orchestrator():
         for account in self._polling_accounts:
             provider_uuid = account.get('provider_uuid')
             provider_status = ProviderStatus(provider_uuid)
-            if provider_status.is_valid() and not provider_status.is_backing_off():
+            LOG.debug('Provider Status: %s', provider_status)
+            if provider_status.is_backing_off():
+                LOG.info('Provider "%s" skipped: %s',
+                         account.get('provider_uuid'),
+                         provider_status)
+                continue
+            elif provider_status.is_valid():
                 LOG.info('Getting report files for account (provider uuid): %s', provider_uuid)
+
+                # set ProviderStatus to IN_PROGRESS and note the parent task ID.
+                provider_status.set_status(ProviderStatusCode.IN_PROGRESS,
+                                           task.request.root_id)
+
                 async_result = (get_report_files.s(**account) | summarize_reports.s()).\
                     apply_async()
 
@@ -114,11 +135,26 @@ class Orchestrator():
                 account, label = labeler.get_label_details()
                 if account:
                     LOG.info('Account: %s Label: %s updated.', account, label)
+            elif provider_status.get_status() == int(ProviderStatusCode.IN_PROGRESS):
+                msg = (f'Provider "{account.get("provider_uuid")}" skipped.'
+                       ' Unable to process reports already in-progress.')
+                LOG.info(msg)
+                if provider_status.get_last_message() == task.request.root_id:
+                    # do nothing else until a new processing task fires.
+                    continue
+
+                now_ts = datetime.now().timestamp()
+                prov_ts = provider_status.get_timestamp().timestamp()
+                if int(now_ts - prov_ts) > MAX_INPROGRESS_TIMEOUT_SECONDS:
+                    msg = ('Provider in-progress timeout exceeded for provider '
+                           f'"{account.get("provider_uuid")}". Resetting status '
+                           f'to "{INPROGRESS_TIMEOUT_ACTION}". Report '
+                           'processing will resume on next polling interval.')
+                    LOG.info(msg)
+                    provider_status.set_status(INPROGRESS_TIMEOUT_ACTION,
+                                               'In-progress timeout exceeded.')
             else:
-                LOG.info('Provider skipped: %s Valid: %s Backing off: %s',
-                         account.get('provider_uuid'),
-                         provider_status.is_valid(),
-                         provider_status.is_backing_off())
+                LOG.critical('ZZZ: %s', provider_status)
         return async_result
 
     def remove_expired_report_data(self, simulate=False):

--- a/koku/masu/processor/orchestrator.py
+++ b/koku/masu/processor/orchestrator.py
@@ -153,8 +153,6 @@ class Orchestrator():
                     LOG.info(msg)
                     provider_status.set_status(INPROGRESS_TIMEOUT_ACTION,
                                                'In-progress timeout exceeded.')
-            else:
-                LOG.critical('ZZZ: %s', provider_status)
         return async_result
 
     def remove_expired_report_data(self, simulate=False):

--- a/koku/masu/providers/status.py
+++ b/koku/masu/providers/status.py
@@ -19,6 +19,7 @@
 import logging
 import random
 from datetime import timedelta
+from pprint import pformat
 
 from masu.database.provider_status_accessor import (ProviderStatusAccessor,
                                                     ProviderStatusCode)
@@ -29,6 +30,18 @@ LOG = logging.getLogger(__name__)
 
 class ProviderStatus(ProviderStatusAccessor):
     """Provider Status."""
+
+    def __repr__(self):
+        """Unambiguous representation."""
+        out = {'is_valid': self.is_valid(),
+               'is_backing_off': self.is_backing_off()}
+        for field in self._obj._meta.fields:
+            out[field.name] = getattr(self._obj, field.name)
+        return out
+
+    def __str__(self):
+        """String representation."""
+        return pformat(self.__repr__())
 
     def is_backing_off(self):
         """Determine if the provider is waiting to retry."""

--- a/koku/masu/test/processor/test_orchestrator.py
+++ b/koku/masu/test/processor/test_orchestrator.py
@@ -299,7 +299,8 @@ class OrchestratorTest(MasuTestCase):
         mock_status = Mock(is_valid=Mock(return_value=False),
                            is_backing_off=Mock(return_value=False),
                            get_status=Mock(return_value=ProviderStatusCode.IN_PROGRESS),
-                           get_last_message=task_id)
+                           get_last_message=Mock(return_value=task_id),
+                           )
         mock_accessor.return_value = mock_status
 
         mock_labeler.return_value = Mock(get_label_details=Mock(return_value=(True, True)))
@@ -334,7 +335,7 @@ class OrchestratorTest(MasuTestCase):
         mock_status = Mock(is_valid=Mock(return_value=False),
                            is_backing_off=Mock(return_value=False),
                            get_status=Mock(return_value=ProviderStatusCode.IN_PROGRESS),
-                           get_last_message=other_task_id,
+                           get_last_message=Mock(return_value=other_task_id),
                            get_timestamp=Mock(return_value=timestamp)
                            )
         mock_accessor.return_value = mock_status
@@ -365,7 +366,7 @@ class OrchestratorTest(MasuTestCase):
         mock_status = Mock(is_valid=Mock(return_value=False),
                            is_backing_off=Mock(return_value=False),
                            get_status=Mock(return_value=ProviderStatusCode.IN_PROGRESS),
-                           get_last_message=other_task_id,
+                           get_last_message=Mock(return_value=other_task_id),
                            get_timestamp=Mock(return_value=timestamp)
                            )
         mock_accessor.return_value = mock_status

--- a/scripts/create_test_customer.py
+++ b/scripts/create_test_customer.py
@@ -59,6 +59,8 @@ except ImportError:
     from yaml import Loader
 import requests
 
+sys.path.append(os.getcwd())
+DEFAULT_CONFIG = pkgutil.get_data('scripts', 'test_customer.yaml')
 SUPPORTED_PROVIDERS = ['aws', 'ocp', 'azure']
 
 
@@ -258,17 +260,12 @@ if __name__ == '__main__':
     ARGS = vars(PARSER.parse_args())
 
     try:
-        sys.path.append(os.getcwd())
-        DEFAULT_CONFIG = pkgutil.get_data('scripts', 'test_customer.yaml')
-        CONFIG = load(DEFAULT_CONFIG, Loader=Loader)
+        CONFIG = load_yaml(ARGS.get('config_file', DEFAULT_CONFIG))
     except AttributeError:
-        CONFIG = None
+        sys.exit('Invalid configuration file.')
 
-    if ARGS.get('config_file'):
-        CONFIG = load_yaml(ARGS.get('config_file'))
-
-    if CONFIG is None:
-        sys.exit('No configuration file provided')
+    if not CONFIG:
+        sys.exit('No configuration file provided.')
 
     CONFIG.update(ARGS)
     print(f'Config: {CONFIG}')


### PR DESCRIPTION
This improves on the logic around how we detect whether a report should be re-downloaded. This change makes use of the existing `ProviderStatus` and adds a new `IN_PROGRESS` state. This should helps us identify Provider state across multiple instances of the `Orchestrator` (i.e. across multiple Celery tasks over time).

The new flow looks something like this:

1. Celery scheduled task fires hourly
2. The task instantiates the `Orchestrator`, now passing the task instance into the `Orchestrator`.
3. If the ProviderStatus is `READY` or `WARNING`, the `Orchestrator` changes the `ProviderStatus` to `IN_PROGRESS`
4. The `Orchestrator` then kicks off the async tasks to download and process reports.
5. If downloading and processing complete successfully, the `ProviderStatus` will be set back to `READY`

New logic has been added to handle the case where the downloading or processing fails and the `ProviderStatus` stays as `IN_PROGRESS`. There's a couple globals defined to set what the automated behavior will be and how long we'll leave the `ProviderStatus` in `IN_PROGRESS` before taking action. Eventually, these globals can be updated to expose those values as configurable settings, if we find that's useful.

This handles the case where a task is either already running or failed in some way that we don't already catch elsewhere. We will wait a certain amount of time for the task to complete on its own before administratively changing the `ProviderStatus` to reset the state.

There will be a future PR to address the second half of #1267 where CostUsageReportStatus has a `last_started_datetime` but no `last_completed_datetime`.

--------

Functional testing results:
1. Normal run - there's no additional logging.

Koku-worker logs:
```
[2019-10-25 17:29:16,202] INFO: Getting report files for account (provider uuid): 3b3a717c-a4a1-427b-8450-403bbebde29d
[2019-10-25 17:29:16,230] INFO: Download queued - schema_name: acct10001, Task ID: 2504c272-1b3c-4bd5-a560-f8b9a8cd4838
[2019-10-25 17:29:16,237] INFO: Getting report files for account (provider uuid): 8eec1b44-4824-4b84-8d0a-28b93963488a
[2019-10-25 17:29:16,259] INFO: Download queued - schema_name: acct10001, Task ID: 275ddaef-d66b-48af-b4b3-0394a0977caa
```

Postgres view:
```
koku=# select * from api_providerstatus;
 id | status | last_message |           timestamp           | retries | provider_id 
----+--------+--------------+-------------------------------+---------+-------------
  2 |      1 | none         | 2019-10-25 17:29:20.703739+00 |       0 |           1
  1 |      1 | none         | 2019-10-25 17:29:34.478645+00 |       0 |           2
(2 rows)
```

2. Set provider to IN_PROGRESS

Postgres:
```
koku=# update api_providerstatus set status=10,last_message='3f0d9eef-ebbe-4e3d-ae9a-2460e0dc1348',timestamp='2019-10-25 13:00:00' where id=1;
UPDATE 1

koku=# select * from api_providerstatus
koku-# ;
 id | status |             last_message             |       timestamp        | retries | provider_id 
----+--------+--------------------------------------+------------------------+---------+-------------
  1 |     10 | 3f0d9eef-ebbe-4e3d-ae9a-2460e0dc1348 | 2019-10-25 13:00:00+00 |       0 |           1
(1 row)

```

Koku-worker:
```

[2019-10-28 18:52:47,803] INFO: Polling for
 schema_name: acct10001
 provider: AZURE
 account (provider uuid): 6c0dbb27-7d0f-4925-9ce1-9183fff47915
[2019-10-28 18:52:47,976] INFO: Provider Status: {'id': 1,
 'is_backing_off': False,
 'is_valid': False,
 'last_message': '3f0d9eef-ebbe-4e3d-ae9a-2460e0dc1348',
 'provider': <Provider: Provider object (1)>,
 'retries': 0,
 'status': 10,
 'timestamp': datetime.datetime(2019, 10, 25, 13, 0, tzinfo=<UTC>)}
[2019-10-28 18:52:47,979] INFO: Provider "6c0dbb27-7d0f-4925-9ce1-9183fff47915" skipped. Unable to process reports already in-progress.
```

3. Timing out the in-progress task and resetting it back to ready:

Setting DB to testable state.
```
koku=# update api_providerstatus set status=10,last_message='frombopulous',timestamp='2019-10-20 13:00:00' where id=1;
UPDATE 1
koku=# select * from api_providerstatus;
 id | status | last_message |       timestamp        | retries |             provider_id              
----+--------+--------------+------------------------+---------+--------------------------------------
  1 |     10 | frombopulous | 2019-10-20 13:00:00+00 |       0 | 75975e32-4851-4315-9d30-91be59908ec9
(1 row)
```

Worker logs:
```
[2019-10-29 15:22:51,544] INFO: Polling for
 schema_name: acct10001
 provider: AZURE
 account (provider uuid): 75975e32-4851-4315-9d30-91be59908ec9
[2019-10-29 15:22:51,778] INFO: Provider "75975e32-4851-4315-9d30-91be59908ec9" skipped. Unable to process reports already in-progress.
[2019-10-29 15:22:51,781] INFO: Provider in-progress timeout exceeded for provider "75975e32-4851-4315-9d30-91be59908ec9". Resetting status to "1". Report processing will resume on next polling interval.
```

DB after reset:
```
koku=# select * from api_providerstatus;
 id | status |         last_message          |           timestamp           | retries |             provider_id             
 
----+--------+-------------------------------+-------------------------------+---------+-------------------------------------
-
  1 |      1 | In-progress timeout exceeded. | 2019-10-29 15:22:51.783472+00 |       0 | 75975e32-4851-4315-9d30-91be59908ec9
(1 row)

