### PR TITLE
1520 add coalesce to infra-cost calculation

### DIFF
--- a/koku/api/report/ocp/provider_map.py
+++ b/koku/api/report/ocp/provider_map.py
@@ -85,7 +85,9 @@ class OCPProviderMap(ProviderMap):
                                 + Coalesce(F('markup_cost'), Value(0, output_field=DecimalField()))
                                 + Coalesce(F('monthly_cost'), Value(0, output_field=DecimalField()))
                             ),
-                            'infrastructure_cost': Sum(F('infra_cost')),
+                            'infrastructure_cost': Sum(
+                                Coalesce(F('infra_cost'), Value(0, output_field=DecimalField()))
+                            ),
                             'derived_cost': Sum(
                                 Coalesce(F('pod_charge_cpu_core_hours'),
                                          Value(0, output_field=DecimalField()))
@@ -112,7 +114,9 @@ class OCPProviderMap(ProviderMap):
                                 + Coalesce(F('markup_cost'), Value(0, output_field=DecimalField()))
                                 + Coalesce(F('monthly_cost'), Value(0, output_field=DecimalField()))
                             ),
-                            'infrastructure_cost': Sum(F('infra_cost')),
+                            'infrastructure_cost': Sum(
+                                Coalesce(F('infra_cost'), Value(0, output_field=DecimalField()))
+                            ),
                             'derived_cost': Sum(
                                 Coalesce(F('pod_charge_cpu_core_hours'),
                                          Value(0, output_field=DecimalField()))
@@ -158,7 +162,9 @@ class OCPProviderMap(ProviderMap):
                                 + Coalesce(F('project_infra_cost'), Value(0, output_field=DecimalField()))
                                 + Coalesce(F('project_markup_cost'), Value(0, output_field=DecimalField()))
                             ),
-                            'infrastructure_cost': Sum(F('project_infra_cost')),
+                            'infrastructure_cost': Sum(
+                                Coalesce(F('project_infra_cost'), Value(0, output_field=DecimalField()))
+                            ),
                             'derived_cost': Sum(
                                 Coalesce(F('pod_charge_cpu_core_hours'),
                                          Value(0, output_field=DecimalField()))
@@ -181,7 +187,9 @@ class OCPProviderMap(ProviderMap):
                                 + Coalesce(F('project_infra_cost'), Value(0, output_field=DecimalField()))
                                 + Coalesce(F('project_markup_cost'), Value(0, output_field=DecimalField()))
                             ),
-                            'infrastructure_cost': Sum(F('project_infra_cost')),
+                            'infrastructure_cost': Sum(
+                                Coalesce(F('project_infra_cost'), Value(0, output_field=DecimalField()))
+                            ),
                             'derived_cost': Sum(
                                 Coalesce(F('pod_charge_cpu_core_hours'),
                                          Value(0, output_field=DecimalField()))


### PR DESCRIPTION
#1520 

We were missing a `Coalesce` on the `infrastructure_cost` and `project_ infrastructure_cost`.

Testing:
1. Add OCP provider, ingest Nise data
2. http://localhost:8000/api/cost-management/v1/reports/openshift/costs/
3. See infra_cost is not null

```
        "total": {
            "cost": {
                "value": 0.0,
                "units": "USD"
            },
            "infrastructure_cost": {
                "value": 0.0,
                "units": "USD"
            },
            "derived_cost": {
                "value": 0.0,
                "units": "USD"
            },
            "markup_cost": {
                "value": 0.0,
                "units": "USD"
            },
            "monthly_cost": {
                "value": 0.0,
                "units": "USD"
            }
        }
```