### PR TITLE
Sources Client startup checks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -251,7 +251,7 @@ services:
   sources-client:
       container_name: sources_client
       image: koku_base
-      restart: always
+      restart: on-failure:25
       working_dir: /koku/
       entrypoint:
         - /koku/run_sources.sh
@@ -275,7 +275,7 @@ services:
         - prometheus_multiproc_dir=/tmp
       privileged: true
       ports:
-          - 4000:8000
+          - 4000:8080
       volumes:
         - '.:/koku'
       links:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -251,6 +251,7 @@ services:
   sources-client:
       container_name: sources_client
       image: koku_base
+      restart: always
       working_dir: /koku/
       entrypoint:
         - /koku/run_sources.sh
@@ -279,11 +280,8 @@ services:
         - '.:/koku'
       links:
         - db
-        - koku-server
       depends_on:
         - koku-base
-        - db
-        - koku-server
 
   koku-beat:
       container_name: koku_beat

--- a/koku/sources/management/commands/sources.py
+++ b/koku/sources/management/commands/sources.py
@@ -37,6 +37,8 @@ class Command(BaseCommand):
         The koku API server is responsible for running all database migrations.  This method
         will return the state of the database and whether or not all migrations have been completed.
 
+        Hat tip to the Stack Overflow contributor: https://stackoverflow.com/a/31847406
+
         Returns:
             Boolean - True if database is available and migrations have completed.  False otherwise.
 

--- a/koku/sources/management/commands/sources.py
+++ b/koku/sources/management/commands/sources.py
@@ -37,7 +37,7 @@ class Command(BaseCommand):
         targets = executor.loader.graph.leaf_nodes()
         return not executor.migration_plan(targets)
 
-    def handle(self, addrport="0.0.0.0:8000", *args, **options):
+    def handle(self, addrport="0.0.0.0:8080", *args, **options):
         if self.check_migrations():
             LOG.info("Starting Sources Kafka Handler")
             initialize_sources_integration()
@@ -47,3 +47,4 @@ class Command(BaseCommand):
             call_command("runserver", addrport, *args, **options)
         else:
             LOG.error("Missing database migrations, Exiting...")
+            exit(1)

--- a/koku/sources/management/commands/sources.py
+++ b/koku/sources/management/commands/sources.py
@@ -1,0 +1,49 @@
+#
+# Copyright 2020 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+import logging
+
+from django.core.management import call_command
+from django.core.management.base import BaseCommand
+from django.db import connections
+from django.db import DEFAULT_DB_ALIAS
+from django.db.migrations.executor import MigrationExecutor
+
+from sources.kafka_listener import initialize_sources_integration
+
+LOG = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Starts koku-sources"
+
+    def check_migrations(self):
+        connection = connections[DEFAULT_DB_ALIAS]
+        connection.prepare_database()
+        executor = MigrationExecutor(connection)
+        targets = executor.loader.graph.leaf_nodes()
+        return not executor.migration_plan(targets)
+
+    def handle(self, addrport="0.0.0.0:8000", *args, **options):
+        if self.check_migrations():
+            LOG.info("Starting Sources Kafka Handler")
+            initialize_sources_integration()
+
+            LOG.info("Starting Sources Client Server")
+            options["use_reloader"] = False
+            call_command("runserver", addrport, *args, **options)
+        else:
+            LOG.error("Missing database migrations, Exiting...")

--- a/koku/sources/management/commands/sources.py
+++ b/koku/sources/management/commands/sources.py
@@ -38,7 +38,7 @@ class Command(BaseCommand):
         will return the state of the database and whether or not all migrations have been completed.
 
         Returns:
-            Boolean - True if database is avaiable and migrations have completed.  False otherwise.
+            Boolean - True if database is available and migrations have completed.  False otherwise.
 
         """
         connection = connections[DEFAULT_DB_ALIAS]
@@ -50,7 +50,7 @@ class Command(BaseCommand):
     def handle(self, addrport="0.0.0.0:8080", *args, **options):
         """Sources command customization point."""
 
-        # Koku API server is responsible for running all database migrations. The Sources Client
+        # Koku API server is responsible for running all database migrations. The sources client
         # server and kafka listener thread should only be started if migration execution is
         # complete.
         if self.check_migrations():
@@ -61,7 +61,7 @@ class Command(BaseCommand):
             options["use_reloader"] = False
             call_command("runserver", addrport, *args, **options)
         else:
-            # Database is not avaiable or migrations are not complete.  Exit so the container
+            # Database is not available or migrations are not complete.  Exit so the container
             # orchestrator can restart the service to try again.
             LOG.error("Missing database migrations, Exiting...")
             exit(1)

--- a/koku/sources/urls.py
+++ b/koku/sources/urls.py
@@ -24,12 +24,6 @@ from django.conf.urls import include
 from django.conf.urls import url
 from django.urls import path
 
-from koku.env import ENVIRONMENT
-from sources.kafka_listener import initialize_sources_integration
-
-IS_SOURCES = ENVIRONMENT.bool("SOURCES", default=False)
-if IS_SOURCES:
-    initialize_sources_integration()
 
 API_PATH_PREFIX = settings.API_PATH_PREFIX
 if API_PATH_PREFIX != "":

--- a/openshift/sources.yaml
+++ b/openshift/sources.yaml
@@ -335,7 +335,6 @@ objects:
             limits:
               cpu: ${CPU_LIMIT}
               memory: ${MEMORY_LIMIT}
-        restartPolicy: OnFailure
         volumes:
         - name: ssl-cert
           projected:

--- a/openshift/sources.yaml
+++ b/openshift/sources.yaml
@@ -312,6 +312,12 @@ objects:
           ports:
             - containerPort: 8080
               protocol: TCP
+          command:
+            - /bin/bash
+            - -c
+            - >
+              PYTHONPATH=. scl enable rh-python36 --
+              python koku/manage.py sources
           readinessProbe:
             httpGet:
               path: ${API_PATH_PREFIX}/v1/status/
@@ -329,6 +335,7 @@ objects:
             limits:
               cpu: ${CPU_LIMIT}
               memory: ${MEMORY_LIMIT}
+        restartPolicy: OnFailure
         volumes:
         - name: ssl-cert
           projected:

--- a/run_sources.sh
+++ b/run_sources.sh
@@ -1,4 +1,2 @@
 #!/bin/sh
-sleep 15
-# python koku/manage.py migrate_schemas
-DJANGO_READ_DOT_ENV_FILE=True SOURCES=True python koku/manage.py runserver 0.0.0.0:8000
+DJANGO_READ_DOT_ENV_FILE=True SOURCES=True python koku/manage.py sources


### PR DESCRIPTION
Verify that database is available and migrations have been run before starting web server and kafka listener thread. 

**Testing**
1. Start Sources Client with no services running (Docker will start DB since it's linked, but migrations will not run unill koku-server runs). Verify that service restarts when detecting migrations have not ran.
2. Start koku-server to run database migrations.
3. Check Sources Client and verify that service is running and listening for sources kafka events.
4. Verify that API server is running (docker host is port 4000)
5. Sanity check Source creation

**Test Results**
[sources_migration_check_ut.txt](https://github.com/project-koku/koku/files/4445623/sources_migration_check_ut.txt)


e2e-deploy update PR: https://github.com/RedHatInsights/e2e-deploy/pull/1423

issue #1203 