### PR TITLE
COST-310: Update the org_unit group_by structure to have one list

### DIFF
--- a/koku/api/report/aws/query_handler.py
+++ b/koku/api/report/aws/query_handler.py
@@ -178,7 +178,6 @@ class AWSReportQueryHandler(ReportQueryHandler):
         obtain the account results, and each sub_org results.
         Else it will return the original query.
         """
-
         original_filters = copy.deepcopy(self.parameters.parameters.get("filter"))
         sub_orgs_dict = {}
         query_data_results = {}

--- a/koku/api/report/aws/query_handler.py
+++ b/koku/api/report/aws/query_handler.py
@@ -137,18 +137,38 @@ class AWSReportQueryHandler(ReportQueryHandler):
         Returns:
             (list) the overall query data results
         """
+        # loop through original query data
+        for each_day in query_data:
+            accounts = each_day.get("accounts", [])
+            # rename id/alias and add type
+            for account in accounts:
+                account["id"] = account.pop("account")
+                account["type"] = "account"
+                for value in account.get("values"):
+                    value["id"] = value.pop("account")
+                    value["alias"] = value.pop("account_alias")
+            # rename entire structure to org_entities
+            each_day["org_entities"] = each_day.pop("accounts", [])
+        # now go through each sub org query
         for org_name, org_data in query_data_results.items():
             for day in org_data:
                 for each_day in query_data:
                     if day["date"] == each_day["date"] and day.get("values"):
-                        each_day["sub_orgs"].append(
+                        values = day.get("values")
+                        for value in values:
+                            # add id and org alias to values
+                            value["id"] = sub_orgs_dict.get(org_name)[0]
+                            value["alias"] = org_name
+                        org_entities = each_day["org_entities"]
+                        org_entities.append(
                             {
-                                "org_unit_name": org_name,
-                                "org_unit_id": sub_orgs_dict.get(org_name)[0],
+                                "id": sub_orgs_dict.get(org_name)[0],
+                                "type": "organizational_unit",
                                 "date": day.get("date"),
-                                "values": day.get("values"),
+                                "values": values,
                             }
                         )
+                        each_day["org_entities"] = org_entities
         return query_data
 
     def execute_query(self):  # noqa: C901
@@ -158,6 +178,7 @@ class AWSReportQueryHandler(ReportQueryHandler):
         obtain the account results, and each sub_org results.
         Else it will return the original query.
         """
+
         original_filters = copy.deepcopy(self.parameters.parameters.get("filter"))
         sub_orgs_dict = {}
         query_data_results = {}
@@ -212,11 +233,7 @@ class AWSReportQueryHandler(ReportQueryHandler):
             sub_query_data, sub_query_sum = self.execute_individual_query()
             query_data_results[sub_org_name] = sub_query_data
             query_sum_results.append(sub_query_sum)
-        # Add the sub_org results to the query_data
         if org_unit_applied:
-            for day in query_data:
-                day["sub_orgs"] = []
-        if query_data_results:
             query_data = self.format_sub_org_results(query_data_results, query_data, sub_orgs_dict)
         # Add each of the sub_org sums to the query_sum
         if query_sum_results:


### PR DESCRIPTION
[COST-310](https://issues.redhat.com/browse/COST-310) - Update the structure of the data returned when doing a `?group_by[org_unit_id]=id`

### Description
Previously sub_orgs and accounts belonging to an org_unit were returned in two separate lists which made it impossible for the UI to sort/paginate/filter on sub_orgs. We revisited the design and decided to combine the two lists and create common fields for the id/alias/type. 
#### Previous Data structure
```
"data": [
   {
       "date": "2020-06-27",
       "accounts": [
           {
               "account": "9999999999990",
               "values": [
                   {
                       "date": "2020-06-27",
                       "account": "9999999999990",
                       "source_uuid": [
                           "aaaf3c18-f940-4723-82ab-b2673295855f"
                       ],
                       "account_alias": "Root A Test",
                       "infrastructure": {
                           ...
                       },
                       "supplementary": {
                           ...
                       },
                       "cost": {
                          ...
                       }
                   }
               ]
           }
       ],
       "sub_orgs": [
           {
               "org_unit_name": "Dept OU_001",
               "org_unit_id": "OU_001",
               "date": "2020-06-27",
               "values": [
                   {
                       "date": "2020-06-27",
                       "source_uuid": [
                           "aaaf3c18-f940-4723-82ab-b2673295855f"
                       ],
                       "infrastructure": {
                           ...
                       },
                       "supplementary": {
                           ...
                       },
                       "cost": {
                           ...
                       }
                   }
               ]
           },
           {
               "org_unit_name": "Dept OU_002",
               "org_unit_id": "OU_002",
               "date": "2020-06-27",
               "values": [
                   {
                       "date": "2020-06-27",
                       "source_uuid": [
                           "aaaf3c18-f940-4723-82ab-b2673295855f"
                       ],
                       "infrastructure": {
                           ...
                       },
                       "supplementary": {
                           ...
                       },
                       "cost": {
                           ...
                       }
                   }
               ]
           }
       ]
   },

```

#### Updated Data structure
Changes: 
* One list called `org_entities` to hold both accounts and org_units
* `account` field changed to `id` 
* `account_alias` field changed to `alias` 
* `type` field was added to specify either `account` or `organizational_unit`
* `org_unit_name` changed to `alias` and was moved inside of the `values` dictionary
* `org_unit_id` changed to `id` and is now in both the outer dictionary as well as the `values` dictionary to mimic accounts

```
"data": [
        {
            "date": "2020-06-30",
            "org_entities": [
                {
                    "values": [
                        {
                            "date": "2020-06-30",
                            "source_uuid": [
                                "4059fb0d-a077-47ae-a725-15c5ae8a1ec1"
                            ],
                            "infrastructure": {
                                ...
                            },
                            "supplementary": {
                                ...
                            },
                            "cost": {
                                ...
                            },
                            "id": "9999999999990",
                            "alias": "Root A Test"
                        }
                    ],
                    "id": "9999999999990",
                    "type": "account"
                },
                {
                    "id": "OU_001",
                    "type": "organizational_unit",
                    "date": "2020-06-30",
                    "values": [
                        {
                            "date": "2020-06-30",
                            "source_uuid": [
                                "4059fb0d-a077-47ae-a725-15c5ae8a1ec1"
                            ],
                            "infrastructure": {
                                ...
                            },
                            "supplementary": {
                                ...
                            },
                            "cost": {
                               ...
                            },
                            "id": "OU_001",
                            "alias": "Dept OU_001"
                        }
                    ]
                },
                {
                    "id": "OU_002",
                    "type": "organizational_unit",
                    "date": "2020-06-30",
                    "values": [
                        {
                            "date": "2020-06-30",
                            "source_uuid": [
                                "4059fb0d-a077-47ae-a725-15c5ae8a1ec1"
                            ],
                            "infrastructure": {
                                ...
                            },
                            "supplementary": {
                                ...
                            },
                            "cost": {
                                ...
                            },
                            "id": "OU_002",
                            "alias": "Dept OU_002"
                        }
                    ]
                }
            ]
```

### Testing
1. Run `make load-aws-org-unit-tree`
2. View the data returned from 
* http://127.0.0.1:8000/api/cost-management/v1/reports/aws/costs/?group_by[org_unit_id]=R_001 (OUs & accounts should be in org_entities list) 
* http://127.0.0.1:8000/api/cost-management/v1/reports/aws/costs/?group_by[org_unit_id]=OU_003 (only an account in the org_entities list for the last day) 
* http://127.0.0.1:8000/api/cost-management/v1/reports/aws/costs/?group_by[org_unit_id]=nonexistent (empty org_entities list)
* http://127.0.0.1:8000/api/cost-management/v1/reports/aws/costs/?group_by[org_unit_id]=* (should only show accounts in org_entities list)

### Smoke tests results
```
FAILED lib/python3.6/site-packages/iqe_hccm/tests/rest_api/v1/test_source.py::test_api_aws_source_crud - iqe_hccm_api.exceptions.ApiException: (...
FAILED lib/python3.6/site-packages/iqe_hccm/tests/rest_api/v1/test_source.py::test_api_azure_source_crud - iqe_hccm_api.exceptions.ApiException:...
FAILED lib/python3.6/site-packages/iqe_hccm/tests/rest_api/v1/test_source.py::test_api_azure_source_raw_calc - AssertionError: Raw calculated va...
===================================== 3 failed, 3462 passed, 80 skipped, 2189 deselected in 747.47s (0:12:27) =====================================
```
All seem unrelated & all were interface errors

### I am going to fix pagination in a separate PR 