### PR TITLE
Cost 702 api enhanced metrics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,3 +43,4 @@ PROMETHEUS_PUSHGATEWAY="pushgateway:9091"
 AUTO_DATA_INGEST=True
 DEVELOPMENT_IDENTITY='{"identity": {"account_number": "10001", "type": "User", "user": {"username": "user_dev", "email": "user_dev@foo.com", "is_org_admin": "True", "access": {}}},"entitlements": {"cost_management": {"is_entitled": "True"}}}'
 CACHED_VIEWS_DISABLED=False
+ACCOUNT_ENHANCED_METRICS=False

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -71,6 +71,7 @@ jobs:
           DATABASE_PASSWORD: postgres
           POSTGRES_SQL_SERVICE_HOST: localhost
           POSTGRES_SQL_SERVICE_PORT: ${{ job.services.postgres.ports[5432] }}
+          ACCOUNT_ENHANCED_METRICS: True
           prometheus_multiproc_dir: /tmp
 
       - name: Convert coverage report to XML

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,7 @@ services:
         - API_PATH_PREFIX=${API_PATH_PREFIX-/api/cost-management}
         - GOOGLE_APPLICATION_CREDENTIALS=${GOOGLE_APPLICATION_CREDENTIALS}
         - DEMO_ACCOUNTS=${DEMO_ACCOUNTS-{}}
+        - ACCOUNT_ENHANCED_METRICS=${ACCOUNT_ENHANCED_METRICS-False}
       privileged: true
       ports:
           - 8000:8000
@@ -90,6 +91,7 @@ services:
         - MASU_SECRET_KEY=abc
         - prometheus_multiproc_dir=/tmp
         - API_PATH_PREFIX=${API_PATH_PREFIX-/api/cost-management}
+        - ACCOUNT_ENHANCED_METRICS=${ACCOUNT_ENHANCED_METRICS-False}
       privileged: true
       ports:
           - 5000:8000

--- a/koku/koku/middleware.py
+++ b/koku/koku/middleware.py
@@ -380,7 +380,7 @@ class DisableCSRF(MiddlewareMixin):
 class AccountEnhancedMetrics(Metrics):
     def register_metric(self, metric_cls, name, documentation, labelnames=(), **kwargs):
         if name in EXTENDED_METRICS:
-            labelnames += ("account",)
+            labelnames.extend(("account",))
         return super().register_metric(metric_cls, name, documentation, labelnames=labelnames, **kwargs)
 
 

--- a/koku/koku/middleware.py
+++ b/koku/koku/middleware.py
@@ -33,6 +33,9 @@ from django.db.utils import OperationalError
 from django.http import HttpResponse
 from django.http import JsonResponse
 from django.utils.deprecation import MiddlewareMixin
+from django_prometheus.middleware import Metrics
+from django_prometheus.middleware import PrometheusAfterMiddleware
+from django_prometheus.middleware import PrometheusBeforeMiddleware
 from prometheus_client import Counter
 from rest_framework.exceptions import ValidationError
 from tenant_schemas.middleware import BaseTenantMiddleware
@@ -59,6 +62,12 @@ MASU = settings.MASU
 SOURCES = settings.SOURCES
 UNIQUE_ACCOUNT_COUNTER = Counter("hccm_unique_account", "Unique Account Counter")
 UNIQUE_USER_COUNTER = Counter("hccm_unique_user", "Unique User Counter", ["account", "user"])
+
+EXTENDED_METRICS = [
+    "django_http_requests_latency_seconds_by_view_method",
+    "django_http_responses_total_by_status_view_method",
+    "django_http_requests_total_by_view_transport_method",
+]
 
 
 def is_no_auth(request):
@@ -366,3 +375,32 @@ class DisableCSRF(MiddlewareMixin):
             request (object): The request object
         """
         setattr(request, "_dont_enforce_csrf_checks", True)
+
+
+class AccountEnhancedMetrics(Metrics):
+    def register_metric(self, metric_cls, name, documentation, labelnames=(), **kwargs):
+        if name in EXTENDED_METRICS:
+            labelnames += ("account",)
+        return super().register_metric(metric_cls, name, documentation, labelnames=labelnames, **kwargs)
+
+
+class AccountEnhancedMetricsBeforeMiddleware(PrometheusBeforeMiddleware):
+    metrics_cls = AccountEnhancedMetrics
+
+
+class AccountEnhancedMetricsAfterMiddleware(PrometheusAfterMiddleware):
+    metrics_cls = AccountEnhancedMetrics
+
+    def label_metric(self, metric, request, response=None, **labels):
+        new_labels = labels
+        if metric._name in EXTENDED_METRICS:
+            account = "unknown"
+            identity_header = request.user.identity_header.get("decoded", {})
+            if identity_header:
+                try:
+                    account = identity_header.get("identity", {}).get("account_number", "unknown")
+                except ValueError:
+                    pass
+            new_labels = {"account": account}
+            new_labels.update(labels)
+        return super().label_metric(metric, request, response=response, **new_labels)

--- a/koku/koku/middleware.py
+++ b/koku/koku/middleware.py
@@ -381,6 +381,7 @@ class AccountEnhancedMetrics(Metrics):
     """A metric with an account label."""
 
     def register_metric(self, metric_cls, name, documentation, labelnames=(), **kwargs):
+        """Override the metric registration to include an account label."""
         if name in EXTENDED_METRICS:
             labelnames.extend(("account",))
         return super().register_metric(metric_cls, name, documentation, labelnames=labelnames, **kwargs)
@@ -398,6 +399,7 @@ class AccountEnhancedMetricsAfterMiddleware(PrometheusAfterMiddleware):
     metrics_cls = AccountEnhancedMetrics
 
     def label_metric(self, metric, request, response=None, **labels):
+        """Add an account label to a prometheus metric."""
         new_labels = labels
         if metric._name in EXTENDED_METRICS:
             account = "unknown"

--- a/koku/koku/middleware.py
+++ b/koku/koku/middleware.py
@@ -378,6 +378,8 @@ class DisableCSRF(MiddlewareMixin):
 
 
 class AccountEnhancedMetrics(Metrics):
+    """A metric with an account label."""
+
     def register_metric(self, metric_cls, name, documentation, labelnames=(), **kwargs):
         if name in EXTENDED_METRICS:
             labelnames.extend(("account",))
@@ -385,10 +387,14 @@ class AccountEnhancedMetrics(Metrics):
 
 
 class AccountEnhancedMetricsBeforeMiddleware(PrometheusBeforeMiddleware):
+    """Set the metric class for account enhanced in before middlemware."""
+
     metrics_cls = AccountEnhancedMetrics
 
 
 class AccountEnhancedMetricsAfterMiddleware(PrometheusAfterMiddleware):
+    """Add specific account label to metrics on API calls."""
+
     metrics_cls = AccountEnhancedMetrics
 
     def label_metric(self, metric, request, response=None, **labels):

--- a/koku/koku/middleware.py
+++ b/koku/koku/middleware.py
@@ -395,10 +395,10 @@ class AccountEnhancedMetricsAfterMiddleware(PrometheusAfterMiddleware):
         new_labels = labels
         if metric._name in EXTENDED_METRICS:
             account = "unknown"
-            identity_header = request.user.identity_header.get("decoded", {})
+            identity_header = request.user.identity_header
             if identity_header:
                 try:
-                    account = identity_header.get("identity", {}).get("account_number", "unknown")
+                    account = identity_header.get("decoded", {}).get("identity", {}).get("account_number", "unknown")
                 except ValueError:
                     pass
             new_labels = {"account": account}

--- a/koku/koku/settings.py
+++ b/koku/koku/settings.py
@@ -108,9 +108,18 @@ TENANT_APPS = ("reporting", "cost_models")
 
 DEFAULT_FILE_STORAGE = "tenant_schemas.storage.TenantFileSystemStorage"
 
+ACCOUNT_ENHANCED_METRICS = ENVIRONMENT.bool("ACCOUNT_ENHANCED_METRICS", default=False)
+
+PROMETHEUS_BEFORE_MIDDLEWARE = "django_prometheus.middleware.PrometheusBeforeMiddleware"
+PROMETHEUS_AFTER_MIDDLEWARE = "django_prometheus.middleware.PrometheusAfterMiddleware"
+
+if ACCOUNT_ENHANCED_METRICS:
+    PROMETHEUS_BEFORE_MIDDLEWARE = "koku.middleware.AccountEnhancedMetricsBeforeMiddleware"
+    PROMETHEUS_AFTER_MIDDLEWARE = "koku.middleware.AccountEnhancedMetricsAfterMiddleware"
+
 ### Middleware setup
 MIDDLEWARE = [
-    "django_prometheus.middleware.PrometheusBeforeMiddleware",
+    PROMETHEUS_BEFORE_MIDDLEWARE,
     "corsheaders.middleware.CorsMiddleware",
     "koku.middleware.DisableCSRF",
     "django.middleware.security.SecurityMiddleware",
@@ -122,7 +131,7 @@ MIDDLEWARE.extend(
         "koku.middleware.KokuTenantMiddleware",
         "django.middleware.clickjacking.XFrameOptionsMiddleware",
         "whitenoise.middleware.WhiteNoiseMiddleware",
-        "django_prometheus.middleware.PrometheusAfterMiddleware",
+        PROMETHEUS_AFTER_MIDDLEWARE,
     ]
 )
 

--- a/testing/compose_files/docker-compose-multilistener.yml
+++ b/testing/compose_files/docker-compose-multilistener.yml
@@ -43,6 +43,7 @@ services:
         - API_PATH_PREFIX=${API_PATH_PREFIX-/api/cost-management}
         - GOOGLE_APPLICATION_CREDENTIALS=${GOOGLE_APPLICATION_CREDENTIALS}
         - DEMO_ACCOUNTS=${DEMO_ACCOUNTS-{}}
+        - ACCOUNT_ENHANCED_METRICS=${ACCOUNT_ENHANCED_METRICS-False}
       privileged: true
       ports:
           - 8000:8000
@@ -90,6 +91,7 @@ services:
         - MASU_SECRET_KEY=abc
         - prometheus_multiproc_dir=/tmp
         - API_PATH_PREFIX=${API_PATH_PREFIX-/api/cost-management}
+        - ACCOUNT_ENHANCED_METRICS=${ACCOUNT_ENHANCED_METRICS-False}
       privileged: true
       ports:
           - 5000:8000

--- a/testing/compose_files/docker-compose-multiworker-make.yml
+++ b/testing/compose_files/docker-compose-multiworker-make.yml
@@ -43,6 +43,7 @@ services:
         - API_PATH_PREFIX=${API_PATH_PREFIX-/api/cost-management}
         - GOOGLE_APPLICATION_CREDENTIALS=${GOOGLE_APPLICATION_CREDENTIALS}
         - DEMO_ACCOUNTS=${DEMO_ACCOUNTS-{}}
+        - ACCOUNT_ENHANCED_METRICS=${ACCOUNT_ENHANCED_METRICS-False}
       privileged: true
       ports:
           - 8000:8000
@@ -90,6 +91,7 @@ services:
         - MASU_SECRET_KEY=abc
         - prometheus_multiproc_dir=/tmp
         - API_PATH_PREFIX=${API_PATH_PREFIX-/api/cost-management}
+        - ACCOUNT_ENHANCED_METRICS=${ACCOUNT_ENHANCED_METRICS-False}
       privileged: true
       ports:
           - 5000:8000

--- a/testing/compose_files/docker-compose-multiworker.yml
+++ b/testing/compose_files/docker-compose-multiworker.yml
@@ -43,6 +43,7 @@ services:
         - API_PATH_PREFIX=${API_PATH_PREFIX-/api/cost-management}
         - GOOGLE_APPLICATION_CREDENTIALS=${GOOGLE_APPLICATION_CREDENTIALS}
         - DEMO_ACCOUNTS=${DEMO_ACCOUNTS-{}}
+        - ACCOUNT_ENHANCED_METRICS=${ACCOUNT_ENHANCED_METRICS-False}
       privileged: true
       ports:
           - 8000:8000
@@ -90,6 +91,7 @@ services:
         - MASU_SECRET_KEY=abc
         - prometheus_multiproc_dir=/tmp
         - API_PATH_PREFIX=${API_PATH_PREFIX-/api/cost-management}
+        - ACCOUNT_ENHANCED_METRICS=${ACCOUNT_ENHANCED_METRICS-False}
       privileged: true
       ports:
           - 5000:8000

--- a/testing/compose_files/docker-compose-multiworkerlistener.yml
+++ b/testing/compose_files/docker-compose-multiworkerlistener.yml
@@ -43,6 +43,7 @@ services:
         - API_PATH_PREFIX=${API_PATH_PREFIX-/api/cost-management}
         - GOOGLE_APPLICATION_CREDENTIALS=${GOOGLE_APPLICATION_CREDENTIALS}
         - DEMO_ACCOUNTS=${DEMO_ACCOUNTS-{}}
+        - ACCOUNT_ENHANCED_METRICS=${ACCOUNT_ENHANCED_METRICS-False}
       privileged: true
       ports:
           - 8000:8000

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,7 @@ setenv =
   DATABASE_ADMIN={env:DATABASE_ADMIN:postgres}
   DATABASE_USER=koku_tester
   DATABASE_PASSWORD={env:DATABASE_PASSWORD:''}
+  ACCOUNT_ENHANCED_METRICS={env:ACCOUNT_ENHANCED_METRICS:True}
   prometheus_multiproc_dir=/tmp
 deps =
   pipenv


### PR DESCRIPTION
## Summary
This will add the account ID to a set of Django Prometheus API metrics. We would then be able to filter/group request latency, response status codes, and requests by view per account. 

## Testing

1. Added `ACCOUNT_ENHANCED_METRICS=True` environment variable.
2. Set pdb in `AccountEnhancedMetricsAfterMiddleware`

```
(Pdb) new_labels
{'account': '10001', 'view': 'sources-list', 'transport': 'http', 'method': 'GET'}
(Pdb) metric._name
'django_http_requests_total_by_view_transport_method'
```