### PR TITLE
rename cloud_accounts to cloud-accounts

### DIFF
--- a/koku/api/cloud_accounts/tests/test_model.py
+++ b/koku/api/cloud_accounts/tests/test_model.py
@@ -26,7 +26,7 @@ class CloudAccountTest(TestCase):
     """Test creating and reading mock model."""
 
     def test_cloud_account_creation(self):
-        """Test creating and reading a mock model."""
+        """Test creating and reading a mock CloudAccount model."""
         cloud_account = CloudAccountCommonTestUtilities.create_cloud_account(self)
         self.assertTrue(isinstance(cloud_account, CloudAccount))
         self.assertEqual(cloud_account.name, 'TEST_AWS_ACCOUNT_ID')

--- a/koku/api/cloud_accounts/tests/test_views.py
+++ b/koku/api/cloud_accounts/tests/test_views.py
@@ -28,7 +28,7 @@ from api.iam.test.iam_test_case import IamTestCase
 class CloudAccountViewTest(IamTestCase):
     """Test Cases for CloudAccountViewSet."""
 
-    def testCloudAccountEmptyViewSet(self):
+    def testCloudAccountViewSet(self):
         """Test that /cloud_accounts endpoint returns 200 HTTP_OK."""
         url = reverse('cloud_accounts-list')
         client = APIClient()
@@ -36,7 +36,7 @@ class CloudAccountViewTest(IamTestCase):
         response = client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-    def testCloudAccountOneItemViewSet(self):
+    def testCloudAccounViewSetWithSecondCloudAccount(self):
         """
         Test that /cloud_account endpoint returns HTTP 200 OK.
 
@@ -52,10 +52,9 @@ class CloudAccountViewTest(IamTestCase):
 
     def testCloudAccountName(self):
         """
-        Test that an expected cloud account is an actual cloud account.
+        Test contents of cloud account.
 
-        Tests that the contents match expected values.
-        There should only be one CloudAccount object returned in the response array.
+        This test creates a cloud account with test values.
         """
         CloudAccountCommonTestUtilities.create_cloud_account(self)
 

--- a/koku/api/urls.py
+++ b/koku/api/urls.py
@@ -52,7 +52,7 @@ ROUTER.register(r'dataexportrequests', DataExportRequestViewSet, base_name='data
 ROUTER.register(r'metrics', CostModelMetricsMapViewSet, base_name='metrics')
 ROUTER.register(r'providers', ProviderViewSet)
 ROUTER.register(r'preferences', UserPreferenceViewSet, base_name='preferences')
-ROUTER.register(r'cloud_accounts', CloudAccountViewSet, base_name='cloud_accounts')
+ROUTER.register(r'cloud-accounts', CloudAccountViewSet, base_name='cloud_accounts')
 # pylint: disable=invalid-name
 urlpatterns = [
 

--- a/koku/koku/middleware.py
+++ b/koku/koku/middleware.py
@@ -48,7 +48,7 @@ def is_no_auth(request):
     no_auth_list = ['status', 'metrics', 'openapi.json',
                     'download', 'report_data', 'expired_data', 'update_charge',
                     'upload_normalized_data',
-                    'authentication', 'billing_source', 'cloud_accounts']
+                    'authentication', 'billing_source', 'cloud-accounts']
     no_auth = any(no_auth_path in request.path for no_auth_path in no_auth_list)
     return no_auth
 


### PR DESCRIPTION
Rename the /cloud_accounts endpoint to /cloud-accounts because the rest of the endpoints use '-' instead of '_' as per @lcouzens feedback

Also edited some cloud-account documentation.

Feature #1284 