### PR TITLE
Bugfix unittest failures

### DIFF
--- a/koku/forecast/test/tests_forecast.py
+++ b/koku/forecast/test/tests_forecast.py
@@ -170,7 +170,7 @@ class AWSForecastTest(IamTestCase):
         for n in range(0, 10):
             expected.append(
                 {
-                    "usage_start": dh.n_days_ago(dh.today, 10 - n).date(),
+                    "usage_start": (dh.this_month_start + timedelta(days=n)).date(),
                     "total_cost": 5,
                     "infrastructure_cost": 3,
                     "supplementary_cost": 2,
@@ -399,7 +399,7 @@ class AzureForecastTest(IamTestCase):
         for n in range(0, 10):
             expected.append(
                 {
-                    "usage_start": dh.n_days_ago(dh.today, 10 - n).date(),
+                    "usage_start": (dh.this_month_start + timedelta(days=n)).date(),
                     "total_cost": 5,
                     "infrastructure_cost": 3,
                     "supplementary_cost": 2,
@@ -447,7 +447,7 @@ class OCPForecastTest(IamTestCase):
         for n in range(0, 10):
             expected.append(
                 {
-                    "usage_start": dh.n_days_ago(dh.today, 10 - n).date(),
+                    "usage_start": (dh.this_month_start + timedelta(days=n)).date(),
                     "total_cost": 5,
                     "infrastructure_cost": 3,
                     "supplementary_cost": 2,
@@ -527,7 +527,7 @@ class OCPAllForecastTest(IamTestCase):
         for n in range(0, 10):
             expected.append(
                 {
-                    "usage_start": dh.n_days_ago(dh.today, 10 - n).date(),
+                    "usage_start": (dh.this_month_start + timedelta(days=n)).date(),
                     "total_cost": 5,
                     "infrastructure_cost": 3,
                     "supplementary_cost": 2,
@@ -575,7 +575,7 @@ class OCPAWSForecastTest(IamTestCase):
         for n in range(0, 10):
             expected.append(
                 {
-                    "usage_start": dh.n_days_ago(dh.today, 10 - n).date(),
+                    "usage_start": (dh.this_month_start + timedelta(days=n)).date(),
                     "total_cost": 5,
                     "infrastructure_cost": 3,
                     "supplementary_cost": 2,
@@ -623,7 +623,7 @@ class OCPAzureForecastTest(IamTestCase):
         for n in range(0, 10):
             expected.append(
                 {
-                    "usage_start": dh.n_days_ago(dh.today, 10 - n).date(),
+                    "usage_start": (dh.this_month_start + timedelta(days=n)).date(),
                     "total_cost": 5,
                     "infrastructure_cost": 3,
                     "supplementary_cost": 2,

--- a/koku/masu/test/util/test_common.py
+++ b/koku/masu/test/util/test_common.py
@@ -200,10 +200,11 @@ class CommonUtilTests(MasuTestCase):
         provider_type = Provider.PROVIDER_AWS
         provider_uuid = self.aws_provider_uuid
         start_date = datetime.utcnow().date()
+        year = start_date.strftime("%Y")
+        month = start_date.strftime("%m")
         expected_path_prefix = f"{Config.WAREHOUSE_PATH}/{Config.PARQUET_DATA_TYPE}"
         expected_path = (
-            f"{expected_path_prefix}/{account}/{provider_type}/"
-            f"source={provider_uuid}/year={start_date.year}/month={start_date.month}"
+            f"{expected_path_prefix}/{account}/{provider_type}/" f"source={provider_uuid}/year={year}/month={month}"
         )
 
         path = common_utils.get_path_prefix(account, provider_type, provider_uuid, start_date, "parquet")
@@ -213,7 +214,7 @@ class CommonUtilTests(MasuTestCase):
         report_type = "pod_report"
         expected_path = (
             f"{expected_path_prefix}/{account}/{provider_type}/{report_type}/"
-            f"source={provider_uuid}/year={start_date.year}/month={start_date.month}"
+            f"source={provider_uuid}/year={year}/month={month}"
         )
         path = common_utils.get_path_prefix(
             account, provider_type, provider_uuid, start_date, "parquet", report_type=report_type


### PR DESCRIPTION
## Summary
This addresses a few failing unit tests. 
- Fixes a date format comparison that was incorrect.
- For the forecast tests, this forces the dates used to all come from the same month. Using these date strings has already bene identified as an issue in https://issues.redhat.com/browse/COST-392, so this is a stopgap to get the tests fixed. We should switch to using consecutive integers with a y-intercept as the QA findings indicate. 