### PR TITLE
Provider delete removes associated items using post delete signal.

### DIFF
--- a/koku/api/provider/models.py
+++ b/koku/api/provider/models.py
@@ -17,14 +17,12 @@
 """Models for provider management."""
 
 import logging
-from functools import partial
 from uuid import uuid4
 
 from django.contrib.postgres.fields import JSONField
-from django.db import models, transaction
+from django.db import models
 from django.db.models.constraints import CheckConstraint
-from django.db.models.signals import post_delete
-from django.dispatch import receiver
+
 
 LOG = logging.getLogger(__name__)
 
@@ -169,32 +167,6 @@ class Provider(models.Model):
     # which (if any) cloud provider the cluster is on
     infrastructure = models.ForeignKey('ProviderInfrastructureMap', null=True,
                                        on_delete=models.SET_NULL)
-
-
-@receiver(post_delete, sender=Provider)
-def provider_post_delete_callback(*args, **kwargs):
-    """
-    Asynchronously delete this Provider's archived data.
-
-    Note: Signal receivers must accept keyword arguments (**kwargs).
-    """
-    provider = kwargs['instance']
-    if not provider.customer:
-        LOG.warning(
-            'Provider %s has no Customer; we cannot call delete_archived_data.',
-            provider.uuid,
-        )
-        return
-    # Local import of task function to avoid potential import cycle.
-    from masu.celery.tasks import delete_archived_data
-
-    delete_func = partial(
-        delete_archived_data.delay,
-        provider.customer.schema_name,
-        provider.type,
-        provider.uuid,
-    )
-    transaction.on_commit(delete_func)
 
 
 class Sources(models.Model):

--- a/koku/api/provider/test/tests_models.py
+++ b/koku/api/provider/test/tests_models.py
@@ -1,5 +1,20 @@
+#
+# Copyright 2019 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
 """Test for the Provider model."""
-
 import logging
 from unittest.mock import call, patch
 from uuid import UUID
@@ -38,14 +53,18 @@ class ProviderModelTest(MasuTestCase):
         self, mock_delete_archived_data
     ):
         """Assert the delete_archived_data task is not called if Customer is None."""
+        # remove filters on logging
         logging.disable(logging.NOTSET)
         with tenant_context(self.tenant), self.assertLogs(
-            'api.provider.models', 'WARNING'
+            'api.provider.provider_manager', 'WARNING'
         ) as captured_logs:
             self.aws_provider.customer = None
             self.aws_provider.delete()
         mock_delete_archived_data.delay.assert_not_called()
         self.assertIn('has no Customer', captured_logs.output[0])
+
+        # restore filters on logging
+        logging.disable(logging.CRITICAL)
 
     @patch('masu.celery.tasks.delete_archived_data')
     def test_delete_all_providers_from_queryset(self, mock_delete_archived_data):


### PR DESCRIPTION
* Move clean up of associated cost modes, authentication, billing source to post delete signal.
* Don't trigger celery task if archiving is not enabled.