### PR TITLE
Revert revert cleanup

### DIFF
--- a/koku/sources/kafka_listener.py
+++ b/koku/sources/kafka_listener.py
@@ -339,7 +339,7 @@ def cost_mgmt_msg_filter(msg_data):
 
 
 @transaction.atomic  # noqa: C901
-async def process_message(app_type_id, msg, loop=EVENT_LOOP):  # noqa: C901
+def process_message(app_type_id, msg):  # noqa: C901
     """
     Process message from Platform-Sources kafka service.
 
@@ -353,8 +353,6 @@ async def process_message(app_type_id, msg, loop=EVENT_LOOP):  # noqa: C901
     Args:
         app_type_id - application type identifier
         msg - kafka message
-        loop - asyncio loop for ThreadPoolExecutor
-
 
     Returns:
         None
@@ -363,8 +361,7 @@ async def process_message(app_type_id, msg, loop=EVENT_LOOP):  # noqa: C901
     LOG.info(f"Processing Event: {msg}")
     msg_data = None
     try:
-        with concurrent.futures.ThreadPoolExecutor() as pool:
-            msg_data = await loop.run_in_executor(pool, cost_mgmt_msg_filter, msg)
+        msg_data = cost_mgmt_msg_filter(msg)
     except SourceNotFoundError:
         LOG.warning(f"Source not found in platform sources. Skipping msg: {msg}")
         return
@@ -376,11 +373,8 @@ async def process_message(app_type_id, msg, loop=EVENT_LOOP):  # noqa: C901
 
         storage.create_source_event(msg_data.get("source_id"), msg_data.get("auth_header"), msg_data.get("offset"))
 
-        with concurrent.futures.ThreadPoolExecutor() as pool:
-            if storage.is_known_source(msg_data.get("source_id")):
-                await loop.run_in_executor(
-                    pool, sources_network_info, msg_data.get("source_id"), msg_data.get("auth_header")
-                )
+        if storage.is_known_source(msg_data.get("source_id")):
+            sources_network_info(msg_data.get("source_id"), msg_data.get("auth_header"))
 
     elif msg_data.get("event_type") in (KAFKA_AUTHENTICATION_CREATE, KAFKA_AUTHENTICATION_UPDATE):
         if msg_data.get("event_type") in (KAFKA_AUTHENTICATION_CREATE,):
@@ -388,17 +382,13 @@ async def process_message(app_type_id, msg, loop=EVENT_LOOP):  # noqa: C901
                 msg_data.get("source_id"), msg_data.get("auth_header"), msg_data.get("offset")
             )
 
-        with concurrent.futures.ThreadPoolExecutor() as pool:
-            await loop.run_in_executor(pool, save_auth_info, msg_data.get("auth_header"), msg_data.get("source_id"))
+        save_auth_info(msg_data.get("auth_header"), msg_data.get("source_id"))
 
     elif msg_data.get("event_type") in (KAFKA_SOURCE_UPDATE,):
-        with concurrent.futures.ThreadPoolExecutor() as pool:
-            if storage.is_known_source(msg_data.get("source_id")) is False:
-                LOG.info("Update event for unknown source id, skipping...")
-                return
-            await loop.run_in_executor(
-                pool, sources_network_info, msg_data.get("source_id"), msg_data.get("auth_header")
-            )
+        if storage.is_known_source(msg_data.get("source_id")) is False:
+            LOG.info("Update event for unknown source id, skipping...")
+            return
+        sources_network_info(msg_data.get("source_id"), msg_data.get("auth_header"))
 
     elif msg_data.get("event_type") in (KAFKA_APPLICATION_DESTROY,):
         storage.enqueue_source_delete(msg_data.get("source_id"), msg_data.get("offset"), allow_out_of_order=True)
@@ -429,7 +419,7 @@ async def listen_for_messages_loop(event_loop, application_source_id):
 
 
 @KAFKA_CONNECTION_ERRORS_COUNTER.count_exceptions()  # noqa: C901
-async def listen_for_messages(consumer, application_source_id):  # noqa: C901
+async def listen_for_messages(consumer, application_source_id, loop=EVENT_LOOP):  # noqa: C901
     """
     Listen for Platform-Sources kafka messages.
 
@@ -456,7 +446,8 @@ async def listen_for_messages(consumer, application_source_id):  # noqa: C901
             if msg:
                 LOG.debug(f"Cost Management Message to process: {str(msg)}")
                 try:
-                    await process_message(application_source_id, msg)
+                    with concurrent.futures.ThreadPoolExecutor() as pool:
+                        await loop.run_in_executor(pool, process_message, application_source_id, msg)
                 except (InterfaceError, OperationalError) as err:
                     connection.close()
                     LOG.error(err)

--- a/koku/sources/kafka_listener.py
+++ b/koku/sources/kafka_listener.py
@@ -439,7 +439,8 @@ async def listen_for_messages(consumer, application_source_id, loop=EVENT_LOOP):
         async for msg in consumer:
             LOG.debug(f"Filtering Message: {str(msg)}")
             try:
-                msg = get_sources_msg_data(msg, application_source_id)
+                with concurrent.futures.ThreadPoolExecutor() as pool:
+                    msg = await loop.run_in_executor(pool, get_sources_msg_data, msg, application_source_id)
             except SourcesMessageError:
                 await consumer.commit()
                 continue

--- a/koku/sources/test/test_kafka_listener.py
+++ b/koku/sources/test/test_kafka_listener.py
@@ -890,10 +890,9 @@ class SourcesKafkaMsgHandlerTest(TestCase):
         ]
         for test in test_matrix:
             msg_data = MsgDataGenerator(event_type=test.get("event"), value=test.get("value")).get_data()
-            run_loop = asyncio.new_event_loop()
             with patch.object(SourcesHTTPClient, "get_source_details", return_value={"source_type_id": "1"}):
                 with patch.object(SourcesHTTPClient, "get_source_type_name", return_value=test.get("source_name")):
-                    run_loop.run_until_complete(process_message(test_application_id, msg_data, run_loop))
+                    process_message(test_application_id, msg_data)
                     test.get("expected_fn")(msg_data, test, mock_sources_network_info)
 
     @patch.object(Config, "SOURCES_API_URL", "http://www.sources.com")
@@ -906,10 +905,8 @@ class SourcesKafkaMsgHandlerTest(TestCase):
             "value": {"id": 1, "source_id": 1, "application_type_id": test_application_id},
         }
         msg_data = MsgDataGenerator(event_type=test.get("event"), value=test.get("value")).get_data()
-        run_loop = asyncio.new_event_loop()
         with patch.object(SourcesHTTPClient, "get_source_details", side_effect=SourceNotFoundError("NOT FOUND TEST")):
-            result = run_loop.run_until_complete(process_message(test_application_id, msg_data, run_loop))
-            self.assertIsNone(result)
+            self.assertIsNone(process_message(test_application_id, msg_data))
 
     @patch.object(Config, "SOURCES_API_URL", "http://www.sources.com")
     @patch("sources.kafka_listener.sources_network_info", returns=None)
@@ -970,7 +967,6 @@ class SourcesKafkaMsgHandlerTest(TestCase):
 
         for test in test_matrix:
             msg_data = MsgDataGenerator(event_type=test.get("event"), value=test.get("value")).get_data()
-            run_loop = asyncio.new_event_loop()
             with patch.object(
                 SourcesHTTPClient, "get_source_id_from_endpoint_id", return_value=test.get("value").get("source_id")
             ):
@@ -981,7 +977,7 @@ class SourcesKafkaMsgHandlerTest(TestCase):
                 ):
                     with patch.object(SourcesHTTPClient, "get_source_details", return_value={"source_type_id": "1"}):
                         with patch.object(SourcesHTTPClient, "get_source_type_name", return_value="amazon"):
-                            run_loop.run_until_complete(process_message(test_application_id, msg_data, run_loop))
+                            process_message(test_application_id, msg_data)
                             test.get("expected_fn")(msg_data, test, mock_save_auth_info)
 
     @patch.object(Config, "SOURCES_API_URL", "http://www.sources.com")
@@ -1014,13 +1010,12 @@ class SourcesKafkaMsgHandlerTest(TestCase):
 
         for test in test_matrix:
             msg_data = MsgDataGenerator(event_type=test.get("event"), value=test.get("value")).get_data()
-            run_loop = asyncio.new_event_loop()
             with patch(
                 "sources.kafka_listener.storage.is_known_source", return_value=test.get("expected_known_source")
             ):
                 with patch.object(SourcesHTTPClient, "get_source_details", return_value={"source_type_id": "1"}):
                     with patch.object(SourcesHTTPClient, "get_source_type_name", return_value="amazon"):
-                        run_loop.run_until_complete(process_message(test_application_id, msg_data, run_loop))
+                        process_message(test_application_id, msg_data)
                         test.get("expected_fn")(msg_data, test.get("expected_known_source"), mock_sources_network_info)
 
     @patch.object(Config, "SOURCES_API_URL", "http://www.sources.com")
@@ -1049,10 +1044,9 @@ class SourcesKafkaMsgHandlerTest(TestCase):
         for test in test_matrix:
             storage.create_source_event(test.get("value").get("source_id"), Config.SOURCES_FAKE_HEADER, 3)
             msg_data = MsgDataGenerator(event_type=test.get("event"), value=test.get("value")).get_data()
-            run_loop = asyncio.new_event_loop()
             with patch.object(SourcesHTTPClient, "get_source_details", return_value={"source_type_id": "1"}):
                 with patch.object(SourcesHTTPClient, "get_source_type_name", return_value="amazon"):
-                    run_loop.run_until_complete(process_message(test_application_id, msg_data, run_loop))
+                    process_message(test_application_id, msg_data)
                     test.get("expected_fn")(msg_data)
             Sources.objects.all().delete()
 
@@ -1096,7 +1090,6 @@ class SourcesKafkaMsgHandlerTest(TestCase):
             )
             test_source.save()
             msg_data = MsgDataGenerator(event_type=test.get("event"), value=test.get("value")).get_data()
-            run_loop = asyncio.new_event_loop()
             with patch.object(
                 SourcesHTTPClient, "get_source_id_from_endpoint_id", return_value=test.get("value").get("source_id")
             ):
@@ -1107,7 +1100,7 @@ class SourcesKafkaMsgHandlerTest(TestCase):
                 ):
                     with patch.object(SourcesHTTPClient, "get_source_details", return_value={"source_type_id": "1"}):
                         with patch.object(SourcesHTTPClient, "get_source_type_name", return_value="amazon"):
-                            run_loop.run_until_complete(process_message(test_application_id, msg_data, run_loop))
+                            process_message(test_application_id, msg_data)
                             test.get("expected_fn")(test)
                             Sources.objects.all().delete()
 
@@ -1138,7 +1131,7 @@ class SourcesKafkaMsgHandlerTest(TestCase):
             mock_consumer = MockKafkaConsumer([msg])
 
             run_loop.run_until_complete(
-                source_integration.listen_for_messages(mock_consumer, cost_management_app_type)
+                source_integration.listen_for_messages(mock_consumer, cost_management_app_type, run_loop)
             )
             if test.get("expected_process"):
                 mock_process_message.assert_called()
@@ -1167,23 +1160,24 @@ class SourcesKafkaMsgHandlerTest(TestCase):
         ]
 
         for test in test_matrix:
-            msg = ConsumerRecord(
-                topic="platform.sources.event-stream",
-                offset=5,
-                event_type="Application.create",
-                auth_header="testheader",
-                value=bytes(test.get("test_value"), encoding="utf-8"),
-            )
+            with self.subTest(test=test):
+                msg = ConsumerRecord(
+                    topic="platform.sources.event-stream",
+                    offset=5,
+                    event_type="Application.create",
+                    auth_header="testheader",
+                    value=bytes(test.get("test_value"), encoding="utf-8"),
+                )
 
-            mock_consumer = MockKafkaConsumer([msg])
+                mock_consumer = MockKafkaConsumer([msg])
 
-            mock_process_message.side_effect = test.get("side_effect")
-            with patch("sources.kafka_listener.connection.close") as close_mock:
-                with patch.object(Config, "RETRY_SECONDS", 0):
-                    run_loop.run_until_complete(
-                        source_integration.listen_for_messages(mock_consumer, cost_management_app_type)
-                    )
-                    close_mock.assert_called()
+                mock_process_message.side_effect = test.get("side_effect")
+                with patch("sources.kafka_listener.connection.close") as close_mock:
+                    with patch.object(Config, "RETRY_SECONDS", 0):
+                        run_loop.run_until_complete(
+                            source_integration.listen_for_messages(mock_consumer, cost_management_app_type, run_loop)
+                        )
+                        close_mock.assert_called()
 
     @patch("sources.kafka_listener.process_message")
     def test_listen_for_messages_network_error(self, mock_process_message):
@@ -1217,7 +1211,7 @@ class SourcesKafkaMsgHandlerTest(TestCase):
             with patch("sources.kafka_listener.connection.close") as close_mock:
                 with patch.object(Config, "RETRY_SECONDS", 0):
                     run_loop.run_until_complete(
-                        source_integration.listen_for_messages(mock_consumer, cost_management_app_type)
+                        source_integration.listen_for_messages(mock_consumer, cost_management_app_type, run_loop)
                     )
                     close_mock.assert_not_called()
 


### PR DESCRIPTION
Putting back the cleanup with one additional pool execution for `get_sources_msg_data`.