### PR TITLE
Fix make load-test-customer-data by removing tag rate from json

### DIFF
--- a/scripts/openshift_on_prem_cost_model.json
+++ b/scripts/openshift_on_prem_cost_model.json
@@ -82,24 +82,6 @@
             "usage_end": null
         }],
         "cost_type": "Infrastructure"
-    },
-    {
-        "metric": {"name": "cluster_cost_per_month"},
-        "tag_rates": [{
-                "tag_key": "tag_one",
-                "tag_values": [{
-                        "tag_value": "value_one",
-                        "unit": "USD",
-                        "usage": {
-                            "unit": "USD",
-                            "usage_end": null,
-                            "usage_start": null},
-                        "value": 0.2,
-                        "description": "",
-                        "default": false
-                    }]
-            }],
-        "cost_type": "Infrastructure"
     }
     ]
 }


### PR DESCRIPTION
I accidentally left a tag rate in the `openshift_on_prem_cost_model.json` from when I was working on: https://github.com/project-koku/koku/pull/2375

It really only broke local development for those who run `make load-test-customer-data` resulting in the following error:
```
koku_worker       |     for key, value in self.price_list.items()
koku_worker       |   File "/koku/koku/masu/database/cost_model_db_accessor.py", line 75, in price_list
koku_worker       |     value_to_add = float(new_tiered_rate[0].get("value"))
koku_worker       | TypeError: 'NoneType' object is not subscriptable
```
The price list is not yet ready to handle a tag rate. 

**How to test**
Run: `make load-test-customer-data` and see no error. 