### PR TITLE
1436 OCP no-tag

### DIFF
--- a/koku/api/report/ocp/query_handler.py
+++ b/koku/api/report/ocp/query_handler.py
@@ -125,8 +125,6 @@ class OCPReportQueryHandler(ReportQueryHandler):
         q_table = self._mapper.query_table
         with tenant_context(self.tenant):
             query = q_table.objects.filter(self.query_filter)
-            if self.query_exclusions:
-                query = query.exclude(self.query_exclusions)
             query_data = query.annotate(**self.annotations)
             group_by_value = self._get_group_by()
 

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -58,7 +58,6 @@ class ReportQueryHandler(QueryHandler):
         self.query_delta = {'value': None, 'percent': None}
 
         self.query_filter = self._get_filter()
-        self.query_exclusions = self._get_exclusions()
 
     def initialize_totals(self):
         """Initialize the total response column values."""
@@ -273,32 +272,6 @@ class ReportQueryHandler(QueryHandler):
 
         LOG.debug(f'_get_filter: {composed_filters}')
         return composed_filters
-
-    def _get_exclusions(self, delta=False):
-        """Create dictionary for filter parameters for exclude clause.
-
-        Returns:
-            (Dict): query filter dictionary
-
-        """
-        exclusions = QueryFilterCollection()
-        tag_column = self._mapper.tag_column
-        tag_group_by = self.get_tag_group_by_keys()
-        if tag_group_by:
-            for tag in tag_group_by:
-                tag_db_name = tag_column + '__' + strip_tag_prefix(tag)
-                filt = {
-                    'field': tag_db_name,
-                    'operation': 'isnull',
-                    'parameter': True
-                }
-                q_filter = QueryFilter(**filt)
-                exclusions.add(q_filter)
-
-        composed_exclusions = exclusions.compose()
-
-        LOG.debug(f'_get_exclusions: {composed_exclusions}')
-        return composed_exclusions
 
     def _get_group_by(self):
         """Create list for group_by parameters."""

--- a/koku/api/report/test/ocp/test_ocp_query_handler.py
+++ b/koku/api/report/test/ocp/test_ocp_query_handler.py
@@ -470,22 +470,6 @@ class OCPReportQueryHandlerTest(IamTestCase):
 
         self.assertEqual(repr(filters), expected)
 
-    def test_get_exclusions(self):
-        """Test that exclusions are properly set."""
-        url = '?'
-        query_params = self.mocked_query_params(url, OCPTagView)
-        handler = OCPTagQueryHandler(query_params)
-        tag_keys = handler.get_tag_keys(filters=False)
-
-        group_by_key = tag_keys[0]
-        group_by_value = 'group_By'
-        url = f'?group_by[tag:{group_by_key}]={group_by_value}'
-        query_params = self.mocked_query_params(url, OCPCpuView)
-        handler = OCPReportQueryHandler(query_params)
-        exclusions = handler._get_exclusions()
-        expected = f"<Q: (AND: ('pod_labels__{group_by_key}__isnull', True))>"
-        self.assertEqual(repr(exclusions), expected)
-
     def test_get_tag_group_by(self):
         """Test that tag based group bys work."""
         url = '?'


### PR DESCRIPTION
#1436 
Now that we want to report things that are not tagged, we need to remove the query_exclusions from the OCP query handler.

Testing:
1. Generate Nise data using the 4 static files in the linked issue.
2. Ingest the Nise data.
3.  reports/openshift/costs/?group_by[or:tag:qe]=*&filter[resolution]=monthly

See the `no-qe` entry.

```
"data": [
        {
            "date": "2020-01",
            "qes": [
                {
                    "qe": "rock",
                    "values": [
                        {
                            "qe": "rock",
                            "date": "2020-01",
                            "cost": {
                                "value": 0.0,
                                "units": "USD"
                            },
                            "infrastructure_cost": {
                                "value": 0.0,
                                "units": "USD"
                            },
                            "derived_cost": {
                                "value": 0.0,
                                "units": "USD"
                            },
                            "markup_cost": {
                                "value": 0.0,
                                "units": "USD"
                            }
                        }
                    ]
                },
                {
                    "qe": "no-qe",
                    "values": [
                        {
                            "qe": "no-qe",
                            "date": "2020-01",
                            "cost": {
                                "value": 0.0,
                                "units": "USD"
                            },
                            "infrastructure_cost": {
                                "value": 0.0,
                                "units": "USD"
                            },
                            "derived_cost": {
                                "value": 0.0,
                                "units": "USD"
                            },
                            "markup_cost": {
                                "value": 0.0,
                                "units": "USD"
                            }
                        }
                    ]
                }
            ]
        }
    ]
```