### PR TITLE
Remove etag check in azure downloader

### DIFF
--- a/koku/masu/external/downloader/azure/azure_report_downloader.py
+++ b/koku/masu/external/downloader/azure/azure_report_downloader.py
@@ -245,15 +245,15 @@ class AzureReportDownloader(ReportDownloaderBase, DownloaderInterface):
             LOG.error(log_json(self.request_id, msg, self.context))
             raise AzureReportDownloaderError(msg)
 
-        if etag != stored_etag:
-            msg = f"Downloading {key} to {full_file_path}"
-            LOG.info(log_json(self.request_id, msg, self.context))
-            blob = self._azure_client.download_cost_export(key, self.container_name, destination=full_file_path)
-            # Push to S3
-            s3_csv_path = get_path_prefix(self.account, self._provider_uuid, start_date, Config.CSV_DATA_TYPE)
-            copy_local_report_file_to_s3_bucket(
-                self.request_id, s3_csv_path, full_file_path, local_filename, manifest_id, start_date, self.context
-            )
+        msg = f"Downloading {key} to {full_file_path}"
+        LOG.info(log_json(self.request_id, msg, self.context))
+        blob = self._azure_client.download_cost_export(key, self.container_name, destination=full_file_path)
+        # Push to S3
+        s3_csv_path = get_path_prefix(self.account, self._provider_uuid, start_date, Config.CSV_DATA_TYPE)
+        copy_local_report_file_to_s3_bucket(
+            self.request_id, s3_csv_path, full_file_path, local_filename, manifest_id, start_date, self.context
+        )
+
         msg = f"Returning full_file_path: {full_file_path}, etag: {etag}"
         LOG.info(log_json(self.request_id, msg, self.context))
         return full_file_path, etag


### PR DESCRIPTION
## Summary
We have other checks now in the ReportProcessor (https://github.com/project-koku/koku/blob/cf6baabb2af527a2c5ae1b9fd6bb5ef4546ec876/koku/masu/external/report_downloader.py#L223) to skip re-downloading processed files. The etag check here was preventing us from downloading the file on the worker when we did need to re-try processing. We had previously downloaded and logged the etag of the file on a different worker pod, and so this block prevents us from downloading it on the worker trying to re-process (when it is the worker that does not have the file downloaded). 