### PR TITLE
Remove yaml from insert_aws_org_tree script.

### DIFF
--- a/koku/koku/koku_test_runner.py
+++ b/koku/koku/koku_test_runner.py
@@ -24,6 +24,7 @@ from django.conf import settings
 from django.db import connections
 from django.test.runner import DiscoverRunner
 from django.test.utils import get_unique_databases_and_mirrors
+from scripts.insert_org_tree import UploadAwsTree
 from tenant_schemas.utils import tenant_context
 
 from api.models import Customer
@@ -96,10 +97,13 @@ def setup_databases(verbosity, interactive, keepdb=False, debug_sql=False, paral
                     data_loader = NiseDataLoader(KokuTestRunner.schema)
                     # grab the dates to get the start date
                     dates = data_loader.dates
-                    org_tree_obj = InsertAwsOrgTree(
-                        schema=KokuTestRunner.schema, tree_yaml="scripts/aws_org_tree.yml", start_date=dates[0][0]
-                    )
-                    org_tree_obj.insert_tree()
+                    # Obtain the day_list from yaml
+                    read_yaml = UploadAwsTree(None, None, None, None)
+                    tree_yaml = read_yaml.import_yaml(yaml_file_path="scripts/aws_org_tree.yml")
+                    day_list = tree_yaml["account_structure"]["days"]
+                    # Insert the tree
+                    org_tree_obj = InsertAwsOrgTree(schema=KokuTestRunner.schema, start_date=dates[0][0])
+                    org_tree_obj.insert_tree(day_list=day_list)
                     data_loader.load_openshift_data(customer, "ocp_aws_static_data.yml", "OCP-on-AWS")
                     data_loader.load_openshift_data(customer, "ocp_azure_static_data.yml", "OCP-on-Azure")
                     data_loader.load_aws_data(customer, "aws_static_data.yml")

--- a/koku/masu/util/aws/insert_aws_org_tree.py
+++ b/koku/masu/util/aws/insert_aws_org_tree.py
@@ -16,12 +16,10 @@
 #
 """AWS Utility functions for inserting a aws org unit tree for testing."""
 import logging
-import os
 from datetime import datetime
 from datetime import timedelta
 
 import ciso8601
-import yaml
 from tenant_schemas.utils import schema_context
 
 from reporting.provider.aws.models import AWSAccountAlias
@@ -39,7 +37,7 @@ class InsertAwsOrgTreeError(Exception):
 class InsertAwsOrgTree:
     """Insert aws org tree abstract class."""
 
-    def __init__(self, schema, start_date=None, tree_yaml=None):
+    def __init__(self, schema, start_date=None):
         self.schema = schema
         self.start_date = start_date
         self.yesterday_accounts = []
@@ -47,20 +45,6 @@ class InsertAwsOrgTree:
         self.today_accounts = []
         self.today_orgs = []
         self.account_alias_mapping = {}
-        self.tree_yaml = tree_yaml
-
-    def _load_yaml_file(self, filename):
-        """Local data from yaml file."""
-        yamlfile = None
-        if not os.path.isfile(filename):
-            err_msg = "Error: No such file: {filename}"
-            raise InsertAwsOrgTreeError(err_msg=err_msg)
-        try:
-            with open(filename, "r+") as yaml_file:
-                yamlfile = yaml.safe_load(yaml_file)
-        except TypeError:
-            yamlfile = yaml.safe_load(filename)
-        return yamlfile
 
     def calculate_date(self, day_delta):
         """Calculate the date based off of a delta and a range start date."""
@@ -131,12 +115,9 @@ class InsertAwsOrgTree:
                     removed_org_unit.save()
                     LOG.info(f"Updating org={removed_org_unit.org_unit_id} with delete_timestamp={date}")
 
-    def insert_tree(self, day_list=None):  # noqa: C901
+    def insert_tree(self, day_list):  # noqa: C901
         """Inserts the tree into the database."""
         try:
-            if self.tree_yaml:
-                yaml_contents = self._load_yaml_file(self.tree_yaml)
-                day_list = yaml_contents["account_structure"]["days"]
             for day_dict in day_list:
                 day = day_dict["day"]
                 date_delta = day["date"]


### PR DESCRIPTION
I discovered that I was only using the yaml for the koku_test_runner. Since we we used to be able to read a yaml in the koku_test_runner before my changes here: https://github.com/project-koku/koku/pull/2394/files#diff-f4a4362ad27dc47ace11a3c5e7d805d7L100

I went ahead and implemented a similar logic where I import a class from scripts to read the yaml file and pass the day_list to the insert script to populate the database. That way I could remove the yaml import in the insert_aws_org_tree.py  all together.