### PR TITLE
Closing an AWS onboarding test gap and handling orchestrator manifest download exceptions

### DIFF
--- a/koku/masu/processor/orchestrator.py
+++ b/koku/masu/processor/orchestrator.py
@@ -26,6 +26,7 @@ from masu.external.accounts_accessor import AccountsAccessor
 from masu.external.accounts_accessor import AccountsAccessorError
 from masu.external.date_accessor import DateAccessor
 from masu.external.report_downloader import ReportDownloader
+from masu.external.report_downloader import ReportDownloaderError
 from masu.processor.tasks import get_report_files
 from masu.processor.tasks import record_all_manifest_files
 from masu.processor.tasks import record_report_status
@@ -220,7 +221,18 @@ class Orchestrator:
                         provider_uuid,
                     )
                     account["report_month"] = month
-                    self.start_manifest_processing(**account)
+                    try:
+                        self.start_manifest_processing(**account)
+                    except ReportDownloaderError as err:
+                        LOG.warning(f"Unable to download manifest for provider: {provider_uuid}. Error: {str(err)}.")
+                        continue
+                    except Exception as err:
+                        # Broad exception catching is important here because any errors thrown can
+                        # block all subsequent account processing.
+                        LOG.error(
+                            f"Unexpected manifest processing error for provider: {provider_uuid}. Error: {str(err)}."
+                        )
+                        continue
 
                     # update labels
                     labeler = AccountLabel(

--- a/koku/masu/test/processor/test_orchestrator.py
+++ b/koku/masu/test/processor/test_orchestrator.py
@@ -26,6 +26,7 @@ from masu.config import Config
 from masu.external.accounts_accessor import AccountsAccessor
 from masu.external.accounts_accessor import AccountsAccessorError
 from masu.external.date_accessor import DateAccessor
+from masu.external.report_downloader import ReportDownloaderError
 from masu.processor.expired_data_remover import ExpiredDataRemover
 from masu.processor.orchestrator import Orchestrator
 from masu.test import MasuTestCase
@@ -185,6 +186,32 @@ class OrchestratorTest(MasuTestCase):
         results = orchestrator.remove_expired_report_data()
 
         self.assertEqual(results, [])
+
+    @patch("masu.processor.orchestrator.AccountLabel", spec=True)
+    @patch("masu.processor.orchestrator.ProviderStatus", spec=True)
+    @patch("masu.processor.orchestrator.Orchestrator.start_manifest_processing", side_effect=ReportDownloaderError)
+    def test_prepare_w_downloader_error(self, mock_task, mock_accessor, mock_labeler):
+        """Test that Orchestrator.prepare() handles downloader errors."""
+        mock_accessor().is_valid.return_value = True
+        mock_accessor().is_backing_off.return_value = False
+
+        orchestrator = Orchestrator()
+        orchestrator.prepare()
+        mock_task.assert_called()
+        mock_labeler.assert_not_called()
+
+    @patch("masu.processor.orchestrator.AccountLabel", spec=True)
+    @patch("masu.processor.orchestrator.ProviderStatus", spec=True)
+    @patch("masu.processor.orchestrator.Orchestrator.start_manifest_processing", side_effect=Exception)
+    def test_prepare_w_exception(self, mock_task, mock_accessor, mock_labeler):
+        """Test that Orchestrator.prepare() handles broad exceptions."""
+        mock_accessor().is_valid.return_value = True
+        mock_accessor().is_backing_off.return_value = False
+
+        orchestrator = Orchestrator()
+        orchestrator.prepare()
+        mock_task.assert_called()
+        mock_labeler.assert_not_called()
 
     @patch("masu.processor.orchestrator.AccountLabel", spec=True)
     @patch("masu.processor.orchestrator.ProviderStatus", spec=True)

--- a/koku/providers/aws/provider.py
+++ b/koku/providers/aws/provider.py
@@ -106,6 +106,13 @@ def _check_cost_report_access(credential_name, credentials, region="us-east-1", 
         # filter report definitions to reports with a matching S3 bucket name.
         bucket_matched = list(filter(lambda rep: bucket in rep.get("S3Bucket"), reports))
 
+        if not bucket_matched:
+            key = ProviderErrors.AWS_REPORT_CONFIG
+            msg = (
+                f"Cost management requires that an AWS Cost and Usage Report is configured for bucket: {str(bucket)}."
+            )
+            raise serializers.ValidationError(error_obj(key, msg))
+
         for report in bucket_matched:
             if report.get("Compression") not in ALLOWED_COMPRESSIONS:
                 key = ProviderErrors.AWS_COMPRESSION_REPORT_CONFIG

--- a/koku/providers/test/aws/tests_aws_provider.py
+++ b/koku/providers/test/aws/tests_aws_provider.py
@@ -184,6 +184,36 @@ class AWSProviderTestCase(TestCase):
             self.fail(exc)
 
     @patch("providers.aws.provider.boto3.client")
+    def test_check_cost_report_access_bucket_not_configured_error(self, mock_boto3_client):
+        """Test _check_cost_report_access fails when bucket has no report definition."""
+        test_bucket = "test-bucket"
+        other_bucket = "not-test-bucket"
+
+        s3_client = Mock()
+        s3_client.describe_report_definitions.return_value = {
+            "ReportDefinitions": [
+                {
+                    "ReportName": FAKE.word(),
+                    "Compression": "Parquet",
+                    "AdditionalSchemaElements": ["RESOURCES"],
+                    "S3Bucket": test_bucket,
+                    "S3Region": "us-east-1",
+                }
+            ]
+        }
+        mock_boto3_client.return_value = s3_client
+        with self.assertRaises(ValidationError):
+            _check_cost_report_access(
+                FAKE.word(),
+                {
+                    "aws_access_key_id": FAKE.md5(),
+                    "aws_secret_access_key": FAKE.md5(),
+                    "aws_session_token": FAKE.md5(),
+                },
+                bucket=other_bucket,
+            )
+
+    @patch("providers.aws.provider.boto3.client")
     def test_check_cost_report_access_compression_error(self, mock_boto3_client):
         """Test _check_cost_report_access success."""
         test_bucket = "test-bucket"


### PR DESCRIPTION
There was an AWS onboarding check gap which didn't cover the case for:
1. Valid ARN 
2. Bucket exists 
3. Cost usage report definition is accessible 
4. Bucket not configured for cost usage reports.

The following user facing error string will be visible in platform sources for this case:
`Cost management requires that an AWS Cost and Usage Report is configured for bucket: [bucketname].`

Now that the orchestrator is downloading/processing manifest files to queue the appropriate report file downloads it's critical that the new logic does not cause the celery task to fail.  A broad exception was added here to ensure that the problem is logged but handled.

**Testing**
1.  Attempt to add an AWS account with a valid roleARN and S3 bucket.  Ensure the bucket does not have cost and usage reports configured.
2. Comment out provider check and attempt to ingest data.  Verify that orchestrator exception handling does not fail the celery task.
3.  Add a valid AWS account and hit /download to verify other account processing is not blocked

**Test Results**
[manifest_download_exception_handling.txt](https://github.com/project-koku/koku/files/5042526/manifest_download_exception_handling.txt)
