### PR TITLE
Restoring provider active flag

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -3501,6 +3501,11 @@
                                 "description": "Flag to indicate if provider is linked to source.",
                                 "default": false
                             },
+                            "active": {
+                                "type": "boolean",
+                                "description": "Flag to indicate if provider is successfully configured.",
+                                "default": false
+                            },
                             "infrastructure": {
                                 "type": "string",
                                 "description": "OpenShift foundational infrastructure type.",

--- a/koku/api/provider/provider_manager.py
+++ b/koku/api/provider/provider_manager.py
@@ -73,6 +73,10 @@ class ProviderManager:
         """Get the name of the provider."""
         return self.model.name
 
+    def get_active_status(self):
+        """Get provider active status."""
+        return self.model.active
+
     def get_infrastructure_name(self):
         """Get the name of the infrastructure that the provider is running on."""
         if self.model.infrastructure and self.model.infrastructure.infrastructure_type:

--- a/koku/api/provider/test/test_provider_manager.py
+++ b/koku/api/provider/test/test_provider_manager.py
@@ -102,6 +102,20 @@ class ProviderManagerTest(IamTestCase):
         manager = ProviderManager(provider_uuid)
         self.assertEqual(manager.get_name(), provider_name)
 
+    def test_get_active_status(self):
+        """Can the provider active status be returned."""
+        # Create Provider
+        provider_name = "sample_provider"
+        with patch("masu.celery.tasks.check_report_updates"):
+            provider = Provider.objects.create(name=provider_name, created_by=self.user, customer=self.customer)
+
+        # Get Provider UUID
+        provider_uuid = provider.uuid
+
+        # Get Provider Manager
+        manager = ProviderManager(provider_uuid)
+        self.assertTrue(manager.get_active_status())
+
     def test_get_providers_queryset_for_customer(self):
         """Verify all providers returned by a customer."""
         # Verify no providers are returned

--- a/koku/sources/api/view.py
+++ b/koku/sources/api/view.py
@@ -226,10 +226,12 @@ class SourcesViewSet(*MIXIN_LIST):
                 manager = ProviderManager(source["uuid"])
             except ProviderManagerError:
                 source["provider_linked"] = False
+                source["active"] = False
                 source["infrastructure"] = "Unknown"
                 source["cost_models"] = []
             else:
                 source["provider_linked"] = True
+                source["active"] = manager.get_active_status()
                 source["infrastructure"] = manager.get_infrastructure_name()
                 connection.set_tenant(tenant)
                 source["cost_models"] = [
@@ -250,10 +252,12 @@ class SourcesViewSet(*MIXIN_LIST):
             manager = ProviderManager(response.data["uuid"])
         except ProviderManagerError:
             response.data["provider_linked"] = False
+            response.data["active"] = False
             response.data["infrastructure"] = "Unknown"
             response.data["cost_models"] = []
         else:
             response.data["provider_linked"] = True
+            response.data["active"] = manager.get_active_status()
             response.data["infrastructure"] = manager.get_infrastructure_name()
             connection.set_tenant(tenant)
             response.data["cost_models"] = [


### PR DESCRIPTION
After working on COST-244 it become evident that having the provider active flag back in the response would be helpful for testing.  In addition to that it will also be potentially used for COST-56.  Getting the change in early will give @dlabrecq something to work with and we can decide if further enhancements are needed when we start COST-56 work.

**Testing**
1. Create a healthy source and verify provider is active in the sources response
```
GET /api/cost-management/v1/sources/
HTTP 200 OK
Allow: GET, HEAD, POST
Cache-Control: max-age=0, no-cache, no-store, must-revalidate
Content-Type: application/json
Expires: Wed, 12 Aug 2020 14:29:43 GMT
Vary: Accept

{
    "meta": {
        "count": 1
    },
    "links": {
        "first": "/api/cost-management/v1/sources/?limit=10&offset=0",
        "next": null,
        "previous": null,
        "last": "/api/cost-management/v1/sources/?limit=10&offset=0"
    },
    "data": [
        {
            "id": 1,
            "uuid": "bbec8b80-4be5-47f8-b96e-1ca64d53a227",
            "name": "AWS Source",
            "source_type": "AWS",
            "authentication": {
                "resource_name": "arn:aws:iam::999999999999:role/CostManagement"
            },
            "billing_source": {
                "bucket": "dougsources"
            },
            "provider_linked": true,
            "active": true,
            "infrastructure": "Unknown",
            "cost_models": []
        }
    ]
}

GET /api/cost-management/v1/sources/1/
HTTP 200 OK
Allow: GET, HEAD, PATCH, DELETE
Cache-Control: max-age=0, no-cache, no-store, must-revalidate
Content-Type: application/json
Expires: Wed, 12 Aug 2020 14:30:32 GMT
Vary: Accept

{
    "id": 1,
    "uuid": "bbec8b80-4be5-47f8-b96e-1ca64d53a227",
    "name": "AWS Source",
    "source_type": "AWS",
    "authentication": {
        "resource_name": "arn:aws:iam:: 999999999999:role/CostManagement"
    },
    "billing_source": {
        "bucket": "dougsources"
    },
    "provider_linked": true,
    "active": true,
    "infrastructure": "Unknown",
    "cost_models": []
}

```

2. Misconfigure the source (bad S3 bucket in this case) and verify provider is not active
```
GET /api/cost-management/v1/sources/
HTTP 200 OK
Allow: GET, HEAD, POST
Cache-Control: max-age=0, no-cache, no-store, must-revalidate
Content-Type: application/json
Expires: Wed, 12 Aug 2020 14:30:57 GMT
Vary: Accept

{
    "meta": {
        "count": 1
    },
    "links": {
        "first": "/api/cost-management/v1/sources/?limit=10&offset=0",
        "next": null,
        "previous": null,
        "last": "/api/cost-management/v1/sources/?limit=10&offset=0"
    },
    "data": [
        {
            "id": 1,
            "uuid": "bbec8b80-4be5-47f8-b96e-1ca64d53a227",
            "name": "AWS Source",
            "source_type": "AWS",
            "authentication": {
                "resource_name": "arn:aws:iam:: 999999999999:role/CostManagement"
            },
            "billing_source": {
                "bucket": "bad-dougsources"
            },
            "provider_linked": true,
            "active": false,
            "infrastructure": "Unknown",
            "cost_models": []
        }
    ]
}

GET /api/cost-management/v1/sources/1/
HTTP 200 OK
Allow: GET, HEAD, PATCH, DELETE
Cache-Control: max-age=0, no-cache, no-store, must-revalidate
Content-Type: application/json
Expires: Wed, 12 Aug 2020 14:31:14 GMT
Vary: Accept

{
    "id": 1,
    "uuid": "bbec8b80-4be5-47f8-b96e-1ca64d53a227",
    "name": "AWS Source",
    "source_type": "AWS",
    "authentication": {
        "resource_name": "arn:aws:iam:: 999999999999:role/CostManagement"
    },
    "billing_source": {
        "bucket": "bad-dougsources"
    },
    "provider_linked": true,
    "active": false,
    "infrastructure": "Unknown",
    "cost_models": []
}
```