### PR TITLE
Corrections to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,13 +37,14 @@ For Mac OSX
 Development
 ===========
 
-To get started developing against Koku first clone a local copy of the git repository. ::
+To get started developing against Koku you first need to clone a local copy of the git repositories. ::
 
     git clone https://github.com/project-koku/koku
+    git clone https://github.com/project-koku/nise
 
 This project is developed using the Django web framework. Many configuration settings can be read in from a ``.env`` file. To configure, do the following:
 
-1. Copy ``env.example`` into a ``.env``
+1. Copy ``.env.example`` into a ``.env``
 2. Obtain AWS values and update the following in your ``.env``::
 
     AWS_ACCESS_KEY_ID=YOUR_AWS_ACCESS_KEY
@@ -79,11 +80,6 @@ This project is developed using the Django web framework. Many configuration set
 9. Install the pre-commit hooks for the repository ::
 
     pre-commit install
-
-10. Clone a local copy of the  git repository. This should be in the same location as the cloned koku git repository ::
-
-        git clone https://github.com/project-koku/nise
-
 
 
 Developing with Docker Compose


### PR DESCRIPTION
* Move the git clone for nise to the beginning, allows the .env updates to be made one time.
* Correctly identify .example.env by placing a '.' in front of example.