### PR TITLE
Update product manifest to include base container name.

### DIFF
--- a/koku-manifest
+++ b/koku-manifest
@@ -1,3 +1,4 @@
+mgmt_services/cost-mgmt:koku/registry.access.redhat.com/ubi7/python-36:latest
 mgmt_services/cost-mgmt:koku/python-adal:1.2.2.pipfile
 mgmt_services/cost-mgmt:koku/python-aiokafka:0.5.2.pipfile
 mgmt_services/cost-mgmt:koku/python-amqp:2.5.2.pipfile

--- a/scripts/create_manifest.py
+++ b/scripts/create_manifest.py
@@ -19,11 +19,13 @@ import json
 
 lockfile = {}
 
+CONTAINER_NAME = "registry.access.redhat.com/ubi7/python-36:latest"
 
 with open("Pipfile.lock") as json_file:
     lockfile = json.load(json_file)
 
 with open("koku-manifest", "w") as manifest:
+    manifest.write(f"mgmt_services/cost-mgmt:koku/{CONTAINER_NAME}\n")
     for name, value in sorted(lockfile["default"].items()):
         if "version" in value:
             version = value["version"].replace("=", "")


### PR DESCRIPTION
* Update output script to include base container name
* Update resulting manifest

```
mgmt_services/cost-mgmt:koku/registry.access.redhat.com/ubi7/python-36:latest
mgmt_services/cost-mgmt:koku/python-adal:1.2.2.pipfile
mgmt_services/cost-mgmt:koku/python-aiokafka:0.5.2.pipfile
mgmt_services/cost-mgmt:koku/python-amqp:2.5.2.pipfile
mgmt_services/cost-mgmt:koku/python-azure-common:1.1.24.pipfile
mgmt_services/cost-mgmt:koku/python-azure-mgmt-costmanagement:0.1.0.pipfile
mgmt_services/cost-mgmt:koku/python-azure-mgmt-resource:8.0.1.pipfile
mgmt_services/cost-mgmt:koku/python-azure-mgmt-storage:7.1.0.pipfile
mgmt_services/cost-mgmt:koku/python-azure-nspkg:3.0.2.pipfile
mgmt_services/cost-mgmt:koku/python-azure-storage:0.36.0.pipfile
mgmt_services/cost-mgmt:koku/python-azure-storage-blob:2.1.0.pipfile
mgmt_services/cost-mgmt:koku/python-azure-storage-common:2.1.0.pipfile
mgmt_services/cost-mgmt:koku/python-beautifulsoup4:4.8.2.pipfile
mgmt_services/cost-mgmt:koku/python-billiard:3.6.2.0.pipfile
mgmt_services/cost-mgmt:koku/python-boto3:1.10.2.pipfile
mgmt_services/cost-mgmt:koku/python-botocore:1.13.50.pipfile
mgmt_services/cost-mgmt:koku/python-bs4:0.0.1.pipfile
mgmt_services/cost-mgmt:koku/python-cachetools:4.0.0.pipfile
mgmt_services/cost-mgmt:koku/python-celery:4.3.0.pipfile
mgmt_services/cost-mgmt:koku/python-celery-prometheus-exporter:1.7.0.pipfile
mgmt_services/cost-mgmt:koku/python-certifi:2019.11.28.pipfile
mgmt_services/cost-mgmt:koku/python-cffi:1.13.2.pipfile
mgmt_services/cost-mgmt:koku/python-chardet:3.0.4.pipfile
mgmt_services/cost-mgmt:koku/python-ciso8601:2.1.2.pipfile
mgmt_services/cost-mgmt:koku/python-cryptography:2.8.pipfile
mgmt_services/cost-mgmt:koku/python-django:2.2.10.pipfile
mgmt_services/cost-mgmt:koku/python-django-cors-headers:3.1.1.pipfile
mgmt_services/cost-mgmt:koku/python-django-environ:0.4.5.pipfile
mgmt_services/cost-mgmt:koku/python-django-filter:2.2.0.pipfile
mgmt_services/cost-mgmt:koku/python-django-prometheus:1.1.0.pipfile
mgmt_services/cost-mgmt:koku/python-django-redis:4.10.0.pipfile
mgmt_services/cost-mgmt:koku/python-django-tenant-schemas:1.10.0.pipfile
mgmt_services/cost-mgmt:koku/python-djangorestframework:3.11.0.pipfile
mgmt_services/cost-mgmt:koku/python-djangorestframework-csv:2.1.0.pipfile
mgmt_services/cost-mgmt:koku/python-docutils:0.15.2.pipfile
mgmt_services/cost-mgmt:koku/python-drf-nested-routers:0.91.pipfile
mgmt_services/cost-mgmt:koku/python-entrypoints:0.3.pipfile
mgmt_services/cost-mgmt:koku/python-flake8:3.7.9.pipfile
mgmt_services/cost-mgmt:koku/python-google-api-core:1.16.0.pipfile
mgmt_services/cost-mgmt:koku/python-google-auth:1.11.0.pipfile
mgmt_services/cost-mgmt:koku/python-google-cloud-core:1.3.0.pipfile
mgmt_services/cost-mgmt:koku/python-google-cloud-storage:1.19.1.pipfile
mgmt_services/cost-mgmt:koku/python-google-resumable-media:0.4.1.pipfile
mgmt_services/cost-mgmt:koku/python-googleapis-common-protos:1.51.0.pipfile
mgmt_services/cost-mgmt:koku/python-gunicorn:20.0.4.pipfile
mgmt_services/cost-mgmt:koku/python-idna:2.8.pipfile
mgmt_services/cost-mgmt:koku/python-importlib-metadata:1.5.0.pipfile
mgmt_services/cost-mgmt:koku/python-isodate:0.6.0.pipfile
mgmt_services/cost-mgmt:koku/python-jinja2:2.11.1.pipfile
mgmt_services/cost-mgmt:koku/python-jinjasql:0.1.7.pipfile
mgmt_services/cost-mgmt:koku/python-jmespath:0.9.4.pipfile
mgmt_services/cost-mgmt:koku/python-kafka-python:1.4.6.pipfile
mgmt_services/cost-mgmt:koku/python-kombu:4.6.7.pipfile
mgmt_services/cost-mgmt:koku/python-markupsafe:1.1.1.pipfile
mgmt_services/cost-mgmt:koku/python-mccabe:0.6.1.pipfile
mgmt_services/cost-mgmt:koku/python-msrest:0.6.11.pipfile
mgmt_services/cost-mgmt:koku/python-msrestazure:0.6.2.pipfile
mgmt_services/cost-mgmt:koku/python-numpy:1.18.1.pipfile
mgmt_services/cost-mgmt:koku/python-oauthlib:3.1.0.pipfile
mgmt_services/cost-mgmt:koku/python-ordered-set:3.1.1.pipfile
mgmt_services/cost-mgmt:koku/python-pandas:0.25.3.pipfile
mgmt_services/cost-mgmt:koku/python-pint:0.9.pipfile
mgmt_services/cost-mgmt:koku/python-prometheus-client:0.7.1.pipfile
mgmt_services/cost-mgmt:koku/python-protobuf:3.11.3.pipfile
mgmt_services/cost-mgmt:koku/python-psutil:5.6.3.pipfile
mgmt_services/cost-mgmt:koku/python-psycopg2-binary:2.8.4.pipfile
mgmt_services/cost-mgmt:koku/python-pyasn1:0.4.8.pipfile
mgmt_services/cost-mgmt:koku/python-pyasn1-modules:0.2.8.pipfile
mgmt_services/cost-mgmt:koku/python-pycodestyle:2.5.0.pipfile
mgmt_services/cost-mgmt:koku/python-pycparser:2.19.pipfile
mgmt_services/cost-mgmt:koku/python-pyflakes:2.1.1.pipfile
mgmt_services/cost-mgmt:koku/python-pyjwt:1.7.1.pipfile
mgmt_services/cost-mgmt:koku/python-python-dateutil:2.8.1.pipfile
mgmt_services/cost-mgmt:koku/python-pytz:2019.3.pipfile
mgmt_services/cost-mgmt:koku/python-querystring-parser:1.2.4.pipfile
mgmt_services/cost-mgmt:koku/python-redis:3.4.1.pipfile
mgmt_services/cost-mgmt:koku/python-requests:2.22.0.pipfile
mgmt_services/cost-mgmt:koku/python-requests-oauthlib:1.3.0.pipfile
mgmt_services/cost-mgmt:koku/python-rsa:4.0.pipfile
mgmt_services/cost-mgmt:koku/python-s3transfer:0.2.1.pipfile
mgmt_services/cost-mgmt:koku/python-sentry-sdk:0.13.5.pipfile
mgmt_services/cost-mgmt:koku/python-six:1.14.0.pipfile
mgmt_services/cost-mgmt:koku/python-soupsieve:1.9.5.pipfile
mgmt_services/cost-mgmt:koku/python-sqlparse:0.3.0.pipfile
mgmt_services/cost-mgmt:koku/python-ujson:1.35.pipfile
mgmt_services/cost-mgmt:koku/python-unicodecsv:0.14.1.pipfile
mgmt_services/cost-mgmt:koku/python-urllib3:1.25.8.pipfile
mgmt_services/cost-mgmt:koku/python-vine:1.3.0.pipfile
mgmt_services/cost-mgmt:koku/python-watchtower:0.7.3.pipfile
mgmt_services/cost-mgmt:koku/python-whitenoise:5.0.1.pipfile
mgmt_services/cost-mgmt:koku/python-zipp:2.1.0.pipfile
```

Changes on `latest` will trigger a rebuild.