### PR TITLE
COST-684: Catching AttributeError in autovacuum_tune_schema

### DIFF
--- a/koku/masu/processor/tasks.py
+++ b/koku/masu/processor/tasks.py
@@ -570,7 +570,7 @@ SELECT s.relname as "table_name",
                 table_name, n_live_tup, table_options = table
                 try:
                     table_scale_option = Decimal(table_options.get("autovacuum_vacuum_scale_factor", no_scale))
-                except InvalidOperation:
+                except (InvalidOperation, AttributeError):
                     table_scale_option = no_scale
 
                 for threshold, scale in scale_table:

--- a/koku/masu/processor/tasks.py
+++ b/koku/masu/processor/tasks.py
@@ -515,7 +515,7 @@ def autovacuum_tune_schema(schema_name):  # noqa: C901
     table_sql = """
 SELECT s.relname as "table_name",
        s.n_live_tup,
-       coalesce(table_options.options, '{}'::jsonb) as "options"
+       coalesce(table_options.options, '{}'::jsonb)::jsonb as "options"
   FROM pg_stat_user_tables s
   LEFT
   JOIN (

--- a/koku/masu/processor/tasks.py
+++ b/koku/masu/processor/tasks.py
@@ -499,6 +499,15 @@ def vacuum_schema(schema_name):
                 LOG.info(cursor.statusmessage)
 
 
+def normalize_table_options(table_options):
+    """Normalize autovaccume_tune_schema table_options to dict type."""
+    if not table_options:
+        table_options = {}
+    elif isinstance(table_options, str):
+        table_options = json.loads(table_options)
+    return table_options
+
+
 # The autovacuum settings should be tuned over time to account for a table's records
 # growing or shrinking. Based on the number of live tuples recorded from the latest
 # statistics run, the autovacuum_vacuum_scale_factor will be adjusted up or down.
@@ -568,10 +577,7 @@ SELECT s.relname as "table_name",
             for table in tables:
                 scale_factor = zero
                 table_name, n_live_tup, table_options = table
-                if not table_options:
-                    table_options = {}
-                elif isinstance(table_options, str):
-                    table_options = json.loads(table_options)
+                table_options = normalize_table_options(table_options)
                 try:
                     table_scale_option = Decimal(table_options.get("autovacuum_vacuum_scale_factor", no_scale))
                 except InvalidOperation:

--- a/koku/masu/processor/tasks.py
+++ b/koku/masu/processor/tasks.py
@@ -558,6 +558,7 @@ SELECT s.relname as "table_name",
         scale_table = [[int(e[0]), Decimal(str(e[1]))] for e in autovacuum_settings]
 
     scale_table.sort(key=lambda e: e[0], reverse=True)
+    info_msg = "autovacuum_tune_schema({}) : table: {}; n_live_tup: {}; table_options: {}"
 
     # Execute the scale based on table analyzsis
     with schema_context(schema_name):
@@ -568,6 +569,9 @@ SELECT s.relname as "table_name",
             for table in tables:
                 scale_factor = zero
                 table_name, n_live_tup, table_options = table
+                LOG.info(info_msg.format(schema_name, table_name, n_live_tup, table_options))
+                if not isinstance(table_options, dict):
+                    LOG.warning(f"table_options type = {type(table_options)}")
                 try:
                     table_scale_option = Decimal(table_options.get("autovacuum_vacuum_scale_factor", no_scale))
                 except (InvalidOperation, AttributeError):


### PR DESCRIPTION
Reproducing this locally I was seeing that `table_options={}`

```
koku_worker       | [2020-11-10 21:55:03,282: INFO/ForkPoolWorker-1] [masu.processor.tasks.autovacuum_tune_schema(2054a747-2d9c-49e6-8104-b398b191d4b0 via 2054a747-2d9c-49e6-8104-b398b191d4b0)] table: ('reporting_awscostentrylineitem', 12287, '{}')
koku_worker       | [2020-11-10 21:55:03,282: INFO/ForkPoolWorker-1] [masu.processor.tasks.autovacuum_tune_schema(2054a747-2d9c-49e6-8104-b398b191d4b0 via 2054a747-2d9c-49e6-8104-b398b191d4b0)] table_name: reporting_awscostentrylineitem, n_live_tup: 12287, table_options: {}
koku_worker       | [2020-11-10 21:55:03,294] ERROR 2054a747-2d9c-49e6-8104-b398b191d4b0 Task failed: 'str' object has no attribute 'get'
koku_worker       | Traceback (most recent call last):
koku_worker       |   File "/opt/app-root/lib64/python3.8/site-packages/celery/app/trace.py", line 412, in trace_task
koku_worker       |     R = retval = fun(*args, **kwargs)
koku_worker       |   File "/opt/app-root/lib64/python3.8/site-packages/celery/app/trace.py", line 704, in __protected_call__
koku_worker       |     return self.run(*args, **kwargs)
koku_worker       |   File "/koku/koku/masu/processor/tasks.py", line 574, in autovacuum_tune_schema
koku_worker       |     table_scale_option = Decimal(table_options.get("autovacuum_vacuum_scale_factor", no_scale))
koku_worker       | AttributeError: 'str' object has no attribute 'get'
koku_worker       | [2020-11-10 21:55:03,294: ERROR/ForkPoolWorker-1] Task failed: 'str' object has no attribute 'get'
koku_worker       | Traceback (most recent call last):
koku_worker       |   File "/opt/app-root/lib64/python3.8/site-packages/celery/app/trace.py", line 412, in trace_task
koku_worker       |     R = retval = fun(*args, **kwargs)
koku_worker       |   File "/opt/app-root/lib64/python3.8/site-packages/celery/app/trace.py", line 704, in __protected_call__
koku_worker       |     return self.run(*args, **kwargs)
koku_worker       |   File "/koku/koku/masu/processor/tasks.py", line 574, in autovacuum_tune_schema
koku_worker       |     table_scale_option = Decimal(table_options.get("autovacuum_vacuum_scale_factor", no_scale))
koku_worker       | AttributeError: 'str' object has no attribute 'get'
```


**Testing**
```
➜  koku2 git:(auto_tune_fix) ✗ docker exec -it koku_server bash
(app-root) bash-4.2# python koku/manage.py shell
Loading : /koku/.env
The .env file has been loaded.
[2020-11-10 22:03:38,241] INFO None Database configured.
[2020-11-10 22:03:38,245] INFO None Celery autodiscover tasks.
Python 3.8.0 (default, May 28 2020, 09:35:11) 
[GCC 9.3.1 20200408 (Red Hat 9.3.1-2)] on linux
Type "help", "copyright", "credits" or "license" for more information.
(InteractiveConsole)
>>> from masu.processor.tasks import autovacuum_tune_schema
>>> autovacuum_tune_schema.delay('acct10001')
<AsyncResult: 4e89b342-3150-4ef9-8b7f-5d6eeec8d9b3>
>>> 
```

```
koku_worker       | [2020-11-10 22:03:51,198: INFO/ForkPoolWorker-1] [masu.processor.tasks.autovacuum_tune_schema(4e89b342-3150-4ef9-8b7f-5d6eeec8d9b3 via 4e89b342-3150-4ef9-8b7f-5d6eeec8d9b3)] Altered autovacuum_vacuum_scale_factor on 0 tables


```