### PR TITLE
Handle unexpected errors found in Sources CI

### DIFF
--- a/koku/sources/kafka_listener.py
+++ b/koku/sources/kafka_listener.py
@@ -262,6 +262,10 @@ def sources_network_info(source_id, auth_header):
     source_type_name = sources_network.get_source_type_name(source_type_id)
     endpoint_id = sources_network.get_endpoint_id()
 
+    if not endpoint_id:
+        LOG.error(f'Unable to find endpoint for Source ID: {source_id}')
+        return
+
     if source_type_name == SOURCES_OCP_SOURCE_NAME:
         source_type = 'OCP'
     elif source_type_name == SOURCES_AWS_SOURCE_NAME:

--- a/koku/sources/sources_http_client.py
+++ b/koku/sources/sources_http_client.py
@@ -169,4 +169,3 @@ class SourcesHTTPClient:
                 raise SourcesHTTPClientError(f'Unable to set status for Source: {self._source_id}')
             return True
         return False
-

--- a/koku/sources/sources_http_client.py
+++ b/koku/sources/sources_http_client.py
@@ -167,3 +167,6 @@ class SourcesHTTPClient:
             application_response = requests.patch(application_url, json=json_data, headers=self._identity_header)
             if application_response.status_code != 204:
                 raise SourcesHTTPClientError(f'Unable to set status for Source: {self._source_id}')
+            return True
+        return False
+

--- a/koku/sources/sources_http_client.py
+++ b/koku/sources/sources_http_client.py
@@ -58,9 +58,9 @@ class SourcesHTTPClient:
             raise SourcesHTTPClientError('Status Code: ', r.status_code)
         endpoint_response = r.json()
 
-        if not endpoint_response.get('data'):
-            raise SourcesHTTPClientError(f'No authentication details for Source: {self._source_id}')
-        endpoint_id = endpoint_response.get('data')[0].get('id')
+        endpoint_id = None
+        if endpoint_response.get('data'):
+            endpoint_id = endpoint_response.get('data')[0].get('id')
 
         return endpoint_id
 
@@ -153,15 +153,17 @@ class SourcesHTTPClient:
         application_query_url = '{}/applications?filter[application_type_id]={}&filter[source_id]={}'.\
             format(self._base_url, cost_management_type_id, str(self._source_id))
         application_query_response = requests.get(application_query_url, headers=self._identity_header)
-        application_id = application_query_response.json().get('data')[0].get('id')
+        response_data = application_query_response.json().get('data')
+        if response_data:
+            application_id = response_data[0].get('id')
 
-        application_url = '{}/applications/{}'.format(self._base_url, str(application_id))
-        if error_msg:
-            status = 'unavailable'
-        else:
-            status = 'available'
-            error_msg = ''
-        json_data = {'availability_status': status, 'availability_status_error': str(error_msg)}
-        application_response = requests.patch(application_url, json=json_data, headers=self._identity_header)
-        if application_response.status_code != 204:
-            raise SourcesHTTPClientError(f'Unable to set status for Source: {self._source_id}')
+            application_url = '{}/applications/{}'.format(self._base_url, str(application_id))
+            if error_msg:
+                status = 'unavailable'
+            else:
+                status = 'available'
+                error_msg = ''
+            json_data = {'availability_status': status, 'availability_status_error': str(error_msg)}
+            application_response = requests.patch(application_url, json=json_data, headers=self._identity_header)
+            if application_response.status_code != 204:
+                raise SourcesHTTPClientError(f'Unable to set status for Source: {self._source_id}')

--- a/koku/sources/test/test_sources_http_client.py
+++ b/koku/sources/test/test_sources_http_client.py
@@ -230,8 +230,7 @@ class SourcesHTTPClientTest(TestCase):
         with requests_mock.mock() as m:
             m.get(f'http://www.sources.com/api/v1.0/endpoints?filter[source_id]={source_id}',
                   status_code=200, json={'data': []})
-            with self.assertRaises(SourcesHTTPClientError):
-                client.get_endpoint_id()
+            self.assertIsNone(client.get_endpoint_id())
 
     @patch.object(Config, 'SOURCES_API_URL', 'http://www.sources.com')
     def test_get_endpoint_id_misconfigured(self):

--- a/koku/sources/test/test_sources_http_client.py
+++ b/koku/sources/test/test_sources_http_client.py
@@ -255,7 +255,8 @@ class SourcesHTTPClientTest(TestCase):
         error_msg = 'my error'
         client = SourcesHTTPClient(auth_header=Config.SOURCES_FAKE_HEADER, source_id=test_source_id)
         with requests_mock.mock() as m:
-            m.get(f'http://www.sources.com/api/v1.0/applications?filter[application_type_id]={application_type_id}&filter[source_id]={test_source_id}',
+            m.get((f'http://www.sources.com/api/v1.0/applications?'
+                   f'filter[application_type_id]={application_type_id}&filter[source_id]={test_source_id}'),
                   status_code=200, json={'data': [{'id': application_id}]})
             m.patch(f'http://www.sources.com/api/v1.0/applications/{application_id}',
                     status_code=204, json={'availability_status': status, 'availability_status_error': str(error_msg)})
@@ -270,7 +271,8 @@ class SourcesHTTPClientTest(TestCase):
         error_msg = 'my error'
         client = SourcesHTTPClient(auth_header=Config.SOURCES_FAKE_HEADER, source_id=test_source_id)
         with requests_mock.mock() as m:
-            m.get(f'http://www.sources.com/api/v1.0/applications?filter[application_type_id]={application_type_id}&filter[source_id]={test_source_id}',
+            m.get((f'http://www.sources.com/api/v1.0/applications?'
+                   f'filter[application_type_id]={application_type_id}&filter[source_id]={test_source_id}'),
                   status_code=200, json={'data': []})
             response = client.set_source_status(error_msg, application_type_id)
             self.assertFalse(response)
@@ -285,7 +287,8 @@ class SourcesHTTPClientTest(TestCase):
         error_msg = 'my error'
         client = SourcesHTTPClient(auth_header=Config.SOURCES_FAKE_HEADER, source_id=test_source_id)
         with requests_mock.mock() as m:
-            m.get(f'http://www.sources.com/api/v1.0/applications?filter[application_type_id]={application_type_id}&filter[source_id]={test_source_id}',
+            m.get((f'http://www.sources.com/api/v1.0/applications?'
+                   f'filter[application_type_id]={application_type_id}&filter[source_id]={test_source_id}'),
                   status_code=200, json={'data': [{'id': application_id}]})
             m.patch(f'http://www.sources.com/api/v1.0/applications/{application_id}',
                     status_code=400, json={'availability_status': status, 'availability_status_error': str(error_msg)})


### PR DESCRIPTION
Handling a exception found in CI when setting a source status to a source that's been deleted and not catching an error when the endpoint id is not found for a source.

**Testing**
Did full CRUD tests for all provider types