### PR TITLE
update sources header

### DIFF
--- a/koku/sources/config.py
+++ b/koku/sources/config.py
@@ -31,9 +31,9 @@ class Config:
     SOURCES_API_URL = f'http://{SOURCES_API_HOST}:{SOURCES_API_PORT}'
     SOURCES_API_PREFIX = os.getenv('SOURCES_API_PREFIX', '/api/v1.0')
     SOURCES_INTERNAL_API_PREFIX = os.getenv('SOURCES_INTERNAL_API_PREFIX', '/internal/v1.0')
-    SOURCES_FAKE_HEADER = os.getenv('SOURCES_FAKE_HEADER', ('eyJpZGVudGl0eSI6IHsiYWNjb3VudF9udW1i'
-                                                            'ZXIiOiAiMTIzNDUiLCAiaW50ZXJuYWwiOiB7'
-                                                            'Im9yZ19pZCI6ICI1NDMyMSJ9fX0='))
+    SOURCES_FAKE_HEADER = os.getenv('SOURCES_FAKE_HEADER', (
+        'eyJpZGVudGl0eSI6IHsiYWNjb3VudF9udW1iZXIiOiAiMTIzNDUiLCAidXNlciI6IHsiaXNfb3'
+        'JnX2FkbWluIjogImZhbHNlIn0sICJpbnRlcm5hbCI6IHsib3JnX2lkIjogIjU0MzIxIn19fQ=='))
     KOKU_API_HOST = os.getenv('KOKU_API_HOST', 'localhost')
     KOKU_API_PORT = os.getenv('KOKU_API_PORT', '8000')
     KOKU_API_PATH_PREFIX = os.getenv('KOKU_API_PATH_PREFIX', '/api/cost-management')


### PR DESCRIPTION
The old header here was resulting in 401 Unauthorized when making GET requests to sources endpoints. Updating the header gets koku-sources working again.