### PR TITLE
Update insert_org_tree script to not require arn env variable.

### DIFF
--- a/scripts/insert_org_tree.py
+++ b/scripts/insert_org_tree.py
@@ -80,7 +80,7 @@ class UploadAwsTree:
         json_info = {
             "name": "aws_org_tree",
             "source_type": "AWS-local",
-            "authentication": {"credentials": {"role_arn": require_env("AWS_RESOURCE_NAME")}},
+            "authentication": {"credentials": {"role_arn": "arn:aws:iam::111111111111:role/LocalAWSSource"}},
             "billing_source": {"data_source": {"bucket": "/tmp/local_bucket_1"}},
         }
         LOG.info("Creating a source with the following information:\n" f"\t{json_info}")


### PR DESCRIPTION
Just want to update the switch from grabbing the arn from an environment variable