### PR TITLE
Allow processing demo data from objectstore (S3 or AzureBlob).

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ services:
         - prometheus_multiproc_dir=/tmp
         - API_PATH_PREFIX=${API_PATH_PREFIX-/api/cost-management}
         - GOOGLE_APPLICATION_CREDENTIALS=${GOOGLE_APPLICATION_CREDENTIALS}
+        - DEMO_ACCOUNTS=${DEMO_ACCOUNTS}
       privileged: true
       ports:
           - 8000:8000
@@ -166,6 +167,7 @@ services:
         - KOKU_CELERY_ENABLE_SENTRY
         - KOKU_CELERY_SENTRY_DSN
         - KOKU_SENTRY_ENVIRONMENT
+        - DEMO_ACCOUNTS=${DEMO_ACCOUNTS}
       privileged: true
       volumes:
         - '.:/koku'

--- a/koku/api/provider/test/tests_serializers.py
+++ b/koku/api/provider/test/tests_serializers.py
@@ -497,7 +497,7 @@ class ProviderSerializerTest(IamTestCase):
         instance = None
 
         account_id = self.customer_data.get("account_id")
-        with self.settings(DEMO_ACCOUNTS=[account_id]):
+        with self.settings(DEMO_ACCOUNTS={account_id: {}}):
             with patch.object(ProviderAccessor, "cost_usage_source_ready") as mock_method:
                 serializer = ProviderSerializer(data=provider, context=self.request_context)
                 if serializer.is_valid(raise_exception=True):

--- a/koku/koku/settings.py
+++ b/koku/koku/settings.py
@@ -389,4 +389,4 @@ SOURCES_CLIENT_BASE_URL = "http://{}:{}{}/v1".format(
 )
 
 # Demo Accounts list
-DEMO_ACCOUNTS = ENVIRONMENT.list("DEMO_ACCOUNTS", default=[])
+DEMO_ACCOUNTS = ENVIRONMENT.json("DEMO_ACCOUNTS", {})

--- a/koku/masu/test/external/downloader/aws/test_aws_report_downloader.py
+++ b/koku/masu/test/external/downloader/aws/test_aws_report_downloader.py
@@ -532,3 +532,24 @@ class AWSReportDownloaderTest(MasuTestCase):
             )
             # Re-enable log suppression
             logging.disable(logging.CRITICAL)
+
+    def test_init_with_demo_account(self):
+        """Test init with the demo account."""
+        mock_task = Mock(request=Mock(id=str(self.fake.uuid4()), return_value={}))
+        account_id = "123456"
+        auth_credential = fake_arn(service="iam", generate_account_id=True)
+        report_name = FAKE.word()
+        demo_accounts = {account_id: {auth_credential: {"report_name": report_name, "report_prefix": FAKE.word()}}}
+        with self.settings(DEMO_ACCOUNTS=demo_accounts):
+            with patch("masu.util.aws.common.get_assume_role_session") as mock_session:
+                AWSReportDownloader(
+                    **{
+                        "task": mock_task,
+                        "customer_name": f"acct{account_id}",
+                        "auth_credential": auth_credential,
+                        "bucket": FAKE.word(),
+                        "report_name": report_name,
+                        "provider_uuid": self.aws_provider_uuid,
+                    }
+                )
+                mock_session.assert_called_once()

--- a/koku/masu/test/external/downloader/azure/test_azure_report_downloader.py
+++ b/koku/masu/test/external/downloader/azure/test_azure_report_downloader.py
@@ -214,3 +214,29 @@ class AzureReportDownloaderTest(MasuTestCase):
         self.assertEqual(full_file_path, expected_full_path)
         self.assertEqual(etag, self.mock_data.export_etag)
         mock_download_cost_method._azure_client.download_cost_export.assert_not_called()
+
+    @patch("masu.external.downloader.azure.azure_report_downloader.AzureReportDownloader")
+    @patch("masu.external.downloader.azure.azure_report_downloader.AzureService", return_value=MockAzureService())
+    def test_init_with_demo_account(self, mock_download_cost_method, _):
+        """Test init with the demo account."""
+        account_id = "123456"
+        report_name = self.fake.word()
+        client_id = self.auth_credential.get("client_id")
+        demo_accounts = {
+            account_id: {
+                client_id: {
+                    "report_name": report_name,
+                    "report_prefix": self.fake.word(),
+                    "container_name": self.fake.word(),
+                }
+            }
+        }
+        with self.settings(DEMO_ACCOUNTS=demo_accounts):
+            AzureReportDownloader(
+                task=self.mock_task,
+                customer_name=f"acct{account_id}",
+                auth_credential=self.auth_credential,
+                billing_source=self.billing_source,
+                provider_uuid=self.azure_provider_uuid,
+            )
+            mock_download_cost_method._azure_client.download_cost_export.assert_not_called()


### PR DESCRIPTION
* Convert DEMO_ACCOUNTS environment to be JSON to supply processing data
* Update docker-compose to allow processing of DEMO_ACCOUNTS env

DEMO_ACCOUNTS can now support the following (as a single line string):
```
{
	"<ACCOUNT>": {
		"<AWS ARN>": {
			"report_prefix": "cur",
			"report_name": "awscost"
		},
		"<AZURE CLIENT ID>": {
			"report_prefix": "cur",
			"report_name": "azurecost",
			"container_name": "cur"
		}
	}
}
```

After processing the data you can get populated cost data:
[1738-process-demo-data-aws.txt](https://github.com/project-koku/koku/files/4215593/1738-process-demo-data-aws.txt)
[1738-process-demo-data-azure.txt](https://github.com/project-koku/koku/files/4215594/1738-process-demo-data-azure.txt)

