### PR TITLE
Display $/month/node cost under derived_cost in reports.

### DIFF
--- a/koku/api/provider/models.py
+++ b/koku/api/provider/models.py
@@ -40,7 +40,7 @@ class ProviderAuthentication(models.Model):
 
     # XXX: This field is DEPRECATED
     # XXX: the credentials field should be used instead.
-    # Ex: AWS ARN for cross-acount role access
+    # Ex: AWS ARN for cross-account role access
     provider_resource_name = models.TextField(null=True, unique=True)
 
     credentials = JSONField(null=True, default=dict)

--- a/koku/api/report/ocp/provider_map.py
+++ b/koku/api/report/ocp/provider_map.py
@@ -95,12 +95,11 @@ class OCPProviderMap(ProviderMap):
                                            Value(0, output_field=DecimalField()))
                                 + Coalesce(F('persistentvolumeclaim_charge_gb_month'),
                                            Value(0, output_field=DecimalField()))
+                                + Coalesce(F('monthly_cost'), Value(0, output_field=DecimalField()))
+
                             ),
                             'markup_cost': Sum(
                                 Coalesce(F('markup_cost'), Value(0, output_field=DecimalField()))
-                            ),
-                            'monthly_cost': Sum(
-                                Coalesce(F('monthly_cost'), Value(0, output_field=DecimalField()))
                             ),
                         },
                         'default_ordering': {'cost': 'desc'},
@@ -124,12 +123,10 @@ class OCPProviderMap(ProviderMap):
                                            Value(0, output_field=DecimalField()))
                                 + Coalesce(F('persistentvolumeclaim_charge_gb_month'),
                                            Value(0, output_field=DecimalField()))
+                                + Coalesce(F('monthly_cost'), Value(0, output_field=DecimalField()))
                             ),
                             'markup_cost': Sum(
                                 Coalesce(F('markup_cost'), Value(0, output_field=DecimalField()))
-                            ),
-                            'monthly_cost': Sum(
-                                Coalesce(F('monthly_cost'), Value(0, output_field=DecimalField()))
                             ),
                             'cost_units': Value('USD', output_field=CharField())
                         },
@@ -147,7 +144,7 @@ class OCPProviderMap(ProviderMap):
                         },
                         'filter': [{}],
                         'cost_units_key': 'USD',
-                        'sum_columns': ['cost', 'infrastructure_cost', 'derived_cost', 'markup_cost', 'monthly_cost'],
+                        'sum_columns': ['cost', 'infrastructure_cost', 'derived_cost', 'markup_cost'],
                     },
                     'costs_by_project': {
                         'tables': {

--- a/koku/cost_models/models.py
+++ b/koku/cost_models/models.py
@@ -16,13 +16,19 @@
 #
 
 """Models for cost models."""
+import logging
+from functools import partial
 from uuid import uuid4
 
 from django.contrib.postgres.fields import ArrayField, JSONField
 from django.core.serializers.json import DjangoJSONEncoder
-from django.db import models
+from django.db import models, transaction
+from django.dispatch import receiver
 
 from api.provider.models import Provider
+
+
+LOG = logging.getLogger(__name__)
 
 
 class CostModel(models.Model):
@@ -58,6 +64,41 @@ class CostModel(models.Model):
     rates = JSONField(default=dict)
 
     markup = JSONField(encoder=DjangoJSONEncoder, default=dict)
+
+
+@receiver(models.signals.pre_delete, sender=CostModel)
+def cost_model_pre_delete_callback(*args, **kwargs):
+    """
+    Before deleting the cost model, queue tasks to recalculate costs associated with this.
+
+    Note: Signal receivers must accept keyword arguments (**kwargs).
+    """
+    cost_model = kwargs['instance']
+
+    # Local import of task function to avoid potential import cycle.
+    from masu.processor.tasks import update_charge_info
+
+    cost_model_maps = CostModelMap.objects.filter(cost_model=cost_model)
+    for cost_model_map in cost_model_maps:
+        try:
+            provider = Provider.objects.get(uuid=cost_model_map.provider_uuid)
+            if not provider.customer:
+                LOG.warning(
+                    'Provider %s has no Customer; we cannot call update_charge_info.',
+                    provider.uuid,
+                )
+                continue
+            schema_name = provider.customer.schema_name
+            delete_func = partial(
+                update_charge_info.delay,
+                schema_name,
+                cost_model_map.provider_uuid,
+            )
+            transaction.on_commit(delete_func)
+        except Provider.DoesNotExist:
+            LOG.warning('Cost model map %s refers to invalid provider id %s.',
+                        cost_model_map.id,
+                        cost_model_map.provider_uuid)
 
 
 class CostModelAudit(models.Model):

--- a/koku/cost_models/test/test_models.py
+++ b/koku/cost_models/test/test_models.py
@@ -1,0 +1,90 @@
+"""Test for the CostModels model."""
+import logging
+import random
+from unittest.mock import patch
+from uuid import UUID
+
+from faker import Faker
+from tenant_schemas.utils import tenant_context
+
+from api.iam.models import Tenant
+from api.provider.models import Provider
+from cost_models.models import CostModel, CostModelMap
+from masu.test import MasuTestCase
+
+FAKE = Faker()
+
+
+class CostModelTest(MasuTestCase):
+    """Test cases for the CostModel model."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up the test class."""
+        super().setUpClass()
+        if not getattr(cls, 'tenant', None):
+            cls.tenant = Tenant.objects.get_or_create(schema_name=cls.schema)[0]
+
+        # Must set this to capture the logger messages in the tests.
+        logging.disable(0)
+
+    def setUp(self):
+        """Set up the shared variables for each test case."""
+        super().setUp()
+        with tenant_context(self.tenant):
+            self.cost_model = CostModel.objects.create(
+                name=FAKE.word(),
+                description=FAKE.word(),
+                source_type=random.choice(Provider.PROVIDER_CHOICES)
+            )
+            self.cost_model_map = CostModelMap.objects.create(
+                cost_model=self.cost_model, provider_uuid=self.aws_provider_uuid
+            )
+
+    @patch('masu.processor.tasks.update_charge_info')
+    def test_delete_cost_model_instance(self, mock_update_charge_info):
+        """Assert the update_charge_info task is called on instance delete."""
+        with tenant_context(self.tenant):
+            self.cost_model.delete()
+        mock_update_charge_info.delay.assert_called_with(
+            self.schema, UUID(self.aws_provider_uuid)
+        )
+
+    @patch('masu.processor.tasks.update_charge_info')
+    def test_delete_cost_model_instance_skips_task_if_provider_has_no_customers(
+        self, mock_update_charge_info
+    ):
+        """Assert the update_charge_info task is not called if Customer is None."""
+        with tenant_context(self.tenant), self.assertLogs(
+            'cost_models.models', 'WARNING'
+        ) as captured_logs:
+            self.aws_provider.customer = None
+            self.aws_provider.save()
+            self.cost_model.delete()
+        mock_update_charge_info.delay.assert_not_called()
+        self.assertIn('has no Customer', captured_logs.output[0])
+
+    @patch('masu.processor.tasks.update_charge_info')
+    def test_delete_cost_model_instance_skips_task_if_provider_uuid_invalid(
+        self, mock_update_charge_info
+    ):
+        """Assert the update_charge_info task is not called if the provider uuid is invalid."""
+        with tenant_context(self.tenant), self.assertLogs(
+            'cost_models.models', 'WARNING'
+        ) as captured_logs:
+            self.cost_model_map.provider_uuid = FAKE.uuid4()
+            self.cost_model_map.save()
+            self.cost_model.delete()
+        mock_update_charge_info.delay.assert_not_called()
+        self.assertIn('invalid provider id', captured_logs.output[0])
+
+    @patch('masu.processor.tasks.update_charge_info')
+    def test_delete_cost_model_instance_skips_task_if_cost_model_map_does_not_exist(
+        self, mock_update_charge_info
+    ):
+        """Assert the update_charge_info task is not called if a cost_model_map does not exist."""
+
+        with tenant_context(self.tenant):
+            self.cost_model_map.delete()
+            self.cost_model.delete()
+        mock_update_charge_info.delay.assert_not_called()

--- a/koku/masu/database/ocp_report_db_accessor.py
+++ b/koku/masu/database/ocp_report_db_accessor.py
@@ -774,3 +774,30 @@ class OCPReportDBAccessor(ReportDBAccessorBase):
                     usage_end=first_curr_month,
                     monthly_cost=total_cost
                 )
+
+    def remove_monthly_cost(self):
+        """Delete all the monthly costs of a customer."""
+
+        # start_date should be the first month this ocp was used
+        start_date = OCPUsageLineItemDailySummary.objects.aggregate(
+            Min('usage_start')
+        )['usage_start__min']
+        # If end_date is not provided, recalculate till the latest month
+        end_date = OCPUsageLineItemDailySummary.objects.aggregate(
+            Max('usage_end')
+        )['usage_end__max']
+
+        LOG.info('Removing monthly costs from %s to %s.', start_date, end_date)
+
+        first_month = start_date.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+
+        with schema_context(self.schema):
+            # Calculate monthly cost for every month
+            for curr_month in rrule(freq=MONTHLY, until=end_date, dtstart=first_month):
+                first_curr_month, _ = month_date_range_tuple(curr_month)
+
+                # Remove existing monthly costs
+                OCPUsageLineItemDailySummary.objects.filter(
+                    usage_start=first_curr_month,
+                    monthly_cost__isnull=False
+                ).delete()

--- a/koku/masu/processor/ocp/ocp_report_charge_updater.py
+++ b/koku/masu/processor/ocp/ocp_report_charge_updater.py
@@ -294,9 +294,17 @@ class OCPReportChargeUpdater(OCPCloudUpdaterBase):
                 if rates:
                     tiers = self._normalize_tier(rates.get('tiered_rates', []))
                     for tier in tiers:
+                        LOG.info('Updating Monthly Cost for'
+                                 '\n\tSchema: %s \n\tProvider: %s \n\tDates: %s - %s',
+                                 self._schema, self._provider_uuid, start_date, end_date)
+
                         node_rate = Decimal(tier.get('value'))
                         report_accessor.populate_monthly_cost(node_rate, start_date, end_date)
-
+                else:
+                    LOG.info('Removing Monthly Cost for'
+                             'Schema: %s, Provider: %s ',
+                             self._schema, self._provider_uuid)
+                    report_accessor.remove_monthly_cost()
         except OCPReportChargeUpdaterError as error:
             LOG.error('Unable to update monthly costs. Error: %s', str(error))
 


### PR DESCRIPTION
Queue  update_charge_info task  when a cost_model is deleted.