### PR TITLE
set permissions on /var/lib/rabbitmq

### DIFF
--- a/openshift/buildenv/rabbitmq/Dockerfile
+++ b/openshift/buildenv/rabbitmq/Dockerfile
@@ -28,6 +28,7 @@ RUN curl -LO https://github.com/rabbitmq/erlang-rpm/releases/download/v${ERLANG_
     mkdir -p /var/lib/rabbitmq/mnesia && \
     usermod -G root,wheel rabbitmq && \
     chown -R 999:0 /var/lib/rabbitmq /var/log/rabbitmq /etc/rabbitmq && \
+    chmod -R 2777 /var/lib/rabbitmq && \
     rabbitmq-plugins --offline enable rabbitmq_peer_discovery_k8s
 
 COPY docker-entrypoint.sh /usr/local/bin


### PR DESCRIPTION
This change alters the RabbitMQ Dockerfile to ensure that regardless of what user the container is running as, it will have access to /var/lib/rabbitmq.

This is to work around the lack of `anyuid` privileges when running in some environments.