### PR TITLE
Skip retry when called from provider delete

### DIFF
--- a/koku/api/provider/provider_manager.py
+++ b/koku/api/provider/provider_manager.py
@@ -241,7 +241,9 @@ def provider_post_delete_callback(*args, **kwargs):
         delete_func = partial(delete_archived_data.delay, provider.customer.schema_name, provider.type, provider.uuid)
         transaction.on_commit(delete_func)
     try:
-        refresh_materialized_views.s(provider.customer.schema_name, provider.type).apply()
+        refresh_materialized_views.s(
+            provider.customer.schema_name, provider.type, provider_uuid=provider.uuid, synchronous=True
+        ).apply()
     except TaskRunningError:
         # Because this is a sychronous call to refresh, we don't want to wait on retry
         pass

--- a/koku/masu/processor/tasks.py
+++ b/koku/masu/processor/tasks.py
@@ -455,12 +455,16 @@ def update_cost_model_costs(self, schema_name, provider_uuid, start_date=None, e
     max_retries=100,
     bind=True,
 )
-def refresh_materialized_views(self, schema_name, provider_type, manifest_id=None):
+def refresh_materialized_views(
+    self, schema_name, provider_type, manifest_id=None, provider_uuid=None, synchronous=False
+):
     """Refresh the database's materialized views for reporting."""
     task_id = None
     if self.request:
         task_id = self.request.id
-    if is_task_currently_running("masu.processor.tasks.refresh_materialized_views", task_id, [schema_name]):
+    if not synchronous and is_task_currently_running(
+        "masu.processor.tasks.refresh_materialized_views", task_id, [schema_name]
+    ):
         msg = f"Already running refresh_materialized_views for {schema_name}."
         # Raising an exception will fail the task and trigger Celery's retry logic
         raise TaskRunningError(msg)


### PR DESCRIPTION
## Summary
Don't engage task retry on synchronous provider delete call. 