### PR TITLE
Update the tag release action in working order

### DIFF
--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -1,23 +1,44 @@
 name: Tag Release
 on:
-  push:
-    branches:
-      - stable
+  issue_comment:
+    types: [created]
 jobs:
   tag_release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: Tag stable branch for release
-      run: |
-        DATE=$(date +"%Y.%m.%d")
-        PREV_RELEASE=$(git tag --list | tail -1)
-        MINOR_VERSION=0
-        if [[ "$PREV_RELEASE" == *"$DATE"* ]]; then
-            MINOR_VERSION="$PREV_RELEASE" | cut -d'.' -f5
-            let MINOR_VERSION++
-        fi
-        TAG="r.$DATE.$MINOR_VERSION"
-        git log $(git tag --list | tail -1)..$(git rev-parse --abbrev-ref HEAD) | git tag -a $TAG -F -
-        git push origin $TAG
-      shell: bash
+      - name: Check for Command
+        id: command
+        uses: xt0rted/slash-command-action@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          command: release
+          reaction: "true"
+          reaction-type: "rocket"
+          allow-edits: "false"
+          permission-level: admin
+      - uses: actions/checkout@v2
+        with:
+          ref: stable
+      - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+      - name: Tag this release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          DATE=$(date +"%Y.%m.%d")
+          PREV_RELEASE=$(git tag --list | tail -1)
+          MINOR_VERSION=0
+          case $PREV_RELEASE in
+            *"$DATE"*)
+              MINOR_VERSION="$PREV_RELEASE" | cut -d'.' -f5
+              MINOR_VERSION=$((MINOR_VERSION+1))
+              ;;
+            *)
+              MINOR_VERSION=0
+              ;;
+          esac
+          TAG="r.$DATE.$MINOR_VERSION"
+          git config --local user.email "cost-mgmt@redhat.com"
+          git config --local user.name "Cost Management Release Action"
+          git log $(git tag --list | tail -1)..stable | git tag -a $TAG -F -
+          git push origin $TAG
+        shell: bash


### PR DESCRIPTION
## Summary
Fix our Action to trigger a tagged release with the `/release` command on a PR