### PR TITLE
Fix the status_probe failure

### DIFF
--- a/scripts/run_migrations.sh
+++ b/scripts/run_migrations.sh
@@ -7,6 +7,11 @@ APP_PORT="${KOKU_SERVICE_PORT:-'8080'}"
 TARGET_DEFAULT="http://${APP_NAME}.${APP_NAMESPACE}.svc.cluster.local:${APP_PORT}"
 TARGET="${2:-$TARGET_DEFAULT}"
 COMMIT=$(scl enable rh-python38 "${STATUS_PROBE} --status-url ${TARGET}${API_PATH_PREFIX}/v1/status/ --path commit")
+# Fallback
+if [[ -z "$COMMIT" ]]
+then
+    COMMIT=$(curl -s -GET ${TARGET}${API_PATH_PREFIX}/v1/status/ | "${STATUS_PROBE} --path commit
+fi
 
 echo "COMMIT=$COMMIT"
 echo "OPENSHIFT_BUILD_COMMIT=$OPENSHIFT_BUILD_COMMIT"


### PR DESCRIPTION
## Jira Ticket

[COST-476](https://issues.redhat.com/browse/COST-476)

## Description

Changed to use the `requests` module instead of `urllib`

Also, if the status url is not passed in, the probe will assume a file should be read. If no file given, it will read from stdin.

The `run_migrations.sh` script will try the status probe directly first. If that fails to populate `COMMIT`, then `curl` will be used with the status probe reading and parsing the result of the call.

## Testing

1. The script should not fail to run (`run_migrations.sh` or `status_probe.py`)
2. If the hash can be determined, then `COMMIT` should be set properly blocking repeat executions of the migrations.
3. This is difficult, if not impossible, to test locally. But the results can be viewed in CI, QA, and staging. _The staging environment is where I saw it fail._