### PR TITLE
Fixing race conditions between source create and destroy

### DIFF
--- a/koku/providers/aws/provider.py
+++ b/koku/providers/aws/provider.py
@@ -126,6 +126,10 @@ class AWSProvider(ProviderInterface):
 
     def cost_usage_source_is_reachable(self, credential_name, storage_resource_name):
         """Verify that the S3 bucket exists and is reachable."""
+        LOG.info("SLEEPING IN IN AWS CREDS CHECK")
+        # import time
+
+        # time.sleep(30)
         if not credential_name or credential_name.isspace():
             key = "authentication.provider_resource_name"
             message = "Provider resource name is a required parameter for AWS and must not be blank."

--- a/koku/providers/aws/provider.py
+++ b/koku/providers/aws/provider.py
@@ -126,10 +126,6 @@ class AWSProvider(ProviderInterface):
 
     def cost_usage_source_is_reachable(self, credential_name, storage_resource_name):
         """Verify that the S3 bucket exists and is reachable."""
-        LOG.info("SLEEPING IN IN AWS CREDS CHECK")
-        # import time
-
-        # time.sleep(30)
         if not credential_name or credential_name.isspace():
             key = "authentication.provider_resource_name"
             message = "Provider resource name is a required parameter for AWS and must not be blank."

--- a/koku/providers/provider_access.py
+++ b/koku/providers/provider_access.py
@@ -103,7 +103,10 @@ class ProviderAccessor:
             ValidationError: Error string
 
         """
-        return self.service.cost_usage_source_is_reachable(credential, source_name)
+        LOG.info(f"Provider account validation started for {str(credential)}")
+        reachable_status = self.service.cost_usage_source_is_reachable(credential, source_name)
+        LOG.info(f"Provider account validation complete for {str(credential)}")
+        return reachable_status
 
     def availability_status(self, credential, source_name):
         """

--- a/koku/sources/api/serializers.py
+++ b/koku/sources/api/serializers.py
@@ -155,7 +155,8 @@ class SourcesSerializer(serializers.ModelSerializer):
 
         # create provider with celery task
         try:
-            create_or_update_provider.delay(instance.source_id)
+            task = create_or_update_provider.delay(instance.source_id)
+            LOG.info(f"Updating Koku Provider for Source ID: {str(instance.source_id)} in task: {task.id}")
         except OperationalError:
             key = "sources"
             message = f"RabbitMQ unavailable. Unable to update Source ID {instance.source_id}."

--- a/koku/sources/kafka_listener.py
+++ b/koku/sources/kafka_listener.py
@@ -41,11 +41,11 @@ from api.provider.models import Sources
 from masu.prometheus_stats import KAFKA_CONNECTION_ERRORS_COUNTER
 from sources import storage
 from sources.config import Config
-from sources.kafka_source_manager import KafkaSourceManager
 from sources.sources_http_client import SourceNotFoundError
 from sources.sources_http_client import SourcesHTTPClient
 from sources.sources_http_client import SourcesHTTPClientError
 from sources.tasks import create_or_update_provider
+from sources.tasks import delete_source_and_provider
 
 LOG = logging.getLogger(__name__)
 
@@ -493,7 +493,6 @@ def execute_koku_provider_op(msg, cost_management_type_id):
     """
     provider = msg.get("provider")
     operation = msg.get("operation")
-    source_mgr = KafkaSourceManager(provider.auth_header)
 
     try:
         if operation == "create":
@@ -503,13 +502,11 @@ def execute_koku_provider_op(msg, cost_management_type_id):
             task = create_or_update_provider.delay(provider.source_id)
             LOG.info(f"Updating Koku Provider for Source ID: {str(provider.source_id)} in task: {task.id}")
         elif operation == "destroy":
-            if provider.koku_uuid:
-                try:
-                    source_mgr.destroy_provider(provider.koku_uuid)
-                    LOG.info(f"Koku Provider UUID ({str(provider.koku_uuid)}) Removal Succeeded")
-                except Exception as err:
-                    LOG.info(f"Koku Provider removal failed. Error: {str(err)}.")
-            storage.destroy_source_event(provider.source_id)
+            task = delete_source_and_provider.delay(provider.source_id, provider.source_uuid, provider.auth_header)
+            LOG.info(f"Deleting Koku Provider/Source for Source ID: {str(provider.source_id)} in task: {task.id}")
+        else:
+            LOG.info("unknown operation")
+
     except RabbitOperationalError:
         err_msg = f"RabbitmQ unavailable. Unable to {operation} Source ID: {provider.source_id}"
         LOG.error(err_msg)

--- a/koku/sources/kafka_listener.py
+++ b/koku/sources/kafka_listener.py
@@ -505,7 +505,7 @@ def execute_koku_provider_op(msg, cost_management_type_id):
             task = delete_source_and_provider.delay(provider.source_id, provider.source_uuid, provider.auth_header)
             LOG.info(f"Deleting Koku Provider/Source for Source ID: {str(provider.source_id)} in task: {task.id}")
         else:
-            LOG.info("unknown operation")
+            LOG.error(f"unknown operation: {operation}")
 
     except RabbitOperationalError:
         err_msg = f"RabbitmQ unavailable. Unable to {operation} Source ID: {provider.source_id}"

--- a/koku/sources/tasks.py
+++ b/koku/sources/tasks.py
@@ -15,6 +15,8 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 from celery.utils.log import get_task_logger
+from django.db import InterfaceError
+from django.db import OperationalError
 from rest_framework.exceptions import ValidationError
 
 from api.provider.models import Provider
@@ -23,6 +25,7 @@ from koku.celery import app
 from sources.kafka_source_manager import KafkaSourceManager
 from sources.sources_http_client import SourcesHTTPClient
 from sources.sources_http_client import SourcesHTTPClientError
+from sources.storage import destroy_source_event
 from sources.storage import SCREEN_MAP
 
 LOG = get_task_logger(__name__)
@@ -30,12 +33,13 @@ LOG = get_task_logger(__name__)
 
 @app.task(name="sources.tasks.create_or_update_provider", queue_name="sources")
 def create_or_update_provider(source_id):
+    LOG.info(f"Running Sources create/update provider for Source ID: {source_id}")
     try:
         instance = Sources.objects.get(source_id=source_id)
     except Exception as e:
         LOG.error(f"[create_or_update_provider] This Source ID {source_id} should exist. error: {e}")
         return
-
+    LOG.info(f"Found Source Instance: {str(instance)}")
     uuid = instance.source_uuid
     source_mgr = KafkaSourceManager(instance.auth_header)
 
@@ -46,6 +50,7 @@ def create_or_update_provider(source_id):
     try:
         obj = Provider.objects.get(uuid=uuid)
     except Provider.DoesNotExist:
+        LOG.info(f"Provider not found for Source UUID {str(uuid)}, Source ID: {source_id}")
         screen_fn = SCREEN_MAP.get(instance.source_type)
         if not (screen_fn and screen_fn(instance)):
             LOG.info(f"Source ID {source_id} incomplete, skipping Provider creation.")
@@ -54,26 +59,64 @@ def create_or_update_provider(source_id):
         provider.append(instance.source_uuid)
         operation = "create"
     else:
+        LOG.info(f"Provider found for Source ID: {source_id}.  Implied update operation selected.")
         provider_func = source_mgr.update_provider
         provider.insert(0, instance.koku_uuid)
         operation = "update"
 
     try:
+        LOG.info(f"Running provider operation: {operation}")
         obj = provider_func(*provider)
     except ValidationError as err:
         LOG.info(f"Provider {operation} ValidationError: {err}")
         status = "unavailable"
         err_msg = str(err)
     else:
+        LOG.info(f"Provider operation: {operation} complete")
         instance.koku_uuid = obj.uuid
         instance.pending_update = False
         LOG.info(f"Provider {operation}d: {obj.uuid}")
 
-    status_info = {"availability_status": status, "availability_status_error": str(err_msg)}
-    instance.status = status_info
-    instance.save()
+    try:
+        LOG.info(f"Verifying Source ID: {source_id} still exists before saving Source.")
+        instance = Sources.objects.get(source_id=source_id)
+        status_info = {"availability_status": status, "availability_status_error": str(err_msg)}
+        instance.status = status_info
+        instance.save()
+        set_status_for_source.delay(source_id, err_msg)
+    except Sources.DoesNotExist:
+        LOG.info(f"Source ID: {source_id} already removing.  Rolling back provider creation")
+        source_mgr.destroy_provider(obj.uuid)
+        LOG.info(f"Destroying Provider {obj.uuid} since source was already removed")
+    return
 
-    set_status_for_source.delay(source_id, err_msg)
+
+@app.task(name="sources.tasks.delete_source_and_provider", queue_name="sources")  # noqa: C901
+def delete_source_and_provider(source_id, source_uuid, auth_header):
+    provider_instance = None
+    source_instance = None
+    try:
+        provider_instance = Provider.objects.get(uuid=source_uuid)
+        try:
+            source_instance = Sources.objects.get(source_id=source_id)
+        except Sources.DoesNotExist:
+            LOG.info(f"delete_source_and_provider: Source ID: {source_id} does not exist")
+    except Provider.DoesNotExist:
+        LOG.info(f"delete_source_and_provider: Provider UUID: {source_uuid} does not exist")
+
+    if provider_instance:
+        try:
+            source_mgr = KafkaSourceManager(auth_header)
+            source_mgr.destroy_provider(source_uuid)
+        except Exception as err:
+            LOG.info(f"Koku Provider removal failed. Error: {err}.")
+
+    if source_instance:
+        try:
+            destroy_source_event(source_instance.source_id)
+        except (InterfaceError, OperationalError) as error:
+            # TODO: WE CANT RECOVER FROM THIS AS IS, SINCE WE ARE IN THE WORKER GRRRR
+            LOG.error(f"Koku Source removal failed. Error: {error}.")
 
 
 @app.task(name="sources.tasks.set_status_for_source", queue_name="sources")

--- a/koku/sources/tasks.py
+++ b/koku/sources/tasks.py
@@ -90,7 +90,6 @@ def create_or_update_provider(source_id):
         LOG.info(f"Source ID: {source_id} already removing.  Rolling back provider creation")
         source_mgr.destroy_provider(obj.uuid)
         LOG.info(f"Destroying Provider {obj.uuid} since source was already removed")
-    return
 
 
 @app.task(name="sources.tasks.delete_source_and_provider", queue_name="sources")

--- a/koku/sources/tasks.py
+++ b/koku/sources/tasks.py
@@ -102,6 +102,9 @@ def delete_source_and_provider(source_id, source_uuid, auth_header):
         LOG.info(f"delete_source_and_provider: Provider UUID: {source_uuid} does not exist")
     except Exception as err:
         LOG.info(f"Koku Provider removal failed. Error: {err}.")
+        # An error has occurred while removing the Provider.  Return now so that the
+        # Source will remain linked with the Provider
+        return
 
     try:
         source_instance = Sources.objects.get(source_id=source_id)

--- a/koku/sources/test/test_kafka_listener.py
+++ b/koku/sources/test/test_kafka_listener.py
@@ -227,8 +227,8 @@ class SourcesKafkaMsgHandlerTest(TestCase):
     def test_execute_koku_provider_op_destroy_provider_not_found(self, mock_destroy, mock_status):
         """Test to execute Koku Operations to sync with Sources for destruction with provider missing.
 
-        First, raise ProviderManagerError. Check that provider still exists, but source was removed.
-        Then, re-call provider destroy without exception, then see provider is gone.
+        First, raise ProviderManagerError. Check that provider and source still exists.
+        Then, re-call provider destroy without exception, then see both source and provider are gone.
 
         """
         source_id = self.aws_source.get("source_id")
@@ -246,7 +246,7 @@ class SourcesKafkaMsgHandlerTest(TestCase):
         with patch.object(KafkaSourceManager, "destroy_provider", side_effect=raise_provider_manager_error):
             source_integration.execute_koku_provider_op(msg, application_type_id)
             self.assertTrue(Provider.objects.filter(uuid=provider.source_uuid).exists())
-            self.assertFalse(Sources.objects.filter(source_uuid=provider.source_uuid).exists())
+            self.assertTrue(Sources.objects.filter(source_uuid=provider.source_uuid).exists())
 
         source_integration.execute_koku_provider_op(msg, application_type_id)
         self.assertFalse(Provider.objects.filter(uuid=provider.source_uuid).exists())

--- a/koku/sources/test/test_kafka_listener.py
+++ b/koku/sources/test/test_kafka_listener.py
@@ -48,6 +48,7 @@ from sources.sources_http_client import SourceNotFoundError
 from sources.sources_http_client import SourcesHTTPClient
 from sources.sources_http_client import SourcesHTTPClientError
 from sources.tasks import create_or_update_provider
+from sources.tasks import delete_source_and_provider
 
 faker = Faker()
 SOURCES_APPS = "http://www.sources.com/api/v1.0/applications?filter[application_type_id]={}&filter[source_id]={}"
@@ -130,6 +131,15 @@ class MockTask:
         create_or_update_provider(*args)
 
 
+class MockDestroyTask:
+    """Mock destroy task class."""
+
+    def __init__(self, *args):
+        """Initialize the task."""
+        self.id = uuid4()
+        delete_source_and_provider(*args)
+
+
 class MockKafkaConsumer:
     def __init__(self, preloaded_messages=["hi", "world"]):
         self.preloaded_messages = preloaded_messages
@@ -200,7 +210,7 @@ class SourcesKafkaMsgHandlerTest(TestCase):
         self.assertFalse(Sources.objects.get(source_id=source_id).pending_update)
         self.assertEqual(Sources.objects.get(source_id=source_id).koku_uuid, str(provider.source_uuid))
 
-    @patch("sources.tasks.delete_source_and_provider.delay", side_effect=MockTask)
+    @patch("sources.tasks.delete_source_and_provider.delay", side_effect=MockDestroyTask)
     def test_execute_koku_provider_op_destroy(self, mock_destroy):
         """Test to execute Koku Operations to sync with Sources for destruction."""
         source_id = self.aws_source.get("source_id")
@@ -213,7 +223,7 @@ class SourcesKafkaMsgHandlerTest(TestCase):
         self.assertEqual(Sources.objects.filter(source_id=source_id).exists(), False)
 
     @patch("sources.tasks.set_status_for_source.delay")
-    @patch("sources.tasks.delete_source_and_provider.delay", side_effect=MockTask)
+    @patch("sources.tasks.delete_source_and_provider.delay", side_effect=MockDestroyTask)
     def test_execute_koku_provider_op_destroy_provider_not_found(self, mock_destroy, mock_status):
         """Test to execute Koku Operations to sync with Sources for destruction with provider missing.
 
@@ -1110,7 +1120,7 @@ class SourcesKafkaMsgHandlerTest(TestCase):
             priority, _ = test_queue.get_nowait()
             self.assertEqual(priority, i)
 
-    @patch("sources.storage.destroy_source_event")
+    @patch("sources.tasks.delete_source_and_provider.delay")
     def test_process_synchronize_sources_msg(self, mock_destroy):
         """Test processing synchronize messages."""
         provider = Sources(**self.aws_source)

--- a/koku/sources/test/test_kafka_listener.py
+++ b/koku/sources/test/test_kafka_listener.py
@@ -200,7 +200,8 @@ class SourcesKafkaMsgHandlerTest(TestCase):
         self.assertFalse(Sources.objects.get(source_id=source_id).pending_update)
         self.assertEqual(Sources.objects.get(source_id=source_id).koku_uuid, str(provider.source_uuid))
 
-    def test_execute_koku_provider_op_destroy(self):
+    @patch("sources.tasks.delete_source_and_provider.delay", side_effect=MockTask)
+    def test_execute_koku_provider_op_destroy(self, mock_destroy):
         """Test to execute Koku Operations to sync with Sources for destruction."""
         source_id = self.aws_source.get("source_id")
         application_type_id = 2
@@ -212,7 +213,8 @@ class SourcesKafkaMsgHandlerTest(TestCase):
         self.assertEqual(Sources.objects.filter(source_id=source_id).exists(), False)
 
     @patch("sources.tasks.set_status_for_source.delay")
-    def test_execute_koku_provider_op_destroy_provider_not_found(self, mock_status):
+    @patch("sources.tasks.delete_source_and_provider.delay", side_effect=MockTask)
+    def test_execute_koku_provider_op_destroy_provider_not_found(self, mock_destroy, mock_status):
         """Test to execute Koku Operations to sync with Sources for destruction with provider missing.
 
         First, raise ProviderManagerError. Check that provider still exists, but source was removed.


### PR DESCRIPTION
Still need to do more extensive testing but this should fix the problems we are seeing in CI/Vortex with having left over sources at the end of QE tests.

**Race condition overview and how we can fix it with current implementation**
There are two race conditions when adding and removing sources.
Race 1: Long Account Verification
1.  PATCH to complete source.  This kicks off provider creation celery task.
2.  While in the task (create_or_update_provider) the first Source existence check passes.
3. create_or_update_provider Calls Provider Serializer which does the account cloud checks.
4. Source destroy happens while step 3 is in progress.
5. create_or_update_provider would re-save the Source entry since it is not re-checking that it existence at the time the provider serializer completed.
6. This will create the source entry that was removed as part of step 4 and we are stuck with both provider and source db entries, when the platform has already lost it.
7. Need to check that source still exists when provider serializer finishes then roll back the provider creation in create_or_update_provider if it doesn't

Race 2: Source Destroy happens before provider-source link is established.  
1. PATCH occurs to kick off sources-worker task to create source.
2. Source destroy occurs before link is established.  Delayed due to sources-worker (TODO: Come back and fill in these details)
3. Sources Client would process the destroy locally (not in the worker like create, update).  Source db entry is removed unconditionally if the provider link is established.
4. Need to do source and provider destroy in the sources-worker to serialize this action. Checks for both entries need to be done when cleaning these up.  Source UUID needs to be used since it happens to match the provider UUID and it's always known.

**Why are we facing this class of problems?**
These problems are presenting themselves because of the overly coupled architecture of managing sources and providers.  This could all be avoided if all database activity for source creation was relegated to the Sources Client and provider CRUD was done through a well defined interface where the Sources Client is the central authority.


**Test Results:**
[sources_worker_del_races_ut.txt](https://github.com/project-koku/koku/files/4497021/sources_worker_del_races_ut.txt)
