### PR TITLE
COST-311 - only populate markup on existing bill_ids

### DIFF
--- a/koku/masu/database/aws_report_db_accessor.py
+++ b/koku/masu/database/aws_report_db_accessor.py
@@ -306,5 +306,3 @@ class AWSReportDBAccessor(ReportDBAccessorBase):
                     AWSCostEntryLineItemDailySummary.objects.filter(cost_entry_bill_id=bill_id).update(
                         markup_cost=(F("unblended_cost") * markup)
                     )
-            else:
-                AWSCostEntryLineItemDailySummary.objects.update(markup_cost=(F("unblended_cost") * markup))

--- a/koku/masu/database/azure_report_db_accessor.py
+++ b/koku/masu/database/azure_report_db_accessor.py
@@ -161,8 +161,6 @@ class AzureReportDBAccessor(ReportDBAccessorBase):
                     AzureCostEntryLineItemDailySummary.objects.filter(cost_entry_bill_id=bill_id).update(
                         markup_cost=(F("pretax_cost") * markup)
                     )
-            else:
-                AzureCostEntryLineItemDailySummary.objects.update(markup_cost=(F("pretax_cost") * markup))
 
     def get_bill_query_before_date(self, date, provider_uuid=None):
         """Get the cost entry bill objects with billing period before provided date."""

--- a/koku/masu/test/database/test_aws_report_db_accessor.py
+++ b/koku/masu/test/database/test_aws_report_db_accessor.py
@@ -987,23 +987,3 @@ class AWSReportDBAccessorTest(MasuTestCase):
             )
             actual_markup = query.get("markup_cost__sum")
             self.assertAlmostEqual(actual_markup, expected_markup, 6)
-
-    def test_populate_markup_cost_no_billsids(self):
-        """Test that the daily summary table is populated."""
-        summary_table_name = AWS_CUR_TABLE_MAP["line_item_daily_summary"]
-        summary_table = getattr(self.accessor.report_schema, summary_table_name)
-
-        query = self.accessor._get_db_obj_query(summary_table_name)
-        with schema_context(self.schema):
-            expected_markup = query.aggregate(markup=Sum(F("unblended_cost") * decimal.Decimal(0.1)))
-            expected_markup = expected_markup.get("markup")
-
-            summary_entry = summary_table.objects.all().aggregate(Min("usage_start"), Max("usage_start"))
-            start_date = summary_entry["usage_start__min"]
-            end_date = summary_entry["usage_start__max"]
-
-        self.accessor.populate_markup_cost(0.1, start_date, end_date, None)
-        with schema_context(self.schema):
-            query = self.accessor._get_db_obj_query(summary_table_name).aggregate(Sum("markup_cost"))
-            actual_markup = query.get("markup_cost__sum")
-            self.assertAlmostEqual(actual_markup, expected_markup, 6)

--- a/koku/masu/test/database/test_azure_report_db_accessor.py
+++ b/koku/masu/test/database/test_azure_report_db_accessor.py
@@ -227,25 +227,6 @@ class AzureReportDBAccessorTest(MasuTestCase):
             actual_markup = query.get("markup_cost__sum")
             self.assertAlmostEqual(actual_markup, expected_markup, 6)
 
-    def test_populate_markup_cost_no_billsids(self):
-        """Test that the daily summary table is populated."""
-        summary_table_name = AZURE_REPORT_TABLE_MAP["line_item_daily_summary"]
-        summary_table = getattr(self.accessor.report_schema, summary_table_name)
-
-        query = self.accessor._get_db_obj_query(summary_table_name)
-        with schema_context(self.schema):
-            expected_markup = query.aggregate(markup=Sum(F("pretax_cost") * decimal.Decimal(0.1)))
-            expected_markup = expected_markup.get("markup")
-            summary_entry = summary_table.objects.all().aggregate(Min("usage_start"), Max("usage_start"))
-            start_date = summary_entry["usage_start__min"]
-            end_date = summary_entry["usage_start__max"]
-
-        self.accessor.populate_markup_cost(0.1, start_date, end_date, None)
-        with schema_context(self.schema):
-            query = self.accessor._get_db_obj_query(summary_table_name).aggregate(Sum("markup_cost"))
-            actual_markup = query.get("markup_cost__sum")
-            self.assertAlmostEqual(actual_markup, expected_markup, 6)
-
     def test_populate_ocp_on_azure_cost_daily_summary(self):
         """Test the method to run OpenShift on Azure SQL."""
         summary_table_name = AZURE_REPORT_TABLE_MAP["ocp_on_azure_daily_summary"]


### PR DESCRIPTION
Only populate markup costs when the summary table has a corresponding bill id (otherwise, what exactly is the markup being applied to?).

Likely related to [COST-311](https://issues.redhat.com/browse/COST-311)

Testing:
1. Add a first AWS source that has data that can be ingested. Let the data ingest.
2. Add a second AWS source that does _not_ have data that can be ingested.
3. Add a markup cost model to the second AWS source. Let the Worker finish updating.
4. Check the reports/aws/costs/ endpoint. The only data that will appear here is associated with the first AWS source. the Markup should have a value of ZERO.