### PR TITLE
Fix minor openapi spec bug.

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -2021,7 +2021,7 @@
                                 "schema": {
                                     "type": "array",
                                     "items": {
-                                        "$ref": "#/components/schemas/Setting"
+                                        "$ref": "#/components/schemas/SettingOut"
                                     },
                                     "example": [{
                                         "fields": [{


### PR DESCRIPTION
Found a openapi spec bug when looking at next story for OCP tag enablement.