### PR TITLE
Determine project query when operators are present in group_by or filter.

### DIFF
--- a/koku/api/report/all/openshift/query_handler.py
+++ b/koku/api/report/all/openshift/query_handler.py
@@ -19,6 +19,7 @@
 from api.models import Provider
 from api.report.all.openshift.provider_map import OCPAllProviderMap
 from api.report.ocp_aws.query_handler import OCPInfrastructureReportQueryHandlerBase
+from api.report.queries import is_grouped_or_filtered_by_project
 
 
 class OCPAllReportQueryHandler(OCPInfrastructureReportQueryHandlerBase):
@@ -35,10 +36,8 @@ class OCPAllReportQueryHandler(OCPInfrastructureReportQueryHandlerBase):
         """
         self._mapper = OCPAllProviderMap(provider=self.provider,
                                          report_type=parameters.report_type)
-        group_by = parameters.parameters.get('group_by', {})
         # Update which field is used to calculate cost by group by param.
-        if (group_by and group_by.get('project')) or \
-                parameters.parameters.get('filter', {}).get('project'):
+        if is_grouped_or_filtered_by_project(parameters):
             self._report_type = parameters.report_type + '_by_project'
             self._mapper = OCPAllProviderMap(
                 provider=self.provider, report_type=self._report_type

--- a/koku/api/report/azure/openshift/query_handler.py
+++ b/koku/api/report/azure/openshift/query_handler.py
@@ -24,6 +24,7 @@ from tenant_schemas.utils import tenant_context
 from api.models import Provider
 from api.report.azure.openshift.provider_map import OCPAzureProviderMap
 from api.report.azure.query_handler import AzureReportQueryHandler
+from api.report.queries import is_grouped_or_filtered_by_project
 
 
 class OCPAzureReportQueryHandler(AzureReportQueryHandler):
@@ -41,10 +42,8 @@ class OCPAzureReportQueryHandler(AzureReportQueryHandler):
         self._mapper = OCPAzureProviderMap(
             provider=self.provider, report_type=parameters.report_type
         )
-        group_by = parameters.parameters.get('group_by', {})
         # Update which field is used to calculate cost by group by param.
-        if (group_by and group_by.get('project')) or \
-                parameters.parameters.get('filter', {}).get('project'):
+        if is_grouped_or_filtered_by_project(parameters):
             self._report_type = parameters.report_type + '_by_project'
             self._mapper = OCPAzureProviderMap(
                 provider=self.provider, report_type=self._report_type

--- a/koku/api/report/ocp/query_handler.py
+++ b/koku/api/report/ocp/query_handler.py
@@ -25,7 +25,7 @@ from tenant_schemas.utils import tenant_context
 
 from api.models import Provider
 from api.report.ocp.provider_map import OCPProviderMap
-from api.report.queries import ReportQueryHandler
+from api.report.queries import ReportQueryHandler, is_grouped_or_filtered_by_project
 
 
 class OCPReportQueryHandler(ReportQueryHandler):
@@ -50,9 +50,7 @@ class OCPReportQueryHandler(ReportQueryHandler):
         # super() needs to be called before _get_group_by is called
 
         # Update which field is used to calculate cost by group by param.
-        group_by = self._get_group_by()
-        if (group_by and 'project' in group_by
-                or 'project' in parameters.get('filter', {}).keys()) \
+        if is_grouped_or_filtered_by_project(parameters) \
                 and parameters.report_type == 'costs':
             self._report_type = parameters.report_type + '_by_project'
             self._mapper = OCPProviderMap(provider=self.provider,

--- a/koku/api/report/ocp_aws/query_handler.py
+++ b/koku/api/report/ocp_aws/query_handler.py
@@ -24,6 +24,7 @@ from tenant_schemas.utils import tenant_context
 from api.models import Provider
 from api.report.aws.query_handler import AWSReportQueryHandler
 from api.report.ocp_aws.provider_map import OCPAWSProviderMap
+from api.report.queries import is_grouped_or_filtered_by_project
 
 
 class OCPInfrastructureReportQueryHandlerBase(AWSReportQueryHandler):
@@ -138,10 +139,8 @@ class OCPAWSReportQueryHandler(OCPInfrastructureReportQueryHandlerBase):
         self._mapper = OCPAWSProviderMap(
             provider=self.provider, report_type=parameters.report_type
         )
-        group_by = parameters.parameters.get('group_by', {})
         # Update which field is used to calculate cost by group by param.
-        if (group_by and group_by.get('project')) or \
-                parameters.parameters.get('filter', {}).get('project'):
+        if is_grouped_or_filtered_by_project(parameters):
             self._report_type = parameters.report_type + '_by_project'
             self._mapper = OCPAWSProviderMap(
                 provider=self.provider, report_type=self._report_type

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -38,6 +38,14 @@ def strip_tag_prefix(tag):
     return tag.replace('tag:', '').replace('and:', '').replace('or:', '')
 
 
+def is_grouped_or_filtered_by_project(parameters):
+    """Determine if grouped or filtered by project."""
+    group_by = list(parameters.parameters.get('group_by', {}).keys())
+    filters = list(parameters.parameters.get('filter', {}).keys())
+    effects = group_by + filters
+    return [key for key in effects if 'project' in key]
+
+
 class ReportQueryHandler(QueryHandler):
     """Handles report queries and responses."""
 


### PR DESCRIPTION
* Created utility method
* Check based on presence of 'project' in list of keys from group_by and filter

The offending line of code was:
https://github.com/project-koku/koku/blob/master/koku/api/report/all/openshift/query_handler.py#L40-L41
```
        if (group_by and group_by.get('project')) or \
                parameters.parameters.get('filter', {}).get('project'):
```

As the incoming group by data looks like this:
```
group_by=OrderedDict([('and:tag:app', ['cost']), ('and:project', ['cost']), ('and:cluster', ['cost'])])
```
The code was not properly handling the potential boolean prefixes.
Similar code existed in the codebase with the same bug, so a utility method was created to handle these case.

Updated result for the query in the issue:
[1650-project-with-operators.txt](https://github.com/project-koku/koku/files/4140986/1650-project-with-operators.txt)

