### PR TITLE
Report view test refactor

### DIFF
--- a/koku/api/report/test/aws/test_views.py
+++ b/koku/api/report/test/aws/test_views.py
@@ -15,20 +15,12 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 """Test the AWS Report views."""
-from unittest.mock import Mock, patch
-
-from django.http import HttpRequest, QueryDict
-# from django.test import RequestFactory
 from django.urls import reverse
 from rest_framework import status
-from rest_framework.request import Request
-from rest_framework.response import Response
 from rest_framework.test import APIClient
 
 from api.iam.serializers import UserSerializer
 from api.iam.test.iam_test_case import IamTestCase
-from api.models import User
-from api.report.aws.view import AWSCostView
 from api.report.view import _convert_units
 from api.utils import UnitConverter
 

--- a/koku/api/report/test/azure/openshift/test_views.py
+++ b/koku/api/report/test/azure/openshift/test_views.py
@@ -20,7 +20,6 @@ from django.test import RequestFactory
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
-from rest_framework_csv.renderers import CSVRenderer
 
 from api.iam.serializers import UserSerializer
 from api.iam.test.iam_test_case import IamTestCase
@@ -44,40 +43,6 @@ class AzureReportViewTest(IamTestCase):
             serializer.save()
         self.client = APIClient()
         self.factory = RequestFactory()
-
-    def test_get_named_view(self):
-        """Test costs reports runs with a customer owner."""
-        for name in self.NAMES:
-            with self.subTest(name=name):
-                url = reverse(name)
-                response = self.client.get(url, **self.headers)
-                self.assertEqual(response.status_code, status.HTTP_200_OK)
-                json_result = response.json()
-                self.assertIsNotNone(json_result.get('data'))
-                self.assertIsInstance(json_result.get('data'), list)
-                self.assertTrue(len(json_result.get('data')) > 0)
-
-    def test_get_names_invalid_query_param(self):
-        """Test costs reports runs with an invalid query param."""
-        for name in self.NAMES:
-            with self.subTest(name=name):
-                query = 'group_by[invalid]=*'
-                url = reverse(name) + '?' + query
-                response = self.client.get(url, **self.headers)
-                self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-
-    def test_get_named_csv(self):
-        """Test CSV output of inventory named reports."""
-        self.client = APIClient(HTTP_ACCEPT='text/csv')
-        for name in self.NAMES:
-            with self.subTest(name=name):
-                url = reverse(name)
-                response = self.client.get(url, content_type='text/csv', **self.headers)
-                response.render()
-
-                self.assertEqual(response.status_code, status.HTTP_200_OK)
-                self.assertEqual(response.accepted_media_type, 'text/csv')
-                self.assertIsInstance(response.accepted_renderer, CSVRenderer)
 
     def test_execute_query_w_delta_total(self):
         """Test that delta=total returns deltas."""

--- a/koku/api/report/test/ocp/tests_views.py
+++ b/koku/api/report/test/ocp/tests_views.py
@@ -462,13 +462,6 @@ class OCPReportViewTest(IamTestCase):
                 self.assertTrue('usage' in values)
                 self.assertTrue('request' in values)
 
-    def test_execute_query_ocp_memory(self):
-        """Test that OCP Mem endpoint works."""
-        url = reverse('reports-openshift-memory')
-        client = APIClient()
-        response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-
     def test_execute_query_ocp_memory_group_by_limit(self):
         """Test that OCP Mem endpoint works with limits."""
         url = reverse('reports-openshift-memory')
@@ -506,13 +499,6 @@ class OCPReportViewTest(IamTestCase):
                 usage_total = projects[0].get('values')[0].get('usage', {}).get('value') + \
                     projects[1].get('values')[0].get('usage', {}).get('value')
                 self.assertEqual(usage_total, totals.get(date))
-
-    def test_execute_query_ocp_costs(self):
-        """Test that the costs endpoint is reachable."""
-        url = reverse('reports-openshift-costs')
-        client = APIClient()
-        response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_execute_query_ocp_costs_group_by_cluster(self):
         """Test that the costs endpoint is reachable."""

--- a/koku/api/report/test/tests_views.py
+++ b/koku/api/report/test/tests_views.py
@@ -15,30 +15,58 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 """Test the Report views."""
-from unittest.mock import patch
-
-from django.http import HttpRequest, QueryDict
+from django.test import RequestFactory
 from django.urls import reverse
 from rest_framework import status
-from rest_framework.request import Request
-from rest_framework.response import Response
 from rest_framework.test import APIClient
 from rest_framework_csv.renderers import CSVRenderer
 
 from api.common.pagination import ReportPagination, ReportRankedPagination
 from api.iam.serializers import UserSerializer
 from api.iam.test.iam_test_case import IamTestCase
-from api.models import User
-from api.report.aws.view import AWSCostView
-from api.report.view import (_convert_units,
-                             _fill_in_missing_units,
+from api.report.view import (_fill_in_missing_units,
                              _find_unit,
                              get_paginator)
-from api.utils import UnitConverter
 
 
 class ReportViewTest(IamTestCase):
     """Tests the report view."""
+
+    ENDPOINTS = [
+        # aws
+        'reports-aws-costs',
+        'reports-aws-storage',
+        'reports-aws-instance-type',
+
+        # azure
+        'reports-azure-costs',
+        'reports-azure-storage',
+        'reports-azure-instance-type',
+
+        # openshift
+        'reports-openshift-costs',
+        'reports-openshift-memory',
+        'reports-openshift-cpu',
+        'reports-openshift-volume',
+
+        # openshift - on - aws
+        'reports-openshift-aws-costs',
+        'reports-openshift-aws-storage',
+        'reports-openshift-aws-instance-type',
+
+        # openshift - on - azure
+        'reports-openshift-azure-costs',
+        'reports-openshift-azure-storage',
+        'reports-openshift-azure-instance-type',
+    ]
+    TAGS = [
+        # tags
+        # 'aws-tags',
+        # 'azure-tags',
+        # 'openshift-tags',
+        # 'openshift-aws-tags',
+        # 'openshift-azure-tags',  # TODO: uncomment when we do tagging
+    ]
 
     def setUp(self):
         """Set up the customer view tests."""
@@ -46,241 +74,42 @@ class ReportViewTest(IamTestCase):
         serializer = UserSerializer(data=self.user_data, context=self.request_context)
         if serializer.is_valid(raise_exception=True):
             serializer.save()
+        self.client = APIClient()
+        self.factory = RequestFactory()
 
-        self.report = {
-            'group_by': {
-                'account': ['*']
-            },
-            'filter': {
-                'resolution': 'monthly',
-                'time_scope_value': -1,
-                'time_scope_units': 'month',
-                'resource_scope': []
-            },
-            'data': [
-                {
-                    'date': '2018-07',
-                    'accounts': [
-                        {
-                            'account': '4418636104713',
-                            'values': [
-                                {
-                                    'date': '2018-07',
-                                    'units': 'GB-Mo',
-                                    'account': '4418636104713',
-                                    'total': 1826.74238146924
-                                }
-                            ]
-                        },
-                        {
-                            'account': '8577742690384',
-                            'values': [
-                                {
-                                    'date': '2018-07',
-                                    'units': 'GB-Mo',
-                                    'account': '8577742690384',
-                                    'total': 1137.74036198065
-                                }
-                            ]
-                        },
-                        {
-                            'account': '3474227945050',
-                            'values': [
-                                {
-                                    'date': '2018-07',
-                                    'units': 'GB-Mo',
-                                    'account': '3474227945050',
-                                    'total': 1045.80659412797
-                                }
-                            ]
-                        },
-                        {
-                            'account': '7249815104968',
-                            'values': [
-                                {
-                                    'date': '2018-07',
-                                    'units': 'GB-Mo',
-                                    'account': '7249815104968',
-                                    'total': 807.326470618818
-                                }
-                            ]
-                        },
-                        {
-                            'account': '9420673783214',
-                            'values': [
-                                {
-                                    'date': '2018-07',
-                                    'units': 'GB-Mo',
-                                    'account': '9420673783214',
-                                    'total': 658.306642830709
-                                }
-                            ]
-                        }
-                    ]
-                }
-            ],
-            'total': {
-                'value': 5475.922451027388,
-                'units': 'GB-Mo'
-            }
-        }
+    def test_endpoint_view(self):
+        """Test endpoint runs with a customer owner."""
+        for endpoint in self.ENDPOINTS:
+            with self.subTest(endpoint=endpoint):
+                url = reverse(endpoint)
+                response = self.client.get(url, **self.headers)
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+                json_result = response.json()
+                self.assertIsNotNone(json_result.get('data'))
+                self.assertIsInstance(json_result.get('data'), list)
+                self.assertTrue(len(json_result.get('data')) > 0)
 
-    def test_get_costs_customer_owner(self):
-        """Test costs reports runs with a customer owner."""
-        url = reverse('reports-aws-costs')
-        client = APIClient()
-        response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        json_result = response.json()
-        self.assertIsNotNone(json_result.get('data'))
-        self.assertIsInstance(json_result.get('data'), list)
-        self.assertTrue(len(json_result.get('data')) > 0)
+    def test_endpoints_invalid_query_param(self):
+        """Test endpoint runs with an invalid query param."""
+        for endpoint in self.ENDPOINTS:
+            with self.subTest(endpoint=endpoint):
+                query = 'group_by[invalid]=*'
+                url = reverse(endpoint) + '?' + query
+                response = self.client.get(url, **self.headers)
+                self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-    def test_get_instance_customer_owner(self):
-        """Test inventory instance reports runs with a customer owner."""
-        url = reverse('reports-aws-instance-type')
-        client = APIClient()
-        response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        json_result = response.json()
-        self.assertIsNotNone(json_result.get('data'))
-        self.assertIsInstance(json_result.get('data'), list)
-        self.assertTrue(len(json_result.get('data')) > 0)
+    def test_endpoint_csv(self):
+        """Test CSV output of inventory endpoint reports."""
+        self.client = APIClient(HTTP_ACCEPT='text/csv')
+        for endpoint in self.ENDPOINTS:
+            with self.subTest(endpoint=endpoint):
+                url = reverse(endpoint)
+                response = self.client.get(url, content_type='text/csv', **self.headers)
+                response.render()
 
-    def test_get_storage_customer_owner(self):
-        """Test inventory storage reports runs with a customer owner."""
-        url = reverse('reports-aws-storage')
-        client = APIClient()
-        response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        json_result = response.json()
-        self.assertIsNotNone(json_result.get('data'))
-        self.assertIsInstance(json_result.get('data'), list)
-        self.assertTrue(len(json_result.get('data')) > 0)
-
-    def test_get_costs_invalid_query_param(self):
-        """Test costs reports runs with an invalid query param."""
-        qs = 'group_by%5Binvalid%5D=account1&filter%5Bresolution%5D=daily'
-        url = reverse('reports-aws-costs') + '?' + qs
-        client = APIClient()
-        response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-
-    def test_get_instance_usage_invalid_query_param(self):
-        """Test instance usage reports runs with an invalid query param."""
-        qs = 'group_by%5Binvalid%5D=account1&filter%5Bresolution%5D=daily'
-        url = reverse('reports-aws-instance-type') + '?' + qs
-        client = APIClient()
-        response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-
-    def test_get_storage_usage_invalid_query_param(self):
-        """Test storage usage reports runs with an invalid query param."""
-        qs = 'group_by%5Binvalid%5D=account1&filter%5Bresolution%5D=daily'
-        url = reverse('reports-aws-storage') + '?' + qs
-        client = APIClient()
-        response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-
-    def test_get_costs_csv(self):
-        """Test CSV output of costs reports."""
-        url = reverse('reports-aws-costs')
-        client = APIClient(HTTP_ACCEPT='text/csv')
-
-        response = client.get(url, **self.headers)
-        response.render()
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.accepted_media_type, 'text/csv')
-        self.assertIsInstance(response.accepted_renderer, CSVRenderer)
-
-    def test_get_instance_csv(self):
-        """Test CSV output of inventory instance reports."""
-        url = reverse('reports-aws-instance-type')
-        client = APIClient(HTTP_ACCEPT='text/csv')
-        response = client.get(url, content_type='text/csv', **self.headers)
-        response.render()
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.accepted_media_type, 'text/csv')
-        self.assertIsInstance(response.accepted_renderer, CSVRenderer)
-
-    def test_get_storage_csv(self):
-        """Test CSV output of inventory storage reports."""
-        url = reverse('reports-aws-storage')
-        client = APIClient(HTTP_ACCEPT='text/csv')
-        response = client.get(url, content_type='text/csv', **self.headers)
-        response.render()
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.accepted_media_type, 'text/csv')
-        self.assertIsInstance(response.accepted_renderer, CSVRenderer)
-
-    def test_convert_units_success(self):
-        """Test unit conversion succeeds."""
-        converter = UnitConverter()
-        to_unit = 'byte'
-        expected_unit = f'{to_unit}-Mo'
-        report_total = self.report.get('total', {}).get('value')
-
-        result = _convert_units(converter, self.report, to_unit)
-        result_unit = result.get('total', {}).get('units')
-        result_total = result.get('total', {}).get('value')
-
-        self.assertEqual(expected_unit, result_unit)
-        self.assertEqual(report_total * 1E9, result_total)
-
-    def test_convert_units_list(self):
-        """Test that the list check is hit."""
-        converter = UnitConverter()
-        to_unit = 'byte'
-        expected_unit = f'{to_unit}-Mo'
-        report_total = self.report.get('total', {}).get('value')
-
-        report = [self.report]
-        result = _convert_units(converter, report, to_unit)
-        result_unit = result[0].get('total', {}).get('units')
-        result_total = result[0].get('total', {}).get('value')
-
-        self.assertEqual(expected_unit, result_unit)
-        self.assertEqual(report_total * 1E9, result_total)
-
-    def test_convert_units_total_not_dict(self):
-        """Test that the total not dict block is hit."""
-        converter = UnitConverter()
-        to_unit = 'byte'
-        expected_unit = f'{to_unit}-Mo'
-
-        report = self.report['data'][0]['accounts'][0]['values'][0]
-        report_total = report.get('total')
-        result = _convert_units(converter, report, to_unit)
-        result_unit = result.get('units')
-        result_total = result.get('total')
-
-        self.assertEqual(expected_unit, result_unit)
-        self.assertEqual(report_total * 1E9, result_total)
-
-    @patch('api.report.aws.query_handler.AWSReportQueryHandler')
-    def test_awsreportview_with_units_success(self, mock_handler):
-        """Test unit conversion succeeds in aws report."""
-        mock_handler.return_value.execute_query.return_value = self.report
-        params = {'filter': {'resolution': 'daily',
-                             'time_scope_value': -1,
-                             'time_scope_units': 'month'},
-                  'group_by': {'account': ['*']}}
-        user = User.objects.get(
-            username=self.user_data['username']
-        )
-
-        django_request = HttpRequest()
-        qd = QueryDict(mutable=True)
-        qd.update(params)
-        django_request.GET = qd
-        request = Request(django_request)
-        request.user = user
-
-        response = AWSCostView().get(request)
-        self.assertIsInstance(response, Response)
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+                self.assertEqual(response.accepted_media_type, 'text/csv')
+                self.assertIsInstance(response.accepted_renderer, CSVRenderer)
 
     def test_find_unit_list(self):
         """Test that the correct unit is returned."""
@@ -288,74 +117,50 @@ class ReportViewTest(IamTestCase):
         data = [
             {'date': '2018-07-22', 'units': '', 'instance_type': 't2.micro', 'total': 30.0, 'count': 0},
             {'date': '2018-07-22', 'units': expected_unit, 'instance_type': 't2.small', 'total': 17.0, 'count': 0},
-            {'date': '2018-07-22', 'units': expected_unit, 'instance_type': 't2.micro', 'total': 1.0, 'count': 0}
+            {'date': '2018-07-22', 'units': expected_unit, 'instance_type': 't2.micro', 'total': 1.0, 'count': 0},
         ]
-
         result_unit = _find_unit()(data)
         self.assertEqual(expected_unit, result_unit)
 
     def test_find_unit_dict(self):
         """Test that the correct unit is returned for a dictionary."""
-        data = {'date': '2018-07-22', 'units': '', 'instance_type': 't2.micro', 'total': 30.0, 'count': 0},
-
+        data = {'date': '2018-07-22', 'units': '', 'instance_type': 't2.micro', 'total': 30.0, 'count': 0}
         result_unit = _find_unit()(data)
         self.assertIsNone(result_unit)
-
-    def test_fill_in_missing_units_list(self):
-        """Test that missing units are filled in."""
-        expected_unit = 'Hrs'
-        data = [
-            {'date': '2018-07-22', 'units': '', 'instance_type': 't2.micro', 'total': 30.0, 'count': 0},
-            {'date': '2018-07-22', 'units': expected_unit, 'instance_type': 't2.small', 'total': 17.0, 'count': 0},
-            {'date': '2018-07-22', 'units': expected_unit, 'instance_type': 't2.micro', 'total': 1.0, 'count': 0}
-        ]
-
-        unit = _find_unit()(data)
-
-        result = _fill_in_missing_units(unit)(data)
-
-        for entry in result:
-            self.assertEqual(entry.get('units'), expected_unit)
 
     def test_fill_in_missing_units_dict(self):
         """Test that missing units are filled in for a dictionary."""
         expected_unit = 'Hrs'
         data = {'date': '2018-07-22', 'units': '', 'instance_type': 't2.micro', 'total': 30.0, 'count': 0}
-
         result = _fill_in_missing_units(expected_unit)(data)
-
         self.assertEqual(result.get('units'), expected_unit)
 
-    def test_execute_query_w_delta_total(self):
-        """Test that delta=total returns deltas."""
-        qs = 'delta=cost'
-        url = reverse('reports-aws-costs') + '?' + qs
-        client = APIClient()
-        response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-
-    def test_execute_query_w_delta_bad_choice(self):
-        """Test invalid delta value."""
-        bad_delta = 'Invalid'
-        expected = f'"{bad_delta}" is not a valid choice.'
-        qs = f'group_by[account]=*&filter[limit]=2&delta={bad_delta}'
-        url = reverse('reports-aws-costs') + '?' + qs
-        client = APIClient()
-        response = client.get(url, **self.headers)
-        result = str(response.data.get('delta')[0])
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(result, expected)
+    def test_fill_in_missing_units_list(self):
+        """Test that missing units are filled in."""
+        expected_unit = 'Hrs'
+        data = [
+            # AWS
+            {'date': '2018-07-22', 'units': '', 'instance_type': 't2.micro', 'total': 30.0, 'count': 0},
+            {'date': '2018-07-22', 'units': expected_unit, 'instance_type': 't2.small', 'total': 17.0, 'count': 0},
+            {'date': '2018-07-22', 'units': expected_unit, 'instance_type': 't2.micro', 'total': 1.0, 'count': 0},
+            # Azure
+            {'date': '2018-07-22', 'units': '', 'instance_type': 'Standard_A1_v2', 'total': 30.0, 'count': 0},
+            {'date': '2018-07-22', 'units': expected_unit, 'instance_type': 'Standard_A2m_v2', 'total': 17.0, 'count': 0},  # noqa: E501
+            {'date': '2018-07-22', 'units': expected_unit, 'instance_type': 'Standard_A1_v2', 'total': 1.0, 'count': 0},
+        ]
+        unit = _find_unit()(data)
+        result = _fill_in_missing_units(unit)(data)
+        for entry in result:
+            self.assertEqual(entry.get('units'), expected_unit)
 
     def test_get_paginator_default(self):
         """Test that the standard report paginator is returned."""
         params = {}
         paginator = get_paginator(params, 0)
-
         self.assertIsInstance(paginator, ReportPagination)
 
     def test_get_paginator_for_filter_offset(self):
         """Test that the standard report paginator is returned."""
         params = {'offset': 5}
         paginator = get_paginator(params, 0)
-
         self.assertIsInstance(paginator, ReportRankedPagination)

--- a/koku/api/report/test/tests_views.py
+++ b/koku/api/report/test/tests_views.py
@@ -61,11 +61,11 @@ class ReportViewTest(IamTestCase):
     ]
     TAGS = [
         # tags
-        # 'aws-tags',
-        # 'azure-tags',
-        # 'openshift-tags',
-        # 'openshift-aws-tags',
-        # 'openshift-azure-tags',  # TODO: uncomment when we do tagging
+        'aws-tags',
+        'azure-tags',
+        'openshift-tags',
+        'openshift-aws-tags',
+        'openshift-azure-tags',
     ]
 
     def setUp(self):
@@ -88,6 +88,14 @@ class ReportViewTest(IamTestCase):
                 self.assertIsNotNone(json_result.get('data'))
                 self.assertIsInstance(json_result.get('data'), list)
                 self.assertTrue(len(json_result.get('data')) > 0)
+
+    def test_tags_endpoint_view(self):
+        """Test endpoint runs with a customer owner."""
+        for tag_endpoint in self.TAGS:
+            with self.subTest(endpoint=tag_endpoint):
+                url = reverse(tag_endpoint)
+                response = self.client.get(url, **self.headers)
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_endpoints_invalid_query_param(self):
         """Test endpoint runs with an invalid query param."""


### PR DESCRIPTION
This PR refactors some of the Report API view tests. 

- Moves some of the AWS specific tests into an AWS folder. 
- Many of these tests were copies from one provider to another with a simple one line change between the tests. I consolidated these tests into a single test, and the different provider endpoints are iterated through using `unittest.subTest`.