### PR TITLE
updating monthly cluster costs only when report period exists

### DIFF
--- a/koku/masu/database/ocp_report_db_accessor.py
+++ b/koku/masu/database/ocp_report_db_accessor.py
@@ -705,31 +705,32 @@ class OCPReportDBAccessor(ReportDBAccessorBase):
     ):
         """Update or insert a daily summary line item for cluster cost."""
         report_period = self.get_usage_period_by_dates_and_cluster(start_date, end_date, cluster_id)
-        with schema_context(self.schema):
-            line_item = OCPUsageLineItemDailySummary.objects.filter(
-                usage_start=start_date,
-                usage_end=start_date,
-                report_period=report_period,
-                cluster_id=cluster_id,
-                cluster_alias=cluster_alias,
-                monthly_cost_type="Cluster",
-            ).first()
-            if not line_item:
-                line_item = OCPUsageLineItemDailySummary(
+        if report_period:
+            with schema_context(self.schema):
+                line_item = OCPUsageLineItemDailySummary.objects.filter(
                     usage_start=start_date,
                     usage_end=start_date,
                     report_period=report_period,
                     cluster_id=cluster_id,
                     cluster_alias=cluster_alias,
                     monthly_cost_type="Cluster",
-                )
-            if rate_type == CostModelMetricsMap.INFRASTRUCTURE_COST_TYPE:
-                LOG.info("Cluster (%s) has a monthly infrastructure cost of %s.", cluster_id, cluster_cost)
-                line_item.infrastructure_monthly_cost = cluster_cost
-            elif rate_type == CostModelMetricsMap.SUPPLEMENTARY_COST_TYPE:
-                LOG.info("Cluster (%s) has a monthly supplemenarty cost of %s.", cluster_id, cluster_cost)
-                line_item.supplementary_monthly_cost = cluster_cost
-            line_item.save()
+                ).first()
+                if not line_item:
+                    line_item = OCPUsageLineItemDailySummary(
+                        usage_start=start_date,
+                        usage_end=start_date,
+                        report_period=report_period,
+                        cluster_id=cluster_id,
+                        cluster_alias=cluster_alias,
+                        monthly_cost_type="Cluster",
+                    )
+                if rate_type == CostModelMetricsMap.INFRASTRUCTURE_COST_TYPE:
+                    LOG.info("Cluster (%s) has a monthly infrastructure cost of %s.", cluster_id, cluster_cost)
+                    line_item.infrastructure_monthly_cost = cluster_cost
+                elif rate_type == CostModelMetricsMap.SUPPLEMENTARY_COST_TYPE:
+                    LOG.info("Cluster (%s) has a monthly supplemenarty cost of %s.", cluster_id, cluster_cost)
+                    line_item.supplementary_monthly_cost = cluster_cost
+                line_item.save()
 
     def remove_monthly_cost(self, start_date, end_date, cluster_id, cost_type):
         """Delete all monthly costs of a specific type over a date range."""


### PR DESCRIPTION
QE tests `test_api_cost_model_cost_type_sup` and `test_api_cost_model_cost_type_sup_cluster_infra_node` were failing because the monthly cluster cost was being doubled. 

The duplication was happening because a POST /cost-models will trigger an `update_cost_model_costs` job to run.  The `upsert_monthly_cluster_cost_line_item` method has a filter to ensure that only one line item, matching the first() filter is updated.

For this case the POST /cost-models was not returning a reporting_period (since the test is adding the cost model prior to ingest), so we were erroneously adding an extra monthly cost line.

**Testing**
QE tests passed