### PR TITLE
COST-663: Data from original parent in group_by of moved org unit.

### DIFF
--- a/koku/api/report/aws/query_handler.py
+++ b/koku/api/report/aws/query_handler.py
@@ -275,7 +275,7 @@ class AWSReportQueryHandler(ReportQueryHandler):
         # Next we want to loop through each sub_org and execute the query for it
         if org_unit_applied:
             for sub_org_name, value in sub_orgs_dict.items():
-                sub_org_id, _ = value
+                sub_org_id, sub_org_path = value
                 if self.parameters.get_filter("org_unit_id"):
                     self.parameters.parameters["filter"].pop("org_unit_id")
                 if self.parameters.get_filter("org_unit_single_level"):
@@ -288,7 +288,10 @@ class AWSReportQueryHandler(ReportQueryHandler):
                 if self.access:
                     org_access = self.access.get("aws.organizational_unit", {}).get("read", [])
                 if org_access is None or (sub_org_id in org_access or "*" in org_access):
-                    self.parameters.set_filter(org_unit_id=[sub_org_id])
+                    # We need need to use the sub org path here because if we use the org unit id
+                    # it will grab partial data from other orgs if the org unit is moved during
+                    # the report period.
+                    self.parameters.set_filter(org_unit_id=[sub_org_path])
                 self.query_filter = self._get_filter()
                 sub_query_data, sub_query_sum = self.execute_individual_query(org_unit_applied)
                 query_sum = self.total_sum(sub_query_sum, query_sum)


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/COST-663

This fix resolves an issue where the filter & group_by totals were not matching. The problem was that the group_by was not being detailed enough in its substring matching resulting in partial data from the original parent showing up in the group by for the new parent. 

You can recreate the issue by going to master and running `make load-test-customer-data` and then hitting the following endpoints:
- http://127.0.0.1:8000/api/cost-management/v1/reports/aws/costs/?group_by[org_unit_id]=OU_002
- http://127.0.0.1:8000/api/cost-management/v1/reports/aws/costs/?filter[org_unit_id]=OU_002

To test you can do the same steps to reproduce but on this branch. 

And here is a query I used to confirm that OU_005 should in fact not show up under OU_002:

```
SELECT * FROM acct10001.reporting_awscostentrylineitem_daily_summary
INNER JOIN acct10001.reporting_awsorganizationalunit
ON acct10001.reporting_awscostentrylineitem_daily_summary.organizational_unit_id = acct10001.reporting_awsorganizationalunit.id
WHERE usage_start >= '2020-10-19'
AND usage_end <= '2020-10-28'
```

-------

# Smoke Tests
Command: `iqe tests plugin --debug cost_management -k test_api_aws_org_units_group_by_match_filtered_total -m cost_smoke`

Results:
```
====== 14 passed, 5759 deselected in 48.49s ======
```