### PR TITLE
change base_name to basename

### DIFF
--- a/koku/api/urls.py
+++ b/koku/api/urls.py
@@ -57,12 +57,12 @@ from api.views import (
 
 
 ROUTER = DefaultRouter()
-ROUTER.register(r'dataexportrequests', DataExportRequestViewSet, base_name='dataexportrequests')
-ROUTER.register(r'metrics', CostModelMetricsMapViewSet, base_name='metrics')
+ROUTER.register(r'dataexportrequests', DataExportRequestViewSet, basename='dataexportrequests')
+ROUTER.register(r'metrics', CostModelMetricsMapViewSet, basename='metrics')
 ROUTER.register(r'providers', ProviderViewSet)
-ROUTER.register(r'sources', SourcesProxyViewSet, base_name='sources-proxy')
-ROUTER.register(r'preferences', UserPreferenceViewSet, base_name='preferences')
-ROUTER.register(r'cloud-accounts', CloudAccountViewSet, base_name='cloud_accounts')
+ROUTER.register(r'sources', SourcesProxyViewSet, basename='sources-proxy')
+ROUTER.register(r'preferences', UserPreferenceViewSet, basename='preferences')
+ROUTER.register(r'cloud-accounts', CloudAccountViewSet, basename='cloud_accounts')
 # pylint: disable=invalid-name
 urlpatterns = [
 

--- a/koku/cost_models/urls.py
+++ b/koku/cost_models/urls.py
@@ -20,7 +20,7 @@ from rest_framework.routers import DefaultRouter
 from cost_models.views import CostModelViewSet
 
 ROUTER = DefaultRouter()
-ROUTER.register(r'costmodels', CostModelViewSet, base_name='costmodels')
+ROUTER.register(r'costmodels', CostModelViewSet, basename='costmodels')
 
 # pylint: disable=invalid-name
 urlpatterns = [


### PR DESCRIPTION
base_name in ROUTER.register() was deprecated and removed. This PR changes base_name to basename.

For reference, [here is the diff](https://github.com/encode/django-rest-framework/pull/7075/files#diff-88b0cad65f9e1caad64e0c9bb44615f9L61) to djangorestframework that requires this PR.