### PR TITLE
Sources Client handle kafka restarts

### DIFF
--- a/koku/sources/kafka_listener.py
+++ b/koku/sources/kafka_listener.py
@@ -341,6 +341,13 @@ async def listen_for_messages(consumer, application_source_id, msg_pending_queue
         None
 
     """
+    try:
+        await consumer.start()
+    except KafkaError as err:
+        await consumer.stop()
+        LOG.exception(str(err))
+        raise SourcesIntegrationError('Unable to connect to kafka server.')
+
     LOG.info('Listener started.  Waiting for messages...')
     try:
         async for msg in consumer:
@@ -447,14 +454,6 @@ async def synchronize_sources(process_queue, cost_management_type_id):  # pragma
             LOG.error(f'Source {source_id} Unexpected synchronization error: {str(error)}')
 
 
-async def connect_consumer(consumer):  # pragma: no cover
-    """Connect consumer."""
-    try:
-        await consumer.start()
-    except KafkaError as kafka_error:
-        raise SourcesIntegrationError('Unable to connect to kafka server. Reason: ', str(kafka_error))
-
-
 def asyncio_sources_thread(event_loop):  # pragma: no cover
     """
     Configure Sources listener thread function to run the asyncio event loop.
@@ -466,29 +465,24 @@ def asyncio_sources_thread(event_loop):  # pragma: no cover
         None
 
     """
-    consumer = AIOKafkaConsumer(
-        Config.SOURCES_TOPIC,
-        loop=event_loop, bootstrap_servers=Config.SOURCES_KAFKA_ADDRESS, group_id='hccm-sources'
-    )
-    while True:
-        try:
-            event_loop.run_until_complete(connect_consumer(consumer))
-            break
-        except SourcesIntegrationError as err:
-            err_msg = f'Kafka Connection Failure: {str(err)}. Reconnecting...'
-            LOG.error(err_msg)
-        time.sleep(Config.RETRY_SECONDS)
-
     try:
         cost_management_type_id = SourcesHTTPClient(Config.SOURCES_FAKE_HEADER).\
             get_cost_management_application_type_id()
 
         load_process_queue()
         while True:
+            consumer = AIOKafkaConsumer(
+                Config.SOURCES_TOPIC,
+                loop=event_loop, bootstrap_servers=Config.SOURCES_KAFKA_ADDRESS, group_id='hccm-sources'
+            )
             event_loop.create_task(listen_for_messages(consumer, cost_management_type_id, PENDING_PROCESS_QUEUE))
             event_loop.create_task(process_messages(PENDING_PROCESS_QUEUE))
             event_loop.create_task(synchronize_sources(PROCESS_QUEUE, cost_management_type_id))
             event_loop.run_forever()
+    except SourcesIntegrationError as error:
+        err_msg = f'Kafka Connection Failure: {str(error)}. Reconnecting...'
+        LOG.error(err_msg)
+        time.sleep(Config.RETRY_SECONDS)
     except SourcesHTTPClientError as error:
         LOG.error(f'Unable to connect to Sources REST API.  Check configuration and restart server... Error: {error}')
         exit(0)


### PR DESCRIPTION
Handling Kafka connection restarts

**Testing**
1. Create a source to verify end-to-end is functional
2. Restart the sources backend and create a new source. Verify the provider creation was successful.
3. Restart kafka and create a new source.  Verify that the client recovers automatically and a new provider is successfully created.
4.  Verify all providers are in cost management

**Testing Results**
[sources_hardening_ut_2.txt](https://github.com/project-koku/koku/files/3816932/sources_hardening_ut_2.txt)
