### PR TITLE
Sources: on InterfaceError replace db connection with None

### DIFF
--- a/koku/sources/kafka_listener.py
+++ b/koku/sources/kafka_listener.py
@@ -77,12 +77,6 @@ SOURCE_PROVIDER_MAP = {
     SOURCES_AZURE_LOCAL_SOURCE_NAME: Provider.PROVIDER_AZURE_LOCAL,
 }
 
-# import debugpy
-
-# debugpy.listen(("0.0.0.0", 5678))
-# LOG.warning("Waiting for debug attach")
-# debugpy.wait_for_client()
-
 
 class SourcesIntegrationError(ValidationError):
     """Sources Integration error."""

--- a/koku/sources/kafka_listener.py
+++ b/koku/sources/kafka_listener.py
@@ -114,7 +114,7 @@ def _log_process_queue_event(queue, event):
     LOG.info(f"Adding operation {operation} for {name} to process queue (size: {queue.qsize()})")
 
 
-def close_and_set_db_connection():
+def close_and_set_db_connection():  # pragma: no cover
     """Close the db connection and set to None."""
     connections[DEFAULT_DB_ALIAS].connection.close()
     connections[DEFAULT_DB_ALIAS].connection = None

--- a/koku/sources/test/test_kafka_listener.py
+++ b/koku/sources/test/test_kafka_listener.py
@@ -1168,7 +1168,7 @@ class SourcesKafkaMsgHandlerTest(TestCase):
                 mock_consumer = MockKafkaConsumer([msg])
 
                 mock_process_message.side_effect = test.get("side_effect")
-                with patch("sources.kafka_listener.connection.close") as close_mock:
+                with patch("sources.kafka_listener.close_and_set_db_connection") as close_mock:
                     with patch.object(Config, "RETRY_SECONDS", 0):
                         source_integration.listen_for_messages(msg, mock_consumer, cost_management_app_type)
                         close_mock.assert_called()
@@ -1204,7 +1204,7 @@ class SourcesKafkaMsgHandlerTest(TestCase):
             mock_consumer = MockKafkaConsumer([msg])
 
             mock_process_message.side_effect = test.get("side_effect")
-            with patch("sources.kafka_listener.connection.close") as close_mock:
+            with patch("sources.kafka_listener.close_and_set_db_connection") as close_mock:
                 with patch.object(Config, "RETRY_SECONDS", 0):
                     source_integration.listen_for_messages(msg, mock_consumer, cost_management_app_type)
                     close_mock.assert_not_called()
@@ -1226,7 +1226,7 @@ class SourcesKafkaMsgHandlerTest(TestCase):
 
         for i, test in enumerate(test_matrix):
             mock_process_message.side_effect = test.get("side_effect")
-            with patch("sources.kafka_listener.connection.close") as close_mock:
+            with patch("sources.kafka_listener.close_and_set_db_connection") as close_mock:
                 with patch.object(Config, "RETRY_SECONDS", 0):
                     process_synchronize_sources_msg((i, test["test_value"]), test_queue)
                     close_mock.assert_called()

--- a/koku/sources/test/test_kafka_listener.py
+++ b/koku/sources/test/test_kafka_listener.py
@@ -22,6 +22,7 @@ from unittest.mock import patch
 from uuid import uuid4
 
 import requests_mock
+from django.db import IntegrityError
 from django.db import InterfaceError
 from django.db import OperationalError
 from django.db.models.signals import post_save
@@ -43,6 +44,7 @@ from sources import storage
 from sources.config import Config
 from sources.kafka_listener import process_message
 from sources.kafka_listener import process_synchronize_sources_msg
+from sources.kafka_listener import SourcesIntegrationError
 from sources.kafka_listener import storage_callback
 from sources.sources_http_client import SourceNotFoundError
 from sources.sources_http_client import SourcesHTTPClient
@@ -1214,8 +1216,6 @@ class SourcesKafkaMsgHandlerTest(TestCase):
         """Test processing synchronize messages with database errors."""
         provider = Sources.objects.create(**self.aws_source)
         provider.save()
-        future_mock = asyncio.Future()
-        future_mock.set_result("test result")
 
         test_queue = queue.PriorityQueue()
 
@@ -1230,6 +1230,27 @@ class SourcesKafkaMsgHandlerTest(TestCase):
                 with patch.object(Config, "RETRY_SECONDS", 0):
                     process_synchronize_sources_msg((i, test["test_value"]), test_queue)
                     close_mock.assert_called()
+        for i in range(2):
+            priority, _ = test_queue.get_nowait()
+            self.assertEqual(priority, i)
+
+    @patch("sources.kafka_listener.execute_koku_provider_op")
+    def test_process_synchronize_sources_msg_integration_error(self, mock_process_message):
+        """Test processing synchronize messages with database errors."""
+        provider = Sources.objects.create(**self.aws_source)
+        provider.save()
+
+        test_queue = queue.PriorityQueue()
+
+        test_matrix = [
+            {"test_value": {"operation": "update", "provider": provider}, "side_effect": IntegrityError},
+            {"test_value": {"operation": "update", "provider": provider}, "side_effect": SourcesIntegrationError},
+        ]
+
+        for i, test in enumerate(test_matrix):
+            mock_process_message.side_effect = test.get("side_effect")
+            with patch.object(Config, "RETRY_SECONDS", 0):
+                process_synchronize_sources_msg((i, test["test_value"]), test_queue)
         for i in range(2):
             priority, _ = test_queue.get_nowait()
             self.assertEqual(priority, i)


### PR DESCRIPTION
In sources-client, if the DB connection times-out and raises an InterfaceError, we can potentially get stuck in a retry loop. Calling `connection.close()` was insufficient to reset the connection to the DB. We need to go one step further and replace the connection with None.

This PR:
- Close and replace db connection with None when InterfaceError or OperationalError is encountered.
- Moved IntegrityError catch because these exceptions do not require resetting the db connection.

Testing (I could not figure out how to reproduce this without vscode and remote attaching to the running sources-client container):
1. Add a source thru the sources backend.
2. Set a breakpoint just inside the transaction.atomic of the ProviderSerliazer.update method.
3. Send a source.update event and let the debugger stop on the breakpoint.
4. Wait 30 seconds.
5. Hit continue on the debugger. This will raise the InterfaceError.
6. At this point, you should see the sources-client retry and you will stop at the same breakpoint again. Hit continue and the source should update correctly.