### PR TITLE
[WIP] [COST-272] Tag API Filter on Tag Key

### DIFF
--- a/koku/api/tags/aws/queries.py
+++ b/koku/api/tags/aws/queries.py
@@ -15,6 +15,8 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 """AWS Tag Query Handling."""
+from copy import deepcopy
+
 from api.models import Provider
 from api.report.aws.provider_map import AWSProviderMap
 from api.tags.queries import TagQueryHandler
@@ -26,8 +28,11 @@ class AWSTagQueryHandler(TagQueryHandler):
 
     provider = Provider.PROVIDER_AWS
     data_sources = [{"db_table": AWSTagsSummary, "db_column_period": "cost_entry_bill__billing_period"}]
-    SUPPORTED_FILTERS = ["account"]
-    FILTER_MAP = {"account": {"field": "accounts", "operation": "icontains", "composition_key": "account_filter"}}
+    SUPPORTED_FILTERS = TagQueryHandler.SUPPORTED_FILTERS + ["account"]
+    FILTER_MAP = deepcopy(TagQueryHandler.FILTER_MAP)
+    FILTER_MAP.update(
+        {"account": {"field": "accounts", "operation": "icontains", "composition_key": "account_filter"}}
+    )
 
     def __init__(self, parameters):
         """Establish AWS report query handler.

--- a/koku/api/tags/azure/openshift/queries.py
+++ b/koku/api/tags/azure/openshift/queries.py
@@ -15,11 +15,12 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 """OCP-on-Azure Tag Query Handling."""
+from copy import deepcopy
+
 from api.models import Provider
 from api.report.azure.openshift.provider_map import OCPAzureProviderMap
 from api.tags.azure.queries import AzureTagQueryHandler
 from api.tags.ocp.queries import OCPTagQueryHandler
-from api.utils import merge_dicts
 from reporting.models import OCPAzureTagsSummary
 
 
@@ -29,7 +30,8 @@ class OCPAzureTagQueryHandler(AzureTagQueryHandler, OCPTagQueryHandler):
     provider = Provider.OCP_AZURE
     data_sources = [{"db_table": OCPAzureTagsSummary, "db_column_period": "cost_entry_bill__billing_period"}]
     SUPPORTED_FILTERS = AzureTagQueryHandler.SUPPORTED_FILTERS + OCPTagQueryHandler.SUPPORTED_FILTERS
-    FILTER_MAP = merge_dicts(AzureTagQueryHandler.FILTER_MAP, OCPTagQueryHandler.FILTER_MAP)
+    FILTER_MAP = deepcopy(AzureTagQueryHandler.FILTER_MAP)
+    FILTER_MAP.update(OCPTagQueryHandler.FILTER_MAP)
     # override cluster since we are getting it from a different table and field(s)
     FILTER_MAP["cluster"] = [
         {"field": "cluster_alias", "operation": "icontains", "composition_key": "cluster_filter"},

--- a/koku/api/tags/azure/queries.py
+++ b/koku/api/tags/azure/queries.py
@@ -16,6 +16,7 @@
 #
 """Azure Tag Query Handling."""
 import logging
+from copy import deepcopy
 
 from api.models import Provider
 from api.report.azure.provider_map import AzureProviderMap
@@ -30,8 +31,9 @@ class AzureTagQueryHandler(TagQueryHandler):
 
     provider = Provider.PROVIDER_AZURE
     data_sources = [{"db_table": AzureTagsSummary, "db_column_period": "cost_entry_bill__billing_period"}]
-    SUPPORTED_FILTERS = ["subscription_guid"]
-    FILTER_MAP = {"subscription_guid": {"field": "subscription_guid", "operation": "icontains"}}
+    SUPPORTED_FILTERS = TagQueryHandler.SUPPORTED_FILTERS + ["subscription_guid"]
+    FILTER_MAP = deepcopy(TagQueryHandler.FILTER_MAP)
+    FILTER_MAP.update({"subscription_guid": {"field": "subscription_guid", "operation": "icontains"}})
 
     def __init__(self, parameters):
         """Establish Azure report query handler.

--- a/koku/api/tags/ocp/queries.py
+++ b/koku/api/tags/ocp/queries.py
@@ -15,6 +15,8 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 """OCP Tag Query Handling."""
+from copy import deepcopy
+
 from django.db.models import Exists
 from django.db.models import OuterRef
 
@@ -45,15 +47,22 @@ class OCPTagQueryHandler(TagQueryHandler):
             "annotations": {"enabled": Exists(enabled)},
         },
     ]
-    SUPPORTED_FILTERS = ["project", "enabled", "cluster"]
-    FILTER_MAP = {
-        "project": {"field": "namespace", "operation": "icontains"},
-        "enabled": {"field": "enabled", "operation": "exact", "parameter": True},
-        "cluster": [
-            {"field": "report_period__cluster_id", "operation": "icontains", "composition_key": "cluster_filter"},
-            {"field": "report_period__cluster_alias", "operation": "icontains", "composition_key": "cluster_filter"},
-        ],
-    }
+    SUPPORTED_FILTERS = TagQueryHandler.SUPPORTED_FILTERS + ["project", "enabled", "cluster"]
+    FILTER_MAP = deepcopy(TagQueryHandler.FILTER_MAP)
+    FILTER_MAP.update(
+        {
+            "project": {"field": "namespace", "operation": "icontains"},
+            "enabled": {"field": "enabled", "operation": "exact", "parameter": True},
+            "cluster": [
+                {"field": "report_period__cluster_id", "operation": "icontains", "composition_key": "cluster_filter"},
+                {
+                    "field": "report_period__cluster_alias",
+                    "operation": "icontains",
+                    "composition_key": "cluster_filter",
+                },
+            ],
+        }
+    )
 
     def __init__(self, parameters):
         """Establish AWS report query handler.

--- a/koku/api/tags/ocp_aws/queries.py
+++ b/koku/api/tags/ocp_aws/queries.py
@@ -15,11 +15,12 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 """OCP-on-AWS Tag Query Handling."""
+from copy import deepcopy
+
 from api.models import Provider
 from api.report.ocp_aws.provider_map import OCPAWSProviderMap
 from api.tags.aws.queries import AWSTagQueryHandler
 from api.tags.ocp.queries import OCPTagQueryHandler
-from api.utils import merge_dicts
 from reporting.models import OCPAWSTagsSummary
 
 
@@ -29,7 +30,8 @@ class OCPAWSTagQueryHandler(AWSTagQueryHandler, OCPTagQueryHandler):
     provider = Provider.OCP_AWS
     data_sources = [{"db_table": OCPAWSTagsSummary, "db_column_period": "cost_entry_bill__billing_period"}]
     SUPPORTED_FILTERS = AWSTagQueryHandler.SUPPORTED_FILTERS + OCPTagQueryHandler.SUPPORTED_FILTERS
-    FILTER_MAP = merge_dicts(AWSTagQueryHandler.FILTER_MAP, OCPTagQueryHandler.FILTER_MAP)
+    FILTER_MAP = deepcopy(AWSTagQueryHandler.FILTER_MAP)
+    FILTER_MAP.update(OCPTagQueryHandler.FILTER_MAP)
     # override cluster since we are getting it from a different table and field(s)
     FILTER_MAP["cluster"] = [
         {"field": "cluster_id", "operation": "icontains", "composition_key": "cluster_filter"},

--- a/koku/api/tags/queries.py
+++ b/koku/api/tags/queries.py
@@ -63,8 +63,8 @@ class TagQueryHandler(QueryHandler):
 
     provider = "TAGS"
     data_sources = []
-    SUPPORTED_FILTERS = []
-    FILTER_MAP = {}
+    SUPPORTED_FILTERS = ["key"]
+    FILTER_MAP = {"key": {"field": "key", "operation": "icontains", "composition_key": "key_filter"}}
 
     dh = DateHelper()
 

--- a/koku/api/tags/serializers.py
+++ b/koku/api/tags/serializers.py
@@ -34,6 +34,7 @@ class FilterSerializer(serializers.Serializer):
     TIME_CHOICES = (("-10", "-10"), ("-30", "-30"), ("-1", "-1"), ("-2", "-2"))
     TIME_UNIT_CHOICES = (("day", "day"), ("month", "month"))
 
+    key = StringOrListField(required=False)
     resolution = serializers.ChoiceField(choices=RESOLUTION_CHOICES, required=False)
     time_scope_value = serializers.ChoiceField(choices=TIME_CHOICES, required=False)
     time_scope_units = serializers.ChoiceField(choices=TIME_UNIT_CHOICES, required=False)

--- a/koku/api/tags/test/aws/test_aws_tag_query_handler.py
+++ b/koku/api/tags/test/aws/test_aws_tag_query_handler.py
@@ -100,6 +100,14 @@ class AWSTagQueryHandlerTest(IamTestCase):
         self.assertEqual(handler.time_scope_units, "day")
         self.assertEqual(handler.time_scope_value, -10)
 
+    def test_execute_query_for_key(self):
+        """Test that the execute query runs properly with key query."""
+        url = f"?filter[key]={self.fake.word()}"
+        query_params = self.mocked_query_params(url, AWSTagView)
+        handler = AWSTagQueryHandler(query_params)
+        query_output = handler.execute_query()
+        self.assertIsNotNone(query_output.get("data"))
+
     def test_slice_tag_values_list(self):
         """Test that long tag value lists are sliced."""
         slice_limit = 2

--- a/koku/api/tags/test/azure/tests_azure_tag_query_handler.py
+++ b/koku/api/tags/test/azure/tests_azure_tag_query_handler.py
@@ -106,6 +106,14 @@ class AzureTagQueryHandlerTest(IamTestCase):
         self.assertEqual(handler.time_scope_units, "day")
         self.assertEqual(handler.time_scope_value, -10)
 
+    def test_execute_query_for_key(self):
+        """Test that the execute query runs properly with key query."""
+        url = f"?filter[key]={self.fake.word()}"
+        query_params = self.mocked_query_params(url, AzureTagView)
+        handler = AzureTagQueryHandler(query_params)
+        query_output = handler.execute_query()
+        self.assertIsNotNone(query_output.get("data"))
+
     def test_get_tag_keys_filter_true(self):
         """Test that not all tag keys are returned with a filter."""
         url = "?filter[time_scope_units]=month&filter[time_scope_value]=-2&filter[resolution]=monthly"

--- a/koku/api/tags/test/ocp/test_ocp_tag_query_handler.py
+++ b/koku/api/tags/test/ocp/test_ocp_tag_query_handler.py
@@ -110,6 +110,14 @@ class OCPTagQueryHandlerTest(IamTestCase):
         self.assertEqual(handler.time_scope_units, "day")
         self.assertEqual(handler.time_scope_value, -10)
 
+    def test_execute_query_for_key(self):
+        """Test that the execute query runs properly with key query."""
+        url = f"?filter[key]={self.fake.word()}"
+        query_params = self.mocked_query_params(url, OCPTagView)
+        handler = OCPTagQueryHandler(query_params)
+        query_output = handler.execute_query()
+        self.assertIsNotNone(query_output.get("data"))
+
     def test_get_tag_keys_filter_true(self):
         """Test that not all tag keys are returned with a filter."""
         url = (

--- a/koku/api/tags/test/ocp_aws/tests_queries.py
+++ b/koku/api/tags/test/ocp_aws/tests_queries.py
@@ -106,6 +106,14 @@ class OCPAWSTagQueryHandlerTest(IamTestCase):
         self.assertEqual(handler.time_scope_units, "day")
         self.assertEqual(handler.time_scope_value, -10)
 
+    def test_specific_key(self):
+        """Test that execute_query() succeeds with key parameter."""
+        url = f"?filter[key]={self.fake.word()}"
+        query_params = self.mocked_query_params(url, OCPAWSTagView)
+        handler = OCPAWSTagQueryHandler(query_params)
+        query_output = handler.execute_query()
+        self.assertIsNotNone(query_output.get("data"))
+
     def test_get_tag_keys(self):
         """Test that all OCP-on-AWS tag keys are returned."""
         url = "?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly"


### PR DESCRIPTION
Added ability to filter based on Tag Key that supports partial matching. 

Testing:
- Load in some tagged data 
- Go to /tags/{provider}/?filter[key]={tag} and all tags that match or partially match the {tag} should be there.