### PR TITLE
remove nise print statement suppression

### DIFF
--- a/koku/koku/koku_test_runner.py
+++ b/koku/koku/koku_test_runner.py
@@ -34,9 +34,6 @@ from reporting.models import OCPEnabledTagKeys
 LOG = logging.getLogger(__name__)
 OCP_ENABLED_TAGS = ["app", "storageclass", "environment", "version"]
 
-# import sys
-# sys.stdout = open(os.devnull, "w")
-
 
 class KokuTestRunner(DiscoverRunner):
     """Koku Test Runner for Unit Tests."""

--- a/koku/koku/koku_test_runner.py
+++ b/koku/koku/koku_test_runner.py
@@ -18,7 +18,6 @@
 """Koku Test Runner."""
 import logging
 import os
-import sys
 
 from django.conf import settings
 from django.db import connections
@@ -34,7 +33,9 @@ from reporting.models import OCPEnabledTagKeys
 
 LOG = logging.getLogger(__name__)
 OCP_ENABLED_TAGS = ["app", "storageclass", "environment", "version"]
-sys.stdout = open(os.devnull, "w")
+
+# import sys
+# sys.stdout = open(os.devnull, "w")
 
 
 class KokuTestRunner(DiscoverRunner):


### PR DESCRIPTION
The code removed by this PR was initially needed when Nise used print statements. The github action that ran the unittests used to fail with a Pipe error before this code was added.

All print statements were replaced with LOG statements in Nise making the suppression code unnecessary. 