### PR TITLE
Fix metrics endpoint 401.

### DIFF
--- a/koku/koku/middleware.py
+++ b/koku/koku/middleware.py
@@ -56,7 +56,7 @@ UNIQUE_USER_COUNTER = Counter("hccm_unique_user", "Unique User Counter", ["accou
 
 def is_no_auth(request):
     """Check condition for needing to authenticate the user."""
-    no_auth_list = ["/status", "openapi.json"]
+    no_auth_list = ["/status", "openapi.json", "/metrics"]
     no_auth = any(no_auth_path in request.path for no_auth_path in no_auth_list)
     return no_auth or MASU or SOURCES
 


### PR DESCRIPTION
* Add metrics endpoint to the no auth list.

Before change with `DEVELOPMENT=False`:
```
April 13, 2020 - 18:38:03
Django version 2.2.11, using settings 'koku.settings'
Starting development server at http://127.0.0.1:8000/
Quit the server with CONTROL-C.
[2020-04-13 18:38:08,488] WARNING None Could not obtain identity on request.
[2020-04-13 18:38:08,493] INFO None {'method': 'GET', 'path': '/metrics', 'status': <HTTPStatus.UNAUTHORIZED: 401>, 'request_id': None, 'account': None, 'username': None, 'is_admin': False}
[2020-04-13 18:38:08,493] WARNING None Unauthorized: /metrics
[2020-04-13 18:38:08,493] WARNING None "GET /metrics HTTP/1.1" 401 0
[2020-04-13 18:38:11,692] WARNING None Could not obtain identity on request.
[2020-04-13 18:38:11,693] INFO None {'method': 'GET', 'path': '/metrics', 'status': <HTTPStatus.UNAUTHORIZED: 401>, 'request_id': None, 'account': None, 'username': None, 'is_admin': False}
[2020-04-13 18:38:11,693] WARNING None Unauthorized: /metrics
[2020-04-13 18:38:11,694] WARNING None "GET /metrics HTTP/1.1" 401 0
```
After change:
```
The .env file has been loaded.
[2020-04-13 18:38:26,486] INFO None Clearing worker task cache.
[2020-04-13 18:38:26,504] INFO None Database configured.
[2020-04-13 18:38:26,507] INFO None Celery autodiscover tasks.
[2020-04-13 18:38:26,519] INFO None Watching for file changes with StatReloader
Performing system checks...
System check identified no issues (0 silenced).
April 13, 2020 - 18:38:28
Django version 2.2.11, using settings 'koku.settings'
Starting development server at http://127.0.0.1:8000/
Quit the server with CONTROL-C.
[2020-04-13 18:38:36,310] INFO None {'method': 'GET', 'path': '/metrics', 'status': 200, 'request_id': None, 'account': None, 'username': None, 'is_admin': False}
[2020-04-13 18:38:36,311] INFO None "GET /metrics HTTP/1.1" 200 14064
```