### PR TITLE
adjusting resource type operationids in spec

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -1766,7 +1766,7 @@
                     "Resource Type"
                 ],
                 "summary": "List AWS Accounts For RBAC",
-                "operationId": "listAwsAccounts",
+                "operationId": "listResourcesAwsAccounts",
                 "parameters": [{
                         "$ref": "#/components/parameters/QueryOffset"
                     },
@@ -1800,7 +1800,7 @@
                     "Resource Type"
                 ],
                 "summary": "List AWS Organizational Units For RBAC",
-                "operationId": "listAwsOrgUnits",
+                "operationId": "listResourcesAwsOrgUnits",
                 "parameters": [{
                         "$ref": "#/components/parameters/QueryOffset"
                     },
@@ -1834,7 +1834,7 @@
                     "Resource Type"
                 ],
                 "summary": "List Azure Subscription Guids For RBAC",
-                "operationId": "listAzureSubGuids",
+                "operationId": "listResourcesAzureSubGuids",
                 "parameters": [{
                         "$ref": "#/components/parameters/QueryOffset"
                     },
@@ -1868,7 +1868,7 @@
                     "Resource Type"
                 ],
                 "summary": "List OpenShift Clusters For RBAC",
-                "operationId": "listOpenShiftClusters",
+                "operationId": "listResourcesOpenShiftClusters",
                 "parameters": [{
                         "$ref": "#/components/parameters/QueryOffset"
                     },
@@ -1902,7 +1902,7 @@
                     "Resource Type"
                 ],
                 "summary": "List OpenShift Nodes For RBAC",
-                "operationId": "listOpenShiftNodes",
+                "operationId": "listResourcesOpenShiftNodes",
                 "parameters": [{
                         "$ref": "#/components/parameters/QueryOffset"
                     },
@@ -1936,7 +1936,7 @@
                     "Resource Type"
                 ],
                 "summary": "List OpenShift Projects For RBAC",
-                "operationId": "listOpenShiftProjects",
+                "operationId": "listResourcesOpenShiftProjects",
                 "parameters": [{
                         "$ref": "#/components/parameters/QueryOffset"
                     },
@@ -1970,7 +1970,7 @@
                     "Resource Type"
                 ],
                 "summary": "List Cost Models For RBAC",
-                "operationId": "listCostModels",
+                "operationId": "listResourcesCostModels",
                 "parameters": [{
                         "$ref": "#/components/parameters/QueryOffset"
                     },

--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -1766,7 +1766,7 @@
                     "Resource Type"
                 ],
                 "summary": "List AWS Accounts For RBAC",
-                "operationId": "listAwsAccountsForResourceType",
+                "operationId": "listAwsAccounts",
                 "parameters": [{
                         "$ref": "#/components/parameters/QueryOffset"
                     },
@@ -1800,7 +1800,7 @@
                     "Resource Type"
                 ],
                 "summary": "List AWS Organizational Units For RBAC",
-                "operationId": "listAwsOrgUnitsForResourceType",
+                "operationId": "listAwsOrgUnits",
                 "parameters": [{
                         "$ref": "#/components/parameters/QueryOffset"
                     },
@@ -1834,7 +1834,7 @@
                     "Resource Type"
                 ],
                 "summary": "List Azure Subscription Guids For RBAC",
-                "operationId": "listAzureSubGuidsForResourceType",
+                "operationId": "listAzureSubGuids",
                 "parameters": [{
                         "$ref": "#/components/parameters/QueryOffset"
                     },
@@ -1868,7 +1868,7 @@
                     "Resource Type"
                 ],
                 "summary": "List OpenShift Clusters For RBAC",
-                "operationId": "listOpenShiftClustersForResourceType",
+                "operationId": "listOpenShiftClusters",
                 "parameters": [{
                         "$ref": "#/components/parameters/QueryOffset"
                     },
@@ -1902,7 +1902,7 @@
                     "Resource Type"
                 ],
                 "summary": "List OpenShift Nodes For RBAC",
-                "operationId": "listOpenShiftNodesForResourceTypes",
+                "operationId": "listOpenShiftNodes",
                 "parameters": [{
                         "$ref": "#/components/parameters/QueryOffset"
                     },
@@ -1936,7 +1936,7 @@
                     "Resource Type"
                 ],
                 "summary": "List OpenShift Projects For RBAC",
-                "operationId": "listOpenShiftProjectsForResourceType",
+                "operationId": "listOpenShiftProjects",
                 "parameters": [{
                         "$ref": "#/components/parameters/QueryOffset"
                     },
@@ -1970,7 +1970,7 @@
                     "Resource Type"
                 ],
                 "summary": "List Cost Models For RBAC",
-                "operationId": "listCostModelsForResourceType",
+                "operationId": "listCostModels",
                 "parameters": [{
                         "$ref": "#/components/parameters/QueryOffset"
                     },


### PR DESCRIPTION
@lcouzens noticed that the API client generated had some redundant naming in the path.