### PR TITLE
do not override provider_type if already in lowercase

### DIFF
--- a/koku/api/provider/serializers.py
+++ b/koku/api/provider/serializers.py
@@ -321,7 +321,7 @@ class ProviderSerializer(serializers.ModelSerializer):
 
     def update(self, instance, validated_data):
         """Update a Provider instance from validated data."""
-        provider_type = validated_data['type']
+        provider_type = validated_data['type'].lower()
         provider_type = Provider.PROVIDER_CASE_MAPPING.get(provider_type)
         validated_data['type'] = provider_type
         if instance.type != provider_type:

--- a/koku/api/provider/serializers.py
+++ b/koku/api/provider/serializers.py
@@ -238,7 +238,7 @@ class ProviderSerializer(serializers.ModelSerializer):
 
         provider_type = None
         if data and data != empty:
-            provider_type = data.get('type')
+            provider_type = data.get('type').lower()
 
         if provider_type and provider_type.lower() not in LCASE_PROVIDER_CHOICE_LIST:
             key = 'type'
@@ -247,9 +247,9 @@ class ProviderSerializer(serializers.ModelSerializer):
 
         if provider_type:
             self.fields['authentication'] = AUTHENTICATION_SERIALIZERS.get(
-                Provider.PROVIDER_CASE_MAPPING.get(provider_type.lower()))()
+                Provider.PROVIDER_CASE_MAPPING.get(provider_type))()
             self.fields['billing_source'] = BILLING_SOURCE_SERIALIZERS.get(
-                Provider.PROVIDER_CASE_MAPPING.get(provider_type.lower()))(
+                Provider.PROVIDER_CASE_MAPPING.get(provider_type))(
                 default={'bucket': '', 'data_source': {'bucket': ''}}
             )
         else:

--- a/koku/api/provider/serializers.py
+++ b/koku/api/provider/serializers.py
@@ -289,7 +289,7 @@ class ProviderSerializer(serializers.ModelSerializer):
         authentication = validated_data.pop('authentication')
         credentials = authentication.get('credentials')
         provider_resource_name = credentials.get('provider_resource_name')
-        provider_type = validated_data['type']
+        provider_type = validated_data['type'].lower()
         provider_type = Provider.PROVIDER_CASE_MAPPING.get(provider_type)
         validated_data['type'] = provider_type
         interface = ProviderAccessor(provider_type)

--- a/koku/api/provider/serializers.py
+++ b/koku/api/provider/serializers.py
@@ -289,7 +289,7 @@ class ProviderSerializer(serializers.ModelSerializer):
         authentication = validated_data.pop('authentication')
         credentials = authentication.get('credentials')
         provider_resource_name = credentials.get('provider_resource_name')
-        provider_type = validated_data['type'].lower()
+        provider_type = validated_data['type']
         provider_type = Provider.PROVIDER_CASE_MAPPING.get(provider_type)
         validated_data['type'] = provider_type
         interface = ProviderAccessor(provider_type)

--- a/koku/api/provider/view.py
+++ b/koku/api/provider/view.py
@@ -141,21 +141,11 @@ class ProviderViewSet(mixins.CreateModelMixin,
     @never_cache
     def create(self, request, *args, **kwargs):
         """Create a Provider."""
-        provider_type = request.data.get('type')
-        if (provider_type
-                and Provider.PROVIDER_CASE_MAPPING.get(provider_type.lower())
-                and provider_type != provider_type.lower()):
-            request.data['type'] = request.data.get('type', '').lower()
         return super().create(request=request, args=args, kwargs=kwargs)
 
     @never_cache
     def update(self, request, *args, **kwargs):
         """Update a Provider."""
-        provider_type = request.data.get('type')
-        if (provider_type
-                and Provider.PROVIDER_CASE_MAPPING.get(provider_type.lower())
-                and provider_type != provider_type.lower()):
-            request.data['type'] = provider_type.lower()
         if request.method == 'PATCH':
             raise ProviderMethodException('PATCH not supported')
         user = request.user

--- a/koku/api/provider/view.py
+++ b/koku/api/provider/view.py
@@ -141,11 +141,21 @@ class ProviderViewSet(mixins.CreateModelMixin,
     @never_cache
     def create(self, request, *args, **kwargs):
         """Create a Provider."""
+        provider_type = request.data.get('type')
+        if (provider_type
+                and Provider.PROVIDER_CASE_MAPPING.get(provider_type.lower())
+                and provider_type != provider_type.lower()):
+            request.data['type'] = request.data.get('type', '').lower()
         return super().create(request=request, args=args, kwargs=kwargs)
 
     @never_cache
     def update(self, request, *args, **kwargs):
         """Update a Provider."""
+        provider_type = request.data.get('type')
+        if (provider_type
+                and Provider.PROVIDER_CASE_MAPPING.get(provider_type.lower())
+                and provider_type != provider_type.lower()):
+            request.data['type'] = provider_type.lower()
         if request.method == 'PATCH':
             raise ProviderMethodException('PATCH not supported')
         user = request.user

--- a/koku/api/provider/view.py
+++ b/koku/api/provider/view.py
@@ -128,7 +128,9 @@ class ProviderViewSet(mixins.CreateModelMixin,
     def create(self, request, *args, **kwargs):
         """Create a Provider."""
         provider_type = request.data.get('type')
-        if provider_type and Provider.PROVIDER_CASE_MAPPING.get(provider_type.lower()):
+        if (provider_type
+                and Provider.PROVIDER_CASE_MAPPING.get(provider_type.lower())
+                and provider_type != provider_type.lower()):
             request.data['type'] = request.data.get('type', '').lower()
         return super().create(request=request, args=args, kwargs=kwargs)
 
@@ -136,7 +138,9 @@ class ProviderViewSet(mixins.CreateModelMixin,
     def update(self, request, *args, **kwargs):
         """Update a Provider."""
         provider_type = request.data.get('type')
-        if provider_type and Provider.PROVIDER_CASE_MAPPING.get(provider_type.lower()):
+        if (provider_type
+                and Provider.PROVIDER_CASE_MAPPING.get(provider_type.lower())
+                and provider_type != provider_type.lower()):
             request.data['type'] = provider_type.lower()
         if request.method == 'PATCH':
             raise ProviderMethodException('PATCH not supported')


### PR DESCRIPTION
#1626 

Small fix so HTML form in browsable API can be used. The HTML form sends the provider type in lowercase so there is no need to override the provider type during creation.

Testing:
1. Go to [http://localhost:8000/api/cost-management/v1/providers/](http://localhost:8000/api/cost-management/v1/providers/)
2. Add provider using HTML form (See screenshot in linked issue)
3. See provider created successfully.

Try to create provider by POSTing directly to API and see creation is successful.
Try PUT request in Browsable API and Postman and see success.