### PR TITLE
add flag to change stdout to devnull when running in github action

### DIFF
--- a/koku/koku/koku_test_runner.py
+++ b/koku/koku/koku_test_runner.py
@@ -30,12 +30,14 @@ from tenant_schemas.utils import tenant_context
 from api.models import Customer
 from api.models import Tenant
 from api.report.test.utils import NiseDataLoader
+from koku.env import ENVIRONMENT
 from reporting.models import OCPEnabledTagKeys
 
+GITHUB_ACTIONS = ENVIRONMENT.bool("GITHUB_ACTIONS", default=False)
 LOG = logging.getLogger(__name__)
 OCP_ENABLED_TAGS = ["app", "storageclass", "environment", "version"]
 
-if bool(os.getenv("GITHUB_ACTIONS", False)):
+if GITHUB_ACTIONS:
     sys.stdout = open(os.devnull, "w")
 
 

--- a/koku/koku/koku_test_runner.py
+++ b/koku/koku/koku_test_runner.py
@@ -18,6 +18,7 @@
 """Koku Test Runner."""
 import logging
 import os
+import sys
 
 from django.conf import settings
 from django.db import connections
@@ -33,6 +34,9 @@ from reporting.models import OCPEnabledTagKeys
 
 LOG = logging.getLogger(__name__)
 OCP_ENABLED_TAGS = ["app", "storageclass", "environment", "version"]
+
+if bool(os.getenv("GITHUB_ACTIONS", False)):
+    sys.stdout = open(os.devnull, "w")
 
 
 class KokuTestRunner(DiscoverRunner):


### PR DESCRIPTION
1. add back the devnull stdout logging that was removed in #2221.
2. add a flag so that we only write to devull when koku-test-runner is running in the github-action.

Testing:
1. Watch logs in the unittest github-action -> see that migration information is _not_ logged.
2. Start tests locally: see that migration information _is_ logged.

The 'migration info' I'm talking about is, for example:
```
[standard:public] === Running migrate for schema public
[standard:public] Operations to perform:
[standard:public]   Synchronize unmigrated apps:
```