### PR TITLE
Enable default filtering of OCP enabled tags.

### DIFF
--- a/koku/api/query_handler.py
+++ b/koku/api/query_handler.py
@@ -89,6 +89,8 @@ class QueryHandler:
             (Boolean): if wildcard is present in list
 
         """
+        if isinstance(in_list, bool):
+            return False
         if not in_list:
             return False
         return any(WILDCARD == item for item in in_list)

--- a/koku/api/report/test/ocp/tests_views.py
+++ b/koku/api/report/test/ocp/tests_views.py
@@ -915,7 +915,7 @@ class OCPReportViewTest(IamTestCase):
 
     def test_execute_query_with_tag_filter(self):
         """Test that data is filtered by tag key."""
-        url = "?filter[type]=pod&filter[time_scope_value]=-10"
+        url = "?filter[type]=pod&filter[time_scope_value]=-10&filter[enabled]=false"
         query_params = self.mocked_query_params(url, OCPTagView)
         handler = OCPTagQueryHandler(query_params)
         tag_keys = handler.get_tag_keys()
@@ -962,7 +962,7 @@ class OCPReportViewTest(IamTestCase):
 
     def test_execute_costs_query_with_tag_filter(self):
         """Test that data is filtered by tag key."""
-        url = "?filter[type]=pod&filter[time_scope_value]=-10"
+        url = "?filter[type]=pod&filter[time_scope_value]=-10&filter[enabled]=false"
         query_params = self.mocked_query_params(url, OCPTagView)
         handler = OCPTagQueryHandler(query_params)
         tag_keys = handler.get_tag_keys()
@@ -1010,7 +1010,7 @@ class OCPReportViewTest(IamTestCase):
 
     def test_execute_query_with_wildcard_tag_filter(self):
         """Test that data is filtered to include entries with tag key."""
-        url = "?filter[type]=pod"
+        url = "?filter[type]=pod&filter[enabled]=false"
         query_params = self.mocked_query_params(url, OCPTagView)
         handler = OCPTagQueryHandler(query_params)
         tag_keys = handler.get_tag_keys()
@@ -1048,7 +1048,7 @@ class OCPReportViewTest(IamTestCase):
 
     def test_execute_query_with_tag_group_by(self):
         """Test that data is grouped by tag key."""
-        url = "?filter[type]=pod"
+        url = "?filter[type]=pod&filter[enabled]=false"
         query_params = self.mocked_query_params(url, OCPTagView)
         handler = OCPTagQueryHandler(query_params)
         tag_keys = handler.get_tag_keys()
@@ -1070,7 +1070,7 @@ class OCPReportViewTest(IamTestCase):
 
     def test_execute_costs_query_with_tag_group_by(self):
         """Test that data is grouped by tag key."""
-        url = "?filter[type]=pod"
+        url = "?filter[type]=pod&filter[enabled]=false"
         query_params = self.mocked_query_params(url, OCPTagView)
         handler = OCPTagQueryHandler(query_params)
         tag_keys = handler.get_tag_keys()
@@ -1471,7 +1471,7 @@ class OCPReportViewTest(IamTestCase):
 
     def test_execute_query_with_and_tag_filter(self):
         """Test the filter[and:tag:] param in the view."""
-        url = "?filter[type]=pod&filter[time_scope_value]=-1"
+        url = "?filter[type]=pod&filter[time_scope_value]=-1&filter[enabled]=false"
         query_params = self.mocked_query_params(url, OCPTagView)
         handler = OCPTagQueryHandler(query_params)
         tag_keys = handler.get_tag_keys()
@@ -1504,7 +1504,7 @@ class OCPReportViewTest(IamTestCase):
 
     def test_execute_query_with_and_tag_group_by(self):
         """Test the group_by[and:tag:] param in the view."""
-        url = "?filter[type]=pod&filter[time_scope_value]=-1"
+        url = "?filter[type]=pod&filter[time_scope_value]=-1&filter[enabled]=false"
         query_params = self.mocked_query_params(url, OCPTagView)
         handler = OCPTagQueryHandler(query_params)
         tag_keys = handler.get_tag_keys()

--- a/koku/api/settings/ocp.py
+++ b/koku/api/settings/ocp.py
@@ -54,7 +54,10 @@ class OpenShiftSettings:
             (List) - List of available tag keys objects
             (List) - List of enabled tag keys strings
         """
-        url = "?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&key_only=True"
+        url = (
+            "?filter[time_scope_units]=month&filter[time_scope_value]=-1"
+            "&filter[resolution]=monthly&key_only=True&filter[enabled]=False"
+        )
         tag_request = self.factory.get(url)
         tag_request.user = self.request.user
         query_params = QueryParameters(tag_request, OCPTagView)

--- a/koku/api/settings/test/tests_views.py
+++ b/koku/api/settings/test/tests_views.py
@@ -85,7 +85,10 @@ class SettingsViewTest(IamTestCase):
         all_keys = duallist.get("options")
         self.assertIsNotNone(all_keys)
         all_key_values = [key_obj.get("value") for key_obj in all_keys]
-        url = "?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&key_only=True"
+        url = (
+            "?filter[time_scope_units]=month&filter[time_scope_value]=-1"
+            "&filter[resolution]=monthly&key_only=True&filter[enabled]=False"
+        )
         query_params = self.mocked_query_params(url, OCPTagView)
         handler = OCPTagQueryHandler(query_params)
         query_output = handler.execute_query()
@@ -94,7 +97,10 @@ class SettingsViewTest(IamTestCase):
 
     def test_post_settings_ocp_tag_enabled(self):
         """Test setting OCP tags as enabled."""
-        url = "?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&key_only=True"
+        url = (
+            "?filter[time_scope_units]=month&filter[time_scope_value]=-1"
+            "&filter[resolution]=monthly&key_only=True&filter[enabled]=False"
+        )
         query_params = self.mocked_query_params(url, OCPTagView)
         handler = OCPTagQueryHandler(query_params)
         query_output = handler.execute_query()

--- a/koku/api/tags/azure/openshift/queries.py
+++ b/koku/api/tags/azure/openshift/queries.py
@@ -39,5 +39,9 @@ class OCPAzureTagQueryHandler(AzureTagQueryHandler, OCPTagQueryHandler):
 
         """
         self._mapper = OCPAzureProviderMap(provider=self.provider, report_type=parameters.report_type)
+        if "enabled" in self.SUPPORTED_FILTERS:
+            self.SUPPORTED_FILTERS.remove("enabled")
+        if "enabled" in self.FILTER_MAP.keys():
+            del self.FILTER_MAP["enabled"]
         # super() needs to be called after _mapper is set
         super().__init__(parameters)

--- a/koku/api/tags/ocp_aws/queries.py
+++ b/koku/api/tags/ocp_aws/queries.py
@@ -39,5 +39,10 @@ class OCPAWSTagQueryHandler(AWSTagQueryHandler, OCPTagQueryHandler):
 
         """
         self._mapper = OCPAWSProviderMap(provider=self.provider, report_type=parameters.report_type)
+        if "enabled" in self.SUPPORTED_FILTERS:
+            self.SUPPORTED_FILTERS.remove("enabled")
+        if "enabled" in self.FILTER_MAP.keys():
+            del self.FILTER_MAP["enabled"]
+
         # super() needs to be called after _mapper is set
         super().__init__(parameters)

--- a/koku/api/tags/queries.py
+++ b/koku/api/tags/queries.py
@@ -333,8 +333,9 @@ class TagQueryHandler(QueryHandler):
             if dikt and dikt.get("type") == source.get("type"):
                 dikt["values"].extend(v.get("values"))
             else:
-                v["type"] = source.get("type")
-                final_data.append(v)
+                copy_value = copy.deepcopy(v)
+                copy_value["type"] = source.get("type")
+                final_data.append(copy_value)
 
     def append_to_final_data_without_type(self, final_data, converted_data):
         """Convert data to final list without a source type."""
@@ -343,7 +344,7 @@ class TagQueryHandler(QueryHandler):
             if dikt and dikt.get("type") is None:
                 dikt["values"].extend(v.get("values"))
             elif not dikt:
-                final_data.append(v)
+                final_data.append(copy.deepcopy(v))
 
     def execute_query(self):
         """Execute query and return provided data.

--- a/koku/api/tags/queries.py
+++ b/koku/api/tags/queries.py
@@ -339,7 +339,6 @@ class TagQueryHandler(QueryHandler):
     def append_to_final_data_without_type(self, final_data, converted_data):
         """Convert data to final list without a source type."""
         for k, v in converted_data.items():
-            print(f"v={v}")
             dikt = self._get_dictionary_for_key(final_data, k)
             if dikt and dikt.get("type") is None:
                 dikt["values"].extend(v.get("values"))

--- a/koku/api/tags/serializers.py
+++ b/koku/api/tags/serializers.py
@@ -22,7 +22,7 @@ from api.report.serializers import handle_invalid_fields
 from api.report.serializers import StringOrListField
 from api.report.serializers import validate_field
 
-OCP_FILTER_OP_FIELDS = ["project"]
+OCP_FILTER_OP_FIELDS = ["project", "enabled"]
 AWS_FILTER_OP_FIELDS = ["account"]
 AZURE_FILTER_OP_FIELDS = ["subscription_guid"]
 
@@ -83,8 +83,8 @@ class OCPFilterSerializer(FilterSerializer):
 
     TYPE_CHOICES = (("pod", "pod"), ("storage", "storage"), ("*", "*"))
     type = serializers.ChoiceField(choices=TYPE_CHOICES, required=False)
-
     project = StringOrListField(child=serializers.CharField(), required=False)
+    enabled = serializers.BooleanField(default=True, required=False)
 
     def __init__(self, *args, **kwargs):
         """Initialize the OCPFilterSerializer."""

--- a/koku/api/tags/test/azure/tests_queries.py
+++ b/koku/api/tags/test/azure/tests_queries.py
@@ -37,7 +37,11 @@ class AzureTagQueryHandlerTest(IamTestCase):
         source = {}
         qs1 = [("ms-resource-usage", ["azure-cloud-shell"]), ("project", ["p1", "p2"]), ("cost", ["management"])]
         tag_keys = tagHandler._convert_to_dict(qs1)
-        expected_dikt = {"ms-resource-usage": ["azure-cloud-shell"], "project": ["p1", "p2"], "cost": ["management"]}
+        expected_dikt = {
+            "ms-resource-usage": {"key": "ms-resource-usage", "values": ["azure-cloud-shell"]},
+            "project": {"key": "project", "values": ["p1", "p2"]},
+            "cost": {"key": "cost", "values": ["management"]},
+        }
         self.assertEqual(tag_keys, expected_dikt)
 
         expected_1 = [
@@ -71,12 +75,14 @@ class AzureTagQueryHandlerTest(IamTestCase):
             {"key": "project", "values": ["p1", "p2"], "type": "storage"},
             {"key": "cost", "values": ["management"], "type": "storage"},
         ]
-
         self.assertEqual(final, expected_3)
 
         qs2 = [("ms-resource-usage", ["azure-cloud-shell2"]), ("project", ["p1", "p3"])]
         tag_keys2 = tagHandler._convert_to_dict(qs2)
-        expected_tag_keys2 = {"ms-resource-usage": ["azure-cloud-shell2"], "project": ["p1", "p3"]}
+        expected_tag_keys2 = {
+            "ms-resource-usage": {"key": "ms-resource-usage", "values": ["azure-cloud-shell2"]},
+            "project": {"key": "project", "values": ["p1", "p3"]},
+        }
         self.assertEqual(tag_keys2, expected_tag_keys2)
 
         tagHandler.append_to_final_data_without_type(final, tag_keys2)

--- a/koku/api/tags/test/ocp/tests_view.py
+++ b/koku/api/tags/test/ocp/tests_view.py
@@ -69,10 +69,14 @@ class OCPTagsViewTest(IamTestCase):
     def test_execute_ocp_tags_queries_keys_only(self):
         """Test that tag key data is for the correct time queries."""
         test_cases = [
-            {"value": "-1", "unit": "month", "resolution": "monthly"},
-            {"value": "-2", "unit": "month", "resolution": "monthly"},
-            {"value": "-10", "unit": "day", "resolution": "daily"},
-            {"value": "-30", "unit": "day", "resolution": "daily"},
+            {"value": "-1", "unit": "month", "resolution": "monthly", "enabled": False},
+            {"value": "-2", "unit": "month", "resolution": "monthly", "enabled": False},
+            {"value": "-10", "unit": "day", "resolution": "daily", "enabled": False},
+            {"value": "-30", "unit": "day", "resolution": "daily", "enabled": False},
+            {"value": "-1", "unit": "month", "resolution": "monthly", "enabled": True},
+            {"value": "-2", "unit": "month", "resolution": "monthly", "enabled": True},
+            {"value": "-10", "unit": "day", "resolution": "daily", "enabled": True},
+            {"value": "-30", "unit": "day", "resolution": "daily", "enabled": True},
         ]
 
         for case in test_cases:
@@ -83,7 +87,7 @@ class OCPTagsViewTest(IamTestCase):
                 "filter[time_scope_value]": case.get("value"),
                 "filter[time_scope_units]": case.get("unit"),
                 "key_only": True,
-                "filter[enabled]": False,
+                "filter[enabled]": case.get("enabled"),
             }
             url = url + "?" + urlencode(params, quote_via=quote_plus)
             response = client.get(url, **self.headers)
@@ -91,7 +95,8 @@ class OCPTagsViewTest(IamTestCase):
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             data = response.json()
 
-            self.assertTrue(data.get("data"))
+            if not case.get("enabled"):
+                self.assertTrue(data.get("data"))
             self.assertTrue(isinstance(data.get("data"), list))
 
     def test_execute_ocp_tags_queries(self):

--- a/koku/api/tags/test/ocp/tests_view.py
+++ b/koku/api/tags/test/ocp/tests_view.py
@@ -83,6 +83,7 @@ class OCPTagsViewTest(IamTestCase):
                 "filter[time_scope_value]": case.get("value"),
                 "filter[time_scope_units]": case.get("unit"),
                 "key_only": True,
+                "filter[enabled]": False,
             }
             url = url + "?" + urlencode(params, quote_via=quote_plus)
             response = client.get(url, **self.headers)
@@ -110,6 +111,7 @@ class OCPTagsViewTest(IamTestCase):
                 "filter[time_scope_value]": case.get("value"),
                 "filter[time_scope_units]": case.get("unit"),
                 "key_only": False,
+                "filter[enabled]": False,
             }
             url = url + "?" + urlencode(params, quote_via=quote_plus)
             response = client.get(url, **self.headers)
@@ -141,6 +143,7 @@ class OCPTagsViewTest(IamTestCase):
                 "filter[time_scope_units]": case.get("unit"),
                 "key_only": False,
                 "filter[type]": case.get("type"),
+                "filter[enabled]": False,
             }
             url = url + "?" + urlencode(params, quote_via=quote_plus)
             response = client.get(url, **self.headers)


### PR DESCRIPTION
* Add "filter[enabled]" query parameter flow
* Add enabled annotation to OCP tag queries
* Update settings to utilize the request all tag keys


[1834-ut.txt](https://github.com/project-koku/koku/files/4333479/1834-ut.txt)