### PR TITLE
Fix secrets project reference and koku-sentry

### DIFF
--- a/scripts/e2e-deploy.sh
+++ b/scripts/e2e-deploy.sh
@@ -166,10 +166,10 @@ done
 ### deploy application
 if [[ ${DEPLOY_HCCM_OPTIONAL} ]]; then
     echo "Creating HCCM & HCCM-Optional application."
-    ${IQE} oc deploy -t templates -s hccm,hccm-optional -e dev-self-contained hccm
+    ${IQE} oc deploy -t templates -s hccm,hccm-optional -e dev-self-contained hccm --secrets-src-project ${SECRETS_PROJECT}
 else
     echo "Creating HCCM application."
-    ${IQE} oc deploy -t templates -s hccm -e dev-self-contained hccm
+    ${IQE} oc deploy -t templates -s hccm -e dev-self-contained hccm --secrets-src-project ${SECRETS_PROJECT}
 fi
 
 ### expose API route

--- a/scripts/e2e-secrets.yml
+++ b/scripts/e2e-secrets.yml
@@ -113,6 +113,19 @@ objects:
     name: koku-secret
     namespace: secrets
   type: Opaque
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: koku-sentry
+  stringData:
+    api-sentry-dsn: ${KOKU_API_SENTRY_DSN}
+    celery-sentry-dsn: ${KOKU_CELERY_SENTRY_DSN}
+  labels:
+    app: koku
+    template: koku-secret
+  name: koku-sentry
+  namespace: secrets
+
 parameters:
 # database params
 - displayName: Database Name
@@ -211,3 +224,13 @@ parameters:
   name: FLOWER_OAUTH2_DOMAINS
   required: false
   value: '.*@example\.com'
+
+  # optional sentry params
+- description: Koku API Sentry DSN
+  displayName: Koku API Sentry DSN
+  name: KOKU_API_SENTRY_DSN
+  required: false
+- description: Koku Celery Sentry DSN
+  displayName: Koku Celery Sentry DSN
+  name: KOKU_CELERY_SENTRY_DSN
+  required: false


### PR DESCRIPTION
As part of my work with #1859, I found some errors when running the e2e scripts.  My secrets were not found because they were in the secrets project but the command was looking in hccm.  Additionally, I was requried to add koku-sentry to fix some of the validation issues detected by Brandon's e2e validation checks.