### PR TITLE
Capture celery errors in status for alerting.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -246,6 +246,7 @@ services:
         - KOKU_API_PATH_PREFIX=${KOKU_API_PATH_PREFIX-/api/cost-management/v1}
         - SOURCES_KAFKA_HOST=${SOURCES_KAFKA_HOST-kafka}
         - SOURCES_KAFKA_PORT=${SOURCES_KAFKA_PORT-29092}
+        - prometheus_multiproc_dir=/tmp
       privileged: true
       ports:
           - 4000:8000

--- a/koku/masu/prometheus_stats.py
+++ b/koku/masu/prometheus_stats.py
@@ -53,6 +53,10 @@ KAFKA_CONNECTION_ERRORS_COUNTER = Counter('kafka_connection_errors',
                                           'Number of Kafka connection errors',
                                           registry=WORKER_REGISTRY)
 
+CELERY_ERRORS_COUNTER = Counter('celery_errors',
+                                'Number of celery errors',
+                                registry=WORKER_REGISTRY)
+
 
 def initialize_prometheus_exporter():
     """Start Prometheus stats HTTP server."""


### PR DESCRIPTION
* Our liveliness probe will hit the status endpoint and create the metric updates.
* Status also returns the status of celery properly when it cannot connect.

Initially:
<img width="522" alt="image" src="https://user-images.githubusercontent.com/29379759/72168401-1a280800-339b-11ea-8fcc-1ef2b25047ce.png">

After RabbitMQ connection failure:
<img width="525" alt="image" src="https://user-images.githubusercontent.com/29379759/72168497-46438900-339b-11ea-8e08-7ace27e2f13e.png">

Prometheus metric counter:
<img width="507" alt="image" src="https://user-images.githubusercontent.com/29379759/72168548-607d6700-339b-11ea-9955-75ff9e9a5b81.png">

Monitoring alert added here: https://github.com/RedHatInsights/e2e-deploy/pull/943