### PR TITLE
COST-278: Fix code refactor miss s3 copy

### DIFF
--- a/koku/masu/external/downloader/aws/aws_report_downloader.py
+++ b/koku/masu/external/downloader/aws/aws_report_downloader.py
@@ -275,14 +275,7 @@ class AWSReportDownloader(ReportDownloaderBase, DownloaderInterface):
             # Push to S3
             s3_csv_path = get_path_prefix(self.account, self._provider_uuid, start_date, Config.CSV_DATA_TYPE)
             utils.copy_local_report_file_to_s3_bucket(
-                self.request_id,
-                self.account,
-                self._provider_uuid,
-                full_file_path,
-                local_s3_filename,
-                manifest_id,
-                start_date,
-                self.context,
+                self.request_id, s3_csv_path, full_file_path, local_s3_filename, manifest_id, start_date, self.context
             )
             utils.remove_files_not_in_set_from_s3_bucket(self.request_id, s3_csv_path, manifest_id)
 


### PR DESCRIPTION
During code refactor of https://github.com/project-koku/koku/pull/2210 AWS code update was missed for `copy_local_report_file_to_s3_bucket()`

Associated with: https://issues.redhat.com/browse/COST-278

UT logs:
[278-ut.txt](https://github.com/project-koku/koku/files/4822298/278-ut.txt)
