### PR TITLE
remove + Value(0, output_field=DecimalField())

### DIFF
--- a/koku/api/report/aws/provider_map.py
+++ b/koku/api/report/aws/provider_map.py
@@ -107,27 +107,17 @@ class AWSProviderMap(ProviderMap):
                             "infra_total": Sum(
                                 Coalesce(F("unblended_cost"), Value(0, output_field=DecimalField()))
                                 + Coalesce(F("markup_cost"), Value(0, output_field=DecimalField()))
-                                + Value(0, output_field=DecimalField())
                             ),
                             "sup_raw": Value(0, output_field=DecimalField()),
                             "sup_usage": Value(0, output_field=DecimalField()),
                             "sup_markup": Value(0, output_field=DecimalField()),
                             "sup_total": Value(0, output_field=DecimalField()),
-                            "cost_raw": Sum(
-                                Coalesce(F("unblended_cost"), Value(0, output_field=DecimalField()))
-                                + Value(0, output_field=DecimalField())
-                            ),
-                            "cost_usage": Sum(
-                                Value(0, output_field=DecimalField()) + Value(0, output_field=DecimalField())
-                            ),
-                            "cost_markup": Sum(
-                                Coalesce(F("markup_cost"), Value(0, output_field=DecimalField()))
-                                + Value(0, output_field=DecimalField())
-                            ),
+                            "cost_raw": Sum(Coalesce(F("unblended_cost"), Value(0, output_field=DecimalField()))),
+                            "cost_usage": Value(0, output_field=DecimalField()),
+                            "cost_markup": Sum(Coalesce(F("markup_cost"), Value(0, output_field=DecimalField()))),
                             "cost_total": Sum(
                                 Coalesce(F("unblended_cost"), Value(0, output_field=DecimalField()))
                                 + Coalesce(F("markup_cost"), Value(0, output_field=DecimalField()))
-                                + Value(0, output_field=DecimalField())
                             ),
                             "cost_units": Coalesce(Max("currency_code"), Value("USD")),
                             "source_uuid": ArrayAgg(F("source_uuid"), distinct=True),
@@ -175,25 +165,17 @@ class AWSProviderMap(ProviderMap):
                             "infra_total": Sum(
                                 Coalesce(F("unblended_cost"), Value(0, output_field=DecimalField()))
                                 + Coalesce(F("markup_cost"), Value(0, output_field=DecimalField()))
-                                + Value(0, output_field=DecimalField())
                             ),
                             "sup_raw": Value(0, output_field=DecimalField()),
                             "sup_usage": Value(0, output_field=DecimalField()),
                             "sup_markup": Value(0, output_field=DecimalField()),
                             "sup_total": Value(0, output_field=DecimalField()),
-                            "cost_raw": Sum(
-                                Coalesce(F("unblended_cost"), Value(0, output_field=DecimalField()))
-                                + Value(0, output_field=DecimalField())
-                            ),
+                            "cost_raw": Sum(Coalesce(F("unblended_cost"), Value(0, output_field=DecimalField()))),
                             "cost_usage": Value(0, output_field=DecimalField()),
-                            "cost_markup": Sum(
-                                Coalesce(F("markup_cost"), Value(0, output_field=DecimalField()))
-                                + Value(0, output_field=DecimalField())
-                            ),
+                            "cost_markup": Sum(Coalesce(F("markup_cost"), Value(0, output_field=DecimalField()))),
                             "cost_total": Sum(
                                 Coalesce(F("unblended_cost"), Value(0, output_field=DecimalField()))
                                 + Coalesce(F("markup_cost"), Value(0, output_field=DecimalField()))
-                                + Value(0, output_field=DecimalField())
                             ),
                             "cost_units": Coalesce(Max("currency_code"), Value("USD")),
                             "count": Max("resource_count"),
@@ -243,27 +225,17 @@ class AWSProviderMap(ProviderMap):
                             "infra_total": Sum(
                                 Coalesce(F("unblended_cost"), Value(0, output_field=DecimalField()))
                                 + Coalesce(F("markup_cost"), Value(0, output_field=DecimalField()))
-                                + Value(0, output_field=DecimalField())
                             ),
                             "sup_raw": Value(0, output_field=DecimalField()),
                             "sup_usage": Value(0, output_field=DecimalField()),
                             "sup_markup": Value(0, output_field=DecimalField()),
                             "sup_total": Value(0, output_field=DecimalField()),
-                            "cost_raw": Sum(
-                                Coalesce(F("unblended_cost"), Value(0, output_field=DecimalField()))
-                                + Value(0, output_field=DecimalField())
-                            ),
-                            "cost_usage": Sum(
-                                Value(0, output_field=DecimalField()) + Value(0, output_field=DecimalField())
-                            ),
-                            "cost_markup": Sum(
-                                Coalesce(F("markup_cost"), Value(0, output_field=DecimalField()))
-                                + Value(0, output_field=DecimalField())
-                            ),
+                            "cost_raw": Sum(Coalesce(F("unblended_cost"), Value(0, output_field=DecimalField()))),
+                            "cost_usage": Sum(Value(0, output_field=DecimalField())),
+                            "cost_markup": Sum(Coalesce(F("markup_cost"), Value(0, output_field=DecimalField()))),
                             "cost_total": Sum(
                                 Coalesce(F("unblended_cost"), Value(0, output_field=DecimalField()))
                                 + Coalesce(F("markup_cost"), Value(0, output_field=DecimalField()))
-                                + Value(0, output_field=DecimalField())
                             ),
                             "cost_units": Coalesce(Max("currency_code"), Value("USD")),
                             "usage": Sum("usage_amount"),


### PR DESCRIPTION
AWS provider map had some `+ Value(0, output_field=DecimalField())`s. This PR removes those since they aren't necessary.