### PR TITLE
Fix test cases to handle month the case where a month has less than 30 days.

### DIFF
--- a/koku/masu/test/processor/aws/test_aws_report_summary_updater.py
+++ b/koku/masu/test/processor/aws/test_aws_report_summary_updater.py
@@ -149,6 +149,8 @@ class AWSReportSummaryUpdaterTest(MasuTestCase):
         dates = list(
             rrule(freq=DAILY, dtstart=expected_start_date, until=expected_end_date, interval=5)
         )
+        if expected_end_date not in dates:
+            dates.append(expected_end_date)
         # Remove the first date since it's the start date
         expected_start_date = dates.pop(0)
         expected_calls = []
@@ -311,6 +313,8 @@ class AWSReportSummaryUpdaterTest(MasuTestCase):
         dates = list(
             rrule(freq=DAILY, dtstart=expected_start_date, until=expected_end_date, interval=5)
         )
+        if expected_end_date not in dates:
+            dates.append(expected_end_date)
         # Remove the first date since it's the start date
         expected_start_date = dates.pop(0)
         expected_calls = []

--- a/koku/masu/test/processor/azure/test_azure_report_summary_updater.py
+++ b/koku/masu/test/processor/azure/test_azure_report_summary_updater.py
@@ -139,6 +139,8 @@ class AzureReportSummaryUpdaterTest(MasuTestCase):
         dates = list(
             rrule(freq=DAILY, dtstart=expected_start_date, until=expected_end_date, interval=5)
         )
+        if expected_end_date not in dates:
+            dates.append(expected_end_date)
         # Remove the first date since it's the start date
         dates.pop(0)
         expected_calls = []

--- a/koku/masu/test/processor/ocp/test_ocp_report_summary_updater.py
+++ b/koku/masu/test/processor/ocp/test_ocp_report_summary_updater.py
@@ -181,6 +181,8 @@ class OCPReportSummaryUpdaterTest(MasuTestCase):
         dates = list(
             rrule(freq=DAILY, dtstart=expected_start_date, until=expected_end_date, interval=5)
         )
+        if expected_end_date not in dates:
+            dates.append(expected_end_date)
         # Remove the first date since it's the start date
         dates.pop(0)
         expected_calls = []


### PR DESCRIPTION
* Test checks that the full month gets summarized by intervals of 5
* If less than 30 days, then one more call happens than is checked for and test fails.