### PR TITLE
rename `pre-commit` -> `check-manifest` in the check-manifest workflow

### DIFF
--- a/.github/workflows/check-manifest.yml
+++ b/.github/workflows/check-manifest.yml
@@ -5,7 +5,7 @@ on:
     branches: [master]
 
 jobs:
-  pre-commit:
+  check-manifest:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository


### PR DESCRIPTION
This PR fixes the name of the job that runs in the check-manifest action.