### PR TITLE
COST-954: add AnyUserAccess; small refactor

### DIFF
--- a/koku/api/user_access/test/test_view.py
+++ b/koku/api/user_access/test/test_view.py
@@ -26,6 +26,8 @@ from api.iam.test.iam_test_case import RbacPermissions
 class UserAccessViewTest(IamTestCase):
     """Tests the resource types views."""
 
+    NUM_ACCESS_CLASSES = 6
+
     def setUp(self):
         """Set up the UserAccess view tests."""
         super().setUp()
@@ -49,7 +51,8 @@ class UserAccessViewTest(IamTestCase):
         url = reverse("user-access")
         response = self.client.get(url, **self.headers)
 
-        self.assertEqual(len(response.data.get("data")), 5)
+        self.assertEqual(len(response.data.get("data")), self.NUM_ACCESS_CLASSES)
+        self.assertTrue({"type": "any", "access": True} in response.data.get("data"))
         self.assertTrue({"type": "aws", "access": True} in response.data.get("data"))
         self.assertTrue({"type": "ocp", "access": False} in response.data.get("data"))
         self.assertTrue({"type": "gcp", "access": False} in response.data.get("data"))
@@ -74,7 +77,8 @@ class UserAccessViewTest(IamTestCase):
         url = reverse("user-access")
         response = self.client.get(url, **self.headers)
 
-        self.assertEqual(len(response.data.get("data")), 5)
+        self.assertEqual(len(response.data.get("data")), self.NUM_ACCESS_CLASSES)
+        self.assertTrue({"type": "any", "access": True} in response.data.get("data"))
         self.assertTrue({"type": "aws", "access": True} in response.data.get("data"))
         self.assertTrue({"type": "ocp", "access": False} in response.data.get("data"))
         self.assertTrue({"type": "gcp", "access": False} in response.data.get("data"))
@@ -99,7 +103,8 @@ class UserAccessViewTest(IamTestCase):
         url = reverse("user-access")
         response = self.client.get(url, **self.headers)
 
-        self.assertEqual(len(response.data.get("data")), 5)
+        self.assertEqual(len(response.data.get("data")), self.NUM_ACCESS_CLASSES)
+        self.assertTrue({"type": "any", "access": True} in response.data.get("data"))
         self.assertTrue({"type": "aws", "access": True} in response.data.get("data"))
         self.assertTrue({"type": "ocp", "access": False} in response.data.get("data"))
         self.assertTrue({"type": "gcp", "access": False} in response.data.get("data"))
@@ -124,7 +129,8 @@ class UserAccessViewTest(IamTestCase):
         url = reverse("user-access")
         response = self.client.get(url, **self.headers)
 
-        self.assertEqual(len(response.data.get("data")), 5)
+        self.assertEqual(len(response.data.get("data")), self.NUM_ACCESS_CLASSES)
+        self.assertTrue({"type": "any", "access": True} in response.data.get("data"))
         self.assertTrue({"type": "aws", "access": False} in response.data.get("data"))
         self.assertTrue({"type": "ocp", "access": True} in response.data.get("data"))
         self.assertTrue({"type": "gcp", "access": False} in response.data.get("data"))
@@ -149,7 +155,8 @@ class UserAccessViewTest(IamTestCase):
         url = reverse("user-access")
         response = self.client.get(url, **self.headers)
 
-        self.assertEqual(len(response.data.get("data")), 5)
+        self.assertEqual(len(response.data.get("data")), self.NUM_ACCESS_CLASSES)
+        self.assertTrue({"type": "any", "access": True} in response.data.get("data"))
         self.assertTrue({"type": "aws", "access": False} in response.data.get("data"))
         self.assertTrue({"type": "ocp", "access": True} in response.data.get("data"))
         self.assertTrue({"type": "gcp", "access": False} in response.data.get("data"))
@@ -174,7 +181,8 @@ class UserAccessViewTest(IamTestCase):
         url = reverse("user-access")
         response = self.client.get(url, **self.headers)
 
-        self.assertEqual(len(response.data.get("data")), 5)
+        self.assertEqual(len(response.data.get("data")), self.NUM_ACCESS_CLASSES)
+        self.assertTrue({"type": "any", "access": True} in response.data.get("data"))
         self.assertTrue({"type": "aws", "access": False} in response.data.get("data"))
         self.assertTrue({"type": "ocp", "access": True} in response.data.get("data"))
         self.assertTrue({"type": "gcp", "access": False} in response.data.get("data"))
@@ -200,7 +208,8 @@ class UserAccessViewTest(IamTestCase):
 
         response = self.client.get(url, **self.headers)
 
-        self.assertEqual(len(response.data.get("data")), 5)
+        self.assertEqual(len(response.data.get("data")), self.NUM_ACCESS_CLASSES)
+        self.assertTrue({"type": "any", "access": True} in response.data.get("data"))
         self.assertTrue({"type": "aws", "access": False} in response.data.get("data"))
         self.assertTrue({"type": "ocp", "access": True} in response.data.get("data"))
         self.assertTrue({"type": "gcp", "access": False} in response.data.get("data"))
@@ -226,7 +235,8 @@ class UserAccessViewTest(IamTestCase):
 
         response = self.client.get(url, **self.headers)
 
-        self.assertEqual(len(response.data.get("data")), 5)
+        self.assertEqual(len(response.data.get("data")), self.NUM_ACCESS_CLASSES)
+        self.assertTrue({"type": "any", "access": True} in response.data.get("data"))
         self.assertTrue({"type": "aws", "access": False} in response.data.get("data"))
         self.assertTrue({"type": "ocp", "access": True} in response.data.get("data"))
         self.assertTrue({"type": "gcp", "access": False} in response.data.get("data"))
@@ -252,7 +262,8 @@ class UserAccessViewTest(IamTestCase):
 
         response = self.client.get(url, **self.headers)
 
-        self.assertEqual(len(response.data.get("data")), 5)
+        self.assertEqual(len(response.data.get("data")), self.NUM_ACCESS_CLASSES)
+        self.assertTrue({"type": "any", "access": True} in response.data.get("data"))
         self.assertTrue({"type": "aws", "access": False} in response.data.get("data"))
         self.assertTrue({"type": "ocp", "access": True} in response.data.get("data"))
         self.assertTrue({"type": "gcp", "access": False} in response.data.get("data"))
@@ -277,7 +288,8 @@ class UserAccessViewTest(IamTestCase):
         url = reverse("user-access")
         response = self.client.get(url, **self.headers)
 
-        self.assertEqual(len(response.data.get("data")), 5)
+        self.assertEqual(len(response.data.get("data")), self.NUM_ACCESS_CLASSES)
+        self.assertTrue({"type": "any", "access": True} in response.data.get("data"))
         self.assertTrue({"type": "aws", "access": False} in response.data.get("data"))
         self.assertTrue({"type": "ocp", "access": False} in response.data.get("data"))
         self.assertTrue({"type": "gcp", "access": True} in response.data.get("data"))
@@ -302,7 +314,8 @@ class UserAccessViewTest(IamTestCase):
         url = reverse("user-access")
         response = self.client.get(url, **self.headers)
 
-        self.assertEqual(len(response.data.get("data")), 5)
+        self.assertEqual(len(response.data.get("data")), self.NUM_ACCESS_CLASSES)
+        self.assertTrue({"type": "any", "access": True} in response.data.get("data"))
         self.assertTrue({"type": "aws", "access": False} in response.data.get("data"))
         self.assertTrue({"type": "ocp", "access": False} in response.data.get("data"))
         self.assertTrue({"type": "gcp", "access": True} in response.data.get("data"))
@@ -328,7 +341,8 @@ class UserAccessViewTest(IamTestCase):
 
         response = self.client.get(url, **self.headers)
 
-        self.assertEqual(len(response.data.get("data")), 5)
+        self.assertEqual(len(response.data.get("data")), self.NUM_ACCESS_CLASSES)
+        self.assertTrue({"type": "any", "access": True} in response.data.get("data"))
         self.assertTrue({"type": "aws", "access": False} in response.data.get("data"))
         self.assertTrue({"type": "ocp", "access": False} in response.data.get("data"))
         self.assertTrue({"type": "gcp", "access": True} in response.data.get("data"))
@@ -354,7 +368,8 @@ class UserAccessViewTest(IamTestCase):
 
         response = self.client.get(url, **self.headers)
 
-        self.assertEqual(len(response.data.get("data")), 5)
+        self.assertEqual(len(response.data.get("data")), self.NUM_ACCESS_CLASSES)
+        self.assertTrue({"type": "any", "access": True} in response.data.get("data"))
         self.assertTrue({"type": "aws", "access": False} in response.data.get("data"))
         self.assertTrue({"type": "ocp", "access": False} in response.data.get("data"))
         self.assertTrue({"type": "gcp", "access": True} in response.data.get("data"))
@@ -379,7 +394,8 @@ class UserAccessViewTest(IamTestCase):
         url = reverse("user-access")
         response = self.client.get(url, **self.headers)
 
-        self.assertEqual(len(response.data.get("data")), 5)
+        self.assertEqual(len(response.data.get("data")), self.NUM_ACCESS_CLASSES)
+        self.assertTrue({"type": "any", "access": True} in response.data.get("data"))
         self.assertTrue({"type": "aws", "access": False} in response.data.get("data"))
         self.assertTrue({"type": "ocp", "access": False} in response.data.get("data"))
         self.assertTrue({"type": "gcp", "access": False} in response.data.get("data"))
@@ -404,11 +420,26 @@ class UserAccessViewTest(IamTestCase):
         url = reverse("user-access")
         response = self.client.get(url, **self.headers)
 
-        self.assertEqual(len(response.data.get("data")), 5)
+        self.assertEqual(len(response.data.get("data")), self.NUM_ACCESS_CLASSES)
+        self.assertTrue({"type": "any", "access": True} in response.data.get("data"))
         self.assertTrue({"type": "aws", "access": False} in response.data.get("data"))
         self.assertTrue({"type": "ocp", "access": False} in response.data.get("data"))
         self.assertTrue({"type": "gcp", "access": False} in response.data.get("data"))
         self.assertTrue({"type": "azure", "access": True} in response.data.get("data"))
+        self.assertTrue({"type": "cost_model", "access": False} in response.data.get("data"))
+
+    @RbacPermissions({})
+    def test_view_no_access(self):
+        """Test user-access view as an org admin."""
+        url = reverse("user-access")
+        response = self.client.get(url, **self.headers)
+
+        self.assertEqual(len(response.data.get("data")), self.NUM_ACCESS_CLASSES)
+        self.assertTrue({"type": "any", "access": False} in response.data.get("data"))
+        self.assertTrue({"type": "aws", "access": False} in response.data.get("data"))
+        self.assertTrue({"type": "ocp", "access": False} in response.data.get("data"))
+        self.assertTrue({"type": "gcp", "access": False} in response.data.get("data"))
+        self.assertTrue({"type": "azure", "access": False} in response.data.get("data"))
         self.assertTrue({"type": "cost_model", "access": False} in response.data.get("data"))
 
     def test_view_as_org_admin(self):
@@ -416,7 +447,8 @@ class UserAccessViewTest(IamTestCase):
         url = reverse("user-access")
         response = self.client.get(url, **self.headers)
 
-        self.assertEqual(len(response.data.get("data")), 5)
+        self.assertEqual(len(response.data.get("data")), self.NUM_ACCESS_CLASSES)
+        self.assertTrue({"type": "any", "access": True} in response.data.get("data"))
         self.assertTrue({"type": "aws", "access": True} in response.data.get("data"))
         self.assertTrue({"type": "ocp", "access": True} in response.data.get("data"))
         self.assertTrue({"type": "gcp", "access": True} in response.data.get("data"))

--- a/koku/api/user_access/view.py
+++ b/koku/api/user_access/view.py
@@ -29,99 +29,119 @@ from api.common.pagination import ListPaginator
 LOG = logging.getLogger(__name__)
 
 
-class UserAccess:
-    def check_access(self, access_list):
-        if access_list.get("read") or access_list.get("write"):
-            return True
-        return False
+class UIFeatureAccess:
+    """Class for determining a user's access to a UI feature.
 
+    This class enables the UI and platform to query for whether a user has access to certain resources.
 
-class AWSUserAccess(UserAccess):
+    The purpose of this API is two things:
+        1. to keep UI and API in sync about RBAC permissions
+        2. to provide the UI (both our UI and the platform's chroming) with a simple boolean response regarding whether
+            a user has access to specific features of the UI.
+
+    Class attributes:
+
+        access_keys (list) - a list of access keys to check. must be implemented by sub-classes.
+                             multiple keys will be ORed; i.e. if a user has access to anything in the list,
+                             this API returns True
+    """
+
     def __init__(self, access):
-        self.account_access = access.get("aws.account")
+        """Class Constructor.
+
+        Args:
+            access (dict) - an RBAC dict; see: koku.koku.middleware.IdentityHeaderMiddleware
+        """
+        self.access_dict = access
+
+    def _get_access_value(self, key1, key2, default=None):
+        """Return the access value from the inner dict."""
+        return self.access_dict.get(key1, {}).get(key2, default)
 
     @property
     def access(self):
-        if self.check_access(self.account_access):
-            return True
+        """Access property returns whether the user has the requested access.
+
+        Return:
+            (bool)
+        """
+        for key in self.access_keys:
+            if self._get_access_value(key, "read") or self._get_access_value(key, "write"):
+                return True
         return False
 
 
-class OCPUserAccess(UserAccess):
-    def __init__(self, access):
-        self.cluster_access = access.get("openshift.cluster")
-        self.node_access = access.get("openshift.node")
-        self.project_access = access.get("openshift.project")
+class AWSUserAccess(UIFeatureAccess):
+    """Access to AWS UI Features."""
 
-    @property
-    def access(self):
-        if (
-            self.check_access(self.cluster_access)
-            or self.check_access(self.node_access)
-            or self.check_access(self.project_access)
-        ):
-            return True
-        return False
+    access_keys = ["aws.account"]
 
 
-class AzureUserAccess(UserAccess):
-    def __init__(self, access):
-        self.subscription_access = access.get("azure.subscription_guid")
+class OCPUserAccess(UIFeatureAccess):
+    """Access to OCP UI Features."""
 
-    @property
-    def access(self):
-        if self.check_access(self.subscription_access):
-            return True
-        return False
+    access_keys = ["openshift.cluster", "openshift.node", "openshift.project"]
 
 
-class GCPUserAccess(UserAccess):
-    def __init__(self, access):
-        self.account_access = access.get("gcp.account")
-        self.project_access = access.get("gcp.project")
+class AzureUserAccess(UIFeatureAccess):
+    """Access to Azure UI Features."""
 
-    @property
-    def access(self):
-        if self.check_access(self.account_access) or self.check_access(self.project_access):
-            return True
-        return False
+    access_keys = ["azure.subscription_guid"]
 
 
-class CostModelUserAccess(UserAccess):
-    def __init__(self, access):
-        self.subscription_access = access.get("cost_model")
+class GCPUserAccess(UIFeatureAccess):
+    """Access to GCP UI Features."""
 
-    @property
-    def access(self):
-        if self.check_access(self.subscription_access):
-            return True
-        return False
+    access_keys = ["gcp.account", "gcp.project"]
+
+
+class CostModelUserAccess(UIFeatureAccess):
+    """Access to Cost Model UI Features."""
+
+    access_keys = ["cost_model"]
+
+
+class AnyUserAccess(UIFeatureAccess):
+    """Check for if the user has access to any features."""
+
+    access_keys = (
+        AWSUserAccess.access_keys + AzureUserAccess.access_keys + GCPUserAccess.access_keys + OCPUserAccess.access_keys
+    )
 
 
 class UserAccessView(APIView):
-    """API GET view for User API."""
+    """View class for handling requests to determine a user's access to a resource."""
 
     permission_classes = [AllowAny]
 
+    _source_types = [
+        {"type": "any", "access_class": AnyUserAccess},
+        {"type": "aws", "access_class": AWSUserAccess},
+        {"type": "azure", "access_class": AzureUserAccess},
+        {"type": "cost_model", "access_class": CostModelUserAccess},
+        {"type": "gcp", "access_class": GCPUserAccess},
+        {"type": "ocp", "access_class": OCPUserAccess},
+    ]
+
     @method_decorator(vary_on_headers(CACHE_RH_IDENTITY_HEADER))
     def get(self, request, **kwargs):
+        """Respond to HTTP GET requests.
+
+        Args:
+            request (Request) HTTP Request object
+            kwargs (dict) optional keyword args
+        """
         query_params = request.query_params
         user_access = request.user.access
         LOG.debug(f"User Access RBAC permissions: {str(user_access)}. Org Admin: {str(request.user.admin)}")
         admin_user = request.user.admin
         LOG.debug(f"User Access admin user: {str(admin_user)}")
 
-        source_types = [
-            {"type": "aws", "access_class": AWSUserAccess},
-            {"type": "ocp", "access_class": OCPUserAccess},
-            {"type": "gcp", "access_class": GCPUserAccess},
-            {"type": "azure", "access_class": AzureUserAccess},
-            {"type": "cost_model", "access_class": CostModelUserAccess},
-        ]
-
         source_type = query_params.get("type")
         if source_type:
-            source_accessor = next((item for item in source_types if item.get("type") == source_type.lower()), False)
+            source_accessor = next(
+                (item for item in self._source_types if item.get("type") == source_type.lower()), False
+            )
             if source_accessor:
                 access_class = source_accessor.get("access_class")
                 if admin_user:
@@ -133,7 +153,7 @@ class UserAccessView(APIView):
                 return Response({f"Unknown source type: {source_type}"}, status=status.HTTP_400_BAD_REQUEST)
 
         data = []
-        for source_type in source_types:
+        for source_type in self._source_types:
             access_granted = False
             if admin_user:
                 access_granted = True

--- a/koku/koku/settings.py
+++ b/koku/koku/settings.py
@@ -469,3 +469,7 @@ except JSONDecodeError:
     pass
 
 OPENSHIFT_DOC_VERSION = ENVIRONMENT.get_value("OPENSHIFT_DOC_VERSION", default="4.5")
+
+# Aids the UI in showing pre-release features in allowed environments.
+# see: koku.api.user_access.view
+ENABLE_PRERELEASE_FEATURES = ENVIRONMENT.bool("ENABLE_PRERELEASE_FEATURES", default=False)


### PR DESCRIPTION
This PR adds a new type to the user-access API endpoint. The `AnyUserAccess` returns `True` if the user has access to any resource, regardless of provider.

This PR also adds support for a new deployment parameter: `ENABLE_PRERELEASE_FEATURES` This flag will designate environments where users will be able to see UI features that are not yet production-ready.

Base API request, showing new `any` type.
```
GET http://{{koku_hostname}}/{{api_prefix}}/user-access/

{
    "meta": {
        "count": 6
    },
    "links": {
        "first": "/api/cost-management/v1/user-access/?limit=10&offset=0",
        "next": null,
        "previous": null,
        "last": "/api/cost-management/v1/user-access/?limit=10&offset=0"
    },
    "data": [
        {
            "type": "any",
            "access": true
        },
        {
            "type": "aws",
            "access": true
        },
        {
            "type": "azure",
            "access": true
        },
        {
            "type": "cost_model",
            "access": true
        },
        {
            "type": "gcp",
            "access": true
        },
        {
            "type": "ocp",
            "access": true
        }
    ]
}
```

Example uses of beta parameter:
```
[2021-02-08 17:56:15,788] INFO None {'method': 'GET', 'path': '/api/cost-management/v1/user-access/?type=aws&beta=true', 'status': 200, 'request_id': None, 'account': '10001', 'username': 'user_dev', 'is_admin': 'True'}
10.116.0.1 - - [08/Feb/2021:17:56:15 +0000] "GET /api/cost-management/v1/user-access/?type=aws&beta=true HTTP/1.1" 200 13 "-" "PostmanRuntime/7.26.10"
```

```
[2021-02-08 17:59:50,755] INFO None {'method': 'GET', 'path': '/api/cost-management/v1/user-access/?type=aws&beta=false', 'status': 200, 'request_id': None, 'account': '10001', 'username': 'user_dev', 'is_admin': 'True'}
10.116.0.1 - - [08/Feb/2021:17:59:50 +0000] "GET /api/cost-management/v1/user-access/?type=aws&beta=false HTTP/1.1" 200 13 "-" "PostmanRuntime/7.26.10"
```
