### PR TITLE
use override_settings() instead of patch.object()

### DIFF
--- a/koku/api/report/test/utils.py
+++ b/koku/api/report/test/utils.py
@@ -1,3 +1,20 @@
+#
+# Copyright 2020 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""Test utilities."""
 import os
 import pkgutil
 import shutil
@@ -5,6 +22,7 @@ from unittest.mock import patch
 
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
+from django.test.utils import override_settings
 from jinja2 import Template
 from model_bakery import baker
 from nise.__main__ import run
@@ -76,7 +94,7 @@ class NiseDataLoader:
     def load_openshift_data(self, customer, static_data_file, cluster_id):
         """Load OpenShift data into the database."""
         provider_type = Provider.PROVIDER_OCP
-        with patch.object(settings, "AUTO_DATA_INGEST", False):
+        with override_settings(AUTO_DATA_INGEST=False):
             provider = baker.make(
                 "Provider",
                 type=provider_type,

--- a/koku/koku/tests_middleware.py
+++ b/koku/koku/tests_middleware.py
@@ -21,10 +21,10 @@ import logging
 from unittest.mock import Mock
 from unittest.mock import patch
 
-from django.conf import settings
 from django.core.cache import caches
 from django.core.exceptions import PermissionDenied
 from django.db.utils import OperationalError
+from django.test.utils import override_settings
 from faker import Faker
 from requests.exceptions import ConnectionError  # pylint: disable=W0622
 from rest_framework import status
@@ -260,7 +260,7 @@ class IdentityHeaderMiddlewareTest(IamTestCase):
         self.assertEqual(response.status_code, status.HTTP_424_FAILED_DEPENDENCY)
         mocked_get.assert_called()
 
-    @patch.object(settings, "DEVELOPMENT", True)
+    @override_settings(DEVELOPMENT=True)
     def test_process_developer_identity(self):
         """Test that process_request() passes-through a custom identity."""
         fake = Faker()

--- a/koku/masu/test/processor/test_worker_cache.py
+++ b/koku/masu/test/processor/test_worker_cache.py
@@ -16,10 +16,9 @@
 #
 """Test Cache of worker tasks currently running."""
 import logging
-from unittest.mock import patch
 
-from django.conf import settings
 from django.core.cache import cache
+from django.test.utils import override_settings
 
 from masu.processor.worker_cache import WorkerCache
 from masu.test import MasuTestCase
@@ -100,7 +99,7 @@ class WorkerCacheTest(MasuTestCase):
         for task in first_host_list:
             _cache.add_task_to_cache(task)
 
-        with patch.object(settings, "HOSTNAME", second_host):
+        with override_settings(HOSTNAME=second_host):
             _cache = WorkerCache()
             for task in second_host_list:
                 _cache.add_task_to_cache(task)

--- a/koku/sources/test/test_tasks.py
+++ b/koku/sources/test/test_tasks.py
@@ -18,10 +18,10 @@ import logging
 from unittest.mock import patch
 from uuid import uuid4
 
-from django.conf import settings
 from django.db import InterfaceError
 from django.db.models.signals import post_save
 from django.test import TestCase
+from django.test.utils import override_settings
 
 from api.provider.models import Provider
 from api.provider.models import Sources
@@ -142,7 +142,7 @@ class SourcesTasksTest(TestCase):
         source = Sources.objects.get(source_id=self.aws_source_info.get("source_id"))
         self.assertEqual(source.status.get("availability_status"), "unavailable")
 
-    @patch.object(settings, "DEVELOPMENT", False)
+    @override_settings(DEVELOPMENT=False)
     @patch("masu.celery.tasks.check_report_updates")
     @patch("sources.tasks.set_status_for_source", side_effect=MockStatus)
     @patch("sources.sources_http_client.SourcesHTTPClient.set_source_status")
@@ -156,7 +156,7 @@ class SourcesTasksTest(TestCase):
 
         mock_call.assert_called()
 
-    @patch.object(settings, "DEVELOPMENT", False)
+    @override_settings(DEVELOPMENT=False)
     @patch("masu.celery.tasks.check_report_updates")
     @patch("sources.tasks.set_status_for_source.delay", side_effect=MockStatus)
     @patch(


### PR DESCRIPTION
This PR tidies up a few places where we use `patch.object` instead of django's built-in `override_settings`.

Also, I've added the license stanza to one file where it was missing.