### PR TITLE
Use DRF browsable API in dev only

### DIFF
--- a/koku/koku/settings.py
+++ b/koku/koku/settings.py
@@ -263,17 +263,18 @@ INTERNAL_IPS = ["127.0.0.1"]
 DEFAULT_PAGINATION_CLASS = "api.common.pagination.StandardResultsSetPagination"
 DEFAULT_EXCEPTION_HANDLER = "api.common.exception_handler.custom_exception_handler"
 
+DEFAULT_RENDERER_CLASSES = ("rest_framework.renderers.JSONRenderer", "api.common.csv.PaginatedCSVRenderer")
+
+if DEVELOPMENT:
+    DEFAULT_RENDERER_CLASSES = DEFAULT_RENDERER_CLASSES + ("rest_framework.renderers.BrowsableAPIRenderer",)
+
 # django rest_framework settings
 REST_FRAMEWORK = {
     # Use Django's standard `django.contrib.auth` permissions,
     # or allow read-only access for unauthenticated users.
     "DEFAULT_PERMISSION_CLASSES": ["rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly"],
     "DEFAULT_PAGINATION_CLASS": DEFAULT_PAGINATION_CLASS,
-    "DEFAULT_RENDERER_CLASSES": (
-        "rest_framework.renderers.JSONRenderer",
-        "api.common.csv.PaginatedCSVRenderer",
-        "rest_framework.renderers.BrowsableAPIRenderer",
-    ),
+    "DEFAULT_RENDERER_CLASSES": DEFAULT_RENDERER_CLASSES,
     "EXCEPTION_HANDLER": DEFAULT_EXCEPTION_HANDLER,
 }
 


### PR DESCRIPTION
## Summary
Remove DRF Browsable API access outside of the dev environment.