### PR TITLE
recording all ocp files before processing

### DIFF
--- a/koku/masu/external/kafka_msg_handler.py
+++ b/koku/masu/external/kafka_msg_handler.py
@@ -51,6 +51,7 @@ from masu.processor._tasks.process import _process_report_file
 from masu.processor.report_processor import ReportProcessorDBError
 from masu.processor.report_processor import ReportProcessorError
 from masu.processor.tasks import convert_reports_to_parquet
+from masu.processor.tasks import record_all_manifest_files
 from masu.processor.tasks import summarize_reports
 from masu.prometheus_stats import KAFKA_CONNECTION_ERRORS_COUNTER
 from masu.util.ocp import common as utils
@@ -350,6 +351,7 @@ def extract_payload(url, request_id, context={}):  # noqa: C901
         try:
             shutil.copy(payload_source_path, payload_destination_path)
             current_meta["current_file"] = payload_destination_path
+            record_all_manifest_files(report_meta["manifest_id"], report_meta.get("files"))
             if not record_report_status(report_meta["manifest_id"], report_file, request_id, context):
                 msg = f"Successfully extracted OCP for {report_meta.get('cluster_id')}/{usage_month}"
                 LOG.info(log_json(request_id, msg, context))

--- a/koku/masu/processor/tasks.py
+++ b/koku/masu/processor/tasks.py
@@ -28,6 +28,7 @@ from dateutil import parser
 from django.conf import settings
 from django.db import connection
 from django.db import transaction
+from django.db.utils import IntegrityError
 from tenant_schemas.utils import schema_context
 
 import masu.prometheus_stats as worker_stats
@@ -66,6 +67,21 @@ from reporting.models import OCP_ON_AZURE_MATERIALIZED_VIEWS
 from reporting.models import OCP_ON_INFRASTRUCTURE_MATERIALIZED_VIEWS
 
 LOG = get_task_logger(__name__)
+
+
+def record_all_manifest_files(manifest_id, report_files):
+    """Store all report file names for manifest ID."""
+    for report in report_files:
+        try:
+            with ReportStatsDBAccessor(report, manifest_id):
+                LOG.debug(f"Logging {report} for manifest ID: {manifest_id}")
+        except IntegrityError:
+            # OCP records the entire file list for a new manifest when the listener
+            # recieves a payload.  With multiple listeners it is possilbe for
+            # two listeners to recieve a report file for the same manifest at
+            # roughly the same time.  In that case the report file may already
+            # exist and an IntegrityError would be thrown.
+            LOG.debug(f"Report {report} has already been recorded.")
 
 
 @app.task(name="masu.processor.tasks.get_report_files", queue_name="download", bind=True)  # noqa: C901

--- a/koku/masu/test/external/test_kafka_msg_handler.py
+++ b/koku/masu/test/external/test_kafka_msg_handler.py
@@ -445,7 +445,7 @@ class KafkaMsgHandlerTest(MasuTestCase):
                     with patch(
                         "masu.external.kafka_msg_handler.get_account_from_cluster_id", return_value=fake_account
                     ):
-                        with patch("masu.external.kafka_msg_handler.create_manifest_entries", returns=1):
+                        with patch("masu.external.kafka_msg_handler.create_manifest_entries", return_value=1):
                             with patch("masu.external.kafka_msg_handler.record_report_status", returns=None):
                                 msg_handler.extract_payload(payload_url, "test_request_id")
                                 expected_path = "{}/{}/{}/".format(
@@ -484,7 +484,7 @@ class KafkaMsgHandlerTest(MasuTestCase):
                     with patch(
                         "masu.external.kafka_msg_handler.get_account_from_cluster_id", return_value=fake_account
                     ):
-                        with patch("masu.external.kafka_msg_handler.create_manifest_entries", returns=1):
+                        with patch("masu.external.kafka_msg_handler.create_manifest_entries", return_value=1):
                             with patch("masu.external.kafka_msg_handler.record_report_status"):
                                 msg_handler.extract_payload(payload_url, "test_request_id")
                                 expected_path = "{}/{}/{}/".format(

--- a/koku/masu/test/processor/test_tasks.py
+++ b/koku/masu/test/processor/test_tasks.py
@@ -32,6 +32,7 @@ import faker
 from dateutil import relativedelta
 from django.db.models import Max
 from django.db.models import Min
+from django.db.utils import IntegrityError
 from tenant_schemas.utils import schema_context
 
 import koku.celery as koku_celery
@@ -54,6 +55,7 @@ from masu.processor.report_processor import ReportProcessorError
 from masu.processor.tasks import autovacuum_tune_schema
 from masu.processor.tasks import convert_to_parquet
 from masu.processor.tasks import get_report_files
+from masu.processor.tasks import record_all_manifest_files
 from masu.processor.tasks import refresh_materialized_views
 from masu.processor.tasks import remove_expired_data
 from masu.processor.tasks import summarize_reports
@@ -67,6 +69,7 @@ from masu.test.external.downloader.aws import fake_arn
 from reporting.models import AWS_MATERIALIZED_VIEWS
 from reporting.models import AZURE_MATERIALIZED_VIEWS
 from reporting.models import OCP_MATERIALIZED_VIEWS
+from reporting_common.models import CostUsageReportStatus
 
 
 class FakeDownloader(Mock):
@@ -1162,3 +1165,25 @@ class TestUpdateSummaryTablesTask(MasuTestCase):
         vh = next(iter(koku_celery.app.conf.beat_schedule["vacuum-schemas"]["schedule"].hour))
         avh = next(iter(koku_celery.app.conf.beat_schedule["autovacuum-tune-schemas"]["schedule"].hour))
         self.assertTrue(avh == (23 if vh == 0 else (vh - 1)))
+
+    def test_record_all_manifest_files(self):
+        """Test that file list is saved in ReportStatsDBAccessor."""
+        files_list = ["file1.csv", "file2.csv", "file3.csv"]
+        manifest_id = 1
+
+        record_all_manifest_files(manifest_id, files_list)
+
+        for report_file in files_list:
+            CostUsageReportStatus.objects.filter(report_name=report_file).exists()
+
+    def test_record_all_manifest_files_concurrent_writes(self):
+        """Test that file list is saved in ReportStatsDBAccessor race condition."""
+        files_list = ["file1.csv", "file2.csv", "file3.csv"]
+        manifest_id = 1
+
+        record_all_manifest_files(manifest_id, files_list)
+        with patch.object(ReportStatsDBAccessor, "add", side_effect=IntegrityError):
+            record_all_manifest_files(manifest_id, files_list)
+
+        for report_file in files_list:
+            CostUsageReportStatus.objects.filter(report_name=report_file).exists()

--- a/koku/masu/test/processor/test_tasks.py
+++ b/koku/masu/test/processor/test_tasks.py
@@ -1182,8 +1182,9 @@ class TestUpdateSummaryTablesTask(MasuTestCase):
         manifest_id = 1
 
         record_all_manifest_files(manifest_id, files_list)
-        with patch.object(ReportStatsDBAccessor, "add", side_effect=IntegrityError):
-            record_all_manifest_files(manifest_id, files_list)
+        with patch.object(ReportStatsDBAccessor, "does_db_entry_exist", return_value=False):
+            with patch.object(ReportStatsDBAccessor, "add", side_effect=IntegrityError):
+                record_all_manifest_files(manifest_id, files_list)
 
         for report_file in files_list:
             CostUsageReportStatus.objects.filter(report_name=report_file).exists()


### PR DESCRIPTION
Missed `record_all_manifest_files` when factoring out the `num_processed_files` change from worker scaling PR
*Testing*
Ingested multi-file OCP payload and verified summary was ran after all files were processed