### PR TITLE
Creating wrapper for kafka producer

### DIFF
--- a/koku/masu/test/external/test_kafka_msg_handler.py
+++ b/koku/masu/test/external/test_kafka_msg_handler.py
@@ -22,7 +22,6 @@ import shutil
 import tempfile
 import uuid
 from datetime import datetime
-from unittest.mock import Mock
 from unittest.mock import patch
 
 import requests_mock
@@ -631,8 +630,7 @@ class KafkaMsgHandlerTest(MasuTestCase):
         """Set up the test for raising a kafka error during sending confirmation."""
         # grab the connection error count before
         connection_errors_before = WORKER_REGISTRY.get_sample_value("kafka_connection_errors_total")
-        with patch("masu.external.kafka_msg_handler.PRODUCER", new_callable=Mock()) as mock_producer:
-            mock_producer.flush.side_effect = KafkaMsgHandlerError
+        with patch("masu.external.kafka_msg_handler.get_producer", side_effect=KafkaMsgHandlerError):
             with self.assertRaises(msg_handler.KafkaMsgHandlerError):
                 msg_handler.send_confirmation(request_id="foo", status=msg_handler.SUCCESS_CONFIRM_STATUS)
             # assert that the error caused the kafka error metric to be incremented


### PR DESCRIPTION
https://github.com/project-koku/koku/pull/2265 was getting some Producer connect failures while running tox.  It's not clear why this connection is now happening in this PR and not in master.  I suspect there's a pipenv change, contributing to it?

Putting this producer instantiation in a wrapper and not as a constant should fix it.

Test: Verify that validation message was sent to ingress service
```
koku_listener     | [2020-08-06 15:49:12,834] INFO None Sending Ingress Service confirmation for: /var/tmp/masu/insights_local/my-ocp-cluster/20200801-20200901/ccfbf29c-6264-427d-94ad-fe9296e42e34_openshift_report.2.csv
koku_listener     | [2020-08-06 15:49:12,863] INFO None Validation message delivered.
```