### PR TITLE
Allowing for OCP single manifest, multiple payloads

### DIFF
--- a/koku/masu/external/downloader/ocp/ocp_report_downloader.py
+++ b/koku/masu/external/downloader/ocp/ocp_report_downloader.py
@@ -98,20 +98,12 @@ class OCPReportDownloader(ReportDownloaderBase, DownloaderInterface):
 
         manifest = self._get_manifest(date_time)
         LOG.info("manifest found: %s", str(manifest))
-        latest_uuid = manifest.get("uuid")
 
         reports = []
-        try:
-            if latest_uuid:
-                for file in os.listdir(directory):
-                    if file.startswith(latest_uuid):
-                        report_full_path = os.path.join(directory, file)
-                        LOG.info("Found file %s", report_full_path)
-                        reports.append(report_full_path)
-            else:
-                LOG.error("Current UUID for report could not be found.")
-        except OSError as error:
-            LOG.error("Unable to get report. Error: %s", str(error))
+        for file in manifest.get("files", []):
+            report_full_path = os.path.join(directory, file)
+            reports.append(report_full_path)
+
         return reports
 
     def download_file(self, key, stored_etag=None):

--- a/koku/masu/external/kafka_msg_handler.py
+++ b/koku/masu/external/kafka_msg_handler.py
@@ -154,8 +154,8 @@ def extract_payload(url):  # noqa: C901
         try:
             shutil.copy(payload_source_path, payload_destination_path)
         except FileNotFoundError as error:
-            LOG.error("Unable to find file in payload. %s", str(error))
-            raise KafkaMsgHandlerError("Missing file in payload")
+            LOG.warning("Manifest file not yet downloaded. %s", str(error))
+
     LOG.info("Successfully extracted OCP for %s/%s", report_meta.get("cluster_id"), usage_month)
     # Remove temporary directory and files
     shutil.rmtree(temp_dir)

--- a/koku/masu/processor/_tasks/process.py
+++ b/koku/masu/processor/_tasks/process.py
@@ -19,7 +19,6 @@ from os import path
 
 import psutil
 from celery.utils.log import get_task_logger
-from django.db import transaction
 
 from masu.database.provider_db_accessor import ProviderDBAccessor
 from masu.database.report_manifest_db_accessor import ReportManifestDBAccessor
@@ -76,22 +75,21 @@ def _process_report_file(schema_name, provider, provider_uuid, report_dict):
         manifest_id=manifest_id,
     )
 
-    with transaction.atomic():
-        processor.process()
-        with ReportStatsDBAccessor(file_name, manifest_id) as stats_recorder:
-            stats_recorder.log_last_completed_datetime()
+    processor.process()
+    with ReportStatsDBAccessor(file_name, manifest_id) as stats_recorder:
+        stats_recorder.log_last_completed_datetime()
 
-        with ReportManifestDBAccessor() as manifest_accesor:
-            manifest = manifest_accesor.get_manifest_by_id(manifest_id)
-            if manifest:
-                manifest.num_processed_files += 1
-                manifest.save()
-                manifest_accesor.mark_manifest_as_updated(manifest)
-            else:
-                LOG.error("Unable to find manifest for ID: %s, file %s", manifest_id, file_name)
+    with ReportManifestDBAccessor() as manifest_accesor:
+        manifest = manifest_accesor.get_manifest_by_id(manifest_id)
+        if manifest:
+            manifest.num_processed_files += 1
+            manifest.save()
+            manifest_accesor.mark_manifest_as_updated(manifest)
+        else:
+            LOG.error("Unable to find manifest for ID: %s, file %s", manifest_id, file_name)
 
-        with ProviderDBAccessor(provider_uuid=provider_uuid) as provider_accessor:
-            if provider_accessor.get_setup_complete():
-                files = processor.remove_processed_files(path.dirname(report_path))
-                LOG.info("Temporary files removed: %s", str(files))
-            provider_accessor.setup_complete()
+    with ProviderDBAccessor(provider_uuid=provider_uuid) as provider_accessor:
+        if provider_accessor.get_setup_complete():
+            files = processor.remove_processed_files(path.dirname(report_path))
+            LOG.info("Temporary files removed: %s", str(files))
+        provider_accessor.setup_complete()

--- a/koku/masu/processor/report_summary_updater.py
+++ b/koku/masu/processor/report_summary_updater.py
@@ -115,19 +115,6 @@ class ReportSummaryUpdater:
             end_date = end_date.strftime("%Y-%m-%d")
         return start_date, end_date
 
-    def manifest_is_ready(self):
-        """Check if processing should continue."""
-        if self._manifest and self._manifest.num_processed_files != self._manifest.num_total_files:
-            # Bail if all manifest files have not been processed
-            LOG.info(
-                "Not all manifest files have completed processing."
-                "Summary deferred. Processed Files: %s, Total Files: %s",
-                str(self._manifest.num_processed_files),
-                str(self._manifest.num_total_files),
-            )
-            return False
-        return True
-
     def update_daily_tables(self, start_date, end_date):
         """
         Update report daily rollup tables.

--- a/koku/masu/processor/report_summary_updater.py
+++ b/koku/masu/processor/report_summary_updater.py
@@ -125,6 +125,7 @@ class ReportSummaryUpdater:
                 str(self._manifest.num_processed_files),
                 str(self._manifest.num_total_files),
             )
+            return False
         return True
 
     def update_daily_tables(self, start_date, end_date):

--- a/koku/masu/processor/tasks.py
+++ b/koku/masu/processor/tasks.py
@@ -229,9 +229,10 @@ def update_summary_tables(schema_name, provider, provider_uuid, start_date, end_
     LOG.info(stmt)
 
     updater = ReportSummaryUpdater(schema_name, provider_uuid, manifest_id)
-    if updater.manifest_is_ready():
-        start_date, end_date = updater.update_daily_tables(start_date, end_date)
-        updater.update_summary_tables(start_date, end_date)
+
+    start_date, end_date = updater.update_daily_tables(start_date, end_date)
+    updater.update_summary_tables(start_date, end_date)
+
     if provider_uuid:
         dh = DateHelper(utc=True)
         prev_month_last_day = dh.last_month_end

--- a/koku/masu/test/external/downloader/ocp/test_ocp_report_downloader.py
+++ b/koku/masu/test/external/downloader/ocp/test_ocp_report_downloader.py
@@ -59,6 +59,10 @@ class OCPReportDownloaderTest(MasuTestCase):
         self.test_file_path = os.path.join(report_path, os.path.basename(test_file_path))
         shutil.copyfile(test_file_path, os.path.join(report_path, self.test_file_path))
 
+        test_storage_file_path = "./koku/masu/test/data/ocp/e6b3701e-1e91" "-433b-b238-a31e49937558_storage.csv"
+        self.test_storage_file_path = os.path.join(report_path, os.path.basename(test_storage_file_path))
+        shutil.copyfile(test_file_path, os.path.join(report_path, self.test_storage_file_path))
+
         test_manifest_path = "./koku/masu/test/data/ocp/manifest.json"
         self.test_manifest_path = os.path.join(report_path, os.path.basename(test_manifest_path))
         shutil.copyfile(test_manifest_path, os.path.join(report_path, self.test_manifest_path))
@@ -103,8 +107,9 @@ class OCPReportDownloaderTest(MasuTestCase):
         test_report_date = datetime(year=2018, month=9, day=7)
         with patch.object(DateAccessor, "today", return_value=test_report_date):
             os.remove(self.test_file_path)
-            reports = self.report_downloader.download_report(test_report_date)
-        self.assertEqual(reports, [])
+            os.remove(self.test_storage_file_path)
+            with self.assertRaises(FileNotFoundError):
+                self.report_downloader.download_report(test_report_date)
 
     def test_download_bucket_non_csv_found(self):
         """Test to verify that basic report downloading with non .csv file in source directory."""
@@ -112,13 +117,13 @@ class OCPReportDownloaderTest(MasuTestCase):
         with patch.object(DateAccessor, "today", return_value=test_report_date):
             # Remove .csv
             os.remove(self.test_file_path)
+            os.remove(self.test_storage_file_path)
 
             # Create .txt file
             txt_file_path = "{}/{}".format(os.path.dirname(self.test_file_path), "report.txt")
             open(txt_file_path, "a").close()
-
-            reports = self.report_downloader.download_report(test_report_date)
-        self.assertEqual(reports, [])
+            with self.assertRaises(FileNotFoundError):
+                self.report_downloader.download_report(test_report_date)
 
     def test_download_bucket_source_directory_missing(self):
         """Test to verify that basic report downloading when source directory doesn't exist."""

--- a/koku/masu/test/external/test_kafka_msg_handler.py
+++ b/koku/masu/test/external/test_kafka_msg_handler.py
@@ -97,8 +97,8 @@ class KafkaMsgHandlerTest(MasuTestCase):
                     shutil.rmtree(fake_dir)
                     shutil.rmtree(fake_pvc_dir)
 
-    def test_extract_bad_payload(self):
-        """Test to verify extracting payload missing report files is not successful."""
+    def test_extract_incomplete_file_payload(self):
+        """Test to verify extracting payload missing report files is successful."""
         payload_url = "http://insights-upload.com/quarnantine/file_to_validate"
         with requests_mock.mock() as m:
             m.get(payload_url, content=self.bad_tarball_file)
@@ -107,8 +107,7 @@ class KafkaMsgHandlerTest(MasuTestCase):
             fake_pvc_dir = tempfile.mkdtemp()
             with patch.object(Config, "INSIGHTS_LOCAL_REPORT_DIR", fake_dir):
                 with patch.object(Config, "TMP_DIR", fake_dir):
-                    with self.assertRaises(msg_handler.KafkaMsgHandlerError):
-                        msg_handler.extract_payload(payload_url)
+                    msg_handler.extract_payload(payload_url)
                     shutil.rmtree(fake_dir)
                     shutil.rmtree(fake_pvc_dir)
 

--- a/koku/masu/test/processor/test_report_summary_updater.py
+++ b/koku/masu/test/processor/test_report_summary_updater.py
@@ -173,39 +173,6 @@ class ReportSummaryUpdaterTest(MasuTestCase):
         with self.assertRaises(ReportSummaryUpdaterError):
             _ = ReportSummaryUpdater(self.schema, self.unkown_test_provider_uuid)
 
-    def test_manifest_is_ready_is_ready(self):
-        """Test that True is returned when a manifest is ready to process."""
-        billing_start = DateAccessor().today_with_timezone("UTC").replace(day=1)
-        manifest_dict = {
-            "assembly_id": "1234",
-            "billing_period_start_datetime": billing_start,
-            "num_total_files": 2,
-            "num_processed_files": 2,
-            "provider_uuid": self.ocp_provider_uuid,
-        }
-        with ReportManifestDBAccessor() as accessor:
-            manifest = accessor.add(**manifest_dict)
-        manifest_id = manifest.id
-        updater = ReportSummaryUpdater(self.schema, self.ocp_test_provider_uuid, manifest_id)
-        self.assertTrue(updater.manifest_is_ready())
-
-    def test_manifest_is_ready_is_not_ready(self):
-        """Test that False is returned when a manifest is not ready to process."""
-        billing_start = DateAccessor().today_with_timezone("UTC").replace(day=1)
-        manifest_dict = {
-            "assembly_id": "1234",
-            "billing_period_start_datetime": billing_start,
-            "num_total_files": 2,
-            "num_processed_files": 1,
-            "provider_uuid": self.ocp_provider_uuid,
-        }
-        with ReportManifestDBAccessor() as accessor:
-            manifest = accessor.add(**manifest_dict)
-        manifest_id = manifest.id
-        updater = ReportSummaryUpdater(self.schema, self.ocp_test_provider_uuid, manifest_id)
-
-        self.assertFalse(updater.manifest_is_ready())
-
     def test_no_provider_on_create(self):
         """Test that an error is raised when no provider exists."""
         billing_start = DateAccessor().today_with_timezone("UTC").replace(day=1)

--- a/koku/masu/test/processor/test_report_summary_updater.py
+++ b/koku/masu/test/processor/test_report_summary_updater.py
@@ -204,8 +204,7 @@ class ReportSummaryUpdaterTest(MasuTestCase):
         manifest_id = manifest.id
         updater = ReportSummaryUpdater(self.schema, self.ocp_test_provider_uuid, manifest_id)
 
-        # manifest_is_ready is now unconditionally returning True, so summary is expected.
-        self.assertTrue(updater.manifest_is_ready())
+        self.assertFalse(updater.manifest_is_ready())
 
     def test_no_provider_on_create(self):
         """Test that an error is raised when no provider exists."""

--- a/koku/masu/test/processor/test_tasks.py
+++ b/koku/masu/test/processor/test_tasks.py
@@ -344,18 +344,20 @@ class ProcessReportFileTests(MasuTestCase):
         summarize_reports(reports_to_summarize)
         mock_update_summary.delay.assert_called()
 
-    @patch("masu.processor._tasks.process.ProviderDBAccessor.setup_complete")
-    @patch("masu.processor._tasks.process.ReportProcessor")
-    def test_process_report_files_with_transaction_atomic_error(self, mock_processor, mock_setup_complete):
+    @patch("masu.processor.tasks._process_report_file")
+    @patch("masu.processor.tasks._get_report_files")
+    def test_process_report_files_with_transaction_atomic_error(self, mock_files, mock_processor):
         """Test than an exception rolls back the atomic transaction."""
         path = "{}/{}".format("test", "file1.csv")
+        mock_files.return_value = [{"file": path, "compression": "GZIP"}]
         schema_name = self.schema
         provider = Provider.PROVIDER_AWS
         provider_uuid = self.aws_provider_uuid
+        report_month = DateHelper().today
         manifest_dict = {
             "assembly_id": "12345",
-            "billing_period_start_datetime": DateHelper().today,
-            "num_total_files": 2,
+            "billing_period_start_datetime": report_month,
+            "num_total_files": 1,
             "provider_uuid": self.aws_provider_uuid,
             "task": "170653c0-3e66-4b7e-a764-336496d7ca5a",
         }
@@ -365,20 +367,28 @@ class ProcessReportFileTests(MasuTestCase):
             manifest_id = manifest.id
             initial_update_time = manifest.manifest_updated_datetime
 
+        with ReportStatsDBAccessor("file1.csv", manifest_id) as stats_accessor:
+            stats_accessor.get_last_completed_datetime
+
         with ReportStatsDBAccessor(path, manifest_id) as report_file_accessor:
             report_file_accessor.get_last_started_datetime()
 
-        report_dict = {
-            "file": path,
-            "compression": "gzip",
-            "start_date": str(DateHelper().today),
-            "manifest_id": manifest_id,
-        }
-
-        mock_setup_complete.side_effect = Exception
+        mock_processor.side_effect = Exception
 
         with self.assertRaises(Exception):
-            _process_report_file(schema_name, provider, provider_uuid, report_dict)
+            customer_name = "Fake Customer"
+            authentication = "auth"
+            billing_source = "bill"
+            provider_type = provider
+            get_report_files(
+                customer_name=customer_name,
+                authentication=authentication,
+                billing_source=billing_source,
+                provider_type=provider_type,
+                schema_name=schema_name,
+                provider_uuid=provider_uuid,
+                report_month=report_month,
+            )
 
         with ReportStatsDBAccessor(path, manifest_id) as report_file_accessor:
             self.assertIsNone(report_file_accessor.get_last_completed_datetime())


### PR DESCRIPTION
When ingesting data from a large OCP cluster, the payloads need to be split in order to be within the ingress service file size limit.

Changes to korekuta that need to be made are to use a common manifest across multiple payloads.  That way when the summarization tasks are kicked off it won't summarize until all line item report data has completed processing.

**Testing**
1. Create and ingest multi-file OCP payload.
2. Verify processing is successful.
3. Repeat steps 1-3 but for local OCP ingest.  Verify API results match.

**Test Results**
[ocp_multi_payload_ut.txt](https://github.com/project-koku/koku/files/4566196/ocp_multi_payload_ut.txt)

Smoke Tests Passed

**Testing Failure Path**
Test should focus on ensuring that logic can handle when a report processing fails in the middle of processing a manifest.  The expected behavior is that failures should gracefully update stats, report to ingress service that download was successful and API should not change.

Note: A subsequent change could be considered to do manual kafka commits (like sources-client) to where we would re-download/process report failures.  Since we get reports every 45 minutes I think for now it's ok to make sure that subsequent payloads process successfully.

1. Generate/Ingest reports.  Sample API response
2. Re-generate/upload same yaml file but bring down db after second file processing last_completed_datetime
3. Bring DB up, Re-generate/upload report.  Verify that processing was successful and API matches #1

**Test Results**
[ocp_multi_error_path_ut.txt](https://github.com/project-koku/koku/files/4576205/ocp_multi_error_path_ut.txt)
