### PR TITLE
Revert our parallel migrations

### DIFF
--- a/scripts/run_migrations.sh
+++ b/scripts/run_migrations.sh
@@ -14,5 +14,5 @@ echo "OPENSHIFT_BUILD_COMMIT=$OPENSHIFT_BUILD_COMMIT"
 if [ "$COMMIT" = "$OPENSHIFT_BUILD_COMMIT" ]; then
     echo "Migration already executed."
 else
-    scl enable rh-python38 "${APP_HOME}/manage.py migrate_schemas --executor=parallel"
+    scl enable rh-python38 "${APP_HOME}/manage.py migrate_schemas --noinput"
 fi


### PR DESCRIPTION
## Summary
Releasing stable to QA just now saw some locks prevent our partitioned table migrations from running properly. Reverting parallel execution.