### PR TITLE
exempting endpoint and authentication requirement for sources ocp

### DIFF
--- a/koku/sources/kafka_listener.py
+++ b/koku/sources/kafka_listener.py
@@ -277,7 +277,7 @@ def sources_network_info(source_id, auth_header):
     source_type_name = sources_network.get_source_type_name(source_type_id)
     endpoint_id = sources_network.get_endpoint_id()
 
-    if not endpoint_id:
+    if not endpoint_id and not source_type_name == SOURCES_OCP_SOURCE_NAME:
         LOG.error(f'Unable to find endpoint for Source ID: {source_id}')
         return
 

--- a/scripts/create_sources.py
+++ b/scripts/create_sources.py
@@ -257,11 +257,7 @@ def main(args):
         source_id = generator.create_source(name, 'ocp', cluster_id)
         print(f'Creating OCP Source. Source ID: {source_id}')
 
-        endpoint_id = generator.create_endpoint(source_id)
-        authentication_id = generator.create_ocp_authentication(endpoint_id)
-
-        print(
-            f'OCP Provider Setup Successfully\n\tSource ID: {source_id}\n\tEndpoint ID: {endpoint_id}\n\tAuthentication ID: {authentication_id}')
+        print(f'OCP Provider Setup Successfully\n\tSource ID: {source_id}')
         if create_application:
             application_id = generator.create_application(source_id, 'cost_management')
             print(f'Attached Cost Management Application ID {application_id} to Source ID {source_id}')


### PR DESCRIPTION
@boaz0 This should enable testing for your OCP Sources Wizard PR

The OCP Sources Wizard will not be creating an endpoint or authentication object.  I previously was under the impression that the UI would always be creating these.

**Testing**
1. Create OCP and AWS source.  Verify successful and that the sources endpoint and authentication doesn't exist for OCP

**Test Results**
[ocp_sources_no_endpoint.txt](https://github.com/project-koku/koku/files/3911924/ocp_sources_no_endpoint.txt)
