### PR TITLE
COST-854: pass exog vars to wls_prediction_std

### DIFF
--- a/koku/forecast/forecast.py
+++ b/koku/forecast/forecast.py
@@ -346,7 +346,7 @@ class Forecast:
         x = sm.add_constant(x)
         model = sm.OLS(y, x)
         results = model.fit()
-        return LinearForecastResult(results)
+        return LinearForecastResult(results, exog=x)
 
     def _uniquify_qset(self, qset, field="total_cost"):
         """Take a QuerySet list, sum costs within the same day, and arrange it into a list of tuples.
@@ -394,14 +394,15 @@ class LinearForecastResult:
     Note: this class should be considered read-only
     """
 
-    def __init__(self, regression_result):
+    def __init__(self, regression_result, exog=None):
         """Class constructor.
 
         Args:
             regression_result (RegressionResult) the results of a statsmodels regression
+            exog (array-like) exogenous variables for points to predict
         """
         self._regression_result = regression_result
-        self._std_err, self._conf_lower, self._conf_upper = wls_prediction_std(regression_result)
+        self._std_err, self._conf_lower, self._conf_upper = wls_prediction_std(regression_result, exog=exog)
 
         try:
             LOG.debug(regression_result.summary())


### PR DESCRIPTION
This fixes the bug described in the fourth list item in COST-854. This ensures that both the forecast and the confidence intervals are using the same exogenous variables, including the added constant.