### PR TITLE
adjusted cache file to handle use of DummyCache 

### DIFF
--- a/koku/koku/cache.py
+++ b/koku/koku/cache.py
@@ -20,6 +20,7 @@ import logging
 from django.conf import settings
 from django.core.cache import caches
 from django.core.cache.backends import locmem
+from django.core.cache.backends.dummy import DummyCache
 from django.core.cache.backends.locmem import LocMemCache
 from django_redis.cache import RedisCache
 from redis import Redis
@@ -56,6 +57,9 @@ def invalidate_view_cache_for_tenant_and_cache_key(schema_name, cache_key_prefix
     elif isinstance(cache, LocMemCache):
         all_keys = list(locmem._caches.get(settings.TEST_CACHE_LOCATION).keys())
         all_keys = [key.split(":", 2)[-1] for key in all_keys]
+    elif isinstance(cache, DummyCache):
+        LOG.info("Skipping cache invalidation because views caching is disabled.")
+        return
     else:
         msg = "Using an unsupported caching backend!"
         raise KokuCacheError(msg)

--- a/koku/koku/tests_cache.py
+++ b/koku/koku/tests_cache.py
@@ -75,11 +75,7 @@ class KokuCacheTest(IamTestCase):
         self.assertIsNone(self.cache.get(key_to_clear))
         self.assertIsNotNone(self.cache.get(remaining_key))
 
-    @override_settings(
-        CACHES={
-            "default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}
-        }
-    )
+    @override_settings(CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}})
     def test_invalidate_view_cache_for_tenant_and_cache_key_dummy_cache(self):
         """Test that using DummyCache logs correctly."""
         with self.assertLogs(logger="koku.cache", level="INFO"):

--- a/koku/koku/tests_cache.py
+++ b/koku/koku/tests_cache.py
@@ -77,6 +77,16 @@ class KokuCacheTest(IamTestCase):
 
     @override_settings(
         CACHES={
+            "default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache", "LOCATION": "worker_cache_table"}
+        }
+    )
+    def test_invalidate_view_cache_for_tenant_and_cache_key_dummy_cache(self):
+        """Test that using DummyCache logs correctly."""
+        with self.assertLogs(logger="koku.cache", level="INFO"):
+            invalidate_view_cache_for_tenant_and_cache_key(self.schema_name, self.cache_key_prefix)
+
+    @override_settings(
+        CACHES={
             "default": {"BACKEND": "django.core.cache.backends.db.DatabaseCache", "LOCATION": "worker_cache_table"}
         }
     )

--- a/koku/koku/tests_cache.py
+++ b/koku/koku/tests_cache.py
@@ -77,7 +77,7 @@ class KokuCacheTest(IamTestCase):
 
     @override_settings(
         CACHES={
-            "default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache", "LOCATION": "worker_cache_table"}
+            "default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}
         }
     )
     def test_invalidate_view_cache_for_tenant_and_cache_key_dummy_cache(self):


### PR DESCRIPTION
When deleting a source and having view caching disabled a KokuCacheError was raised when trying to invalidated caches since DummyCache wasn't a caching backend that was handled. DummyCache is now on the list since that is being used to disable view caching.

To test: 
1. Disable view caching by changing "CACHED_VIEWS_DISABLED"  to True in .env
2. add a source and go to the following endpoint: [http://localhost:8000/api/cost-management/v1/sources/](http://localhost:8000/api/cost-management/v1/sources/) to see the source
3. go to the source and attempt to delete it, before a KokuCacheError was raised and now it should not be.