### PR TITLE
[COST-338] Gracefully handle the update summary flow when a provider has been removed.

### DIFF
--- a/koku/masu/test/util/aws/test_common.py
+++ b/koku/masu/test/util/aws/test_common.py
@@ -245,6 +245,10 @@ class TestAWSUtils(MasuTestCase):
 
         self.assertEqual(bill_ids, expected_bill_ids)
 
+        # Try with unknown provider uuid
+        bills = utils.get_bills_from_provider(self.unkown_test_provider_uuid, self.schema)
+        self.assertEqual(bills, [])
+
     def test_get_bill_ids_from_provider_with_start_date(self):
         """Test that bill IDs are returned for an AWS provider with start date."""
         date_accessor = DateAccessor()

--- a/koku/masu/util/aws/common.py
+++ b/koku/masu/util/aws/common.py
@@ -254,6 +254,11 @@ def get_bills_from_provider(provider_uuid, schema, start_date=None, end_date=Non
     with ProviderDBAccessor(provider_uuid) as provider_accessor:
         provider = provider_accessor.get_provider()
 
+    if not provider:
+        err_msg = "Provider UUID is not associated with a given provider."
+        LOG.warning(err_msg)
+        return []
+
     if provider.type not in (Provider.PROVIDER_AWS, Provider.PROVIDER_AWS_LOCAL):
         err_msg = f"Provider UUID is not an AWS type.  It is {provider.type}"
         LOG.warning(err_msg)


### PR DESCRIPTION

* Check for provider presence and return empty bill list if not found
* Add unit test coverage for missing provider case

Associated with: https://issues.redhat.com/browse/COST-338