### PR TITLE
COST-908: bugfix for summary table lookup

### DIFF
--- a/koku/forecast/forecast.py
+++ b/koku/forecast/forecast.py
@@ -87,7 +87,7 @@ class Forecast:
                 self.cost_summary_table = materialized_view
             else:
                 # We have access constraints, but no view to accomodate, default to daily summary table
-                self.cost_summary_table = self.provider_map.report_type_map.get("tables", {}).get("query")
+                self.cost_summary_table = self.provider_map.query_table
 
         self.forecast_days_required = (self.dh.this_month_end - self.dh.yesterday).days
 
@@ -396,7 +396,7 @@ class LinearForecastResult:
 
         Args:
             regression_result (RegressionResult) the results of a statsmodels regression
-            exog (array-like) exogenous variables for points to predict
+            exog (array-like) future exogenous variables; points to predict
         """
         self._exog = exog
         self._regression_result = regression_result

--- a/koku/forecast/test/tests_forecast.py
+++ b/koku/forecast/test/tests_forecast.py
@@ -46,6 +46,7 @@ from forecast import OCPAWSForecast
 from forecast import OCPAzureForecast
 from forecast import OCPForecast
 from forecast.forecast import LinearForecastResult
+from reporting.provider.aws.models import AWSCostEntryLineItemDailySummary
 from reporting.provider.gcp.models import GCPCostSummary
 from reporting.provider.gcp.models import GCPCostSummaryByAccount
 from reporting.provider.gcp.models import GCPCostSummaryByProject
@@ -427,6 +428,13 @@ class AWSForecastTest(IamTestCase):
             with self.subTest(dates=scenario["dates"], expected=scenario["expected"]):
                 out = instance._enumerate_dates(scenario["dates"])
                 self.assertEqual(out, scenario["expected"])
+
+    def test_summary_table(self):
+        """COST-908: Test that the expected summary table is used."""
+        mock_access = {"aws.organizational_unit": {"read": ["1234", "5678"]}}
+        params = self.mocked_query_params("?", AWSCostForecastView, access=mock_access)
+        instance = AWSForecast(params)
+        self.assertEqual(instance.cost_summary_table, AWSCostEntryLineItemDailySummary)
 
 
 class AzureForecastTest(IamTestCase):


### PR DESCRIPTION
This fixes the bug described in COST-908. A conditional branch was referencing a part of the ProviderMap that doesn't exist.