### PR TITLE
Catch id is not an int and not found uuid and throw 404

### DIFF
--- a/koku/sources/api/view.py
+++ b/koku/sources/api/view.py
@@ -19,6 +19,7 @@ import logging
 
 from django.conf import settings
 from django.db import connection
+from django.http import Http404
 from django.shortcuts import get_object_or_404
 from django.utils.encoding import force_text
 from django.views.decorators.cache import never_cache
@@ -142,8 +143,14 @@ class SourcesViewSet(*MIXIN_LIST):
                 return obj
         except (ValidationError, Sources.DoesNotExist):
             pass
-        obj = get_object_or_404(queryset, **{"pk": pk})
-        self.check_object_permissions(self.request, obj)
+
+        try:
+            int(pk)
+            obj = get_object_or_404(queryset, **{"pk": pk})
+            self.check_object_permissions(self.request, obj)
+        except ValueError:
+            raise Http404
+
         return obj
 
     def _get_account_and_tenant(self, request):

--- a/koku/sources/test/api/test_view.py
+++ b/koku/sources/test/api/test_view.py
@@ -16,8 +16,10 @@
 #
 """Test the sources view."""
 import json
+from random import randint
 from unittest.mock import patch
 from unittest.mock import PropertyMock
+from uuid import uuid4
 
 import requests_mock
 from django.test.utils import override_settings
@@ -246,3 +248,39 @@ class SourcesViewTests(IamTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIsNotNone(body)
         self.assertFalse(body["provider_linked"])
+
+    def test_source_get_random_int(self):
+        """Test the GET endpoint with non-existent source int id."""
+        source_id = randint(20, 100)
+        with requests_mock.mock() as m:
+            m.get(
+                f"http://www.sourcesclient.com/api/v1/sources/{source_id}/",
+                status_code=404,
+                headers={"Content-Type": "application/json"},
+            )
+
+            url = reverse("sources-detail", kwargs={"pk": source_id})
+
+            response = self.client.get(url, content_type="application/json", **self.request_context["request"].META)
+            body = response.json()
+
+            self.assertEqual(response.status_code, 404)
+            self.assertIsNotNone(body)
+
+    def test_source_get_random_uuid(self):
+        """Test the GET endpoint with non-existent source uuid."""
+        source_id = uuid4()
+        with requests_mock.mock() as m:
+            m.get(
+                f"http://www.sourcesclient.com/api/v1/sources/{source_id}/",
+                status_code=404,
+                headers={"Content-Type": "application/json"},
+            )
+
+            url = reverse("sources-detail", kwargs={"pk": source_id})
+
+            response = self.client.get(url, content_type="application/json", **self.request_context["request"].META)
+            body = response.json()
+
+            self.assertEqual(response.status_code, 404)
+            self.assertIsNotNone(body)


### PR DESCRIPTION
* Check if id is an int before performing lookup by int id
* Fallback to 404 if uuid not found and not an int
* Add test cases for get object when doesn't exit