### PR TITLE
Use UUIDS for uniqueness

### DIFF
--- a/koku/masu/database/sql/reporting_ocpawscostlineitem_daily_summary.sql
+++ b/koku/masu/database/sql/reporting_ocpawscostlineitem_daily_summary.sql
@@ -6,7 +6,7 @@
 -- We use a LATERAL JOIN here to get the JSON tags split out into key, value
 -- columns. We reference this split multiple times so we put it in a
 -- TEMPORARY TABLE for re-use
-CREATE TEMPORARY TABLE reporting_aws_tags AS (
+CREATE TEMPORARY TABLE reporting_aws_tags_{{uuid | sqlsafe}} AS (
     SELECT aws.*,
         LOWER(key) as key,
         LOWER(value) as value
@@ -28,7 +28,7 @@ CREATE TEMPORARY TABLE reporting_aws_tags AS (
 -- We use a LATERAL JOIN here to get the JSON tags split out into key, value
 -- columns. We reference this split multiple times so we put it in a
 -- TEMPORARY TABLE for re-use
-CREATE TEMPORARY TABLE reporting_ocp_storage_tags AS (
+CREATE TEMPORARY TABLE reporting_ocp_storage_tags_{{uuid | sqlsafe}} AS (
     SELECT ocp.*,
         LOWER(key) as key,
         LOWER(value) as value
@@ -60,7 +60,7 @@ CREATE TEMPORARY TABLE reporting_ocp_storage_tags AS (
 -- We use a LATERAL JOIN here to get the JSON tags split out into key, value
 -- columns. We reference this split multiple times so we put it in a
 -- TEMPORARY TABLE for re-use
-CREATE TEMPORARY TABLE reporting_ocp_pod_tags AS (
+CREATE TEMPORARY TABLE reporting_ocp_pod_tags_{{uuid | sqlsafe}} AS (
     SELECT ocp.*,
         LOWER(key) as key,
         LOWER(value) as value
@@ -77,7 +77,7 @@ CREATE TEMPORARY TABLE reporting_ocp_pod_tags AS (
 
 -- First we match OCP pod data to AWS data using a direct
 -- resource id match. This usually means OCP node -> AWS EC2 instance ID.
-CREATE TEMPORARY TABLE reporting_ocp_aws_resource_id_matched AS (
+CREATE TEMPORARY TABLE reporting_ocp_aws_resource_id_matched_{{uuid | sqlsafe}} AS (
     WITH cte_resource_id_matched AS (
         SELECT ocp.id AS ocp_id,
             ocp.report_period_id,
@@ -170,7 +170,7 @@ CREATE TEMPORARY TABLE reporting_ocp_aws_resource_id_matched AS (
 
 -- Next we match where the pod label key and value
 -- and AWS tag key and value match directly
-CREATE TEMPORARY TABLE reporting_ocp_aws_direct_tag_matched AS (
+CREATE TEMPORARY TABLE reporting_ocp_aws_direct_tag_matched_{{uuid | sqlsafe}} AS (
     WITH cte_tag_matched AS (
         SELECT ocp.id AS ocp_id,
             ocp.report_period_id,
@@ -217,12 +217,12 @@ CREATE TEMPORARY TABLE reporting_ocp_aws_direct_tag_matched AS (
             aws.public_on_demand_rate,
             aws.tax_type,
             aws.tags
-        FROM reporting_aws_tags as aws
-        JOIN reporting_ocp_pod_tags as ocp
+        FROM reporting_aws_tags_{{uuid | sqlsafe}} as aws
+        JOIN reporting_ocp_pod_tags_{{uuid | sqlsafe}} as ocp
             ON aws.key = ocp.key
                 AND aws.value = ocp.value
                 AND aws.usage_start::date = ocp.usage_start::date
-        LEFT JOIN reporting_ocp_aws_resource_id_matched AS rm
+        LEFT JOIN reporting_ocp_aws_resource_id_matched_{{uuid | sqlsafe}} AS rm
             ON rm.aws_id = aws.id
         WHERE date(aws.usage_start) >= {{start_date}}
             AND date(aws.usage_start) <= {{end_date}}
@@ -254,7 +254,7 @@ CREATE TEMPORARY TABLE reporting_ocp_aws_direct_tag_matched AS (
 
 -- Next we match where the AWS tag is the special openshift_project key
 -- and the value matches an OpenShift project name
-CREATE TEMPORARY TABLE reporting_ocp_aws_openshift_project_tag_matched AS (
+CREATE TEMPORARY TABLE reporting_ocp_aws_openshift_project_tag_matched_{{uuid | sqlsafe}} AS (
     WITH cte_tag_matched AS (
         SELECT ocp.id AS ocp_id,
             ocp.report_period_id,
@@ -301,13 +301,13 @@ CREATE TEMPORARY TABLE reporting_ocp_aws_openshift_project_tag_matched AS (
             aws.public_on_demand_rate,
             aws.tax_type,
             aws.tags
-        FROM reporting_aws_tags as aws
-        JOIN reporting_ocp_pod_tags as ocp
+        FROM reporting_aws_tags_{{uuid | sqlsafe}} as aws
+        JOIN reporting_ocp_pod_tags_{{uuid | sqlsafe}} as ocp
             ON aws.key = 'openshift_project' AND aws.value = ocp.namespace
                 AND aws.usage_start::date = ocp.usage_start::date
-        LEFT JOIN reporting_ocp_aws_resource_id_matched AS rm
+        LEFT JOIN reporting_ocp_aws_resource_id_matched_{{uuid | sqlsafe}} AS rm
             ON rm.aws_id = aws.id
-        LEFT JOIN reporting_ocp_aws_direct_tag_matched AS dtm
+        LEFT JOIN reporting_ocp_aws_direct_tag_matched_{{uuid | sqlsafe}} AS dtm
             ON dtm.aws_id = aws.id
         WHERE date(aws.usage_start) >= {{start_date}}
             AND date(aws.usage_start) <= {{end_date}}
@@ -341,7 +341,7 @@ CREATE TEMPORARY TABLE reporting_ocp_aws_openshift_project_tag_matched AS (
 
 -- Next we match where the AWS tag is the special openshift_node key
 -- and the value matches an OpenShift node name
-CREATE TEMPORARY TABLE reporting_ocp_aws_openshift_node_tag_matched AS (
+CREATE TEMPORARY TABLE reporting_ocp_aws_openshift_node_tag_matched_{{uuid | sqlsafe}} AS (
     WITH cte_tag_matched AS (
         SELECT ocp.id AS ocp_id,
             ocp.report_period_id,
@@ -388,16 +388,16 @@ CREATE TEMPORARY TABLE reporting_ocp_aws_openshift_node_tag_matched AS (
             aws.public_on_demand_rate,
             aws.tax_type,
             aws.tags
-        FROM reporting_aws_tags as aws
-        JOIN reporting_ocp_pod_tags as ocp
+        FROM reporting_aws_tags_{{uuid | sqlsafe}} as aws
+        JOIN reporting_ocp_pod_tags_{{uuid | sqlsafe}} as ocp
             ON aws.key = 'openshift_node' AND aws.value = ocp.node
                 AND aws.usage_start::date = ocp.usage_start::date
         -- ANTI JOIN to remove rows that already matched
-        LEFT JOIN reporting_ocp_aws_resource_id_matched AS rm
+        LEFT JOIN reporting_ocp_aws_resource_id_matched_{{uuid | sqlsafe}} AS rm
             ON rm.aws_id = aws.id
-        LEFT JOIN reporting_ocp_aws_direct_tag_matched AS dtm
+        LEFT JOIN reporting_ocp_aws_direct_tag_matched_{{uuid | sqlsafe}} AS dtm
             ON dtm.aws_id = aws.id
-        LEFT JOIN reporting_ocp_aws_openshift_project_tag_matched as ptm
+        LEFT JOIN reporting_ocp_aws_openshift_project_tag_matched_{{uuid | sqlsafe}} as ptm
             ON ptm.aws_id = aws.id
         WHERE date(aws.usage_start) >= {{start_date}}
             AND date(aws.usage_start) <= {{end_date}}
@@ -431,7 +431,7 @@ CREATE TEMPORARY TABLE reporting_ocp_aws_openshift_node_tag_matched AS (
 
 -- Next we match where the AWS tag is the special openshift_cluster key
 -- and the value matches an OpenShift cluster name
-CREATE TEMPORARY TABLE reporting_ocp_aws_openshift_cluster_tag_matched AS (
+CREATE TEMPORARY TABLE reporting_ocp_aws_openshift_cluster_tag_matched_{{uuid | sqlsafe}} AS (
     WITH cte_tag_matched AS (
         SELECT ocp.id AS ocp_id,
             ocp.report_period_id,
@@ -478,19 +478,19 @@ CREATE TEMPORARY TABLE reporting_ocp_aws_openshift_cluster_tag_matched AS (
             aws.public_on_demand_rate,
             aws.tax_type,
             aws.tags
-        FROM reporting_aws_tags as aws
-        JOIN reporting_ocp_pod_tags as ocp
+        FROM reporting_aws_tags_{{uuid | sqlsafe}} as aws
+        JOIN reporting_ocp_pod_tags_{{uuid | sqlsafe}} as ocp
             ON (aws.key = 'openshift_cluster' AND aws.value = ocp.cluster_id
                 OR aws.key = 'openshift_cluster' AND aws.value = ocp.cluster_alias)
                 AND aws.usage_start::date = ocp.usage_start::date
         -- ANTI JOIN to remove rows that already matched
-        LEFT JOIN reporting_ocp_aws_resource_id_matched AS rm
+        LEFT JOIN reporting_ocp_aws_resource_id_matched_{{uuid | sqlsafe}} AS rm
             ON rm.aws_id = aws.id
-        LEFT JOIN reporting_ocp_aws_direct_tag_matched AS dtm
+        LEFT JOIN reporting_ocp_aws_direct_tag_matched_{{uuid | sqlsafe}} AS dtm
             ON dtm.aws_id = aws.id
-        LEFT JOIN reporting_ocp_aws_openshift_project_tag_matched as ptm
+        LEFT JOIN reporting_ocp_aws_openshift_project_tag_matched_{{uuid | sqlsafe}} as ptm
             ON ptm.aws_id = aws.id
-        LEFT JOIN reporting_ocp_aws_openshift_node_tag_matched as ntm
+        LEFT JOIN reporting_ocp_aws_openshift_node_tag_matched_{{uuid | sqlsafe}} as ntm
             ON ntm.aws_id = aws.id
         WHERE date(aws.usage_start) >= {{start_date}}
             AND date(aws.usage_start) <= {{end_date}}
@@ -527,32 +527,32 @@ CREATE TEMPORARY TABLE reporting_ocp_aws_openshift_cluster_tag_matched AS (
 -- OpenShift pod data matches for easier use.
 CREATE TEMPORARY TABLE reporting_ocpawsusagelineitem_daily_{{uuid | sqlsafe}} AS (
     SELECT *
-    FROM reporting_ocp_aws_resource_id_matched
+    FROM reporting_ocp_aws_resource_id_matched_{{uuid | sqlsafe}}
 
     UNION
 
     SELECT *
-    FROM reporting_ocp_aws_direct_tag_matched
+    FROM reporting_ocp_aws_direct_tag_matched_{{uuid | sqlsafe}}
 
     UNION
 
     SELECT *
-    FROM reporting_ocp_aws_openshift_project_tag_matched
+    FROM reporting_ocp_aws_openshift_project_tag_matched_{{uuid | sqlsafe}}
 
     UNION
 
     SELECT *
-    FROM reporting_ocp_aws_openshift_node_tag_matched
+    FROM reporting_ocp_aws_openshift_node_tag_matched_{{uuid | sqlsafe}}
 
     UNION
 
     SELECT *
-    FROM reporting_ocp_aws_openshift_cluster_tag_matched
+    FROM reporting_ocp_aws_openshift_cluster_tag_matched_{{uuid | sqlsafe}}
 );
 
 -- Then we match for OpenShift volume data where the volume label key and value
 -- and AWS tag key and value match directly
-CREATE TEMPORARY TABLE reporting_ocp_aws_storage_direct_tag_matched AS (
+CREATE TEMPORARY TABLE reporting_ocp_aws_storage_direct_tag_matched_{{uuid | sqlsafe}} AS (
     WITH cte_tag_matched AS (
         SELECT ocp.id AS ocp_id,
             ocp.report_period_id,
@@ -596,8 +596,8 @@ CREATE TEMPORARY TABLE reporting_ocp_aws_storage_direct_tag_matched AS (
             aws.public_on_demand_rate,
             aws.tax_type,
             aws.tags
-        FROM reporting_aws_tags as aws
-        JOIN reporting_ocp_storage_tags as ocp
+        FROM reporting_aws_tags_{{uuid | sqlsafe}} as aws
+        JOIN reporting_ocp_storage_tags_{{uuid | sqlsafe}} as ocp
             ON aws.key = ocp.key
                 AND aws.value = ocp.value
                 AND aws.usage_start::date = ocp.usage_start::date
@@ -630,7 +630,7 @@ CREATE TEMPORARY TABLE reporting_ocp_aws_storage_direct_tag_matched AS (
 
 -- Then we match where the AWS tag is the special openshift_project key
 -- and the value matches an OpenShift project name
-CREATE TEMPORARY TABLE reporting_ocp_aws_storage_openshift_project_tag_matched AS (
+CREATE TEMPORARY TABLE reporting_ocp_aws_storage_openshift_project_tag_matched_{{uuid | sqlsafe}} AS (
     WITH cte_tag_matched AS (
         SELECT ocp.id AS ocp_id,
             ocp.report_period_id,
@@ -674,11 +674,11 @@ CREATE TEMPORARY TABLE reporting_ocp_aws_storage_openshift_project_tag_matched A
             aws.public_on_demand_rate,
             aws.tax_type,
             aws.tags
-        FROM reporting_aws_tags as aws
-        JOIN reporting_ocp_storage_tags as ocp
+        FROM reporting_aws_tags_{{uuid | sqlsafe}} as aws
+        JOIN reporting_ocp_storage_tags_{{uuid | sqlsafe}} as ocp
             ON aws.key = 'openshift_project' AND aws.value = ocp.namespace
                 AND aws.usage_start::date = ocp.usage_start::date
-        LEFT JOIN reporting_ocp_aws_storage_direct_tag_matched AS dtm
+        LEFT JOIN reporting_ocp_aws_storage_direct_tag_matched_{{uuid | sqlsafe}} AS dtm
             ON dtm.aws_id = aws.id
         WHERE date(aws.usage_start) >= {{start_date}}
             AND date(aws.usage_start) <= {{end_date}}
@@ -711,7 +711,7 @@ CREATE TEMPORARY TABLE reporting_ocp_aws_storage_openshift_project_tag_matched A
 
 -- Next we match where the AWS tag is the special openshift_node key
 -- and the value matches an OpenShift node name
-CREATE TEMPORARY TABLE reporting_ocp_aws_storage_openshift_node_tag_matched AS (
+CREATE TEMPORARY TABLE reporting_ocp_aws_storage_openshift_node_tag_matched_{{uuid | sqlsafe}} AS (
     WITH cte_tag_matched AS (
         SELECT ocp.id AS ocp_id,
             ocp.report_period_id,
@@ -755,14 +755,14 @@ CREATE TEMPORARY TABLE reporting_ocp_aws_storage_openshift_node_tag_matched AS (
             aws.public_on_demand_rate,
             aws.tax_type,
             aws.tags
-        FROM reporting_aws_tags as aws
-        JOIN reporting_ocp_storage_tags as ocp
+        FROM reporting_aws_tags_{{uuid | sqlsafe}} as aws
+        JOIN reporting_ocp_storage_tags_{{uuid | sqlsafe}} as ocp
             ON aws.key = 'openshift_node' AND aws.value = ocp.node
                 AND aws.usage_start::date = ocp.usage_start::date
         -- ANTI JOIN to remove rows that already matched
-        LEFT JOIN reporting_ocp_aws_storage_direct_tag_matched AS dtm
+        LEFT JOIN reporting_ocp_aws_storage_direct_tag_matched_{{uuid | sqlsafe}} AS dtm
             ON dtm.aws_id = aws.id
-        LEFT JOIN reporting_ocp_aws_storage_openshift_project_tag_matched as ptm
+        LEFT JOIN reporting_ocp_aws_storage_openshift_project_tag_matched_{{uuid | sqlsafe}} as ptm
             ON ptm.aws_id = aws.id
         WHERE date(aws.usage_start) >= {{start_date}}
             AND date(aws.usage_start) <= {{end_date}}
@@ -795,7 +795,7 @@ CREATE TEMPORARY TABLE reporting_ocp_aws_storage_openshift_node_tag_matched AS (
 
 -- Next we match where the AWS tag is the special openshift_cluster key
 -- and the value matches an OpenShift cluster name
-CREATE TEMPORARY TABLE reporting_ocp_aws_storage_openshift_cluster_tag_matched AS (
+CREATE TEMPORARY TABLE reporting_ocp_aws_storage_openshift_cluster_tag_matched_{{uuid | sqlsafe}} AS (
     WITH cte_tag_matched AS (
         SELECT ocp.id AS ocp_id,
             ocp.report_period_id,
@@ -839,17 +839,17 @@ CREATE TEMPORARY TABLE reporting_ocp_aws_storage_openshift_cluster_tag_matched A
             aws.public_on_demand_rate,
             aws.tax_type,
             aws.tags
-        FROM reporting_aws_tags as aws
-        JOIN reporting_ocp_storage_tags as ocp
+        FROM reporting_aws_tags_{{uuid | sqlsafe}} as aws
+        JOIN reporting_ocp_storage_tags_{{uuid | sqlsafe}} as ocp
             ON (aws.key = 'openshift_cluster' AND aws.value = ocp.cluster_id
                 OR aws.key = 'openshift_cluster' AND aws.value = ocp.cluster_alias)
                 AND aws.usage_start::date = ocp.usage_start::date
         -- ANTI JOIN to remove rows that already matched
-        LEFT JOIN reporting_ocp_aws_storage_direct_tag_matched AS dtm
+        LEFT JOIN reporting_ocp_aws_storage_direct_tag_matched_{{uuid | sqlsafe}} AS dtm
             ON dtm.aws_id = aws.id
-        LEFT JOIN reporting_ocp_aws_storage_openshift_project_tag_matched as ptm
+        LEFT JOIN reporting_ocp_aws_storage_openshift_project_tag_matched_{{uuid | sqlsafe}} as ptm
             ON ptm.aws_id = aws.id
-        LEFT JOIN reporting_ocp_aws_storage_openshift_node_tag_matched as ntm
+        LEFT JOIN reporting_ocp_aws_storage_openshift_node_tag_matched_{{uuid | sqlsafe}} as ntm
             ON ntm.aws_id = aws.id
         WHERE date(aws.usage_start) >= {{start_date}}
             AND date(aws.usage_start) <= {{end_date}}
@@ -885,23 +885,23 @@ CREATE TEMPORARY TABLE reporting_ocp_aws_storage_openshift_cluster_tag_matched A
 -- OpenShift volume data matches for easier use.
 CREATE TEMPORARY TABLE reporting_ocpawsstoragelineitem_daily_{{uuid | sqlsafe}} AS (
     SELECT *
-    FROM reporting_ocp_aws_storage_direct_tag_matched
+    FROM reporting_ocp_aws_storage_direct_tag_matched_{{uuid | sqlsafe}}
 
     UNION
 
 
     SELECT *
-    FROM reporting_ocp_aws_storage_openshift_project_tag_matched
+    FROM reporting_ocp_aws_storage_openshift_project_tag_matched_{{uuid | sqlsafe}}
 
     UNION
 
     SELECT *
-    FROM reporting_ocp_aws_storage_openshift_node_tag_matched
+    FROM reporting_ocp_aws_storage_openshift_node_tag_matched_{{uuid | sqlsafe}}
 
     UNION
 
     SELECT *
-    FROM reporting_ocp_aws_storage_openshift_cluster_tag_matched
+    FROM reporting_ocp_aws_storage_openshift_cluster_tag_matched_{{uuid | sqlsafe}}
 );
 
 -- The full summary data for Openshift pod<->AWS and

--- a/koku/masu/database/sql/reporting_ocpinfrastructure_provider_map.sql
+++ b/koku/masu/database/sql/reporting_ocpinfrastructure_provider_map.sql
@@ -1,54 +1,60 @@
 
-SELECT rp.provider_id as ocp_uuid,
-    p.uuid as infra_uuid,
-    p.type
-FROM {{schema | sqlsafe}}.reporting_awscostentrylineitem_daily as aws
-JOIN {{schema | sqlsafe}}.reporting_awscostentrybill as bill
-    ON aws.cost_entry_bill_id = bill.id
-JOIN {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily as ocp
-    ON date(aws.usage_start) = date(ocp.usage_start)
-        AND aws.resource_id = ocp.resource_id
-JOIN {{schema | sqlsafe}}.reporting_ocpusagereportperiod as rp
-    ON ocp.report_period_id = rp.id
-JOIN public.api_provider as p
-    ON bill.provider_id = p.uuid
-WHERE date(aws.usage_start) >= {{start_date}}
-    AND date(aws.usage_start) <= {{end_date}}
-    AND date(ocp.usage_start) >= {{start_date}}
-    AND date(ocp.usage_start) <= {{end_date}}
-    {% if aws_provider_uuid %}
-    AND bill.provider_id = {{aws_provider_uuid}}
-    {% endif %}
-    {% if ocp_provider_uuid %}
-    AND rp.provider_id = {{ocp_provider_uuid}}
-    {% endif %}
-GROUP BY rp.provider_id, p.uuid, p.type
+{% if aws_provider_uuid or ocp_provider_uuid %}
+    SELECT rp.provider_id as ocp_uuid,
+        p.uuid as infra_uuid,
+        p.type
+    FROM {{schema | sqlsafe}}.reporting_awscostentrylineitem_daily as aws
+    JOIN {{schema | sqlsafe}}.reporting_awscostentrybill as bill
+        ON aws.cost_entry_bill_id = bill.id
+    JOIN {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily as ocp
+        ON date(aws.usage_start) = date(ocp.usage_start)
+            AND aws.resource_id = ocp.resource_id
+    JOIN {{schema | sqlsafe}}.reporting_ocpusagereportperiod as rp
+        ON ocp.report_period_id = rp.id
+    JOIN public.api_provider as p
+        ON bill.provider_id = p.uuid
+    WHERE date(aws.usage_start) >= {{start_date}}
+        AND date(aws.usage_start) <= {{end_date}}
+        AND date(ocp.usage_start) >= {{start_date}}
+        AND date(ocp.usage_start) <= {{end_date}}
+        {% if aws_provider_uuid %}
+        AND bill.provider_id = {{aws_provider_uuid}}
+        {% endif %}
+        {% if ocp_provider_uuid %}
+        AND rp.provider_id = {{ocp_provider_uuid}}
+        {% endif %}
+    GROUP BY rp.provider_id, p.uuid, p.type
+{% endif %}
 
-UNION
+{% if ocp_provider_uuid  %}
+    UNION
+{% endif %}
 
-SELECT rp.provider_id as ocp_uuid,
-    p.uuid as infra_uuid,
-    p.type
-FROM {{schema | sqlsafe}}.reporting_azurecostentrylineitem_daily as azure
-JOIN {{schema | sqlsafe}}.reporting_azurecostentryproductservice as aps
-        ON azure.cost_entry_product_id = aps.id
-JOIN {{schema | sqlsafe}}.reporting_azurecostentrybill as bill
-    ON azure.cost_entry_bill_id = bill.id
-JOIN {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily as ocp
-    ON split_part(aps.instance_id, '/', 9) = ocp.node
-        AND date(azure.usage_date_time) = date(ocp.usage_start)
-JOIN {{schema | sqlsafe}}.reporting_ocpusagereportperiod as rp
-    ON ocp.report_period_id = rp.id
-JOIN public.api_provider as p
-    ON bill.provider_id = p.uuid
-WHERE date(azure.usage_date_time) >= {{start_date}}
-    AND date(azure.usage_date_time) <= {{end_date}}
-    AND date(ocp.usage_start) >= {{start_date}}
-    AND date(ocp.usage_start) <= {{end_date}}
-    {% if azure_provider_uuid %}
-    AND bill.provider_id = {{azure_provider_uuid}}
-    {% endif %}
-    {% if ocp_provider_uuid %}
-    AND rp.provider_id = {{ocp_provider_uuid}}
-    {% endif %}
-GROUP BY rp.provider_id, p.uuid, p.type
+{% if azure_provider_uuid or ocp_provider_uuid %}
+    SELECT rp.provider_id as ocp_uuid,
+        p.uuid as infra_uuid,
+        p.type
+    FROM {{schema | sqlsafe}}.reporting_azurecostentrylineitem_daily as azure
+    JOIN {{schema | sqlsafe}}.reporting_azurecostentryproductservice as aps
+            ON azure.cost_entry_product_id = aps.id
+    JOIN {{schema | sqlsafe}}.reporting_azurecostentrybill as bill
+        ON azure.cost_entry_bill_id = bill.id
+    JOIN {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily as ocp
+        ON split_part(aps.instance_id, '/', 9) = ocp.node
+            AND date(azure.usage_date_time) = date(ocp.usage_start)
+    JOIN {{schema | sqlsafe}}.reporting_ocpusagereportperiod as rp
+        ON ocp.report_period_id = rp.id
+    JOIN public.api_provider as p
+        ON bill.provider_id = p.uuid
+    WHERE date(azure.usage_date_time) >= {{start_date}}
+        AND date(azure.usage_date_time) <= {{end_date}}
+        AND date(ocp.usage_start) >= {{start_date}}
+        AND date(ocp.usage_start) <= {{end_date}}
+        {% if azure_provider_uuid %}
+        AND bill.provider_id = {{azure_provider_uuid}}
+        {% endif %}
+        {% if ocp_provider_uuid %}
+        AND rp.provider_id = {{ocp_provider_uuid}}
+        {% endif %}
+    GROUP BY rp.provider_id, p.uuid, p.type
+{% endif %}


### PR DESCRIPTION
## Summary
This should allow running multiple OCP on AWS/Azure providers in a row. We just use a unique table name for the temp tables created. 
* Apply to all temp tables for OCP on Infrastructure SQL
* Add conditionals to infra map SQL so only parts relevant to provider are run