### PR TITLE
Unittest workflow fix

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -51,7 +51,7 @@ jobs:
           path: |
             ~/.cache/pipenv
             ~/.local/share/virtualenvs
-          key: ${{ runner.os }}-env-${{ matrix.python-version }}-${{ hashFiles('**/Pipfile.lock') }}-${{ github.ref }}
+          key: ${{ runner.os }}-env-${{ matrix.python-version }}-${{ hashFiles('**/Pipfile.lock') }}
 
       - name: Install dependencies
         if: steps.cache-dependencies.outputs.cache-hit != 'true'

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -46,16 +46,13 @@ jobs:
 
       - name: Cache dependencies
         id: cache-dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
-          path: ~/.cache/pipenv
-          key: ${{ runner.os }}-pipenv-${{ matrix.python-version }}-${{ hashFiles('**/Pipfile.lock') }}-${{ github.ref }}
-      - name: Cache virtualenv
-        id: cache-virtualenv
-        uses: actions/cache@v1
-        with:
-          path: ~/.local/share/virtualenvs
-          key: ${{ runner.os }}-venv-${{ matrix.python-version }}-${{ hashFiles('**/Pipfile.lock') }}-${{ github.ref }}
+          path: |
+            ~/.cache/pipenv
+            ~/.local/share/virtualenvs
+          key: ${{ runner.os }}-env-${{ matrix.python-version }}-${{ hashFiles('**/Pipfile.lock') }}-${{ github.ref }}
+
       - name: Install dependencies
         if: steps.cache-dependencies.outputs.cache-hit != 'true' || steps.cache-virtualenv.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -54,7 +54,7 @@ jobs:
           key: ${{ runner.os }}-env-${{ matrix.python-version }}-${{ hashFiles('**/Pipfile.lock') }}-${{ github.ref }}
 
       - name: Install dependencies
-        if: steps.cache-dependencies.outputs.cache-hit != 'true' || steps.cache-virtualenv.outputs.cache-hit != 'true'
+        if: steps.cache-dependencies.outputs.cache-hit != 'true'
         run: |
           pipenv install --dev --ignore-pipfile --python ${{ matrix.python-version }}
 

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -42,9 +42,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install pipenv
-        uses: dschep/install-pipenv-action@v1
-        with:
-          version: 2018.11.26
+        run: sudo python3 -m pip install pipenv==2018.11.26
+
       - name: Cache dependencies
         id: cache-dependencies
         uses: actions/cache@v1

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -49,13 +49,13 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/.cache/pipenv
-          key: ${{ runner.os }}-pipenv-${{ matrix.python-version }}-${{ hashFiles('**/Pipfile.lock') }}
+          key: ${{ runner.os }}-pipenv-${{ matrix.python-version }}-${{ hashFiles('**/Pipfile.lock') }}-${{ github.ref }}
       - name: Cache virtualenv
         id: cache-virtualenv
         uses: actions/cache@v1
         with:
           path: ~/.local/share/virtualenvs
-          key: ${{ runner.os }}-venv-${{ matrix.python-version }}-${{ hashFiles('**/Pipfile.lock') }}
+          key: ${{ runner.os }}-venv-${{ matrix.python-version }}-${{ hashFiles('**/Pipfile.lock') }}-${{ github.ref }}
       - name: Install dependencies
         if: steps.cache-dependencies.outputs.cache-hit != 'true' || steps.cache-virtualenv.outputs.cache-hit != 'true'
         run: |


### PR DESCRIPTION
For whatever reason, a workflow was using python2 to run the python3.6 unit tests: [https://github.com/project-koku/koku/runs/850175190?check_suite_focus=true](https://github.com/project-koku/koku/runs/850175190?check_suite_focus=true) 🤨 

This PR:
- specifies to install pipenv using python3
- specifies the branch in the cache key <- this ensures that the dependencies are installed when the branch is first pushed to github