### PR TITLE
implement forecasting for OCP-on-All, OCP-on-AWS, OCP-on-Azure

### DIFF
--- a/koku/forecast/test/tests_forecast.py
+++ b/koku/forecast/test/tests_forecast.py
@@ -25,6 +25,9 @@ from django.utils import timezone
 
 from api.forecast.views import AWSCostForecastView
 from api.forecast.views import AzureCostForecastView
+from api.forecast.views import OCPAllCostForecastView
+from api.forecast.views import OCPAWSCostForecastView
+from api.forecast.views import OCPAzureCostForecastView
 from api.forecast.views import OCPCostForecastView
 from api.iam.test.iam_test_case import IamTestCase
 from api.query_filter import QueryFilter
@@ -33,6 +36,9 @@ from api.report.test.tests_queries import assertSameQ
 from api.utils import DateHelper
 from forecast import AWSForecast
 from forecast import AzureForecast
+from forecast import OCPAllForecast
+from forecast import OCPAWSForecast
+from forecast import OCPAzureForecast
 from forecast import OCPForecast
 
 LOG = logging.getLogger(__name__)
@@ -352,6 +358,105 @@ class OCPForecastTest(IamTestCase):
 
         params = self.mocked_query_params("?", OCPCostForecastView)
         instance = OCPForecast(params)
+
+        instance.cost_summary_table = mocked_table
+
+        results = instance.predict()
+
+        for item in results:
+            self.assertRegex(item.get("date"), r"\d{4}-\d{2}-\d{2}")
+            self.assertAlmostEqual(float(item.get("value")), 5, delta=0.0001)
+            self.assertAlmostEqual(float(item.get("confidence_max")), 5, delta=0.0001)
+            self.assertAlmostEqual(float(item.get("confidence_min")), 5, delta=0.0001)
+            self.assertAlmostEqual(float(item.get("rsquared")), 1, delta=0.0001)
+            self.assertGreaterEqual(float(item.get("pvalues")), 0)
+
+
+class OCPAllForecastTest(IamTestCase):
+    """Tests the OCPAllForecast class."""
+
+    def test_predict_flat(self):
+        """Test that predict() returns expected values for flat costs."""
+        dh = DateHelper()
+
+        expected = []
+        for n in range(0, 10):
+            expected.append({"usage_start": dh.n_days_ago(dh.yesterday, 10 - n).date(), "total_cost": 5})
+
+        mocked_table = Mock()
+        mocked_table.objects.filter.return_value.order_by.return_value.values.return_value.annotate.return_value = (  # noqa: E501
+            expected
+        )
+        mocked_table.len = len(expected)
+
+        params = self.mocked_query_params("?", OCPAllCostForecastView)
+        instance = OCPAllForecast(params)
+
+        instance.cost_summary_table = mocked_table
+
+        results = instance.predict()
+
+        for item in results:
+            self.assertRegex(item.get("date"), r"\d{4}-\d{2}-\d{2}")
+            self.assertAlmostEqual(float(item.get("value")), 5, delta=0.0001)
+            self.assertAlmostEqual(float(item.get("confidence_max")), 5, delta=0.0001)
+            self.assertAlmostEqual(float(item.get("confidence_min")), 5, delta=0.0001)
+            self.assertAlmostEqual(float(item.get("rsquared")), 1, delta=0.0001)
+            self.assertGreaterEqual(float(item.get("pvalues")), 0)
+
+
+class OCPAWSForecastTest(IamTestCase):
+    """Tests the OCPAWSForecast class."""
+
+    def test_predict_flat(self):
+        """Test that predict() returns expected values for flat costs."""
+        dh = DateHelper()
+
+        expected = []
+        for n in range(0, 10):
+            expected.append({"usage_start": dh.n_days_ago(dh.yesterday, 10 - n).date(), "total_cost": 5})
+
+        mocked_table = Mock()
+        mocked_table.objects.filter.return_value.order_by.return_value.values.return_value.annotate.return_value = (  # noqa: E501
+            expected
+        )
+        mocked_table.len = len(expected)
+
+        params = self.mocked_query_params("?", OCPAWSCostForecastView)
+        instance = OCPAWSForecast(params)
+
+        instance.cost_summary_table = mocked_table
+
+        results = instance.predict()
+
+        for item in results:
+            self.assertRegex(item.get("date"), r"\d{4}-\d{2}-\d{2}")
+            self.assertAlmostEqual(float(item.get("value")), 5, delta=0.0001)
+            self.assertAlmostEqual(float(item.get("confidence_max")), 5, delta=0.0001)
+            self.assertAlmostEqual(float(item.get("confidence_min")), 5, delta=0.0001)
+            self.assertAlmostEqual(float(item.get("rsquared")), 1, delta=0.0001)
+            self.assertGreaterEqual(float(item.get("pvalues")), 0)
+
+
+class OCPAzureForecastTest(IamTestCase):
+    """Tests the OCPAzureForecast class."""
+
+    def test_predict_flat(self):
+        """Test that predict() returns expected values for flat costs."""
+        dh = DateHelper()
+
+        expected = []
+        for n in range(0, 10):
+            expected.append({"usage_start": dh.n_days_ago(dh.yesterday, 10 - n).date(), "total_cost": 5})
+
+        mocked_table = Mock()
+        mocked_table.objects.filter.return_value.order_by.return_value.values.return_value.annotate.return_value = (  # noqa: E501
+            expected
+        )
+        mocked_table.len = len(expected)
+
+        params = self.mocked_query_params("?", OCPAzureCostForecastView)
+        instance = OCPAzureForecast(params)
 
         instance.cost_summary_table = mocked_table
 


### PR DESCRIPTION
This finishes off the initial implementation of forecasting. This adds the OCP-on-* endpoints.

OCP-on-ALL:
```
GET http://localhost:8000/api/cost-management/v1/forecasts/openshift/infrastructures/all/costs/?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly

{
    "meta": {
        "count": 13
    },
    "links": {
        "first": "/api/cost-management/v1/forecasts/openshift/infrastructures/all/costs/?filter%5Bresolution%5D=monthly&filter%5Btime_scope_units%5D=month&filter%5Btime_scope_value%5D=-1&limit=10&offset=0",
        "next": "/api/cost-management/v1/forecasts/openshift/infrastructures/all/costs/?filter%5Bresolution%5D=monthly&filter%5Btime_scope_units%5D=month&filter%5Btime_scope_value%5D=-1&limit=10&offset=10",
        "previous": null,
        "last": "/api/cost-management/v1/forecasts/openshift/infrastructures/all/costs/?filter%5Bresolution%5D=monthly&filter%5Btime_scope_units%5D=month&filter%5Btime_scope_value%5D=-1&limit=10&offset=3"
    },
    "data": [
        {
            "date": "2020-11-18",
            "value": 56.253,
            "confidence_max": 65.019,
            "confidence_min": 47.486,
            "rsquared": "0.99521954",
            "pvalues": "0.00000000"
        },
        {
            "date": "2020-11-19",
            "value": 56.253,
            "confidence_max": 65.019,
            "confidence_min": 47.486,
            "rsquared": "0.99521954",
            "pvalues": "0.00000000"
        },
        {
            "date": "2020-11-20",
            "value": 56.253,
            "confidence_max": 65.019,
            "confidence_min": 47.486,
            "rsquared": "0.99521954",
            "pvalues": "0.00000000"
        },
        {
            "date": "2020-11-21",
            "value": 56.253,
            "confidence_max": 65.019,
            "confidence_min": 47.486,
            "rsquared": "0.99521954",
            "pvalues": "0.00000000"
        },
        {
            "date": "2020-11-22",
            "value": 56.253,
            "confidence_max": 65.019,
            "confidence_min": 47.486,
            "rsquared": "0.99521954",
            "pvalues": "0.00000000"
        },
        {
            "date": "2020-11-23",
            "value": 56.253,
            "confidence_max": 65.019,
            "confidence_min": 47.486,
            "rsquared": "0.99521954",
            "pvalues": "0.00000000"
        },
        {
            "date": "2020-11-24",
            "value": 56.253,
            "confidence_max": 65.019,
            "confidence_min": 47.486,
            "rsquared": "0.99521954",
            "pvalues": "0.00000000"
        },
        {
            "date": "2020-11-25",
            "value": 56.253,
            "confidence_max": 65.019,
            "confidence_min": 47.486,
            "rsquared": "0.99521954",
            "pvalues": "0.00000000"
        },
        {
            "date": "2020-11-26",
            "value": 56.253,
            "confidence_max": 65.019,
            "confidence_min": 47.486,
            "rsquared": "0.99521954",
            "pvalues": "0.00000000"
        },
        {
            "date": "2020-11-27",
            "value": 56.253,
            "confidence_max": 65.019,
            "confidence_min": 47.486,
            "rsquared": "0.99521954",
            "pvalues": "0.00000000"
        }
    ]
}
```

OCP-on-AWS:
```
GET http://localhost:8000/api/cost-management/v1/forecasts/openshift/infrastructures/aws/costs/?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly

{
    "meta": {
        "count": 13
    },
    "links": {
        "first": "/api/cost-management/v1/forecasts/openshift/infrastructures/aws/costs/?filter%5Bresolution%5D=monthly&filter%5Btime_scope_units%5D=month&filter%5Btime_scope_value%5D=-1&limit=10&offset=0",
        "next": "/api/cost-management/v1/forecasts/openshift/infrastructures/aws/costs/?filter%5Bresolution%5D=monthly&filter%5Btime_scope_units%5D=month&filter%5Btime_scope_value%5D=-1&limit=10&offset=10",
        "previous": null,
        "last": "/api/cost-management/v1/forecasts/openshift/infrastructures/aws/costs/?filter%5Bresolution%5D=monthly&filter%5Btime_scope_units%5D=month&filter%5Btime_scope_value%5D=-1&limit=10&offset=3"
    },
    "data": [
        {
            "date": "2020-11-18",
            "value": 54.797,
            "confidence_max": 62.569,
            "confidence_min": 47.025,
            "rsquared": "0.99603690",
            "pvalues": "0.00000000"
        },
        {
            "date": "2020-11-19",
            "value": 54.797,
            "confidence_max": 62.569,
            "confidence_min": 47.025,
            "rsquared": "0.99603690",
            "pvalues": "0.00000000"
        },
        {
            "date": "2020-11-20",
            "value": 54.797,
            "confidence_max": 62.569,
            "confidence_min": 47.025,
            "rsquared": "0.99603690",
            "pvalues": "0.00000000"
        },
        {
            "date": "2020-11-21",
            "value": 54.797,
            "confidence_max": 62.569,
            "confidence_min": 47.025,
            "rsquared": "0.99603690",
            "pvalues": "0.00000000"
        },
        {
            "date": "2020-11-22",
            "value": 54.797,
            "confidence_max": 62.569,
            "confidence_min": 47.025,
            "rsquared": "0.99603690",
            "pvalues": "0.00000000"
        },
        {
            "date": "2020-11-23",
            "value": 54.797,
            "confidence_max": 62.569,
            "confidence_min": 47.025,
            "rsquared": "0.99603690",
            "pvalues": "0.00000000"
        },
        {
            "date": "2020-11-24",
            "value": 54.797,
            "confidence_max": 62.569,
            "confidence_min": 47.025,
            "rsquared": "0.99603690",
            "pvalues": "0.00000000"
        },
        {
            "date": "2020-11-25",
            "value": 54.797,
            "confidence_max": 62.569,
            "confidence_min": 47.025,
            "rsquared": "0.99603690",
            "pvalues": "0.00000000"
        },
        {
            "date": "2020-11-26",
            "value": 54.797,
            "confidence_max": 62.569,
            "confidence_min": 47.025,
            "rsquared": "0.99603690",
            "pvalues": "0.00000000"
        },
        {
            "date": "2020-11-27",
            "value": 54.797,
            "confidence_max": 62.569,
            "confidence_min": 47.025,
            "rsquared": "0.99603690",
            "pvalues": "0.00000000"
        }
    ]
}
```

OCP-on-Azure:
```
GET http://localhost:8000/api/cost-management/v1/forecasts/openshift/infrastructures/azure/costs/?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly

{
    "meta": {
        "count": 13
    },
    "links": {
        "first": "/api/cost-management/v1/forecasts/openshift/infrastructures/azure/costs/?filter%5Bresolution%5D=monthly&filter%5Btime_scope_units%5D=month&filter%5Btime_scope_value%5D=-1&limit=10&offset=0",
        "next": "/api/cost-management/v1/forecasts/openshift/infrastructures/azure/costs/?filter%5Bresolution%5D=monthly&filter%5Btime_scope_units%5D=month&filter%5Btime_scope_value%5D=-1&limit=10&offset=10",
        "previous": null,
        "last": "/api/cost-management/v1/forecasts/openshift/infrastructures/azure/costs/?filter%5Bresolution%5D=monthly&filter%5Btime_scope_units%5D=month&filter%5Btime_scope_value%5D=-1&limit=10&offset=3"
    },
    "data": [
        {
            "date": "2020-11-14",
            "value": 1.904,
            "confidence_max": 2.697,
            "confidence_min": 1.11,
            "rsquared": "0.96961032",
            "pvalues": "0.00000000"
        },
        {
            "date": "2020-11-15",
            "value": 1.904,
            "confidence_max": 2.697,
            "confidence_min": 1.11,
            "rsquared": "0.96961032",
            "pvalues": "0.00000000"
        },
        {
            "date": "2020-11-16",
            "value": 1.904,
            "confidence_max": 2.697,
            "confidence_min": 1.11,
            "rsquared": "0.96961032",
            "pvalues": "0.00000000"
        },
        {
            "date": "2020-11-17",
            "value": 1.904,
            "confidence_max": 2.697,
            "confidence_min": 1.11,
            "rsquared": "0.96961032",
            "pvalues": "0.00000000"
        },
        {
            "date": "2020-11-18",
            "value": 1.904,
            "confidence_max": 2.697,
            "confidence_min": 1.11,
            "rsquared": "0.96961032",
            "pvalues": "0.00000000"
        },
        {
            "date": "2020-11-19",
            "value": 1.904,
            "confidence_max": 2.697,
            "confidence_min": 1.11,
            "rsquared": "0.96961032",
            "pvalues": "0.00000000"
        },
        {
            "date": "2020-11-20",
            "value": 1.904,
            "confidence_max": 2.697,
            "confidence_min": 1.11,
            "rsquared": "0.96961032",
            "pvalues": "0.00000000"
        },
        {
            "date": "2020-11-21",
            "value": 1.904,
            "confidence_max": 2.697,
            "confidence_min": 1.11,
            "rsquared": "0.96961032",
            "pvalues": "0.00000000"
        },
        {
            "date": "2020-11-22",
            "value": 1.904,
            "confidence_max": 2.697,
            "confidence_min": 1.11,
            "rsquared": "0.96961032",
            "pvalues": "0.00000000"
        },
        {
            "date": "2020-11-23",
            "value": 1.904,
            "confidence_max": 2.697,
            "confidence_min": 1.11,
            "rsquared": "0.96961032",
            "pvalues": "0.00000000"
        }
    ]
}