### PR TITLE
add default cost type to openapi spec

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -2723,7 +2723,8 @@
                     "metric",
                     "label_metric",
                     "label_measurement",
-                    "label_measurement_unit"
+                    "label_measurement_unit",
+                    "default_cost_type"
                 ],
                 "properties": {
                     "source_type": {
@@ -2739,6 +2740,9 @@
                         "type": "string"
                     },
                     "label_measurement_unit": {
+                        "type": "string"
+                    },
+                    "default_cost_type": {
                         "type": "string"
                     }
                 }

--- a/koku/api/report/test/aws/tests_queries.py
+++ b/koku/api/report/test/aws/tests_queries.py
@@ -415,13 +415,6 @@ class AWSReportQueryTest(IamTestCase):
 
         total = query_output.get("total")
         self.assertIsNotNone(total.get("count"))
-        dh = DateHelper()
-        if dh.today.day >= 10:
-            num_entries = 10
-        else:
-            num_entries = dh.today.day
-
-        self.assertEqual(total.get("count", {}).get("value"), num_entries)
 
         annotations = {
             "date": F("usage_start"),
@@ -443,12 +436,15 @@ class AWSReportQueryTest(IamTestCase):
                     else:
                         count_dict[str(item["date"])][item["type"]] = 1
 
+        total_count = 0
         for data_item in data:
             instance_types = data_item.get("instance_types")
             for it in instance_types:
                 expected_count = count_dict.get(data_item.get("date")).get(it["instance_type"])
-                actual_count = it["values"][0].get("count", {}).get("value")
+                actual_count = it["values"][0].get("count", {}).get("value", 0)
                 self.assertEqual(actual_count, expected_count)
+                total_count += actual_count
+        self.assertEqual(total.get("count", {}).get("value"), total_count)
 
     def test_execute_query_without_counts(self):
         """Test execute_query without counts of unique resources."""

--- a/koku/api/report/test/utils.py
+++ b/koku/api/report/test/utils.py
@@ -34,6 +34,8 @@ class NiseDataLoader:
     def get_test_data_dates(self, num_days):
         """Return a list of tuples with dates for nise data."""
         end_date = self.dh.today
+        if end_date.day == 1:
+            end_date += relativedelta(days=1)
         n_days_ago = self.dh.n_days_ago(end_date, num_days)
         start_date = n_days_ago
         if self.dh.this_month_start > n_days_ago:


### PR DESCRIPTION
- add default_cost_type to openapi spec.
- Travis fixes for first of the month