### PR TITLE
[proposal] add PrintableModelMixin to enable easier debugging.

### DIFF
--- a/koku/api/provider/models.py
+++ b/koku/api/provider/models.py
@@ -26,6 +26,8 @@ from django.db.models.constraints import CheckConstraint
 from django.db.models.signals import post_delete
 from django.dispatch import receiver
 
+from api.utils import PrintableModelMixIn
+
 LOG = logging.getLogger(__name__)
 
 
@@ -90,7 +92,7 @@ class ProviderBillingSource(models.Model):
         ]
 
 
-class Provider(models.Model):
+class Provider(PrintableModelMixIn, models.Model):
     """A Koku Provider.
 
     Used for modeling cost providers like AWS Accounts.
@@ -288,7 +290,7 @@ class ProviderStatus(models.Model):
     retries = models.IntegerField(null=False, default=0)
 
 
-class ProviderInfrastructureMap(models.Model):
+class ProviderInfrastructureMap(PrintableModelMixIn, models.Model):
     """A lookup table for OpenShift providers.
 
     Used to determine which underlying instrastructure and


### PR DESCRIPTION
This PR is an idea I've had lingering in my git stash for a while. I use it for debugging and local development when I need to see what rows from the DB that the code is using.

This enables me to add `print(some_model_obj)` or the equivalent `logging` statments and see all of the field names and values in the printed output.

This is intended as a proof-of-concept and, if it seems useful, I'll finish it off, add the appropriate unit tests and docs to make this a complete PR.