### PR TITLE
Fix account filter for ocp on all tags

### DIFF
--- a/koku/api/tags/all/openshift/queries.py
+++ b/koku/api/tags/all/openshift/queries.py
@@ -17,7 +17,9 @@
 """OCP-on-All Tag Query Handling."""
 from copy import deepcopy
 
+from django.db.models import DecimalField
 from django.db.models import F
+from django.db.models import Value
 
 from api.models import Provider
 from api.report.all.openshift.provider_map import OCPAllProviderMap
@@ -37,7 +39,10 @@ class OCPAllTagQueryHandler(TagQueryHandler):
         {
             "db_table": OCPAzureTagsSummary,
             "db_column_period": "cost_entry_bill__billing_period",
-            "annotations": {"accounts": F("subscription_guid")},
+            "annotations": {
+                "usage_account_id": F("subscription_guid"),
+                "account_alias__account_alias": Value(0, output_field=DecimalField()),
+            },
         },
     ]
     TAGS_VALUES_SOURCE = [


### PR DESCRIPTION
## Summary
This will fix a 500 on OCP on ALL tags endpoints when filtering by account. 

## Testing

Using Azure sub guid value
```
GET /api/cost-management/v1/tags/openshift/infrastructures/all/version/?filter[account]=38f1
HTTP 200 OK
Allow: GET, HEAD, OPTIONS
Content-Type: application/json
Vary: X_RH_IDENTITY, Accept

{
    "meta": {
        "count": 4,
        "filter": {
            "account": [
                "38f1"
            ],
            "enabled": true,
            "time_scope_value": "-10",
            "time_scope_units": "day",
            "resolution": "daily"
        },
        "key_only": false,
        "group_by": {},
        "order_by": {},
        "access": {}
    },
    "links": {
        "first": "/api/cost-management/v1/tags/openshift/infrastructures/all/version/?filter%5Baccount%5D=38f1&limit=100&offset=0",
        "next": null,
        "previous": null,
        "last": "/api/cost-management/v1/tags/openshift/infrastructures/all/version/?filter%5Baccount%5D=38f1&limit=100&offset=0"
    },
    "data": [
        "Andromeda",
        "Mars",
        "MilkyWay",
        "Sombrero"
    ]
}
```

Using AWS usage account id value

```
GET /api/cost-management/v1/tags/openshift/infrastructures/all/version/?filter[account]=999
HTTP 200 OK
Allow: GET, HEAD, OPTIONS
Content-Type: application/json
Vary: X_RH_IDENTITY, Accept

{
    "meta": {
        "count": 4,
        "filter": {
            "account": [
                "999"
            ],
            "enabled": true,
            "time_scope_value": "-10",
            "time_scope_units": "day",
            "resolution": "daily"
        },
        "key_only": false,
        "group_by": {},
        "order_by": {},
        "access": {}
    },
    "links": {
        "first": "/api/cost-management/v1/tags/openshift/infrastructures/all/version/?filter%5Baccount%5D=999&limit=100&offset=0",
        "next": null,
        "previous": null,
        "last": "/api/cost-management/v1/tags/openshift/infrastructures/all/version/?filter%5Baccount%5D=999&limit=100&offset=0"
    },
    "data": [
        "beta",
        "gamma",
        "master",
        "prod"
    ]
}
```