### PR TITLE
COST-623: Fix the settings API to include empty enabled list

### DIFF
--- a/koku/api/settings/tag_management.py
+++ b/koku/api/settings/tag_management.py
@@ -150,6 +150,7 @@ class TagManagementSettings:
                 "filterValueText": "Remove your filter to see all enabled tag keys",
                 "filterOptionsText": "Remove your filter to see all available tag keys",
                 "initialValue": enabled,
+                "clearedValue": [],
             }
             dual_list_name = f"{self._get_tag_management_prefix(providerName)}.enabled"
             dual_list_title = obtainTagKeysProvidersParams[providerName]["title"]


### PR DESCRIPTION
closes COST 623.

By adding `clearedValue` it will set empty enabled list to `[ ]` rather than remove it from the object sent to the API.