### PR TITLE
COST-589: recreating tenant in sources client after being cleaned

### DIFF
--- a/koku/api/provider/provider_builder.py
+++ b/koku/api/provider/provider_builder.py
@@ -112,7 +112,10 @@ class ProviderBuilder:
         """Call to create provider."""
         connection.set_schema_to_public()
         context, customer, _ = self._create_context()
-        tenant = Tenant.objects.get(schema_name=customer.schema_name)
+        tenant, created = Tenant.objects.get_or_create(schema_name=customer.schema_name)
+        if created:
+            msg = f"Created tenant {customer.schema_name}"
+            LOG.info(msg)
         provider_type = source.source_type
         json_data = {
             "name": source.name,

--- a/koku/sources/test/test_kafka_source_manager.py
+++ b/koku/sources/test/test_kafka_source_manager.py
@@ -22,6 +22,7 @@ from django.test import TestCase
 from faker import Faker
 from rest_framework.exceptions import ValidationError
 
+from api.iam.models import Tenant
 from api.models import Provider
 from api.provider.provider_builder import ProviderBuilder
 from api.provider.provider_builder import ProviderBuilderError
@@ -66,6 +67,16 @@ class ProviderBuilderTest(TestCase):
 
     def test_create_provider(self):
         """Test to create a provider."""
+        # Delete tenants
+        Tenant.objects.all().delete()
+        client = ProviderBuilder(auth_header=Config.SOURCES_FAKE_HEADER)
+        with patch.object(ProviderAccessor, "cost_usage_source_ready", returns=True):
+            mock_source = MockSourceObject(self.name, self.provider_type, self.authentication, self.billing_source)
+            provider = client.create_provider_from_source(mock_source)
+            self.assertEqual(provider.name, self.name)
+
+    def test_create_provider_no_tenant(self):
+        """Test to create a provider after tenant was removed."""
         client = ProviderBuilder(auth_header=Config.SOURCES_FAKE_HEADER)
         with patch.object(ProviderAccessor, "cost_usage_source_ready", returns=True):
             mock_source = MockSourceObject(self.name, self.provider_type, self.authentication, self.billing_source)


### PR DESCRIPTION
This should address: https://sentry.io/organizations/project-koku/issues/1865053269/?project=5183020&referrer=slack

When the tenant cleaner task removes a tenant, the sources client is failing to recreate the tenant on the OCP source creation flow.  This doesn't apply to AWS and Azure since they require an API PATCH call and the tenant is recreated successfully on that path.

**Testing**
1. Set DEVELOPMENT=False and create an OCP source without hitting an APIs (to ensure no tenant exists and sources client creates it)
2. Force tenant cleaner to run and remove tenant
3. Re-add source and verify tenant is re-created and source create is successful

**Test Results**
[sources_tenant_recreate_ut.txt](https://github.com/project-koku/koku/files/5313458/sources_tenant_recreate_ut.txt)
