### PR TITLE
Bugfix processed files check

### DIFF
--- a/koku/masu/external/report_downloader.py
+++ b/koku/masu/external/report_downloader.py
@@ -167,7 +167,7 @@ class ReportDownloader:
             raise ReportDownloaderError(str(err))
         return reports
 
-    def is_report_processed(self, report_name):
+    def is_report_processed(self, report_name, manifest_id):
         """Check if report_name has completed processing.
 
         Filter by the report name and then check the last_completed_datetime.
@@ -175,7 +175,7 @@ class ReportDownloader:
         Otherwise returns False.
 
         """
-        report_record = CostUsageReportStatus.objects.filter(report_name=report_name)
+        report_record = CostUsageReportStatus.objects.filter(manifest_id=manifest_id, report_name=report_name)
         if report_record:
             return report_record.filter(last_completed_datetime__isnull=False).exists()
         return False
@@ -200,7 +200,7 @@ class ReportDownloader:
             report_dictionary = {}
             local_file_name = self._downloader.get_local_file_for_report(report)
 
-            if self.is_report_processed(local_file_name):
+            if self.is_report_processed(local_file_name, manifest_id):
                 LOG.info(f"File has already been processed: {local_file_name}. Skipping...")
                 continue
             with ReportStatsDBAccessor(local_file_name, manifest_id) as stats_recorder:

--- a/koku/masu/test/external/test_report_downloader.py
+++ b/koku/masu/test/external/test_report_downloader.py
@@ -174,19 +174,19 @@ class ReportDownloaderTest(MasuTestCase):
         3. look for existing report-name with not null last_completed_datetime: `is_report_processed` returns True.
 
         """
+        manifest_id = 99
         downloader = self.create_downloader(Provider.PROVIDER_AWS)
         report_name = FAKE.slug()
-        self.assertFalse(downloader.is_report_processed(report_name))
+        self.assertFalse(downloader.is_report_processed(report_name, manifest_id))
 
-        manifest_id = 99
         baker.make(CostUsageReportManifest, id=manifest_id)
         baker.make(
             CostUsageReportStatus, report_name=report_name, manifest_id=manifest_id, last_completed_datetime=None
         )
-        self.assertFalse(downloader.is_report_processed(report_name))
+        self.assertFalse(downloader.is_report_processed(report_name, manifest_id))
 
         CostUsageReportStatus.objects.update(last_completed_datetime=FAKE.date())
-        self.assertTrue(downloader.is_report_processed(report_name))
+        self.assertTrue(downloader.is_report_processed(report_name, manifest_id))
 
     @patch("masu.external.downloader.aws.aws_report_downloader.AWSReportDownloader.download_file")
     @patch("masu.external.downloader.aws.aws_report_downloader.AWSReportDownloader.get_local_file_for_report")
@@ -203,12 +203,12 @@ class ReportDownloaderTest(MasuTestCase):
         This test checks that the 2 files are correctly returned.
 
         """
-        report_context = {"files": ["file-1.csv.gz", "file-2.csv.gz", "file-3.csv.gz"]}
+        manifest_id = 99
+        report_context = {"files": ["file-1.csv.gz", "file-2.csv.gz", "file-3.csv.gz"], "manifest_id": manifest_id}
         mock_dl_context.return_value = report_context
         mock_dl_local_files.side_effect = lambda x: x
         mock_dl_download.side_effect = lambda x, y: (x, y)
 
-        manifest_id = 99
         baker.make(CostUsageReportManifest, id=manifest_id)
         baker.make(
             CostUsageReportStatus,


### PR DESCRIPTION
## Summary
This adds an additional filter to our `is_report_processed` check in the ReportDownlaoder. Although report files are likely to be uniquely named, we encountered an issue with QE data that uses the same report file name and adding an additional filter on the specific manifest should fix that as well as just add an additional level of specificity to our query. 

## Testing
Updated unit tests and 

```
IQE Smoke Test Results

== 3440 passed, 80 skipped, 2256 deselected in 942.15s (0:15:42) ====
```