### PR TITLE
Filtering for identity header in sources kafka messages

### DIFF
--- a/koku/sources/kafka_listener.py
+++ b/koku/sources/kafka_listener.py
@@ -251,13 +251,16 @@ def get_sources_msg_data(msg, app_type_id):
                 msg_data["auth_header"] = _extract_from_header(msg.headers(), KAFKA_HDR_RH_IDENTITY)
                 LOG.info(
                     f"Source Update/Destroy Message headers for Source ID: "
-                    f"{value.get('source_id')}: {str(msg.headers())}"
+                    f"{value.get('id')}: {str(msg.headers())}"
                 )
             else:
                 LOG.debug("Other Message: %s", str(msg))
         except (AttributeError, ValueError, TypeError) as error:
             LOG.error("Unable load message: %s. Error: %s", str(msg.value), str(error))
             raise SourcesMessageError("Unable to load message")
+        if msg_data.get("event_type") and not msg_data.get("auth_header"):
+            LOG.error("Missing identity header for message: %s.  Headers: %s", str(msg_data), str(msg.headers()))
+            raise SourcesMessageError("Unable to get identity header.")
 
     return msg_data
 
@@ -498,6 +501,8 @@ def listen_for_messages(msg, consumer, application_source_id):  # noqa: C901
             offset = msg.get("offset")
             partition = msg.get("partition")
         except SourcesMessageError:
+            LOG.warning('Committing invalid message')
+            consumer.commit()
             return
         if msg:
             LOG.info(f"Processing message offset: {offset} partition: {partition}")

--- a/koku/sources/kafka_listener.py
+++ b/koku/sources/kafka_listener.py
@@ -250,8 +250,7 @@ def get_sources_msg_data(msg, app_type_id):
                 msg_data["source_id"] = int(value.get("id"))
                 msg_data["auth_header"] = _extract_from_header(msg.headers(), KAFKA_HDR_RH_IDENTITY)
                 LOG.info(
-                    f"Source Update/Destroy Message headers for Source ID: "
-                    f"{value.get('id')}: {str(msg.headers())}"
+                    f"Source Update/Destroy Message headers for Source ID: " f"{value.get('id')}: {str(msg.headers())}"
                 )
             else:
                 LOG.debug("Other Message: %s", str(msg))
@@ -501,7 +500,7 @@ def listen_for_messages(msg, consumer, application_source_id):  # noqa: C901
             offset = msg.get("offset")
             partition = msg.get("partition")
         except SourcesMessageError:
-            LOG.warning('Committing invalid message')
+            LOG.warning("Committing invalid message")
             consumer.commit()
             return
         if msg:


### PR DESCRIPTION
Investigations are underway as to why we are getting kafka message headers without the Red Hat identity header.  This problem is leading to 401s and a blocked processing loop.

This change will log and commit those messages so we won't block the queue.  There could be subsequent changes once the queue is unblocked in CI.  But this is the first step...

**Testing**
1. Create OCP source
2. Update code such that the header list [('event_type', b'Source.update'), ('encoding', b'json')] is used for a Source.update event for source_id=1.  Update source name and verify state is in the 401 retry loop
3. Create a new Source so that it is queued in kafka:
4. Uncomment line: raise SourcesMessageError("Unable to get identity header.").  On restart verify that message is committed and OCP Source 2 exists and the source update message is commited but not processed.

[sources_missing_header_ut.txt](https://github.com/project-koku/koku/files/5772750/sources_missing_header_ut.txt)
