### PR TITLE
allow for no trailing / in source-status endpoint

### DIFF
--- a/koku/sources/api/urls.py
+++ b/koku/sources/api/urls.py
@@ -28,7 +28,6 @@ ROUTER.register(r"sources", SourcesViewSet)
 # # pylint: disable=invalid-name
 urlpatterns = [
     url(r"^status/$", get_status, name="server-status"),
-    url(r"^source-status/$", source_status, name="source-status"),
-    url(r"^source-status$", source_status, name="source-status"),
+    url(r"^source-status/?$", source_status, name="source-status"),
     url(r"^", include(ROUTER.urls)),
 ]

--- a/koku/sources/api/urls.py
+++ b/koku/sources/api/urls.py
@@ -29,5 +29,6 @@ ROUTER.register(r"sources", SourcesViewSet)
 urlpatterns = [
     url(r"^status/$", get_status, name="server-status"),
     url(r"^source-status/$", source_status, name="source-status"),
+    url(r"^source-status$", source_status, name="source-status"),
     url(r"^", include(ROUTER.urls)),
 ]


### PR DESCRIPTION
Platform Sources is calling source-status without a trailing slash and it results in:

```
 - - [26/Mar/2020:15:00:23 +0000] "POST /api/cost-management/v1/source-status HTTP/1.1" 404 77 "-" "Ruby"
[2020-03-26 15:00:24,568] INFO None POST: /api/cost-management/v1/source-status 404
```

**Test Results**
```
[2020-03-26 15:14:52,132] INFO None Delivering source status for Source ID: 1
[2020-03-26 15:14:52,145] INFO None POST: /api/cost-management/v1/source-status/ 204
[2020-03-26 15:14:52,146] INFO None "POST /api/cost-management/v1/source-status/ HTTP/1.1" 204 0
[2020-03-26 15:14:57,677] INFO None Delivering source status for Source ID: 1
[2020-03-26 15:14:57,679] INFO None POST: /api/cost-management/v1/source-status 204
[2020-03-26 15:14:57,679] INFO None "POST /api/cost-management/v1/source-status HTTP/1.1" 204 0
```