### PR TITLE
Update logging setting on manifest checks to avoid sentry alerts.

### DIFF
--- a/koku/masu/external/downloader/aws/aws_report_downloader.py
+++ b/koku/masu/external/downloader/aws/aws_report_downloader.py
@@ -174,7 +174,7 @@ class AWSReportDownloader(ReportDownloaderBase, DownloaderInterface):
         try:
             manifest_file, _ = self.download_file(manifest)
         except AWSReportDownloaderNoFileError as err:
-            LOG.error('Unable to get report manifest. Reason: %s', str(err))
+            LOG.info('Unable to get report manifest. Reason: %s', str(err))
             return '', self.empty_manifest
 
         manifest_json = None

--- a/koku/masu/external/downloader/azure/azure_report_downloader.py
+++ b/koku/masu/external/downloader/azure/azure_report_downloader.py
@@ -124,7 +124,7 @@ class AzureReportDownloader(ReportDownloaderBase, DownloaderInterface):
         try:
             blob = self._azure_client.get_latest_cost_export_for_path(report_path, self.container_name)
         except AzureCostReportNotFound as ex:
-            LOG.error('Unable to find manifest. Error: %s', str(ex))
+            LOG.info('Unable to find manifest. Error: %s', str(ex))
             return manifest
         report_name = blob.name
 


### PR DESCRIPTION
* Continue to capture the logs, but decrease severity to avoid sentry alerts.


Still getting alerts in slack:
https://ansible.slack.com/archives/CR53S4APK/p1581012968010400
https://ansible.slack.com/archives/CR53S4APK/p1581012975010500