### PR TITLE
COST-786: Handling celery inspect unavailability in worker cache 

### DIFF
--- a/koku/masu/processor/worker_cache.py
+++ b/koku/masu/processor/worker_cache.py
@@ -74,14 +74,19 @@ class WorkerCache:
     def active_workers(self):
         """Return a list of active workers."""
         running_workers = []
-        for host in CELERY_INSPECT.reserved().keys():
+        celery_inspect_instance = CELERY_INSPECT.reserved()
+        if celery_inspect_instance:
+            hosts = celery_inspect_instance.keys()
+            for host in hosts:
 
-            # Celery returns workers in the form of celery@hostname.
-            hostname_pattern = r"[^@]*$"
-            found = re.search(hostname_pattern, host)
-            if found:
-                hostname = found.group()
-                running_workers.append(hostname)
+                # Celery returns workers in the form of celery@hostname.
+                hostname_pattern = r"[^@]*$"
+                found = re.search(hostname_pattern, host)
+                if found:
+                    hostname = found.group()
+                    running_workers.append(hostname)
+        else:
+            LOG.warning("Unable to get celery inspect instance.")
         return running_workers
 
     @property

--- a/koku/masu/test/processor/test_worker_cache.py
+++ b/koku/masu/test/processor/test_worker_cache.py
@@ -159,7 +159,7 @@ class WorkerCacheTest(MasuTestCase):
                 mock_inspect.reserved.return_value = mock_worker_list
                 _cache = WorkerCache()
                 self.assertEqual(_cache.active_workers, test.get("expected_workers"))
-    
+
     @patch("masu.processor.worker_cache.CELERY_INSPECT")
     def test_active_worker_property_instance_not_available(self, mock_inspect):
         """Test the active_workers property when celery inspect is not available."""

--- a/koku/masu/test/processor/test_worker_cache.py
+++ b/koku/masu/test/processor/test_worker_cache.py
@@ -159,6 +159,13 @@ class WorkerCacheTest(MasuTestCase):
                 mock_inspect.reserved.return_value = mock_worker_list
                 _cache = WorkerCache()
                 self.assertEqual(_cache.active_workers, test.get("expected_workers"))
+    
+    @patch("masu.processor.worker_cache.CELERY_INSPECT")
+    def test_active_worker_property_instance_not_available(self, mock_inspect):
+        """Test the active_workers property when celery inspect is not available."""
+        mock_inspect.reserved.return_value = None
+        _cache = WorkerCache()
+        self.assertEqual(_cache.active_workers, [])
 
     @override_settings(HOSTNAME="kokuworker")
     @patch("masu.processor.worker_cache.CELERY_INSPECT")


### PR DESCRIPTION
If Celery Inspect is unable to determine the active workers it will return `CELERY_INSPECT.reserved()` will return `None`.  This would mean that no offline worker cleanup would occur.  Sentry has shown that this is a rare occurrence.  The offline worker would be attempted to be cleaned up in the next hourly poll of the Orchestrator.

