### PR TITLE
fix dashboards, add script to aid in validating them

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,3 +28,12 @@ repos:
   rev: v0.0.3
   hooks:
     - id: check-pipfile-lock
+- repo: local
+  hooks:
+    - id: validate-dashboards
+      name: Validate Grafana Dashboards
+      description: Ensures dashboard files are valid JSON
+      entry: scripts/validate_dashboards.sh
+      language: script
+      pass_filenames: false
+      files: dashboards\/.*\.yaml

--- a/dashboards/grafana-dashboard-insights-hccm-postgresql.configmap.yaml
+++ b/dashboards/grafana-dashboard-insights-hccm-postgresql.configmap.yaml
@@ -917,7 +917,7 @@ data:
             "current": {
               "selected": true,
               "text": "hccm-stage",
-              "value": "hccm-stage",
+              "value": "hccm-stage"
             },
             "datasource": "$Datasource",
             "definition": "label_values(kubernetes_namespace)",

--- a/dashboards/grafana-dashboard-insights-hccm-presto.configmap.yaml
+++ b/dashboards/grafana-dashboard-insights-hccm-presto.configmap.yaml
@@ -1239,7 +1239,7 @@ data:
             "current": {
               "selected": true,
               "text": "hccm-stage",
-              "value": "hccm-stage",
+              "value": "hccm-stage"
             },
             "datasource": "$Datasource",
             "definition": "label_values(kubernetes_namespace)",

--- a/dashboards/grafana-dashboard-insights-hccm-redis.configmap.yaml
+++ b/dashboards/grafana-dashboard-insights-hccm-redis.configmap.yaml
@@ -1253,7 +1253,7 @@ data:
             "current": {
               "selected": true,
               "text": "hccm-stage",
-              "value": "hccm-stage",
+              "value": "hccm-stage"
             },
             "datasource": "$Datasource",
             "definition": "label_values(redis_up, instance)",

--- a/dashboards/grafana-dashboard-insights-hccm.configmap.yaml
+++ b/dashboards/grafana-dashboard-insights-hccm.configmap.yaml
@@ -3234,7 +3234,7 @@ data:
             "query": "cost-management-stage, cost-management-prod",
             "skipUrlSync": false,
             "type": "custom"
-          }
+          },
           {
             "current": {
               "selected": true,

--- a/scripts/validate_dashboards.sh
+++ b/scripts/validate_dashboards.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Copyright 2020 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+trap handle_errors ERR
+
+function handle_errors() {
+    echo "Validation failed."
+    exit 1
+}
+
+SCRIPT_DIR="$( pushd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+DASHBOARD_DIR="$SCRIPT_DIR/../dashboards"
+
+OC=$(which oc)
+JQ=$(which jq)
+
+for dashboard in $(ls -1 $DASHBOARD_DIR/*.yaml); do
+    echo "Checking $dashboard"
+    $OC extract -f $dashboard --to=- | $JQ '.' > /dev/null
+done
+
+echo "Success. All files valid."


### PR DESCRIPTION
This fixes a few syntax issues in our dashboard JSON. 

I've also added a simple validation script to automate validating future changes. This script has been added to the pre-commit validations.

Parse failure:
```
./scripts/validate_dashboards.sh 
Checking /home/blentz/git/koku/scripts/../dashboards/grafana-dashboard-insights-hccm.configmap.yaml
# hccm.json
parse error: Expected separator between values at line 3235, column 7
Validation failed.
```

Required command is not in $PATH:
```
./scripts/validate_dashboards.sh 
which: no jq in (/home/blentz/.virtualenvs/koku/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/home/blentz/bin:/home/blentz/.go:/home/blentz/.go/bin:/home/blentz/bin:/home/blentz/.go:/home/blentz/.go/bin)
Validation failed.
```
Success:
```
./scripts/validate_dashboards.sh 
Checking /home/blentz/git/koku/scripts/../dashboards/grafana-dashboard-insights-hccm.configmap.yaml
# hccm.json
Checking /home/blentz/git/koku/scripts/../dashboards/grafana-dashboard-insights-hccm-postgresql.configmap.yaml
# hccm-postgresql.json
Checking /home/blentz/git/koku/scripts/../dashboards/grafana-dashboard-insights-hccm-presto.configmap.yaml
# hccm-presto.json
Checking /home/blentz/git/koku/scripts/../dashboards/grafana-dashboard-insights-hccm-redis.configmap.yaml
# hccm-redis.json
Success. All files valid.
```

Pre-commit failed:
```
$ git ci -m 'test'
Reorder python imports......................................(no files to check)Skipped
pyupgrade...................................................(no files to check)Skipped
black.......................................................(no files to check)Skipped
Trim Trailing Whitespace........................................................Passed
Fix End of Files................................................................Passed
Debug Statements (Python)...................................(no files to check)Skipped
Flake8......................................................(no files to check)Skipped
Check pipenv's Pipfile.lock to be consistent with Pipfile...(no files to check)Skipped
Validate Grafana Dashboards.....................................................Failed
- hook id: validate-dashboards
- exit code: 1

Checking /home/blentz/git/koku/scripts/../dashboards/grafana-dashboard-insights-hccm.configmap.yaml
# hccm.json
parse error: Expected separator between values at line 15, column 12
Validation failed.
```

Pre-commit success:
```
$ git ci -m 'test'
Reorder python imports......................................(no files to check)Skipped
pyupgrade...................................................(no files to check)Skipped
black.......................................................(no files to check)Skipped
Trim Trailing Whitespace........................................................Passed
Fix End of Files................................................................Passed
Debug Statements (Python)...................................(no files to check)Skipped
Flake8......................................................(no files to check)Skipped
Check pipenv's Pipfile.lock to be consistent with Pipfile...(no files to check)Skipped
Validate Grafana Dashboards.....................................................Passed
[grafana_dashboards 6ec615d7] test
 1 file changed, 1 insertion(+), 1 deletion(-)
```