### PR TITLE
bugfixes for scripts, part 2 (COST-106)

### DIFF
--- a/scripts/e2e-deploy.sh
+++ b/scripts/e2e-deploy.sh
@@ -175,10 +175,10 @@ done
 ### deploy application
 if [[ ${DEPLOY_HCCM_OPTIONAL} ]]; then
     echo "Creating HCCM & HCCM-Optional application."
-    ${IQE} oc deploy -t templates -s hccm,hccm-optional -e dev-self-contained hccm --secrets-src-project ${SECRETS_PROJECT}
+    ${IQE} oc deploy -t templates -s hccm,hccm-optional -e dev-self-contained hccm --secrets-src-project ${SECRETS_PROJECT} || true
 else
     echo "Creating HCCM application."
-    ${IQE} oc deploy -t templates -s hccm -e dev-self-contained hccm --secrets-src-project ${SECRETS_PROJECT}
+    ${IQE} oc deploy -t templates -s hccm -e dev-self-contained hccm --secrets-src-project ${SECRETS_PROJECT} || true
 fi
 
 ### expose API route


### PR DESCRIPTION
Part 2 of scripting fixes.

This PR ensures that `load_test_customer.sh` uploads all of the test buckets when using OCP.

I've also changed the `e2e-deploy` script to not fail during the main deployment loop. Failures there are often correctable after-the-fact. But, it's important that the script runs to completion so that the local OCP is fully configured.