### PR TITLE
Add MinIO for local S3 development work in docker-compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,9 +16,16 @@ AWS_SECRET_ACCESS_KEY=AWS_SECRET_KEY
 ENABLE_S3_ARCHIVING=False
 S3_BUCKET_NAME=koku-bucket
 S3_BUCKET_PATH=data_archive
-S3_ENDPOINT=s3.us-east-1.amazonaws.com
+S3_ENDPOINT=http://s3.us-east-1.amazonaws.com
 S3_ACCESS_KEY=S3_ACCESS_KEY
 S3_SECRET=S3_SECRET
+
+# Local MinIO.  Defaults are set for docker-compose settings
+#S3_BUCKET_NAME=koku-bucket
+#S3_ENDPOINT=http://kokuminio:9000
+#S3_ACCESS_KEY=kokuminioaccess
+#S3_SECRET=kokuminiosecret
+
 GOOGLE_APPLICATION_CREDENTIALS=/path/to/gcp/credentials
 API_PATH_PREFIX='/api/cost-management'
 NISE_REPO_PATH=/path/to/nise

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -165,6 +165,31 @@ services:
     volumes:
       - ./pgadmin_servers.json:/pgadmin4/servers.json
 
+  koku-minio:
+    image: minio/minio:latest
+    container_name: koku_minio
+    environment:
+      MINIO_ACCESS_KEY: minio
+      MINIO_SECRET_KEY: minio123
+    ports:
+      - 9000:9000
+    command: server /data
+    volumes:
+      - ./testing/parquet_data:/data
+
+  koku-create-parquet-bucket:
+    image: minio/mc:latest
+    depends_on:
+      - koku-minio
+    entrypoint: >
+      /bin/sh -c "
+      /usr/bin/mc config host rm local;
+      /usr/bin/mc config host add --quiet --api s3v4 local http://koku_minio:9000 minio minio123;
+      /usr/bin/mc rb --force local/koku-bucket/;
+      /usr/bin/mc mb --quiet local/koku-bucket/;
+      /usr/bin/mc policy set public local/koku-bucket;
+      "
+  
   grafana:
     container_name: koku_grafana
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -167,10 +167,10 @@ services:
 
   koku-minio:
     image: minio/minio:latest
-    container_name: koku_minio
+    container_name: kokuminio
     environment:
-      MINIO_ACCESS_KEY: minio
-      MINIO_SECRET_KEY: minio123
+      MINIO_ACCESS_KEY: kokuminioaccess
+      MINIO_SECRET_KEY: kokuminiosecret
     ports:
       - 9000:9000
     command: server /data
@@ -184,12 +184,12 @@ services:
     entrypoint: >
       /bin/sh -c "
       /usr/bin/mc config host rm local;
-      /usr/bin/mc config host add --quiet --api s3v4 local http://koku_minio:9000 minio minio123;
+      /usr/bin/mc config host add --quiet --api s3v4 local http://kokuminio:9000 kokuminioaccess kokuminiosecret;
       /usr/bin/mc rb --force local/koku-bucket/;
       /usr/bin/mc mb --quiet local/koku-bucket/;
       /usr/bin/mc policy set public local/koku-bucket;
       "
-  
+
   grafana:
     container_name: koku_grafana
     build:

--- a/koku/koku/settings.py
+++ b/koku/koku/settings.py
@@ -416,7 +416,7 @@ CELERY_WORKER_TASK_LOG_FORMAT = (
 S3_BUCKET_NAME = ENVIRONMENT.get_value("S3_BUCKET_NAME", default="koku-reports")
 S3_BUCKET_PATH = ENVIRONMENT.get_value("S3_BUCKET_PATH", default="data_archive")
 S3_REGION = ENVIRONMENT.get_value("S3_REGION", default="us-east-1")
-S3_ENDPOINT = ENVIRONMENT.get_value("S3_ENDPOINT", default="s3.us-east-1.amazonaws.com")
+S3_ENDPOINT = ENVIRONMENT.get_value("S3_ENDPOINT", default="http://s3.us-east-1.amazonaws.com")
 S3_ACCESS_KEY = ENVIRONMENT.get_value("S3_ACCESS_KEY", default=None)
 S3_SECRET = ENVIRONMENT.get_value("S3_SECRET", default=None)
 ENABLE_S3_ARCHIVING = ENVIRONMENT.bool("ENABLE_S3_ARCHIVING", default=False)

--- a/koku/masu/util/aws/common.py
+++ b/koku/masu/util/aws/common.py
@@ -285,7 +285,7 @@ def get_s3_resource():
         aws_secret_access_key=settings.S3_SECRET,
         region_name=settings.S3_REGION,
     )
-    s3_resource = aws_session.resource("s3")
+    s3_resource = aws_session.resource("s3", endpoint_url=settings.S3_ENDPOINT)
     return s3_resource
 
 

--- a/scripts/clear_testing.py
+++ b/scripts/clear_testing.py
@@ -31,6 +31,7 @@ TESTING_DIRS = [
     "local_providers/insights_local",
     "pvc_dir/insights_local",
     "pvc_dir/processing",
+    "parquet_data"
 ]
 
 

--- a/scripts/e2e-secrets.yml
+++ b/scripts/e2e-secrets.yml
@@ -300,4 +300,4 @@ parameters:
 - displayName: S3 Endpoint
   name: S3_ENDPOINT
   required: true
-  value: s3.us-east-1.amazonaws.com
+  value: http://s3.us-east-1.amazonaws.com

--- a/testing/compose_files/docker-compose-multilistener.yml
+++ b/testing/compose_files/docker-compose-multilistener.yml
@@ -398,3 +398,28 @@ services:
         - db
       depends_on:
         - koku-base
+
+  koku-minio:
+    image: minio/minio:latest
+    container_name: kokuminio
+    environment:
+      MINIO_ACCESS_KEY: kokuminioaccess
+      MINIO_SECRET_KEY: kokuminiosecret
+    ports:
+      - 9000:9000
+    command: server /data
+    volumes:
+      - ./testing/parquet_data:/data
+
+  koku-create-parquet-bucket:
+    image: minio/mc:latest
+    depends_on:
+      - koku-minio
+    entrypoint: >
+      /bin/sh -c "
+      /usr/bin/mc config host rm local;
+      /usr/bin/mc config host add --quiet --api s3v4 local http://kokuminio:9000 kokuminioaccess kokuminiosecret;
+      /usr/bin/mc rb --force local/koku-bucket/;
+      /usr/bin/mc mb --quiet local/koku-bucket/;
+      /usr/bin/mc policy set public local/koku-bucket;
+      "

--- a/testing/compose_files/docker-compose-multiworker.yml
+++ b/testing/compose_files/docker-compose-multiworker.yml
@@ -846,3 +846,28 @@ services:
         - db
       depends_on:
         - koku-base
+
+  koku-minio:
+    image: minio/minio:latest
+    container_name: kokuminio
+    environment:
+      MINIO_ACCESS_KEY: kokuminioaccess
+      MINIO_SECRET_KEY: kokuminiosecret
+    ports:
+      - 9000:9000
+    command: server /data
+    volumes:
+      - ./testing/parquet_data:/data
+
+  koku-create-parquet-bucket:
+    image: minio/mc:latest
+    depends_on:
+      - koku-minio
+    entrypoint: >
+      /bin/sh -c "
+      /usr/bin/mc config host rm local;
+      /usr/bin/mc config host add --quiet --api s3v4 local http://kokuminio:9000 kokuminioaccess kokuminiosecret;
+      /usr/bin/mc rb --force local/koku-bucket/;
+      /usr/bin/mc mb --quiet local/koku-bucket/;
+      /usr/bin/mc policy set public local/koku-bucket;
+      "

--- a/testing/compose_files/docker-compose-multiworkerlistener.yml
+++ b/testing/compose_files/docker-compose-multiworkerlistener.yml
@@ -412,3 +412,28 @@ services:
         - db
       depends_on:
         - koku-base
+
+  koku-minio:
+    image: minio/minio:latest
+    container_name: kokuminio
+    environment:
+      MINIO_ACCESS_KEY: kokuminioaccess
+      MINIO_SECRET_KEY: kokuminiosecret
+    ports:
+      - 9000:9000
+    command: server /data
+    volumes:
+      - ./testing/parquet_data:/data
+
+  koku-create-parquet-bucket:
+    image: minio/mc:latest
+    depends_on:
+      - koku-minio
+    entrypoint: >
+      /bin/sh -c "
+      /usr/bin/mc config host rm local;
+      /usr/bin/mc config host add --quiet --api s3v4 local http://kokuminio:9000 kokuminioaccess kokuminiosecret;
+      /usr/bin/mc rb --force local/koku-bucket/;
+      /usr/bin/mc mb --quiet local/koku-bucket/;
+      /usr/bin/mc policy set public local/koku-bucket;
+      "


### PR DESCRIPTION

Start docker-compose with the Minio configuration 
```
(koku) ➜  koku git:(minio_compose) echo $S3_BUCKET_NAME
koku-bucket
(koku) ➜  koku git:(minio_compose) echo $S3_ENDPOINT
http://kokuminio:9000
(koku) ➜  koku git:(minio_compose) echo $S3_ACCESS_KEY
kokuminioaccess
(koku) ➜  koku git:(minio_compose) echo $S3_SECRET
kokuminiosecret
(koku) ➜  koku git:(minio_compose) docker-compose up -d
WARNING: The GOOGLE_APPLICATION_CREDENTIALS variable is not set. Defaulting to a blank string.
Creating koku_koku-base_1 ... done
Creating koku-pushgateway ... done
Creating koku_redis       ... done
Creating pgAdmin          ... done
Creating koku_rabbit      ... done
Creating koku_db          ... done
Creating kokuminio        ... done
Creating koku_beat                         ... done
Creating koku_worker                       ... done
Creating koku_grafana                      ... done
Creating masu_server                       ... done
Creating sources_client                    ... done
Creating koku_listener                     ... done
Creating koku_koku-create-parquet-bucket_1 ... done
Creating koku_server                       ... done
(koku) ➜  koku git:(minio_compose) 
```

You can visit the MinIO Browser at localhost:9000
![minio_empty](https://user-images.githubusercontent.com/4523309/90532381-2ea85c00-e145-11ea-8c83-8b3b32adc7f9.png)


Add AWS source and verify csv and parquet are in MinIO

![minio_populated](https://user-images.githubusercontent.com/4523309/90532596-6d3e1680-e145-11ea-8ffb-250818de730e.png)

```
(koku) ➜  koku git:(minio_compose) ls testing/parquet_data/koku-bucket/data/csv/10001/25228fa6-597a-4a80-af65-8cef8d2c9707/2020/07
3730caa0-6b1c-4f23-b388-b7807a9bcdba-koku-1.csv.gz
(koku) ➜  koku git:(minio_compose) ls testing/parquet_data/koku-bucket/data/parquet/10001/25228fa6-597a-4a80-af65-8cef8d2c9707/2020/07/                                                    
3730caa0-6b1c-4f23-b388-b7807a9bcdba-koku-1.parquet
(koku) ➜  koku git:(minio_compose) 
```