### PR TITLE
1493 collect db metrics with celery task

### DIFF
--- a/koku/api/apps.py
+++ b/koku/api/apps.py
@@ -16,8 +16,6 @@
 #
 """API application configuration module."""
 
-import sys
-
 from django.apps import AppConfig
 
 
@@ -25,9 +23,3 @@ class ApiConfig(AppConfig):
     """API application configuration."""
 
     name = 'api'
-
-    def ready(self):
-        """Determine if app is ready on application startup."""
-        # Don't run on Django tab completion commands
-        if 'manage.py' in sys.argv[0] and 'runserver' not in sys.argv:
-            return

--- a/koku/koku/celery.py
+++ b/koku/koku/celery.py
@@ -119,7 +119,7 @@ app.conf.beat_schedule['vacuum-schemas'] = {
 # Collect prometheus metrics.
 app.conf.beat_schedule['db_metrics'] = {
     'task': 'koku.metrics.collect_metrics',
-    'schedule': crontab(hour='*/3'),
+    'schedule': crontab(minute='*/15'),
 }
 
 # Toggle to enable/disable S3 archiving of account data.

--- a/koku/koku/celery.py
+++ b/koku/koku/celery.py
@@ -116,6 +116,12 @@ app.conf.beat_schedule['vacuum-schemas'] = {
     'args': []
 }
 
+# Collect prometheus metrics.
+app.conf.beat_schedule['db_metrics'] = {
+    'task': 'koku.metrics.collect_metrics',
+    'schedule': crontab(hour='*/3'),
+}
+
 # Toggle to enable/disable S3 archiving of account data.
 if ENVIRONMENT.bool('ENABLE_S3_ARCHIVING', default=True):
     app.conf.beat_schedule['daily_upload_normalized_reports_to_s3'] = {

--- a/koku/koku/metrics.py
+++ b/koku/koku/metrics.py
@@ -33,7 +33,7 @@ PGSQL_GAUGE = Gauge('postgresql_schema_size_bytes',
 class DatabaseStatus():
     """Database status information."""
 
-    def query(self, query):
+    def query(self, query):  # pylint: disable=R0201
         """Execute a SQL query, format the results.
 
         Returns:

--- a/koku/koku/settings.py
+++ b/koku/koku/settings.py
@@ -435,7 +435,7 @@ RABBITMQ_HOST = os.getenv('RABBITMQ_HOST', 'localhost')
 RABBITMQ_PORT = os.getenv('RABBITMQ_PORT', '5672')
 
 CELERY_BROKER_URL = f'amqp://{RABBITMQ_HOST}:{RABBITMQ_PORT}'
-CELERY_IMPORTS = ('masu.processor.tasks', 'masu.celery.tasks',)
+CELERY_IMPORTS = ('masu.processor.tasks', 'masu.celery.tasks', 'koku.metrics',)
 CELERY_BROKER_POOL_LIMIT = None
 CELERY_WORKER_PREFETCH_MULTIPLIER = 1
 CELERY_WORKER_CONCURRENCY = 1

--- a/koku/koku/tests_metrics.py
+++ b/koku/koku/tests_metrics.py
@@ -24,7 +24,7 @@ from django.db import OperationalError
 from faker import Faker
 
 from api.iam.test.iam_test_case import IamTestCase
-from koku.metrics import DatabaseStatus
+from koku.metrics import DatabaseStatus, collect_metrics
 
 FAKE = Faker()
 
@@ -49,6 +49,14 @@ class DatabaseStatusTest(IamTestCase):
         """Test collect()."""
         dbs = DatabaseStatus()
         dbs.collect()
+        self.assertTrue(mock_gauge.called)
+
+    @patch('koku.metrics.PGSQL_GAUGE.labels')
+    @patch('koku.metrics.DatabaseStatus.query', return_value=[{'schema': 'foo',
+                                                               'size': 10}])
+    def test_collect_metrics(self, _, mock_gauge):
+        """Test collect_metrics."""
+        collect_metrics()
         self.assertTrue(mock_gauge.called)
 
     @patch('koku.metrics.PGSQL_GAUGE.labels')

--- a/koku/koku/tests_metrics.py
+++ b/koku/koku/tests_metrics.py
@@ -61,7 +61,7 @@ class DatabaseStatusTest(IamTestCase):
         self.assertFalse(mock_gauge.called)
 
     @patch('time.sleep', return_value=None)  # make this test go 6 seconds faster :)
-    def test_query_exception(self, patched_sleep):
+    def test_query_exception(self, patched_sleep):  # pylint: disable=W0613
         """Test _query() when an exception is thrown."""
         logging.disable(logging.NOTSET)
         with mock.patch('django.db.backends.utils.CursorWrapper') as mock_cursor:

--- a/koku/koku/tests_metrics.py
+++ b/koku/koku/tests_metrics.py
@@ -17,7 +17,6 @@
 """Test the prometheus metrics."""
 import logging
 import random
-from datetime import datetime
 from unittest import mock
 from unittest.mock import Mock, patch
 
@@ -61,14 +60,6 @@ class DatabaseStatusTest(IamTestCase):
         dbs.collect()
         self.assertFalse(mock_gauge.called)
 
-    def test_query_cache(self):
-        """Test that query() returns a cached response when available."""
-        dbs = DatabaseStatus()
-        dbs._last_result = 1
-        dbs._last_query = datetime.now()
-        result = dbs.query('SELECT count(*) from now()')
-        self.assertEqual(result, 1)
-
     def test_query_exception(self):
         """Test _query() when an exception is thrown."""
         logging.disable(0)
@@ -77,7 +68,7 @@ class DatabaseStatusTest(IamTestCase):
             mock_cursor.execute.side_effect = OperationalError('test exception')
             test_query = 'SELECT count(*) from now()'
             dbs = DatabaseStatus()
-            with self.assertLogs(level=logging.WARNING):
+            with self.assertLogs(logger='koku.metrics.collect_metrics', level=logging.WARNING):
                 dbs.query(test_query)
 
     @patch('koku.metrics.connection')


### PR DESCRIPTION
#1493 

The db metrics collection thread was started on django startup. Whenever the connection to the db was dropped, the connection was never reestablished.

This PR makes the metrics collection a celery task. It runs every 3 hours.

For testing, I applied this diff:
```
--- a/koku/koku/celery.py
+++ b/koku/koku/celery.py
@@ -119,7 +119,7 @@ app.conf.beat_schedule['vacuum-schemas'] = {
 # Collect prometheus metrics.
 app.conf.beat_schedule['db_metrics'] = {
     'task': 'koku.metrics.collect_metrics',
-    'schedule': crontab(hour='*/3'),
+    'schedule': crontab(),
 }
```
Then:
1. Start all services and enable logs for koku-worker. `docker-compose up -d && docker-compose logs -f koku-worker`
2. Wait. See this error logged every minute:
```
koku_worker       | [2020-01-09 22:35:07,276: ERROR/ForkPoolWorker-1] [koku.metrics.collect_metrics(dba29943-9928-4392-aa7e-876bea009c2b via dba29943-9928-4392-aa7e-876bea009c2b)] Query failed to return results.
koku_worker       | [2020-01-09 22:35:07,290: ERROR/ForkPoolWorker-1] [koku.metrics.collect_metrics(78925e6d-1b40-4ca4-aab4-553d8d9a5125 via 78925e6d-1b40-4ca4-aab4-553d8d9a5125)] Query failed to return results.
```
3. Hit an endpoint (i.e. http://localhost:8000/api/cost-management/v1/providers/) and notice that the error stops appearing.
4. Stop the db: `docker-compose stop db`
5. Do some more waiting and notice a new error:
```
koku_worker       | [2020-01-09 22:38:00,014: WARNING/ForkPoolWorker-1] [koku.metrics.collect_metrics(4fb19b65-a699-4ea1-98f2-a99bc1eeb2e9 via 4fb19b65-a699-4ea1-98f2-a99bc1eeb2e9)] could not translate host name "db" to address: Name or service not known
koku_worker       | 
koku_worker       | [2020-01-09 22:38:02,017: WARNING/ForkPoolWorker-1] [koku.metrics.collect_metrics(4fb19b65-a699-4ea1-98f2-a99bc1eeb2e9 via 4fb19b65-a699-4ea1-98f2-a99bc1eeb2e9)] could not translate host name "db" to address: Name or service not known
koku_worker       | 
koku_worker       | [2020-01-09 22:38:04,022: WARNING/ForkPoolWorker-1] [koku.metrics.collect_metrics(4fb19b65-a699-4ea1-98f2-a99bc1eeb2e9 via 4fb19b65-a699-4ea1-98f2-a99bc1eeb2e9)] could not translate host name "db" to address: Name or service not known
koku_worker       | 
koku_worker       | [2020-01-09 22:38:06,025: ERROR/ForkPoolWorker-1] [koku.metrics.collect_metrics(4fb19b65-a699-4ea1-98f2-a99bc1eeb2e9 via 4fb19b65-a699-4ea1-98f2-a99bc1eeb2e9)] Query failed to return results.
```
6. restart the server: `docker-compose up -d db` and notice that errors stop.

I have not touched the error logging. If anyone thinks the logged errors should be changed, I'm open to suggestions.