### PR TITLE
Optimize docker-compose build

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,14 @@
 version: '3'
 
 services:
+  koku-base:
+      build:
+        context: .
+        dockerfile: Dockerfile-env
+
   koku-server:
       container_name: koku_server
-      build:
-          context: .
-          dockerfile: Dockerfile-env
+      image: koku_koku-base
       working_dir: /koku
       entrypoint:
         - /koku/run_server.sh
@@ -47,13 +50,12 @@ services:
         - koku-rabbit
         - masu-server
       depends_on:
+        - koku-base
         - db
 
   masu-server:
       container_name: masu_server
-      build:
-          context: .
-          dockerfile: Dockerfile-env
+      image: koku_koku-base
       working_dir: /koku
       entrypoint:
         - /koku/run_internal.sh
@@ -93,6 +95,7 @@ services:
         - db
         - koku-rabbit
       depends_on:
+        - koku-base
         - db
 
   redis:
@@ -135,6 +138,7 @@ services:
     links:
         - db
     depends_on:
+        - koku-base
         - db
 
   koku-rabbit:
@@ -150,9 +154,7 @@ services:
   koku-worker:
       container_name: koku_worker
       hostname: koku_worker
-      build:
-          context: .
-          dockerfile: Dockerfile-env
+      image: koku_koku-base
       working_dir: /koku/koku
       entrypoint: ['watchmedo', 'auto-restart', '--directory=./', '--pattern=*.py', '--recursive', '--', 'celery', '-A', 'koku', 'worker', '-l', 'info', '-Q', 'celery,download,remove_expired,reporting,process,upload,customer_data_sync,delete_archived_data,query_upload']
       environment:
@@ -196,13 +198,12 @@ services:
       links:
           - koku-rabbit
       depends_on:
+          - koku-base
           - koku-rabbit
 
   koku-listener:
       container_name: koku_listener
-      build:
-          context: .
-          dockerfile: Dockerfile-env
+      image: koku_koku-base
       working_dir: /koku/
       entrypoint: ['python', 'koku/manage.py', 'listener']
       environment:
@@ -236,14 +237,13 @@ services:
         - db
         - koku-rabbit
       depends_on:
+        - koku-base
         - db
         - koku-rabbit
 
   sources-client:
       container_name: sources_client
-      build:
-          context: .
-          dockerfile: Dockerfile-env
+      image: koku_koku-base
       working_dir: /koku/
       entrypoint:
         - /koku/run_sources.sh
@@ -270,15 +270,14 @@ services:
         - db
         - koku-server
       depends_on:
+        - koku-base
         - db
         - koku-server
 
   koku-beat:
       container_name: koku_beat
       hostname: koku_beat
-      build:
-          context: .
-          dockerfile: Dockerfile-env
+      image: koku_koku-base
       working_dir: /koku/koku
       entrypoint: ['celery', '--pidfile=/opt/celeryd.pid', '-A', 'koku', 'beat', '-l', 'info']
 
@@ -307,4 +306,5 @@ services:
       links:
           - koku-rabbit
       depends_on:
+          - koku-base
           - koku-rabbit


### PR DESCRIPTION
## Description

This will optimize the docker-compose build (`make docker-up`) to build a base image, then all other koku components not relying on an external image or other docker file will reference that base image.

This base image will always be built. This was done on purpose to always be able to pick up config or build changes and to eliminate a dependency on a an external repo.

This improvement is for **docker-compose** builds.

To utilize, this change, you should execute:
1. `make docker-down`
2. `make remove-db`
3. `docker volume prune -f`
4. `make docker-up`

## Testing

- [x] Tox tests pass
- [x] iqe smoke tests pass

## Observed improvement

Even with having to build one base image, the observed build time for a `make docker-up` command on Fedora is **~27 - 28 seconds**.