### PR TITLE
Force default sort order to asc on tags

### DIFF
--- a/koku/api/tags/queries.py
+++ b/koku/api/tags/queries.py
@@ -83,6 +83,7 @@ class TagQueryHandler(QueryHandler):
         if parameters.kwargs.get("key"):
             self.key = parameters.kwargs.get("key")
             self.query_filter = self._get_key_filter()
+        self.default_ordering = {"values": "asc"}
 
     def _get_key_filter(self):
         """Add new `exact` QueryFilter that filters on the key name."""
@@ -376,10 +377,10 @@ class TagQueryHandler(QueryHandler):
         """
         if self.parameters.get("key_only"):
             tag_data = self.get_tag_keys()
-            query_data = sorted(tag_data, reverse=self.order_direction == "asc")
+            query_data = sorted(tag_data, reverse=self.order_direction == "desc")
         else:
             tag_data = self.get_tags()
-            query_data = sorted(tag_data, key=lambda k: k["key"], reverse=self.order_direction == "asc")
+            query_data = sorted(tag_data, key=lambda k: k["key"], reverse=self.order_direction == "desc")
 
         self.query_data = query_data
 


### PR DESCRIPTION
##Summary
By setting `default_ordering` in the tag query handler we force the default sort order to ascending. 

## Testing

```
GET /api/cost-management/v1/tags/aws/?filter[time_scope_value]=-1&key_only=True
HTTP 200 OK
Allow: GET, HEAD, OPTIONS
Content-Type: application/json
Vary: X_RH_IDENTITY, Accept

{
    "meta": {
        "count": 4,
        "filter": {
            "time_scope_value": "-1",
            "time_scope_units": "month",
            "resolution": "monthly"
        },
        "key_only": true,
        "group_by": {},
        "order_by": {}
    },
    "links": {
        "first": "/api/cost-management/v1/tags/aws/?filter%5Btime_scope_value%5D=-1&key_only=True&limit=100&offset=0",
        "next": null,
        "previous": null,
        "last": "/api/cost-management/v1/tags/aws/?filter%5Btime_scope_value%5D=-1&key_only=True&limit=100&offset=0"
    },
    "data": [
        "app",
        "environment",
        "storageclass",
        "version"
    ]
}
```

and 

```
GET /api/cost-management/v1/tags/aws/?filter[time_scope_value]=-1
HTTP 200 OK
Allow: GET, HEAD, OPTIONS
Content-Type: application/json
Vary: X_RH_IDENTITY, Accept

{
    "meta": {
        "count": 4,
        "filter": {
            "time_scope_value": "-1",
            "time_scope_units": "month",
            "resolution": "monthly"
        },
        "key_only": false,
        "group_by": {},
        "order_by": {}
    },
    "links": {
        "first": "/api/cost-management/v1/tags/aws/?filter%5Btime_scope_value%5D=-1&limit=100&offset=0",
        "next": null,
        "previous": null,
        "last": "/api/cost-management/v1/tags/aws/?filter%5Btime_scope_value%5D=-1&limit=100&offset=0"
    },
    "data": [
        {
            "key": "app",
            "values": [
                "analytics",
                "catalog",
                "cost"
            ]
        },
        {
            "key": "environment",
            "values": [
                "dev"
            ]
        },
        {
            "key": "storageclass",
            "values": [
                "bravo",
                "charlie",
                "delta",
                "epsilon",
                "gamma"
            ]
        },
        {
            "key": "version",
            "values": [
                "beta",
                "gamma",
                "master",
                "prod"
            ]
        }
    ]
}
```