### PR TITLE
COST-842 Check for term first

### DIFF
--- a/koku/forecast/forecast.py
+++ b/koku/forecast/forecast.py
@@ -217,11 +217,12 @@ class Forecast:
         date_based_dict = results[check_term][0] if results[check_term] else []
         for date in date_based_dict:
             for cost_term in results:
-                results_by_date[date][cost_term] = (
-                    results[cost_term][0][date],
-                    {"rsquared": results[cost_term][1]},
-                    {"pvalues": results[cost_term][2]},
-                )
+                if results[cost_term][0].get(date):
+                    results_by_date[date][cost_term] = (
+                        results[cost_term][0][date],
+                        {"rsquared": results[cost_term][1]},
+                        {"pvalues": results[cost_term][2]},
+                    )
         return results_by_date
 
     def format_result(self, results):


### PR DESCRIPTION
## Summary
We remove outliers prior to re-sorting this data, so it's possible for a date to not exist in the dictionary and we were hitting a KeyError. This adds an if check first.