### PR TITLE
Test failures when 31 days in month

### DIFF
--- a/docs/source/providers/gcp.rst
+++ b/docs/source/providers/gcp.rst
@@ -37,9 +37,20 @@ Grant Access to Storage Bucket
 
 #. Navigate to the storage bucket you've created previously.
 #. Open the Info Panel
-#. Add the koku service account `koku-test-service-acct@fine-way-252818.iam.gserviceaccount.com` as a new member of the storage account with the role previously created.
+#. Add the koku service account for the correct environment as a new member of the storage account with the role previously created.
 
-TODO: Set up production GCP account and update service account to prod account. This is a koku test account for now.
+
++-------------+----------------------------------------------------------+
+| Environment | Service Account                                          |
++-------------+----------------------------------------------------------+
+| prod        | koku-prod@cost-management-prod.iam.gserviceaccount.com   |
++-------------+----------------------------------------------------------+
+| stage       | koku-stage@cost-management-stage.iam.gserviceaccount.com |
++-------------+----------------------------------------------------------+
+| qa          | koku-qa@cost-management-qa.iam.gserviceaccount.com       |
++-------------+----------------------------------------------------------+
+| ci          | koku-ci@cost-management-ci.iam.gserviceaccount.com       |
++-------------+----------------------------------------------------------+
 
 
 Create an GCP Account Provider
@@ -47,7 +58,24 @@ Create an GCP Account Provider
 
 Create a GCP account provider with the *Storage Bucket Name* above. You can optionally include a report_prefix if you used one during GCP data export setup.
 
-```
-http POST 0.0.0.0:8000/api/v1/providers/ name="GCP Provider" type=GCP billing_source:='{"data_source": {"bucket": "koku-billing-bucket", "report_prefix": "my-prefix"}}' authentication:='{"credentials": {"project_id": "gcp_project_id"}}'
+.. code-block::
 
-```
+    http POST 0.0.0.0:8000/api/v1/providers/ name="GCP Provider" type=GCP billing_source:='{"data_source": {"bucket": "koku-billing-bucket", "report_prefix": "my-prefix"}}' authentication:='{"credentials": {"project_id": "gcp_project_id"}}'
+
+
+Creating a GCP Service Account for Local Testing
+************************************************
+
+Login to your GCP account. Navigate to `IAM > Service Accounts` and create an account.
+Take note of the generated email which will look something like `service-accnt@project-id.iam.gserviceaccount.com`.
+Create and download the key for this service account, and save it onto your local file system.
+
+
+Tell google where this file is by setting an environment variable:
+
+.. code-block::
+
+    SET GOOGLE_APPLICATION_CREDENTIALS=/path/to/credentials/file
+
+
+Now when you granting access to storage bucket, make sure you use the email of your service account.

--- a/koku/api/report/test/azure/tests_azure_query_handler.py
+++ b/koku/api/report/test/azure/tests_azure_query_handler.py
@@ -17,6 +17,7 @@
 """Test the Azure Provider query handler."""
 
 import random
+from dateutil.relativedelta import relativedelta
 from decimal import Decimal, ROUND_HALF_UP
 from uuid import UUID
 
@@ -759,7 +760,7 @@ class AzureReportQueryHandlerTest(IamTestCase):
 
                 prev = AzureCostEntryLineItemDailySummary.objects.filter(
                     usage_start__date__gte=self.dh.last_month_start,
-                    usage_start__date__lte=self.dh.today.replace(month=self.dh.today.month - 1),
+                    usage_start__date__lte=self.dh.today - relativedelta(months=1),
                     subscription_guid=sub.get('subscription_guid')).aggregate(
                         value=Sum(F('pretax_cost') + F('markup_cost')))
                 prev_total = Decimal(prev.get('value', Decimal(0)))

--- a/koku/api/report/test/azure/tests_azure_query_handler.py
+++ b/koku/api/report/test/azure/tests_azure_query_handler.py
@@ -919,7 +919,7 @@ class AzureReportQueryHandlerTest(IamTestCase):
 
             prev = AzureCostEntryLineItemDailySummary.objects.filter(
                 usage_start__gte=self.dh.last_month_start,
-                usage_start__lte=self.dh.today.replace(month=self.dh.today.month - 1),
+                usage_start__lte=self.dh.today - relativedelta(months=1),
             ).aggregate(value=Sum(F('pretax_cost') + F('markup_cost')))
             prev_total = Decimal(prev.get('value'))
 

--- a/koku/api/report/test/tests_queries.py
+++ b/koku/api/report/test/tests_queries.py
@@ -34,14 +34,16 @@ from api.report.queries import strip_tag_prefix
 from api.report.test import FakeAWSCostData, FakeQueryParameters
 from api.tags.aws.queries import AWSTagQueryHandler
 from api.utils import DateHelper
-from reporting.models import (AWSAccountAlias,
-                              AWSCostEntry,
-                              AWSCostEntryBill,
-                              AWSCostEntryLineItem,
-                              AWSCostEntryLineItemDaily,
-                              AWSCostEntryLineItemDailySummary,
-                              AWSCostEntryPricing,
-                              AWSCostEntryProduct)
+from reporting.models import (
+    AWSAccountAlias,
+    AWSCostEntry,
+    AWSCostEntryBill,
+    AWSCostEntryLineItem,
+    AWSCostEntryLineItemDaily,
+    AWSCostEntryLineItemDailySummary,
+    AWSCostEntryPricing,
+    AWSCostEntryProduct,
+)
 
 
 class ReportQueryUtilsTest(TestCase):
@@ -65,34 +67,81 @@ class ReportQueryUtilsTest(TestCase):
     def test_group_data_by_list(self):
         """Test the _group_data_by_list method."""
         group_by = ['account', 'service']
-        data = [{'account': 'a1', 'service': 's1', 'units': 'USD', 'total': 4},
-                {'account': 'a1', 'service': 's2', 'units': 'USD', 'total': 5},
-                {'account': 'a2', 'service': 's1', 'units': 'USD', 'total': 6},
-                {'account': 'a2', 'service': 's2', 'units': 'USD', 'total': 5},
-                {'account': 'a1', 'service': 's3', 'units': 'USD', 'total': 5}]
+        data = [
+            {'account': 'a1', 'service': 's1', 'units': 'USD', 'total': 4},
+            {'account': 'a1', 'service': 's2', 'units': 'USD', 'total': 5},
+            {'account': 'a2', 'service': 's1', 'units': 'USD', 'total': 6},
+            {'account': 'a2', 'service': 's2', 'units': 'USD', 'total': 5},
+            {'account': 'a1', 'service': 's3', 'units': 'USD', 'total': 5},
+        ]
         out_data = AWSReportQueryHandler._group_data_by_list(group_by, 0, data)
-        expected = {'a1':
-                    {'s1': [{'account': 'a1', 'service': 's1', 'units': 'USD', 'total': 4}],
-                     's2': [{'account': 'a1', 'service': 's2', 'units': 'USD', 'total': 5}],
-                        's3': [
-                        {'account': 'a1', 'service': 's3', 'units': 'USD', 'total': 5}]},
-                    'a2':
-                    {'s1': [{'account': 'a2', 'service': 's1', 'units': 'USD', 'total': 6}],
-                        's2': [{'account': 'a2', 'service': 's2', 'units': 'USD', 'total': 5}]}}
+        expected = {
+            'a1': {
+                's1': [{'account': 'a1', 'service': 's1', 'units': 'USD', 'total': 4}],
+                's2': [{'account': 'a1', 'service': 's2', 'units': 'USD', 'total': 5}],
+                's3': [{'account': 'a1', 'service': 's3', 'units': 'USD', 'total': 5}],
+            },
+            'a2': {
+                's1': [{'account': 'a2', 'service': 's1', 'units': 'USD', 'total': 6}],
+                's2': [{'account': 'a2', 'service': 's2', 'units': 'USD', 'total': 5}],
+            },
+        }
         self.assertEqual(expected, out_data)
 
     def test_group_data_by_list_missing_units(self):
         """Test the _group_data_by_list method when duplicates occur due to missing units."""
         group_by = ['instance_type']
-        data = [{'date': '2018-07-22', 'units': '', 'instance_type': 't2.micro', 'total': 30.0, 'count': 0},
-                {'date': '2018-07-22', 'units': 'Hrs', 'instance_type': 't2.small', 'total': 17.0, 'count': 0},
-                {'date': '2018-07-22', 'units': 'Hrs', 'instance_type': 't2.micro', 'total': 1.0, 'count': 0}]
+        data = [
+            {
+                'date': '2018-07-22',
+                'units': '',
+                'instance_type': 't2.micro',
+                'total': 30.0,
+                'count': 0,
+            },
+            {
+                'date': '2018-07-22',
+                'units': 'Hrs',
+                'instance_type': 't2.small',
+                'total': 17.0,
+                'count': 0,
+            },
+            {
+                'date': '2018-07-22',
+                'units': 'Hrs',
+                'instance_type': 't2.micro',
+                'total': 1.0,
+                'count': 0,
+            },
+        ]
         out_data = AWSReportQueryHandler._group_data_by_list(group_by, 0, data)
-        expected = {'t2.micro': [
-            {'date': '2018-07-22', 'units': 'Hrs', 'instance_type': 't2.micro', 'total': 1.0, 'count': 0},
-            {'date': '2018-07-22', 'units': '', 'instance_type': 't2.micro', 'total': 30.0, 'count': 0}],
+        expected = {
+            't2.micro': [
+                {
+                    'date': '2018-07-22',
+                    'units': 'Hrs',
+                    'instance_type': 't2.micro',
+                    'total': 1.0,
+                    'count': 0,
+                },
+                {
+                    'date': '2018-07-22',
+                    'units': '',
+                    'instance_type': 't2.micro',
+                    'total': 30.0,
+                    'count': 0,
+                },
+            ],
             't2.small': [
-                {'date': '2018-07-22', 'units': 'Hrs', 'instance_type': 't2.small', 'total': 17.0, 'count': 0}]}
+                {
+                    'date': '2018-07-22',
+                    'units': 'Hrs',
+                    'instance_type': 't2.small',
+                    'total': 17.0,
+                    'count': 0,
+                }
+            ],
+        }
         self.assertEqual(expected, out_data)
 
 
@@ -121,7 +170,7 @@ class ReportQueryTest(IamTestCase):
             'resource_id',
             'tax_type',
             'product_code',
-            'tags'
+            'tags',
         ]
         annotations = {
             'usage_start': Cast('usage_start', DateTimeField()),
@@ -135,12 +184,12 @@ class ReportQueryTest(IamTestCase):
             'blended_rate': Max('blended_rate'),
             'blended_cost': Sum('blended_cost'),
             'public_on_demand_cost': Sum('public_on_demand_cost'),
-            'public_on_demand_rate': Max('public_on_demand_rate')
+            'public_on_demand_rate': Max('public_on_demand_rate'),
         }
 
-        entries = AWSCostEntryLineItem.objects\
-            .values(*included_fields)\
-            .annotate(**annotations)
+        entries = AWSCostEntryLineItem.objects.values(*included_fields).annotate(
+            **annotations
+        )
         for entry in entries:
             daily = AWSCostEntryLineItemDaily(**entry)
             daily.save()
@@ -151,7 +200,7 @@ class ReportQueryTest(IamTestCase):
             'usage_end',
             'usage_account_id',
             'availability_zone',
-            'tags'
+            'tags',
         ]
         annotations = {
             'product_family': Concat('cost_entry_product__product_family', Value('')),
@@ -170,19 +219,24 @@ class ReportQueryTest(IamTestCase):
             'public_on_demand_cost': Sum('public_on_demand_cost'),
             'public_on_demand_rate': Max('public_on_demand_rate'),
             'resource_count': Count('resource_id', distinct=True),
-            'resource_ids': ArrayAgg('resource_id', distinct=True)
+            'resource_ids': ArrayAgg('resource_id', distinct=True),
         }
 
-        entries = AWSCostEntryLineItemDaily.objects\
-            .values(*included_fields)\
-            .annotate(**annotations)
+        entries = AWSCostEntryLineItemDaily.objects.values(*included_fields).annotate(
+            **annotations
+        )
         for entry in entries:
             alias = AWSAccountAlias.objects.filter(account_id=entry['usage_account_id'])
-            summary = AWSCostEntryLineItemDailySummary(**entry,
-                                                       account_alias=list(alias).pop())
+            summary = AWSCostEntryLineItemDailySummary(
+                **entry, account_alias=list(alias).pop()
+            )
             summary.save()
-            self.current_month_total += entry['unblended_cost'] + entry['unblended_cost'] * Decimal(0.1)
-        AWSCostEntryLineItemDailySummary.objects.update(markup_cost=F('unblended_cost') * 0.1)
+            self.current_month_total += entry['unblended_cost'] + entry[
+                'unblended_cost'
+            ] * Decimal(0.1)
+        AWSCostEntryLineItemDailySummary.objects.update(
+            markup_cost=F('unblended_cost') * 0.1
+        )
 
     def _populate_tag_summary_table(self):
         """Populate pod label key and values."""
@@ -211,8 +265,8 @@ class ReportQueryTest(IamTestCase):
         with tenant_context(self.tenant):
             # get or create alias
             AWSAccountAlias.objects.get_or_create(
-                account_id=data.account_id,
-                account_alias=data.account_alias)
+                account_id=data.account_id, account_alias=data.account_alias
+            )
 
             # create bill
             bill, _ = AWSCostEntryBill.objects.get_or_create(**data.bill)
@@ -247,12 +301,16 @@ class ReportQueryTest(IamTestCase):
 
                 # create line item
                 line_item_data = curr_data.line_item(product)
-                model_instances = {'cost_entry': cost_entry,
-                                   'cost_entry_bill': bill,
-                                   'cost_entry_product': ce_product,
-                                   'cost_entry_pricing': ce_pricing}
+                model_instances = {
+                    'cost_entry': cost_entry,
+                    'cost_entry_bill': bill,
+                    'cost_entry_product': ce_product,
+                    'cost_entry_pricing': ce_pricing,
+                }
                 line_item_data.update(model_instances)
-                line_item, _ = AWSCostEntryLineItem.objects.get_or_create(**line_item_data)
+                line_item, _ = AWSCostEntryLineItem.objects.get_or_create(
+                    **line_item_data
+                )
 
                 current = end_hour
 
@@ -266,12 +324,16 @@ class ReportQueryTest(IamTestCase):
         groups = ['region']
         group_index = 0
         data = {None: [{'region': None, 'units': 'USD'}]}
-        expected = [{'region': 'no-region', 'values': [{'region': 'no-region', 'units': 'USD'}]}]
+        expected = [
+            {'region': 'no-region', 'values': [{'region': 'no-region', 'units': 'USD'}]}
+        ]
         out_data = handler._transform_data(groups, group_index, data)
         self.assertEqual(expected, out_data)
 
         data = {'us-east': [{'region': 'us-east', 'units': 'USD'}]}
-        expected = [{'region': 'us-east', 'values': [{'region': 'us-east', 'units': 'USD'}]}]
+        expected = [
+            {'region': 'us-east', 'values': [{'region': 'us-east', 'units': 'USD'}]}
+        ]
         out_data = handler._transform_data(groups, group_index, data)
         self.assertEqual(expected, out_data)
 
@@ -284,8 +346,7 @@ class ReportQueryTest(IamTestCase):
         """Test the _get_group_by method with limit and group by params."""
         expected = ['account']
         # '?group_by[account]=*&filter[limit]=1'
-        params = {'group_by': {'account': ['*']},
-                  'filter': {'limit': 1}}
+        params = {'group_by': {'account': ['*']}, 'filter': {'limit': 1}}
         query_params = FakeQueryParameters(params, report_type='instance_type')
         handler = AWSReportQueryHandler(query_params.mock_qp)
         group_by = handler._get_group_by()
@@ -350,9 +411,13 @@ class ReportQueryTest(IamTestCase):
     def test_get_time_frame_filter_current_month(self):
         """Test _get_time_frame_filter for current month."""
         # '?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=daily'
-        params = {'filter': {'resolution': 'daily',
-                             'time_scope_value': -1,
-                             'time_scope_units': 'month'}}
+        params = {
+            'filter': {
+                'resolution': 'daily',
+                'time_scope_value': -1,
+                'time_scope_units': 'month',
+            }
+        }
         query_params = FakeQueryParameters(params)
         handler = AWSReportQueryHandler(query_params.mock_qp)
         start = handler.start_datetime
@@ -366,9 +431,13 @@ class ReportQueryTest(IamTestCase):
     def test_get_time_frame_filter_previous_month(self):
         """Test _get_time_frame_filter for previous month."""
         # '?filter[time_scope_units]=month&filter[time_scope_value]=-2&filter[resolution]=daily'
-        params = {'filter': {'resolution': 'daily',
-                             'time_scope_value': -2,
-                             'time_scope_units': 'month'}}
+        params = {
+            'filter': {
+                'resolution': 'daily',
+                'time_scope_value': -2,
+                'time_scope_units': 'month',
+            }
+        }
         query_params = FakeQueryParameters(params)
         handler = AWSReportQueryHandler(query_params.mock_qp)
         start = handler.start_datetime
@@ -382,14 +451,20 @@ class ReportQueryTest(IamTestCase):
     def test_get_time_frame_filter_last_ten(self):
         """Test _get_time_frame_filter for last ten days."""
         # '?filter[time_scope_units]=day&filter[time_scope_value]=-10&filter[resolution]=daily'
-        params = {'filter': {'resolution': 'daily',
-                             'time_scope_value': -10,
-                             'time_scope_units': 'day'}}
+        params = {
+            'filter': {
+                'resolution': 'daily',
+                'time_scope_value': -10,
+                'time_scope_units': 'day',
+            }
+        }
         query_params = FakeQueryParameters(params)
         handler = AWSReportQueryHandler(query_params.mock_qp)
         dh = DateHelper()
         nine_days_ago = dh.n_days_ago(dh.today, 9)
-        start = handler.start_datetime.replace(hour=0, minute=0, second=0, microsecond=0)
+        start = handler.start_datetime.replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
         end = handler.end_datetime.replace(hour=0, minute=0, second=0, microsecond=0)
         interval = handler.time_interval
         self.assertEqual(start, nine_days_ago)
@@ -400,14 +475,20 @@ class ReportQueryTest(IamTestCase):
     def test_get_time_frame_filter_last_thirty(self):
         """Test _get_time_frame_filter for last thirty days."""
         # '?filter[time_scope_units]=day&filter[time_scope_value]=-30&filter[resolution]=daily'
-        params = {'filter': {'resolution': 'daily',
-                             'time_scope_value': -30,
-                             'time_scope_units': 'day'}}
+        params = {
+            'filter': {
+                'resolution': 'daily',
+                'time_scope_value': -30,
+                'time_scope_units': 'day',
+            }
+        }
         query_params = FakeQueryParameters(params)
         handler = AWSReportQueryHandler(query_params.mock_qp)
         dh = DateHelper()
         twenty_nine_days_ago = dh.n_days_ago(dh.today, 29)
-        start = handler.start_datetime.replace(hour=0, minute=0, second=0, microsecond=0)
+        start = handler.start_datetime.replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
         end = handler.end_datetime.replace(hour=0, minute=0, second=0, microsecond=0)
         interval = handler.time_interval
         self.assertEqual(start, twenty_nine_days_ago)
@@ -429,9 +510,13 @@ class ReportQueryTest(IamTestCase):
     def test_execute_query_current_month_daily(self):
         """Test execute_query for current month on daily breakdown."""
         # '?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=daily'
-        params = {'filter': {'resolution': 'daily',
-                             'time_scope_value': -1,
-                             'time_scope_units': 'month'}}
+        params = {
+            'filter': {
+                'resolution': 'daily',
+                'time_scope_value': -1,
+                'time_scope_units': 'month',
+            }
+        }
         query_params = FakeQueryParameters(params, tenant=self.tenant)
         handler = AWSReportQueryHandler(query_params.mock_qp)
         query_output = handler.execute_query()
@@ -439,14 +524,20 @@ class ReportQueryTest(IamTestCase):
         self.assertIsNotNone(query_output.get('total'))
         total = query_output.get('total')
         self.assertIsNotNone(total.get('cost'))
-        self.assertAlmostEqual(total.get('cost', {}).get('value'), self.current_month_total, 6)
+        self.assertAlmostEqual(
+            total.get('cost', {}).get('value'), self.current_month_total, 6
+        )
 
     def test_execute_query_current_month_monthly(self):
         """Test execute_query for current month on monthly breakdown."""
         # '?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly'
-        params = {'filter': {'resolution': 'monthly',
-                             'time_scope_value': -1,
-                             'time_scope_units': 'month'}}
+        params = {
+            'filter': {
+                'resolution': 'monthly',
+                'time_scope_value': -1,
+                'time_scope_units': 'month',
+            }
+        }
         query_params = FakeQueryParameters(params, tenant=self.tenant)
         handler = AWSReportQueryHandler(query_params.mock_qp)
         query_output = handler.execute_query()
@@ -454,15 +545,21 @@ class ReportQueryTest(IamTestCase):
         self.assertIsNotNone(query_output.get('total'))
         total = query_output.get('total')
         self.assertIsNotNone(total.get('cost'))
-        self.assertAlmostEqual(total.get('cost', {}).get('value'), self.current_month_total, 6)
+        self.assertAlmostEqual(
+            total.get('cost', {}).get('value'), self.current_month_total, 6
+        )
 
     def test_execute_query_current_month_by_service(self):
         """Test execute_query for current month on monthly breakdown by service."""
         # '?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&group_by[service]=*'
-        params = {'filter': {'resolution': 'monthly',
-                             'time_scope_value': -1,
-                             'time_scope_units': 'month'},
-                  'group_by': {'service': ['*']}}
+        params = {
+            'filter': {
+                'resolution': 'monthly',
+                'time_scope_value': -1,
+                'time_scope_units': 'month',
+            },
+            'group_by': {'service': ['*']},
+        }
         query_params = FakeQueryParameters(params, tenant=self.tenant)
         handler = AWSReportQueryHandler(query_params.mock_qp)
         query_output = handler.execute_query()
@@ -471,7 +568,9 @@ class ReportQueryTest(IamTestCase):
         self.assertIsNotNone(query_output.get('total'))
         total = query_output.get('total')
         self.assertIsNotNone(total.get('cost'))
-        self.assertAlmostEqual(total.get('cost', {}).get('value'), self.current_month_total, 6)
+        self.assertAlmostEqual(
+            total.get('cost', {}).get('value'), self.current_month_total, 6
+        )
 
         cmonth_str = DateHelper().this_month_start.strftime('%Y-%m')
         for data_item in data:
@@ -487,10 +586,14 @@ class ReportQueryTest(IamTestCase):
     def test_execute_query_by_filtered_service(self):
         """Test execute_query monthly breakdown by filtered service."""
         # '?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&group_by[service]=AmazonEC2'
-        params = {'filter': {'resolution': 'monthly',
-                             'time_scope_value': -1,
-                             'time_scope_units': 'month'},
-                  'group_by': {'service': ['AmazonEC2']}}
+        params = {
+            'filter': {
+                'resolution': 'monthly',
+                'time_scope_value': -1,
+                'time_scope_units': 'month',
+            },
+            'group_by': {'service': ['AmazonEC2']},
+        }
         query_params = FakeQueryParameters(params, tenant=self.tenant)
         handler = AWSReportQueryHandler(query_params.mock_qp)
         query_output = handler.execute_query()
@@ -499,7 +602,9 @@ class ReportQueryTest(IamTestCase):
         self.assertIsNotNone(query_output.get('total'))
         total = query_output.get('total')
         self.assertIsNotNone(total.get('cost'))
-        self.assertAlmostEqual(total.get('cost', {}).get('value'), self.current_month_total, 6)
+        self.assertAlmostEqual(
+            total.get('cost', {}).get('value'), self.current_month_total, 6
+        )
 
         cmonth_str = DateHelper().this_month_start.strftime('%Y-%m')
         for data_item in data:
@@ -515,10 +620,14 @@ class ReportQueryTest(IamTestCase):
     def test_query_by_partial_filtered_service(self):
         """Test execute_query monthly breakdown by filtered service."""
         # '?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&group_by[service]=eC2'
-        params = {'filter': {'resolution': 'monthly',
-                             'time_scope_value': -1,
-                             'time_scope_units': 'month'},
-                  'group_by': {'service': ['eC2']}}
+        params = {
+            'filter': {
+                'resolution': 'monthly',
+                'time_scope_value': -1,
+                'time_scope_units': 'month',
+            },
+            'group_by': {'service': ['eC2']},
+        }
         query_params = FakeQueryParameters(params, tenant=self.tenant)
         handler = AWSReportQueryHandler(query_params.mock_qp)
         query_output = handler.execute_query()
@@ -527,7 +636,9 @@ class ReportQueryTest(IamTestCase):
         self.assertIsNotNone(query_output.get('total'))
         total = query_output.get('total')
         self.assertIsNotNone(total.get('cost'))
-        self.assertAlmostEqual(total.get('cost', {}).get('value'), self.current_month_total, 6)
+        self.assertAlmostEqual(
+            total.get('cost', {}).get('value'), self.current_month_total, 6
+        )
 
         cmonth_str = DateHelper().this_month_start.strftime('%Y-%m')
         for data_item in data:
@@ -543,10 +654,14 @@ class ReportQueryTest(IamTestCase):
     def test_execute_query_current_month_by_account(self):
         """Test execute_query for current month on monthly breakdown by account."""
         # '?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&group_by[account]=*'
-        params = {'filter': {'resolution': 'monthly',
-                             'time_scope_value': -1,
-                             'time_scope_units': 'month'},
-                  'group_by': {'account': ['*']}}
+        params = {
+            'filter': {
+                'resolution': 'monthly',
+                'time_scope_value': -1,
+                'time_scope_units': 'month',
+            },
+            'group_by': {'account': ['*']},
+        }
         query_params = FakeQueryParameters(params, tenant=self.tenant)
         handler = AWSReportQueryHandler(query_params.mock_qp)
         query_output = handler.execute_query()
@@ -555,7 +670,9 @@ class ReportQueryTest(IamTestCase):
         self.assertIsNotNone(query_output.get('total'))
         total = query_output.get('total')
         self.assertIsNotNone(total.get('cost'))
-        self.assertAlmostEqual(total.get('cost', {}).get('value'), self.current_month_total, 6)
+        self.assertAlmostEqual(
+            total.get('cost', {}).get('value'), self.current_month_total, 6
+        )
 
         cmonth_str = DateHelper().this_month_start.strftime('%Y-%m')
         for data_item in data:
@@ -571,11 +688,14 @@ class ReportQueryTest(IamTestCase):
     def test_execute_query_by_account_by_service(self):
         """Test execute_query for current month breakdown by account by service."""
         # '?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&group_by[account]=*&group_by[service]=*'
-        params = {'filter': {'resolution': 'monthly',
-                             'time_scope_value': -1,
-                             'time_scope_units': 'month'},
-                  'group_by': {'account': ['*'],
-                               'service': ['*']}}
+        params = {
+            'filter': {
+                'resolution': 'monthly',
+                'time_scope_value': -1,
+                'time_scope_units': 'month',
+            },
+            'group_by': {'account': ['*'], 'service': ['*']},
+        }
         query_params = FakeQueryParameters(params, tenant=self.tenant)
         handler = AWSReportQueryHandler(query_params.mock_qp)
         query_output = handler.execute_query()
@@ -584,7 +704,9 @@ class ReportQueryTest(IamTestCase):
         self.assertIsNotNone(query_output.get('total'))
         total = query_output.get('total')
         self.assertIsNotNone(total.get('cost'))
-        self.assertAlmostEqual(total.get('cost', {}).get('value'), self.current_month_total, 6)
+        self.assertAlmostEqual(
+            total.get('cost', {}).get('value'), self.current_month_total, 6
+        )
 
         cmonth_str = DateHelper().this_month_start.strftime('%Y-%m')
         for data_item in data:
@@ -603,12 +725,17 @@ class ReportQueryTest(IamTestCase):
             instance_type = AWSCostEntryProduct.objects.first().instance_type
 
         # '?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&group_by[instance_type]=*'
-        params = {'filter': {'resolution': 'monthly',
-                             'time_scope_value': -1,
-                             'time_scope_units': 'month'},
-                  'group_by': {'instance_type': ['*']}}
-        query_params = FakeQueryParameters(params, report_type='instance_type',
-                                           tenant=self.tenant)
+        params = {
+            'filter': {
+                'resolution': 'monthly',
+                'time_scope_value': -1,
+                'time_scope_units': 'month',
+            },
+            'group_by': {'instance_type': ['*']},
+        }
+        query_params = FakeQueryParameters(
+            params, report_type='instance_type', tenant=self.tenant
+        )
         handler = AWSReportQueryHandler(query_params.mock_qp)
         query_output = handler.execute_query()
         data = query_output.get('data')
@@ -631,11 +758,15 @@ class ReportQueryTest(IamTestCase):
         self.add_data_to_tenant(FakeAWSCostData(self.provider))
 
         # '?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[limit]=2&group_by[account]=*'
-        params = {'filter': {'resolution': 'monthly',
-                             'time_scope_value': -1,
-                             'time_scope_units': 'month',
-                             'limit': 2},
-                  'group_by': {'account': ['*']}}
+        params = {
+            'filter': {
+                'resolution': 'monthly',
+                'time_scope_value': -1,
+                'time_scope_units': 'month',
+                'limit': 2,
+            },
+            'group_by': {'account': ['*']},
+        }
         query_params = FakeQueryParameters(params, tenant=self.tenant)
         handler = AWSReportQueryHandler(query_params.mock_qp)
         query_output = handler.execute_query()
@@ -644,7 +775,9 @@ class ReportQueryTest(IamTestCase):
         self.assertIsNotNone(query_output.get('total'))
         total = query_output.get('total')
         self.assertIsNotNone(total.get('cost'))
-        self.assertAlmostEqual(total.get('cost', {}).get('value'), self.current_month_total, 6)
+        self.assertAlmostEqual(
+            total.get('cost', {}).get('value'), self.current_month_total, 6
+        )
 
         cmonth_str = DateHelper().this_month_start.strftime('%Y-%m')
         for data_item in data:
@@ -662,11 +795,15 @@ class ReportQueryTest(IamTestCase):
         self.add_data_to_tenant(FakeAWSCostData(self.provider))
 
         # '?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&group_by[account]=*&order_by[cost]=asc'
-        params = {'filter': {'resolution': 'monthly',
-                             'time_scope_value': -1,
-                             'time_scope_units': 'month'},
-                  'group_by': {'account': ['*']},
-                  'order_by': {'cost': 'asc'}}
+        params = {
+            'filter': {
+                'resolution': 'monthly',
+                'time_scope_value': -1,
+                'time_scope_units': 'month',
+            },
+            'group_by': {'account': ['*']},
+            'order_by': {'cost': 'asc'},
+        }
         query_params = FakeQueryParameters(params, tenant=self.tenant)
         handler = AWSReportQueryHandler(query_params.mock_qp)
         query_output = handler.execute_query()
@@ -675,7 +812,9 @@ class ReportQueryTest(IamTestCase):
         self.assertIsNotNone(query_output.get('total'))
         total = query_output.get('total')
         self.assertIsNotNone(total.get('cost'))
-        self.assertAlmostEqual(total.get('cost', {}).get('value'), self.current_month_total, 6)
+        self.assertAlmostEqual(
+            total.get('cost', {}).get('value'), self.current_month_total, 6
+        )
 
         cmonth_str = DateHelper().this_month_start.strftime('%Y-%m')
         for data_item in data:
@@ -688,8 +827,12 @@ class ReportQueryTest(IamTestCase):
             for month_item in month_data:
                 self.assertIsInstance(month_item.get('account'), str)
                 self.assertIsInstance(month_item.get('values'), list)
-                self.assertIsNotNone(month_item.get('values')[0].get('cost', {}).get('value'))
-                data_point_total = month_item.get('values')[0].get('cost', {}).get('value')
+                self.assertIsNotNone(
+                    month_item.get('values')[0].get('cost', {}).get('value')
+                )
+                data_point_total = (
+                    month_item.get('values')[0].get('cost', {}).get('value')
+                )
                 self.assertLess(current_total, data_point_total)
                 current_total = data_point_total
 
@@ -698,11 +841,15 @@ class ReportQueryTest(IamTestCase):
         self.add_data_to_tenant(FakeAWSCostData(self.provider))
 
         # '?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&group_by[account]=*&order_by[account]=asc'
-        params = {'filter': {'resolution': 'monthly',
-                             'time_scope_value': -1,
-                             'time_scope_units': 'month'},
-                  'group_by': {'account': ['*']},
-                  'order_by': {'account': 'asc'}}
+        params = {
+            'filter': {
+                'resolution': 'monthly',
+                'time_scope_value': -1,
+                'time_scope_units': 'month',
+            },
+            'group_by': {'account': ['*']},
+            'order_by': {'account': 'asc'},
+        }
         query_params = FakeQueryParameters(params, tenant=self.tenant)
         handler = AWSReportQueryHandler(query_params.mock_qp)
         query_output = handler.execute_query()
@@ -711,7 +858,9 @@ class ReportQueryTest(IamTestCase):
         self.assertIsNotNone(query_output.get('total'))
         total = query_output.get('total')
         self.assertIsNotNone(total.get('cost'))
-        self.assertAlmostEqual(total.get('cost', {}).get('value'), self.current_month_total, 6)
+        self.assertAlmostEqual(
+            total.get('cost', {}).get('value'), self.current_month_total, 6
+        )
 
         cmonth_str = DateHelper().this_month_start.strftime('%Y-%m')
         for data_item in data:
@@ -732,10 +881,14 @@ class ReportQueryTest(IamTestCase):
     def test_execute_query_curr_month_by_region(self):
         """Test execute_query for current month on monthly breakdown by region."""
         # '?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&group_by[region]=*'
-        params = {'filter': {'resolution': 'monthly',
-                             'time_scope_value': -1,
-                             'time_scope_units': 'month'},
-                  'group_by': {'region': ['*']}}
+        params = {
+            'filter': {
+                'resolution': 'monthly',
+                'time_scope_value': -1,
+                'time_scope_units': 'month',
+            },
+            'group_by': {'region': ['*']},
+        }
         query_params = FakeQueryParameters(params, tenant=self.tenant)
         handler = AWSReportQueryHandler(query_params.mock_qp)
         query_output = handler.execute_query()
@@ -744,7 +897,9 @@ class ReportQueryTest(IamTestCase):
         self.assertIsNotNone(query_output.get('total'))
         total = query_output.get('total')
         self.assertIsNotNone(total.get('cost'))
-        self.assertAlmostEqual(total.get('cost', {}).get('value'), self.current_month_total, 6)
+        self.assertAlmostEqual(
+            total.get('cost', {}).get('value'), self.current_month_total, 6
+        )
 
         cmonth_str = DateHelper().this_month_start.strftime('%Y-%m')
         for data_item in data:
@@ -761,10 +916,14 @@ class ReportQueryTest(IamTestCase):
     def test_execute_query_curr_month_by_filtered_region(self):
         """Test execute_query for current month on monthly breakdown by filtered region."""
         # '?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&group_by[region]=[some_region]'
-        params = {'filter': {'resolution': 'monthly',
-                             'time_scope_value': -1,
-                             'time_scope_units': 'month'},
-                  'group_by': {'region': [self.fake_aws.region]}}
+        params = {
+            'filter': {
+                'resolution': 'monthly',
+                'time_scope_value': -1,
+                'time_scope_units': 'month',
+            },
+            'group_by': {'region': [self.fake_aws.region]},
+        }
         query_params = FakeQueryParameters(params, tenant=self.tenant)
         handler = AWSReportQueryHandler(query_params.mock_qp)
         query_output = handler.execute_query()
@@ -789,10 +948,14 @@ class ReportQueryTest(IamTestCase):
     def test_execute_query_curr_month_by_avail_zone(self):
         """Test execute_query for current month on monthly breakdown by avail_zone."""
         # '?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&group_by[az]=*'
-        params = {'filter': {'resolution': 'monthly',
-                             'time_scope_value': -1,
-                             'time_scope_units': 'month'},
-                  'group_by': {'az': ['*']}}
+        params = {
+            'filter': {
+                'resolution': 'monthly',
+                'time_scope_value': -1,
+                'time_scope_units': 'month',
+            },
+            'group_by': {'az': ['*']},
+        }
         query_params = FakeQueryParameters(params, tenant=self.tenant)
         handler = AWSReportQueryHandler(query_params.mock_qp)
         query_output = handler.execute_query()
@@ -801,7 +964,9 @@ class ReportQueryTest(IamTestCase):
         self.assertIsNotNone(query_output.get('total'))
         total = query_output.get('total')
         self.assertIsNotNone(total.get('cost'))
-        self.assertAlmostEqual(total.get('cost', {}).get('value'), self.current_month_total, 6)
+        self.assertAlmostEqual(
+            total.get('cost', {}).get('value'), self.current_month_total, 6
+        )
 
         cmonth_str = DateHelper().this_month_start.strftime('%Y-%m')
         for data_item in data:
@@ -818,10 +983,14 @@ class ReportQueryTest(IamTestCase):
     def test_execute_query_curr_month_by_filtered_avail_zone(self):
         """Test execute_query for current month on monthly breakdown by filtered avail_zone."""
         # '?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&group_by[az]=[some_zone]'
-        params = {'filter': {'resolution': 'monthly',
-                             'time_scope_value': -1,
-                             'time_scope_units': 'month'},
-                  'group_by': {'az': [self.fake_aws.availability_zone]}}
+        params = {
+            'filter': {
+                'resolution': 'monthly',
+                'time_scope_value': -1,
+                'time_scope_units': 'month',
+            },
+            'group_by': {'az': [self.fake_aws.availability_zone]},
+        }
         query_params = FakeQueryParameters(params, tenant=self.tenant)
         handler = AWSReportQueryHandler(query_params.mock_qp)
         query_output = handler.execute_query()
@@ -847,10 +1016,14 @@ class ReportQueryTest(IamTestCase):
     def test_execute_query_current_month_filter_account(self):
         """Test execute_query for current month on monthly filtered by account."""
         # '?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[account]=[some_account]'
-        params = {'filter': {'resolution': 'monthly',
-                             'time_scope_value': -1,
-                             'time_scope_units': 'month',
-                             'account': [self.fake_aws.account_alias]}}
+        params = {
+            'filter': {
+                'resolution': 'monthly',
+                'time_scope_value': -1,
+                'time_scope_units': 'month',
+                'account': [self.fake_aws.account_alias],
+            }
+        }
         query_params = FakeQueryParameters(params, tenant=self.tenant)
         handler = AWSReportQueryHandler(query_params.mock_qp)
         query_output = handler.execute_query()
@@ -859,7 +1032,9 @@ class ReportQueryTest(IamTestCase):
         self.assertIsNotNone(query_output.get('total'))
         total = query_output.get('total')
         self.assertIsNotNone(total.get('cost'))
-        self.assertAlmostEqual(total.get('cost', {}).get('value'), self.current_month_total, 6)
+        self.assertAlmostEqual(
+            total.get('cost', {}).get('value'), self.current_month_total, 6
+        )
 
         cmonth_str = DateHelper().this_month_start.strftime('%Y-%m')
         for data_item in data:
@@ -871,10 +1046,14 @@ class ReportQueryTest(IamTestCase):
     def test_execute_query_current_month_filter_service(self):
         """Test execute_query for current month on monthly filtered by service."""
         # '?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[service]=[AmazonEC2]'
-        params = {'filter': {'resolution': 'monthly',
-                             'time_scope_value': -1,
-                             'time_scope_units': 'month',
-                             'service': ['AmazonEC2']}}
+        params = {
+            'filter': {
+                'resolution': 'monthly',
+                'time_scope_value': -1,
+                'time_scope_units': 'month',
+                'service': ['AmazonEC2'],
+            }
+        }
         query_params = FakeQueryParameters(params, tenant=self.tenant)
         handler = AWSReportQueryHandler(query_params.mock_qp)
         query_output = handler.execute_query()
@@ -885,7 +1064,9 @@ class ReportQueryTest(IamTestCase):
 
         total = query_output.get('total')
         self.assertIsNotNone(total.get('cost'))
-        self.assertAlmostEqual(total.get('cost', {}).get('value'), self.current_month_total, 6)
+        self.assertAlmostEqual(
+            total.get('cost', {}).get('value'), self.current_month_total, 6
+        )
 
         cmonth_str = DateHelper().this_month_start.strftime('%Y-%m')
         for data_item in data:
@@ -897,10 +1078,14 @@ class ReportQueryTest(IamTestCase):
     def test_execute_query_current_month_filter_region(self):
         """Test execute_query for current month on monthly filtered by region."""
         # '?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[region]=[some_region]'
-        params = {'filter': {'resolution': 'monthly',
-                             'time_scope_value': -1,
-                             'time_scope_units': 'month',
-                             'region': [self.fake_aws.region]}}
+        params = {
+            'filter': {
+                'resolution': 'monthly',
+                'time_scope_value': -1,
+                'time_scope_units': 'month',
+                'region': [self.fake_aws.region],
+            }
+        }
         query_params = FakeQueryParameters(params, tenant=self.tenant)
         handler = AWSReportQueryHandler(query_params.mock_qp)
         query_output = handler.execute_query()
@@ -921,10 +1106,14 @@ class ReportQueryTest(IamTestCase):
     def test_execute_query_current_month_filter_avail_zone(self):
         """Test execute_query for current month on monthly filtered by avail_zone."""
         # '?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[az]=[some_az]'
-        params = {'filter': {'resolution': 'monthly',
-                             'time_scope_value': -1,
-                             'time_scope_units': 'month',
-                             'az': [self.fake_aws.availability_zone]}}
+        params = {
+            'filter': {
+                'resolution': 'monthly',
+                'time_scope_value': -1,
+                'time_scope_units': 'month',
+                'az': [self.fake_aws.availability_zone],
+            }
+        }
         query_params = FakeQueryParameters(params, tenant=self.tenant)
         handler = AWSReportQueryHandler(query_params.mock_qp)
         query_output = handler.execute_query()
@@ -933,7 +1122,9 @@ class ReportQueryTest(IamTestCase):
         self.assertIsNotNone(query_output.get('total'))
         total = query_output.get('total')
         self.assertIsNotNone(total.get('cost'))
-        self.assertAlmostEqual(total.get('cost', {}).get('value'), self.current_month_total, 6)
+        self.assertAlmostEqual(
+            total.get('cost', {}).get('value'), self.current_month_total, 6
+        )
 
         cmonth_str = DateHelper().this_month_start.strftime('%Y-%m')
         for data_item in data:
@@ -945,12 +1136,17 @@ class ReportQueryTest(IamTestCase):
     def test_execute_query_current_month_filter_avail_zone_csv(self):
         """Test execute_query for current month on monthly filtered by avail_zone for csv."""
         # '?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[az]=[some_az]'
-        params = {'filter': {'resolution': 'monthly',
-                             'time_scope_value': -1,
-                             'time_scope_units': 'month',
-                             'az': [self.fake_aws.availability_zone]}}
-        query_params = FakeQueryParameters(params, accept_type='text/csv',
-                                           tenant=self.tenant)
+        params = {
+            'filter': {
+                'resolution': 'monthly',
+                'time_scope_value': -1,
+                'time_scope_units': 'month',
+                'az': [self.fake_aws.availability_zone],
+            }
+        }
+        query_params = FakeQueryParameters(
+            params, accept_type='text/csv', tenant=self.tenant
+        )
         handler = AWSReportQueryHandler(query_params.mock_qp)
         query_output = handler.execute_query()
         data = query_output.get('data')
@@ -958,7 +1154,9 @@ class ReportQueryTest(IamTestCase):
         self.assertIsNotNone(query_output.get('total'))
         total = query_output.get('total')
         self.assertIsNotNone(total.get('cost'))
-        self.assertAlmostEqual(total.get('cost', {}).get('value'), self.current_month_total, 6)
+        self.assertAlmostEqual(
+            total.get('cost', {}).get('value'), self.current_month_total, 6
+        )
 
         cmonth_str = DateHelper().this_month_start.strftime('%Y-%m')
         self.assertEqual(len(data), 1)
@@ -971,13 +1169,18 @@ class ReportQueryTest(IamTestCase):
         self.add_data_to_tenant(FakeAWSCostData(self.provider))
 
         # '?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[limit]=2&group_by[account]=*'
-        params = {'filter': {'resolution': 'monthly',
-                             'time_scope_value': -1,
-                             'time_scope_units': 'month',
-                             'limit': 2},
-                  'group_by': {'account': ['*']}}
-        query_params = FakeQueryParameters(params, accept_type=['text/csv'],
-                                           tenant=self.tenant)
+        params = {
+            'filter': {
+                'resolution': 'monthly',
+                'time_scope_value': -1,
+                'time_scope_units': 'month',
+                'limit': 2,
+            },
+            'group_by': {'account': ['*']},
+        }
+        query_params = FakeQueryParameters(
+            params, accept_type=['text/csv'], tenant=self.tenant
+        )
         handler = AWSReportQueryHandler(query_params.mock_qp)
         query_output = handler.execute_query()
         data = query_output.get('data')
@@ -986,7 +1189,9 @@ class ReportQueryTest(IamTestCase):
         self.assertIsNotNone(query_output.get('total'))
         total = query_output.get('total')
         self.assertIsNotNone(total.get('cost'))
-        self.assertAlmostEqual(total.get('cost', {}).get('value'), self.current_month_total, 6)
+        self.assertAlmostEqual(
+            total.get('cost', {}).get('value'), self.current_month_total, 6
+        )
 
         cmonth_str = DateHelper().this_month_start.strftime('%Y-%m')
         self.assertEqual(len(data), 2)
@@ -1014,13 +1219,13 @@ class ReportQueryTest(IamTestCase):
         # fetch the expected sums from the DB.
         with tenant_context(self.tenant):
             curr = AWSCostEntryLineItemDailySummary.objects.filter(
-                usage_start__gte=dh.this_month_start,
-                usage_end__lte=dh.this_month_end).aggregate(value=Sum(F('unblended_cost') + F('markup_cost')))
+                usage_start__gte=dh.this_month_start, usage_end__lte=dh.this_month_end
+            ).aggregate(value=Sum(F('unblended_cost') + F('markup_cost')))
             current_total = Decimal(curr.get('value'))
 
             prev = AWSCostEntryLineItemDailySummary.objects.filter(
-                usage_start__gte=dh.last_month_start,
-                usage_end__lte=dh.last_month_end).aggregate(value=Sum(F('unblended_cost') + F('markup_cost')))
+                usage_start__gte=dh.last_month_start, usage_end__lte=dh.last_month_end
+            ).aggregate(value=Sum(F('unblended_cost') + F('markup_cost')))
             prev_total = Decimal(prev.get('value'))
 
         expected_delta_value = Decimal(current_total - prev_total)
@@ -1029,11 +1234,15 @@ class ReportQueryTest(IamTestCase):
         )
 
         # '?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&group_by[account]=*&delta=cost'
-        params = {'filter': {'resolution': 'monthly',
-                             'time_scope_value': -1,
-                             'time_scope_units': 'month'},
-                  'group_by': {'account': ['*']},
-                  'delta': 'cost'}
+        params = {
+            'filter': {
+                'resolution': 'monthly',
+                'time_scope_value': -1,
+                'time_scope_units': 'month',
+            },
+            'group_by': {'account': ['*']},
+            'delta': 'cost',
+        }
         query_params = FakeQueryParameters(params, tenant=self.tenant)
         handler = AWSReportQueryHandler(query_params.mock_qp)
 
@@ -1060,8 +1269,10 @@ class ReportQueryTest(IamTestCase):
         expected_delta_percent = None
 
         # '?filter[time_scope_value]=-1&delta=cost'
-        params = {'filter': {'time_scope_value': -1},
-                  'delta': 'cost'}
+        params = {
+            'filter': {'time_scope_value': -1, 'time_scope_units': 'month'},
+            'delta': 'cost',
+        }
         query_params = FakeQueryParameters(params, tenant=self.tenant)
         handler = AWSReportQueryHandler(query_params.mock_qp)
         query_output = handler.execute_query()
@@ -1098,12 +1309,16 @@ class ReportQueryTest(IamTestCase):
         previous_data.usage_start = dh.last_month_start + timedelta(days=1)
 
         # '?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&order_by[delta]=asc&group_by[account]=*&delta=cost'
-        params = {'filter': {'resolution': 'monthly',
-                             'time_scope_value': -1,
-                             'time_scope_units': 'month'},
-                  'order_by': {'delta': 'asc'},
-                  'group_by': {'account': ['*']},
-                  'delta': 'cost'}
+        params = {
+            'filter': {
+                'resolution': 'monthly',
+                'time_scope_value': -1,
+                'time_scope_units': 'month',
+            },
+            'order_by': {'delta': 'asc'},
+            'group_by': {'account': ['*']},
+            'delta': 'cost',
+        }
         query_params = FakeQueryParameters(params, tenant=self.tenant)
         handler = AWSReportQueryHandler(query_params.mock_qp)
         query_output = handler.execute_query()
@@ -1124,11 +1339,15 @@ class ReportQueryTest(IamTestCase):
     def test_execute_query_with_account_alias(self):
         """Test execute_query when account alias is avaiable."""
         # '?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[limit]=2&group_by[account]=*'
-        params = {'filter': {'resolution': 'monthly',
-                             'time_scope_value': -1,
-                             'time_scope_units': 'month',
-                             'limit': 2},
-                  'group_by': {'account': ['*']}}
+        params = {
+            'filter': {
+                'resolution': 'monthly',
+                'time_scope_value': -1,
+                'time_scope_units': 'month',
+                'limit': 2,
+            },
+            'group_by': {'account': ['*']},
+        }
         query_params = FakeQueryParameters(params, tenant=self.tenant)
         handler = AWSReportQueryHandler(query_params.mock_qp)
         query_output = handler.execute_query()
@@ -1148,11 +1367,15 @@ class ReportQueryTest(IamTestCase):
 
         # execute query
         # '?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&group_by[account]=*&order_by[account_alias]=asc'
-        params = {'filter': {'resolution': 'monthly',
-                             'time_scope_value': -1,
-                             'time_scope_units': 'month'},
-                  'group_by': {'account': ['*']},
-                  'order_by': {'account_alias': 'asc'}}
+        params = {
+            'filter': {
+                'resolution': 'monthly',
+                'time_scope_value': -1,
+                'time_scope_units': 'month',
+            },
+            'group_by': {'account': ['*']},
+            'order_by': {'account_alias': 'asc'},
+        }
         query_params = FakeQueryParameters(params, tenant=self.tenant)
         handler = AWSReportQueryHandler(query_params.mock_qp)
         query_output = handler.execute_query()
@@ -1170,16 +1393,22 @@ class ReportQueryTest(IamTestCase):
     def test_calculate_total(self):
         """Test that calculated totals return correctly."""
         # '?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly'
-        params = {'filter': {'resolution': 'monthly',
-                             'time_scope_value': -1,
-                             'time_scope_units': 'month'}}
+        params = {
+            'filter': {
+                'resolution': 'monthly',
+                'time_scope_value': -1,
+                'time_scope_units': 'month',
+            }
+        }
         query_params = FakeQueryParameters(params)
         handler = AWSReportQueryHandler(query_params.mock_qp)
         expected_units = 'USD'
         with tenant_context(self.tenant):
             result = handler.calculate_total(**{'cost_units': expected_units})
 
-        self.assertAlmostEqual(result.get('cost', {}).get('value'), self.current_month_total, 6)
+        self.assertAlmostEqual(
+            result.get('cost', {}).get('value'), self.current_month_total, 6
+        )
         self.assertEqual(result.get('cost', {}).get('units'), expected_units)
 
     def test_percent_delta(self):
@@ -1191,24 +1420,36 @@ class ReportQueryTest(IamTestCase):
     def test_rank_list(self):
         """Test rank list limit with account alias."""
         # '?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[limit]=2&group_by[account]=*'
-        params = {'filter': {'resolution': 'monthly',
-                             'time_scope_value': -1,
-                             'time_scope_units': 'month',
-                             'limit': 2},
-                  'group_by': {'account': ['*']}}
+        params = {
+            'filter': {
+                'resolution': 'monthly',
+                'time_scope_value': -1,
+                'time_scope_units': 'month',
+                'limit': 2,
+            },
+            'group_by': {'account': ['*']},
+        }
         query_params = FakeQueryParameters(params)
         handler = AWSReportQueryHandler(query_params.mock_qp)
         data_list = [
             {'account': '1', 'account_alias': '1', 'total': 5, 'rank': 1},
             {'account': '2', 'account_alias': '2', 'total': 4, 'rank': 2},
             {'account': '3', 'account_alias': '3', 'total': 3, 'rank': 3},
-            {'account': '4', 'account_alias': '4', 'total': 2, 'rank': 4}
+            {'account': '4', 'account_alias': '4', 'total': 2, 'rank': 4},
         ]
         expected = [
             {'account': '1', 'account_alias': '1', 'total': 5, 'rank': 1},
             {'account': '2', 'account_alias': '2', 'total': 4, 'rank': 2},
-            {'account': '2 Others', 'account_alias': '2 Others', 'cost': 0, 'markup_cost': 0,
-             'derived_cost': 0, 'infrastructure_cost': 0, 'total': 5, 'rank': 3}
+            {
+                'account': '2 Others',
+                'account_alias': '2 Others',
+                'cost': 0,
+                'markup_cost': 0,
+                'derived_cost': 0,
+                'infrastructure_cost': 0,
+                'total': 5,
+                'rank': 3,
+            },
         ]
         ranked_list = handler._ranked_list(data_list)
         self.assertEqual(ranked_list, expected)
@@ -1216,24 +1457,35 @@ class ReportQueryTest(IamTestCase):
     def test_rank_list_no_account(self):
         """Test rank list limit with out account alias."""
         # '?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[limit]=2&group_by[service]=*'
-        params = {'filter': {'resolution': 'monthly',
-                             'time_scope_value': -1,
-                             'time_scope_units': 'month',
-                             'limit': 2},
-                  'group_by': {'service': ['*']}}
+        params = {
+            'filter': {
+                'resolution': 'monthly',
+                'time_scope_value': -1,
+                'time_scope_units': 'month',
+                'limit': 2,
+            },
+            'group_by': {'service': ['*']},
+        }
         query_params = FakeQueryParameters(params)
         handler = AWSReportQueryHandler(query_params.mock_qp)
         data_list = [
             {'service': '1', 'total': 5, 'rank': 1},
             {'service': '2', 'total': 4, 'rank': 2},
             {'service': '3', 'total': 3, 'rank': 3},
-            {'service': '4', 'total': 2, 'rank': 4}
+            {'service': '4', 'total': 2, 'rank': 4},
         ]
         expected = [
             {'service': '1', 'total': 5, 'rank': 1},
             {'service': '2', 'total': 4, 'rank': 2},
-            {'cost': 0, 'derived_cost': 0, 'infrastructure_cost': 0,
-             'markup_cost': 0, 'service': '2 Others', 'total': 5, 'rank': 3}
+            {
+                'cost': 0,
+                'derived_cost': 0,
+                'infrastructure_cost': 0,
+                'markup_cost': 0,
+                'service': '2 Others',
+                'total': 5,
+                'rank': 3,
+            },
         ]
         ranked_list = handler._ranked_list(data_list)
         self.assertEqual(ranked_list, expected)
@@ -1241,23 +1493,25 @@ class ReportQueryTest(IamTestCase):
     def test_rank_list_with_offset(self):
         """Test rank list limit and offset with account alias."""
         # '?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[limit]=1&filter[offset]=1&group_by[account]=*'
-        params = {'filter': {'resolution': 'monthly',
-                             'time_scope_value': -1,
-                             'time_scope_units': 'month',
-                             'limit': 1,
-                             'offset': 1},
-                  'group_by': {'account': ['*']}}
+        params = {
+            'filter': {
+                'resolution': 'monthly',
+                'time_scope_value': -1,
+                'time_scope_units': 'month',
+                'limit': 1,
+                'offset': 1,
+            },
+            'group_by': {'account': ['*']},
+        }
         query_params = FakeQueryParameters(params)
         handler = AWSReportQueryHandler(query_params.mock_qp)
         data_list = [
             {'account': '1', 'account_alias': '1', 'total': 5, 'rank': 1},
             {'account': '2', 'account_alias': '2', 'total': 4, 'rank': 2},
             {'account': '3', 'account_alias': '3', 'total': 3, 'rank': 3},
-            {'account': '4', 'account_alias': '4', 'total': 2, 'rank': 4}
+            {'account': '4', 'account_alias': '4', 'total': 2, 'rank': 4},
         ]
-        expected = [
-            {'account': '2', 'account_alias': '2', 'total': 4, 'rank': 2},
-        ]
+        expected = [{'account': '2', 'account_alias': '2', 'total': 4, 'rank': 2}]
         ranked_list = handler._ranked_list(data_list)
         self.assertEqual(ranked_list, expected)
 
@@ -1271,10 +1525,14 @@ class ReportQueryTest(IamTestCase):
         self.add_data_to_tenant(FakeAWSCostData(self.provider), product='ebs')
 
         # '?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&group_by[account]=*'
-        params = {'filter': {'resolution': 'monthly',
-                             'time_scope_value': -1,
-                             'time_scope_units': 'month'},
-                  'group_by': {'account': ['*']}}
+        params = {
+            'filter': {
+                'resolution': 'monthly',
+                'time_scope_value': -1,
+                'time_scope_units': 'month',
+            },
+            'group_by': {'account': ['*']},
+        }
         query_params = FakeQueryParameters(params, tenant=self.tenant)
         handler = AWSReportQueryHandler(query_params.mock_qp)
         query_output = handler.execute_query()
@@ -1299,12 +1557,17 @@ class ReportQueryTest(IamTestCase):
         self.add_data_to_tenant(FakeAWSCostData(self.provider), product='ec2')
 
         # '?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&group_by[instance_type]=*'
-        params = {'filter': {'resolution': 'monthly',
-                             'time_scope_value': -1,
-                             'time_scope_units': 'month'},
-                  'group_by': {'instance_type': ['*']}}
-        query_params = FakeQueryParameters(params, report_type='instance_type',
-                                           tenant=self.tenant)
+        params = {
+            'filter': {
+                'resolution': 'monthly',
+                'time_scope_value': -1,
+                'time_scope_units': 'month',
+            },
+            'group_by': {'instance_type': ['*']},
+        }
+        query_params = FakeQueryParameters(
+            params, report_type='instance_type', tenant=self.tenant
+        )
         handler = AWSReportQueryHandler(query_params.mock_qp)
         query_output = handler.execute_query()
         data = query_output.get('data')
@@ -1330,12 +1593,17 @@ class ReportQueryTest(IamTestCase):
         self.add_data_to_tenant(FakeAWSCostData(self.provider), product='ebs')
 
         # '?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&group_by[service]=*'
-        params = {'filter': {'resolution': 'monthly',
-                             'time_scope_value': -1,
-                             'time_scope_units': 'month'},
-                  'group_by': {'service': ['*']}}
-        query_params = FakeQueryParameters(params, report_type='storage',
-                                           tenant=self.tenant)
+        params = {
+            'filter': {
+                'resolution': 'monthly',
+                'time_scope_value': -1,
+                'time_scope_units': 'month',
+            },
+            'group_by': {'service': ['*']},
+        }
+        query_params = FakeQueryParameters(
+            params, report_type='storage', tenant=self.tenant
+        )
         handler = AWSReportQueryHandler(query_params.mock_qp)
         query_output = handler.execute_query()
         data = query_output.get('data')
@@ -1350,77 +1618,59 @@ class ReportQueryTest(IamTestCase):
                     self.assertIsNotNone(srv.get('values'))
                     self.assertGreater(len(srv.get('values')), 0)
                     for value in srv.get('values'):
-                        self.assertIsInstance(value.get('cost', {}).get('value'), Decimal)
-                        self.assertGreater(value.get('cost', {}).get('value'), Decimal(0))
-                        self.assertIsInstance(value.get('usage', {}).get('value'), Decimal)
-                        self.assertGreater(value.get('usage', {}).get('value'), Decimal(0))
+                        self.assertIsInstance(
+                            value.get('cost', {}).get('value'), Decimal
+                        )
+                        self.assertGreater(
+                            value.get('cost', {}).get('value'), Decimal(0)
+                        )
+                        self.assertIsInstance(
+                            value.get('usage', {}).get('value'), Decimal
+                        )
+                        self.assertGreater(
+                            value.get('usage', {}).get('value'), Decimal(0)
+                        )
 
     def test_order_by(self):
         """Test that order_by returns properly sorted data."""
         today = datetime.utcnow()
         yesterday = today - timedelta(days=1)
         # '?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly'
-        params = {'filter': {'resolution': 'monthly',
-                             'time_scope_value': -1,
-                             'time_scope_units': 'month'}}
+        params = {
+            'filter': {
+                'resolution': 'monthly',
+                'time_scope_value': -1,
+                'time_scope_units': 'month',
+            }
+        }
         query_params = FakeQueryParameters(params)
         handler = AWSReportQueryHandler(query_params.mock_qp)
 
-        unordered_data = [{'date': today,
-                           'delta_percent': 8,
-                           'total': 6.2,
-                           'rank': 2},
-                          {'date': yesterday,
-                           'delta_percent': 4,
-                           'total': 2.2,
-                           'rank': 1},
-                          {'date': today,
-                           'delta_percent': 7,
-                           'total': 8.2,
-                           'rank': 1},
-                          {'date': yesterday,
-                           'delta_percent': 4,
-                           'total': 2.2,
-                           'rank': 2}, ]
+        unordered_data = [
+            {'date': today, 'delta_percent': 8, 'total': 6.2, 'rank': 2},
+            {'date': yesterday, 'delta_percent': 4, 'total': 2.2, 'rank': 1},
+            {'date': today, 'delta_percent': 7, 'total': 8.2, 'rank': 1},
+            {'date': yesterday, 'delta_percent': 4, 'total': 2.2, 'rank': 2},
+        ]
 
         order_fields = ['date', 'rank']
-        expected = [{'date': yesterday,
-                     'delta_percent': 4,
-                     'total': 2.2,
-                     'rank': 1},
-                    {'date': yesterday,
-                     'delta_percent': 4,
-                     'total': 2.2,
-                     'rank': 2},
-                    {'date': today,
-                     'delta_percent': 7,
-                     'total': 8.2,
-                     'rank': 1},
-                    {'date': today,
-                     'delta_percent': 8,
-                     'total': 6.2,
-                     'rank': 2}, ]
+        expected = [
+            {'date': yesterday, 'delta_percent': 4, 'total': 2.2, 'rank': 1},
+            {'date': yesterday, 'delta_percent': 4, 'total': 2.2, 'rank': 2},
+            {'date': today, 'delta_percent': 7, 'total': 8.2, 'rank': 1},
+            {'date': today, 'delta_percent': 8, 'total': 6.2, 'rank': 2},
+        ]
 
         ordered_data = handler.order_by(unordered_data, order_fields)
         self.assertEqual(ordered_data, expected)
 
         order_fields = ['date', '-delta']
-        expected = [{'date': yesterday,
-                     'delta_percent': 4,
-                     'total': 2.2,
-                     'rank': 1},
-                    {'date': yesterday,
-                     'delta_percent': 4,
-                     'total': 2.2,
-                     'rank': 2},
-                    {'date': today,
-                     'delta_percent': 8,
-                     'total': 6.2,
-                     'rank': 2},
-                    {'date': today,
-                     'delta_percent': 7,
-                     'total': 8.2,
-                     'rank': 1}, ]
+        expected = [
+            {'date': yesterday, 'delta_percent': 4, 'total': 2.2, 'rank': 1},
+            {'date': yesterday, 'delta_percent': 4, 'total': 2.2, 'rank': 2},
+            {'date': today, 'delta_percent': 8, 'total': 6.2, 'rank': 2},
+            {'date': today, 'delta_percent': 7, 'total': 8.2, 'rank': 1},
+        ]
 
         ordered_data = handler.order_by(unordered_data, order_fields)
         self.assertEqual(ordered_data, expected)
@@ -1433,9 +1683,13 @@ class ReportQueryTest(IamTestCase):
 
     def test_execute_query_with_wildcard_tag_filter(self):
         """Test that data is filtered to include entries with tag key."""
-        params = {'filter': {'resolution': 'monthly',
-                             'time_scope_value': -1,
-                             'time_scope_units': 'month'}}
+        params = {
+            'filter': {
+                'resolution': 'monthly',
+                'time_scope_value': -1,
+                'time_scope_units': 'month',
+            }
+        }
         query_params = FakeQueryParameters(params, tenant=self.tenant)
         handler = AWSTagQueryHandler(query_params.mock_qp)
         tag_keys = handler.get_tag_keys()
@@ -1443,18 +1697,26 @@ class ReportQueryTest(IamTestCase):
         tag_keys = ['tag:' + tag for tag in tag_keys]
 
         with tenant_context(self.tenant):
-            totals = AWSCostEntryLineItemDailySummary.objects\
-                .filter(usage_start__gte=self.dh.this_month_start)\
-                .filter(**{'tags__has_key': filter_key})\
-                .aggregate(
-                    **{'cost': Sum(F('unblended_cost') + F('markup_cost'))})
+            totals = (
+                AWSCostEntryLineItemDailySummary.objects.filter(
+                    usage_start__gte=self.dh.this_month_start
+                )
+                .filter(**{'tags__has_key': filter_key})
+                .aggregate(**{'cost': Sum(F('unblended_cost') + F('markup_cost'))})
+            )
 
         # '?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[tag:some_key]=some_value'
-        params = {'filter': {'resolution': 'monthly',
-                             'time_scope_value': -1,
-                             'time_scope_units': 'month',
-                             f'tag:{filter_key}': ['*']}}
-        query_params = FakeQueryParameters(params, tenant=self.tenant, tag_keys=tag_keys)
+        params = {
+            'filter': {
+                'resolution': 'monthly',
+                'time_scope_value': -1,
+                'time_scope_units': 'month',
+                f'tag:{filter_key}': ['*'],
+            }
+        }
+        query_params = FakeQueryParameters(
+            params, tenant=self.tenant, tag_keys=tag_keys
+        )
         handler = AWSReportQueryHandler(query_params.mock_qp)
         data = handler.execute_query()
         data_totals = data.get('total', {})
@@ -1464,9 +1726,13 @@ class ReportQueryTest(IamTestCase):
 
     def test_execute_query_with_tag_group_by(self):
         """Test that data is grouped by tag key."""
-        params = {'filter': {'resolution': 'monthly',
-                             'time_scope_value': -1,
-                             'time_scope_units': 'month'}}
+        params = {
+            'filter': {
+                'resolution': 'monthly',
+                'time_scope_value': -1,
+                'time_scope_units': 'month',
+            }
+        }
         query_params = FakeQueryParameters(params, tenant=self.tenant)
         handler = AWSTagQueryHandler(query_params.mock_qp)
         tag_keys = handler.get_tag_keys()
@@ -1474,18 +1740,26 @@ class ReportQueryTest(IamTestCase):
         tag_keys = ['tag:' + tag for tag in tag_keys]
 
         with tenant_context(self.tenant):
-            totals = AWSCostEntryLineItemDailySummary.objects\
-                .filter(usage_start__gte=self.dh.this_month_start)\
-                .filter(**{'tags__has_key': group_by_key})\
-                .aggregate(
-                    **{'cost': Sum(F('unblended_cost') + F('markup_cost'))})
+            totals = (
+                AWSCostEntryLineItemDailySummary.objects.filter(
+                    usage_start__gte=self.dh.this_month_start
+                )
+                .filter(**{'tags__has_key': group_by_key})
+                .aggregate(**{'cost': Sum(F('unblended_cost') + F('markup_cost'))})
+            )
 
         # '?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&group_by[tag:some_key]=some_value'
-        params = {'filter': {'resolution': 'monthly',
-                             'time_scope_value': -1,
-                             'time_scope_units': 'month'},
-                  'group_by': {f'tag:{group_by_key}': ['*']}}
-        query_params = FakeQueryParameters(params, tenant=self.tenant, tag_keys=tag_keys)
+        params = {
+            'filter': {
+                'resolution': 'monthly',
+                'time_scope_value': -1,
+                'time_scope_units': 'month',
+            },
+            'group_by': {f'tag:{group_by_key}': ['*']},
+        }
+        query_params = FakeQueryParameters(
+            params, tenant=self.tenant, tag_keys=tag_keys
+        )
         handler = AWSReportQueryHandler(query_params.mock_qp)
 
         data = handler.execute_query()
@@ -1498,11 +1772,73 @@ class ReportQueryTest(IamTestCase):
             result = data_totals.get(key, {}).get('value')
             self.assertEqual(result, totals[key])
 
+    def test_execute_query_return_others_with_tag_group_by(self):
+        """Test that data is grouped by tag key."""
+        import pdb
+
+        pdb.set_trace()
+        params = {
+            'filter': {
+                'resolution': 'monthly',
+                'time_scope_value': -1,
+                'time_scope_units': 'month',
+            }
+        }
+        query_params = FakeQueryParameters(params, tenant=self.tenant)
+        handler = AWSTagQueryHandler(query_params.mock_qp)
+        tag_keys = handler.get_tag_keys()
+        group_by_key = tag_keys[0]
+        tag_keys = ['tag:' + tag for tag in tag_keys]
+
+        with tenant_context(self.tenant):
+            totals = (
+                AWSCostEntryLineItemDailySummary.objects.filter(
+                    usage_start__gte=self.dh.this_month_start
+                )
+                .filter(**{'tags__has_key': group_by_key})
+                .aggregate(**{'cost': Sum(F('unblended_cost') + F('markup_cost'))})
+            )
+            others_totals = (
+                AWSCostEntryLineItemDailySummary.objects.filter(
+                    usage_start__gte=self.dh.this_month_start
+                )
+                .exclude(**{'tags__has_key': group_by_key})
+                .aggregate(**{'cost': Sum(F('unblended_cost') + F('markup_cost'))})
+            )
+
+        # '?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&group_by[tag:some_key]=some_value'
+        params = {
+            'filter': {
+                'resolution': 'monthly',
+                'time_scope_value': -1,
+                'time_scope_units': 'month',
+            },
+            'group_by': {f'or:tag:{group_by_key}': ['*']},
+        }
+        query_params = FakeQueryParameters(
+            params, tenant=self.tenant, tag_keys=tag_keys
+        )
+        handler = AWSReportQueryHandler(query_params.mock_qp)
+
+        data = handler.execute_query()
+        data_totals = data.get('total', {})
+        data = data.get('data', [])
+        expected_keys = ['date', group_by_key + 's']
+        for entry in data:
+            self.assertEqual(list(entry.keys()), expected_keys)
+        for key in totals:
+            result = data_totals.get(key, {}).get('value')
+            self.assertAlmostEqual(result, (totals[key] + others_totals[key]), 6)
+
     def test_execute_query_with_tag_filter(self):
         """Test that data is filtered by tag key."""
-        params = {'filter': {'resolution': 'monthly',
-                             'time_scope_value': -1,
-                             'time_scope_units': 'month'}}
+        params = {
+            'filter': {
+                'resolution': 'monthly',
+                'time_scope_value': -1,
+                'time_scope_units': 'month',
+            }
+        }
         query_params = FakeQueryParameters(params, tenant=self.tenant)
         handler = AWSTagQueryHandler(query_params.mock_qp)
         tag_keys = handler.get_tag_keys()
@@ -1510,25 +1846,37 @@ class ReportQueryTest(IamTestCase):
         tag_keys = ['tag:' + tag for tag in tag_keys]
 
         with tenant_context(self.tenant):
-            labels = AWSCostEntryLineItemDailySummary.objects\
-                .filter(usage_start__gte=self.dh.this_month_start)\
-                .filter(tags__has_key=filter_key)\
-                .values(*['tags'])\
+            labels = (
+                AWSCostEntryLineItemDailySummary.objects.filter(
+                    usage_start__gte=self.dh.this_month_start
+                )
+                .filter(tags__has_key=filter_key)
+                .values(*['tags'])
                 .all()
+            )
             label_of_interest = labels[0]
             filter_value = label_of_interest.get('tags', {}).get(filter_key)
 
-            totals = AWSCostEntryLineItemDailySummary.objects\
-                .filter(usage_start__gte=self.dh.this_month_start)\
-                .filter(**{f'tags__{filter_key}': filter_value})\
+            totals = (
+                AWSCostEntryLineItemDailySummary.objects.filter(
+                    usage_start__gte=self.dh.this_month_start
+                )
+                .filter(**{f'tags__{filter_key}': filter_value})
                 .aggregate(**{'cost': Sum(F('unblended_cost') + F('markup_cost'))})
+            )
 
         # '?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&group_by[tag:some_key]=some_value'
-        params = {'filter': {'resolution': 'monthly',
-                             'time_scope_value': -1,
-                             'time_scope_units': 'month',
-                             f'tag:{filter_key}': [filter_value]}}
-        query_params = FakeQueryParameters(params, tenant=self.tenant, tag_keys=tag_keys)
+        params = {
+            'filter': {
+                'resolution': 'monthly',
+                'time_scope_value': -1,
+                'time_scope_units': 'month',
+                f'tag:{filter_key}': [filter_value],
+            }
+        }
+        query_params = FakeQueryParameters(
+            params, tenant=self.tenant, tag_keys=tag_keys
+        )
         handler = AWSReportQueryHandler(query_params.mock_qp)
 
         data = handler.execute_query()

--- a/koku/api/report/test/tests_queries.py
+++ b/koku/api/report/test/tests_queries.py
@@ -1774,9 +1774,6 @@ class ReportQueryTest(IamTestCase):
 
     def test_execute_query_return_others_with_tag_group_by(self):
         """Test that data is grouped by tag key."""
-        import pdb
-
-        pdb.set_trace()
         params = {
             'filter': {
                 'resolution': 'monthly',


### PR DESCRIPTION
This PR will address the 2 failures in Travis.

The failure of `test_execute_query_w_delta` was simple calculation error.

The failure of `test_execute_query_w_delta_no_previous_data` involves mocking in `FakeQueryParameters`. The test sets `time_scope_value` and not `time_scope_units`. The `QueryParameter.__init__` sets `time_scope_units` when the query specifies `time_scope_value`, so this test should work just fine. But, the _mock_ in this test does *not* set this value. The fix in this PR is temporary so that we can merge outstanding PRs, but these tests should be addressed further in a follow up PR.