### PR TITLE
COST-734: Updating GCP permissions to check dataset.

### DIFF
--- a/koku/providers/provider_errors.py
+++ b/koku/providers/provider_errors.py
@@ -43,6 +43,11 @@ class ProviderErrors:
     AZURE_CREDENTAL_UNREACHABLE = "authentication.credentials.unreachable"
     AZURE_CLIENT_ERROR = "azure.exception"
 
+    GCP_PROJECT_DATASET_INCORRECT = "authentication.project_id.notfound"
+    GCP_BIGQUERY_ROLE_MISCONFIGURED = "gcp.bigquery.configuration"
+    GCP_BIGQUERY_DATASET_NOTAUTHORIZED = "gcp.bigquery.notauthorized"
+    GCP_UNKNOWN_ERROR = "gcp.error.unknown"
+
     # MESSAGES
     INVALID_SOURCE_TYPE_MESSAGE = "The given source type is not supported."
 
@@ -107,3 +112,5 @@ class ProviderErrors:
         "Edit your Azure source and verify the subscription ID."
     )
     AZURE_GENERAL_CLIENT_ERROR_MESSAGE = "Azure client configuration error."
+
+    GCP_UNKNOWN_ERROR_MESSAGE = "Google Cloud Platform configuration failed."


### PR DESCRIPTION
Updates to GCP permission checking to look for the BigQuery User dataset permission rather than the project custom role.

- [ ] Unit Tests

**Testing**
1. Attempt to create a GCP source with an invalid project id:
2. Attempt to create a GCP source with an invalid dataset.
3. Misconfigure dataset permissions and verify error message.
4.  Add dataset permissions for wrong service account and verify error message.
5. Add dataset permissions for correct service account but wrong role.

**Test Results**
[gcp_dataset_perms_ut.txt](https://github.com/project-koku/koku/files/5575174/gcp_dataset_perms_ut.txt)
