### PR TITLE
adjust logging level of insufficient data message.

### DIFF
--- a/koku/forecast/forecast.py
+++ b/koku/forecast/forecast.py
@@ -141,7 +141,7 @@ class Forecast(ABC):
         LOG.debug("Forecast input data: %s", data)
 
         if len(data) < 2:
-            LOG.error("Unable to calculate forecast. Insufficient Data.")
+            LOG.warning("Unable to calculate forecast. Insufficient data for %s.", self.params.tenant)
             return []
 
         if len(data) < self.MINIMUM:

--- a/koku/forecast/test/tests_forecast.py
+++ b/koku/forecast/test/tests_forecast.py
@@ -250,7 +250,7 @@ class AWSForecastTest(IamTestCase):
                 instance.cost_summary_table = mocked_table
                 if number == 1:
                     # forecasting isn't possible with only 1 data point.
-                    with self.assertLogs(logger="forecast.forecast", level=logging.ERROR):
+                    with self.assertLogs(logger="forecast.forecast", level=logging.WARNING):
                         results = instance.predict()
                         self.assertEqual(results, [])
                 else:


### PR DESCRIPTION
This adjusts the log level for the "insufficient data to run forecast" message so that Sentry doesn't think it's a critical error.