### PR TITLE
COST-623: checking filter source type settings when updating

### DIFF
--- a/koku/api/settings/tag_management.py
+++ b/koku/api/settings/tag_management.py
@@ -186,7 +186,7 @@ class TagManagementSettings:
         updated = [False] * len(obtainTagKeysProvidersParams)
         for ix, providerName in enumerate(obtainTagKeysProvidersParams):
             provider_in_settings = settings.get(providerName)
-            if not provider_in_settings:
+            if provider_in_settings is None:
                 continue
             enabled_tags = provider_in_settings.get("enabled", [])
             remove_tags = []

--- a/koku/api/settings/tag_management.py
+++ b/koku/api/settings/tag_management.py
@@ -185,7 +185,10 @@ class TagManagementSettings:
         """
         updated = [False] * len(obtainTagKeysProvidersParams)
         for ix, providerName in enumerate(obtainTagKeysProvidersParams):
-            enabled_tags = settings.get(providerName, {}).get("enabled", [])
+            provider_in_settings = settings.get(providerName)
+            if not provider_in_settings:
+                continue
+            enabled_tags = provider_in_settings.get("enabled", [])
             remove_tags = []
             tag_view = obtainTagKeysProvidersParams[providerName]["tag_view"]
             query_handler = obtainTagKeysProvidersParams[providerName]["query_handler"]

--- a/koku/api/settings/test/tests_views.py
+++ b/koku/api/settings/test/tests_views.py
@@ -115,6 +115,38 @@ class SettingsViewTest(IamTestCase):
         enabled = duallist.get("initialValue")
         self.assertIn(tag, enabled)
 
+        # Verify that disabling tags for a different source type does not clear openshift tags.
+        body = {"api": {"settings": {"tag-management": {"aws": {"enabled": []}}}}}
+        response = self.post_settings(body)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        response = self.get_settings()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        duallist = self.get_duallist_from_response(response)
+        enabled = duallist.get("initialValue")
+        self.assertIn(tag, enabled)
+
+        body = {"api": {"settings": {"tag-management": {"openshift": {"enabled": []}}}}}
+        response = self.post_settings(body)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        response = self.get_settings()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        duallist = self.get_duallist_from_response(response)
+        enabled = duallist.get("initialValue")
+        self.assertEqual([], enabled)
+
+        # DDF will give an empty dictionary when disabling all
+        body = {"api": {"settings": {"tag-management": {"openshift": {}}}}}
+        response = self.post_settings(body)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        response = self.get_settings()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        duallist = self.get_duallist_from_response(response)
+        enabled = duallist.get("initialValue")
+        self.assertEqual([], enabled)
+
     def test_post_settings_ocp_tag_enabled_invalid_tag(self):
         """Test setting OCP tags as enabled with invalid tag key."""
         tag = "Invalid_tag_key_test"


### PR DESCRIPTION
Updating settings API to ensure that only source types listed in POST data are updated.

**Testing**
1.  Enable tags for OCP and AWS
2. Clear AWS enabled tags and verify OCP remains

**Test Results**
[settings_source_type_ut.txt](https://github.com/project-koku/koku/files/5496546/settings_source_type_ut.txt)
