### PR TITLE
convert action trigger to `push`

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -1,8 +1,7 @@
 name: Unit Tests
 
 on:
-  pull_request:
-    branches: [master]
+  push
 
 jobs:
   build:


### PR DESCRIPTION
Codecov has been saying `Missing base report` for who knows how long now, hence why all of our codecov reports are non-sense. I'm changing the action trigger to match the codecov-action example (see [here](https://github.com/codecov/codecov-action)). On `push` we will trigger the unittest action to run.

If this does not resolve our base report issues in Codecov, then I have another idea. The `missing base report` indicates that the commit where the branch is started doesn't have a coverage report associated with it (see [here](https://docs.codecov.io/docs/error-reference)). I'm wondering if we need an additional action that runs the coverage when we merge to master. 