### PR TITLE
Delete stale manifest files

### DIFF
--- a/koku/masu/external/downloader/aws/aws_report_downloader.py
+++ b/koku/masu/external/downloader/aws/aws_report_downloader.py
@@ -175,7 +175,7 @@ class AWSReportDownloader(ReportDownloaderBase, DownloaderInterface):
             manifest_file, _ = self.download_file(manifest)
         except AWSReportDownloaderNoFileError as err:
             LOG.error('Unable to get report manifest. Reason: %s', str(err))
-            return self.empty_manifest
+            return '', self.empty_manifest
 
         manifest_json = None
         with open(manifest_file, 'r') as manifest_file_handle:

--- a/koku/masu/external/downloader/aws/aws_report_downloader.py
+++ b/koku/masu/external/downloader/aws/aws_report_downloader.py
@@ -187,10 +187,9 @@ class AWSReportDownloader(ReportDownloaderBase, DownloaderInterface):
         """Clean up the manifest file after extracting information."""
         try:
             os.remove(manifest_file)
-            LOG.info('Deleted manifest file at %s', directory)
-        except OSError as error:
-            LOG.error('Could not delete manifest file at %s', directory)
-
+            LOG.info('Deleted manifest file at %s', manifest_file)
+        except OSError:
+            LOG.error('Could not delete manifest file at %s', manifest_file)
 
         return None
 

--- a/koku/masu/external/downloader/aws/aws_report_downloader.py
+++ b/koku/masu/external/downloader/aws/aws_report_downloader.py
@@ -181,7 +181,18 @@ class AWSReportDownloader(ReportDownloaderBase, DownloaderInterface):
         with open(manifest_file, 'r') as manifest_file_handle:
             manifest_json = json.load(manifest_file_handle)
 
-        return manifest_json
+        return manifest_file, manifest_json
+
+    def _remove_manifest_file(self, manifest_file):
+        """Clean up the manifest file after extracting information."""
+        try:
+            os.remove(manifest_file)
+            LOG.info('Deleted manifest file at %s', directory)
+        except OSError as error:
+            LOG.error('Could not delete manifest file at %s', directory)
+
+
+        return None
 
     def _get_report_path(self, date_time):
         """
@@ -276,12 +287,13 @@ class AWSReportDownloader(ReportDownloaderBase, DownloaderInterface):
         should_download = True
         manifest_dict = {}
         report_dict = {}
-        manifest = self._get_manifest(date_time)
+        manifest_file, manifest = self._get_manifest(date_time)
         if manifest != self.empty_manifest:
             manifest_dict = self._prepare_db_manifest_record(manifest)
             should_download = self.check_if_manifest_should_be_downloaded(
                 manifest_dict.get('assembly_id')
             )
+        self._remove_manifest_file(manifest_file)
 
         if not should_download:
             manifest_id = self._get_existing_manifest_db_id(manifest_dict.get('assembly_id'))

--- a/koku/masu/external/downloader/aws_local/aws_local_report_downloader.py
+++ b/koku/masu/external/downloader/aws_local/aws_local_report_downloader.py
@@ -141,7 +141,17 @@ class AWSLocalReportDownloader(ReportDownloaderBase, DownloaderInterface):
         with open(manifest_file, 'r') as manifest_file_handle:
             manifest_json = json.load(manifest_file_handle)
 
-        return manifest_json
+        return manifest_file, manifest_json
+
+    def _remove_manifest_file(self, manifest_file):
+        """Clean up the manifest file after extracting information."""
+        try:
+            os.remove(manifest_file)
+            LOG.info('Deleted manifest file at %s', directory)
+        except OSError as error:
+            LOG.error('Could not delete manifest file at %s', directory)
+
+        return None
 
     def _get_report_path(self, date_time):
         """
@@ -207,10 +217,12 @@ class AWSLocalReportDownloader(ReportDownloaderBase, DownloaderInterface):
 
         """
         report_dict = {}
-        manifest = self._get_manifest(date_time)
+        manifest_file, manifest = self._get_manifest(date_time)
         manifest_id = None
         if manifest != self.empty_manifest:
             manifest_id = self._prepare_db_manifest_record(manifest)
+
+        self._remove_manifest_file(manifest_file)
 
         report_dict['manifest_id'] = manifest_id
         report_dict['assembly_id'] = manifest.get('assemblyId')

--- a/koku/masu/external/downloader/aws_local/aws_local_report_downloader.py
+++ b/koku/masu/external/downloader/aws_local/aws_local_report_downloader.py
@@ -147,9 +147,9 @@ class AWSLocalReportDownloader(ReportDownloaderBase, DownloaderInterface):
         """Clean up the manifest file after extracting information."""
         try:
             os.remove(manifest_file)
-            LOG.info('Deleted manifest file at %s', directory)
-        except OSError as error:
-            LOG.error('Could not delete manifest file at %s', directory)
+            LOG.info('Deleted manifest file at %s', manifest_file)
+        except OSError:
+            LOG.error('Could not delete manifest file at %s', manifest_file)
 
         return None
 

--- a/koku/masu/external/downloader/aws_local/aws_local_report_downloader.py
+++ b/koku/masu/external/downloader/aws_local/aws_local_report_downloader.py
@@ -135,7 +135,7 @@ class AWSLocalReportDownloader(ReportDownloaderBase, DownloaderInterface):
             manifest_file, _ = self.download_file(manifest)
         except AWSReportDownloaderNoFileError as err:
             LOG.error('Unable to get report manifest. Reason: %s', str(err))
-            return self.empty_manifest
+            return '', self.empty_manifest
 
         manifest_json = None
         with open(manifest_file, 'r') as manifest_file_handle:

--- a/koku/masu/external/downloader/azure/azure_report_downloader.py
+++ b/koku/masu/external/downloader/azure/azure_report_downloader.py
@@ -20,7 +20,6 @@
 # disabled until we get travis to not fail on warnings, or the fixme is
 # resolved.
 import datetime
-import json
 import logging
 import os
 

--- a/koku/masu/external/downloader/azure/azure_report_downloader.py
+++ b/koku/masu/external/downloader/azure/azure_report_downloader.py
@@ -141,10 +141,6 @@ class AzureReportDownloader(ReportDownloaderBase, DownloaderInterface):
         manifest['reportKeys'] = [report_name]
         manifest['Compression'] = UNCOMPRESSED
 
-        manifest_file = '{}/{}'.format(self._get_exports_data_directory(), 'Manifest.json')
-        with open(manifest_file, 'w') as manifest_hdl:
-            manifest_hdl.write(json.dumps(manifest))
-
         return manifest
 
     def get_report_context_for_date(self, date_time):

--- a/koku/masu/external/downloader/azure_local/azure_local_report_downloader.py
+++ b/koku/masu/external/downloader/azure_local/azure_local_report_downloader.py
@@ -99,10 +99,6 @@ class AzureLocalReportDownloader(AzureReportDownloader):
         manifest['reportKeys'] = [f'{local_path}/{report_name}']
         manifest['Compression'] = UNCOMPRESSED
 
-        manifest_file = '{}/{}'.format(self._get_exports_data_directory(), 'Manifest.json')
-        with open(manifest_file, 'w') as manifest_hdl:
-            manifest_hdl.write(json.dumps(manifest))
-
         return manifest
 
     def download_file(self, key, stored_etag=None):

--- a/koku/masu/external/downloader/azure_local/azure_local_report_downloader.py
+++ b/koku/masu/external/downloader/azure_local/azure_local_report_downloader.py
@@ -17,7 +17,6 @@
 """Azure-Local Report Downloader."""
 
 import hashlib
-import json
 import logging
 import os
 import shutil

--- a/koku/masu/external/downloader/ocp/ocp_report_downloader.py
+++ b/koku/masu/external/downloader/ocp/ocp_report_downloader.py
@@ -68,6 +68,20 @@ class OCPReportDownloader(ReportDownloaderBase, DownloaderInterface):
         report_meta = utils.get_report_details(directory)
         return report_meta
 
+    def _remove_manifest_file(self, date_time):
+        """Clean up the manifest file after extracting information."""
+        dates = utils.month_date_range(date_time)
+        directory = '{}/{}/{}'.format(REPORTS_DIR, self.cluster_id, dates)
+
+        manifest_path = '{}/{}'.format(directory, 'manifest.json')
+        try:
+            os.remove(manifest_path)
+            LOG.info('Deleted manifest file at %s', directory)
+        except OSError as error:
+            LOG.error('Could not delete manifest file at %s', directory)
+
+        return None
+
     def get_report_for(self, date_time):
         """
         Get OCP usage report files corresponding to a date.
@@ -157,6 +171,9 @@ class OCPReportDownloader(ReportDownloaderBase, DownloaderInterface):
         report_dict['assembly_id'] = manifest.get('uuid')
         report_dict['compression'] = UNCOMPRESSED
         report_dict['files'] = self.get_report_for(date_time)
+        # Remove the manifest file now that we have saved the info
+        # in the database.
+        self._remove_manifest_file(date_time)
         return report_dict
 
     def get_local_file_for_report(self, report):

--- a/koku/masu/external/downloader/ocp/ocp_report_downloader.py
+++ b/koku/masu/external/downloader/ocp/ocp_report_downloader.py
@@ -127,12 +127,9 @@ class OCPReportDownloader(ReportDownloaderBase, DownloaderInterface):
 
         """
         local_filename = utils.get_local_file_name(key)
-        manifest_filename = 'manifest.json'
-        source_manifest_path = f'{os.path.dirname(key)}/{manifest_filename}'
 
         directory_path = f'{DATA_DIR}/{self.customer_name}/ocp/{self.cluster_id}'
         full_file_path = f'{directory_path}/{local_filename}'
-        full_manfiest_path = f'{directory_path}/{manifest_filename}'
 
         # Make sure the data directory exists
         os.makedirs(directory_path, exist_ok=True)
@@ -143,7 +140,6 @@ class OCPReportDownloader(ReportDownloaderBase, DownloaderInterface):
         if ocp_etag != stored_etag or not os.path.isfile(full_file_path):
             LOG.info('Downloading %s to %s', key, full_file_path)
             shutil.move(key, full_file_path)
-            shutil.copy2(source_manifest_path, full_manfiest_path)
         return full_file_path, ocp_etag
 
     def get_report_context_for_date(self, date_time):

--- a/koku/masu/external/downloader/ocp/ocp_report_downloader.py
+++ b/koku/masu/external/downloader/ocp/ocp_report_downloader.py
@@ -77,7 +77,7 @@ class OCPReportDownloader(ReportDownloaderBase, DownloaderInterface):
         try:
             os.remove(manifest_path)
             LOG.info('Deleted manifest file at %s', directory)
-        except OSError as error:
+        except OSError:
             LOG.error('Could not delete manifest file at %s', directory)
 
         return None

--- a/koku/masu/test/external/downloader/aws/test_aws_report_downloader.py
+++ b/koku/masu/test/external/downloader/aws/test_aws_report_downloader.py
@@ -249,7 +249,7 @@ class AWSReportDownloaderTest(MasuTestCase):
         }
 
         with patch.object(
-            AWSReportDownloader, '_get_manifest', return_value=mock_manifest
+            AWSReportDownloader, '_get_manifest', return_value=('', mock_manifest)
         ):
             with self.assertRaises(AWSReportDownloaderError):
                 report_downloader = ReportDownloader(
@@ -468,12 +468,15 @@ class AWSReportDownloaderTest(MasuTestCase):
         assembly_id = '1234'
         compression = downloader.report.get('Compression')
         report_keys = ['file1', 'file2']
-        mock_manifest.return_value = {
-            'assemblyId': assembly_id,
-            'Compression': compression,
-            'reportKeys': report_keys,
-            'billingPeriod': {'start': start_str}
-        }
+        mock_manifest.return_value = (
+            '',
+            {
+                'assemblyId': assembly_id,
+                'Compression': compression,
+                'reportKeys': report_keys,
+                'billingPeriod': {'start': start_str}
+            }
+        )
         mock_check.return_value = True
 
         expected = {
@@ -513,12 +516,15 @@ class AWSReportDownloaderTest(MasuTestCase):
         assembly_id = '1234'
         compression = downloader.report.get('Compression')
         report_keys = ['file1', 'file2']
-        mock_manifest.return_value = {
-            'assemblyId': assembly_id,
-            'Compression': compression,
-            'reportKeys': report_keys,
-            'billingPeriod': {'start': start_str}
-        }
+        mock_manifest.return_value = (
+            '',
+            {
+                'assemblyId': assembly_id,
+                'Compression': compression,
+                'reportKeys': report_keys,
+                'billingPeriod': {'start': start_str}
+            }
+        )
         mock_check.return_value = False
 
         expected = {}

--- a/koku/masu/test/external/downloader/azure/test_azure_report_downloader.py
+++ b/koku/masu/test/external/downloader/azure/test_azure_report_downloader.py
@@ -156,9 +156,6 @@ class AzureReportDownloaderTest(MasuTestCase):
         self.assertEqual(manifest.get('billingPeriod').get('start'), expected_start)
         self.assertEqual(manifest.get('billingPeriod').get('end'), expected_end)
 
-        expected_manifest_path = '{}/{}'.format(self.downloader._get_exports_data_directory(), 'Manifest.json')
-        self.assertTrue(Path(expected_manifest_path).exists())
-
     def test_get_manifest_unexpected_report_name(self):
         """Test that error is thrown when getting manifest with an unexpected report name."""
 

--- a/koku/masu/test/external/downloader/ocp/test_ocp_report_downloader.py
+++ b/koku/masu/test/external/downloader/ocp/test_ocp_report_downloader.py
@@ -139,3 +139,10 @@ class OCPReportDownloaderTest(MasuTestCase):
         with patch.object(DateAccessor, 'today', return_value=test_report_date):
             reports = self.report_downloader.download_report(test_report_date)
         self.assertEqual(reports, [])
+
+    def test_remove_manifest_file(self):
+        """Test that a manifest file is deleted after use."""
+        test_report_date = datetime(year=2018, month=9, day=7)
+        self.assertTrue(os.path.isfile(self.test_manifest_path))
+        self.ocp_report_downloader._remove_manifest_file(test_report_date)
+        self.assertFalse(os.path.isfile(self.test_manifest_path))


### PR DESCRIPTION
## Summary
We don't actually need manifest files after we've stored info in the database and it's causing repeat runs of vortex to fail. This is just a cleanup step to remove manifest files after processing. 