### PR TITLE
Use the materialized view for deltas when possible

### DIFF
--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -763,10 +763,7 @@ class ReportQueryHandler(QueryHandler):
         """
         delta_group_by = ["date"] + self._get_group_by()
         delta_filter = self._get_filter(delta=True)
-        q_table = self._mapper.query_table
-        if hasattr(self, "query_table"):
-            q_table = self.query_table
-        previous_query = q_table.objects.filter(delta_filter)
+        previous_query = self.query_table.objects.filter(delta_filter)
         previous_dict = self._create_previous_totals(previous_query, delta_group_by)
         for row in query_data:
             key = tuple(row[key] for key in delta_group_by)

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -764,6 +764,8 @@ class ReportQueryHandler(QueryHandler):
         delta_group_by = ["date"] + self._get_group_by()
         delta_filter = self._get_filter(delta=True)
         q_table = self._mapper.query_table
+        if hasattr(self, "query_table"):
+            q_table = self.query_table
         previous_query = q_table.objects.filter(delta_filter)
         previous_dict = self._create_previous_totals(previous_query, delta_group_by)
         for row in query_data:

--- a/koku/masu/database/sql/reporting_ocpcosts_summary.sql
+++ b/koku/masu/database/sql/reporting_ocpcosts_summary.sql
@@ -61,7 +61,7 @@ UPDATE reporting_ocpusagelineitem_daily_summary ods
         AND ods.namespace = ic.namespace
         AND ods.data_source = ic.data_source
         AND ods.node = ic.node
-        AND ods.pod_labels = ic.pod_labels
+        AND ic.pod_labels @> ods.pod_labels
 ;
 
 UPDATE reporting_ocpusagelineitem_daily_summary ods
@@ -76,7 +76,7 @@ UPDATE reporting_ocpusagelineitem_daily_summary ods
         AND ods.namespace = ic.namespace
         AND ods.data_source = ic.data_source
         AND ods.node = ic.node
-        AND ods.volume_labels = ic.pod_labels
+        AND ic.pod_labels @> ods.volume_labels
 ;
 
 UPDATE reporting_ocpusagelineitem_daily_summary ods


### PR DESCRIPTION
## Summary
This uses the query table attribute when available in the delta calculation. This allows us to utilize the materialized view for deltas as well. This should significantly speed up the default load and simple cases for the details pages in the UI. As well as reduce our API response times on the details page.

## Testing 
I hit our reports APIs to make sure nothing crashed with deltas. 

Ran smoke tests 

`=== 3440 passed, 80 skipped, 2246 deselected in 1181.24s (0:19:41) ===`