### PR TITLE
Mixin changed to only validate TextField

### DIFF
--- a/koku/api/model_utils.py
+++ b/koku/api/model_utils.py
@@ -17,7 +17,7 @@
 """Django model mixins and utilities."""
 
 
-class RunFieldValidators:
+class RunTextFieldValidators:
     """
     Mixin to run all field validators on a save method call
     This mixin should appear BEFORE Model.
@@ -27,6 +27,8 @@ class RunFieldValidators:
         """
         For all fields, run any default and specified validators before calling save
         """
-        for f in (c for c in self._meta.get_fields() if hasattr(self, c.name)):
+        for f in (
+            c for c in self._meta.get_fields() if hasattr(self, c.name) and c.get_internal_type() == "TextField"
+        ):
             f.run_validators(getattr(self, f.name))
         super().save(*args, **kwargs)

--- a/koku/api/model_utils.py
+++ b/koku/api/model_utils.py
@@ -30,5 +30,9 @@ class RunTextFieldValidators:
         for f in (
             c for c in self._meta.get_fields() if hasattr(self, c.name) and c.get_internal_type() == "TextField"
         ):
-            f.run_validators(getattr(self, f.name))
+            val = getattr(self, f.name)
+            if val is not None:
+                val = str(val)
+            f.run_validators(val)
+
         super().save(*args, **kwargs)

--- a/koku/api/provider/models.py
+++ b/koku/api/provider/models.py
@@ -24,7 +24,7 @@ from django.db import models
 from django.db import transaction
 from django.db.models import JSONField
 
-from api.model_utils import RunFieldValidators
+from api.model_utils import RunTextFieldValidators
 
 LOG = logging.getLogger(__name__)
 
@@ -165,7 +165,7 @@ class Provider(models.Model):
             transaction.on_commit(lambda: check_report_updates.delay(provider_uuid=self.uuid))
 
 
-class Sources(RunFieldValidators, models.Model):
+class Sources(RunTextFieldValidators, models.Model):
     """Platform-Sources table.
 
     Used for managing Platform-Sources.

--- a/koku/api/provider/test/tests_models.py
+++ b/koku/api/provider/test/tests_models.py
@@ -52,17 +52,37 @@ class SourcesModelTest(MasuTestCase):
         short_source = Sources(
             source_id=-12, name=short_name, offset=1, source_type=Provider.PROVIDER_AWS, authentication={}
         )
-        int_source = Sources(source_id=-13, name=10, offset=1, source_type=Provider.PROVIDER_AWS, authentication={})
-        none_source = Sources(source_id=-14, name=None, offset=1, source_type=Provider.PROVIDER_AWS, authentication={})
-        unnamed_source = Sources(source_id=-15, offset=1, source_type=Provider.PROVIDER_AWS, authentication={})
         with tenant_context(self.tenant):
             with self.assertRaises(ValidationError):
                 long_source.save()
             max_source.save()
             short_source.save()
+
+    def test_text_field_non_str_val(self):
+        """Test that textfields with non-str values will pass."""
+        int_source = Sources(source_id=-20, name=10, offset=1, source_type=Provider.PROVIDER_AWS, authentication={})
+        none_source = Sources(source_id=-21, name=None, offset=1, source_type=Provider.PROVIDER_AWS, authentication={})
+        unnamed_source = Sources(source_id=-22, offset=1, source_type=Provider.PROVIDER_AWS, authentication={})
+        with tenant_context(self.tenant):
             int_source.save()
             none_source.save()
             unnamed_source.save()
+
+    def text_only_text_field_validated(self):
+        """Test that only model textfields are validated."""
+        max_length = Sources._meta.get_field("name").max_length
+        long_name = "x" * (max_length + 1)
+        short_name = "x" * (max_length - 1)
+        long_source = Sources(
+            source_id=-30, name=long_name, offset=1, source_type=Provider.PROVIDER_AWS, authentication={}
+        )
+        str_id_source = Sources(
+            source_id="-31", name=short_name, offset=1, source_type=Provider.PROVIDER_AWS, authentication={}
+        )
+        with tenant_context(self.tenant):
+            with self.assertRaises(ValidationError):
+                long_source.save()
+            str_id_source.save()
 
 
 class ProviderModelTest(MasuTestCase):

--- a/koku/api/provider/test/tests_models.py
+++ b/koku/api/provider/test/tests_models.py
@@ -52,11 +52,17 @@ class SourcesModelTest(MasuTestCase):
         short_source = Sources(
             source_id=-12, name=short_name, offset=1, source_type=Provider.PROVIDER_AWS, authentication={}
         )
+        int_source = Sources(source_id=-13, name=10, offset=1, source_type=Provider.PROVIDER_AWS, authentication={})
+        none_source = Sources(source_id=-14, name=None, offset=1, source_type=Provider.PROVIDER_AWS, authentication={})
+        unnamed_source = Sources(source_id=-15, offset=1, source_type=Provider.PROVIDER_AWS, authentication={})
         with tenant_context(self.tenant):
             with self.assertRaises(ValidationError):
                 long_source.save()
             max_source.save()
             short_source.save()
+            int_source.save()
+            none_source.save()
+            unnamed_source.save()
 
 
 class ProviderModelTest(MasuTestCase):


### PR DESCRIPTION
## Jira ticket

[COST-971](https://issues.redhat.com/browse/COST-971)

## Description

The fix for COST-821 ( #2629 ) was running **all** field validators directly. This leads to issues with other fields having values inconsistent with their DB types. This change will validate only TextField values and has some protections against putting in a non-str value for the model class attribute.

## Testing

Simplest way to explicitly test:

1. `cd <KOKU-REPO-ROOT>/koku`
2. `python ./manage.py shell`
3. `from api.provider.models import Sources`
4. `Sources.objects.create(source_id='-1', name='some name', offset=1, authentication={})`
5. _**4** should succeed_
6. `Sources.objects.create(source_id='-2', name=1, offset=1, authentication={})`
7. _**6** should succeed_
8. `Sources.objects.create(source_id='-3', name=('x' * 500), offset=1, authentication={})`
9. _**8** should fail_
10. `CTRL+D`

Simplest way to test via API:

1. Launch the api using this branch
2. Create a source
2. 