### PR TITLE
log messages for kafka message headers

### DIFF
--- a/koku/api/report/ocp/query_handler.py
+++ b/koku/api/report/ocp/query_handler.py
@@ -196,7 +196,7 @@ class OCPReportQueryHandler(ReportQueryHandler):
 
         return Window(expression=RowNumber(), partition_by=F("date"), order_by=rank_orders)
 
-    def get_cluster_capacity(self, query_data):
+    def get_cluster_capacity(self, query_data):  # noqa: C901
         """Calculate cluster capacity for all nodes over the date range."""
         annotations = self._mapper.report_type_map.get("capacity_aggregate")
         if not annotations:
@@ -219,10 +219,13 @@ class OCPReportQueryHandler(ReportQueryHandler):
                 usage_start = entry.get("usage_start", "")
                 if isinstance(usage_start, datetime.date):
                     usage_start = usage_start.isoformat()
-                capacity_by_cluster[cluster_id] += entry.get(cap_key, 0)
-                daily_capacity_by_cluster[usage_start][cluster_id] = entry.get(cap_key, 0)
-                daily_total_capacity[usage_start] += entry.get(cap_key, 0)
-                total_capacity += entry.get(cap_key, 0)
+                cap_value = entry.get(cap_key, 0)
+                if cap_value is None:
+                    cap_value = 0
+                capacity_by_cluster[cluster_id] += cap_value
+                daily_capacity_by_cluster[usage_start][cluster_id] = cap_value
+                daily_total_capacity[usage_start] += cap_value
+                total_capacity += cap_value
 
         if self.resolution == "daily":
             for row in query_data:

--- a/koku/sources/kafka_listener.py
+++ b/koku/sources/kafka_listener.py
@@ -224,7 +224,8 @@ def get_sources_msg_data(msg, app_type_id):
                     msg_data["source_id"] = int(value.get("source_id"))
                     msg_data["auth_header"] = _extract_from_header(msg.headers(), KAFKA_HDR_RH_IDENTITY)
                     LOG.info(
-                        f"Application Create/Destroy Message headers for Source ID: {value.get('source_id')}: {str(msg.headers())}"
+                        f"Application Create/Destroy Message headers for Source ID: "
+                        f"{value.get('source_id')}: {str(msg.headers())}"
                     )
             elif event_type in (KAFKA_AUTHENTICATION_CREATE, KAFKA_AUTHENTICATION_UPDATE):
                 LOG.debug("Authentication Message: %s", str(msg))
@@ -236,7 +237,8 @@ def get_sources_msg_data(msg, app_type_id):
                     msg_data["resource_type"] = value.get("resource_type")
                     msg_data["auth_header"] = _extract_from_header(msg.headers(), KAFKA_HDR_RH_IDENTITY)
                     LOG.info(
-                        f"Authentication Create/Update Message headers for Source ID: {value.get('resource_id')}: {str(msg.headers())}"
+                        f"Authentication Create/Update Message headers for Source ID: "
+                        f"{value.get('resource_id')}: {str(msg.headers())}"
                     )
 
             elif event_type in (KAFKA_SOURCE_DESTROY, KAFKA_SOURCE_UPDATE):
@@ -247,7 +249,8 @@ def get_sources_msg_data(msg, app_type_id):
                 msg_data["source_id"] = int(value.get("id"))
                 msg_data["auth_header"] = _extract_from_header(msg.headers(), KAFKA_HDR_RH_IDENTITY)
                 LOG.info(
-                    f"Source Update/Destroy Message headers for Source ID: {value.get('source_id')}: {str(msg.headers())}"
+                    f"Source Update/Destroy Message headers for Source ID: "
+                    f"{value.get('source_id')}: {str(msg.headers())}"
                 )
             else:
                 LOG.debug("Other Message: %s", str(msg))

--- a/koku/sources/kafka_listener.py
+++ b/koku/sources/kafka_listener.py
@@ -223,6 +223,7 @@ def get_sources_msg_data(msg, app_type_id):
                     msg_data["partition"] = msg.partition()
                     msg_data["source_id"] = int(value.get("source_id"))
                     msg_data["auth_header"] = _extract_from_header(msg.headers(), KAFKA_HDR_RH_IDENTITY)
+                    LOG.info(f"Application Create/Destroy Message headers for Source ID: {value.get('source_id')}: {str(msg.headers())}")
             elif event_type in (KAFKA_AUTHENTICATION_CREATE, KAFKA_AUTHENTICATION_UPDATE):
                 LOG.debug("Authentication Message: %s", str(msg))
                 if value.get("resource_type") in ("Endpoint", "Application"):
@@ -232,6 +233,8 @@ def get_sources_msg_data(msg, app_type_id):
                     msg_data["resource_id"] = int(value.get("resource_id"))
                     msg_data["resource_type"] = value.get("resource_type")
                     msg_data["auth_header"] = _extract_from_header(msg.headers(), KAFKA_HDR_RH_IDENTITY)
+                    LOG.info(f"Authentication Create/Update Message headers for Source ID: {value.get('resource_id')}: {str(msg.headers())}")
+
             elif event_type in (KAFKA_SOURCE_DESTROY, KAFKA_SOURCE_UPDATE):
                 LOG.debug("Source Message: %s", str(msg))
                 msg_data["event_type"] = event_type
@@ -239,6 +242,7 @@ def get_sources_msg_data(msg, app_type_id):
                 msg_data["partition"] = msg.partition()
                 msg_data["source_id"] = int(value.get("id"))
                 msg_data["auth_header"] = _extract_from_header(msg.headers(), KAFKA_HDR_RH_IDENTITY)
+                LOG.info(f"Source Update/Destroy Message headers for Source ID: {value.get('source_id')}: {str(msg.headers())}")
             else:
                 LOG.debug("Other Message: %s", str(msg))
         except (AttributeError, ValueError, TypeError) as error:

--- a/koku/sources/kafka_listener.py
+++ b/koku/sources/kafka_listener.py
@@ -223,7 +223,9 @@ def get_sources_msg_data(msg, app_type_id):
                     msg_data["partition"] = msg.partition()
                     msg_data["source_id"] = int(value.get("source_id"))
                     msg_data["auth_header"] = _extract_from_header(msg.headers(), KAFKA_HDR_RH_IDENTITY)
-                    LOG.info(f"Application Create/Destroy Message headers for Source ID: {value.get('source_id')}: {str(msg.headers())}")
+                    LOG.info(
+                        f"Application Create/Destroy Message headers for Source ID: {value.get('source_id')}: {str(msg.headers())}"
+                    )
             elif event_type in (KAFKA_AUTHENTICATION_CREATE, KAFKA_AUTHENTICATION_UPDATE):
                 LOG.debug("Authentication Message: %s", str(msg))
                 if value.get("resource_type") in ("Endpoint", "Application"):
@@ -233,7 +235,9 @@ def get_sources_msg_data(msg, app_type_id):
                     msg_data["resource_id"] = int(value.get("resource_id"))
                     msg_data["resource_type"] = value.get("resource_type")
                     msg_data["auth_header"] = _extract_from_header(msg.headers(), KAFKA_HDR_RH_IDENTITY)
-                    LOG.info(f"Authentication Create/Update Message headers for Source ID: {value.get('resource_id')}: {str(msg.headers())}")
+                    LOG.info(
+                        f"Authentication Create/Update Message headers for Source ID: {value.get('resource_id')}: {str(msg.headers())}"
+                    )
 
             elif event_type in (KAFKA_SOURCE_DESTROY, KAFKA_SOURCE_UPDATE):
                 LOG.debug("Source Message: %s", str(msg))
@@ -242,7 +246,9 @@ def get_sources_msg_data(msg, app_type_id):
                 msg_data["partition"] = msg.partition()
                 msg_data["source_id"] = int(value.get("id"))
                 msg_data["auth_header"] = _extract_from_header(msg.headers(), KAFKA_HDR_RH_IDENTITY)
-                LOG.info(f"Source Update/Destroy Message headers for Source ID: {value.get('source_id')}: {str(msg.headers())}")
+                LOG.info(
+                    f"Source Update/Destroy Message headers for Source ID: {value.get('source_id')}: {str(msg.headers())}"
+                )
             else:
                 LOG.debug("Other Message: %s", str(msg))
         except (AttributeError, ValueError, TypeError) as error:


### PR DESCRIPTION
Sources kafka message headers appear to be missing the authentication header which is resulting in 401s while processing source update messages.  This log additions will help narrow down if it's a problem on the cost management message parsing or if something has changed on the sources side.

Example
```
sources_client    | [2021-01-05 16:04:18,949] INFO None Application Create/Destroy Message headers for Source ID: 1: [('event_type', b'Application.create'), ('x-rh-identity', b'eyJpZGVudGl0eSI6IHsiYWNjb3VudF9udW1iZXIiOiAiMTAwMDEiLCAidHlwZSI6ICJVc2VyIiwgInVzZXIiOiB7InVzZXJuYW1lIjogInVzZXJfZGV2IiwgImVtYWlsIjogInVzZXJfZGV2QGZvby5jb20iLCAiaXNfb3JnX2FkbWluIjogdHJ1ZX19LCAiZW50aXRsZW1lbnRzIjogeyJjb3N0X21hbmFnZW1lbnQiOiB7ImlzX2VudGl0bGVkIjogdHJ1ZX19fQ=='), ('encoding', b'json')]
sources_client    | [2021-01-05 16:04:18,950] INFO None Processing message offset: 12 partition: 0
sources_client    | [2021-01-05 16:04:18,950] INFO None Cost Management Message to process: {'event_type': 'Application.create', 'offset': 12, 'partition': 0, 'source_id': 1, 'auth_header': 'eyJpZGVudGl0eSI6IHsiYWNjb3VudF9udW1iZXIiOiAiMTAwMDEiLCAidHlwZSI6ICJVc2VyIiwgInVzZXIiOiB7InVzZXJuYW1lIjogInVzZXJfZGV2IiwgImVtYWlsIjogInVzZXJfZGV2QGZvby5jb20iLCAiaXNfb3JnX2FkbWluIjogdHJ1ZX19LCAiZW50aXRsZW1lbnRzIjogeyJjb3N0X21hbmFnZW1lbnQiOiB7ImlzX2VudGl0bGVkIjogdHJ1ZX19fQ=='}
sources_client    | [2021-01-05 16:04:18,950] INFO None Processing Event: {'event_type': 'Application.create', 'offset': 12, 'partition': 0, 'source_id': 1, 'auth_header': 'eyJpZGVudGl0eSI6IHsiYWNjb3VudF9udW1iZXIiOiAiMTAwMDEiLCAidHlwZSI6ICJVc2VyIiwgInVzZXIiOiB7InVzZXJuYW1lIjogInVzZXJfZGV2IiwgImVtYWlsIjogInVzZXJfZGV2QGZvby5jb20iLCAiaXNfb3JnX2FkbWluIjogdHJ1ZX19LCAiZW50aXRsZW1lbnRzIjogeyJjb3N0X21hbmFnZW1lbnQiOiB7ImlzX2VudGl0bGVkIjogdHJ1ZX19fQ=='}
sources_client    | [2021-01-05 16:04:18,965] INFO None source.storage.create_source_event created Source ID: 1
sources_client    | [2021-01-05 16:04:19,111] INFO None Adding operation create for OCP Source to process queue (size: 0)
sources_client    | [2021-01-05 16:04:19,112] INFO None Koku provider operation to execute: create for Source ID: 1
sources_client    | [2021-01-05 16:04:19,113] INFO None Creating Koku Provider for Source ID: 1
sources_client    | [2021-01-05 16:04:19,213] INFO None Verify that clone function "public.clone_schema(source_schema text, dest_schema text, copy_data boolean DEFAULT false, _verbose boolean DEFAULT false)" exists
sources_client    | [2021-01-05 16:04:19,298] INFO None Verify that template schema "template0" exists
sources_client    | [2021-01-05 16:04:19,307] INFO None Using superclass for "template0" schema creation
sources_client    | === Running migrate for schema template0
sources_client    | Operations to perform:
sources_client    |   Apply all migrations: api, auth, contenttypes, cost_models, reporting, reporting_common, sessions
sources_client    | Running migrations:
sources_client    |   Applying api.0001_initial...
sources_client    |  OK
sources_client    |   Applying api.0030_auto_20201007_1403...
sources_client    |  OK
sources_client    |   Applying api.0031_clone_schema...
sources_client    |  OK
sources_client    |   Applying api.0032_presto_delete_log_trigger_func...
sources_client    |  OK
sources_client    |   Applying api.0033_sources_name_text...
sources_client    |  OK
sources_client    |   Applying contenttypes.0001_initial...
sources_client    |  OK
sources_client    |   Applying contenttypes.0002_remove_content_type_name...
sources_client    |  OK
sources_client    |   Applying auth.0001_initial...
sources_client    |  OK
sources_client    |   Applying auth.0002_alter_permission_name_max_length...
sources_client    |  OK
sources_client    |   Applying auth.0003_alter_user_email_max_length...
sources_client    |  OK
sources_client    |   Applying auth.0004_alter_user_username_opts...
sources_client    |  OK
sources_client    |   Applying auth.0005_alter_user_last_login_null...
sources_client    |  OK
sources_client    |   Applying auth.0006_require_contenttypes_0002...
sources_client    |  OK
sources_client    |   Applying auth.0007_alter_validators_add_error_messages...
sources_client    |  OK
sources_client    |   Applying auth.0008_alter_user_username_max_length...
sources_client    |  OK
sources_client    |   Applying auth.0009_alter_user_last_name_max_length...
sources_client    |  OK
sources_client    |   Applying auth.0010_alter_group_name_max_length...
sources_client    |  OK
sources_client    |   Applying auth.0011_update_proxy_permissions...
sources_client    |  OK
sources_client    |   Applying auth.0012_alter_user_first_name_max_length...
sources_client    |  OK
sources_client    |   Applying cost_models.0001_initial...
sources_client    |  OK
sources_client    |   Applying reporting.0001_initial...
sources_client    |  OK
sources_client    |   Applying reporting.0143_awsorganizationalunit_provider...
sources_client    |  OK
sources_client    |   Applying reporting.0144_auto_20201007_1441...
sources_client    |  OK
sources_client    |   Applying reporting.0145_awsenabledtagkeys_azureenabledtagkeys...
sources_client    |  OK
sources_client    |   Applying reporting.0146_auto_20200917_1448...
sources_client    |  OK
sources_client    |   Applying reporting.0147_auto_20201028_1305...
sources_client    |  OK
sources_client    |   Applying reporting.0148_presto_delete_log...
sources_client    |  OK
sources_client    |   Applying reporting.0149_auto_20201112_1414...
sources_client    |  OK
sources_client    |   Applying reporting.0150_presto_bulk_pk_delete...
sources_client    |  OK
sources_client    |   Applying reporting.0151_ocp_summary_table_presto_interface...
sources_client    |  OK
sources_client    |   Applying reporting.0152_gcpcostentrylineitem...
sources_client    |  OK
sources_client    |   Applying reporting.0153_ocpnamespacelabellineitem...
sources_client    |  OK
sources_client    |   Applying reporting.0154_gcp_summary_tables...
sources_client    |  OK
sources_client    |   Applying reporting.0155_gcp_partitioned...
sources_client    |  OK
sources_client    |   Applying reporting.0156_auto_20201208_2029...
sources_client    |  OK
sources_client    |   Applying reporting.0157_auto_20201214_1757...
sources_client    |  OK
sources_client    |   Applying reporting.0158_auto_20201214_1757...
sources_client    |  OK
sources_client    |   Applying reporting.0159_gcp_cost_summary...
sources_client    |  OK
sources_client    |   Applying reporting_common.0001_initial...
sources_client    |  OK
sources_client    |   Applying sessions.0001_initial...
sources_client    |  OK
sources_client    | [2021-01-05 16:04:35,549] INFO None Cloning template schema "template0" to "acct10001" with data
sources_client    | [2021-01-05 16:04:37,053] INFO None Successful clone of "template0" to "acct10001"
sources_client    | [2021-01-05 16:04:37,054] INFO None Created new customer from account_id 10001.
sources_client    | [2021-01-05 16:04:37,068] INFO None Created new user user_dev for customer(account_id 10001).
sources_client    | [2021-01-05 16:04:37,073] INFO None Provider account validation started for {}.
sources_client    | [2021-01-05 16:04:37,073] INFO None Stub to verify that OCP report for cluster my-cluster is accessible.
sources_client    | [2021-01-05 16:04:37,073] INFO None Provider account validation complete for {}.
sources_client    | [2021-01-05 16:04:37,157] INFO None Starting data ingest task for Provider 13e1b5e7-126b-4172-9b81-990c4647e171
sources_client    | [2021-01-05 16:04:37,165] INFO None Creating provider 13e1b5e7-126b-4172-9b81-990c4647e171 for Source ID: 1
sources_client    | [2021-01-05 16:04:37,239] INFO None Source ID: 1 is available.
sources_client    | [2021-01-05 16:04:37,366] INFO None Koku provider operation to execute: create for Source ID: 1 complete.
sources_client    | [2021-01-05 16:04:37,370] INFO None Authentication attached to Source ID: 1
```