### PR TITLE
reapply application-side text field size check

### DIFF
--- a/koku/api/model_utils.py
+++ b/koku/api/model_utils.py
@@ -1,0 +1,32 @@
+#
+# Copyright 2021 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""Django model mixins and utilities."""
+
+
+class RunFieldValidators:
+    """
+    Mixin to run all field validators on a save method call
+    This mixin should appear BEFORE Model.
+    """
+
+    def save(self, *args, **kwargs):
+        """
+        For all fields, run any default and specified validators before calling save
+        """
+        for f in (c for c in self._meta.get_fields() if hasattr(self, c.name)):
+            f.run_validators(getattr(self, f.name))
+        super().save(*args, **kwargs)

--- a/koku/api/provider/models.py
+++ b/koku/api/provider/models.py
@@ -19,9 +19,12 @@ import logging
 from uuid import uuid4
 
 from django.conf import settings
+from django.core.validators import MaxLengthValidator
 from django.db import models
 from django.db import transaction
 from django.db.models import JSONField
+
+from api.model_utils import RunFieldValidators
 
 LOG = logging.getLogger(__name__)
 
@@ -162,7 +165,7 @@ class Provider(models.Model):
             transaction.on_commit(lambda: check_report_updates.delay(provider_uuid=self.uuid))
 
 
-class Sources(models.Model):
+class Sources(RunFieldValidators, models.Model):
     """Platform-Sources table.
 
     Used for managing Platform-Sources.
@@ -182,7 +185,7 @@ class Sources(models.Model):
     source_uuid = models.UUIDField(unique=True, null=True)
 
     # Source name.
-    name = models.TextField(null=True)
+    name = models.TextField(max_length=256, null=True, validators=[MaxLengthValidator(256)])
 
     # Red Hat identity header.  Passed along to Koku API for entitlement and rbac reasons.
     auth_header = models.TextField(null=True)


### PR DESCRIPTION
## Jira Ticket

[COST-836](https://issues.redhat.com/browse/COST-836)

## Description

Checking into expanding the data type change to the provider table was going to require that the change be propagated to many other `reporting_*` tables as well as requiring manual migrations against at least one partitioned table. Also some of the materialized views would have to be dropped and re-created.

After speaking with Doug, we decided to re-implement the 256-char limit on the `api_sources.name` column. This will be done in the api by forcing field validations to run against `Sources` model instances on a call to `save()`. This change will run the default and specified validators only without calling the `clean()` functionality.

This was done as a mixin that will override `Model.save()` and can be applied to any Cost Management Django model.

## Testing

Creating a source with a name > 256 will throw a django ValidationError exception.