### PR TITLE
Cost 440 ocp summary presto small tweaks

### DIFF
--- a/koku/masu/database/ocp_report_db_accessor.py
+++ b/koku/masu/database/ocp_report_db_accessor.py
@@ -525,7 +525,7 @@ class OCPReportDBAccessor(ReportDBAccessorBase):
         self._execute_raw_sql_query(table_name, summary_sql, start_date, end_date, list(summary_sql_params))
 
     def populate_line_item_daily_summary_table_presto(
-        self, start_date, end_date, report_period_id, cluster_id, cluster_alias, markup_value
+        self, start_date, end_date, report_period_id, cluster_id, cluster_alias
     ):
         """Populate the daily aggregate of line items table.
 
@@ -558,7 +558,6 @@ class OCPReportDBAccessor(ReportDBAccessorBase):
             "cluster_id": cluster_id,
             "cluster_alias": cluster_alias,
             "schema": self.schema,
-            "markup": markup_value or 0,
         }
         summary_sql, summary_sql_params = self.jinja_sql.prepare_query(summary_sql, summary_sql_params)
         self._execute_raw_sql_query(
@@ -566,7 +565,7 @@ class OCPReportDBAccessor(ReportDBAccessorBase):
         )
 
     def populate_storage_line_item_daily_summary_table_presto(
-        self, start_date, end_date, report_period_id, cluster_id, cluster_alias, markup_value
+        self, start_date, end_date, report_period_id, cluster_id, cluster_alias
     ):
         """Populate the daily aggregate of storage line items table.
 
@@ -597,7 +596,6 @@ class OCPReportDBAccessor(ReportDBAccessorBase):
             "cluster_id": cluster_id,
             "cluster_alias": cluster_alias,
             "schema": self.schema,
-            "markup": markup_value or 0,
         }
         summary_sql, summary_sql_params = self.jinja_sql.prepare_query(summary_sql, summary_sql_params)
         self._execute_raw_sql_query(table_name, summary_sql, start_date, end_date, list(summary_sql_params))

--- a/koku/masu/processor/ocp/ocp_report_parquet_summary_updater.py
+++ b/koku/masu/processor/ocp/ocp_report_parquet_summary_updater.py
@@ -18,13 +18,12 @@
 import calendar
 import logging
 
+import ciso8601
 from tenant_schemas.utils import schema_context
 
-from masu.database.cost_model_db_accessor import CostModelDBAccessor
 from masu.database.ocp_report_db_accessor import OCPReportDBAccessor
-from masu.database.report_manifest_db_accessor import ReportManifestDBAccessor
 from masu.external.date_accessor import DateAccessor
-from masu.util.common import date_range_pair
+from masu.util.common import determine_if_full_summary_update_needed
 from masu.util.ocp.common import get_cluster_alias_from_cluster_id
 from masu.util.ocp.common import get_cluster_id_from_provider
 
@@ -47,6 +46,33 @@ class OCPReportParquetSummaryUpdater:
         self._cluster_id = get_cluster_id_from_provider(self._provider.uuid)
         self._cluster_alias = get_cluster_alias_from_cluster_id(self._cluster_id)
         self._date_accessor = DateAccessor()
+
+    def _get_sql_inputs(self, start_date, end_date):
+        """Get the required inputs for running summary SQL."""
+        with OCPReportDBAccessor(self._schema) as accessor:
+            # This is the normal processing route
+            if self._manifest:
+                # Override the bill date to correspond with the manifest
+                bill_date = self._manifest.billing_period_start_datetime.date()
+                report_periods = accessor.get_usage_period_query_by_provider(self._provider.uuid)
+                report_periods = report_periods.filter(report_period_start=bill_date).all()
+                first_period = report_periods.first()
+                do_month_update = False
+                with schema_context(self._schema):
+                    if first_period:
+                        do_month_update = determine_if_full_summary_update_needed(first_period)
+                if do_month_update:
+                    last_day_of_month = calendar.monthrange(bill_date.year, bill_date.month)[1]
+                    start_date = bill_date
+                    end_date = bill_date.replace(day=last_day_of_month)
+                    LOG.info("Overriding start and end date to process full month.")
+
+        if isinstance(start_date, str):
+            start_date = ciso8601.parse_datetime(start_date).date()
+        if isinstance(end_date, str):
+            end_date = ciso8601.parse_datetime(end_date).date()
+
+        return start_date, end_date
 
     def update_daily_tables(self, start_date, end_date):
         """Populate the daily tables for reporting.
@@ -77,50 +103,47 @@ class OCPReportParquetSummaryUpdater:
         """
         start_date, end_date = self._get_sql_inputs(start_date, end_date)
 
-        with CostModelDBAccessor(self._schema, self._provider.uuid) as cost_model_accessor:
-            markup = cost_model_accessor.markup
-            markup_value = float(markup.get("value", 0)) / 100
-
         report_periods = None
         with OCPReportDBAccessor(self._schema) as accessor:
-            report_periods = accessor.report_periods_for_provider_uuid(self._provider.uuid, start_date)
             with schema_context(self._schema):
-                report_period_ids = [report_period.id for report_period in report_periods]
-                report_date_map = {
-                    (report_period.report_period_start, report_period.report_period_end): report_period.id
-                    for report_period in report_periods
-                }
-            for start, end in date_range_pair(start_date, end_date):
-                LOG.info(
-                    "Updating OpenShift report summary tables for \n\tSchema: %s "
-                    "\n\tProvider: %s \n\tCluster: %s \n\tDates: %s - %s",
-                    self._schema,
-                    self._provider.uuid,
-                    self._cluster_id,
-                    start,
-                    end,
-                )
+                report_periods = accessor.report_periods_for_provider_uuid(self._provider.uuid, start_date)
+                current_report_period_id = report_periods.first().id if report_periods else None
+                # report_period_ids = [report_period.id for report_period in report_periods]
+                # report_date_map = {
+                #     (report_period.report_period_start, report_period.report_period_end): report_period.id
+                #     for report_period in report_periods
+                # }
+            # for start, end in date_range_pair(start_date, end_date):
+            LOG.info(
+                "Updating OpenShift report summary tables for \n\tSchema: %s "
+                "\n\tProvider: %s \n\tCluster: %s \n\tDates: %s - %s",
+                self._schema,
+                self._provider.uuid,
+                self._cluster_id,
+                start_date,
+                end_date,
+            )
 
-                # Find the associated report_period_id for the date range
-                #
-                report_period_id = None
-                for report_date_range, rp_id in report_date_map.items():
-                    rps, rpe = report_date_range
-                    if (rps <= end) and (rpe >= start):
-                        report_period_id = rp_id
-                if report_period_id is None:
-                    msg = f"Cannot determine report_period_id from date range {start} - {end}"
-                    LOG.error(msg)
-                    raise ValueError(msg)
+            # Find the associated report_period_id for the date range
+            #
+            # report_period_id = None
+            # for report_date_range, rp_id in report_date_map.items():
+            #     rps, rpe = report_date_range
+            #     if (rps <= end) and (rpe >= start):
+            #         report_period_id = rp_id
+            # if report_period_id is None:
+            #     msg = f"Cannot determine report_period_id from date range {start} - {end}"
+            #     LOG.error(msg)
+            #     raise ValueError(msg)
 
-                accessor.populate_line_item_daily_summary_table_presto(
-                    start, end, report_period_id, self._cluster_id, self._cluster_alias, markup_value
-                )
-                accessor.populate_storage_line_item_daily_summary_table_presto(
-                    start, end, report_period_id, self._cluster_id, self._cluster_alias, markup_value
-                )
-            accessor.populate_pod_label_summary_table_presto(report_period_ids)
-            accessor.populate_volume_label_summary_table_presto(report_period_ids)
+            accessor.populate_line_item_daily_summary_table_presto(
+                start_date, end_date, current_report_period_id, self._cluster_id, self._cluster_alias
+            )
+            accessor.populate_storage_line_item_daily_summary_table_presto(
+                start_date, end_date, current_report_period_id, self._cluster_id, self._cluster_alias
+            )
+            accessor.populate_pod_label_summary_table_presto(current_report_period_id)
+            accessor.populate_volume_label_summary_table_presto(current_report_period_id)
 
             for period in report_periods:
                 if period.summary_data_creation_datetime is None:
@@ -129,40 +152,3 @@ class OCPReportParquetSummaryUpdater:
                 period.save()
 
         return start_date, end_date
-
-    def _get_sql_inputs(self, start_date, end_date):
-        """Get the required inputs for running summary SQL."""
-        # Default to this month's bill
-        with OCPReportDBAccessor(self._schema) as accessor:
-            if self._manifest:
-                # Override the bill date to correspond with the manifest
-                bill_date = self._manifest.billing_period_start_datetime.date()
-                report_periods = accessor.get_usage_period_query_by_provider(self._provider.uuid)
-                report_periods = report_periods.filter(report_period_start=bill_date).all()
-                do_month_update = True
-                with schema_context(self._schema):
-                    if report_periods is not None and len(report_periods) > 0:
-                        do_month_update = self._determine_if_full_summary_update_needed(report_periods[0])
-                if do_month_update:
-                    last_day_of_month = calendar.monthrange(bill_date.year, bill_date.month)[1]
-                    start_date = bill_date.strftime("%Y-%m-%d")
-                    end_date = bill_date.replace(day=last_day_of_month)
-                    end_date = end_date.strftime("%Y-%m-%d")
-                    LOG.info("Overriding start and end date to process full month.")
-                LOG.info("Returning start: %s, end: %s", str(start_date), str(end_date))
-        return start_date, end_date
-
-    def _determine_if_full_summary_update_needed(self, report_period):
-        """Decide whether to update summary tables for full billing period."""
-        summary_creation = report_period.summary_data_creation_datetime
-        is_done_processing = False
-        with ReportManifestDBAccessor() as manifest_accesor:
-            is_done_processing = manifest_accesor.manifest_ready_for_summary(self._manifest.id)
-        is_new_period = summary_creation is None
-
-        # Run the full month if this is the first time we've seen this report
-        # period
-        if is_done_processing and is_new_period:
-            return True
-
-        return False

--- a/koku/masu/processor/report_summary_updater.py
+++ b/koku/masu/processor/report_summary_updater.py
@@ -29,7 +29,7 @@ from masu.processor.aws.aws_report_parquet_summary_updater import AWSReportParqu
 from masu.processor.aws.aws_report_summary_updater import AWSReportSummaryUpdater
 from masu.processor.azure.azure_report_summary_updater import AzureReportSummaryUpdater
 from masu.processor.ocp.ocp_cloud_summary_updater import OCPCloudReportSummaryUpdater
-from masu.processor.ocp.ocp_report_summary_updater import OCPReportParquetSummaryUpdater
+from masu.processor.ocp.ocp_report_parquet_summary_updater import OCPReportParquetSummaryUpdater
 from masu.processor.ocp.ocp_report_summary_updater import OCPReportSummaryUpdater
 
 LOG = logging.getLogger(__name__)
@@ -89,19 +89,8 @@ class ReportSummaryUpdater:
 
         """
         if self._provider.type in (Provider.PROVIDER_AWS, Provider.PROVIDER_AWS_LOCAL):
-            if settings.ENABLE_PARQUET_PROCESSING:
-                return (
-                    AWSReportParquetSummaryUpdater(self._schema, self._provider, self._manifest),
-                    OCPCloudReportSummaryUpdater(self._schema, self._provider, self._manifest),
-                )
-            return (
-                AWSReportSummaryUpdater(self._schema, self._provider, self._manifest),
-                OCPCloudReportSummaryUpdater(self._schema, self._provider, self._manifest),
-            )
-        if self._provider.type in (Provider.PROVIDER_AZURE, Provider.PROVIDER_AZURE_LOCAL):
-            return (
-                AzureReportSummaryUpdater(self._schema, self._provider, self._manifest),
-                OCPCloudReportSummaryUpdater(self._schema, self._provider, self._manifest),
+            report_summary_updater = (
+                AWSReportParquetSummaryUpdater if settings.ENABLE_PARQUET_PROCESSING else AWSReportSummaryUpdater
             )
         elif self._provider.type in (Provider.PROVIDER_AZURE, Provider.PROVIDER_AZURE_LOCAL):
             report_summary_updater = AzureReportSummaryUpdater

--- a/koku/masu/util/common.py
+++ b/koku/masu/util/common.py
@@ -31,6 +31,7 @@ from dateutil.rrule import DAILY
 from dateutil.rrule import rrule
 
 from api.models import Provider
+from api.utils import DateHelper
 from masu.config import Config
 from masu.external import LISTEN_INGEST
 from masu.external import POLL_INGEST
@@ -323,3 +324,25 @@ def get_hive_table_path(account, provider_type, report_type=None):
     if report_type:
         table_path += f"/{report_type}"
     return table_path
+
+
+def determine_if_full_summary_update_needed(bill):
+    """Decide whether to update summary tables for full billing period."""
+    now_utc = DateHelper().now_utc
+    is_new_bill = bill.summary_data_creation_datetime is None
+    is_current_month = False
+    if hasattr(bill, "billing_period_start"):
+        is_current_month = (
+            bill.billing_period_start.year == now_utc.year and bill.billing_period_start.month == now_utc.month
+        )
+    elif hasattr(bill, "report_period_start"):
+        is_current_month = (
+            bill.report_period_start.year == now_utc.year and bill.report_period_start.month == now_utc.month
+        )
+
+    # Do a full month update if this is the first time we've seen the current month's data
+    # or if it is from a previous month
+    if is_new_bill or not is_current_month:
+        return True
+
+    return False


### PR DESCRIPTION
## Summary
- Fix import error
- Remove markup for OCP. Markup is specific to cloud sources.
- Align _get_sql_inputs with AWS/Azure with specific Presto logic. 
- An unfortunate hack on update_summary_tables to not run in 3 day chunks. I think it was useful in Postgres, but Presto does the work of distributing work out so we don't realize the same gain here. Also, I think we can cleanup the logic end to end, but I don't think we ever want to allow multiple bills to be run at the same time, it will always be the 1 bill for a billing period for a source, so once we have everything implemented, I think we should come back and clean up the references to multiple bills in the update_summary_tables methods. 