### PR TITLE
rework config loading for test customer script

### DIFF
--- a/scripts/create_test_customer.py
+++ b/scripts/create_test_customer.py
@@ -45,7 +45,6 @@ koku:
 
 import argparse
 import os
-import pkgutil
 import sys
 from base64 import b64encode
 from json import dumps as json_dumps

--- a/scripts/create_test_customer.py
+++ b/scripts/create_test_customer.py
@@ -59,6 +59,8 @@ except ImportError:
     from yaml import Loader
 import requests
 
+sys.path.append(os.getcwd())
+DEFAULT_CONFIG = pkgutil.get_data('scripts', 'test_customer.yaml')
 SUPPORTED_PROVIDERS = ['aws', 'ocp', 'azure']
 
 
@@ -258,17 +260,12 @@ if __name__ == '__main__':
     ARGS = vars(PARSER.parse_args())
 
     try:
-        sys.path.append(os.getcwd())
-        DEFAULT_CONFIG = pkgutil.get_data('scripts', 'test_customer.yaml')
-        CONFIG = load(DEFAULT_CONFIG, Loader=Loader)
+        CONFIG = load_yaml(ARGS.get('config_file', DEFAULT_CONFIG))
     except AttributeError:
-        CONFIG = None
+        sys.exit('Invalid configuration file.')
 
-    if ARGS.get('config_file'):
-        CONFIG = load_yaml(ARGS.get('config_file'))
-
-    if CONFIG is None:
-        sys.exit('No configuration file provided')
+    if not CONFIG:
+        sys.exit('No configuration file provided.')
 
     CONFIG.update(ARGS)
     print(f'Config: {CONFIG}')

--- a/scripts/create_test_customer.py
+++ b/scripts/create_test_customer.py
@@ -59,8 +59,8 @@ except ImportError:
     from yaml import Loader
 import requests
 
-sys.path.append(os.getcwd())
-DEFAULT_CONFIG = pkgutil.get_data('scripts', 'test_customer.yaml')
+BASEDIR = os.path.dirname(os.path.realpath(__file__))
+DEFAULT_CONFIG = BASEDIR + '/test_customer.yaml'
 SUPPORTED_PROVIDERS = ['aws', 'ocp', 'azure']
 
 
@@ -243,6 +243,7 @@ def get_token(account_id, username, email):
 
 def load_yaml(filename):
     """Load from a YAML file."""
+    print(f'Loading: {filename}')
     try:
         with open(filename, 'r+') as fhandle:
             yamlfile = load(fhandle, Loader=Loader)
@@ -254,13 +255,14 @@ def load_yaml(filename):
 if __name__ == '__main__':
     PARSER = argparse.ArgumentParser()
     PARSER.add_argument('-f', '--file', dest='config_file',
-                        help='YAML-formatted configuration file name')
+                        help='YAML-formatted configuration file name',
+                        default=DEFAULT_CONFIG)
     PARSER.add_argument('--bypass-api', dest='bypass_api', action='store_true',
                         help='Create Provider in DB, bypassing Koku API')
     ARGS = vars(PARSER.parse_args())
 
     try:
-        CONFIG = load_yaml(ARGS.get('config_file', DEFAULT_CONFIG))
+        CONFIG = load_yaml(ARGS.get('config_file'))
     except AttributeError:
         sys.exit('Invalid configuration file.')
 


### PR DESCRIPTION
This PR reworks the way the `create_test_customer.py` script handles loading of config files.

This allows the script to load a config file without requiring the default config file to be valid. Previously, if the default `test_customer.yaml` was invalid or not present, the script would abort with a traceback, even when a different, valid config file was specified on the CLI.