### PR TITLE
Add converters and post processing logic to pandas read_csv so parquet types are as expected.

### DIFF
--- a/koku/masu/processor/ocp/ocp_report_processor.py
+++ b/koku/masu/processor/ocp/ocp_report_processor.py
@@ -196,22 +196,10 @@ class OCPReportProcessorBase(ReportProcessorBase):
             label_string (str): The raw report string of pod labels
 
         Returns:
-            (dict): The JSON dictionary made from the label string
+            (str): The JSON dictionary as a string made from the label string
 
         """
-        labels = label_string.split("|") if label_string else []
-        label_dict = {}
-
-        for label in labels:
-            try:
-                key, value = label.split(":")
-                key = key.replace("label_", "")
-                label_dict[key] = value
-            except ValueError as err:
-                LOG.warning(err)
-                LOG.warning("%s could not be properly split", label)
-                continue
-
+        label_dict = utils.process_openshift_labels(label_string)
         return json.dumps(label_dict)
 
     def _update_mappings(self):

--- a/koku/masu/test/util/ocp/test_common.py
+++ b/koku/masu/test/util/ocp/test_common.py
@@ -21,6 +21,8 @@ import tempfile
 from unittest.mock import patch
 from uuid import UUID
 
+import pandas as pd
+
 from masu.config import Config
 from masu.database import OCP_REPORT_TABLE_MAP
 from masu.database.ocp_report_db_accessor import OCPReportDBAccessor
@@ -89,3 +91,10 @@ class OCPUtilTests(MasuTestCase):
             os.makedirs(expected_path, exist_ok=True)
             self.assertTrue(utils.poll_ingest_override_for_provider(self.ocp_test_provider_uuid))
         shutil.rmtree(fake_dir)
+
+    def test_process_openshift_datetime(self):
+        """Test process_openshift_datetime method with good and bad values."""
+        expected_dt_str = "2020-07-01 00:00:00"
+        expected = pd.to_datetime(expected_dt_str)
+        dt = utils.process_openshift_datetime("2020-07-01 00:00:00 +0000 UTC")
+        self.assertEqual(expected, dt)

--- a/koku/masu/test/util/test_common.py
+++ b/koku/masu/test/util/test_common.py
@@ -173,6 +173,23 @@ class CommonUtilTests(MasuTestCase):
         with self.assertRaises(StopIteration):
             next(date_generator)
 
+    def test_safe_float(self):
+        """Test the safe_float method handles good and bad inputs."""
+        out = common_utils.safe_float("foo")
+        self.assertEqual(out, float(0))
+
+        out = common_utils.safe_float("1.1")
+        self.assertEqual(out, float("1.1"))
+
+    def test_safe_dict(self):
+        """Test the safe_dict method handles good and bad inputs."""
+        out = common_utils.safe_dict(1)
+        self.assertEqual(out, "{}")
+
+        expected = '{"a": "b", "c": "d"}'
+        out = common_utils.safe_dict(expected)
+        self.assertEqual(out, expected)
+
 
 class NamedTemporaryGZipTests(TestCase):
     """Tests for NamedTemporaryGZip."""

--- a/koku/masu/util/aws/common.py
+++ b/koku/masu/util/aws/common.py
@@ -16,6 +16,7 @@
 #
 """AWS utility functions."""
 import datetime
+import json
 import logging
 import re
 import shutil
@@ -374,8 +375,32 @@ def remove_files_not_in_set_from_s3_bucket(request_id, s3_path, manifest_id, con
     return removed
 
 
-def convert_csv_to_parquet(
-    request_id, s3_csv_path, s3_parquet_path, local_path, manifest_id, csv_filename, context={}
+def aws_post_processor(data_frame):
+    """
+    Consume the AWS data and add a column creating a dictionary for the aws tags
+    """
+    resource_tags_dict = data_frame.apply(
+        lambda row: {
+            column.replace("resourceTags/user:", ""): value
+            for column, value in row.items()
+            if "resourceTags/user:" in column and value
+        },
+        axis=1,
+    )
+    data_frame["resourceTags"] = resource_tags_dict.apply(json.dumps)
+    return data_frame
+
+
+def convert_csv_to_parquet(  # noqa: C901
+    request_id,
+    s3_csv_path,
+    s3_parquet_path,
+    local_path,
+    manifest_id,
+    csv_filename,
+    converters={},
+    post_processor=None,
+    context={},
 ):
     """
     Convert CSV files to parquet on S3.
@@ -420,7 +445,11 @@ def convert_csv_to_parquet(
 
     output_file = f"{local_path}/{parquet_file}"
     try:
-        data_frame = pd.read_csv(tmpfile, **kwargs)
+        col_names = pd.read_csv(tmpfile, nrows=0, **kwargs).columns
+        converters.update({col: str for col in col_names if col not in converters})
+        data_frame = pd.read_csv(tmpfile, converters=converters, **kwargs)
+        if post_processor:
+            data_frame = post_processor(data_frame)
         data_frame.to_parquet(output_file)
     except Exception as err:
         shutil.rmtree(local_path, ignore_errors=True)

--- a/koku/masu/util/common.py
+++ b/koku/masu/util/common.py
@@ -134,8 +134,8 @@ def safe_float(val):
     """
     result = float(0)
     try:
-        float(val)
-    except ValueError:
+        result = float(val)
+    except (ValueError, TypeError):
         pass
     return result
 
@@ -147,7 +147,7 @@ def safe_dict(val):
     result = {}
     try:
         result = json.loads(val)
-    except ValueError:
+    except (ValueError, TypeError):
         pass
     return json.dumps(result)
 

--- a/koku/masu/util/ocp/common.py
+++ b/koku/masu/util/ocp/common.py
@@ -272,3 +272,42 @@ def detect_type(report_path):
         if report_columns == sorted_columns:
             return report_type, report_enum
     return None, OCPReportTypes.UNKNOWN
+
+
+def process_openshift_datetime(val):
+    """
+    Convert the date time from the Metering operator reports to a consumable datetime.
+    """
+    result = None
+    try:
+        datetime_str = str(val).replace(" +0000 UTC", "")
+        result = pd.to_datetime(datetime_str)
+    except parser.ParserError:
+        pass
+    return result
+
+
+def process_openshift_labels(label_string):
+    """Convert the report string to a JSON dictionary.
+
+    Args:
+        label_string (str): The raw report string of pod labels
+
+    Returns:
+        (dict): The JSON dictionary made from the label string
+
+    """
+    labels = label_string.split("|") if label_string else []
+    label_dict = {}
+
+    for label in labels:
+        try:
+            key, value = label.split(":")
+            key = key.replace("label_", "")
+            label_dict[key] = value
+        except ValueError as err:
+            LOG.warning(err)
+            LOG.warning("%s could not be properly split", label)
+            continue
+
+    return label_dict


### PR DESCRIPTION
During prototyping with parquet files it was found that the default pandas.read_csv() made unexpected data type decisions:
[parquet_data_types.txt](https://github.com/project-koku/koku/files/4881777/parquet_data_types.txt)

In order to be able to query the data in expected formats coverters are now passed in for data types that need to be handled as non-strings (timestamps, doubles, JSON). The converters mirror the data types found in the provider models for line items.

Post-processor logic was added for the AWS case in order to create a "resourceTags" column that mirrors the JSON string stored in the current model.

With these updates you can see that the parquet files store in the expected types:
`parquet-tools inspect 69fffff0-65b4-4042-9c31-5d2b082bccb2-July-2020-None.parquet`
[parquet-inspect.txt](https://github.com/project-koku/koku/files/4881799/parquet-inspect.txt)

And after setting up the table in Presto you can query the data on S3:
```
docker exec -it presto presto-cli --catalog hive --execute "SELECT * FROM default.aws_data_10001_e52fc443_e559_4718_9d6c_80e1450d11c2"
"5d629550c058e3617603a7f43a062b8669a00eda","2020-07-01T00:00:00Z/2020-07-01T01:00:00Z","","AWS","Anniversary","9999999999999","2020-07-01 00:00:00.000","2020-08-01 00:00:00.000","9999999999999","Usage","2020-07-01 00:00:00.000","2020-07-01 01:00:00.000","AmazonEC2","BoxUsage:m5.large","RunInstances","us-east-1a","i-55555555","0.0","0.0","0.0","USD","0.0","0.0","0.0","0.0","$0.096 per On Demand Linux m5.large Instance Hour","","Amazon Elastic Compute Cloud","","","","","","","2.8 GHz","","","Yes","","","","","","","","","","","14","","","Yes","","","","","","","","General Purpose","m5.large","","","","No License required","US East (N. Virginia)","AWS Region","","","","","8 GiB","","","","","Moderate","Linux","RunInstances","","","Intel Xeon Family","NA","","64-bit","Intel AVX Intel Turbo","Compute Instance","","","","","","us-east-1","","","","","","AmazonEC2","VEAJHRNKTJZQ","","EBS Only","","","","","Shared","","","","","","BoxUsage:m5.large","2","","","","","","","0.0","0.0","OnDemand","Hrs","","","","","","","","","","prod","","","","","{""version"": ""prod""}"
```