### PR TITLE
Added a make target to create an iqe container based off local hccm.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,7 @@ help:
 	@echo "  docker-shell                         run Django and database containers with shell access to server (for pdb)"
 	@echo "  docker-logs                          connect to console logs for all services"
 	@echo "  docker-test-all                      run unittests"
+	@echo "  docker-iqe-local-hccm                create container based off local hccm plugin. Requires env 'HCCM_PLUGIN_PATH'"
 	@echo "  docker-iqe-smokes-tests              run smoke tests"
 	@echo "  docker-iqe-api-tests                 run api tests"
 	@echo "  docker-iqe-vortex-tests              run vortex tests"
@@ -527,6 +528,9 @@ docker-up-db-monitor:
 _set-test-dir-permissions:
 	@$(PREFIX) chmod -R o+rw,g+rw ./testing
 	@$(PREFIX) find ./testing -type d -exec chmod o+x,g+x {} \;
+
+docker-iqe-local-hccm: docker-reinitdb _set-test-dir-permissions clear-testing
+	./testing/run_test.sh
 
 docker-iqe-smokes-tests: docker-reinitdb _set-test-dir-permissions clear-testing
 	./testing/run_smoke_tests.sh

--- a/Makefile
+++ b/Makefile
@@ -500,9 +500,9 @@ docker-test-all:
 
 docker-up-koku:
 	@docker-compose up $(build) -d koku-server
-	@echo -n "Waiting on koku status: "
+	@echo "Waiting on koku status: "
 	@until ./scripts/check_for_koku_server.sh $${KOKU_API_HOST:-localhost} $$API_PATH_PREFIX $${KOKU_API_PORT:-8000} >/dev/null 2>&1 ; do \
-        echo -n "." ; \
+        printf "." ; \
         sleep 1 ; \
     done
 	@echo " koku is available!"

--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,7 @@ help:
 	@echo "  docker-logs                          connect to console logs for all services"
 	@echo "  docker-test-all                      run unittests"
 	@echo "  docker-iqe-local-hccm                create container based off local hccm plugin. Requires env 'HCCM_PLUGIN_PATH'"
+	@echo "                                          @param iqe_cmd - (optional) Command to run. Defaults to 'bash'."
 	@echo "  docker-iqe-smokes-tests              run smoke tests"
 	@echo "  docker-iqe-api-tests                 run api tests"
 	@echo "  docker-iqe-vortex-tests              run vortex tests"
@@ -530,7 +531,7 @@ _set-test-dir-permissions:
 	@$(PREFIX) find ./testing -type d -exec chmod o+x,g+x {} \;
 
 docker-iqe-local-hccm: docker-reinitdb _set-test-dir-permissions clear-testing
-	./testing/run_test.sh
+	./testing/run_local_hccm.sh $(iqe_cmd)
 
 docker-iqe-smokes-tests: docker-reinitdb _set-test-dir-permissions clear-testing
 	./testing/run_smoke_tests.sh

--- a/testing/run_local_hccm.sh
+++ b/testing/run_local_hccm.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 COMMAND=$@
+if [ -z "$COMMAND" ]
+then
+   COMMAND=bash
+fi
+
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 IMAGE="docker-registry.upshift.redhat.com/insights-qe/iqe-tests"
 
@@ -9,25 +14,31 @@ if [ $HOST == 'Linux' ]; then
     FLAGS=':Z'
 fi
 
-main() {
-    if command -v docker > /dev/null 2>&1; then
-        CONTAINER_RUNTIME=docker
-    elif command -v podman > /dev/null 2>&1; then
-        CONTAINER_RUNTIME=podman
-    else
-        echo "Please install podman or docker first"
+if command -v docker > /dev/null 2>&1; then
+    CONTAINER_RUNTIME=docker
+elif command -v podman > /dev/null 2>&1; then
+    CONTAINER_RUNTIME=podman
+else
+    echo "Please install podman or docker first"
+    exit 1
+fi
+
+hccm_local_container() {
+    LOCAL_HCCM_PATH="$(printenv | grep 'HCCM_PLUGIN_PATH' | sed 's/HCCM_PLUGIN_PATH=//')"
+    if [ -z "$LOCAL_HCCM_PATH" ]
+    then
+        echo "ERROR: The env var HCCM_PLUGIN_PATH is not set."
         exit 1
     fi
 
-
     $CONTAINER_RUNTIME pull $IMAGE
-
     $CONTAINER_RUNTIME run -it \
                            --rm \
                            --network="host" \
-                           --name "iqe" \
+                           --name "iqe-local-hccm" \
                            -e "IQE_TESTS_LOCAL_CONF_PATH=/iqe_conf" \
                            -e "ENV_FOR_DYNACONF=local" \
+                           -v $LOCAL_HCCM_PATH:/hccm_plugin \
                            -v $SCRIPTPATH/conf:/iqe_conf${FLAGS} \
                            -v $SCRIPTPATH/local_providers/aws_local:/tmp/local_bucket${FLAGS} \
                            -v $SCRIPTPATH/local_providers/aws_local_0:/tmp/local_bucket_0${FLAGS} \
@@ -39,7 +50,6 @@ main() {
                            -v $SCRIPTPATH/local_providers/azure_local:/tmp/local_container${FLAGS} \
                            -v $SCRIPTPATH/pvc_dir/insights_local:/var/tmp/masu/insights_local${FLAGS} \
                            $IMAGE \
-                           $COMMAND
+                           bash -c "iqe plugin uninstall hccm && iqe plugin install --editable /hccm_plugin/ && $COMMAND"
 }
-
-main
+hccm_local_container

--- a/testing/run_test.sh
+++ b/testing/run_test.sh
@@ -50,7 +50,6 @@ hccm_local_container() {
     fi
 
     $CONTAINER_RUNTIME pull $IMAGE
-
     $CONTAINER_RUNTIME run -it \
                            --rm \
                            --network="host" \
@@ -69,7 +68,7 @@ hccm_local_container() {
                            -v $SCRIPTPATH/local_providers/azure_local:/tmp/local_container${FLAGS} \
                            -v $SCRIPTPATH/pvc_dir/insights_local:/var/tmp/masu/insights_local${FLAGS} \
                            $IMAGE \
-                           bash -c "iqe plugin uninstall hccm && iqe plugin install --editable /hccm_plugin/" && bash
+                           bash -c "iqe plugin uninstall hccm && iqe plugin install --editable /hccm_plugin/ && bash"
 }
 
 if [ -z "$COMMAND" ]

--- a/testing/run_test.sh
+++ b/testing/run_test.sh
@@ -9,17 +9,16 @@ if [ $HOST == 'Linux' ]; then
     FLAGS=':Z'
 fi
 
+if command -v docker > /dev/null 2>&1; then
+    CONTAINER_RUNTIME=docker
+elif command -v podman > /dev/null 2>&1; then
+    CONTAINER_RUNTIME=podman
+else
+    echo "Please install podman or docker first"
+    exit 1
+fi
+
 main() {
-    if command -v docker > /dev/null 2>&1; then
-        CONTAINER_RUNTIME=docker
-    elif command -v podman > /dev/null 2>&1; then
-        CONTAINER_RUNTIME=podman
-    else
-        echo "Please install podman or docker first"
-        exit 1
-    fi
-
-
     $CONTAINER_RUNTIME pull $IMAGE
 
     $CONTAINER_RUNTIME run -it \
@@ -42,4 +41,40 @@ main() {
                            $COMMAND
 }
 
-main
+hccm_local_container() {
+    LOCAL_HCCM_PATH="$(printenv | grep 'HCCM_PLUGIN_PATH' | sed 's/HCCM_PLUGIN_PATH=//')"
+    if [ -z "$LOCAL_HCCM_PATH" ]
+    then
+        echo "ERROR: The env var HCCM_PLUGIN_PATH is not set."
+        exit 1
+    fi
+
+    $CONTAINER_RUNTIME pull $IMAGE
+
+    $CONTAINER_RUNTIME run -it \
+                           --rm \
+                           --network="host" \
+                           --name "iqe-local-hccm" \
+                           -e "IQE_TESTS_LOCAL_CONF_PATH=/iqe_conf" \
+                           -e "ENV_FOR_DYNACONF=local" \
+                           -v $LOCAL_HCCM_PATH:/hccm_plugin \
+                           -v $SCRIPTPATH/conf:/iqe_conf${FLAGS} \
+                           -v $SCRIPTPATH/local_providers/aws_local:/tmp/local_bucket${FLAGS} \
+                           -v $SCRIPTPATH/local_providers/aws_local_0:/tmp/local_bucket_0${FLAGS} \
+                           -v $SCRIPTPATH/local_providers/aws_local_1:/tmp/local_bucket_1${FLAGS} \
+                           -v $SCRIPTPATH/local_providers/aws_local_2:/tmp/local_bucket_2${FLAGS} \
+                           -v $SCRIPTPATH/local_providers/aws_local_3:/tmp/local_bucket_3${FLAGS} \
+                           -v $SCRIPTPATH/local_providers/aws_local_4:/tmp/local_bucket_4${FLAGS} \
+                           -v $SCRIPTPATH/local_providers/aws_local_5:/tmp/local_bucket_5${FLAGS} \
+                           -v $SCRIPTPATH/local_providers/azure_local:/tmp/local_container${FLAGS} \
+                           -v $SCRIPTPATH/pvc_dir/insights_local:/var/tmp/masu/insights_local${FLAGS} \
+                           $IMAGE \
+                           bash -c "iqe plugin uninstall hccm && iqe plugin install --editable /hccm_plugin/" && bash
+}
+
+if [ -z "$COMMAND" ]
+then
+   hccm_local_container
+else
+    main
+fi


### PR DESCRIPTION
After a debugging session with @dccurtis yesterday, we thought it would be a nice development feature to have the ability to have a make target that will create and bring up the iqe container based off of your local hccm changes.

The reason we wanted the ability to do this is because if you do have to fix iqe tests, you would have to set them up locally to test that your fixes work. However, with this target you can test that your fixes work without having to setup the iqe_tests venv on your local machine. 

------

### Testing

**Note:** You will need to add the `HCCM_PLUGIN_PATH` environment variable to your `.env` file, and then make sure that it is within your pip environment. 

If you would like to be dropped into a shell of the local hccm container run this command: 
```
make docker-iqe-local-hccm
``` 
Example:
```
(koku) bash-3.2$ make docker-iqe-local-hccm
...
{bunch of stuff happens here}
...
✔ ️SUCCESS: Plugin:  was successfully installed 🍰👊
bash-4.4$ cd /hccm_plugin/
bash-4.4$ ls
'Basic API tasks.ipynb'   README.md	     iqe_hccm	    iqe_hccm_api_README.md     iqe_hccm_sources_api   requirements.txt	 setup.py
 MANIFEST.in		  entry_points.txt   iqe_hccm_api   iqe_hccm_plugin.egg-info   iqe_masu_api	      setup.cfg		 tox.ini
```
If you would like to run a single iqe command in the container you can do so by passing the the command to the make target under the `iqe_cmd` parameter:
```

make docker-iqe-local-hccm iqe_cmd="iqe tests plugin --debug hccm -k test_api -m hccm_smoke"
```
Example:
```
(koku) bash-3.2$ make docker-iqe-local-hccm iqe_cmd="iqe tests plugin --debug hccm -k test_api -m hccm_smoke"
  Running setup.py develop for iqe-hccm-plugin
Successfully installed iqe-hccm-plugin

✔ ️SUCCESS: Plugin:  was successfully installed 🍰👊
tests/rest_api/v1/test_aws_cost_reports.py::test_api_aws_cost_endpoint[query-none]
------------------------------------------------------------------------------------------------ live log call -------------------------------------------------------------------------------------------------
2020-03-20 16:00:40 INFO Using <class 'iqe_hccm_api.api.ClientObject'> object....with url http://localhost:8000/api/cost-management/v1 and verify_ssl set to False
2020-03-20 16:00:40 INFO Setting auth_type to basic
2020-03-20 16:00:40 INFO REST: http://localhost:8000/api/cost-management/v1/reports/aws/costs/
PASSED                                                                                                                                                                                                   [  0%]
tests/rest_api/v1/test_aws_cost_reports.py::test_api_aws_cost_endpoint[last-10-days]
------------------------------------------------------------------------------------------------ live log call -------------------------------------------------------------------------------------------------
2020-03-20 16:00:41 INFO REST: http://localhost:8000/api/cost-management/v1/reports/aws/costs/?filter[resolution]=daily&filter[time_scope_value]=-10&filter[time_scope_units]=day
PASSED                                                                                                                                                                                                   [  0%]
tests/rest_api/v1/test_aws_cost_reports.py::test_api_aws_cost_endpoint[last-30-days]
------------------------------------------------------------------------------------------------ live log call -------------------------------------------------------------------------------------------------
2020-03-20 16:00:41 INFO REST: http://localhost:8000/api/cost-management/v1/reports/aws/costs/?filter[resolution]=daily&filter[time_scope_value]=-30&filter[time_scope_units]=day
PASSED                                                                                                                                                                                                   [  0%]
tests/rest_api/v1/test_aws_cost_reports.py::test_api_aws_cost_endpoint[last-month-daily]
------------------------------------------------------------------------------------------------ live log call -------------------------------------------------------------------------------------------------
2020-03-20 16:00:41 INFO REST: http://localhost:8000/api/cost-management/v1/reports/aws/costs/?filter[resolution]=daily&filter[time_scope_value]=-1&filter[time_scope_units]=month
PASSED                                                                                                                                                                                                   [  0%]
tests/rest_api/v1/test_aws_cost_reports.py::test_api_aws_cost_endpoint[two-months-ago-daily]
------------------------------------------------------------------------------------------------ live log call -------------------------------------------------------------------------------------------------
2020-03-20 16:00:41 INFO REST: http://localhost:8000/api/cost-management/v1/reports/aws/costs/?filter[resolution]=daily&filter[time_scope_value]=-2&filter[time_scope_units]=month
PASSED
```