### PR TITLE
Adding select_related to Provider query

### DIFF
--- a/koku/masu/database/provider_collector.py
+++ b/koku/masu/database/provider_collector.py
@@ -44,7 +44,12 @@ class ProviderCollector(KokuDBAccess):
             (sqlalchemy.orm.query.Query): "SELECT public.api_customer.group_ptr_id ..."
 
         """
-        objs = self._table.objects.all()
+        objs = (
+            self._table.objects.select_related("authentication")
+            .select_related("billing_source")
+            .select_related("customer")
+            .all()
+        )
         return objs
 
     def get_providers(self):


### PR DESCRIPTION
issue #1950 

Since this problem is happening infrequently; I am keeping this change to be as minimal as possible for the time being and only focusing on the foreign keys that the `CURAccountsDB().get_accounts_from_source` logic is accessing.  

Based on the SQL query the foreign keys are now being joined in the Provider query.
```
> /Users/curtisd/projects/repos/koku/koku/masu/database/provider_collector.py(54)_get_db_obj_query()
-> return objs
(Pdb) l     
 49  	            .select_related("billing_source")
 50  	            .select_related("customer")
 51  	            .all()
 52  	        )
 53  	        import pdb; pdb.set_trace()
 54  ->	        return objs
 55  	
 56  	    def get_providers(self):
 57  	        """
 58  	        Return all providers.
 59  	
(Pdb) print(objs.query)
SELECT "api_provider"."uuid", "api_provider"."name", "api_provider"."type", "api_provider"."authentication_id", "api_provider"."billing_source_id", "api_provider"."customer_id", "api_provider"."created_by_id", "api_provider"."setup_complete", "api_provider"."created_timestamp", "api_provider"."active", "api_provider"."infrastructure_id", "api_providerauthentication"."id", "api_providerauthentication"."uuid", "api_providerauthentication"."provider_resource_name", "api_providerauthentication"."credentials", "api_providerbillingsource"."id", "api_providerbillingsource"."uuid", "api_providerbillingsource"."bucket", "api_providerbillingsource"."data_source", "api_customer"."id", "api_customer"."date_created", "api_customer"."uuid", "api_customer"."account_id", "api_customer"."schema_name" FROM "api_provider" LEFT OUTER JOIN "api_providerauthentication" ON ("api_provider"."authentication_id" = "api_providerauthentication"."id") LEFT OUTER JOIN "api_providerbillingsource" ON ("api_provider"."billing_source_id" = "api_providerbillingsource"."id") LEFT OUTER JOIN "api_customer" ON ("api_provider"."customer_id" = "api_customer"."id") ORDER BY "api_provider"."name" ASC
(Pdb) 
```

While it's possible that this could be happening in any of our foreign key accesses I think this particular spot could be more susceptible to the timing issues described here: https://github.com/nesdis/djongo/issues/162 since we are gathering *all* of the provider accounts.  

I didn't spend a lot of time trying to reproduce the problem but if anyone wants to hold off on this change until we can reproduce it I'm good with that too.
