### PR TITLE
Cost 584 migration check upgrade

### DIFF
--- a/db_functions/app_migration_check_func.sql
+++ b/db_functions/app_migration_check_func.sql
@@ -1,0 +1,89 @@
+/*
+Copyright 2020 Red Hat, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+-- Function public.app_migration_check(leaf_migrations, _verbose)
+-- Returns bool: true = run migrations; false = migrations up-to-date
+-- leaf_migrations (jsonb) = leaf migration names by app from the django code
+--    Ex: '{<django-app>: <latest-leaf-migration-name>}'
+-- Set _verbose to true to see notices raised during execution
+DROP FUNCTION IF EXISTS public.app_migration_check(jsonb, boolean);
+
+CREATE OR REPLACE FUNCTION public.app_migration_check(leaf_migrations jsonb, _verbose boolean DEFAULT false)
+RETURNS boolean AS $BODY$
+DECLARE
+    schema_rec record;
+    app_key text;
+    app_keys text[];
+    latest_migrations jsonb;
+    do_migrations boolean := false;
+BEGIN
+    SELECT array_agg(k)
+      INTO app_keys
+      FROM jsonb_object_keys(leaf_migrations) k;
+
+    FOR schema_rec IN
+        SELECT t.schema_name
+          FROM public.api_tenant t
+          JOIN pg_namespace n
+            on n.nspname = t.schema_name
+         ORDER
+            BY case when schema_name = 'public'
+                         then '0public'
+                    else schema_name
+               END::text
+    LOOP
+        IF _verbose
+        THEN
+            RAISE NOTICE 'Checking %', schema_rec.schema_name;
+        END IF;
+        EXECUTE 'SELECT jsonb_object_agg(app, migration) ' ||
+                  'FROM ( ' ||
+                         'SELECT app, ' ||
+                                'max(name) as "migration" ' ||
+                           'FROM ' || quote_ident(schema_rec.schema_name) || '.django_migrations ' ||
+                          'GROUP BY app ' ||
+                       ') AS x ;'
+           INTO latest_migrations;
+
+        FOREACH app_key IN ARRAY app_keys
+        LOOP
+            IF latest_migrations ? app_key
+            THEN
+                IF _verbose
+                THEN
+                    RAISE NOTICE '    checking %.% > %.%', app_key, leaf_migrations->>app_key, app_key, latest_migrations->>app_key;
+                END IF;
+                IF leaf_migrations->>app_key > latest_migrations->>app_key
+                THEN
+                    do_migrations = true;
+                    EXIT;
+                END IF;
+            ELSE
+                IF _verbose
+                THEN
+                    RAISE NOTICE '    app % missing from schema', app_key;
+                END IF;
+                do_migrations = true;
+                EXIT;
+            END IF;
+        END LOOP;
+
+        EXIT WHEN do_migrations;
+    END LOOP;
+
+    RETURN do_migrations;
+END;
+$BODY$ LANGUAGE PLPGSQL;

--- a/db_functions/app_needs_migrations_func.sql
+++ b/db_functions/app_needs_migrations_func.sql
@@ -19,7 +19,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 -- leaf_migrations (jsonb) = leaf migration names by app from the django code
 --    Ex: '{<django-app>: <latest-leaf-migration-name>}'
 -- Set _verbose to true to see notices raised during execution
-DROP FUNCTION IF EXISTS public.app_migration_check(jsonb, boolean);
+DROP FUNCTION IF EXISTS public.app_needs_migrations(jsonb, boolean);
 
 CREATE OR REPLACE FUNCTION public.app_needs_migrations(leaf_migrations jsonb, _verbose boolean DEFAULT false)
 RETURNS boolean AS $BODY$

--- a/koku/koku/database.py
+++ b/koku/koku/database.py
@@ -88,7 +88,7 @@ select p.pronamespace::regnamespace::text || '.' || p.proname ||
        '(' || pg_get_function_arguments(p.oid) || ')' as funcsig
   from pg_proc p
  where pronamespace = 'public'::regnamespace
-   and proname = 'app_migration_check';
+   and proname = 'app_needs_migrations';
 """
     with connection.cursor() as cur:
         cur.execute(sql)
@@ -115,7 +115,7 @@ def verify_migrations_dbfunc(connection):
 
 def check_migrattions_dbfunc(connection, targets):
     """
-    Check the state of the migrations using the app_migration_check
+    Check the state of the migrations using the app_needs_migrations
     database function.
     The database function returns true if the migrations NEED to be run else false.
     """

--- a/koku/koku/database.py
+++ b/koku/koku/database.py
@@ -16,12 +16,14 @@
 #
 """Django database settings."""
 import json
+import logging
 import os
 
 from django.conf import settings
 from django.db import connections
 from django.db import DEFAULT_DB_ALIAS
 from django.db import OperationalError
+from django.db import transaction
 from django.db.migrations.executor import MigrationExecutor
 from django.db.models import DecimalField
 from django.db.models.aggregates import Func
@@ -30,6 +32,9 @@ from django.db.models.fields.json import KeyTextTransform
 from .env import ENVIRONMENT
 from .migration_sql_helpers import apply_sql_file
 from .migration_sql_helpers import find_db_functions_dir
+
+
+LOG = logging.getLogger(__name__)
 
 engines = {
     "sqlite": "django.db.backends.sqlite3",
@@ -73,7 +78,11 @@ def config():
     return _cert_config(db_config, database_cert)
 
 
-def migrations_sproc_exists(connection):
+def dbfunc_exists(connection, function_signature):
+    """
+    Test that the migration check database function exists by
+    checking the existence of the function signature.
+    """
     sql = """
 select p.pronamespace::regnamespace::text || '.' || p.proname ||
        '(' || pg_get_function_arguments(p.oid) || ')' as funcsig
@@ -85,20 +94,39 @@ select p.pronamespace::regnamespace::text || '.' || p.proname ||
         cur.execute(sql)
         res = cur.fetchone()
 
-    return bool(res) and res[0] == "public.app_migration_check(leaf_migrations jsonb, _verbose boolean DEFAULT false)"
+    return bool(res) and res[0] == function_signature
 
 
-def install_migrations_sproc(connection):
+def install_migrations_dbfunc(connection):
+    """
+    Install the migration check database function
+    """
     db_funcs_dir = find_db_functions_dir()
-    migration_check_sql = os.path.join(db_funcs_dir, "app_migration_check_func.sql")
-    apply_sql_file(connection, migration_check_sql)
+    migration_check_sql = os.path.join(db_funcs_dir, "app_needs_migrations_func.sql")
+    LOG.info("Installing migration check db function")
+    apply_sql_file(connection.schema_editor(), migration_check_sql, True)
 
 
-def check_migrattions_sproc(connection, targets):
+def verify_migrations_dbfunc(connection):
+    func_sig = "public.app_needs_migrations(leaf_migrations jsonb, _verbose boolean DEFAULT false)"
+    if not dbfunc_exists(connection, func_sig):
+        install_migrations_dbfunc(connection)
+
+
+def check_migrattions_dbfunc(connection, targets):
+    """
+    Check the state of the migrations using the app_migration_check
+    database function.
+    The database function returns true if the migrations NEED to be run else false.
+    """
+    LOG.info("Checking app migrations via database function")
     with connection.cursor() as cur:
-        cur.execute("SELECT public.app_migration_check(%s::jsonb);", (json.dumps(dict(targets)),))
+        cur.execute("SELECT public.app_needs_migrations(%s::jsonb);", (json.dumps(dict(targets)),))
         res = cur.fetchone()
-        return bool(res) and res[0]
+        ret = not (bool(res) and res[0])
+
+    LOG.info(f"Migrations should {'not ' if ret else ''}be run.")
+    return ret
 
 
 def check_migrations():
@@ -115,11 +143,11 @@ def check_migrations():
         connection.prepare_database()
         executor = MigrationExecutor(connection)
         targets = executor.loader.graph.leaf_nodes()
+        with transaction.atomic():
+            verify_migrations_dbfunc(connection)
+            res = check_migrattions_dbfunc(connection, targets)
 
-        if not migrations_sproc_exists(connection):
-            install_migrations_sproc(connection)
-
-        return check_migrattions_sproc(connection, targets)
+        return res
     except OperationalError:
         return False
 

--- a/koku/koku/test_check_migrations_dbfunc.py
+++ b/koku/koku/test_check_migrations_dbfunc.py
@@ -28,7 +28,7 @@ def execute(conn, sql, values=None):
 
 class TestCheckMigrationDBFunc(IamTestCase):
     def drop_check_func(self):
-        execute(conn, "drop function if exists public.app_migration_check(jsonb, boolean);")
+        execute(conn, "drop function if exists public.app_needs_migrations(jsonb, boolean);")
 
     def get_public_latest_migrations(self):
         cur = execute(
@@ -56,7 +56,7 @@ select app,
         kdb.verify_migrations_dbfunc(conn)
         latest_migrations = self.get_public_latest_migrations()
         res = kdb.check_migrattions_dbfunc(conn, latest_migrations)
-        self.assertEqual(res, False)
+        self.assertEqual(res, True)
 
     def test_migration_check_do_run(self):
         kdb.verify_migrations_dbfunc(conn)
@@ -66,11 +66,11 @@ select app,
         # that is not recorded in the database migrations tables
         latest_migrations.append(("__eek", "0999_eek_1"))
         res = kdb.check_migrattions_dbfunc(conn, latest_migrations)
-        self.assertEqual(res, True)
+        self.assertEqual(res, False)
 
         # Test that migrations should be run when the leaf migrations are greater than
         # the latest migrations recorded in the database
         latest_migrations.pop()  # remove "__eek" app from list
         latest_migrations[0] = (latest_migrations[0][0], "0999_eek")
         res = kdb.check_migrattions_dbfunc(conn, latest_migrations)
-        self.assertEqual(res, True)
+        self.assertEqual(res, False)

--- a/koku/koku/test_check_migrations_dbfunc.py
+++ b/koku/koku/test_check_migrations_dbfunc.py
@@ -1,0 +1,76 @@
+#
+# Copyright 2018 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+from django.db import connection as conn
+
+from . import database as kdb
+from api.iam.test.iam_test_case import IamTestCase
+
+
+def execute(conn, sql, values=None):
+    cur = conn.cursor()
+    cur.execute(sql, values)
+    return cur
+
+
+class TestCheckMigrationDBFunc(IamTestCase):
+    def drop_check_func(self):
+        execute(conn, "drop function if exists public.app_migration_check(jsonb, boolean);")
+
+    def get_public_latest_migrations(self):
+        cur = execute(
+            conn,
+            """
+select app,
+       max(name) as "name"
+  from public.django_migrations
+ group
+    by app;""",
+        )
+        return cur.fetchall()
+
+    def test_migration_check_dbfunc_exists(self):
+        func_sig = "public.app_needs_migrations(leaf_migrations jsonb, _verbose boolean DEFAULT false)"
+        self.drop_check_func()
+        res = kdb.dbfunc_exists(conn, func_sig)
+        self.assertEqual(res, False)
+
+        kdb.install_migrations_dbfunc(conn)
+        res = kdb.dbfunc_exists(conn, func_sig)
+        self.assertEqual(res, True)
+
+    def test_migration_check_do_not_run(self):
+        kdb.verify_migrations_dbfunc(conn)
+        latest_migrations = self.get_public_latest_migrations()
+        res = kdb.check_migrattions_dbfunc(conn, latest_migrations)
+        self.assertEqual(res, False)
+
+    def test_migration_check_do_run(self):
+        kdb.verify_migrations_dbfunc(conn)
+        latest_migrations = self.get_public_latest_migrations()
+
+        # Test that migrations should be run when the leaf migrations contain an app
+        # that is not recorded in the database migrations tables
+        latest_migrations.append(("__eek", "0999_eek_1"))
+        res = kdb.check_migrattions_dbfunc(conn, latest_migrations)
+        self.assertEqual(res, True)
+
+        # Test that migrations should be run when the leaf migrations are greater than
+        # the latest migrations recorded in the database
+        latest_migrations.pop()  # remove "__eek" app from list
+        latest_migrations[0] = (latest_migrations[0][0], "0999_eek")
+        res = kdb.check_migrattions_dbfunc(conn, latest_migrations)
+        self.assertEqual(res, True)


### PR DESCRIPTION
## Ticket

[COST-584](https://issues.redhat.com/browse/COST-584)

## Description

In an attempt to be more thorough regarding detecting the need to run migrations, I have created a function that will scan all tenants that exist (meaning exist in `api_teanat` and in `pg_namespace`) and will cycle through all of them checking the latest recorded migration name by app against the latest code migration leaf by app.

If the `app.leaf` migration name is greater than the `app.latest` migration name, then migrations will be run.

If an app appears in the leaf that is not recorded, then migrations should be run.

This will mean that, when all migrations are up-to-date, this check function will run longer than normal. If, however, migrations need to be run, it will stop processing at the first schema that is out-of-date.

## Testing

### Setup

1. `git fetch && git checkout COST-584-migration-check-upgrade`
2. `make docker-reinitdb-with-sources`

### Call check_migrations

#### Migrations should not be run

1. `python ./koku/manage.py check_migrations`

#### Migrations should be run

1. 
```bash
$ cat <<EOF >./koku/api/migrations/0999_eek.py
from django.db import migrations
class Migration(migrations.Migration):
    dependencies = [("api", "$(basename $(ls -1 ./koku/api/migrations/0*.py | tail -1) | sed -e 's/\.py$//g')")]
    operations = [migrations.RunSQL("""select 1;""")]
EOF

```
2. `python ./koku/manage.py check_migrations`
3. `rm ./koku/api/migrations/0999_eek.py`

### Call db function directly

1. `python ./koku/manage,py shell`
2. 
```python
import json
from koku.database import 
from django.db import connection
from django.db.migrations.executor import MigrationExecutor
from koku.database import verify_migrations_dbfunc
if connection.connection.closed:
    connection.connect()
verify_migrations_dbfunc(connection)
connection.prepare_database()
executor = MigrationExecutor(connection)
targets = executor.loader.graph.leaf_nodes()
json.dumps(dict(targets))
# Copy the string (including the surrounding single-quotes) that is the output from the json.dumps() call
exit
```
3. psql postgresql://postgres@localhost:15432/postgres
4. 
```sql
select public.app_needs_migrations(<paste string here>::jsonb);
-- returns 't' if migrations need to be run else 'f'

-- if you want to see verbose output:
select public.app_needs_migrations(<paste string here>::jsonb, true);

-- if you want to play around, change an app key value in the json string or change the name of one of the migrations.
```
5. `\q`
