### PR TITLE
one guincorn worker for sources client

### DIFF
--- a/koku/gunicorn.py
+++ b/koku/gunicorn.py
@@ -2,9 +2,15 @@
 import multiprocessing
 import os
 
+import environ
+
+ENVIRONMENT = environ.Env()
+
+SOURCES = ENVIRONMENT.bool('SOURCES', default=False)
+
 bind = 'unix:/var/run/koku/gunicorn.sock'
 cpu_resources = int(os.environ.get('POD_CPU_LIMIT', multiprocessing.cpu_count()))
-workers = cpu_resources * 2
+workers = 1 if SOURCES else cpu_resources * 2
 threads = 10
 timeout = int(os.environ.get('TIMEOUT', '90'))
 loglevel = os.environ.get('LOG_LEVEL', 'INFO')


### PR DESCRIPTION
Setting Gunicorn worker count to 1 on sources client to ensure we have only a single asyncio event loop running