### PR TITLE
docker-compose file updates

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -390,8 +390,3 @@ services:
     image: prom/pushgateway
     ports:
       - 9091:9091
-
-networks:
- default:
-   external:
-     name: koku_default

--- a/testing/compose_files/docker-compose-multilistener.yml
+++ b/testing/compose_files/docker-compose-multilistener.yml
@@ -398,3 +398,8 @@ services:
         - db
       depends_on:
         - koku-base
+
+networks:
+ default:
+   external:
+     name: koku_default

--- a/testing/compose_files/docker-compose-multiworker.yml
+++ b/testing/compose_files/docker-compose-multiworker.yml
@@ -846,3 +846,8 @@ services:
         - db
       depends_on:
         - koku-base
+
+networks:
+ default:
+   external:
+     name: koku_default

--- a/testing/compose_files/docker-compose-multiworkerlistener.yml
+++ b/testing/compose_files/docker-compose-multiworkerlistener.yml
@@ -412,3 +412,8 @@ services:
         - db
       depends_on:
         - koku-base
+
+networks:
+ default:
+   external:
+     name: koku_default


### PR DESCRIPTION
- put koku_default network in testing compose files
- remove koku_default network from main compose file (By default, `koku_default` network is created by the main compose file, so we do not need to define it)