### PR TITLE
Remove deprecated cluster_alias from data return.

### DIFF
--- a/koku/api/report/azure/openshift/query_handler.py
+++ b/koku/api/report/azure/openshift/query_handler.py
@@ -18,7 +18,7 @@
 import copy
 
 from django.db.models import F, Window
-from django.db.models.functions import Coalesce, RowNumber
+from django.db.models.functions import RowNumber
 from tenant_schemas.utils import tenant_context
 
 from api.models import Provider
@@ -77,11 +77,6 @@ class OCPAzureReportQueryHandler(AzureReportQueryHandler):
 
             annotations = self._mapper.report_type_map.get('annotations')
             query_data = query_data.values(*query_group_by).annotate(**annotations)
-
-            if 'cluster' in query_group_by or 'cluster' in self.query_filter:
-                query_data = query_data.annotate(
-                    cluster_alias=Coalesce('cluster_alias', 'cluster_id')
-                )
 
             if self._limit:
                 rank_order = getattr(F(self.order_field), self.order_direction)()

--- a/koku/api/report/ocp/query_handler.py
+++ b/koku/api/report/ocp/query_handler.py
@@ -20,7 +20,7 @@ from collections import defaultdict
 from decimal import Decimal, DivisionByZero, InvalidOperation
 
 from django.db.models import F, Value, Window
-from django.db.models.functions import Coalesce, Concat, RowNumber
+from django.db.models.functions import Concat, RowNumber
 from tenant_schemas.utils import tenant_context
 
 from api.models import Provider
@@ -132,10 +132,6 @@ class OCPReportQueryHandler(ReportQueryHandler):
             query_order_by.extend([self.order])
 
             query_data = query_data.values(*query_group_by).annotate(**self.report_annotations)
-
-            if 'cluster' in query_group_by or 'cluster' in self.query_filter:
-                query_data = query_data.annotate(cluster_alias=Coalesce('cluster_alias',
-                                                                        'cluster_id'))
 
             if self._limit and group_by_value:
                 rank_by_total = self.get_rank_window_function(group_by_value)

--- a/koku/api/report/ocp_aws/query_handler.py
+++ b/koku/api/report/ocp_aws/query_handler.py
@@ -55,9 +55,6 @@ class OCPInfrastructureReportQueryHandlerBase(AWSReportQueryHandler):
             if 'account' in query_group_by:
                 query_data = query_data.annotate(account_alias=Coalesce(
                     F(self._mapper.provider_map.get('alias')), 'usage_account_id'))
-            elif 'cluster' in query_group_by or 'cluster' in self.query_filter:
-                query_data = query_data.annotate(cluster_alias=Coalesce('cluster_alias',
-                                                                        'cluster_id'))
 
             if self._limit:
                 rank_order = getattr(F(self.order_field), self.order_direction)()


### PR DESCRIPTION
#1696 
Group by cluster for ocp on azure, ocp on aws, and ocp reports and see that the `cluster_alias` key is no longer in the data return. 

The `cluster_alias` was removed from the UI with this pr: https://github.com/project-koku/koku-ui/pull/1309