### PR TITLE
adding celery timeout for when broker is unavailable

### DIFF
--- a/koku/koku/celery.py
+++ b/koku/koku/celery.py
@@ -91,4 +91,12 @@ app.conf.beat_schedule['daily_upload_normalized_reports_to_s3'] = {
     'schedule': int(os.getenv('UPLOAD_NORMALIZED_DATA_INTERVAL', '86400'))
 }
 
+# Celery timeout if broker is unavaiable to avoid blocking indefintely
+app.conf.broker_transport_options = {
+    'max_retries': 4,
+    'interval_start': 0,
+    'interval_step': 0.5,
+    'interval_max': 3,
+}
+
 app.autodiscover_tasks()


### PR DESCRIPTION
A celery async invocation was added to the provider delete removal with https://github.com/project-koku/koku/pull/1388.  When rabbit is unavailable this will cause the delete process to block indefinitely.  This was resulting in the Sources Client process queue being blocked.

This change adds a timeout to the celery configuration so that async calls will not be blocked indefinitely but will instead timeout after a maximum of 3 seconds.  

**Testing**
1. Create provider
2. Ensure rabbit is down and destroy provider.  Verify network call returns with a 500 but provider is ultimately removed.
3. Create provider with rabbit and worker running.
4. Destroy provider, verify it is removed with 204 response.

**Test Results**
[celery_timeout_ut.txt](https://github.com/project-koku/koku/files/3928735/celery_timeout_ut.txt)
