### PR TITLE
Add servers list with different remote environments and a local dev environment

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -2473,8 +2473,32 @@
         "url": "https://github.com/project-koku/"
     },
     "servers": [{
-        "url": "/api/cost-management/v1"
-    }],
+            "url": "https://{environment}.redhat.com/api/cost-management/v1",
+            "description": "Target Environment",
+            "variables": {
+                "environment": {
+                    "default": "cloud",
+                    "enum": [
+                        "cloud",
+                        "qa.cloud",
+                        "ci.cloud"
+                    ]
+                }
+            }
+        },
+        {
+            "url": "http://localhost:{port}/{basePath}",
+            "description": "Development Server",
+            "variables": {
+                "port": {
+                    "default": "8080"
+                },
+                "basePath": {
+                    "default": "api/cost-management/v1"
+                }
+            }
+        }
+    ],
     "components": {
         "parameters": {
             "QueryDelta": {


### PR DESCRIPTION
Add list of servers to OpenAPI spec:

- Provides enum for production, qa, and ci
- Provides local dev server target

Related to: https://github.com/project-koku/koku/issues/1463