### PR TITLE
[COST-742] TagRates storage metrics now look at volume labels

### DIFF
--- a/koku/masu/database/ocp_report_db_accessor.py
+++ b/koku/masu/database/ocp_report_db_accessor.py
@@ -1553,6 +1553,10 @@ class OCPReportDBAccessor(ReportDBAccessorBase):
             for metric in rate:
                 tags = rate.get(metric, {})
                 usage_type = metric_usage_type_map.get(metric)
+                if usage_type == "storage":
+                    labels_field = "volume_labels"
+                else:
+                    labels_field = "pod_labels"
                 table_name = OCP_REPORT_TABLE_MAP["line_item_daily_summary"]
                 for tag_key in tags:
                     tag_vals = tags.get(tag_key, {})
@@ -1571,6 +1575,7 @@ class OCPReportDBAccessor(ReportDBAccessorBase):
                             "usage_type": usage_type,
                             "metric": metric,
                             "k_v_pair": key_value_pair,
+                            "labels_field": labels_field,
                         }
                         tag_rates_sql, tag_rates_sql_params = self.jinja_sql.prepare_query(
                             tag_rates_sql, tag_rates_sql_params
@@ -1628,6 +1633,10 @@ class OCPReportDBAccessor(ReportDBAccessorBase):
             for metric in rate:
                 tags = rate.get(metric, {})
                 usage_type = metric_usage_type_map.get(metric)
+                if usage_type == "storage":
+                    labels_field = "volume_labels"
+                else:
+                    labels_field = "pod_labels"
                 table_name = OCP_REPORT_TABLE_MAP["line_item_daily_summary"]
                 for tag_key in tags:
                     key_value_pair = []
@@ -1651,6 +1660,7 @@ class OCPReportDBAccessor(ReportDBAccessorBase):
                         "metric": metric,
                         "tag_key": tag_key,
                         "k_v_pair": key_value_pair,
+                        "labels_field": labels_field,
                     }
                     tag_rates_sql, tag_rates_sql_params = self.jinja_sql.prepare_query(
                         tag_rates_sql, tag_rates_sql_params

--- a/koku/masu/database/sql/default_infrastructure_tag_rates.sql
+++ b/koku/masu/database/sql/default_infrastructure_tag_rates.sql
@@ -24,9 +24,9 @@ FROM (
         WHERE lids.cluster_id = {{cluster_id}}
             AND lids.usage_start >= {{start_date}}
             AND lids.usage_start <= {{end_date}}
-            AND lids.pod_labels ? {{tag_key}}
+            AND lids.{{labels_field | sqlsafe}} ? {{tag_key}}
             {% for pair in k_v_pair %}
-            AND NOT lids.pod_labels @> {{pair}}
+            AND NOT lids.{{labels_field | sqlsafe}} @> {{pair}}
             {% endfor %}
     ) AS sub
     GROUP BY sub.uuid

--- a/koku/masu/database/sql/default_supplementary_tag_rates.sql
+++ b/koku/masu/database/sql/default_supplementary_tag_rates.sql
@@ -24,9 +24,9 @@ FROM (
         WHERE lids.cluster_id = {{cluster_id}}
             AND lids.usage_start >= {{start_date}}
             AND lids.usage_start <= {{end_date}}
-            AND lids.pod_labels ? {{tag_key}}
+            AND lids.{{labels_field | sqlsafe}} ? {{tag_key}}
             {% for pair in k_v_pair %}
-            AND NOT lids.pod_labels @> {{pair}}
+            AND NOT lids.{{labels_field | sqlsafe}} @> {{pair}}
             {% endfor %}
     ) AS sub
     GROUP BY sub.uuid

--- a/koku/masu/database/sql/infrastructure_tag_rates.sql
+++ b/koku/masu/database/sql/infrastructure_tag_rates.sql
@@ -21,7 +21,7 @@ FROM (
             END as usage
         FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary AS lids,
             jsonb_each_text(lids.infrastructure_usage_cost) infrastructure_usage_cost
-        WHERE lids.pod_labels @> {{k_v_pair}}
+        WHERE lids.{{labels_field | sqlsafe}} @> {{k_v_pair}}
             AND lids.cluster_id = {{cluster_id}}
             AND lids.usage_start >= {{start_date}}
             AND lids.usage_start <= {{end_date}}

--- a/koku/masu/database/sql/supplementary_tag_rates.sql
+++ b/koku/masu/database/sql/supplementary_tag_rates.sql
@@ -21,7 +21,7 @@ FROM (
             END as usage
         FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary AS lids,
             jsonb_each_text(lids.supplementary_usage_cost) supplementary_usage_cost
-        WHERE lids.pod_labels @> {{k_v_pair}}
+        WHERE lids.{{labels_field | sqlsafe}} @> {{k_v_pair}}
             AND lids.cluster_id = {{cluster_id}}
             AND lids.usage_start >= {{start_date}}
             AND lids.usage_start <= {{end_date}}


### PR DESCRIPTION
The storage metrics should be looking at volume labels instead of pod labels, this is a fix for that. To test, load up some data and add a cost-model with one of the storage metrics and see the costs show up related to the storage metrics.

Example rates for a cost model (tags will need to change to fit the data you use):
```
"rates": [
    {
      "metric": {
        "name": "storage_gb_usage_per_month",
        "label_metric": "Storage",
        "label_measurement": "Usage",
        "label_measurement_unit": "GB-month"
      },
      "description": "",
      "tag_rates": {
        "tag_key": "volume",
        "tag_values": [
          {
            "unit": "USD",
            "usage": {
              "unit": "USD",
              "usage_end": null,
              "usage_start": null
            },
            "value": 1,
            "default": true,
            "tag_value": "king",
            "description": ""
          },
          {
            "unit": "USD",
            "usage": {
              "unit": "USD",
              "usage_end": null,
              "usage_start": null
            },
            "value": 2,
            "default": false,
            "tag_value": "escanor",
            "description": ""
          },
          {
            "unit": "USD",
            "usage": {
              "unit": "USD",
              "usage_end": null,
              "usage_start": null
            },
            "value": 3,
            "default": false,
            "tag_value": "merlin",
            "description": ""
          }
        ]
      },
      "cost_type": "Supplementary"
    }
  ]