### PR TITLE
COST-380 - koku-listener: rewind consumer on retry

### DIFF
--- a/koku/masu/external/kafka_msg_handler.py
+++ b/koku/masu/external/kafka_msg_handler.py
@@ -770,6 +770,7 @@ def listen_for_messages(msg, consumer):
         LOG.info(f"Processing message offset: {offset} partition: {partition}")
         process_messages(msg)
         LOG.debug(f"COMMITTING: message offset: {offset} partition: {partition}")
+        consumer.commit()
     except (InterfaceError, OperationalError, ReportProcessorDBError) as error:
         close_and_set_db_connection()
         LOG.error(f"[listen_for_messages] Database error. Error: {type(error).__name__}: {error}. Retrying...")
@@ -783,8 +784,6 @@ def listen_for_messages(msg, consumer):
         consumer.commit()
     except Exception as error:
         LOG.error(f"[listen_for_messages] UNKNOWN error encountered: {type(error).__name__}: {error}", exc_info=True)
-    else:
-        consumer.commit()
 
 
 def koku_listener_thread():  # pragma: no cover

--- a/koku/masu/external/kafka_msg_handler.py
+++ b/koku/masu/external/kafka_msg_handler.py
@@ -32,7 +32,9 @@ from tarfile import TarFile
 import requests
 from confluent_kafka import Consumer
 from confluent_kafka import Producer
-from django.db import connection
+from confluent_kafka import TopicPartition
+from django.db import connections
+from django.db import DEFAULT_DB_ALIAS
 from django.db import InterfaceError
 from django.db import OperationalError
 from kombu.exceptions import OperationalError as RabbitOperationalError
@@ -66,6 +68,13 @@ PRODUCER = Producer({"bootstrap.servers": Config.INSIGHTS_KAFKA_ADDRESS, "messag
 
 class KafkaMsgHandlerError(Exception):
     """Kafka msg handler error."""
+
+
+def close_and_set_db_connection():  # pragma: no cover
+    """Close the db connection and set to None."""
+    if connections[DEFAULT_DB_ALIAS].connection:
+        connections[DEFAULT_DB_ALIAS].connection.close()
+    connections[DEFAULT_DB_ALIAS].connection = None
 
 
 def delivery_callback(err, msg):
@@ -452,7 +461,7 @@ def handle_message(msg):
             report_metas = extract_payload(value["url"], request_id, context)
             return SUCCESS_CONFIRM_STATUS, report_metas
         except (OperationalError, InterfaceError) as error:
-            connection.close()
+            close_and_set_db_connection()
             msg = f"Unable to extract payload, db closed. {type(error).__name__}: {error}"
             LOG.error(log_json(request_id, msg, context))
             raise KafkaMsgHandlerError(msg)
@@ -695,7 +704,6 @@ def get_consumer():  # pragma: no cover
             "group.id": "hccm-group",
             "queued.max.messages.kbytes": 1024,
             "enable.auto.commit": False,
-            "enable.auto.offset.store": False,
             "max.poll.interval.ms": 1080000,  # 18 minutes
         }
     )
@@ -718,6 +726,13 @@ def listen_for_messages_loop():
             continue
 
         listen_for_messages(msg, consumer)
+
+
+def rewind_consumer_to_retry(consumer, topic_partition):
+    """Helper method to log and rewind kafka consumer for retry."""
+    LOG.info(f"Seeking back to offset: {topic_partition.offset}, partition: {topic_partition.partition}")
+    consumer.seek(topic_partition)
+    time.sleep(Config.RETRY_SECONDS)
 
 
 def listen_for_messages(msg, consumer):
@@ -748,28 +763,28 @@ def listen_for_messages(msg, consumer):
         None
 
     """
+    offset = msg.offset()
+    partition = msg.partition()
+    topic_partition = TopicPartition(topic=HCCM_TOPIC, partition=partition, offset=offset)
     try:
-        offset = msg.offset()
-        partition = msg.partition()
         LOG.info(f"Processing message offset: {offset} partition: {partition}")
         process_messages(msg)
         LOG.debug(f"COMMITTING: message offset: {offset} partition: {partition}")
-        consumer.store_offsets(msg)
-        consumer.commit()
     except (InterfaceError, OperationalError, ReportProcessorDBError) as error:
-        connection.close()
+        close_and_set_db_connection()
         LOG.error(f"[listen_for_messages] Database error. Error: {type(error).__name__}: {error}. Retrying...")
-        time.sleep(Config.RETRY_SECONDS)
+        rewind_consumer_to_retry(consumer, topic_partition)
     except (KafkaMsgHandlerError, RabbitOperationalError) as error:
         LOG.error(f"[listen_for_messages] Internal error. {type(error).__name__}: {error}. Retrying...")
-        time.sleep(Config.RETRY_SECONDS)
+        rewind_consumer_to_retry(consumer, topic_partition)
     except ReportProcessorError as error:
         LOG.error(f"[listen_for_messages] Report processing error: {str(error)}")
         LOG.debug(f"COMMITTING: message offset: {offset} partition: {partition}")
-        consumer.store_offsets(msg)
         consumer.commit()
     except Exception as error:
         LOG.error(f"[listen_for_messages] UNKNOWN error encountered: {type(error).__name__}: {error}", exc_info=True)
+    else:
+        consumer.commit()
 
 
 def koku_listener_thread():  # pragma: no cover

--- a/koku/masu/test/external/test_kafka_msg_handler.py
+++ b/koku/masu/test/external/test_kafka_msg_handler.py
@@ -209,7 +209,7 @@ class KafkaMsgHandlerTest(MasuTestCase):
             mock_consumer = MockKafkaConsumer([msg])
 
             mock_process_message.side_effect = test.get("side_effect")
-            with patch("masu.external.kafka_msg_handler.connection.close") as close_mock:
+            with patch("masu.external.kafka_msg_handler.close_and_set_db_connection") as close_mock:
                 with patch.object(Config, "RETRY_SECONDS", 0):
                     msg_handler.listen_for_messages(msg, mock_consumer)
                     close_mock.assert_called()
@@ -248,7 +248,7 @@ class KafkaMsgHandlerTest(MasuTestCase):
             mock_consumer = MockKafkaConsumer([msg])
 
             mock_process_message.side_effect = test.get("side_effect")
-            with patch("masu.external.kafka_msg_handler.connection.close") as close_mock:
+            with patch("masu.external.kafka_msg_handler.close_and_set_db_connection") as close_mock:
                 with patch.object(Config, "RETRY_SECONDS", 0):
                     msg_handler.listen_for_messages(msg, mock_consumer)
                     close_mock.assert_not_called()
@@ -346,7 +346,8 @@ class KafkaMsgHandlerTest(MasuTestCase):
                                     msg_handler.process_messages(msg)
                                     test.get("expected_fn")(msg, test, confirmation_mock)
 
-    def test_handle_messages(self):
+    @patch("masu.external.kafka_msg_handler.close_and_set_db_connection")
+    def test_handle_messages(self, _):
         """Test to ensure that kafka messages are handled."""
         hccm_msg = MockMessage(msg_handler.HCCM_TOPIC, "http://insights-upload.com/quarnantine/file_to_validate")
         advisor_msg = MockMessage("platform.upload.advisor", "http://insights-upload.com/quarnantine/file_to_validate")

--- a/koku/masu/test/external/test_kafka_msg_handler.py
+++ b/koku/masu/test/external/test_kafka_msg_handler.py
@@ -101,6 +101,9 @@ class MockKafkaConsumer:
     def poll(self, *args, **kwargs):
         return self.preloaded_messages.pop(0)
 
+    def seek(self, *args, **kwargs):
+        pass
+
     def commit(self):
         self.preloaded_messages.pop()
 

--- a/scripts/upgrade_watcher
+++ b/scripts/upgrade_watcher
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+#
+# Copyright 2020 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+# ==============================================
+#  upgrade_watcher
+#  Watches for a specific version reported from the database
+#  Once seen, it will execute a single SQL script
+#
+#  ENVIRONMENT
+#  -------------------------------------------
+#  PGHOST=<database hostname>
+#  PGPORT=<databse port>
+#  PGDATABASE=<database to which to connect
+#  PGUSER=<database superuser>
+#  PGPASSWORD=<password for PGUSER>
+#  TARGET_DATABASE=<database to analyze and reindex>
+#  NEED_VERSION=<version string that the server version must START WITH>
+#  POST_UPGRADE_SCRIPT=</path/to/sql-script>
+#
+
+
+# This check was inspired by a code snippet from
+# https://stackoverflow.com/questions/3601515/how-to-check-if-a-variable-is-set-in-bash
+function assert_var
+{
+    if [[ -z ${!1+x} ]]
+    then
+        echo "$1 environment variable is not set" >&2
+        return 1
+    fi
+
+    return 0
+}
+
+
+# Checks versions by splitting a version string into an int array.
+# This is done for both the need version and the have version.
+# Then checks matches by the shortest array length.
+function version_check
+{
+    echo "Checking for PostgreSQL version ${NEED_VERSION}"
+    read -r -d '' SQL <<EOF
+with need_version as (
+select string_to_array('${NEED_VERSION}', '.')::int[] as version
+),
+have_version as (
+select string_to_array(split_part(setting, ' ', 1)::text, '.')::int[] as version
+  from pg_settings
+ where name = 'server_version'
+),
+min_cardinality as (
+select case when cardinality(n.version) < cardinality(h.version)
+                 then cardinality(n.version)
+            else cardinality(h.version) end::int as min_len
+  from need_version n,
+       have_version h
+)
+select (n.version[:m.min_len] = h.version[:m.min_len])::boolean::int as check
+  from need_version n,
+       have_version h,
+       min_cardinality m;
+EOF
+
+    RES=$(psql -h $PGHOST -p $PGPORT -d $PGDATABASE -U $PGUSER -t --csv -c "${SQL}" 2>/dev/null)
+    test $RES -eq 1
+    return $?
+}
+
+
+# Executes the SQL script and captures output to a log file
+function post_upgrade_tasks
+{
+    echo "Running post-upgrade tasks"
+    psql -h $PGHOST -p $PGPORT -d $PGDATABASE -U $PGUSER -f $POST_UPGRADE_SCRIPT \
+         --variable=TARGET_DB=$TARGET_DATABASE 2>&1 | tee post-upgrade.log
+    return $?
+}
+
+
+# Main routine
+function upgrade_watch
+{
+    while true
+    do
+        if pg_isready -h $PGHOST -p $PGPORT
+        then
+            if version_check
+            then
+                if post_upgrade_tasks
+                then
+                    echo "Post-Upgrade: SUCCESS!"
+                else
+                    echo "Post-Upgrade: *** FAILED ***!"
+                fi
+                echo "See details in post-upgrade.log"
+                break
+            fi
+        fi
+
+        sleep 10
+    done
+
+    return $?
+}
+
+
+# Env var checks
+_EVRES=0
+for _EVAR in PGHOST PGPORT PGDATABASE PGUSER PGPASSWORD TARGET_DATABASE NEED_VERSION POST_UPGRADE_SCRIPT
+do
+    assert_var $_EVAR
+    (( _EVRES += $? ))
+done
+
+
+# Run main routine and exit with a return code
+if [[ $_EVRES -eq 0 ]]
+then
+    upgrade_watch
+    exit $?
+else
+    exit $_EVRES
+fi


### PR DESCRIPTION
Koku-listener was failing to retry kafka event processing. This PR ensures that messages are retried when an exception is raised during processing.

Testing with ingress:
1. Create an OCP source.
2. Push nise data to ingress (the following command will generate a few files, enough for testing):
```
INSIGHTS_ACCOUNT_ID=10001 INSIGHTS_ORG_ID=123 nise report ocp --file-row-limit 500000 --ocp-cluster-id my-cluster-id --insights-upload http://localhost:8080/api/ingress/v1/upload -s 2020-06-01
```
3. Monitor the koku-listener logs and make note of the partion/offset of current message being processed.
4. Restart the DB: `docker-compose restart db`
5. See the message processing fail once the db goes down.
6. Watch the koku-listener logs as it rewinds to the offset of whichever message failed to complete processing.
7. Once database has come online, watch koku-listener logs to make sure message processing resumes from the message offset/partition that originally failed.
8. Once koku-listener has completed processing, restart the listener and make sure that no kafka messages are processed. This ensures that all the messages that were sent from ingress were actually processed and committed before restarting the service.