### PR TITLE
log.error -> log.info for invalid query parameter format, because ser…

### DIFF
--- a/koku/api/query_params.py
+++ b/koku/api/query_params.py
@@ -222,7 +222,7 @@ class QueryParameters:
         try:
             query_params = parser.parse(self.url_data)
         except parser.MalformedQueryStringError:
-            LOG.error('Invalid query parameter format %s.', self.url_data)
+            LOG.info('Invalid query parameter format %s.', self.url_data)
             error = {'details': _(f'Invalid query parameter format.')}
             raise ValidationError(error)
 


### PR DESCRIPTION
change log.error to log.info because the serializer already logs this error. 