### PR TITLE
Sources: Missing bucket during create

### DIFF
--- a/koku/sources/kafka_listener.py
+++ b/koku/sources/kafka_listener.py
@@ -67,7 +67,7 @@ SOURCE_PROVIDER_MAP = {
 }
 
 
-class SourcesIntegrationError(Exception):
+class SourcesIntegrationError(ValidationError):
     """Sources Integration error."""
 
 

--- a/koku/sources/kafka_source_manager.py
+++ b/koku/sources/kafka_source_manager.py
@@ -20,6 +20,7 @@ import logging
 from base64 import b64decode
 
 from django.db import connection
+from rest_framework.exceptions import ValidationError
 
 from api.models import Customer
 from api.models import Provider
@@ -35,7 +36,7 @@ from sources.config import Config
 LOG = logging.getLogger(__name__)
 
 
-class KafkaSourceManagerError(Exception):
+class KafkaSourceManagerError(ValidationError):
     """KafkaSourceManager Error."""
 
     pass

--- a/koku/sources/test/test_kafka_source_manager.py
+++ b/koku/sources/test/test_kafka_source_manager.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 """Test the Kafka Source Manager."""
+import logging
 from unittest.mock import patch
 
 from django.test import TestCase
@@ -22,7 +23,6 @@ from faker import Faker
 from rest_framework.exceptions import ValidationError
 
 from api.models import Provider
-from api.provider.provider_manager import ProviderManagerError
 from koku.middleware import IdentityHeaderMiddleware
 from providers.provider_access import ProviderAccessor
 from sources.config import Config
@@ -102,7 +102,8 @@ class KafkaSourceManagerTest(TestCase):
             )
             self.assertEqual(provider.name, self.name)
             self.assertEqual(str(provider.uuid), source_uuid)
-            with self.assertRaises(ProviderManagerError):
+            logging.disable(logging.NOTSET)
+            with self.assertLogs(logger="sources.kafka_source_manager", level=logging.INFO):
                 client.destroy_provider(faker.uuid4())
 
     def test_update_provider(self):


### PR DESCRIPTION
- Return 400 when patching a source with a missing billing_source or authentication.
- Add try/except to provider delete. Skip provider deletion if it does not exist.