### PR TITLE
Celery tracebacks

### DIFF
--- a/koku/koku/celery.py
+++ b/koku/koku/celery.py
@@ -18,7 +18,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 # pylint: disable=abstract-method
-class LogErrorsTask(Task):
+class LogErrorsTask(Task):  # pragma: no cover
     """Log Celery task exceptions."""
 
     def on_failure(self, exc, task_id, args, kwargs, einfo):  # pylint: disable=too-many-arguments

--- a/koku/koku/celery.py
+++ b/koku/koku/celery.py
@@ -16,14 +16,25 @@ from .env import ENVIRONMENT
 
 LOGGER = logging.getLogger(__name__)
 
+
+# pylint: disable=abstract-method
 class LogErrorsTask(Task):
-    def on_failure(self, exc, task_id, args, kwargs, einfo):
-        LOGGER.exception('Task failed: %s' % exc, exc_info=exc)
+    """Log Celery task exceptions."""
+
+    def on_failure(self, exc, task_id, args, kwargs, einfo):  # pylint: disable=too-many-arguments
+        """Log exceptions when a celery task fails."""
+        LOGGER.exception('Task failed: %s', exc, exc_info=exc)
         super().on_failure(exc, task_id, args, kwargs, einfo)
 
 
 class LoggingCelery(Celery):
+    """Log Celery task exceptions."""
+
     def task(self, *args, **kwargs):
+        """Set the default base logger for the celery app.
+
+        Let's us avoid typing `base=LogErrorsTask` for every app.task.
+        """
         kwargs.setdefault('base', LogErrorsTask)
         return super().task(*args, **kwargs)
 

--- a/koku/koku/celery.py
+++ b/koku/koku/celery.py
@@ -3,7 +3,7 @@ import datetime
 import logging
 import os
 
-from celery import Celery
+from celery import Celery, Task
 from celery.schedules import crontab
 from django.conf import settings
 
@@ -16,6 +16,18 @@ from .env import ENVIRONMENT
 
 LOGGER = logging.getLogger(__name__)
 
+class LogErrorsTask(Task):
+    def on_failure(self, exc, task_id, args, kwargs, einfo):
+        LOGGER.exception('Task failed: %s' % exc, exc_info=exc)
+        super().on_failure(exc, task_id, args, kwargs, einfo)
+
+
+class LoggingCelery(Celery):
+    def task(self, *args, **kwargs):
+        kwargs.setdefault('base', LogErrorsTask)
+        return super().task(*args, **kwargs)
+
+
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'koku.settings')
 
 LOGGER.info('Starting celery.')
@@ -26,7 +38,7 @@ LOGGER.info('Database configured.')
 # 'app' is the recommended convention from celery docs
 # following this for ease of comparison to reference implementation
 # pylint: disable=invalid-name
-app = Celery('koku', broker=settings.CELERY_BROKER_URL)
+app = LoggingCelery('koku', broker=settings.CELERY_BROKER_URL)
 app.config_from_object('django.conf:settings', namespace='CELERY')
 
 LOGGER.info('Celery autodiscover tasks.')

--- a/koku/masu/processor/tasks.py
+++ b/koku/masu/processor/tasks.py
@@ -142,6 +142,7 @@ def get_report_files(self,
             provider_type=provider_type
         ).inc()
         LOG.error(str(processing_error))
+        raise processing_error
 
     return reports_to_summarize
 

--- a/koku/masu/test/processor/test_tasks.py
+++ b/koku/masu/test/processor/test_tasks.py
@@ -43,7 +43,7 @@ from masu.external.report_downloader import ReportDownloader, ReportDownloaderEr
 from masu.processor._tasks.download import _get_report_files
 from masu.processor._tasks.process import _process_report_file
 from masu.processor.expired_data_remover import ExpiredDataRemover
-from masu.processor.report_processor import ReportProcessorError
+from masu.processor.report_processor import ReportProcessor, ReportProcessorError
 from masu.processor.tasks import (
     get_report_files,
     remove_expired_data,
@@ -490,6 +490,26 @@ class TestProcessorTasks(MasuTestCase):
             'billing_source': self.fake.word(),
             'provider_uuid': self.aws_provider_uuid,
         }
+
+    @patch('masu.processor.tasks.ReportStatsDBAccessor.get_last_completed_datetime')
+    @patch('masu.processor.tasks.ReportStatsDBAccessor.get_last_started_datetime')
+    @patch('masu.processor.tasks._get_report_files')
+    @patch(
+        'masu.processor.tasks._process_report_file',
+        side_effect=ReportProcessorError('Mocked Error!')
+    )
+    def test_get_report_exception(
+        self, mock_process_files, mock_get_files, mock_started, mock_completed
+    ):
+        """Test raising processor exception is handled."""
+        mock_get_files.return_value = self.fake_reports
+        mock_started.return_value = None
+
+        # Check that exception is raised
+        with self.assertRaises(ReportProcessorError):
+            # Check that the exception logs an ERROR
+            with self.assertLogs('masu.processor.tasks.get_report_files', level='ERROR'):
+                reports = get_report_files(**self.fake_get_report_args)
 
     @patch('masu.processor.tasks.ReportStatsDBAccessor.get_last_completed_datetime')
     @patch('masu.processor.tasks.ReportStatsDBAccessor.get_last_started_datetime')

--- a/koku/masu/test/processor/test_tasks.py
+++ b/koku/masu/test/processor/test_tasks.py
@@ -43,7 +43,7 @@ from masu.external.report_downloader import ReportDownloader, ReportDownloaderEr
 from masu.processor._tasks.download import _get_report_files
 from masu.processor._tasks.process import _process_report_file
 from masu.processor.expired_data_remover import ExpiredDataRemover
-from masu.processor.report_processor import ReportProcessor, ReportProcessorError
+from masu.processor.report_processor import ReportProcessorError
 from masu.processor.tasks import (
     get_report_files,
     remove_expired_data,
@@ -509,7 +509,7 @@ class TestProcessorTasks(MasuTestCase):
         with self.assertRaises(ReportProcessorError):
             # Check that the exception logs an ERROR
             with self.assertLogs('masu.processor.tasks.get_report_files', level='ERROR'):
-                reports = get_report_files(**self.fake_get_report_args)
+                get_report_files(**self.fake_get_report_args)
 
     @patch('masu.processor.tasks.ReportStatsDBAccessor.get_last_completed_datetime')
     @patch('masu.processor.tasks.ReportStatsDBAccessor.get_last_started_datetime')


### PR DESCRIPTION
This PR is what we've all been waiting for: the ability to see tracebacks in celery tasks 😃 .

Here is an example to show the difference:
1. Apply this diff:
```diff
--- a/koku/masu/processor/azure/azure_report_processor.py
+++ b/koku/masu/processor/azure/azure_report_processor.py
@@ -303,6 +303,7 @@ class AzureReportProcessor(ReportProcessorBase):
             with AzureReportDBAccessor(self._schema, self.column_map) as report_db:
                 LOG.info('File %s opened for processing', str(f))
                 reader = csv.DictReader(f)
+                raise Exception
                 for row in reader:
                     if not self._should_process_row(row, 'UsageDateTime', is_full_month):
                         continue
```
2. Add Azure provider.
3. Ingest data.

Since we've introduced a giant exception in the middle of processing, we should see some kind of error. But, on master, that diff will log a rather pointless message:

```
koku_worker       | [2019-12-03 21:17:15,145: ERROR/ForkPoolWorker-1] masu.processor.tasks.get_report_files[6ded1c2b-9da6-4d1f-bf9b-b9863d6934fc]: 
```


Apply this PR's changes, and the above becomes:
```
koku_worker       | [2019-12-03 21:22:42,695: ERROR/ForkPoolWorker-1] masu.processor.tasks.get_report_files[bc93d3df-44fb-4a5e-925a-09ef129916c9]: 
koku_worker       | [2019-12-03 21:22:42,736] ERROR: Task failed: 
koku_worker       | Traceback (most recent call last):
koku_worker       |   File "/koku/koku/masu/processor/report_processor.py", line 113, in process
koku_worker       |     return self._processor.process()
koku_worker       |   File "/koku/koku/masu/processor/azure/azure_report_processor.py", line 306, in process
koku_worker       |     raise Exception
koku_worker       | Exception
koku_worker       | 
koku_worker       | During handling of the above exception, another exception occurred:
koku_worker       | 
koku_worker       | Traceback (most recent call last):
koku_worker       |   File "/opt/app-root/lib/python3.6/site-packages/celery/app/trace.py", line 385, in trace_task
koku_worker       |     R = retval = fun(*args, **kwargs)
koku_worker       |   File "/opt/app-root/lib/python3.6/site-packages/celery/app/trace.py", line 648, in __protected_call__
koku_worker       |     return self.run(*args, **kwargs)
koku_worker       |   File "/koku/koku/masu/processor/tasks.py", line 145, in get_report_files
koku_worker       |     raise processing_error
koku_worker       |   File "/koku/koku/masu/processor/tasks.py", line 129, in get_report_files
koku_worker       |     _process_report_file(schema_name, provider_type, provider_uuid, report_dict)
koku_worker       |   File "/koku/koku/masu/processor/_tasks/process.py", line 75, in _process_report_file
koku_worker       |     processor.process()
koku_worker       |   File "/koku/koku/masu/processor/report_processor.py", line 115, in process
koku_worker       |     raise ReportProcessorError(str(err))
koku_worker       | masu.processor.report_processor.ReportProcessorError
koku_worker       | [2019-12-03 21:22:42,736: ERROR/ForkPoolWorker-1] Task failed: 
koku_worker       | Traceback (most recent call last):
koku_worker       |   File "/koku/koku/masu/processor/report_processor.py", line 113, in process
koku_worker       |     return self._processor.process()
koku_worker       |   File "/koku/koku/masu/processor/azure/azure_report_processor.py", line 306, in process
koku_worker       |     raise Exception
koku_worker       | Exception
koku_worker       | 
koku_worker       | During handling of the above exception, another exception occurred:
koku_worker       | 
koku_worker       | Traceback (most recent call last):
koku_worker       |   File "/opt/app-root/lib/python3.6/site-packages/celery/app/trace.py", line 385, in trace_task
koku_worker       |     R = retval = fun(*args, **kwargs)
koku_worker       |   File "/opt/app-root/lib/python3.6/site-packages/celery/app/trace.py", line 648, in __protected_call__
koku_worker       |     return self.run(*args, **kwargs)
koku_worker       |   File "/koku/koku/masu/processor/tasks.py", line 145, in get_report_files
koku_worker       |     raise processing_error
koku_worker       |   File "/koku/koku/masu/processor/tasks.py", line 129, in get_report_files
koku_worker       |     _process_report_file(schema_name, provider_type, provider_uuid, report_dict)
koku_worker       |   File "/koku/koku/masu/processor/_tasks/process.py", line 75, in _process_report_file
koku_worker       |     processor.process()
koku_worker       |   File "/koku/koku/masu/processor/report_processor.py", line 115, in process
koku_worker       |     raise ReportProcessorError(str(err))
koku_worker       | masu.processor.report_processor.ReportProcessorError
```

This solution may not work in every situation, but it's at least a start.