### PR TITLE
Double ingest during Provider create

### DIFF
--- a/koku/api/provider/models.py
+++ b/koku/api/provider/models.py
@@ -85,9 +85,6 @@ class ProviderBillingSource(models.Model):
         ]
 
 
-count = 0
-
-
 class Provider(models.Model):
     """A Koku Provider.
 

--- a/koku/api/provider/models.py
+++ b/koku/api/provider/models.py
@@ -197,6 +197,7 @@ class Provider(models.Model):
             # Local import of task function to avoid potential import cycle.
             from masu.celery.tasks import check_report_updates
 
+            LOG.info(f"Starting data ingest task for Provider {self.uuid}")
             transaction.on_commit(lambda: check_report_updates.delay(provider_uuid=self.uuid))
 
 

--- a/koku/api/provider/test/tests_serializers.py
+++ b/koku/api/provider/test/tests_serializers.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 """Test the Provider serializers."""
+import logging
 import random
 import uuid
 from itertools import permutations
@@ -157,7 +158,9 @@ class ProviderSerializerTest(IamTestCase):
         with patch.object(ProviderAccessor, "cost_usage_source_ready", returns=True):
             serializer = ProviderSerializer(data=provider, context=self.request_context)
             if serializer.is_valid(raise_exception=True):
-                instance = serializer.save()
+                with self.assertLogs("api.provider.models", logging.INFO) as logs:
+                    instance = serializer.save()
+                    self.assertEqual(len(logs.output), 1)
 
         schema_name = serializer.data["customer"].get("schema_name")
         self.assertIsInstance(instance.uuid, uuid.UUID)
@@ -178,7 +181,9 @@ class ProviderSerializerTest(IamTestCase):
         with patch.object(ProviderAccessor, "cost_usage_source_ready", returns=True):
             serializer = ProviderSerializer(data=provider, context=self.request_context)
             if serializer.is_valid(raise_exception=True):
-                instance = serializer.save()
+                with self.assertLogs("api.provider.models", logging.INFO) as logs:
+                    instance = serializer.save()
+                    self.assertEqual(len(logs.output), 1)
 
         schema_name = serializer.data["customer"].get("schema_name")
         self.assertIsInstance(instance.uuid, uuid.UUID)
@@ -376,7 +381,9 @@ class ProviderSerializerTest(IamTestCase):
         with patch.object(ProviderAccessor, "cost_usage_source_ready", returns=True):
             serializer = ProviderSerializer(data=provider, context=self.request_context)
             if serializer.is_valid(raise_exception=True):
-                instance = serializer.save()
+                with self.assertLogs("api.provider.models", logging.INFO) as logs:
+                    instance = serializer.save()
+                    self.assertEqual(len(logs.output), 1)
 
         schema_name = serializer.data["customer"].get("schema_name")
         self.assertIsInstance(instance.uuid, uuid.UUID)

--- a/koku/api/provider/test/tests_serializers.py
+++ b/koku/api/provider/test/tests_serializers.py
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 """Test the Provider serializers."""
-import logging
 import random
 import uuid
 from itertools import permutations
@@ -158,9 +157,7 @@ class ProviderSerializerTest(IamTestCase):
         with patch.object(ProviderAccessor, "cost_usage_source_ready", returns=True):
             serializer = ProviderSerializer(data=provider, context=self.request_context)
             if serializer.is_valid(raise_exception=True):
-                with self.assertLogs("api.provider.models", logging.INFO) as logs:
-                    instance = serializer.save()
-                    self.assertEqual(len(logs.output), 1)
+                instance = serializer.save()
 
         schema_name = serializer.data["customer"].get("schema_name")
         self.assertIsInstance(instance.uuid, uuid.UUID)
@@ -181,9 +178,7 @@ class ProviderSerializerTest(IamTestCase):
         with patch.object(ProviderAccessor, "cost_usage_source_ready", returns=True):
             serializer = ProviderSerializer(data=provider, context=self.request_context)
             if serializer.is_valid(raise_exception=True):
-                with self.assertLogs("api.provider.models", logging.INFO) as logs:
-                    instance = serializer.save()
-                    self.assertEqual(len(logs.output), 1)
+                instance = serializer.save()
 
         schema_name = serializer.data["customer"].get("schema_name")
         self.assertIsInstance(instance.uuid, uuid.UUID)
@@ -381,9 +376,7 @@ class ProviderSerializerTest(IamTestCase):
         with patch.object(ProviderAccessor, "cost_usage_source_ready", returns=True):
             serializer = ProviderSerializer(data=provider, context=self.request_context)
             if serializer.is_valid(raise_exception=True):
-                with self.assertLogs("api.provider.models", logging.INFO) as logs:
-                    instance = serializer.save()
-                    self.assertEqual(len(logs.output), 1)
+                instance = serializer.save()
 
         schema_name = serializer.data["customer"].get("schema_name")
         self.assertIsInstance(instance.uuid, uuid.UUID)

--- a/koku/api/report/test/utils.py
+++ b/koku/api/report/test/utils.py
@@ -4,6 +4,7 @@ import shutil
 from unittest.mock import patch
 
 from dateutil.relativedelta import relativedelta
+from django.conf import settings
 from jinja2 import Template
 from model_bakery import baker
 from nise.__main__ import run
@@ -73,7 +74,7 @@ class NiseDataLoader:
     def load_openshift_data(self, customer, static_data_file, cluster_id):
         """Load OpenShift data into the database."""
         provider_type = Provider.PROVIDER_OCP
-        with patch("masu.celery.tasks.check_report_updates"):
+        with patch.object(settings, "AUTO_DATA_INGEST", False):
             provider = baker.make(
                 "Provider",
                 type=provider_type,
@@ -129,7 +130,7 @@ class NiseDataLoader:
             provider_resource_name = "arn:aws:iam::999999999999:role/CostManagement"
         nise_provider_type = provider_type.replace("-local", "")
         report_name = "Test"
-        with patch("masu.celery.tasks.check_report_updates"):
+        with patch.object(settings, "AUTO_DATA_INGEST", False):
             provider = baker.make(
                 "Provider",
                 type=provider_type,
@@ -169,7 +170,7 @@ class NiseDataLoader:
                         elif "manifest" in report.lower():
                             continue
                         self.process_report(report, "GZIP", provider_type, provider, manifest)
-            with patch("masu.processor.tasks.chain"):
+            with patch("masu.processor.tasks.chain"), patch.object(settings, "AUTO_DATA_INGEST", False):
                 update_summary_tables(
                     self.schema, provider_type, provider.uuid, start_date, end_date, manifest_id=manifest.id
                 )
@@ -193,7 +194,7 @@ class NiseDataLoader:
         if data_source is None:
             data_source = {"resource_group": "resourcegroup1", "storage_account": "storageaccount1"}
 
-        with patch("masu.celery.tasks.check_report_updates"):
+        with patch.object(settings, "AUTO_DATA_INGEST", False):
             provider = baker.make(
                 "Provider",
                 type=provider_type,
@@ -228,7 +229,7 @@ class NiseDataLoader:
                 elif "manifest" in report.name.lower():
                     continue
                 self.process_report(report, "PLAIN", provider_type, provider, manifest)
-            with patch("masu.processor.tasks.chain"):
+            with patch("masu.processor.tasks.chain"), patch.object(settings, "AUTO_DATA_INGEST", False):
                 update_summary_tables(
                     self.schema, provider_type, provider.uuid, start_date, end_date, manifest_id=manifest.id
                 )


### PR DESCRIPTION
Update the logic for determining if data ingest task should be started in Provider.save method during Provider create.

The Provider serializer saves the Provider twice in quick succession during a Provider create event. Both saves were starting a data ingest task. In CI, this may have been causing `"files_processed": "2/1"` to appear in the sources/{id}/stats/ endpoint.

The logic introduced with this PR will prevent double ingest tasks and will start the task during the _second_ Provider save in the serializer. When creating a new Provider, the serializer adds the `created_timestamp` field during the first save and the `setup_complete` field during the second save. Checking for `created_timestamp` and `not setup_complete` before `super().save` causes data ingest during the second save.