### PR TITLE
Add human readable openapi.html to static files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ PYTHON	= $(shell which python)
 TOPDIR  = $(shell pwd)
 PYDIR	= koku
 APIDOC  = apidoc
+OPENAPI_SPEC_PATH = ./docs/source/specs/openapi.json
 
 # How to execute Django's manage.py
 DJANGO_MANAGE = DJANGO_READ_DOT_ENV_FILE=True $(PYTHON) $(PYDIR)/manage.py
@@ -36,6 +37,8 @@ ifeq ($(OS),Darwin)
 else
 	PREFIX	= sudo
 endif
+
+NPX := $(shell command -v npx 2> /dev/null)
 
 define HELP_TEXT =
 Please use \`make <target>' where <target> is one of:
@@ -126,6 +129,9 @@ clean:
 
 html:
 	@cd docs; $(MAKE) html
+ifdef NPX
+	npx redoc-cli bundle $(OPENAPI_SPEC_PATH) -o ./docs/source/specs/openapi.html
+endif
 
 lint:
 	tox -e lint

--- a/koku/api/urls.py
+++ b/koku/api/urls.py
@@ -53,6 +53,7 @@ from api.views import (
     authentication,
     billing_source,
     openapi,
+    openapiHtml,
 )
 
 
@@ -68,6 +69,7 @@ urlpatterns = [
 
     url(r'^status/$', StatusView.as_view(), name='server-status'),
     url(r'^openapi.json', openapi, name='openapi'),
+    url(r'^openapi.html', openapiHtml, name='openapiHtml'),
     url(r'^tags/aws/$', AWSTagView.as_view(), name='aws-tags'),
     url(r'^tags/azure/$', AzureTagView.as_view(), name='azure-tags'),
     url(r'^tags/openshift/$', OCPTagView.as_view(), name='openshift-tags'),

--- a/koku/api/views.py
+++ b/koku/api/views.py
@@ -21,7 +21,7 @@
 from api.dataexport.views import DataExportRequestViewSet
 from api.iam.view.user_preference import UserPreferenceViewSet
 from api.metrics.views import CostModelMetricsMapViewSet
-from api.openapi.view import openapi
+from api.openapi.view import openapi, openapiHtml
 from api.provider.view import ProviderViewSet
 from api.report.all.openshift.view import (OCPAllCostView,
                                            OCPAllInstanceTypeView,


### PR DESCRIPTION
Right now, we can see OpenAPI spec in its JSON format but it can be very confusing and not readable.
I thought about using [`redoc`](https://github.com/Redocly/redoc) to get a user-friendly HTML format.

![image](https://user-images.githubusercontent.com/2453279/72063296-3025c200-32e2-11ea-9f90-87b29ccf704a.png)

## What did you change in the code? :thinking: 

I updated `make html` to create `openapi.html` if `npm` is installed as it's required to `redoc-cli`.

I also added a new route to `/openapi.html` to display openapi in HTML format. To avoid code duplication I moved some parts of `get_json` and `openapi` to a new method `static_response`.

Just let me know what you think. I personally think it's much more readable than JSON.