### PR TITLE
Update forecast to handle last day of the month

### DIFF
--- a/koku/api/forecast/views.py
+++ b/koku/api/forecast/views.py
@@ -18,13 +18,12 @@
 import logging
 
 from django.utils.decorators import method_decorator
-from django.views.decorators.vary import vary_on_headers
+from django.views.decorators.cache import never_cache
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.serializers import ValidationError
 from rest_framework.views import APIView
 
-from api.common import CACHE_RH_IDENTITY_HEADER
 from api.common.pagination import ListPaginator
 from api.common.permissions import AwsAccessPermission
 from api.common.permissions import AzureAccessPermission
@@ -58,7 +57,7 @@ class ForecastView(APIView):
 
     report = "forecast"
 
-    @method_decorator(vary_on_headers(CACHE_RH_IDENTITY_HEADER))
+    @method_decorator(never_cache)
     def get(self, request, **kwargs):
         """Respond to GET requests."""
         LOG.debug(f"API: {request.path} USER: {request.user.username}")

--- a/koku/forecast/forecast.py
+++ b/koku/forecast/forecast.py
@@ -151,7 +151,10 @@ class Forecast(ABC):
 
         last_date = None
         for idx, item in enumerate(results.prediction):
-            prediction_date = dates[-1] + timedelta(days=1 + idx)
+            if not last_date and dates[-1] == self.dh.this_month_end.date():
+                prediction_date = dates[-1]
+            else:
+                prediction_date = dates[-1] + timedelta(days=1 + idx)
             if prediction_date > self.dh.this_month_end.date():
                 break
 


### PR DESCRIPTION
**Testing**
1. Run forecast on the last day of the month and verify that only the current day is returned.

```
GET /api/cost-management/v1/forecasts/azure/costs/?filter[limit]=31&filter[time_scope_value]=-1
HTTP 200 OK
Allow: GET, HEAD, OPTIONS
Content-Type: application/json
Vary: X_RH_IDENTITY, Accept

{
    "meta": {
        "count": 1
    },
    "links": {
        "first": "/api/cost-management/v1/forecasts/azure/costs/?filter%5Blimit%5D=31&filter%5Btime_scope_value%5D=-1&limit=10&offset=0",
        "next": null,
        "previous": null,
        "last": "/api/cost-management/v1/forecasts/azure/costs/?filter%5Blimit%5D=31&filter%5Btime_scope_value%5D=-1&limit=10&offset=0"
    },
    "data": [
        {
            "date": "2020-11-30",
            "values": [
                {
                    "date": "2020-11-30",
                    "infrastructure": {
                        "total": {
                            "value": 0.0,
                            "units": "USD"
                        },
                        "confidence_max": {
                            "value": 0.0,
                            "units": "USD"
                        },
                        "confidence_min": {
                            "value": 0.0,
                            "units": "USD"
                        },
                        "rsquared": {
                            "value": "0.00000000",
                            "units": null
                        },
                        "pvalues": {
                            "value": "0.00000000",
                            "units": null
                        }
                    },
                    "supplementary": {
                        "total": {
                            "value": 0.0,
                            "units": "USD"
                        },
                        "confidence_max": {
                            "value": 0.0,
                            "units": "USD"
                        },
                        "confidence_min": {
                            "value": 0.0,
                            "units": "USD"
                        },
                        "rsquared": {
                            "value": "0.00000000",
                            "units": null
                        },
                        "pvalues": {
                            "value": "0.00000000",
                            "units": null
                        }
                    },
                    "cost": {
                        "total": {
                            "value": 2.168,
                            "units": "USD"
                        },
                        "confidence_max": {
                            "value": 2.787,
                            "units": "USD"
                        },
                        "confidence_min": {
                            "value": 1.548,
                            "units": "USD"
                        },
                        "rsquared": {
                            "value": "0.98207639",
                            "units": null
                        },
                        "pvalues": {
                            "value": "0.00000000",
                            "units": null
                        }
                    }
                }
            ]
        }
    ]
}
```