### PR TITLE
Sources ARN move from password to username filed

### DIFF
--- a/koku/sources/sources_http_client.py
+++ b/koku/sources/sources_http_client.py
@@ -235,6 +235,14 @@ class SourcesHTTPClient:
         if not authentications_response.get("data"):
             raise SourcesHTTPClientError(f"Unable to get AWS roleARN for Source: {self._source_id}")
 
+        username = authentications_response.get("data")[0].get("username")
+        LOG.info(f"AUTH RESPONSE: {str(authentications_response)}")
+
+        # Platform sources is moving the ARN from the password to the username field.
+        # We are supporting both until the this change has made it to all environments.
+        if username:
+            return {"role_arn": username}
+
         authentications_id = authentications_response.get("data")[0].get("id")
 
         authentications_internal_url = "{}/authentications/{}?expose_encrypted_attribute[]=password".format(

--- a/koku/sources/sources_http_client.py
+++ b/koku/sources/sources_http_client.py
@@ -236,7 +236,6 @@ class SourcesHTTPClient:
             raise SourcesHTTPClientError(f"Unable to get AWS roleARN for Source: {self._source_id}")
 
         username = authentications_response.get("data")[0].get("username")
-        LOG.info(f"AUTH RESPONSE: {str(authentications_response)}")
 
         # Platform sources is moving the ARN from the password to the username field.
         # We are supporting both until the this change has made it to all environments.

--- a/koku/sources/test/test_sources_http_client.py
+++ b/koku/sources/test/test_sources_http_client.py
@@ -197,6 +197,26 @@ class SourcesHTTPClientTest(TestCase):
             self.assertEqual(response, {"role_arn": self.authentication})
 
     @patch.object(Config, "SOURCES_API_URL", "http://www.sources.com")
+    def test_get_aws_credentials_username(self):
+        """Test to get AWS Role ARN from authentication service from username."""
+        resource_id = 2
+        authentication_id = 3
+        client = SourcesHTTPClient(auth_header=Config.SOURCES_FAKE_HEADER, source_id=self.source_id)
+        with requests_mock.mock() as m:
+            m.get(
+                f"http://www.sources.com/api/v1.0/applications?filter[source_id]={self.source_id}",
+                status_code=200,
+                json={"data": [{"id": resource_id}]},
+            )
+            m.get(
+                (f"http://www.sources.com/api/v1.0/authentications?" f"[authtype]=arn&[resource_id]={resource_id}"),
+                status_code=200,
+                json={"data": [{"id": authentication_id, "username": self.authentication}]},
+            )
+            response = client.get_aws_credentials()
+            self.assertEqual(response, {"role_arn": self.authentication})
+
+    @patch.object(Config, "SOURCES_API_URL", "http://www.sources.com")
     def test_get_aws_credentials_from_app_auth(self):
         """Test to get AWS Role ARN from authentication service for Application authentication."""
         resource_id = 2


### PR DESCRIPTION
Platform sources is moving the AWS ARN value from the Authentications password field to the username filed so that it is visible in the UI during source editing:

Platform Issues:
https://issues.redhat.com/browse/RHCLOUD-11834
https://issues.redhat.com/browse/RHCLOUD-11835

This change will attempt to get the ARN from the username field and then fall back to the password field until the platform change is running in production.  At that point in time we can remove the password ARN logic.

**Testing**
1. Add an AWS source with ARN in the Authentication.password field.
2. Add an AWS source with ARN in the Authentication.username field.

**Test Results**
[sources_arn_move_ut.txt](https://github.com/project-koku/koku/files/5873850/sources_arn_move_ut.txt)
