### PR TITLE
Update openapi.json to document organizations endpoint 

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -446,6 +446,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/ReportQueryLimit"
+                    },
+                    {
+                        "$ref": "#/components/schemas/OrganizationFilter"
                     }
                 ],
                 "responses": {
@@ -3283,6 +3286,23 @@
                     }
                 }
             },
+            "OrganizationFilter": {
+                "type": "object",
+                "properties": {
+                    "resolution": {
+                        "$ref": "#/components/schemas/ReportResolution"
+                    },
+                    "time_scope_value": {
+                        "$ref": "#/components/schemas/ReportTimeScopeValue"
+                    },
+                    "time_scope_units": {
+                        "$ref": "#/components/schemas/ReportTimeScopeUnits"
+                    },
+                    "org_unit_id": {
+                        "$ref": "#/components/schemas/OrgUnitId"
+                    }
+                }
+            },
             "Organization": {
                 "required": [
                     "org_unit_id",
@@ -3595,6 +3615,9 @@
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "org_unit_id": {
+                        "$ref": "#/components/schemas/OrgUnitId"
                     }
                 }
             },
@@ -3928,6 +3951,9 @@
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "org_unit_id": {
+                        "$ref": "#/components/schemas/OrgUnitId"
                     }
                 },
                 "example": {
@@ -4581,6 +4607,10 @@
                     "cost": "asc"
                 },
                 "description": "The ordering to apply to the report. Default is ascending order for the data."
+            },
+            "OrgUnitId": {
+                "type": "string",
+                "example": "R_001"
             },
             "ReportDelta": {
                 "type": "object",

--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -3330,16 +3330,26 @@
                     },
                     "sub_orgs": {
                         "type": "array",
+                        "items": {
+                            "type": "string",
+                            "description": "the individual org"
+                        },
                         "example": [
                             "OU_004",
                             "OU_005"
-                        ]
+                        ],
+                        "description": "the list of sub orgs under the org"
                     },
                     "accounts": {
                         "type": "array",
+                        "items": {
+                            "type": "string",
+                            "description": "individual account"
+                        },
                         "example": [
                             "account 003"
-                        ]
+                        ],
+                        "description": "the list of accounts under the org"
                     }
                 }
             },

--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -426,6 +426,52 @@
                 }
             }
         },
+        "/organizations/aws/": {
+            "get": {
+                "tags": [
+                    "Organizations"
+                ],
+                "summary": "View AWS organizations",
+                "security": [{
+                    "basic_auth": []
+                }],
+                "parameters": [{
+                        "$ref": "#/components/parameters/QueryDelta"
+                    },
+                    {
+                        "$ref": "#/components/parameters/QueryFilter"
+                    },
+                    {
+                        "$ref": "#/components/parameters/QueryOffset"
+                    },
+                    {
+                        "$ref": "#/components/parameters/ReportQueryLimit"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "A paginated list of Organization objects",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/OrganizationPagination"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/reports/aws/costs/": {
             "get": {
                 "tags": [
@@ -1999,6 +2045,16 @@
                     },
                     {
                         "$ref": "#/components/parameters/ReportQueryLimit"
+                    },
+                    {
+                        "name": "key",
+                        "in": "path",
+                        "description": "The tag key to get",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "example": "production"
+                        }
                     }
                 ],
                 "responses": {
@@ -2116,6 +2172,16 @@
                     },
                     {
                         "$ref": "#/components/parameters/ReportQueryLimit"
+                    },
+                    {
+                        "name": "key",
+                        "in": "path",
+                        "description": "The tag key to get",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "example": "production"
+                        }
                     }
                 ],
                 "responses": {
@@ -2233,6 +2299,16 @@
                     },
                     {
                         "$ref": "#/components/parameters/ReportQueryLimit"
+                    },
+                    {
+                        "name": "key",
+                        "in": "path",
+                        "description": "The tag key to get",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "example": "production"
+                        }
                     }
                 ],
                 "responses": {
@@ -2350,6 +2426,16 @@
                     },
                     {
                         "$ref": "#/components/parameters/ReportQueryLimit"
+                    },
+                    {
+                        "name": "key",
+                        "in": "path",
+                        "description": "The tag key to get",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "example": "production"
+                        }
                     }
                 ],
                 "responses": {
@@ -2467,6 +2553,16 @@
                     },
                     {
                         "$ref": "#/components/parameters/ReportQueryLimit"
+                    },
+                    {
+                        "name": "key",
+                        "in": "path",
+                        "description": "The tag key to get",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "example": "production"
+                        }
                     }
                 ],
                 "responses": {
@@ -2584,6 +2680,16 @@
                     },
                     {
                         "$ref": "#/components/parameters/ReportQueryLimit"
+                    },
+                    {
+                        "name": "key",
+                        "in": "path",
+                        "description": "The tag key to get",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "example": "production"
+                        }
                     }
                 ],
                 "responses": {
@@ -3176,6 +3282,66 @@
                         "type": "string"
                     }
                 }
+            },
+            "Organization": {
+                "required": [
+                    "org_unit_id",
+                    "org_unit_path",
+                    "level",
+                    "sub_orgs",
+                    "accounts"
+                ],
+                "properties": {
+                    "org_unit_id": {
+                        "type": "string",
+                        "example": "OU_003"
+                    },
+                    "org_unit_name": {
+                        "type": "string",
+                        "example": "Dept OU_003"
+                    },
+                    "org_unit_path": {
+                        "type": "string",
+                        "example": "R_001&OU_002&OU_003"
+                    },
+                    "level": {
+                        "type": "integer",
+                        "example": 2
+                    },
+                    "sub_orgs": {
+                        "type": "array",
+                        "example": [
+                            "OU_004",
+                            "OU_005"
+                        ]
+                    },
+                    "accounts": {
+                        "type": "array",
+                        "example": [
+                            "account 003"
+                        ]
+                    }
+                }
+            },
+            "OrganizationPagination": {
+                "allOf": [{
+                        "$ref": "#/components/schemas/ListPagination"
+                    },
+                    {
+                        "type": "object",
+                        "required": [
+                            "data"
+                        ],
+                        "properties": {
+                            "data": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/Organization"
+                                }
+                            }
+                        }
+                    }
+                ]
             },
             "Source": {
                 "required": [

--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -462,6 +462,9 @@
                             }
                         }
                     },
+                    "403": {
+                        "description": "Access to the requested resource is forbidden"
+                    },
                     "500": {
                         "description": "Unexpected Error",
                         "content": {


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/COST-141

This PR adds openapi spec documentation for the organizations endpoint and also fixes some pre-existing syntax errors for the tags key parameter documentation. It also documents the `org_unit_id` filter and group_by. 

To test: 
1. Copy the openapi.json contents (or open the file) into http://editor.swagger.io/
2. View that there are no syntax errors and check out the newly documented organizations endpont

#### Also - sidenote, can someone make sure the filters/group by I added look okay - I'm less familiar with documenting those using swagger/openapi