### PR TITLE
Allow list in rbac attribute filter value

### DIFF
--- a/koku/koku/rbac.py
+++ b/koku/koku/rbac.py
@@ -66,7 +66,9 @@ def _extract_resource_definitions(resource_definitions):
         if operation == "equal" and value:
             result.append(value)
         if operation == "in" and value:
-            result += value.split(",")
+            if isinstance(value, str):
+                value = value.split(",")
+            result.extend(value)
     return result
 
 

--- a/koku/koku/tests_rbac.py
+++ b/koku/koku/tests_rbac.py
@@ -233,6 +233,34 @@ class RbacServiceTest(TestCase):
         print(access)
         self.assertEqual(access, expected)
 
+    def test_process_acls_attributeFilter_value_list(self):
+        """Test that we correctly handle a list of values."""
+        acls = [
+            {"permission": "cost-management:cost_model:read", "resourceDefinitions": []},
+            {
+                "permission": "cost-management:cost_model:write",
+                "resourceDefinitions": [
+                    {
+                        "attributeFilter": {
+                            "key": "cost-management.cost_model",
+                            "operation": "in",
+                            "value": ["1", "3", "5"],
+                        }
+                    }
+                ],
+            },
+        ]
+        access = _process_acls(acls)
+        expected = {
+            "cost_model": [
+                {"operation": "read", "resources": ["*"]},
+                {"operation": "write", "resources": ["1", "3", "5"]},
+            ]
+        }
+        print()
+        print(access)
+        self.assertEqual(access, expected)
+
     def test_process_acls_rate_to_cost_model_substitution(self):
         """Test function of _process_acls with a bad permission format."""
         acls = [

--- a/koku/koku/tests_rbac.py
+++ b/koku/koku/tests_rbac.py
@@ -229,8 +229,6 @@ class RbacServiceTest(TestCase):
                 {"operation": "write", "resources": ["8"]},
             ]
         }
-        print()
-        print(access)
         self.assertEqual(access, expected)
 
     def test_process_acls_attributeFilter_value_list(self):
@@ -257,8 +255,6 @@ class RbacServiceTest(TestCase):
                 {"operation": "write", "resources": ["1", "3", "5"]},
             ]
         }
-        print()
-        print(access)
         self.assertEqual(access, expected)
 
     def test_process_acls_rate_to_cost_model_substitution(self):
@@ -286,8 +282,6 @@ class RbacServiceTest(TestCase):
                 {"operation": "write", "resources": ["8"]},
             ]
         }
-        print()
-        print(access)
         self.assertEqual(access, expected)
 
     def test_get_operation_invalid_res_type(self):


### PR DESCRIPTION
## Summary
The new custom resource work in RBAC has changed a comma separated string to a list of values. We were not handling this and this should allow either string or list. 

## Testing
Currently just the unit test which mirrors what is returned by the RBAC API, but real testing will require RBAC up. Will test immediately in CI. 