### PR TITLE
1652 local docker db stats

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -468,6 +468,10 @@ docker-up:
 
 docker-up-db:
 	docker-compose up -d db
+	@until pg_isready -h localhost -p 15432 ; do \
+	    sleep 0.5 ; \
+        done
+	@PGPASSWD=postgres psql -h localhost -p 15432 -d postgres -U postgres -c "create extension if not exists pg_stat_statements;"
 
 docker-iqe-smokes-tests:
 	$(MAKE) docker-reinitdb

--- a/Makefile
+++ b/Makefile
@@ -440,8 +440,7 @@ docker-down:
 	docker-compose down
 
 docker-down-db:
-	docker-compose stop db
-	docker ps -a -f name=koku_db -q | xargs docker container rm
+	docker-compose rm -s -v -f db
 
 docker-logs:
 	docker-compose logs -f
@@ -450,11 +449,9 @@ docker-rabbit:
 	docker-compose up -d rabbit
 
 docker-reinitdb: docker-down-db remove-db docker-up-db
-	sleep 5
 	$(MAKE) create-test-customer-no-providers
 
 docker-reinitdb-with-providers: docker-down-db remove-db docker-up-db
-	sleep 5
 	$(MAKE) create-test-customer
 
 docker-shell:
@@ -468,10 +465,11 @@ docker-up:
 
 docker-up-db:
 	docker-compose up -d db
-	@until pg_isready -h localhost -p 15432 ; do \
+	@until pg_isready -h $$POSTGRES_SQL_SERVICE_HOST -p $$POSTGRES_SQL_SERVICE_PORT >/dev/null ; do \
+	    echo -n '.' ; \
 	    sleep 0.5 ; \
-        done
-	@PGPASSWD=postgres psql -h localhost -p 15432 -d postgres -U postgres -c "create extension if not exists pg_stat_statements;"
+    done
+	@echo ' PostgreSQL is available!'
 
 docker-iqe-smokes-tests:
 	$(MAKE) docker-reinitdb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,6 +111,7 @@ services:
       - "15432:5432"
     volumes:
       - ./pg_data:/var/lib/pgsql/data
+      - ./pg_init:/docker-entrypoint-initdb.d
 
   pgadmin:
     container_name: pgAdmin

--- a/pg_init/99_postgresql_conf.sh
+++ b/pg_init/99_postgresql_conf.sh
@@ -1,0 +1,42 @@
+#! /usr/bin/env bash
+
+echo "Updating ${PGDATA}/postgresql.conf..."
+cat >>${PGDATA}/postgresql.conf <<EOF
+
+# ==============================================
+# -----------------------------
+# PostgreSQL configuration file additions
+# These additions are to allow for local statement statistics
+# These configuration options were taken from PostgreSQL 10.6
+# -----------------------------
+
+shared_preload_libraries = 'pg_stat_statements'		# (change requires restart)
+
+pg_stat_statements.max = 5000          # max number of statements to track
+pg_stat_statements.track = top         # top = statements issued by clients; all = top + statements in functions; none = disable stats
+pg_stat_statements.track_utility = on  # on = track statements other than SELECT INSERT UPDATE DELETE; off = no tracking
+pg_stat_statements.save = off          # on = save stats between restarts; off = do not save
+
+log_min_error_statement = error	# values in order of decreasing detail:
+					#   debug5
+					#   debug4
+					#   debug3
+					#   debug2
+					#   debug1
+					#   info
+					#   notice
+					#   warning
+					#   error
+					#   log
+					#   fatal
+					#   panic (effectively off)
+
+log_min_duration_statement = 5000	# -1 is disabled, 0 logs all statements
+					# and their durations, > 0 logs only
+					# statements running at least this number
+					# of milliseconds
+
+track_functions = pl			# none, pl, all
+
+EOF
+

--- a/pg_init/99_postgresql_conf.sh
+++ b/pg_init/99_postgresql_conf.sh
@@ -14,7 +14,7 @@ shared_preload_libraries = 'pg_stat_statements'		# (change requires restart)
 
 pg_stat_statements.max = 5000          # max number of statements to track
 pg_stat_statements.track = top         # top = statements issued by clients; all = top + statements in functions; none = disable stats
-pg_stat_statements.track_utility = on  # on = track statements other than SELECT INSERT UPDATE DELETE; off = no tracking
+pg_stat_statements.track_utility = off # on = track statements other than SELECT INSERT UPDATE DELETE; off = no tracking
 pg_stat_statements.save = off          # on = save stats between restarts; off = do not save
 
 log_min_error_statement = error	# values in order of decreasing detail:

--- a/pg_init/99_postgresql_conf.sh
+++ b/pg_init/99_postgresql_conf.sh
@@ -38,6 +38,8 @@ log_min_duration_statement = 5000	# -1 is disabled, 0 logs all statements
 
 track_functions = pl			# none, pl, all
 
+track_activity_query_size = 4096   # max statement length in pg_stat_activity
+
 EOF
 
 psql -U postgres -c "create extension if not exists pg_stat_statements;" 2>/dev/null

--- a/pg_init/99_postgresql_conf.sh
+++ b/pg_init/99_postgresql_conf.sh
@@ -31,7 +31,7 @@ log_min_error_statement = error	# values in order of decreasing detail:
 					#   fatal
 					#   panic (effectively off)
 
-log_min_duration_statement = 5000	# -1 is disabled, 0 logs all statements
+log_min_duration_statement = 2000	# -1 is disabled, 0 logs all statements
 					# and their durations, > 0 logs only
 					# statements running at least this number
 					# of milliseconds

--- a/pg_init/99_postgresql_conf.sh
+++ b/pg_init/99_postgresql_conf.sh
@@ -40,3 +40,5 @@ track_functions = pl			# none, pl, all
 
 EOF
 
+psql -U postgres -c "create extension if not exists pg_stat_statements;" 2>/dev/null
+


### PR DESCRIPTION
## Description

Local DB container initialization changes to enable statement statistics. This change will operate in conjunction with the other changes for large data generation.

This was accomplished without needing to build a new image.

## Local Testing

### Setup

`make docker-reinitdb`
Then use psql to connect to the local db

### Copleted Local Tests

- [ ] `show shared_preload_libraries;` should show `pg_stat_statements`
- [ ] `\dx` should show `pg_stat_statements`
- [ ] `select * from pg_stat_statements;` should return records if executed after the first two tests