### PR TITLE
OpenAPI: remove required properties for SourceOut (#1651)

### DIFF
--- a/koku/sources/openapi.json
+++ b/koku/sources/openapi.json
@@ -413,12 +413,7 @@
             {
                 "type": "object",
                 "required": [
-                    "source_id",
-                    "name",
-                    "source_type",
-                    "authentication",
-                    "billing_source",
-                    "source_uuid"
+                    "source_id"
                 ],
                 "properties": {
                     "source_id": {


### PR DESCRIPTION
Make `source_id` the only required property for SourceOut.