### PR TITLE
COST-371 - Sources: check if connection is not None before calling close

### DIFF
--- a/koku/sources/kafka_listener.py
+++ b/koku/sources/kafka_listener.py
@@ -118,7 +118,8 @@ def _log_process_queue_event(queue, event):
 
 def close_and_set_db_connection():  # pragma: no cover
     """Close the db connection and set to None."""
-    connections[DEFAULT_DB_ALIAS].connection.close()
+    if connections[DEFAULT_DB_ALIAS].connection:
+        connections[DEFAULT_DB_ALIAS].connection.close()
     connections[DEFAULT_DB_ALIAS].connection = None
 
 


### PR DESCRIPTION
[COST-371](https://issues.redhat.com/browse/COST-371)

Related alert:
[sentry](https://sentry.io/organizations/project-koku/issues/1798207104/?project=5183020&referrer=slack)

This PR prevents calling `connections[DEFAULT_DB_ALIAS].connection.close()` if the connection is already `None`.