### PR TITLE
COST-839: Fixed false positive asserts in unit tests.

### DIFF
--- a/koku/api/report/test/azure/tests_azure_query_handler.py
+++ b/koku/api/report/test/azure/tests_azure_query_handler.py
@@ -98,16 +98,18 @@ class AzureReportQueryHandlerTest(IamTestCase):
             qf = QueryFilter(**filt)
             filters.update({qf.composed_query_string(): qf.parameter})
         current_totals = self.get_totals_costs_by_time_scope(aggregates, filters)
+        expected_cost_total = current_totals.get("cost_total")
+        self.assertIsNotNone(expected_cost_total)
         query_output = handler.execute_query()
 
         self.assertIsNotNone(query_output.get("data"))
         self.assertIsNotNone(query_output.get("total"))
         total = query_output.get("total")
-
+        self.assertIsNotNone(total.get("usage", {}).get("value"))
         self.assertEqual(total.get("usage", {}).get("value"), current_totals.get("usage"))
-        self.assertEqual(total.get("request", {}).get("value"), current_totals.get("request"))
-        self.assertEqual(total.get("cost", {}).get("value"), current_totals.get("cost"))
-        self.assertEqual(total.get("limit", {}).get("value"), current_totals.get("limit"))
+        result_cost_total = total.get("cost", {}).get("total", {}).get("value")
+        self.assertIsNotNone(result_cost_total)
+        self.assertEqual(result_cost_total, expected_cost_total)
 
     def test_execute_sum_query_costs(self):
         """Test that the sum query runs properly for the costs endpoint."""
@@ -116,11 +118,14 @@ class AzureReportQueryHandlerTest(IamTestCase):
         handler = AzureReportQueryHandler(query_params)
         aggregates = handler._mapper.report_type_map.get("aggregates")
         current_totals = self.get_totals_costs_by_time_scope(aggregates, self.ten_day_filter)
+        expected_cost_total = current_totals.get("cost_total")
+        self.assertIsNotNone(expected_cost_total)
         query_output = handler.execute_query()
         self.assertIsNotNone(query_output.get("data"))
         self.assertIsNotNone(query_output.get("total"))
-        total = query_output.get("total")
-        self.assertEqual(total.get("cost", {}).get("value"), current_totals.get("cost"))
+        result_cost_total = query_output.get("total").get("cost", {}).get("total", {}).get("value")
+        self.assertIsNotNone(result_cost_total)
+        self.assertEqual(result_cost_total, expected_cost_total)
 
     def test_execute_take_defaults(self):
         """Test execute_query for current month on daily breakdown."""
@@ -144,8 +149,11 @@ class AzureReportQueryHandlerTest(IamTestCase):
         total = query_output.get("total")
         aggregates = handler._mapper.report_type_map.get("aggregates")
         current_totals = self.get_totals_costs_by_time_scope(aggregates, self.this_month_filter)
-        self.assertIsNotNone(total.get("cost"))
-        self.assertEqual(total.get("cost", {}).get("value"), current_totals.get("cost"))
+        expected_cost_total = current_totals.get("cost_total")
+        self.assertIsNotNone(expected_cost_total)
+        result_cost_total = total.get("cost", {}).get("total", {}).get("value")
+        self.assertIsNotNone(result_cost_total)
+        self.assertEqual(result_cost_total, expected_cost_total)
 
     def test_execute_query_current_month_monthly(self):
         """Test execute_query for current month on monthly breakdown."""
@@ -158,8 +166,11 @@ class AzureReportQueryHandlerTest(IamTestCase):
         total = query_output.get("total")
         aggregates = handler._mapper.report_type_map.get("aggregates")
         current_totals = self.get_totals_costs_by_time_scope(aggregates, self.this_month_filter)
-        self.assertIsNotNone(total.get("cost"))
-        self.assertEqual(total.get("cost", {}).get("value"), current_totals.get("cost"))
+        expected_cost_total = current_totals.get("cost_total")
+        self.assertIsNotNone(expected_cost_total)
+        result_cost_total = total.get("cost", {}).get("total", {}).get("value")
+        self.assertIsNotNone(result_cost_total)
+        self.assertEqual(result_cost_total, expected_cost_total)
 
     def test_execute_query_current_month_by_service(self):
         """Test execute_query for current month on monthly breakdown by service."""
@@ -178,8 +189,11 @@ class AzureReportQueryHandlerTest(IamTestCase):
         total = query_output.get("total")
         aggregates = handler._mapper.report_type_map.get("aggregates")
         current_totals = self.get_totals_costs_by_time_scope(aggregates, self.this_month_filter)
-        self.assertIsNotNone(total.get("cost"))
-        self.assertEqual(total.get("cost", {}).get("value"), current_totals.get("cost"))
+        expected_cost_total = current_totals.get("cost_total")
+        self.assertIsNotNone(expected_cost_total)
+        result_cost_total = total.get("cost", {}).get("total", {}).get("value")
+        self.assertIsNotNone(result_cost_total)
+        self.assertEqual(result_cost_total, expected_cost_total)
 
         cmonth_str = self.dh.this_month_start.strftime("%Y-%m")
         for data_item in data:
@@ -215,8 +229,11 @@ class AzureReportQueryHandlerTest(IamTestCase):
                 qf = QueryFilter(**filt)
                 filters.update({qf.composed_query_string(): qf.parameter})
         current_totals = self.get_totals_costs_by_time_scope(aggregates, filters)
-        self.assertIsNotNone(total.get("cost"))
-        self.assertEqual(total.get("cost", {}).get("value"), current_totals.get("cost"))
+        expected_cost_total = current_totals.get("cost_total")
+        self.assertIsNotNone(expected_cost_total)
+        result_cost_total = total.get("cost", {}).get("total", {}).get("value")
+        self.assertIsNotNone(result_cost_total)
+        self.assertEqual(result_cost_total, expected_cost_total)
 
         cmonth_str = self.dh.this_month_start.strftime("%Y-%m")
         for data_item in data:
@@ -252,8 +269,11 @@ class AzureReportQueryHandlerTest(IamTestCase):
                 qf = QueryFilter(**filt)
                 filters.update({qf.composed_query_string(): qf.parameter})
         current_totals = self.get_totals_costs_by_time_scope(aggregates, filters)
-        self.assertIsNotNone(total.get("cost"))
-        self.assertEqual(total.get("cost", {}).get("value"), current_totals.get("cost"))
+        expected_cost_total = current_totals.get("cost_total")
+        self.assertIsNotNone(expected_cost_total)
+        result_cost_total = total.get("cost", {}).get("total", {}).get("value")
+        self.assertIsNotNone(result_cost_total)
+        self.assertEqual(result_cost_total, expected_cost_total)
 
         cmonth_str = self.dh.this_month_start.strftime("%Y-%m")
         for data_item in data:
@@ -278,8 +298,11 @@ class AzureReportQueryHandlerTest(IamTestCase):
         total = query_output.get("total")
         aggregates = handler._mapper.report_type_map.get("aggregates")
         current_totals = self.get_totals_costs_by_time_scope(aggregates, self.this_month_filter)
-        self.assertIsNotNone(total.get("cost"))
-        self.assertEqual(total.get("cost", {}).get("value"), current_totals.get("cost"))
+        expected_cost_total = current_totals.get("cost_total")
+        self.assertIsNotNone(expected_cost_total)
+        result_cost_total = total.get("cost", {}).get("total", {}).get("value")
+        self.assertIsNotNone(result_cost_total)
+        self.assertEqual(result_cost_total, expected_cost_total)
 
         cmonth_str = self.dh.this_month_start.strftime("%Y-%m")
         for data_item in data:
@@ -306,8 +329,11 @@ class AzureReportQueryHandlerTest(IamTestCase):
         total = query_output.get("total")
         aggregates = handler._mapper.report_type_map.get("aggregates")
         current_totals = self.get_totals_costs_by_time_scope(aggregates, self.this_month_filter)
-        self.assertIsNotNone(total.get("cost"))
-        self.assertEqual(total.get("cost", {}).get("value"), current_totals.get("cost"))
+        expected_cost_total = current_totals.get("cost_total")
+        self.assertIsNotNone(expected_cost_total)
+        result_cost_total = total.get("cost", {}).get("total", {}).get("value")
+        self.assertIsNotNone(result_cost_total)
+        self.assertEqual(result_cost_total, expected_cost_total)
 
         cmonth_str = DateHelper().this_month_start.strftime("%Y-%m")
         for data_item in data:
@@ -338,8 +364,11 @@ class AzureReportQueryHandlerTest(IamTestCase):
         aggregates = handler._mapper.report_type_map.get("aggregates")
         filters = {**self.this_month_filter, "instance_type__isnull": False}
         current_totals = self.get_totals_costs_by_time_scope(aggregates, filters)
-        self.assertIsNotNone(total.get("cost"))
-        self.assertEqual(total.get("cost", {}).get("value"), current_totals.get("cost"))
+        expected_cost_total = current_totals.get("cost_total")
+        self.assertIsNotNone(expected_cost_total)
+        result_cost_total = total.get("cost", {}).get("total", {}).get("value")
+        self.assertIsNotNone(result_cost_total)
+        self.assertEqual(result_cost_total, expected_cost_total)
 
         for data_item in data:
             instance_types = data_item.get("instance_types")
@@ -360,8 +389,11 @@ class AzureReportQueryHandlerTest(IamTestCase):
         total = query_output.get("total")
         aggregates = handler._mapper.report_type_map.get("aggregates")
         current_totals = self.get_totals_costs_by_time_scope(aggregates, self.this_month_filter)
-        self.assertIsNotNone(total.get("cost"))
-        self.assertEqual(total.get("cost", {}).get("value"), current_totals.get("cost"))
+        expected_cost_total = current_totals.get("cost_total")
+        self.assertIsNotNone(expected_cost_total)
+        result_cost_total = total.get("cost", {}).get("total", {}).get("value")
+        self.assertIsNotNone(result_cost_total)
+        self.assertEqual(result_cost_total, expected_cost_total)
 
         cmonth_str = DateHelper().this_month_start.strftime("%Y-%m")
         for data_item in data:
@@ -386,8 +418,11 @@ class AzureReportQueryHandlerTest(IamTestCase):
         total = query_output.get("total")
         aggregates = handler._mapper.report_type_map.get("aggregates")
         current_totals = self.get_totals_costs_by_time_scope(aggregates, self.this_month_filter)
-        self.assertIsNotNone(total.get("cost"))
-        self.assertEqual(total.get("cost", {}).get("value"), current_totals.get("cost"))
+        expected_cost_total = current_totals.get("cost_total")
+        self.assertIsNotNone(expected_cost_total)
+        result_cost_total = total.get("cost", {}).get("total", {}).get("value")
+        self.assertIsNotNone(result_cost_total)
+        self.assertEqual(result_cost_total, expected_cost_total)
 
         cmonth_str = self.dh.this_month_start.strftime("%Y-%m")
         for data_item in data:
@@ -417,8 +452,11 @@ class AzureReportQueryHandlerTest(IamTestCase):
         total = query_output.get("total")
         aggregates = handler._mapper.report_type_map.get("aggregates")
         current_totals = self.get_totals_costs_by_time_scope(aggregates, self.this_month_filter)
-        self.assertIsNotNone(total.get("cost"))
-        self.assertEqual(total.get("cost", {}).get("value"), current_totals.get("cost"))
+        expected_cost_total = current_totals.get("cost_total")
+        self.assertIsNotNone(expected_cost_total)
+        result_cost_total = total.get("cost", {}).get("total", {}).get("value")
+        self.assertIsNotNone(result_cost_total)
+        self.assertEqual(result_cost_total, expected_cost_total)
 
         cmonth_str = self.dh.this_month_start.strftime("%Y-%m")
         for data_item in data:
@@ -457,8 +495,11 @@ class AzureReportQueryHandlerTest(IamTestCase):
         total = query_output.get("total")
         aggregates = handler._mapper.report_type_map.get("aggregates")
         current_totals = self.get_totals_costs_by_time_scope(aggregates, self.this_month_filter)
-        self.assertIsNotNone(total.get("cost"))
-        self.assertEqual(total.get("cost", {}).get("value"), current_totals.get("cost"))
+        expected_cost_total = current_totals.get("cost_total")
+        self.assertIsNotNone(expected_cost_total)
+        result_cost_total = total.get("cost", {}).get("total", {}).get("value")
+        self.assertIsNotNone(result_cost_total)
+        self.assertEqual(result_cost_total, expected_cost_total)
 
         cmonth_str = DateHelper().this_month_start.strftime("%Y-%m")
         for data_item in data:
@@ -489,10 +530,14 @@ class AzureReportQueryHandlerTest(IamTestCase):
         self.assertIsNotNone(query_output.get("total"))
         total = query_output.get("total")
         aggregates = handler._mapper.report_type_map.get("aggregates")
-        filters = {**self.this_month_filter, "resource_location": location}
+        filters = {**self.this_month_filter}
+        filters["resource_location__icontains"] = location
         current_totals = self.get_totals_costs_by_time_scope(aggregates, filters)
-        self.assertIsNotNone(total.get("cost"))
-        self.assertEqual(total.get("cost", {}).get("value"), current_totals.get("cost"))
+        expected_cost_total = current_totals.get("cost_total")
+        self.assertIsNotNone(expected_cost_total)
+        result_cost_total = total.get("cost", {}).get("raw", {}).get("value")
+        self.assertIsNotNone(result_cost_total)
+        self.assertEqual(result_cost_total, expected_cost_total)
 
         cmonth_str = DateHelper().this_month_start.strftime("%Y-%m")
         for data_item in data:
@@ -522,8 +567,11 @@ class AzureReportQueryHandlerTest(IamTestCase):
         aggregates = handler._mapper.report_type_map.get("aggregates")
         filters = {**self.this_month_filter, "subscription_guid": subscription_guid}
         current_totals = self.get_totals_costs_by_time_scope(aggregates, filters)
-        self.assertIsNotNone(total.get("cost"))
-        self.assertEqual(total.get("cost", {}).get("value"), current_totals.get("cost"))
+        expected_cost_total = current_totals.get("cost_total")
+        self.assertIsNotNone(expected_cost_total)
+        result_cost_total = total.get("cost", {}).get("total", {}).get("value")
+        self.assertIsNotNone(result_cost_total)
+        self.assertEqual(result_cost_total, expected_cost_total)
 
         cmonth_str = self.dh.this_month_start.strftime("%Y-%m")
         for data_item in data:
@@ -553,8 +601,11 @@ class AzureReportQueryHandlerTest(IamTestCase):
                 qf = QueryFilter(**filt)
                 filters.update({qf.composed_query_string(): qf.parameter})
         current_totals = self.get_totals_costs_by_time_scope(aggregates, filters)
-        self.assertIsNotNone(total.get("cost"))
-        self.assertEqual(total.get("cost", {}).get("value"), current_totals.get("cost"))
+        expected_cost_total = current_totals.get("cost_total")
+        self.assertIsNotNone(expected_cost_total)
+        result_cost_total = total.get("cost", {}).get("total", {}).get("value")
+        self.assertIsNotNone(result_cost_total)
+        self.assertEqual(result_cost_total, expected_cost_total)
 
         cmonth_str = self.dh.this_month_start.strftime("%Y-%m")
         for data_item in data:
@@ -580,10 +631,14 @@ class AzureReportQueryHandlerTest(IamTestCase):
         self.assertIsNotNone(query_output.get("total"))
         total = query_output.get("total")
         aggregates = handler._mapper.report_type_map.get("aggregates")
-        filters = {**self.this_month_filter, "resource_location": location}
+        filters = {**self.this_month_filter}
+        filters["resource_location__icontains"] = location
         current_totals = self.get_totals_costs_by_time_scope(aggregates, filters)
-        self.assertIsNotNone(total.get("cost"))
-        self.assertEqual(total.get("cost", {}).get("value"), current_totals.get("cost"))
+        expected_cost_total = current_totals.get("cost_total")
+        self.assertIsNotNone(expected_cost_total)
+        result_cost_total = total.get("cost", {}).get("raw", {}).get("value")
+        self.assertIsNotNone(result_cost_total)
+        self.assertEqual(result_cost_total, expected_cost_total)
 
         cmonth_str = DateHelper().this_month_start.strftime("%Y-%m")
         for data_item in data:
@@ -611,10 +666,14 @@ class AzureReportQueryHandlerTest(IamTestCase):
         self.assertIsNotNone(query_output.get("total"))
         total = query_output.get("total")
         aggregates = handler._mapper.report_type_map.get("aggregates")
-        filters = {**self.this_month_filter, "resource_location": location}
+        filters = {**self.this_month_filter}
+        filters["resource_location__icontains"] = location
         current_totals = self.get_totals_costs_by_time_scope(aggregates, filters)
-        self.assertIsNotNone(total.get("cost"))
-        self.assertEqual(total.get("cost", {}).get("value"), current_totals.get("cost"))
+        expected_cost_total = current_totals.get("cost_total")
+        self.assertIsNotNone(expected_cost_total)
+        result_cost_total = total.get("cost", {}).get("raw", {}).get("value")
+        self.assertIsNotNone(result_cost_total)
+        self.assertEqual(result_cost_total, expected_cost_total)
 
         cmonth_str = DateHelper().this_month_start.strftime("%Y-%m")
         self.assertEqual(len(data), 1)
@@ -638,8 +697,11 @@ class AzureReportQueryHandlerTest(IamTestCase):
         total = query_output.get("total")
         aggregates = handler._mapper.report_type_map.get("aggregates")
         current_totals = self.get_totals_costs_by_time_scope(aggregates, self.this_month_filter)
-        self.assertIsNotNone(total.get("cost"))
-        self.assertEqual(total.get("cost", {}).get("value"), current_totals.get("cost"))
+        expected_cost_total = current_totals.get("cost_total")
+        self.assertIsNotNone(expected_cost_total)
+        result_cost_total = total.get("cost", {}).get("total", {}).get("value")
+        self.assertIsNotNone(result_cost_total)
+        self.assertEqual(result_cost_total, expected_cost_total)
 
         cmonth_str = self.dh.this_month_start.strftime("%Y-%m")
         self.assertEqual(len(data), 1)
@@ -1173,8 +1235,11 @@ class AzureReportQueryHandlerTest(IamTestCase):
         aggregates = handler._mapper.report_type_map.get("aggregates")
         filters = {**self.this_month_filter, "subscription_guid": subscription_guid}
         current_totals = self.get_totals_costs_by_time_scope(aggregates, filters)
-        self.assertIsNotNone(total.get("cost"))
-        self.assertEqual(total.get("cost", {}).get("value"), current_totals.get("cost"))
+        expected_cost_total = current_totals.get("cost_total")
+        self.assertIsNotNone(expected_cost_total)
+        result_cost_total = total.get("cost", {}).get("total", {}).get("value")
+        self.assertIsNotNone(result_cost_total)
+        self.assertEqual(result_cost_total, expected_cost_total)
 
         cmonth_str = self.dh.this_month_start.strftime("%Y-%m")
         for data_item in data:

--- a/koku/api/report/test/ocp/test_ocp_query_handler.py
+++ b/koku/api/report/test/ocp/test_ocp_query_handler.py
@@ -110,11 +110,15 @@ class OCPReportQueryHandlerTest(IamTestCase):
         handler = OCPReportQueryHandler(query_params)
         aggregates = handler._mapper.report_type_map.get("aggregates")
         current_totals = self.get_totals_costs_by_time_scope(aggregates, self.ten_day_filter)
+        expected_cost_total = current_totals.get("cost_total")
+        self.assertIsNotNone(expected_cost_total)
         query_output = handler.execute_query()
         self.assertIsNotNone(query_output.get("data"))
         self.assertIsNotNone(query_output.get("total"))
         total = query_output.get("total")
-        self.assertEqual(total.get("cost", {}).get("value"), current_totals.get("cost"))
+        result_cost_total = total.get("cost", {}).get("total", {}).get("value")
+        self.assertIsNotNone(result_cost_total)
+        self.assertEqual(result_cost_total, expected_cost_total)
 
     def test_get_cluster_capacity_monthly_resolution(self):
         """Test that cluster capacity returns a full month's capacity."""
@@ -126,6 +130,8 @@ class OCPReportQueryHandlerTest(IamTestCase):
         self.assertTrue("capacity" in total_capacity)
         self.assertTrue(isinstance(total_capacity["capacity"], Decimal))
         self.assertTrue("capacity" in query_data[0])
+        self.assertIsNotNone(query_data[0].get("capacity"))
+        self.assertIsNotNone(total_capacity.get("capacity"))
         self.assertEqual(query_data[0].get("capacity"), total_capacity.get("capacity"))
 
     def test_get_cluster_capacity_monthly_resolution_group_by_cluster(self):


### PR DESCRIPTION
Jira Issue:

https://issues.redhat.com/browse/COST-839

There are some false positive asserts in the azure query_handler unit tests.

Example:
https://github.com/project-koku/koku/blob/master/koku/api/report/test/azure/tests_azure_query_handler.py#L112-L123

(Another Example in case the lines move)

```
def test_execute_sum_query_costs(self):
"""Test that the sum query runs properly for the costs endpoint."""
    url = "?"
    query_params = self.mocked_query_params(url, AzureCostView)
    handler = AzureReportQueryHandler(query_params)
    aggregates = handler._mapper.report_type_map.get("aggregates")
    current_totals = self.get_totals_costs_by_time_scope(aggregates, self.ten_day_filter)
    query_output = handler.execute_query()
    self.assertIsNotNone(query_output.get("data"))
    self.assertIsNotNone(query_output.get("total"))
    total = query_output.get("total")
    self.assertEqual(total.get("cost", {}).get("value"), current_totals.get("cost"))
```
 

The problem is that we assert that the query total is not none, but we don't assert that the total.get("cost", {}).get("value") is not None. Therefore, since we use .get() on both the result, and the expected value in the assertEqual, we end up checking that None equals None creating a false positive for the test. 

For example, to confirm that we were getting a false positive I added the following lines to the test above:

```
equal_values = [total.get("cost", {}).get("value"), current_totals.get("cost")]
self.assertNotIn(None, equal_values)
```

The test then failed with: 
```
======================================================================
FAIL: test_execute_sum_query_costs (api.report.test.azure.tests_azure_query_handler.AzureReportQueryHandlerTest)
Test that the sum query runs properly for the costs endpoint.
----------------------------------------------------------------------
Traceback (most recent call last):
File "/Users/cmyers/Desktop/projects/cost_all/koku/koku/api/report/test/azure/tests_azure_query_handler.py", line 125, in test_execute_sum_query_costs
self.assertNotIn(None, equal_values)
AssertionError: None unexpectedly found in [None, None]

----------------------------------------------------------------------
```