### PR TITLE
Fix the development identity in the .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,4 +29,4 @@ SOURCES_KAFKA_HOST=kafka
 KEEPDB=True
 PROMETHEUS_PUSHGATEWAY="pushgateway:9091"
 AUTO_DATA_INGEST=True
-DEVELOPMENT_IDENTITY='{"identity": {"account_number": "10001", "type": "User", "user": {"username": "user_dev", "email": "user_dev@foo.com", "is_org_admin": "True", "access": {}}}},"entitlements": {"cost_management": {"is_entitled": "True"}}}'
+DEVELOPMENT_IDENTITY='{"identity": {"account_number": "10001", "type": "User", "user": {"username": "user_dev", "email": "user_dev@foo.com", "is_org_admin": "True", "access": {}}},"entitlements": {"cost_management": {"is_entitled": "True"}}}'


### PR DESCRIPTION
I was having issues using the default `DEVELOPMENT_IDENTITY` inside of the `.env.example`. When I was used the default I was getting this error: 
```
  |   File "/koku/koku/koku/settings.py", line 146, in <module>
koku_server       |     DEVELOPMENT_IDENTITY = ENVIRONMENT.json("DEVELOPMENT_IDENTITY", default={})
koku_server       |   File "/opt/app-root/lib/python3.6/site-packages/environ/environ.py", line 173, in json
koku_server       |     return self.get_value(var, cast=json.loads, default=default)
koku_server       |   File "/opt/app-root/lib/python3.6/site-packages/environ/environ.py", line 290, in get_value
koku_server       |     value = self.parse_value(value, cast)
koku_server       |   File "/opt/app-root/lib/python3.6/site-packages/environ/environ.py", line 346, in parse_value
koku_server       |     value = cast(value)
koku_server       |   File "/opt/rh/rh-python36/root/usr/lib64/python3.6/json/__init__.py", line 354, in loads
koku_server       |     return _default_decoder.decode(s)
koku_server       |   File "/opt/rh/rh-python36/root/usr/lib64/python3.6/json/decoder.py", line 342, in decode
koku_server       |     raise JSONDecodeError("Extra data", s, end)
koku_server       | json.decoder.JSONDecodeError: Extra data: line 1 column 159 (char 158)
```

