### PR TITLE
[COST-483] Extract cloudwatch secret from koku-aws

### DIFF
--- a/scripts/e2e-secrets.yml
+++ b/scripts/e2e-secrets.yml
@@ -44,23 +44,34 @@ objects:
   stringData:
     aws-access-key-id: ${AWS_ACCESS_KEY_ID}
     aws-secret-access-key: ${AWS_SECRET_ACCESS_KEY}
-    cloudwatch-aws-access-key-id: ${CLOUDWATCH_AWS_ACCESS_KEY_ID}
-    cloudwatch-aws-secret-access-key: ${CLOUDWATCH_AWS_SECRET_ACCESS_KEY}
-    cloudwatch-aws-region: 'us-east-1'
-    cloudwatch-log-group: ${CLOUDWATCH_LOG_GROUP}
   kind: Secret
   metadata:
     annotations:
-      template.openshift.io/expose-access_key: '{.data[''cloudwatch-aws-access-key-id'']}'
       template.openshift.io/expose-aws_access_key_id: '{.data[''aws-access-key-id'']}'
       template.openshift.io/expose-aws_secret_access_key: '{.data[''aws-secret-access-key'']}'
-      template.openshift.io/expose-log_group: '{.data[''cloudwatch-log-group'']}'
-      template.openshift.io/expose-region: '{.data[''cloudwatch-aws-region'']}'
-      template.openshift.io/expose-secret: '{.data[''cloudwatch-aws-secret-access-key'']}'
     labels:
       app: koku
       template: koku-secret
     name: koku-aws
+    namespace: secrets
+  type: Opaque
+- apiVersion: v1
+  stringData:
+    aws_access_key_id: ${CLOUDWATCH_AWS_ACCESS_KEY_ID}
+    aws_secret_access_key: ${CLOUDWATCH_AWS_SECRET_ACCESS_KEY}
+    aws_region: 'us-east-1'
+    log_group_name: ${CLOUDWATCH_LOG_GROUP}
+  kind: Secret
+  metadata:
+    annotations:
+      template.openshift.io/expose-access_key: '{.data[''aws_access_key_id'']}'
+      template.openshift.io/expose-log_group: '{.data[''log_group_name'']}'
+      template.openshift.io/expose-region: '{.data[''aws_region'']}'
+      template.openshift.io/expose-secret: '{.data[''aws_secret_access_key'']}'
+    labels:
+      app: koku
+      template: koku-secret
+    name: cloudwatch
     namespace: secrets
   type: Opaque
 - apiVersion: v1


### PR DESCRIPTION
App-interface creates cloudwatch secret with specific name and values.
In order to fix OpenShift v4 logging we need to separate out cloudwatch into its own secret

Associated e2e-deploy PR: https://github.com/RedHatInsights/e2e-deploy/pull/2170