### PR TITLE
Remove user authorization checking for Sources Client

### DIFF
--- a/koku/koku/middleware.py
+++ b/koku/koku/middleware.py
@@ -49,6 +49,7 @@ from koku.rbac import RbacService
 
 LOG = logging.getLogger(__name__)
 MASU = settings.MASU
+SOURCES = settings.SOURCES
 UNIQUE_ACCOUNT_COUNTER = Counter("hccm_unique_account", "Unique Account Counter")
 UNIQUE_USER_COUNTER = Counter("hccm_unique_user", "Unique User Counter", ["account", "user"])
 
@@ -57,7 +58,7 @@ def is_no_auth(request):
     """Check condition for needing to authenticate the user."""
     no_auth_list = ["/status", "openapi.json"]
     no_auth = any(no_auth_path in request.path for no_auth_path in no_auth_list)
-    return no_auth or MASU
+    return no_auth or MASU or SOURCES
 
 
 def is_no_entitled(request):

--- a/koku/sources/api/source_status.py
+++ b/koku/sources/api/source_status.py
@@ -43,7 +43,7 @@ class SourceStatus:
         self.request = request
         self.user = request.user
         self.source = Sources.objects.get(source_id=source_id)
-        self.auth_header = self.user.identity_header.get("encoded")
+        self.auth_header = request.headers.get("X-Rh-Identity")
         self.sources_client = SourcesHTTPClient(auth_header=self.auth_header, source_id=source_id)
 
     def status(self):

--- a/koku/sources/api/source_status.py
+++ b/koku/sources/api/source_status.py
@@ -42,6 +42,7 @@ class SourceStatus:
         """Initialize source id."""
         self.request = request
         self.user = request.user
+        self.source_id = source_id
         self.source = Sources.objects.get(source_id=source_id)
         self.auth_header = request.headers.get("X-Rh-Identity")
         self.sources_client = SourcesHTTPClient(auth_header=self.auth_header, source_id=source_id)
@@ -96,6 +97,7 @@ def _deliver_status(request, status_obj):
     if request.method == "GET":
         return Response(availability_status, status=status.HTTP_200_OK)
     elif request.method == "POST":
+        LOG.info("Delivering source status for Source ID: %s", status_obj.source_id)
         status_thread = threading.Thread(
             target=status_obj.push_status, args=(availability_status.get("availability_status_error"),)
         )


### PR DESCRIPTION
Platform Sources will periodically call cost management (via an internal cluster call to Koku-sources) to request source status.

The sources-client hosts a `/source-status` endpoint which is registered with the platform to call when they need source status.

This change removes the user authorization requirements for sources-client internal API calls.  The platform.

**Testing**
`POST http://localhost:4000/api/cost-management/v1/source-status/` with data `{"source_id": "1"}` and a user header that matches what the platform will be using base64 encoding of `{"identity":{"account_number":"9999999"}}`.  Ensure that `DEVELOPMENT=False`.

**Test Results**
```
[2020-03-26 14:31:01,471] INFO None Listener started.  Waiting for messages...
[2020-03-26 14:31:07,584] INFO None Delivering source status for Source ID: 1
[2020-03-26 14:31:07,600] INFO None POST: /api/cost-management/v1/source-status/ 204
[2020-03-26 14:31:07,601] INFO None "POST /api/cost-management/v1/source-status/ HTTP/1.1" 204 0
```