### PR TITLE
COST-240: Improve logging for insert aws org tree python script.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,7 +187,11 @@ load-test-customer-data:
 	$(TOPDIR)/scripts/load_test_customer_data.sh $(TOPDIR) $(start) $(end)
 
 load-aws-org-unit-tree:
-	$(PYTHON) $(TOPDIR)/scripts/insert_aws_org_tree.py tree_yml=$(tree_yml) schema=$(schema) nise_yml=$(nise_yml)
+	@if [ $(shell $(PYTHON) -c 'import sys; print(sys.version_info[0])') = '3' ] ; then \
+		$(PYTHON) $(TOPDIR)/scripts/insert_aws_org_tree.py tree_yml=$(tree_yml) schema=$(schema) nise_yml=$(nise_yml) ; \
+	else \
+		echo "This make target requires python3." ; \
+	fi
 
 collect-static:
 	$(DJANGO_MANAGE) collectstatic --no-input

--- a/scripts/aws_org_tree.yml
+++ b/scripts/aws_org_tree.yml
@@ -36,7 +36,7 @@ account_structure:
             parent_path: "R_001"
             accounts:
               - account_alias_id: '9999999999994'
-                account_alias_name: 'Dept OU_004 004'
+                account_alias_name: 'account 004'
           - organizational_unit:
             org_unit_id: 'OU_005'
             org_unit_name: 'Dept OU_005'

--- a/scripts/insert_aws_org_tree.py
+++ b/scripts/insert_aws_org_tree.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import sys
 from datetime import datetime
@@ -7,6 +8,19 @@ import psycopg2
 import requests
 import yaml
 from psycopg2 import sql
+
+logging.basicConfig(level=logging.INFO)
+
+LOG = logging.getLogger(__name__)
+
+
+def require_env(envvar):
+    """Require that the env var be set to move forward with script."""
+    var_value = os.getenv(envvar)
+    if var_value is None:
+        LOG.error(f"The variable '{envvar}' is required in your environment.")
+        sys.exit(1)
+    return var_value
 
 
 class InsertAwsOrgTree:
@@ -28,24 +42,16 @@ class InsertAwsOrgTree:
         self.today_accounts = []
         self.today_orgs = []
         self.nise_accounts = []
-
-    def require_env(self, envvar):
-        """Require that the env var be set to move forward with script."""
-        var_value = os.getenv(envvar)
-        if var_value is None:
-            err_msg = "The variable '%s' is required in your environment."
-            print(err_msg % (envvar))
-            sys.exit(1)
-        return var_value
+        self.account_alias_mapping = {}
 
     def _establish_db_conn(self):
         """Creates a connection to the database."""
         dbinfo = {
             "database": self.db_name,
-            "user": self.require_env("DATABASE_USER"),
-            "password": self.require_env("DATABASE_PASSWORD"),
-            "port": self.require_env("POSTGRES_SQL_SERVICE_PORT"),
-            "host": self.require_env("POSTGRES_SQL_SERVICE_HOST"),
+            "user": require_env("DATABASE_USER"),
+            "password": require_env("DATABASE_PASSWORD"),
+            "port": require_env("POSTGRES_SQL_SERVICE_PORT"),
+            "host": require_env("POSTGRES_SQL_SERVICE_HOST"),
         }
         with psycopg2.connect(**dbinfo) as conn:
             conn.autocommit = True
@@ -56,7 +62,7 @@ class InsertAwsOrgTree:
         """Local data from yaml file."""
         yamlfile = None
         if not os.path.isfile(filename):
-            print("Error: No such file: %s" % filename)
+            LOG.error(f"Error: No such file: {filename}")
             sys.exit(1)
         try:
             with open(filename, "r+") as yaml_file:
@@ -74,6 +80,7 @@ class InsertAwsOrgTree:
         account_alias_sql = sql.SQL(account_alias_sql).format(schema=sql.Identifier(self.schema))
         values = [act_info["account_alias_id"], act_info["account_alias_name"], act_info["account_alias_id"]]
         self.cursor.execute(account_alias_sql, values)
+        LOG.debug(f"Adding account '{values[1]}' to account alias table.")
         account_alias_id = self.cursor.fetchone()[0]
         select_sql = """SELECT * FROM {schema}.reporting_awsorganizationalunit
                         WHERE org_unit_name = %s AND org_unit_id = %s AND org_unit_path = %s
@@ -101,7 +108,12 @@ class InsertAwsOrgTree:
                 org_node["level"],
                 account_alias_id,
             ]
+            self.account_alias_mapping[account_alias_id] = act_info
             self.cursor.execute(insert_account_sql, values)
+            LOG.info(
+                f"Adding account={act_info['account_alias_name']} "
+                f"to org={org_node['org_unit_id']} on created_timestamp={date}."
+            )
 
     def _insert_org_sql(self, org_node, date):
         """Inserts the org unit information into the database."""
@@ -124,6 +136,10 @@ class InsertAwsOrgTree:
                 org_node["level"],
             ]
             self.cursor.execute(org_insert_sql, values)
+            LOG.info(
+                f"Creating OU={org_node['org_unit_id']} with path={org_node['org_path']} "
+                f"at level={org_node['level']} on created_timestamp={date}."
+            )
 
     def _set_deleted_timestamp(self, date):
         """Updates the delete timestamp for values left in the yesterday lists."""
@@ -137,12 +153,16 @@ class InsertAwsOrgTree:
                                        SET deleted_timestamp = %s WHERE account_alias_id = %s"""
                 update_delete_sql = sql.SQL(update_delete_sql).format(schema=sql.Identifier(self.schema))
                 self.cursor.execute(update_delete_sql, [date, alias_id])
+                act_info = self.account_alias_mapping.get(alias_id)
+                LOG.info(f"Updating account={act_info.get('account_alias_name')} with delete_timestamp={date}")
+
         if self.yesterday_orgs != []:
             for org_unit in self.yesterday_orgs:
                 update_delete_sql = """UPDATE {schema}.reporting_awsorganizationalunit
                                        SET deleted_timestamp = %s WHERE org_unit_id = %s"""
                 update_delete_sql = sql.SQL(update_delete_sql).format(schema=sql.Identifier(self.schema))
                 self.cursor.execute(update_delete_sql, [date, org_unit])
+                LOG.info(f"Updating org={org_unit} with delete_timestamp={date}")
         self.yesterday_accounts = self.today_accounts
         self.yesterday_orgs = self.today_orgs
         self.today_accounts = []
@@ -165,6 +185,7 @@ class InsertAwsOrgTree:
                 day = day_dict["day"]
                 date_delta = day["date"]
                 date = self.calculate_date(date_delta)
+                LOG.info(f"Converted date_delta={date_delta} to {date}")
                 for node in day["nodes"]:
                     org_id = node["org_unit_id"]
                     parent_path = node.get("parent_path", "")
@@ -189,7 +210,7 @@ class InsertAwsOrgTree:
                             self._insert_account(node, account, date)
                 self._set_deleted_timestamp(date)
         except KeyError as e:
-            print(
+            LOG.error(
                 f"Error: '{self.tree_yml_path}' file is not formatted correctly, could not find the following key: {e}"
             )
             sys.exit(1)
@@ -201,6 +222,7 @@ class InsertAwsOrgTree:
         for account in self.nise_accounts:
             if account not in new_nise_user_accounts:
                 new_nise_user_accounts.append(account)
+        LOG.info("Adding crawler accounts to nise yaml.")
         self.nise_yaml_contents["accounts"]["user"] = new_nise_user_accounts
         for generator in self.nise_yaml_contents["generators"]:
             for _, metadata in generator.items():
@@ -213,24 +235,26 @@ class InsertAwsOrgTree:
             f"nise report aws --static-report-file {self.nise_yml_path} "
             f"--aws-s3-bucket-name {testing_path} --aws-s3-report-name local-bucket"
         )
+        LOG.info("Running the following Nise command:\n" f"\t{nise_command}")
         os.system(nise_command)
         # Add aws source
         source_url = "http://{}:{}/api/cost-management/v1/sources/".format(
-            self.require_env("KOKU_API_HOSTNAME"), self.require_env("KOKU_PORT")
+            require_env("KOKU_API_HOSTNAME"), require_env("KOKU_PORT")
         )
         json_info = {
             "name": "aws_org_tree",
             "source_type": "AWS-local",
-            "authentication": {"resource_name": self.require_env("AWS_RESOURCE_NAME")},
+            "authentication": {"resource_name": require_env("AWS_RESOURCE_NAME")},
             "billing_source": {"bucket": "/tmp/local_bucket_1"},
         }
+        LOG.info("Creating a source with the following information:\n" f"\t{json_info}")
         requests.post(source_url, json=json_info)
-        # Trigger the download
+        LOG.info("Triggering the masu download")
         download_url = "http://{}:{}/api/cost-management/v1/download/".format(
-            self.require_env("MASU_API_HOSTNAME"), self.require_env("MASU_PORT")
+            require_env("MASU_API_HOSTNAME"), require_env("MASU_PORT")
         )
         requests.get(download_url)
-        nise_repo_path = self.require_env("NISE_REPO_PATH")
+        nise_repo_path = require_env("NISE_REPO_PATH")
         if nise_repo_path in self.nise_yml_path:
             git_checkout_cmd = "cd {} && git checkout -- {}".format(nise_repo_path, "example_aws_static_data.yml")
             os.system(git_checkout_cmd)
@@ -240,13 +264,13 @@ if "__main__" in __name__:
     # Without making sure the migrations are run there is a chance that the
     # reporting_awsorganizationalunit table will not be created in the database yet.
     url = "http://{}:{}/api/cost-management/v1/organizations/aws/".format(
-        os.getenv("KOKU_API_HOSTNAME"), os.getenv("KOKU_PORT")
+        require_env("KOKU_API_HOSTNAME"), require_env("KOKU_PORT")
     )
     requests.get(url)
     default_tree_yml = "scripts/aws_org_tree.yml"
-    default_nise_yml = os.path.join(os.getenv("NISE_REPO_PATH"), "example_aws_static_data.yml")
+    default_nise_yml = os.path.join(require_env("NISE_REPO_PATH"), "example_aws_static_data.yml")
     default_schema = "acct10001"
-    default_db = os.getenv("DATABASE_NAME")
+    default_db = require_env("DATABASE_NAME")
     default_delta_start = today = datetime.today().date()
     arg_list = [default_tree_yml, default_schema, default_db, default_delta_start, default_nise_yml]
     sys_args = sys.argv

--- a/scripts/insert_aws_org_tree.py
+++ b/scripts/insert_aws_org_tree.py
@@ -111,7 +111,7 @@ class InsertAwsOrgTree:
             self.account_alias_mapping[account_alias_id] = act_info
             self.cursor.execute(insert_account_sql, values)
             LOG.info(
-                f"Adding account={act_info['account_alias_name']} "
+                f"Adding account='{act_info['account_alias_name']}' "
                 f"to org={org_node['org_unit_id']} on created_timestamp={date}."
             )
 


### PR DESCRIPTION
This pull request is to address [COST-240](https://issues.redhat.com/browse/COST-240?filter=-1)

_Summary of the Issue_
Essentially since the script is used for the koku's unittest, development workflow, and now on the QE side of things, we wanted to improve the logging in the script to make it easier to understand what is happening in the tree. 

#### How to test

The best way to test is to checkout the branch and run the `make load-aws-org-unit-tree` make target. 

You will now see the following logs:
```
(koku) bash-3.2$ make load-aws-org-unit-tree
INFO:__main__:Converted date_delta=-90 to 2020-04-07
INFO:__main__:Creating OU=R_001 with path=R_001 at level=0 on created_timestamp=2020-04-07.
INFO:__main__:Adding account=Root A Test to org=R_001 on created_timestamp=2020-04-07.
INFO:__main__:Creating OU=OU_001 with path=R_001&OU_001 at level=1 on created_timestamp=2020-04-07.
INFO:__main__:Adding account=account 001 to org=OU_001 on created_timestamp=2020-04-07.
INFO:__main__:Adding account=account 002 to org=OU_001 on created_timestamp=2020-04-07.
INFO:__main__:Creating OU=OU_002 with path=R_001&OU_002 at level=1 on created_timestamp=2020-04-07.
INFO:__main__:Adding account=account 003 to org=OU_002 on created_timestamp=2020-04-07.
INFO:__main__:Creating OU=OU_003 with path=R_001&OU_002&OU_003 at level=2 on created_timestamp=2020-04-07.
INFO:__main__:Creating OU=OU_004 with path=R_001&OU_004 at level=1 on created_timestamp=2020-04-07.
INFO:__main__:Adding account=account 004 to org=OU_004 on created_timestamp=2020-04-07.
INFO:__main__:Creating OU=OU_005 with path=R_001&OU_002&OU_005 at level=2 on created_timestamp=2020-04-07.
INFO:__main__:Converted date_delta=-31 to 2020-06-05
INFO:__main__:Updating account=account 004 with delete_timestamp=2020-06-05
INFO:__main__:Updating org=OU_004 with delete_timestamp=2020-06-05
INFO:__main__:Converted date_delta=0 to 2020-07-06
INFO:__main__:Adding account=account 003 to org=OU_003 on created_timestamp=2020-07-06.
INFO:__main__:Creating OU=OU_005 with path=R_001&OU_001&OU_005 at level=2 on created_timestamp=2020-07-06.
INFO:__main__:Adding crawler accounts to nise yaml.
INFO:__main__:Running the following Nise command:
	nise report aws --static-report-file /Users/cmyers/Desktop/projects/cost_all/nise/example_aws_static_data.yml --aws-s3-bucket-name /Users/cmyers/Desktop/projects/cost_all/koku/testing/local_providers/aws_local_1 --aws-s3-report-name local-bucket
2020-07-06 09:24:48,136 : nise.__main__.452 : INFO : Loading static data...
2020-07-06 09:24:48,145 : nise.__main__.543 : INFO : Creating reports...
2020-07-06 09:24:48,178 : nise.report.422 : INFO : Producing data for 3 generators for 2020-06.
2020-07-06 09:24:48,294 : nise.report.460 : INFO : Done with 0 of 3 generators.
2020-07-06 09:24:48,452 : nise.report.91 : INFO : Writing to June-2020-local-bucket.csv
2020-07-06 09:24:48,580 : nise.copy.47 : INFO : Copied /local-bucket/20200601-20200701/local-bucket-Manifest.json to local directory /Users/cmyers/Desktop/projects/cost_all/koku/testing/local_providers/aws_local_1.
2020-07-06 09:24:48,582 : nise.copy.47 : INFO : Copied /local-bucket/20200601-20200701/9e60943e-4363-4432-96d1-49f9bcb0f5be/local-bucket-Manifest.json to local directory /Users/cmyers/Desktop/projects/cost_all/koku/testing/local_providers/aws_local_1.
2020-07-06 09:24:48,612 : nise.copy.47 : INFO : Copied /local-bucket/20200601-20200701/9e60943e-4363-4432-96d1-49f9bcb0f5be/June-2020-local-bucket.csv.gz to local directory /Users/cmyers/Desktop/projects/cost_all/koku/testing/local_providers/aws_local_1.
2020-07-06 09:24:48,641 : nise.report.422 : INFO : Producing data for 3 generators for 2020-07.
2020-07-06 09:24:48,678 : nise.report.460 : INFO : Done with 0 of 3 generators.
2020-07-06 09:24:48,714 : nise.report.91 : INFO : Writing to July-2020-local-bucket.csv
2020-07-06 09:24:48,741 : nise.copy.47 : INFO : Copied /local-bucket/20200701-20200801/local-bucket-Manifest.json to local directory /Users/cmyers/Desktop/projects/cost_all/koku/testing/local_providers/aws_local_1.
2020-07-06 09:24:48,743 : nise.copy.47 : INFO : Copied /local-bucket/20200701-20200801/4c7ce149-a4f0-47b5-be5d-f37671c26710/local-bucket-Manifest.json to local directory /Users/cmyers/Desktop/projects/cost_all/koku/testing/local_providers/aws_local_1.
2020-07-06 09:24:48,753 : nise.copy.47 : INFO : Copied /local-bucket/20200701-20200801/4c7ce149-a4f0-47b5-be5d-f37671c26710/July-2020-local-bucket.csv.gz to local directory /Users/cmyers/Desktop/projects/cost_all/koku/testing/local_providers/aws_local_1.
INFO:__main__:Creating a source with the following information:
	{'name': 'aws_org_tree', 'source_type': 'AWS-local', 'authentication': {'resource_name': 'arn:aws:iam::589173575009:role/CostManagement'}, 'billing_source': {'bucket': '/tmp/local_bucket_1'}}
INFO:__main__:Triggering the masu download
```