### PR TITLE
Remove unnecessary provider mapping entries in the storage report definition.

### DIFF
--- a/koku/api/report/azure/provider_map.py
+++ b/koku/api/report/azure/provider_map.py
@@ -156,7 +156,6 @@ class AzureProviderMap(ProviderMap):
                                 Coalesce(F('markup_cost'), Value(0, output_field=DecimalField()))
                             ),
                             'derived_cost': Sum(Value(0, output_field=DecimalField())),
-                            'count': Sum(Value(0, output_field=DecimalField())),
                         },
                         'aggregate_key': 'usage_quantity',
                         'annotations': {
@@ -170,8 +169,6 @@ class AzureProviderMap(ProviderMap):
                                 Coalesce(F('markup_cost'), Value(0, output_field=DecimalField()))
                             ),
                             'cost_units': Coalesce(Max('currency'), Value('USD')),
-                            'count': Max('instance_count'),
-                            'count_units': Value('instances', output_field=CharField()),
                             'usage': Sum('usage_quantity'),
                             # FIXME: Waiting on MSFT for usage_units default
                             'usage_units': Coalesce(Max('unit_of_measure'), Value('Storage Type Placeholder'))

--- a/koku/api/report/azure/query_handler.py
+++ b/koku/api/report/azure/query_handler.py
@@ -34,7 +34,7 @@ class AzureReportQueryHandler(ReportQueryHandler):
     provider = 'AZURE'
 
     def __init__(self, parameters):
-        """Establish AWS report query handler.
+        """Establish Azure report query handler.
 
         Args:
             parameters    (QueryParameters): parameter object for query

--- a/koku/api/report/test/azure/tests_azure_query_handler.py
+++ b/koku/api/report/test/azure/tests_azure_query_handler.py
@@ -1006,6 +1006,7 @@ class AzureReportQueryHandlerTest(IamTestCase):
                     self.assertGreater(
                         value.get('usage', {}).get('value', {}), Decimal(0)
                     )
+                    self.assertIsNone(value.get('count'))
 
     def test_order_by(self):
         """Test that order_by returns properly sorted data."""


### PR DESCRIPTION
* Remove entries from totals and each data item.


Related to: #1525 


[1525-ut.txt](https://github.com/project-koku/koku/files/3945939/1525-ut.txt)
