### PR TITLE
COST-681: GCP Cost Forecasting

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -486,6 +486,51 @@
                 }]
             }
         },
+        "/forecasts/gcp/costs": {
+            "summary": "GCP Cost Forecasts",
+            "get": {
+                "tags":["Forecasts"],
+                "parameters": [{
+                    "$ref": "#/components/parameters/QueryFilter",
+                    "name":"QueryFilter"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "An object describing the cost forecast.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Forecast"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Request Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [{
+                    "basic_auth": []
+                }]
+            }
+        },
         "/forecasts/openshift/costs": {
             "summary": "OpenShift Cost Forecasts",
             "get": {

--- a/koku/api/common/permissions/__init__.py
+++ b/koku/api/common/permissions/__init__.py
@@ -16,6 +16,7 @@
 #
 from api.common.permissions.aws_access import AwsAccessPermission
 from api.common.permissions.azure_access import AzureAccessPermission
+from api.common.permissions.gcp_access import GcpAccessPermission
 from api.common.permissions.openshift_access import OpenShiftAccessPermission
 from api.provider.models import Provider
 
@@ -23,10 +24,12 @@ RESOURCE_TYPES = [
     AwsAccessPermission.resource_type,
     AzureAccessPermission.resource_type,
     OpenShiftAccessPermission.resource_type,
+    GcpAccessPermission.resource_type,
 ]
 
 RESOURCE_TYPE_MAP = {
     AwsAccessPermission.resource_type: [Provider.PROVIDER_AWS, Provider.PROVIDER_AWS_LOCAL],
     AzureAccessPermission.resource_type: [Provider.PROVIDER_AZURE, Provider.PROVIDER_AZURE_LOCAL],
     OpenShiftAccessPermission.resource_type: [Provider.PROVIDER_OCP],
+    GcpAccessPermission.resource_type: [Provider.PROVIDER_GCP, Provider.PROVIDER_GCP_LOCAL],
 }

--- a/koku/api/forecast/serializers.py
+++ b/koku/api/forecast/serializers.py
@@ -50,6 +50,10 @@ class AWSCostForecastParamSerializer(ForecastParamSerializer):
     """AWS Cost Forecast Serializer."""
 
 
+class GCPCostForecastParamSerializer(ForecastParamSerializer):
+    """GCP Cost Forecast Serializer."""
+
+
 class AzureCostForecastParamSerializer(ForecastParamSerializer):
     """Azure Cost Forecast Serializer."""
 

--- a/koku/api/forecast/views.py
+++ b/koku/api/forecast/views.py
@@ -27,10 +27,12 @@ from rest_framework.views import APIView
 from api.common.pagination import ForecastListPaginator
 from api.common.permissions import AwsAccessPermission
 from api.common.permissions import AzureAccessPermission
+from api.common.permissions import GcpAccessPermission
 from api.common.permissions import OpenShiftAccessPermission
 from api.common.permissions.openshift_all_access import OpenshiftAllAccessPermission
 from api.forecast.serializers import AWSCostForecastParamSerializer
 from api.forecast.serializers import AzureCostForecastParamSerializer
+from api.forecast.serializers import GCPCostForecastParamSerializer
 from api.forecast.serializers import OCPAllCostForecastParamSerializer
 from api.forecast.serializers import OCPAWSCostForecastParamSerializer
 from api.forecast.serializers import OCPAzureCostForecastParamSerializer
@@ -38,11 +40,13 @@ from api.forecast.serializers import OCPCostForecastParamSerializer
 from api.query_params import QueryParameters
 from forecast import AWSForecast
 from forecast import AzureForecast
+from forecast import GCPForecast
 from forecast import OCPAllForecast
 from forecast import OCPAWSForecast
 from forecast import OCPAzureForecast
 from forecast import OCPForecast
 from reporting.models import AzureTagsSummary
+from reporting.models import GCPTagsSummary
 from reporting.models import OCPAWSTagsSummary
 from reporting.models import OCPAzureTagsSummary
 from reporting.models import OCPStorageVolumeLabelSummary
@@ -128,3 +132,12 @@ class OCPAllCostForecastView(ForecastView):
     query_handler = OCPAllForecast
     serializer = OCPAllCostForecastParamSerializer
     tag_handler = [OCPAWSTagsSummary, OCPAzureTagsSummary]
+
+
+class GCPForecastCostView(ForecastView):
+    """GCP Cost Forecast View."""
+
+    permission_classes = (GcpAccessPermission,)
+    query_handler = GCPForecast
+    serializer = GCPCostForecastParamSerializer
+    tag_handler = [GCPTagsSummary]

--- a/koku/api/urls.py
+++ b/koku/api/urls.py
@@ -39,6 +39,7 @@ from api.views import CostModelResourceTypesView
 from api.views import DataExportRequestViewSet
 from api.views import GCPAccountView
 from api.views import GCPCostView
+from api.views import GCPForecastCostView
 from api.views import GCPProjectsView
 from api.views import GCPTagView
 from api.views import metrics
@@ -317,6 +318,7 @@ urlpatterns = [
     path("resource-types/openshift-nodes/", OCPNodesView.as_view(), name="openshift-nodes"),
     path("resource-types/cost-models/", CostModelResourceTypesView.as_view(), name="cost-models"),
     path("forecasts/aws/costs/", AWSCostForecastView.as_view(), name="aws-cost-forecasts"),
+    path("forecasts/gcp/costs/", GCPForecastCostView.as_view(), name="gcp-cost-forecasts"),
     path("forecasts/azure/costs/", AzureCostForecastView.as_view(), name="azure-cost-forecasts"),
     path("forecasts/openshift/costs/", OCPCostForecastView.as_view(), name="openshift-cost-forecasts"),
     path(

--- a/koku/api/views.py
+++ b/koku/api/views.py
@@ -20,6 +20,7 @@ from api.cloud_accounts.views import cloud_accounts
 from api.dataexport.views import DataExportRequestViewSet
 from api.forecast.views import AWSCostForecastView
 from api.forecast.views import AzureCostForecastView
+from api.forecast.views import GCPForecastCostView
 from api.forecast.views import OCPAllCostForecastView
 from api.forecast.views import OCPAWSCostForecastView
 from api.forecast.views import OCPAzureCostForecastView

--- a/koku/forecast/__init__.py
+++ b/koku/forecast/__init__.py
@@ -18,6 +18,7 @@
 from .forecast import AWSForecast  # noqa: F401
 from .forecast import AzureForecast  # noqa: F401
 from .forecast import Forecast  # noqa: F401
+from .forecast import GCPForecast  # noqa: F401
 from .forecast import OCPAllForecast  # noqa: F401
 from .forecast import OCPAWSForecast  # noqa: F401
 from .forecast import OCPAzureForecast  # noqa: F401

--- a/koku/forecast/forecast.py
+++ b/koku/forecast/forecast.py
@@ -38,6 +38,7 @@ from api.report.aws.openshift.provider_map import OCPAWSProviderMap
 from api.report.aws.provider_map import AWSProviderMap
 from api.report.azure.openshift.provider_map import OCPAzureProviderMap
 from api.report.azure.provider_map import AzureProviderMap
+from api.report.gcp.provider_map import GCPProviderMap
 from api.report.ocp.provider_map import OCPProviderMap
 from api.utils import DateHelper
 from reporting.provider.aws.models import AWSOrganizationalUnit
@@ -557,3 +558,10 @@ class OCPAllForecast(Forecast):
 
     provider = Provider.OCP_ALL
     provider_map_class = OCPAllProviderMap
+
+
+class GCPForecast(Forecast):
+    """GCP forecasting class."""
+
+    provider = Provider.PROVIDER_GCP
+    provider_map_class = GCPProviderMap

--- a/koku/forecast/test/tests_forecast.py
+++ b/koku/forecast/test/tests_forecast.py
@@ -28,6 +28,7 @@ from statsmodels.tools.sm_exceptions import ValueWarning
 
 from api.forecast.views import AWSCostForecastView
 from api.forecast.views import AzureCostForecastView
+from api.forecast.views import GCPForecastCostView
 from api.forecast.views import OCPAllCostForecastView
 from api.forecast.views import OCPAWSCostForecastView
 from api.forecast.views import OCPAzureCostForecastView
@@ -39,11 +40,15 @@ from api.report.test.tests_queries import assertSameQ
 from api.utils import DateHelper
 from forecast import AWSForecast
 from forecast import AzureForecast
+from forecast import GCPForecast
 from forecast import OCPAllForecast
 from forecast import OCPAWSForecast
 from forecast import OCPAzureForecast
 from forecast import OCPForecast
 from forecast.forecast import LinearForecastResult
+from reporting.provider.gcp.models import GCPCostSummary
+from reporting.provider.gcp.models import GCPCostSummaryByAccount
+from reporting.provider.gcp.models import GCPCostSummaryByProject
 from reporting.provider.ocp.models import OCPCostSummary
 from reporting.provider.ocp.models import OCPCostSummaryByNode
 from reporting.provider.ocp.models import OCPUsageLineItemDailySummary
@@ -450,6 +455,84 @@ class AzureForecastTest(IamTestCase):
                     self.assertAlmostEqual(float(item.get("rsquared").get("value")), 1, delta=2.2)
                     for pval in item.get("pvalues").get("value"):
                         self.assertGreaterEqual(float(pval), 0)
+
+
+class GCPForecastTest(IamTestCase):
+    """Tests the GCPForecast class."""
+
+    def test_predict_flat(self):
+        """Test that predict() returns expected values for flat costs."""
+        dh = DateHelper()
+
+        expected = []
+        for n in range(0, 10):
+            # the test data needs to include some jitter to avoid
+            # division-by-zero in the underlying dot-product maths.
+            expected.append(
+                {
+                    "usage_start": (dh.this_month_start + timedelta(days=n)).date(),
+                    "total_cost": 5 + random.random(),
+                    "infrastructure_cost": 3 + random.random(),
+                    "supplementary_cost": 2 + random.random(),
+                }
+            )
+        mock_qset = MockQuerySet(expected)
+
+        mocked_table = Mock()
+        mocked_table.objects.filter.return_value.order_by.return_value.values.return_value.annotate.return_value = (  # noqa: E501
+            mock_qset
+        )
+        mocked_table.len = mock_qset.len
+
+        params = self.mocked_query_params("?", AzureCostForecastView)
+        instance = GCPForecast(params)
+
+        instance.cost_summary_table = mocked_table
+
+        results = instance.predict()
+
+        for result in results:
+            for val in result.get("values", []):
+                self.assertIsInstance(val.get("date"), date)
+
+                for item, cost in [
+                    (val.get("cost"), 5),
+                    (val.get("infrastructure"), 3),
+                    (val.get("supplementary"), 2),
+                ]:
+                    self.assertAlmostEqual(float(item.get("total").get("value")), cost, delta=2.2)
+                    self.assertAlmostEqual(float(item.get("confidence_max").get("value")), cost, delta=2.2)
+                    self.assertAlmostEqual(float(item.get("confidence_min").get("value")), cost, delta=2.2)
+                    self.assertAlmostEqual(float(item.get("rsquared").get("value")), 1, delta=2.2)
+                    for pval in item.get("pvalues").get("value"):
+                        self.assertGreaterEqual(float(pval), 0)
+
+    def test_cost_summary_table(self):
+        """Test that we select a valid table or view."""
+        params = self.mocked_query_params("?", GCPForecastCostView)
+        forecast = GCPForecast(params)
+        self.assertEqual(forecast.cost_summary_table, GCPCostSummary)
+
+        params = self.mocked_query_params("?", GCPForecastCostView, access={"gcp.account": {"read": ["1"]}})
+        forecast = GCPForecast(params)
+        self.assertEqual(forecast.cost_summary_table, GCPCostSummaryByAccount)
+
+        params = self.mocked_query_params("?", GCPForecastCostView, access={"gcp.project": {"read": ["1"]}})
+        forecast = GCPForecast(params)
+        self.assertEqual(forecast.cost_summary_table, GCPCostSummaryByProject)
+
+        params = self.mocked_query_params(
+            "?", GCPForecastCostView, access={"gcp.account": {"read": ["1"]}, "gcp.project": {"read": ["1"]}}
+        )
+        forecast = GCPForecast(params)
+        self.assertEqual(forecast.cost_summary_table, GCPCostSummaryByProject)
+
+        params = self.mocked_query_params(
+            "?", GCPForecastCostView, access={"gcp.account": {"read": ["1"]}, "gcp.project": {"read": ["1"]}}
+        )
+
+        forecast = GCPForecast(params)
+        self.assertEqual(forecast.cost_summary_table, GCPCostSummaryByProject)
 
 
 class OCPForecastTest(IamTestCase):

--- a/koku/sources/test/api/test_view.py
+++ b/koku/sources/test/api/test_view.py
@@ -331,5 +331,11 @@ class SourcesViewTests(IamTestCase):
         mock_user = Mock(admin=False, access=permissions)
         request = Mock(user=mock_user)
         excluded = SourcesViewSet.get_excludes(request)
-        expected = [Provider.PROVIDER_AZURE, Provider.PROVIDER_AZURE_LOCAL, Provider.PROVIDER_OCP]
+        expected = [
+            Provider.PROVIDER_AZURE,
+            Provider.PROVIDER_AZURE_LOCAL,
+            Provider.PROVIDER_OCP,
+            Provider.PROVIDER_GCP,
+            Provider.PROVIDER_GCP_LOCAL,
+        ]
         self.assertEqual(excluded, expected)


### PR DESCRIPTION
Adding the GCP cost API.  Since we are not supporting GCP on OCP this PR doesn't include the `forecasts/openshift/infrastructures/gcp/costs` API.

**Testing**
1. Set gcp.account RBAC permission to an account that doesn't match the source data.  Verify no forecasting data is shown
2. Set gcp.account RBAC permission to an acconut that is part of the source.  Verify forecast is shown.
3. Set gcp.project RBAC permission to a project not part of the source.  Verify no forecast data is shown.
4. Set gcp.project RBAC permission to a project in the soruce data.  Verify forecast is shown.
 
**Test Results**
[gcp_forecast_ut.txt](https://github.com/project-koku/koku/files/5830613/gcp_forecast_ut.txt)
