### PR TITLE
2048 AWS report compression check

### DIFF
--- a/koku/providers/aws/provider.py
+++ b/koku/providers/aws/provider.py
@@ -116,7 +116,7 @@ def _check_cost_report_access(credential_name, credentials, region="us-east-1", 
                 key = "report_configuration"
                 msg = (
                     f"{report.get('Compression')} compression is not supported. "
-                    f"Reports must use any of these compression formats: {ALLOWED_COMPRESSIONS}"
+                    f"Reports must use GZIP compression format."
                 )
                 raise serializers.ValidationError(error_obj(key, msg))
             if "RESOURCES" not in report.get("AdditionalSchemaElements"):

--- a/koku/providers/aws/provider.py
+++ b/koku/providers/aws/provider.py
@@ -27,6 +27,7 @@ from rest_framework import serializers  # meh
 
 from ..provider_interface import ProviderInterface
 from api.models import Provider
+from masu.processor import ALLOWED_COMPRESSIONS
 
 LOG = logging.getLogger(__name__)
 
@@ -111,6 +112,13 @@ def _check_cost_report_access(credential_name, credentials, region="us-east-1", 
         bucket_matched = list(filter(lambda rep: bucket in rep.get("S3Bucket"), reports))
 
         for report in bucket_matched:
+            if report.get("Compression") not in ALLOWED_COMPRESSIONS:
+                key = "report_configuration"
+                msg = (
+                    f"{report.get('Compression')} compression is not supported. "
+                    f"Reports must use any of these compression formats: {ALLOWED_COMPRESSIONS}"
+                )
+                raise serializers.ValidationError(error_obj(key, msg))
             if "RESOURCES" not in report.get("AdditionalSchemaElements"):
                 key = "report_configuration"
                 msg = f"Required Resource IDs are not included in report {report.get('ReportName')}"

--- a/koku/providers/test/aws/tests_aws_provider.py
+++ b/koku/providers/test/aws/tests_aws_provider.py
@@ -184,6 +184,34 @@ class AWSProviderTestCase(TestCase):
             self.fail(exc)
 
     @patch("providers.aws.provider.boto3.client")
+    def test_check_cost_report_access_compression_error(self, mock_boto3_client):
+        """Test _check_cost_report_access success."""
+        test_bucket = "test-bucket"
+        s3_client = Mock()
+        s3_client.describe_report_definitions.return_value = {
+            "ReportDefinitions": [
+                {
+                    "ReportName": FAKE.word(),
+                    "Compression": "Parquet",
+                    "AdditionalSchemaElements": ["RESOURCES"],
+                    "S3Bucket": test_bucket,
+                    "S3Region": "us-east-1",
+                }
+            ]
+        }
+        mock_boto3_client.return_value = s3_client
+        with self.assertRaises(ValidationError):
+            _check_cost_report_access(
+                FAKE.word(),
+                {
+                    "aws_access_key_id": FAKE.md5(),
+                    "aws_secret_access_key": FAKE.md5(),
+                    "aws_session_token": FAKE.md5(),
+                },
+                bucket=test_bucket,
+            )
+
+    @patch("providers.aws.provider.boto3.client")
     def test_check_cost_report_access_fail(self, mock_boto3_client):
         """Test _check_cost_report_access fail."""
         s3_client = Mock()


### PR DESCRIPTION
#2048 

This PR adds a report compression check in `_check_cost_report_access`. If the compression type is not supported, the Provider is not created and an error status is returned to Sources backend.

Testing:
1. Add AWS Source with the `cost-and-usage-report-athena` bucket.
2. See status in sources as: 
```
status              | {"availability_status": "unavailable", "availability_status_error": "{'report_configuration': [ErrorDetail(string='Parquet compression is not supported. Reports must use GZIP compression format.', code='invalid')]}"}
```