### PR TITLE
Fixing user access to expect all rbac types to be present

### DIFF
--- a/koku/api/user_access/test/test_view.py
+++ b/koku/api/user_access/test/test_view.py
@@ -31,7 +31,19 @@ class UserAccessViewTest(IamTestCase):
         super().setUp()
         self.client = APIClient()
 
-    @RbacPermissions({"aws.account": {"read": ["*"]}})
+    @RbacPermissions(
+        {
+            "aws.account": {"read": ["*"]},
+            "aws.organizational_unit": {"read": []},
+            "gcp.account": {"read": []},
+            "gcp.project": {"read": []},
+            "azure.subscription_guid": {"read": []},
+            "openshift.cluster": {"read": []},
+            "openshift.node": {"read": []},
+            "openshift.project": {"read": []},
+            "cost_model": {"read": [], "write": []},
+        }
+    )
     def test_aws_view_read(self):
         """Test user-access view with aws read wildcard permission."""
         url = reverse("user-access")
@@ -44,7 +56,19 @@ class UserAccessViewTest(IamTestCase):
         self.assertTrue({"type": "azure", "access": False} in response.data.get("data"))
         self.assertTrue({"type": "cost_model", "access": False} in response.data.get("data"))
 
-    @RbacPermissions({"aws.account": {"read": ["123"]}})
+    @RbacPermissions(
+        {
+            "aws.account": {"read": ["123"]},
+            "aws.organizational_unit": {"read": []},
+            "gcp.account": {"read": []},
+            "gcp.project": {"read": []},
+            "azure.subscription_guid": {"read": []},
+            "openshift.cluster": {"read": []},
+            "openshift.node": {"read": []},
+            "openshift.project": {"read": []},
+            "cost_model": {"read": [], "write": []},
+        }
+    )
     def test_aws_view_read_specific_account(self):
         """Test user-access view with aws read specific account permission."""
         url = reverse("user-access")
@@ -57,7 +81,19 @@ class UserAccessViewTest(IamTestCase):
         self.assertTrue({"type": "azure", "access": False} in response.data.get("data"))
         self.assertTrue({"type": "cost_model", "access": False} in response.data.get("data"))
 
-    @RbacPermissions({"aws.account": "*"})
+    @RbacPermissions(
+        {
+            "aws.account": {"read": ["*"]},
+            "aws.organizational_unit": {"read": []},
+            "gcp.account": {"read": []},
+            "gcp.project": {"read": []},
+            "azure.subscription_guid": {"read": []},
+            "openshift.cluster": {"read": []},
+            "openshift.node": {"read": []},
+            "openshift.project": {"read": []},
+            "cost_model": {"read": [], "write": []},
+        }
+    )
     def test_aws_view_wildcard(self):
         """Test user-access view with aws wildcard permission."""
         url = reverse("user-access")
@@ -72,9 +108,15 @@ class UserAccessViewTest(IamTestCase):
 
     @RbacPermissions(
         {
+            "aws.account": {"read": []},
+            "aws.organizational_unit": {"read": []},
+            "gcp.account": {"read": []},
+            "gcp.project": {"read": []},
+            "azure.subscription_guid": {"read": []},
             "openshift.cluster": {"read": ["*"]},
-            "openshift.project": {"read": ["myproject"]},
             "openshift.node": {"read": ["mynode"]},
+            "openshift.project": {"read": ["myproject"]},
+            "cost_model": {"read": [], "write": []},
         }
     )
     def test_ocp_view_cluster(self):
@@ -91,9 +133,15 @@ class UserAccessViewTest(IamTestCase):
 
     @RbacPermissions(
         {
+            "aws.account": {"read": []},
+            "aws.organizational_unit": {"read": []},
+            "gcp.account": {"read": []},
+            "gcp.project": {"read": []},
+            "azure.subscription_guid": {"read": []},
             "openshift.cluster": {"read": ["mycluster"]},
-            "openshift.project": {"read": ["*"]},
             "openshift.node": {"read": ["mynode"]},
+            "openshift.project": {"read": ["*"]},
+            "cost_model": {"read": [], "write": []},
         }
     )
     def test_ocp_view_project(self):
@@ -110,9 +158,15 @@ class UserAccessViewTest(IamTestCase):
 
     @RbacPermissions(
         {
+            "aws.account": {"read": []},
+            "aws.organizational_unit": {"read": []},
+            "gcp.account": {"read": []},
+            "gcp.project": {"read": []},
+            "azure.subscription_guid": {"read": []},
             "openshift.cluster": {"read": ["mycluster"]},
-            "openshift.project": {"read": ["myproject"]},
             "openshift.node": {"read": ["*"]},
+            "openshift.project": {"read": ["myproject"]},
+            "cost_model": {"read": [], "write": []},
         }
     )
     def test_ocp_view_node(self):
@@ -127,7 +181,19 @@ class UserAccessViewTest(IamTestCase):
         self.assertTrue({"type": "azure", "access": False} in response.data.get("data"))
         self.assertTrue({"type": "cost_model", "access": False} in response.data.get("data"))
 
-    @RbacPermissions({"openshift.cluster": "*"})
+    @RbacPermissions(
+        {
+            "aws.account": {"read": []},
+            "aws.organizational_unit": {"read": []},
+            "gcp.account": {"read": []},
+            "gcp.project": {"read": []},
+            "azure.subscription_guid": {"read": []},
+            "openshift.cluster": {"read": ["*"]},
+            "openshift.node": {"read": []},
+            "openshift.project": {"read": []},
+            "cost_model": {"read": [], "write": []},
+        }
+    )
     def test_ocp_view_cluster_wildcard(self):
         """Test user-access view with openshift cluster wildcard permission."""
         url = reverse("user-access")
@@ -141,7 +207,19 @@ class UserAccessViewTest(IamTestCase):
         self.assertTrue({"type": "azure", "access": False} in response.data.get("data"))
         self.assertTrue({"type": "cost_model", "access": False} in response.data.get("data"))
 
-    @RbacPermissions({"openshift.project": "*"})
+    @RbacPermissions(
+        {
+            "aws.account": {"read": []},
+            "aws.organizational_unit": {"read": []},
+            "gcp.account": {"read": []},
+            "gcp.project": {"read": []},
+            "azure.subscription_guid": {"read": []},
+            "openshift.cluster": {"read": [""]},
+            "openshift.node": {"read": []},
+            "openshift.project": {"read": ["*"]},
+            "cost_model": {"read": [], "write": []},
+        }
+    )
     def test_ocp_view_project_wildcard(self):
         """Test user-access view with openshift project wildcard permission."""
         url = reverse("user-access")
@@ -155,7 +233,19 @@ class UserAccessViewTest(IamTestCase):
         self.assertTrue({"type": "azure", "access": False} in response.data.get("data"))
         self.assertTrue({"type": "cost_model", "access": False} in response.data.get("data"))
 
-    @RbacPermissions({"openshift.node": "*"})
+    @RbacPermissions(
+        {
+            "aws.account": {"read": []},
+            "aws.organizational_unit": {"read": []},
+            "gcp.account": {"read": []},
+            "gcp.project": {"read": []},
+            "azure.subscription_guid": {"read": []},
+            "openshift.cluster": {"read": []},
+            "openshift.node": {"read": ["*"]},
+            "openshift.project": {"read": []},
+            "cost_model": {"read": [], "write": []},
+        }
+    )
     def test_ocp_view_node_wildcard(self):
         """Test user-access view with openshift node wildcard permission."""
         url = reverse("user-access")
@@ -169,7 +259,19 @@ class UserAccessViewTest(IamTestCase):
         self.assertTrue({"type": "azure", "access": False} in response.data.get("data"))
         self.assertTrue({"type": "cost_model", "access": False} in response.data.get("data"))
 
-    @RbacPermissions({"gcp.account": {"read": ["*"]}, "gcp.project": {"read": ["myproject"]}})
+    @RbacPermissions(
+        {
+            "aws.account": {"read": []},
+            "aws.organizational_unit": {"read": []},
+            "gcp.account": {"read": ["*"]},
+            "gcp.project": {"read": ["myproject"]},
+            "azure.subscription_guid": {"read": []},
+            "openshift.cluster": {"read": []},
+            "openshift.node": {"read": []},
+            "openshift.project": {"read": []},
+            "cost_model": {"read": [], "write": []},
+        }
+    )
     def test_gcp_view_account(self):
         """Test user-access view with gcp account read wildcard permission."""
         url = reverse("user-access")
@@ -182,7 +284,19 @@ class UserAccessViewTest(IamTestCase):
         self.assertTrue({"type": "azure", "access": False} in response.data.get("data"))
         self.assertTrue({"type": "cost_model", "access": False} in response.data.get("data"))
 
-    @RbacPermissions({"gcp.account": {"read": ["myaccount"]}, "gcp.project": {"read": ["*"]}})
+    @RbacPermissions(
+        {
+            "aws.account": {"read": []},
+            "aws.organizational_unit": {"read": []},
+            "gcp.account": {"read": ["myaccount"]},
+            "gcp.project": {"read": ["*"]},
+            "azure.subscription_guid": {"read": []},
+            "openshift.cluster": {"read": []},
+            "openshift.node": {"read": []},
+            "openshift.project": {"read": []},
+            "cost_model": {"read": [], "write": []},
+        }
+    )
     def test_gcp_view_project(self):
         """Test user-access view with gcp project read wildcard permission."""
         url = reverse("user-access")
@@ -195,7 +309,19 @@ class UserAccessViewTest(IamTestCase):
         self.assertTrue({"type": "azure", "access": False} in response.data.get("data"))
         self.assertTrue({"type": "cost_model", "access": False} in response.data.get("data"))
 
-    @RbacPermissions({"gcp.account": "*"})
+    @RbacPermissions(
+        {
+            "aws.account": {"read": []},
+            "aws.organizational_unit": {"read": []},
+            "gcp.account": {"read": ["*"]},
+            "gcp.project": {"read": []},
+            "azure.subscription_guid": {"read": []},
+            "openshift.cluster": {"read": []},
+            "openshift.node": {"read": []},
+            "openshift.project": {"read": []},
+            "cost_model": {"read": [], "write": []},
+        }
+    )
     def test_gcp_view_account_wildcard(self):
         """Test user-access view with gcp account wildcard permission."""
         url = reverse("user-access")
@@ -209,7 +335,19 @@ class UserAccessViewTest(IamTestCase):
         self.assertTrue({"type": "azure", "access": False} in response.data.get("data"))
         self.assertTrue({"type": "cost_model", "access": False} in response.data.get("data"))
 
-    @RbacPermissions({"gcp.project": "*"})
+    @RbacPermissions(
+        {
+            "aws.account": {"read": []},
+            "aws.organizational_unit": {"read": []},
+            "gcp.account": {"read": []},
+            "gcp.project": {"read": ["*"]},
+            "azure.subscription_guid": {"read": []},
+            "openshift.cluster": {"read": []},
+            "openshift.node": {"read": []},
+            "openshift.project": {"read": []},
+            "cost_model": {"read": [], "write": []},
+        }
+    )
     def test_gcp_view_project_wildcard(self):
         """Test user-access view with gcp project wildcard permission."""
         url = reverse("user-access")
@@ -223,7 +361,19 @@ class UserAccessViewTest(IamTestCase):
         self.assertTrue({"type": "azure", "access": False} in response.data.get("data"))
         self.assertTrue({"type": "cost_model", "access": False} in response.data.get("data"))
 
-    @RbacPermissions({"azure.subscription_guid": {"read": ["*"]}})
+    @RbacPermissions(
+        {
+            "aws.account": {"read": []},
+            "aws.organizational_unit": {"read": []},
+            "gcp.account": {"read": []},
+            "gcp.project": {"read": []},
+            "azure.subscription_guid": {"read": ["*"]},
+            "openshift.cluster": {"read": []},
+            "openshift.node": {"read": []},
+            "openshift.project": {"read": []},
+            "cost_model": {"read": [], "write": []},
+        }
+    )
     def test_azure_view_read(self):
         """Test user-access view with azure subscription read wildcard permission."""
         url = reverse("user-access")
@@ -236,7 +386,19 @@ class UserAccessViewTest(IamTestCase):
         self.assertTrue({"type": "azure", "access": True} in response.data.get("data"))
         self.assertTrue({"type": "cost_model", "access": False} in response.data.get("data"))
 
-    @RbacPermissions({"azure.subscription_guid": "*"})
+    @RbacPermissions(
+        {
+            "aws.account": {"read": []},
+            "aws.organizational_unit": {"read": []},
+            "gcp.account": {"read": []},
+            "gcp.project": {"read": []},
+            "azure.subscription_guid": {"read": ["*"]},
+            "openshift.cluster": {"read": []},
+            "openshift.node": {"read": []},
+            "openshift.project": {"read": []},
+            "cost_model": {"read": [], "write": []},
+        }
+    )
     def test_azure_view_wildcard(self):
         """Test user-access view with azure subscription wildcard permission."""
         url = reverse("user-access")
@@ -261,19 +423,6 @@ class UserAccessViewTest(IamTestCase):
         self.assertTrue({"type": "azure", "access": True} in response.data.get("data"))
         self.assertTrue({"type": "cost_model", "access": True} in response.data.get("data"))
 
-    @RbacPermissions({"*": "*"})
-    def test_view_as_cost_admin(self):
-        """Test user-access view as a cost admin."""
-        url = reverse("user-access")
-        response = self.client.get(url, **self.headers)
-
-        self.assertEqual(len(response.data.get("data")), 5)
-        self.assertTrue({"type": "aws", "access": True} in response.data.get("data"))
-        self.assertTrue({"type": "ocp", "access": True} in response.data.get("data"))
-        self.assertTrue({"type": "gcp", "access": True} in response.data.get("data"))
-        self.assertTrue({"type": "azure", "access": True} in response.data.get("data"))
-        self.assertTrue({"type": "cost_model", "access": True} in response.data.get("data"))
-
     def test_aws_view_query_read_org_admin(self):
         """Test user-access view query as an org admin."""
         url = reverse("user-access")
@@ -282,7 +431,19 @@ class UserAccessViewTest(IamTestCase):
 
         self.assertTrue(response.data.get("data"))
 
-    @RbacPermissions({"aws.account": "*"})
+    @RbacPermissions(
+        {
+            "aws.account": {"read": ["*"]},
+            "aws.organizational_unit": {"read": []},
+            "gcp.account": {"read": []},
+            "gcp.project": {"read": []},
+            "azure.subscription_guid": {"read": []},
+            "openshift.cluster": {"read": []},
+            "openshift.node": {"read": []},
+            "openshift.project": {"read": []},
+            "cost_model": {"read": [], "write": []},
+        }
+    )
     def test_aws_view_query_read(self):
         """Test user-access view query for aws."""
         url = reverse("user-access")
@@ -291,7 +452,19 @@ class UserAccessViewTest(IamTestCase):
 
         self.assertTrue(response.data.get("data"))
 
-    @RbacPermissions({"openshift.cluster": "*"})
+    @RbacPermissions(
+        {
+            "aws.account": {"read": []},
+            "aws.organizational_unit": {"read": []},
+            "gcp.account": {"read": []},
+            "gcp.project": {"read": []},
+            "azure.subscription_guid": {"read": []},
+            "openshift.cluster": {"read": ["*"]},
+            "openshift.node": {"read": []},
+            "openshift.project": {"read": []},
+            "cost_model": {"read": [], "write": []},
+        }
+    )
     def test_openshift_view_query_read_for_aws(self):
         """Test user-access view query for aws with openshift permissions."""
         url = reverse("user-access")
@@ -300,7 +473,19 @@ class UserAccessViewTest(IamTestCase):
 
         self.assertFalse(response.data.get("data"))
 
-    @RbacPermissions({"cost_model": "*"})
+    @RbacPermissions(
+        {
+            "aws.account": {"read": []},
+            "aws.organizational_unit": {"read": []},
+            "gcp.account": {"read": []},
+            "gcp.project": {"read": []},
+            "azure.subscription_guid": {"read": []},
+            "openshift.cluster": {"read": ["*"]},
+            "openshift.node": {"read": []},
+            "openshift.project": {"read": []},
+            "cost_model": {"read": ["*"], "write": []},
+        }
+    )
     def test_cost_model_view_query_read_for_aws(self):
         """Test user-access view query for cost_model."""
         url = reverse("user-access")
@@ -309,7 +494,19 @@ class UserAccessViewTest(IamTestCase):
 
         self.assertTrue(response.data.get("data"))
 
-    @RbacPermissions({"cost_model": {"write": ["*"]}})
+    @RbacPermissions(
+        {
+            "aws.account": {"read": []},
+            "aws.organizational_unit": {"read": []},
+            "gcp.account": {"read": []},
+            "gcp.project": {"read": []},
+            "azure.subscription_guid": {"read": []},
+            "openshift.cluster": {"read": ["*"]},
+            "openshift.node": {"read": []},
+            "openshift.project": {"read": []},
+            "cost_model": {"read": [], "write": ["*"]},
+        }
+    )
     def test_cost_model_view_query_write_for_aws(self):
         """Test user-access view query for cost_model with write access."""
         url = reverse("user-access")

--- a/koku/api/user_access/view.py
+++ b/koku/api/user_access/view.py
@@ -31,7 +31,8 @@ LOG = logging.getLogger(__name__)
 
 class UserAccess:
     def check_access(self, access_list):
-        if access_list:
+        LOG.info(f"Access List: {str(access_list)}")
+        if access_list.get("read") or access_list.get("write"):
             return True
         return False
 
@@ -98,17 +99,6 @@ class CostModelUserAccess(UserAccess):
         return False
 
 
-class CostManagementAllAccess(UserAccess):
-    def __init__(self, access):
-        self.all_access = access.get("*")
-
-    @property
-    def access(self):
-        if self.check_access(self.all_access):
-            return True
-        return False
-
-
 class UserAccessView(APIView):
     """API GET view for User API."""
 
@@ -119,7 +109,7 @@ class UserAccessView(APIView):
         query_params = request.query_params
         user_access = request.user.access
         LOG.info(f"User Access RBAC permissions: {str(user_access)}. Org Admin: {str(request.user.admin)}")
-        admin_user = request.user.admin or CostManagementAllAccess(user_access).access
+        admin_user = request.user.admin
         LOG.info(f"User Access admin user: {str(admin_user)}")
 
         source_types = [

--- a/koku/api/user_access/view.py
+++ b/koku/api/user_access/view.py
@@ -31,7 +31,6 @@ LOG = logging.getLogger(__name__)
 
 class UserAccess:
     def check_access(self, access_list):
-        LOG.info(f"Access List: {str(access_list)}")
         if access_list.get("read") or access_list.get("write"):
             return True
         return False
@@ -108,9 +107,9 @@ class UserAccessView(APIView):
     def get(self, request, **kwargs):
         query_params = request.query_params
         user_access = request.user.access
-        LOG.info(f"User Access RBAC permissions: {str(user_access)}. Org Admin: {str(request.user.admin)}")
+        LOG.debug(f"User Access RBAC permissions: {str(user_access)}. Org Admin: {str(request.user.admin)}")
         admin_user = request.user.admin
-        LOG.info(f"User Access admin user: {str(admin_user)}")
+        LOG.debug(f"User Access admin user: {str(admin_user)}")
 
         source_types = [
             {"type": "aws", "access_class": AWSUserAccess},


### PR DESCRIPTION
I was working on a bad assumption that rbac-types would only be present if they were configured.