### PR TITLE
Fixing namespace report processing skip

### DIFF
--- a/koku/masu/processor/_tasks/process.py
+++ b/koku/masu/processor/_tasks/process.py
@@ -83,6 +83,8 @@ def _process_report_file(schema_name, provider, report_dict):
             stats_recorder.clear_last_started_datetime()
         raise processing_error
     except NotImplementedError as err:
+        with ReportStatsDBAccessor(file_name, manifest_id) as stats_recorder:
+            stats_recorder.log_last_completed_datetime()
         raise err
 
     with ReportStatsDBAccessor(file_name, manifest_id) as stats_recorder:

--- a/koku/masu/processor/tasks.py
+++ b/koku/masu/processor/tasks.py
@@ -176,6 +176,13 @@ def get_report_files(
             WorkerCache().remove_task_from_cache(cache_key)
             return None
 
+        report_meta = {
+            "schema_name": schema_name,
+            "provider_type": provider_type,
+            "provider_uuid": provider_uuid,
+            "manifest_id": report_dict.get("manifest_id"),
+        }
+
         try:
             stmt = (
                 f"Processing starting:\n"
@@ -191,13 +198,6 @@ def get_report_files(
             report_dict["provider_type"] = provider_type
 
             _process_report_file(schema_name, provider_type, report_dict)
-
-            report_meta = {
-                "schema_name": schema_name,
-                "provider_type": provider_type,
-                "provider_uuid": provider_uuid,
-                "manifest_id": report_dict.get("manifest_id"),
-            }
 
         except (ReportProcessorError, ReportProcessorDBError) as processing_error:
             worker_stats.PROCESS_REPORT_ERROR_COUNTER.labels(provider_type=provider_type).inc()

--- a/koku/masu/test/processor/test_tasks.py
+++ b/koku/masu/test/processor/test_tasks.py
@@ -315,7 +315,7 @@ class ProcessReportFileTests(MasuTestCase):
             _process_report_file(schema_name, provider, report_dict)
 
         mock_stats_acc.log_last_started_datetime.assert_called()
-        mock_stats_acc.log_last_completed_datetime.assert_not_called()
+        mock_stats_acc.log_last_completed_datetime.assert_called()
         shutil.rmtree(report_dir)
 
     @patch("masu.processor._tasks.process.ReportProcessor")


### PR DESCRIPTION
While testing OCP-local changes with the new nise namespace report (https://github.com/project-koku/nise/pull/303) I was hitting some processing failures.