### PR TITLE
Change github-action cache key

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -47,17 +47,17 @@ jobs:
       - name: Install pipenv
         run: sudo python3 -m pip install pipenv==2018.11.26
 
-      - name: Cache dependencies
-        id: cache-dependencies
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cache/pipenv
-            ~/.local/share/virtualenvs
-          key: ${{ runner.os }}-env-${{ matrix.python-version }}-${{ hashFiles('**/Pipfile.lock') }}-${{ github.ref }}
+      # - name: Cache dependencies
+      #   id: cache-dependencies
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: |
+      #       ~/.cache/pipenv
+      #       ~/.local/share/virtualenvs
+      #     key: ${{ runner.os }}-env-${{ matrix.python-version }}-${{ hashFiles('**/Pipfile.lock') }}-${{ github.ref }}
 
       - name: Install dependencies
-        if: steps.cache-dependencies.outputs.cache-hit != 'true'
+        # if: steps.cache-dependencies.outputs.cache-hit != 'true'
         run: |
           pipenv install --dev --ignore-pipfile --python ${{ matrix.python-version }}
 

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -47,17 +47,17 @@ jobs:
       - name: Install pipenv
         run: sudo python3 -m pip install pipenv==2018.11.26
 
-      # - name: Cache dependencies
-      #   id: cache-dependencies
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: |
-      #       ~/.cache/pipenv
-      #       ~/.local/share/virtualenvs
-      #     key: ${{ runner.os }}-env-${{ matrix.python-version }}-${{ hashFiles('**/Pipfile.lock') }}-${{ github.ref }}
+      - name: Cache dependencies
+        id: cache-dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/pipenv
+            ~/.local/share/virtualenvs
+          key: os-${{ runner.os }}-env-${{ matrix.python-version }}-${{ hashFiles('**/Pipfile.lock') }}-${{ github.ref }}
 
       - name: Install dependencies
-        # if: steps.cache-dependencies.outputs.cache-hit != 'true'
+        if: steps.cache-dependencies.outputs.cache-hit != 'true'
         run: |
           pipenv install --dev --ignore-pipfile --python ${{ matrix.python-version }}
 


### PR DESCRIPTION
Our github-actions cache seems corrupted again. One solution is to change the cache key so that it will be recreated.

This idea came from here: [https://github.com/python-poetry/poetry/pull/1928](https://github.com/python-poetry/poetry/pull/1928). It resolved their issues, so it should work for us too.