### PR TITLE
Gate metrics data update with None check

### DIFF
--- a/koku/koku/metrics.py
+++ b/koku/koku/metrics.py
@@ -85,7 +85,10 @@ class DatabaseStatus():
         """Collect stats and report using Prometheus objects."""
         stats = self.schema_size()
         for item in stats:
-            PGSQL_GAUGE.labels(schema=item.get('schema')).set(item.get('size'))
+            schema = item.get('schema')
+            size = item.get('size')
+            if schema is not None and size is not None:
+                PGSQL_GAUGE.labels(schema).set(size)
 
     def schema_size(self):
         """Show DB storage consumption.

--- a/koku/koku/tests_metrics.py
+++ b/koku/koku/tests_metrics.py
@@ -52,6 +52,15 @@ class DatabaseStatusTest(IamTestCase):
         dbs.collect()
         self.assertTrue(mock_gauge.called)
 
+    @patch('koku.metrics.PGSQL_GAUGE.labels')
+    @patch('koku.metrics.DatabaseStatus.query', return_value=[{'schema': None,
+                                                               'size': None}])
+    def test_collect_bad_schema_size(self, _, mock_gauge):
+        """Test collect with None data types."""
+        dbs = DatabaseStatus()
+        dbs.collect()
+        self.assertFalse(mock_gauge.called)
+
     def test_query_cache(self):
         """Test that query() returns a cached response when available."""
         dbs = DatabaseStatus()


### PR DESCRIPTION
Sentry saw case where data was None and not expected format, which cause error.

Added gate with none checks.

