### PR TITLE
1373 log Celery task IDs

### DIFF
--- a/koku/api/dataexport/syncer/__init__.py
+++ b/koku/api/dataexport/syncer/__init__.py
@@ -1,5 +1,4 @@
 """Data export syncer."""
-import uuid
 from abc import ABC, abstractmethod
 from datetime import timedelta
 from itertools import product
@@ -108,10 +107,8 @@ class AwsS3Syncer(SyncerInterface):
 
         """
         if settings.ENABLE_S3_ARCHIVING:
-            log_uuid = str(uuid.uuid4())
             LOG.info(
-                '%s Beginning sync_bucket to %s for %s from %s to %s',
-                log_uuid,
+                'Beginning sync_bucket to %s for %s from %s to %s',
                 s3_destination_bucket_name,
                 schema_name,
                 date_range[0],
@@ -156,8 +153,7 @@ class AwsS3Syncer(SyncerInterface):
                     self._copy_object(s3_destination_bucket, source_object)
 
             LOG.info(
-                '%s Completed sync_bucket to %s for %s from %s to %s',
-                log_uuid,
+                'Completed sync_bucket to %s for %s from %s to %s',
                 s3_destination_bucket_name,
                 schema_name,
                 date_range[0],

--- a/koku/koku/celery.py
+++ b/koku/koku/celery.py
@@ -49,7 +49,7 @@ LOGGER.info('Database configured.')
 # 'app' is the recommended convention from celery docs
 # following this for ease of comparison to reference implementation
 # pylint: disable=invalid-name
-app = LoggingCelery('koku', broker=settings.CELERY_BROKER_URL)
+app = LoggingCelery('koku', log='koku.log:TaskRootLogging', broker=settings.CELERY_BROKER_URL)
 app.config_from_object('django.conf:settings', namespace='CELERY')
 
 LOGGER.info('Celery autodiscover tasks.')

--- a/koku/koku/log.py
+++ b/koku/koku/log.py
@@ -1,0 +1,44 @@
+"""Custom log-related classes."""
+from celery._state import get_current_task
+from celery.app.log import Logging
+from celery.utils.log import ColorFormatter
+
+
+class TaskFormatter(ColorFormatter):
+    """
+    Formatter for tasks, adding the task name and ids.
+
+    This formatter is strongly inspired by celery.app.log.TaskFormatter.
+    """
+
+    def format(self, record):
+        """Append task-related values to the record upon format."""
+        task = get_current_task()
+
+        if task and task.request:
+            record.__dict__.update(
+                task_id=task.request.id,
+                task_name=task.name,
+                task_root_id=task.request.root_id,
+                task_parent_id=task.request.parent_id,
+            )
+        else:
+            record.__dict__.setdefault('task_name', 'None')
+            record.__dict__.setdefault('task_id', 'None')
+            record.__dict__.setdefault('task_root_id', 'None')
+            record.__dict__.setdefault('task_parent_id', 'None')
+
+        return ColorFormatter.format(self, record)
+
+
+class TaskRootLogging(Logging):
+    """Custom Celery application logging setup."""
+
+    # pylint: disable=too-many-arguments, redefined-builtin, C0330
+    def setup_handlers(
+        self, logger, logfile, format, colorize, formatter=TaskFormatter, **kwargs
+    ):
+        """Always ignore the requested formatter and use our custom one."""
+        return super(TaskRootLogging, self).setup_handlers(
+            logger, logfile, format, colorize, TaskFormatter, **kwargs
+        )

--- a/koku/koku/settings.py
+++ b/koku/koku/settings.py
@@ -299,8 +299,14 @@ LOGGING_FORMATTER = os.getenv('DJANGO_LOG_FORMATTER', 'simple')
 DJANGO_LOGGING_LEVEL = os.getenv('DJANGO_LOG_LEVEL', 'INFO')
 KOKU_LOGGING_LEVEL = os.getenv('KOKU_LOG_LEVEL', 'INFO')
 LOGGING_HANDLERS = os.getenv('DJANGO_LOG_HANDLERS', 'console').split(',')
-VERBOSE_FORMATTING = '%(levelname)s %(asctime)s %(module)s ' \
-    '%(process)d %(thread)d %(message)s'
+VERBOSE_FORMATTING = (
+    '%(levelname)s %(asctime)s %(module)s %(process)d %(thread)d '
+    '%(task_id)s %(task_parent_id)s %(task_root_id)s '
+    '%(message)s'
+)
+SIMPLE_FORMATTING = (
+    '[%(asctime)s] %(levelname)s %(task_root_id)s %(message)s'
+)
 
 LOG_DIRECTORY = os.getenv('LOG_DIRECTORY', BASE_DIR)
 DEFAULT_LOG_FILE = os.path.join(LOG_DIRECTORY, 'app.log')
@@ -314,10 +320,12 @@ LOGGING = {
     'disable_existing_loggers': False,
     'formatters': {
         'verbose': {
-            'format': VERBOSE_FORMATTING
+            '()': 'koku.log.TaskFormatter',
+            'format': VERBOSE_FORMATTING,
         },
         'simple': {
-            'format': '[%(asctime)s] %(levelname)s: %(message)s'
+            '()': 'koku.log.TaskFormatter',
+            'format': SIMPLE_FORMATTING,
         },
     },
     'handlers': {
@@ -436,6 +444,14 @@ CELERY_IMPORTS = ('masu.processor.tasks', 'masu.celery.tasks',)
 CELERY_BROKER_POOL_LIMIT = None
 CELERY_WORKER_PREFETCH_MULTIPLIER = 1
 CELERY_WORKER_CONCURRENCY = 1
+CELERY_WORKER_LOG_FORMAT = (
+    '[%(asctime)s: %(levelname)s/%(processName)s] %(message)s'
+)
+CELERY_WORKER_TASK_LOG_FORMAT = (
+    '[%(asctime)s: %(levelname)s/%(processName)s] '
+    '[%(task_name)s(%(task_id)s via %(task_root_id)s)] '
+    '%(message)s'
+)
 
 
 # AWS S3 Bucket Settings

--- a/koku/masu/celery/tasks.py
+++ b/koku/masu/celery/tasks.py
@@ -22,7 +22,6 @@
 import calendar
 import csv
 import math
-import uuid
 from datetime import date
 
 import boto3
@@ -69,8 +68,7 @@ def remove_expired_data():
 @app.task(name='masu.celery.tasks.upload_normalized_data', queue_name='upload')
 def upload_normalized_data():
     """Scheduled task to export normalized data to s3."""
-    log_uuid = str(uuid.uuid4())
-    LOG.info('%s Beginning upload_normalized_data', log_uuid)
+    LOG.info('Beginning upload_normalized_data')
     curr_date = DateAccessor().today()
     curr_month_range = calendar.monthrange(curr_date.year, curr_date.month)
     curr_month_first_day = date(year=curr_date.year, month=curr_date.month, day=1)
@@ -86,8 +84,7 @@ def upload_normalized_data():
 
     for account in accounts:
         LOG.info(
-            '%s processing schema %s provider uuid %s',
-            log_uuid,
+            'processing schema %s provider uuid %s',
             account['schema_name'],
             account['provider_uuid'],
         )
@@ -114,7 +111,7 @@ def upload_normalized_data():
                 prev_month_first_day,
                 prev_month_last_day,
             )
-    LOG.info('%s Completed upload_normalized_data', log_uuid)
+    LOG.info('Completed upload_normalized_data')
 
 
 @app.task(


### PR DESCRIPTION
For #1373 

As discussed in Slack, this adds task IDs to _all_ current logging formats. I've poked the API and Celery a few different ways and produced examples in many combinations below. In general, we always include the root task ID if it's available. In verbose format, we include the current, parent, _and_ root task IDs if they are available.

----

Example log using verbose formatting and the standard logger when in a Celery task. Current task ID is `329ab870-121e-4dfa-8cac-f413cb3b6a6f` and is the root task.
```
INFO 2019-12-10 16:00:36,545 orchestrator 30356 4443162048 329ab870-121e-4dfa-8cac-f413cb3b6a6f None 329ab870-121e-4dfa-8cac-f413cb3b6a6f Getting report files for account (provider uuid): 1623eab0-ed42-4db9-b458-0620ffe2d732
```

Example logs using simple formatting and the standard logger when in a Celery task. Root task ID is `909074e6-da7b-468b-8cf0-2abdf9a91b90`.
```
[2019-12-10 16:25:43,795] INFO 909074e6-da7b-468b-8cf0-2abdf9a91b90 Provider skipped: 1623eab0-ed42-4db9-b458-0620ffe2d732 Valid: True Backing off: True
[2019-12-10 16:25:43,801] INFO 909074e6-da7b-468b-8cf0-2abdf9a91b90 Getting report files for account (provider uuid): c9ca63e9-1534-43c5-b19f-82b486763935
```

Example logs using simple formatting when not in a task (from koku API). No task IDs.
```
[2019-12-10 16:28:00,744] INFO None API: /api/cost-management/v1/costmodels/ -- ACCOUNT: 10001 USER: user_dev
[2019-12-10 16:28:00,860] INFO None "GET /api/cost-management/v1/costmodels/ HTTP/1.1" 200 195
```

Example log from Celery itself not from our task code. No task IDs.
```
[2019-12-10 16:07:43,829: INFO/ForkPoolWorker-1] Found credentials in environment variables.
```

Example logs using the Celery task logger in a task. Root task ID `82f9a4ff-6f8c-4ba9-a7e9-09844d9cece2` also spawned task ID `251941d9-a16d-4bd2-831b-034269b446a9`.
```
[2019-12-10 16:07:43,805: INFO/ForkPoolWorker-1] [masu.celery.tasks.upload_normalized_data(82f9a4ff-6f8c-4ba9-a7e9-09844d9cece2 via 82f9a4ff-6f8c-4ba9-a7e9-09844d9cece2)] Completed upload_normalized_data
[2019-12-10 16:07:43,807: INFO/ForkPoolWorker-1] [masu.celery.tasks.query_and_upload_to_s3(251941d9-a16d-4bd2-831b-034269b446a9 via 82f9a4ff-6f8c-4ba9-a7e9-09844d9cece2)] query_and_upload_to_s3: schema acct10001 provider_uuid 1623eab0-ed42-4db9-b458-0620ffe2d732 table.output_name reporting_awscostentrylineitem for ('2019-12-01T00:00:00', '2019-12-31T00:00:00')
```

