### PR TITLE
Remove client_secret on to_representation in Sources Serializer.

### DIFF
--- a/koku/sources/api/serializers.py
+++ b/koku/sources/api/serializers.py
@@ -125,6 +125,13 @@ class SourcesSerializer(serializers.ModelSerializer):
 
         return instance
 
+    def to_representation(self, instance):
+        """Control output of serializer."""
+        source = super().to_representation(instance)
+        if source.get("authentication", {}).get("credentials", {}).get("client_secret"):
+            del source["authentication"]["credentials"]["client_secret"]
+        return source
+
 
 class AdminSourcesSerializer(SourcesSerializer):
     """Source serializer specific to administration."""


### PR DESCRIPTION
* Do not respond with client_secret.


```
GET /api/cost-management/v1/sources/
HTTP 200 OK
Allow: GET, POST, HEAD, OPTIONS
Cache-Control: max-age=0, no-cache, no-store, must-revalidate
Content-Type: application/json
Expires: Thu, 05 Mar 2020 14:40:44 GMT
Vary: Accept

{
    "meta": {
        "count": 1
    },
    "links": {
        "first": "/api/cost-management/v1/sources/?limit=10&offset=0",
        "next": null,
        "previous": null,
        "last": "/api/cost-management/v1/sources/?limit=10&offset=0"
    },
    "data": [
        {
            "id": 1,
            "uuid": "6131b04e-8d90-4cff-a551-5e1e028d37da",
            "name": "TestAzureSource",
            "source_type": "Azure-local",
            "authentication": {
                "credentials": {
                    "client_id": "test_client",
                    "tenant_id": "test_tenant",
                    "subscription_id": "test_sub_id"
                }
            },
            "billing_source": {
                "data_source": {
                    "resource_group": "test_resource_group",
                    "storage_account": "test_storage_account"
                }
            },
            "provider_linked": false
        }
    ]
}
```