### PR TITLE
Updated jenkins file to meet new e2e updates

### DIFF
--- a/Jenkinsfile-smoke.groovy
+++ b/Jenkinsfile-smoke.groovy
@@ -9,7 +9,7 @@ if (env.CHANGE_ID) {
     execSmokeTest (
         ocDeployerBuilderPath: "hccm/koku",
         ocDeployerComponentPath: "hccm",
-        ocDeployerServiceSets: "ingress,inventory,platform-mq,hccm",
+        ocDeployerServiceSets: "ingress,platform-mq,hccm",
         iqePlugins: ["iqe-hccm-plugin"],
         pytestMarker: "hccm_smoke",
         // local settings file

--- a/Jenkinsfile-smoke.groovy
+++ b/Jenkinsfile-smoke.groovy
@@ -9,7 +9,7 @@ if (env.CHANGE_ID) {
     execSmokeTest (
         ocDeployerBuilderPath: "hccm/koku",
         ocDeployerComponentPath: "hccm",
-        ocDeployerServiceSets: "hccm,platform,platform-mq",
+        ocDeployerServiceSets: "ingress,inventory,platform-mq,hccm",
         iqePlugins: ["iqe-hccm-plugin"],
         pytestMarker: "hccm_smoke",
         // local settings file


### PR DESCRIPTION
Updating smoke deployment, basically the platform service set was getting too bulky and slowing down smoke deployments + using up quotas. Long story short most apps only need a small subset of services so they are getting split up in e2e. This PR tweaks are requirements so we only deploy the pieces we require for testing. 