### PR TITLE
1908: handle empty ENABLE_S3_ARCHIVING env variable

### DIFF
--- a/scripts/sync_s3_lifecycle.py
+++ b/scripts/sync_s3_lifecycle.py
@@ -27,5 +27,5 @@ def sync_s3_lifecycle():
 
 
 if "__main__" in __name__:
-    if strtobool(os.environ.get("ENABLE_S3_ARCHIVING", "False")):
+    if strtobool(os.environ.get("ENABLE_S3_ARCHIVING") or "False"):
         sync_s3_lifecycle()


### PR DESCRIPTION
#1908 

Testing:
1. Set `ENABLE_S3_ARCHIVING` to True, False, and leave empty.
2. Run this:
```
import os
os.environ.get("ENABLE_S3_ARCHIVING") or "False"
```
3. See proper value returned. When variable is empty, see `False` returned.