### PR TITLE
remove safe methods check for resource type

### DIFF
--- a/koku/api/common/permissions/resource_type_access.py
+++ b/koku/api/common/permissions/resource_type_access.py
@@ -28,7 +28,4 @@ class ResourceTypeAccessPermission(permissions.BasePermission):
         if request.user.admin:
             return True
 
-        if request.method in permissions.SAFE_METHODS:
-            return True
-
         return False

--- a/koku/api/common/permissions/test/tests_resource_types_access.py
+++ b/koku/api/common/permissions/test/tests_resource_types_access.py
@@ -34,13 +34,13 @@ class ResourceTypeAccessPermissionTest(TestCase):
         result = accessPerm.has_permission(request=req, view=None)
         self.assertTrue(result)
 
-    def test_has_perm_with_access_on_get(self):
+    def test_has_perm_with_no_access_on_get(self):
         """Test that a user read."""
         user = Mock(spec=User, admin=False)
         req = Mock(user=user, method="GET")
         accessPerm = ResourceTypeAccessPermission()
         result = accessPerm.has_permission(request=req, view=None)
-        self.assertTrue(result)
+        self.assertFalse(result)
 
     def test_has_perm_with_no_access_on_post(self):
         """Test that a user cannot execute POST."""


### PR DESCRIPTION
## Summary
Right now resource type apis should be for org admins only. Not allowed as a "safe method"