### PR TITLE
Run action only on closed PR to stable

### DIFF
--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -1,25 +1,19 @@
 name: Tag Release
 on:
-  issue_comment:
-    types: [created]
+  pull_request:
+    branches:
+      - stable
+    types: [closed]
 jobs:
   tag_release:
+    if: contains(github.event.pull_request.labels.*.name, 'release')
     runs-on: ubuntu-latest
     steps:
-      - name: Check for Command
-        id: command
-        uses: xt0rted/slash-command-action@v1
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          command: release
-          reaction: "true"
-          reaction-type: "rocket"
-          allow-edits: "false"
-          permission-level: admin
       - uses: actions/checkout@v2
         with:
           ref: stable
-      - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+      - run: |
+          git fetch --prune --unshallow
       - name: Tag this release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Although this was neat, it's sending failure emails when we comment, and that's annoying. This will instead tag stable when we close a PR to stable with the "release" label. 