### PR TITLE
Resolve cloud watch logging stream name collision.

### DIFF
--- a/koku/koku/settings.py
+++ b/koku/koku/settings.py
@@ -387,21 +387,16 @@ LOGGING = {
 }
 
 if CW_AWS_ACCESS_KEY_ID:
-    NAMESPACE = 'unknown'
+    POD_NAME = ENVIRONMENT.get_value('APP_POD_NAME', default='local')
     BOTO3_SESSION = Session(aws_access_key_id=CW_AWS_ACCESS_KEY_ID,
                             aws_secret_access_key=CW_AWS_SECRET_ACCESS_KEY,
                             region_name=CW_AWS_REGION)
-    try:
-        with open("/var/run/secrets/kubernetes.io/serviceaccount/namespace", "r") as f:
-            NAMESPACE = f.read()
-    except Exception:  # pylint: disable=W0703
-        pass
     WATCHTOWER_HANDLER = {
         'level': KOKU_LOGGING_LEVEL,
         'class': 'watchtower.CloudWatchLogHandler',
         'boto3_session': BOTO3_SESSION,
         'log_group': CW_LOG_GROUP,
-        'stream_name': NAMESPACE,
+        'stream_name': POD_NAME,
         'formatter': LOGGING_FORMATTER,
     }
     LOGGING['handlers']['watchtower'] = WATCHTOWER_HANDLER


### PR DESCRIPTION
* Assign stream_name with pod name passed in from environment variable

Related to: https://github.com/RedHatInsights/e2e-deploy/pull/928