### PR TITLE
fix provider type serializer in case of None provider type

### DIFF
--- a/koku/api/provider/serializers.py
+++ b/koku/api/provider/serializers.py
@@ -238,7 +238,7 @@ class ProviderSerializer(serializers.ModelSerializer):
 
         provider_type = None
         if data and data != empty:
-            provider_type = data.get('type').lower()
+            provider_type = data.get('type')
 
         if provider_type and provider_type.lower() not in LCASE_PROVIDER_CHOICE_LIST:
             key = 'type'
@@ -246,6 +246,7 @@ class ProviderSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError(error_obj(key, message))
 
         if provider_type:
+            provider_type = provider_type.lower()
             self.fields['authentication'] = AUTHENTICATION_SERIALIZERS.get(
                 Provider.PROVIDER_CASE_MAPPING.get(provider_type))()
             self.fields['billing_source'] = BILLING_SOURCE_SERIALIZERS.get(


### PR DESCRIPTION
* If a provider type was None - the `.lower()` was causing the API to blow up & if an incorrect provider type was passed in, it was being lower-cased in the error message that was returned.