### PR TITLE
Fix typo in cost model serializer to display label_measurement_unit

### DIFF
--- a/koku/cost_models/serializers.py
+++ b/koku/cost_models/serializers.py
@@ -408,7 +408,7 @@ class CostModelSerializer(serializers.Serializer):
                     {
                         "label_metric": display_data["label_metric"],
                         "label_measurement": display_data["label_measurement"],
-                        "label_measurement_unit": display_data["label_measurement"],
+                        "label_measurement_unit": display_data["label_measurement_unit"],
                     }
                 )
             except (KeyError, TypeError):


### PR DESCRIPTION
@nbon12 can you take a look? :wink: 

related to #2066 