### PR TITLE
Code expecting tuple but unhandled provider type returns only None.

### DIFF
--- a/koku/masu/processor/report_summary_updater.py
+++ b/koku/masu/processor/report_summary_updater.py
@@ -97,7 +97,7 @@ class ReportSummaryUpdater:
             return (OCPReportSummaryUpdater(self._schema, self._provider, self._manifest),
                     OCPCloudReportSummaryUpdater(self._schema, self._provider, self._manifest))
 
-        return None
+        return (None, None)
 
     def _format_dates(self, start_date, end_date):
         """Convert dates to strings for use in the updater."""

--- a/koku/masu/test/__init__.py
+++ b/koku/masu/test/__init__.py
@@ -60,6 +60,7 @@ class MasuTestCase(TransactionTestCase):
         cls.ocp_test_provider_uuid = '3c6e687e-1a09-4a05-970c-2ccf44b0952e'
         cls.aws_test_provider_uuid = '6e212746-484a-40cd-bba0-09a19d132d64'
         cls.azure_test_provider_uuid = 'b16c111a-d05f-488c-a6d9-c2a6f3ee02bb'
+        cls.unkown_test_provider_uuid = '16b38e92-773b-4984-8749-e54086f98db7'
         cls.aws_provider_resource_name = 'arn:aws:iam::111111111111:role/CostManagement'
         cls.ocp_provider_resource_name = 'my-ocp-cluster-1'
         cls.aws_test_billing_source = 'test-bucket'
@@ -151,6 +152,27 @@ class MasuTestCase(TransactionTestCase):
         )
         self.azure_provider.save()
         self.azure_provider_uuid = self.azure_provider.uuid
+
+        self.unknonw_auth = ProviderAuthentication.objects.create(
+            provider_resource_name='unknown',
+        )
+        self.unknonw_auth.save()
+        self.unknown_billing_source = ProviderBillingSource.objects.create(
+            bucket='unknown'
+        )
+        self.unknown_billing_source.save()
+
+        self.unknown_provider = Provider.objects.create(
+            uuid=self.unkown_test_provider_uuid,
+            name='Test Provider',
+            type='FOO',
+            authentication=self.unknonw_auth,
+            billing_source=self.unknown_billing_source,
+            customer=self.customer,
+            setup_complete=False,
+            active=True,
+        )
+        self.unknown_provider.save()
 
         # Load static data into the DB
         # E.g. report column maps

--- a/koku/masu/test/__init__.py
+++ b/koku/masu/test/__init__.py
@@ -153,27 +153,6 @@ class MasuTestCase(TransactionTestCase):
         self.azure_provider.save()
         self.azure_provider_uuid = self.azure_provider.uuid
 
-        self.unknonw_auth = ProviderAuthentication.objects.create(
-            provider_resource_name='unknown',
-        )
-        self.unknonw_auth.save()
-        self.unknown_billing_source = ProviderBillingSource.objects.create(
-            bucket='unknown'
-        )
-        self.unknown_billing_source.save()
-
-        self.unknown_provider = Provider.objects.create(
-            uuid=self.unkown_test_provider_uuid,
-            name='Test Provider',
-            type='FOO',
-            authentication=self.unknonw_auth,
-            billing_source=self.unknown_billing_source,
-            customer=self.customer,
-            setup_complete=False,
-            active=True,
-        )
-        self.unknown_provider.save()
-
         # Load static data into the DB
         # E.g. report column maps
         load_db_map_data()

--- a/koku/masu/test/processor/test_report_summary_updater.py
+++ b/koku/masu/test/processor/test_report_summary_updater.py
@@ -18,7 +18,6 @@
 """Test the ReportSummaryUpdater object."""
 
 import datetime
-import uuid
 from unittest.mock import patch
 
 from masu.database.report_manifest_db_accessor import ReportManifestDBAccessor
@@ -164,8 +163,7 @@ class ReportSummaryUpdaterTest(MasuTestCase):
     def test_bad_provider(self):
         """Test that an unimplemented provider throws an error."""
         with self.assertRaises(ReportSummaryUpdaterError):
-            random_uuid = str(uuid.uuid4())
-            _ = ReportSummaryUpdater(self.schema, random_uuid)
+            _ = ReportSummaryUpdater(self.schema, self.unkown_test_provider_uuid)
 
     def test_manifest_is_ready_is_ready(self):
         """Test that True is returned when a manifest is ready to process."""

--- a/koku/masu/test/processor/test_report_summary_updater.py
+++ b/koku/masu/test/processor/test_report_summary_updater.py
@@ -20,6 +20,8 @@
 import datetime
 from unittest.mock import patch
 
+
+from api.provider.models import Provider, ProviderAuthentication, ProviderBillingSource
 from masu.database.report_manifest_db_accessor import ReportManifestDBAccessor
 from masu.external.date_accessor import DateAccessor
 from masu.processor.aws.aws_report_summary_updater import AWSReportSummaryUpdater
@@ -162,6 +164,27 @@ class ReportSummaryUpdaterTest(MasuTestCase):
 
     def test_bad_provider(self):
         """Test that an unimplemented provider throws an error."""
+        self.unknown_auth = ProviderAuthentication.objects.create(
+            provider_resource_name='unknown',
+        )
+        self.unknown_auth.save()
+        self.unknown_billing_source = ProviderBillingSource.objects.create(
+            bucket='unknown'
+        )
+        self.unknown_billing_source.save()
+
+        self.unknown_provider = Provider.objects.create(
+            uuid=self.unkown_test_provider_uuid,
+            name='Test Provider',
+            type='FOO',
+            authentication=self.unknown_auth,
+            billing_source=self.unknown_billing_source,
+            customer=self.customer,
+            setup_complete=False,
+            active=True,
+        )
+        self.unknown_provider.save()
+
         with self.assertRaises(ReportSummaryUpdaterError):
             _ = ReportSummaryUpdater(self.schema, self.unkown_test_provider_uuid)
 


### PR DESCRIPTION
This is cause because the provider type is `GCP` and there is no case to handle this provider type and the final result only returns a None, but the return object is expected to be a tuple.

<img width="875" alt="image" src="https://user-images.githubusercontent.com/29379759/70641857-43267300-1c0c-11ea-943b-8d1975fc8448.png">


https://github.com/project-koku/koku/blob/master/koku/masu/processor/report_summary_updater.py#L100