### PR TITLE
COST-370 - Sources warning and prometheus metrics

### DIFF
--- a/koku/masu/prometheus_stats.py
+++ b/koku/masu/prometheus_stats.py
@@ -60,3 +60,11 @@ KAFKA_CONNECTION_ERRORS_COUNTER = Counter(
 )
 
 CELERY_ERRORS_COUNTER = Counter("celery_errors", "Number of celery errors", registry=WORKER_REGISTRY)
+
+SOURCES_KAFKA_LOOP_RETRY = Counter(
+    "sources_kafka_retry_errors", "Number of sources kafka retry errors", registry=WORKER_REGISTRY
+)
+
+SOURCES_PROVIDER_OP_RETRY_LOOP_COUNTER = Counter(
+    "sources_provider_op_retry_errors", "Number of sources provider operation retry errors", registry=WORKER_REGISTRY
+)

--- a/koku/sources/kafka_listener.py
+++ b/koku/sources/kafka_listener.py
@@ -545,7 +545,7 @@ def execute_koku_provider_op(msg):
         err_msg = (
             f"Unable to {operation} provider for Source ID: {str(provider.source_id)}. Reason: {str(account_error)}"
         )
-        LOG.error(err_msg)
+        LOG.warning(err_msg)
         sources_client.set_source_status(account_error)
 
 


### PR DESCRIPTION
[COST-370](https://issues.redhat.com/browse/COST-370)

1. log Provider issues as log.warning
2. Add prometheus metrics to increment when we retry either processing a kafka msg or a provider operation (create, update, etc.)

Corresponding e2e: [https://github.com/RedHatInsights/e2e-deploy/pull/2005](https://github.com/RedHatInsights/e2e-deploy/pull/2005)