### PR TITLE
Keep results within the current month

### DIFF
--- a/koku/forecast/forecast.py
+++ b/koku/forecast/forecast.py
@@ -192,6 +192,8 @@ class Forecast:
 
         response = []
         for key in results:
+            if key > self.dh.this_month_end.date():
+                continue
             dikt = {
                 "date": key,
                 "values": [

--- a/koku/forecast/test/tests_forecast.py
+++ b/koku/forecast/test/tests_forecast.py
@@ -298,6 +298,14 @@ class AWSForecastTest(IamTestCase):
                         # test that the results always stop at the end of the month.
                         self.assertEqual(results[-1].get("date"), dh.this_month_end.date())
 
+    def test_results_never_outside_curren_month(self):
+        """Test that our results stop at the end of the current month."""
+        dh = DateHelper()
+        params = self.mocked_query_params("?", AWSCostForecastView)
+        forecast = AWSForecast(params)
+        results = forecast.predict()
+        self.assertNotIn(dh.next_month_start, results)
+
     def test_set_access_filter_with_list(self):
         """
         Tests that when an access restriction, filters, and a filter list are passed in,

--- a/koku/forecast/test/tests_forecast.py
+++ b/koku/forecast/test/tests_forecast.py
@@ -303,8 +303,11 @@ class AWSForecastTest(IamTestCase):
         dh = DateHelper()
         params = self.mocked_query_params("?", AWSCostForecastView)
         forecast = AWSForecast(params)
+        forecast.forecast_days_required = 100
         results = forecast.predict()
-        self.assertNotIn(dh.next_month_start, results)
+        dates = [result.get("date") for result in results]
+        self.assertNotIn(dh.next_month_start, dates)
+        self.assertEqual(dh.this_month_end.date(), max(dates))
 
     def test_set_access_filter_with_list(self):
         """


### PR DESCRIPTION
## Summary
It's possible to have more predictions than there are days left to show in the month. This will just pass on any day that is greater than the last day of the month. 