### PR TITLE
Makefile and create_test_customer adjustments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ create-test-customer-no-providers: run-migrations
 	sleep 1
 	$(DJANGO_MANAGE) runserver > /dev/null 2>&1 &
 	sleep 5
-	$(PYTHON) $(TOPDIR)/scripts/create_test_customer.py --no-providers || echo "WARNING: create_test_customer failed unexpectedly!"
+	$(PYTHON) $(TOPDIR)/scripts/create_test_customer.py --no-providers --bypass-api || echo "WARNING: create_test_customer failed unexpectedly!"
 	kill -HUP $$(ps -eo pid,command | grep "manage.py runserver" | grep -v grep | awk '{print $$1}')
 
 
@@ -465,12 +465,15 @@ docker-up-db:
 	docker-compose up -d db
 
 docker-iqe-smokes-tests:
+	$(MAKE) docker-reinitdb
 	./testing/run_smoke_tests.sh
 
 docker-iqe-api-tests:
+	$(MAKE) docker-reinitdb
 	./testing/run_api_tests.sh
 
 docker-iqe-vortex-tests:
+	$(MAKE) docker-reinitdb
 	./testing/run_vortex_api_tests.sh
 
 ########################

--- a/scripts/create_test_customer.py
+++ b/scripts/create_test_customer.py
@@ -70,7 +70,7 @@ class KokuCustomerOnboarder:
         self.endpoint_base = 'http://{}:{}{}/v1/'.format(
             self.koku.get("host"),
             self.koku.get("port"),
-            os.getenv("API_PATH_PREFIX", self.koku.get("prefix")))
+            self._config.get("api_prefix") or self.koku.get("prefix"))
 
         self.auth_token = get_token(self.customer.get('account_id'),
                                     self.customer.get('user'),
@@ -256,6 +256,9 @@ if __name__ == '__main__':
                         help='Create Provider in DB, bypassing Koku API')
     PARSER.add_argument('--no-providers', dest='no_providers', action='store_true',
                         help='Don\'t create providers at all')
+    PARSER.add_argument('--api-prefix', dest='api_prefix',
+                        help='API path prefix',
+                        default=os.getenv("API_PATH_PREFIX"))
     ARGS = vars(PARSER.parse_args())
 
     if ARGS['no_providers'] and not ARGS['bypass_api']:

--- a/scripts/test_customer.yaml
+++ b/scripts/test_customer.yaml
@@ -42,4 +42,4 @@ customer:
 koku:
   host: localhost
   port: 8000
-  prefix: api
+  prefix: ${API_PATH_PREFIX:/api}

--- a/scripts/test_customer.yaml
+++ b/scripts/test_customer.yaml
@@ -42,4 +42,4 @@ customer:
 koku:
   host: localhost
   port: 8000
-  prefix: ${API_PATH_PREFIX:/api}
+  prefix: /api


### PR DESCRIPTION
Some adjustments to the Makefile and the create_test_customer script. 

For the makefile, added a missing parameter for reinitializing the db without providers. **Also, the db is cleared when IQE tests are run in docker.**

In the create_test_customer, the yaml loader can now grab environment variables. To use an env variable, it must be defined in the yaml like: `${ENV_VAR:default_value}` where `ENV_VAR` is the variable you want, and `default_value` is the default when the variable is undefined. 