### PR TITLE
COST-330: remove "update_fields" from storage_callback

### DIFF
--- a/koku/sources/kafka_listener.py
+++ b/koku/sources/kafka_listener.py
@@ -150,14 +150,7 @@ def execute_process_queue():
 @receiver(post_save, sender=Sources)
 def storage_callback(sender, instance, **kwargs):
     """Load Sources ready for Koku Synchronization when Sources table is updated."""
-    update_fields = kwargs.get("update_fields", ())
-    if (
-        update_fields
-        and "pending_update" in update_fields
-        and instance.koku_uuid
-        and instance.pending_update
-        and not instance.pending_delete
-    ):
+    if instance.koku_uuid and instance.pending_update and not instance.pending_delete:
         update_event = {"operation": "update", "provider": instance}
         _log_process_queue_event(PROCESS_QUEUE, update_event)
         LOG.debug(f"Update Event Queued for:\n{str(instance)}")


### PR DESCRIPTION
This PR fixes PATCH requests for an existing Source. The logic that is removed by this PR is preventing the update task from being added to the PROCESS_QUEUE.

Testing:
1. Create an AWS Source through the sources backend.
```
postgres=# select * from api_provider ;
-[ RECORD 2 ]-----+-------------------------------------
uuid              | 0bc3cace-4861-42ed-a5f2-c3d04afd8d6d
name              | mskarbek-aws
type              | AWS
setup_complete    | f
authentication_id | 6
billing_source_id | 6
created_by_id     | 1
customer_id       | 1
created_timestamp | 2020-07-09 01:13:26.140251+00
active            | t
infrastructure_id | 

postgres=# select * from api_providerbillingsource where id=6;
-[ RECORD 1 ]-------------------------------------
id          | 6
uuid        | 6aea8cec-36cc-4eab-9771-ee0a04ab4890
bucket      | cost-usage-bucket
data_source | {"bucket": "cost-usage-bucket"}
```
2. Once source creation is complete, send another PATCH through koku changing the bucket.
3. Observe that the update completes and the new bucket appears in the db.
```
-[ RECORD 2 ]-----+-------------------------------------
uuid              | 0bc3cace-4861-42ed-a5f2-c3d04afd8d6d
name              | mskarbek-aws
type              | AWS
setup_complete    | t
authentication_id | 6
billing_source_id | 7 <<<<<<<<
created_by_id     | 1
customer_id       | 1
created_timestamp | 2020-07-09 01:13:26.140251+00
active            | t
infrastructure_id | 

postgres=# select * from api_providerbillingsource where id=7;
-[ RECORD 1 ]-------------------------------------
id          | 7
uuid        | da1116e3-2481-4156-8712-6532f78e1b23
bucket      | bucket-sns-test <<<<<<<<<
data_source | {"bucket": "bucket-sns-test"}
```

