### PR TITLE
COST-848: fix use of DateHandler

### DIFF
--- a/koku/api/organizations/queries.py
+++ b/koku/api/organizations/queries.py
@@ -28,7 +28,6 @@ from tenant_schemas.utils import tenant_context
 from api.query_filter import QueryFilter
 from api.query_filter import QueryFilterCollection
 from api.query_handler import QueryHandler
-from api.utils import DateHelper
 
 
 LOG = logging.getLogger(__name__)
@@ -70,8 +69,6 @@ class OrgQueryHandler(QueryHandler):
     data_sources = []
     SUPPORTED_FILTERS = []
     FILTER_MAP = {}
-
-    dh = DateHelper()
 
     def __init__(self, parameters):
         """Establish org query handler.

--- a/koku/api/query_handler.py
+++ b/koku/api/query_handler.py
@@ -59,6 +59,7 @@ class QueryHandler:
 
         """
         LOG.debug(f"Query Params: {parameters}")
+        self.dh = DateHelper()
         parameters = self.filter_to_order_by(parameters)
         self.tenant = parameters.tenant
         self.access = parameters.access
@@ -215,25 +216,24 @@ class QueryHandler:
         time_scope_units = self.get_time_scope_units()
         start = None
         end = None
-        dh = DateHelper()
         if time_scope_units == "month":
             if time_scope_value == -1:
                 # get current month
-                start = dh.this_month_start
-                end = dh.today
+                start = self.dh.this_month_start
+                end = self.dh.today
             else:
                 # get previous month
-                start = dh.last_month_start
-                end = dh.last_month_end
+                start = self.dh.last_month_start
+                end = self.dh.last_month_end
         else:
             if time_scope_value == -10:
                 # get last 10 days
-                start = dh.n_days_ago(dh.this_hour, 9)
-                end = dh.this_hour
+                start = self.dh.n_days_ago(self.dh.this_hour, 9)
+                end = self.dh.this_hour
             else:
                 # get last 30 days
-                start = dh.n_days_ago(dh.this_hour, 29)
-                end = dh.this_hour
+                start = self.dh.n_days_ago(self.dh.this_hour, 29)
+                end = self.dh.this_hour
 
         self.start_datetime = start
         self.end_datetime = end

--- a/koku/api/tags/queries.py
+++ b/koku/api/tags/queries.py
@@ -24,7 +24,6 @@ from tenant_schemas.utils import tenant_context
 from api.query_filter import QueryFilter
 from api.query_filter import QueryFilterCollection
 from api.query_handler import QueryHandler
-from api.utils import DateHelper
 
 LOG = logging.getLogger(__name__)
 
@@ -68,8 +67,6 @@ class TagQueryHandler(QueryHandler):
         "key": {"field": "key", "operation": "icontains", "composition_key": "key_filter"},
         "value": {"field": "value", "operation": "icontains", "composition_key": "value_filter"},
     }
-
-    dh = DateHelper()
 
     def __init__(self, parameters):
         """Establish tag query handler.

--- a/koku/forecast/forecast.py
+++ b/koku/forecast/forecast.py
@@ -62,8 +62,6 @@ class Forecast:
 
     REPORT_TYPE = "costs"
 
-    dh = DateHelper()
-
     def __init__(self, query_params):  # noqa: C901
         """Class Constructor.
 
@@ -73,6 +71,7 @@ class Forecast:
             - filters (QueryFilterCollection)
             - query_range (tuple)
         """
+        self.dh = DateHelper()
         self.params = query_params
 
         # select appropriate model based on access


### PR DESCRIPTION
This fixes the use of DateHelper in a couple of classes. Instead of using a static class variable (initialized once at application startup), I've moved these to instance variables (initialized each time a new instance is created). 

This will ensure that the dates being referenced are relative to the current API request, rather than the application's start date. 

Additionally, I've moved setting the instance variable into the base `QueryHandler` class to DRY up the code and eliminate the need for each sub-class to implement its own version.