### PR TITLE
Add script to clean out testing dirs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ help:
 	@echo "  lint                                  run pre-commit against the project"
 	@echo ""
 	@echo "--- Commands using local services ---"
+	@echo "  clear-testing						   Remove stale files/subdirectories from the testing directory.""
 	@echo "  create-test-customer                  create a test customer and tenant in the database"
 	@echo "  create-test-customer-no-providers     create a test customer and tenant in the database without test providers"
 	@echo "  create-large-ocp-provider-config-file create a config file for nise to generate a large data sample"
@@ -151,6 +152,9 @@ html:
 
 lint:
 	pre-commit run --all-files
+
+clear-testing:
+	$(PYTHON) $(TOPDIR)/scripts/clear_testing.py -p $(TOPDIR)/testing
 
 create-test-customer: run-migrations
 	sleep 1
@@ -494,14 +498,17 @@ docker-up-db:
 
 docker-iqe-smokes-tests:
 	$(MAKE) docker-reinitdb
+	$(MAKE) clear-testing
 	./testing/run_smoke_tests.sh
 
 docker-iqe-api-tests:
 	$(MAKE) docker-reinitdb
+	$(MAKE) clear-testing
 	./testing/run_api_tests.sh
 
 docker-iqe-vortex-tests:
 	$(MAKE) docker-reinitdb
+	$(MAKE) clear-testing
 	./testing/run_vortex_api_tests.sh
 
 ### Provider targets ###

--- a/scripts/clear_testing.py
+++ b/scripts/clear_testing.py
@@ -1,0 +1,58 @@
+#
+# Copyright 2020 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""Clear out our local testing directories."""
+import argparse
+import os
+import shutil
+
+TESTING_DIRS = [
+    "local_providers/aws_local",
+    "local_providers/aws_local_0",
+    "local_providers/aws_local_1",
+    "local_providers/aws_local_2",
+    "local_providers/aws_local_3",
+    "local_providers/aws_local_4",
+    "local_providers/aws_local_5",
+    "local_providers/azure_local",
+    "local_providers/insights_local",
+    "pvc_dir/insights_local",
+    "pvc_dir/processing",
+]
+
+
+def main(*args, **kwargs):
+    testing_path = kwargs["testing_path"]
+
+    paths_to_clear = [f"{testing_path}/{directory}" for directory in TESTING_DIRS]
+
+    for path in paths_to_clear:
+        try:
+            print(f"Checking {path}")
+            dirs_to_remove = [f.path for f in os.scandir(path) if f.is_dir()]
+            for directory in dirs_to_remove:
+                print(f"Removing {directory}")
+                shutil.rmtree(directory)
+        except FileNotFoundError as err:
+            print(err)
+
+
+if __name__ == "__main__":
+    PARSER = argparse.ArgumentParser()
+    PARSER.add_argument("-p", "--path", dest="testing_path", help="The path to the testing directory", required=True)
+
+    ARGS = vars(PARSER.parse_args())
+    main(**ARGS)


### PR DESCRIPTION
## Summary
If there's data sitting in our testing directories, it can cause false failures in our IQE tests. This clears out data before running. 