### PR TITLE
COST-973: Sources hardening

### DIFF
--- a/koku/sources/api/source_status.py
+++ b/koku/sources/api/source_status.py
@@ -34,6 +34,7 @@ from providers.provider_access import ProviderAccessor
 from providers.provider_errors import SkipStatusPush
 from sources.sources_http_client import SourcesHTTPClient
 from sources.sources_http_client import SourcesHTTPClientError
+from django.db.models import Q
 
 LOG = logging.getLogger(__name__)
 
@@ -46,7 +47,9 @@ class SourceStatus:
         self.request = request
         self.user = request.user
         self.source_id = source_id
-        self.source = Sources.objects.get(source_id=source_id)
+        self.source = Sources.objects.filter(Q(source_id=2), ~Q(billing_source={}), ~Q(authentication={})).first()
+        if not self.source:
+            raise ObjectDoesNotExist(f"Source ID: {self.source_id} not ready for status")
         self.sources_client = SourcesHTTPClient(self.source.auth_header, source_id=source_id)
 
     @property

--- a/koku/sources/api/source_status.py
+++ b/koku/sources/api/source_status.py
@@ -34,7 +34,7 @@ from providers.provider_access import ProviderAccessor
 from providers.provider_errors import SkipStatusPush
 from sources.sources_http_client import SourcesHTTPClient
 from sources.sources_http_client import SourcesHTTPClientError
-from django.db.models import Q
+from sources.storage import source_settings_complete
 
 LOG = logging.getLogger(__name__)
 
@@ -47,8 +47,8 @@ class SourceStatus:
         self.request = request
         self.user = request.user
         self.source_id = source_id
-        self.source = Sources.objects.filter(Q(source_id=source_id), ~Q(billing_source={}), ~Q(authentication={})).first()
-        if not self.source:
+        self.source = Sources.objects.get(source_id=source_id)
+        if not source_settings_complete(self.source):
             raise ObjectDoesNotExist(f"Source ID: {self.source_id} not ready for status")
         self.sources_client = SourcesHTTPClient(self.source.auth_header, source_id=source_id)
 

--- a/koku/sources/api/source_status.py
+++ b/koku/sources/api/source_status.py
@@ -47,7 +47,7 @@ class SourceStatus:
         self.request = request
         self.user = request.user
         self.source_id = source_id
-        self.source = Sources.objects.filter(Q(source_id=2), ~Q(billing_source={}), ~Q(authentication={})).first()
+        self.source = Sources.objects.filter(Q(source_id=source_id), ~Q(billing_source={}), ~Q(authentication={})).first()
         if not self.source:
             raise ObjectDoesNotExist(f"Source ID: {self.source_id} not ready for status")
         self.sources_client = SourcesHTTPClient(self.source.auth_header, source_id=source_id)

--- a/koku/sources/api/source_status.py
+++ b/koku/sources/api/source_status.py
@@ -90,7 +90,7 @@ class SourceStatus:
         try:
             status_obj = self.status()
             # self.sources_client.set_source_status(status_obj)
-            LOG.info(f"Pushing Source status- Source ID: {str(self._source_id)}: Status: {str(status_obj)}")
+            LOG.info(f"Source status for Source ID: {str(self.source_id)}: Status: {str(status_obj)}")
         except SkipStatusPush as error:
             LOG.info(f"Platform sources status push skipped. Reason: {str(error)}")
         except SourcesHTTPClientError as error:

--- a/koku/sources/api/source_status.py
+++ b/koku/sources/api/source_status.py
@@ -89,7 +89,8 @@ class SourceStatus:
         """Push status_msg to platform sources."""
         try:
             status_obj = self.status()
-            self.sources_client.set_source_status(status_obj)
+            # self.sources_client.set_source_status(status_obj)
+            LOG.info(f"Pushing Source status- Source ID: {str(self._source_id)}: Status: {str(status_obj)}")
         except SkipStatusPush as error:
             LOG.info(f"Platform sources status push skipped. Reason: {str(error)}")
         except SourcesHTTPClientError as error:

--- a/koku/sources/kafka_listener.py
+++ b/koku/sources/kafka_listener.py
@@ -565,13 +565,13 @@ def execute_koku_provider_op(msg):
         if operation == "create":
             LOG.info(f"Creating Koku Provider for Source ID: {str(provider.source_id)}")
             instance = account_coordinator.create_account(provider)
-            LOG.info(f"Creating provider {instance.uuid} for Source ID: {provider.source_id}")
+            LOG.info(f"Created provider {instance.uuid} for Source ID: {provider.source_id}")
         elif operation == "update":
             instance = account_coordinator.update_account(provider)
-            LOG.info(f"Updating provider {instance.uuid} for Source ID: {provider.source_id}")
+            LOG.info(f"Updated provider {instance.uuid} for Source ID: {provider.source_id}")
         elif operation == "destroy":
             account_coordinator.destroy_account(provider)
-            LOG.info(f"Destroying provider {provider.koku_uuid} for Source ID: {provider.source_id}")
+            LOG.info(f"Destroyed provider {provider.koku_uuid} for Source ID: {provider.source_id}")
         else:
             LOG.error(f"unknown operation: {operation}")
         sources_client.set_source_status(None)

--- a/koku/sources/kafka_listener.py
+++ b/koku/sources/kafka_listener.py
@@ -440,6 +440,7 @@ def process_message(app_type_id, msg):  # noqa: C901
         storage.enqueue_source_delete(msg_data.get("source_id"), msg_data.get("offset"))
 
     if msg_data.get("event_type") in (KAFKA_SOURCE_UPDATE, KAFKA_AUTHENTICATION_UPDATE):
+        sources_network_info(msg_data.get("source_id"), msg_data.get("auth_header"))
         storage.enqueue_source_update(msg_data.get("source_id"))
 
 

--- a/koku/sources/kafka_listener.py
+++ b/koku/sources/kafka_listener.py
@@ -566,9 +566,12 @@ def execute_koku_provider_op(msg):
             LOG.info(f"Creating Koku Provider for Source ID: {str(provider.source_id)}")
             instance = account_coordinator.create_account(provider)
             LOG.info(f"Created provider {instance.uuid} for Source ID: {provider.source_id}")
+            LOG.info(f"Source after Provider Create: {str(provider)}")
         elif operation == "update":
             instance = account_coordinator.update_account(provider)
             LOG.info(f"Updated provider {instance.uuid} for Source ID: {provider.source_id}")
+            LOG.info(f"Source after Provider Update: {str(provider)}")
+
         elif operation == "destroy":
             account_coordinator.destroy_account(provider)
             LOG.info(f"Destroyed provider {provider.koku_uuid} for Source ID: {provider.source_id}")

--- a/koku/sources/kafka_listener.py
+++ b/koku/sources/kafka_listener.py
@@ -402,7 +402,7 @@ def process_message(app_type_id, msg):  # noqa: C901
         None
 
     """
-    LOG.info(f"Processing Event: {msg}")
+    LOG.debug(f"Processing Event: {msg}")
     msg_data = None
     try:
         msg_data = cost_mgmt_msg_filter(msg)

--- a/koku/sources/kafka_listener.py
+++ b/koku/sources/kafka_listener.py
@@ -566,11 +566,9 @@ def execute_koku_provider_op(msg):
             LOG.info(f"Creating Koku Provider for Source ID: {str(provider.source_id)}")
             instance = account_coordinator.create_account(provider)
             LOG.info(f"Created provider {instance.uuid} for Source ID: {provider.source_id}")
-            LOG.info(f"Source after Provider Create: {str(provider)}")
         elif operation == "update":
             instance = account_coordinator.update_account(provider)
             LOG.info(f"Updated provider {instance.uuid} for Source ID: {provider.source_id}")
-            LOG.info(f"Source after Provider Update: {str(provider)}")
 
         elif operation == "destroy":
             account_coordinator.destroy_account(provider)

--- a/koku/sources/kafka_listener.py
+++ b/koku/sources/kafka_listener.py
@@ -317,8 +317,7 @@ def save_auth_info(auth_header, source_id):
     try:
         authentication = get_authentication(source_type, sources_network)
     except SourcesHTTPClientError as error:
-        LOG.info(f"Authentication info not available for Source ID: {source_id}")
-        sources_network.set_source_status(error)
+        LOG.info(f"Authentication info not available for Source ID: {source_id}. Error: {str(error)}")
     else:
         if not authentication:
             return

--- a/koku/sources/sources_http_client.py
+++ b/koku/sources/sources_http_client.py
@@ -390,6 +390,7 @@ class SourcesHTTPClient:
 
             json_data = self.build_source_status(error_msg)
             if storage.save_status(self._source_id, json_data):
+                LOG.info(f"Setting Source Status for Source ID: {str(self._source_id)}: {str(json_data)}")
                 application_response = requests.patch(application_url, json=json_data, headers=status_header)
                 if application_response.status_code != 204:
                     raise SourcesHTTPClientError(

--- a/koku/sources/sources_patch_handler.py
+++ b/koku/sources/sources_patch_handler.py
@@ -41,6 +41,7 @@ class SourcesPatchHandler:
         instance = storage.get_source(source_id, "Unable to PATCH", LOG.error)
         instance.billing_source = billing_source
         if instance.source_uuid:
+            instance.status = {}
             instance.pending_update = True
 
         instance.save()
@@ -52,6 +53,7 @@ class SourcesPatchHandler:
         instance = storage.get_source(source_id, "Unable to PATCH", LOG.error)
         instance.authentication = authentication
         if instance.source_uuid:
+            instance.status = {}
             instance.pending_update = True
 
         instance.save()

--- a/koku/sources/sources_provider_coordinator.py
+++ b/koku/sources/sources_provider_coordinator.py
@@ -57,7 +57,6 @@ class SourcesProviderCoordinator:
         """Call to update provider."""
         try:
             provider = self._provider_builder.update_provider_from_source(source)
-            add_provider_koku_uuid(self._source_id, provider.uuid)
             clear_update_flag(self._source_id)
         except ProviderBuilderError as provider_err:
             raise SourcesProviderCoordinatorError(str(provider_err))

--- a/koku/sources/sources_provider_coordinator.py
+++ b/koku/sources/sources_provider_coordinator.py
@@ -47,15 +47,18 @@ class SourcesProviderCoordinator:
     def create_account(self, source):
         """Call to create provider."""
         try:
+            LOG.info(f"Creating Provider for Source ID: {str(self._source_id)}")
             provider = self._provider_builder.create_provider_from_source(source)
             add_provider_koku_uuid(self._source_id, provider.uuid)
         except ProviderBuilderError as provider_err:
+            LOG.info(f"COORDINATOR ERROR: {str(provider_err)}")
             raise SourcesProviderCoordinatorError(str(provider_err))
         return provider
 
     def update_account(self, source):
         """Call to update provider."""
         try:
+            LOG.info(f"Updating Provider for Source ID: {str(self._source_id)}")
             provider = self._provider_builder.update_provider_from_source(source)
             clear_update_flag(self._source_id)
         except ProviderBuilderError as provider_err:

--- a/koku/sources/sources_provider_coordinator.py
+++ b/koku/sources/sources_provider_coordinator.py
@@ -57,6 +57,7 @@ class SourcesProviderCoordinator:
         """Call to update provider."""
         try:
             provider = self._provider_builder.update_provider_from_source(source)
+            add_provider_koku_uuid(self._source_id, provider.uuid)
             clear_update_flag(self._source_id)
         except ProviderBuilderError as provider_err:
             raise SourcesProviderCoordinatorError(str(provider_err))

--- a/koku/sources/sources_provider_coordinator.py
+++ b/koku/sources/sources_provider_coordinator.py
@@ -51,7 +51,6 @@ class SourcesProviderCoordinator:
             provider = self._provider_builder.create_provider_from_source(source)
             add_provider_koku_uuid(self._source_id, provider.uuid)
         except ProviderBuilderError as provider_err:
-            LOG.info(f"COORDINATOR ERROR: {str(provider_err)}")
             raise SourcesProviderCoordinatorError(str(provider_err))
         return provider
 

--- a/koku/sources/storage.py
+++ b/koku/sources/storage.py
@@ -170,7 +170,6 @@ APP_SETTINGS_SCREEN_MAP = {
 
 def source_settings_complete(provider):
     """Determine if the source application settings are complete."""
-    return False
     if provider.koku_uuid:
         screen_fn = APP_SETTINGS_SCREEN_MAP.get(provider.source_type)
         return screen_fn(provider)

--- a/koku/sources/storage.py
+++ b/koku/sources/storage.py
@@ -296,6 +296,7 @@ def enqueue_source_update(source_id):
     """
     source = get_source(source_id, f"Unable to enqueue source update. Source ID {source_id} not found.", LOG.error)
     if source and source.koku_uuid and not source.pending_delete and not source.pending_update:
+        LOG.info(f"Pending Update Queued for Source ID: {str(source_id)}")
         source.pending_update = True
         source.save(update_fields=["pending_update"])
 
@@ -582,6 +583,9 @@ def update_application_settings(source_id, settings):
                 instance.pending_update = True
                 instance.status = {}
             instance.billing_source = billing_source
+            if updated_billing_source:
+                LOG.info(f"Updating Source ID Billing Source {instance.billing_source} to {updated_billing_source}")
+                instance.billing_source = updated_billing_source
             instance.save()
 
     if authentication:
@@ -597,5 +601,6 @@ def update_application_settings(source_id, settings):
                 instance.status = {}
             instance.authentication = authentication
             if updated_authentication:
+                LOG.info(f"Updating Source ID Authentication {instance.authentication} to {updated_authentication}")
                 instance.authentication = updated_authentication
             instance.save()

--- a/koku/sources/storage.py
+++ b/koku/sources/storage.py
@@ -170,6 +170,7 @@ APP_SETTINGS_SCREEN_MAP = {
 
 def source_settings_complete(provider):
     """Determine if the source application settings are complete."""
+    return False
     if provider.koku_uuid:
         screen_fn = APP_SETTINGS_SCREEN_MAP.get(provider.source_type)
         return screen_fn(provider)

--- a/koku/sources/storage.py
+++ b/koku/sources/storage.py
@@ -49,7 +49,7 @@ class SourcesStorageError(Exception):
 
 def aws_settings_ready(provider):
     """Verify that the Application Settings are complete."""
-    if not provider.pending_update and provider.billing_source and provider.authentication:
+    if provider.billing_source and provider.authentication:
         return True
     return False
 
@@ -170,6 +170,7 @@ APP_SETTINGS_SCREEN_MAP = {
 
 def source_settings_complete(provider):
     """Determine if the source application settings are complete."""
+    LOG.info(f"SOURCE WHEN CHECKING IF SETTINGS ARE COMPLETE: {str(provider)}")
     screen_fn = APP_SETTINGS_SCREEN_MAP.get(provider.source_type)
     return screen_fn(provider)
 

--- a/koku/sources/storage.py
+++ b/koku/sources/storage.py
@@ -49,7 +49,7 @@ class SourcesStorageError(Exception):
 
 def aws_settings_ready(provider):
     """Verify that the Application Settings are complete."""
-    if provider.billing_source and provider.authentication:
+    if provider.koku_uuid and provider.billing_source and provider.authentication:
         return True
     return False
 

--- a/koku/sources/storage.py
+++ b/koku/sources/storage.py
@@ -49,7 +49,7 @@ class SourcesStorageError(Exception):
 
 def aws_settings_ready(provider):
     """Verify that the Application Settings are complete."""
-    if provider.billing_source and provider.authentication:
+    if not provider.pending_update and provider.billing_source and provider.authentication:
         return True
     return False
 
@@ -171,8 +171,7 @@ APP_SETTINGS_SCREEN_MAP = {
 def source_settings_complete(provider):
     """Determine if the source application settings are complete."""
     screen_fn = APP_SETTINGS_SCREEN_MAP.get(provider.source_type)
-    return False
-    #return screen_fn(provider)
+    return screen_fn(provider)
 
 
 def load_providers_to_create():

--- a/koku/sources/storage.py
+++ b/koku/sources/storage.py
@@ -61,6 +61,7 @@ def _aws_provider_ready_for_create(provider):
         and provider.name
         and provider.auth_header
         and aws_settings_ready(provider)
+        and not provider.pending_update
         and not provider.status
         and not provider.koku_uuid
     ):

--- a/koku/sources/storage.py
+++ b/koku/sources/storage.py
@@ -528,17 +528,27 @@ def update_application_settings(source_id, settings):
     billing_source = settings.get("billing_source")
     authentication = settings.get("authentication")
     if billing_source:
+        updated_billing_source = None
         instance = get_source(source_id, "Unable to add billing source", LOG.error)
         if instance.billing_source:
-            billing_source = _update_billing_source(instance, billing_source)
-        instance.billing_source = billing_source
-        instance.pending_update = True
-        instance.save()
+            updated_billing_source = _update_billing_source(instance, billing_source)
+        if instance.billing_source != updated_billing_source:
+            if instance.billing_source:
+                # Queue pending provider update if the billing source was previously
+                # populated and now has changed.
+                instance.pending_update = True
+            instance.billing_source = billing_source
+            instance.save()
 
     if authentication:
+        updated_authentication = None
         instance = get_source(source_id, "Unable to add authentication", LOG.error)
         if instance.authentication:
-            authentication = _update_authentication(instance, authentication)
-        instance.authentication = authentication
-        instance.pending_update = True
-        instance.save()
+            updated_authentication = _update_authentication(instance, authentication)
+        if instance.authentication != updated_authentication:
+            if instance.authentication:
+                # Queue pending provider update if the authentication was previously
+                # populated and now has changed.
+                instance.pending_update = True
+            instance.authentication = authentication
+            instance.save()

--- a/koku/sources/storage.py
+++ b/koku/sources/storage.py
@@ -556,12 +556,12 @@ def _update_billing_source(instance, billing_source):
 def _update_authentication(instance, authentication):
     if instance.source_type not in ALLOWED_AUTHENTICATION_PROVIDERS:
         raise SourcesStorageError(f"Option not supported by source type {instance.source_type}.")
-    auth_dict = instance.authentication
-    if not auth_dict.get("credentials"):
-        auth_dict["credentials"] = {"subscription_id": None}
+    auth_copy = copy.deepcopy(instance.authentication)
+    if not auth_copy.get("credentials"):
+        auth_copy["credentials"] = {"subscription_id": None}
     subscription_id = authentication.get("credentials", {}).get("subscription_id")
-    auth_dict["credentials"]["subscription_id"] = subscription_id
-    return auth_dict
+    auth_copy["credentials"]["subscription_id"] = subscription_id
+    return auth_copy
 
 
 def update_application_settings(source_id, settings):
@@ -593,4 +593,6 @@ def update_application_settings(source_id, settings):
                 # populated and now has changed.
                 instance.pending_update = True
             instance.authentication = authentication
+            if updated_authentication:
+                instance.authentication = updated_authentication
             instance.save()

--- a/koku/sources/storage.py
+++ b/koku/sources/storage.py
@@ -49,7 +49,7 @@ class SourcesStorageError(Exception):
 
 def aws_settings_ready(provider):
     """Verify that the Application Settings are complete."""
-    if provider.koku_uuid and provider.billing_source and provider.authentication:
+    if provider.billing_source and provider.authentication:
         return True
     return False
 
@@ -171,8 +171,10 @@ APP_SETTINGS_SCREEN_MAP = {
 def source_settings_complete(provider):
     """Determine if the source application settings are complete."""
     LOG.info(f"SOURCE WHEN CHECKING IF SETTINGS ARE COMPLETE: {str(provider)}")
-    screen_fn = APP_SETTINGS_SCREEN_MAP.get(provider.source_type)
-    return screen_fn(provider)
+    is provider.koku_uuid:
+        screen_fn = APP_SETTINGS_SCREEN_MAP.get(provider.source_type)
+        return screen_fn(provider)
+    return False
 
 
 def load_providers_to_create():

--- a/koku/sources/storage.py
+++ b/koku/sources/storage.py
@@ -171,7 +171,8 @@ APP_SETTINGS_SCREEN_MAP = {
 def source_settings_complete(provider):
     """Determine if the source application settings are complete."""
     screen_fn = APP_SETTINGS_SCREEN_MAP.get(provider.source_type)
-    return screen_fn(provider)
+    return False
+    #return screen_fn(provider)
 
 
 def load_providers_to_create():

--- a/koku/sources/storage.py
+++ b/koku/sources/storage.py
@@ -582,7 +582,6 @@ def _update_billing_source_app_settings(source_id, billing_source):
             instance.status = {}
         instance.billing_source = billing_source
         if updated_billing_source:
-            LOG.info(f"Updating Source ID Billing Source {instance.billing_source} to {updated_billing_source}")
             instance.billing_source = updated_billing_source
         instance.save()
 
@@ -601,7 +600,6 @@ def _update_authentication_app_settings(source_id, authentication):
             instance.status = {}
         instance.authentication = authentication
         if updated_authentication:
-            LOG.info(f"Updating Source ID Authentication {instance.authentication} to {updated_authentication}")
             instance.authentication = updated_authentication
         instance.save()
 

--- a/koku/sources/storage.py
+++ b/koku/sources/storage.py
@@ -579,6 +579,7 @@ def update_application_settings(source_id, settings):
                 # Queue pending provider update if the billing source was previously
                 # populated and now has changed.
                 instance.pending_update = True
+                instance.status = {}
             instance.billing_source = billing_source
             instance.save()
 
@@ -592,6 +593,7 @@ def update_application_settings(source_id, settings):
                 # Queue pending provider update if the authentication was previously
                 # populated and now has changed.
                 instance.pending_update = True
+                instance.status = {}
             instance.authentication = authentication
             if updated_authentication:
                 instance.authentication = updated_authentication

--- a/koku/sources/storage.py
+++ b/koku/sources/storage.py
@@ -583,8 +583,7 @@ def update_application_settings(source_id, settings):
             if instance.billing_source:
                 # Queue pending provider update if the billing source was previously
                 # populated and now has changed.
-                if instance.koku_uuid:
-                    instance.pending_update = True
+                instance.pending_update = True
                 instance.status = {}
             instance.billing_source = billing_source
             if updated_billing_source:

--- a/koku/sources/storage.py
+++ b/koku/sources/storage.py
@@ -467,6 +467,7 @@ def add_provider_koku_uuid(source_id, koku_uuid):
     """
     source = get_source(source_id, f"Source ID {source_id} does not exist.", LOG.error)
     if source and source.koku_uuid != koku_uuid:
+        LOG.info(f"Adding provider uuid {str(koku_uuid)} to Source ID: {str(source_id)}")
         source.koku_uuid = koku_uuid
         source.save()
 

--- a/koku/sources/storage.py
+++ b/koku/sources/storage.py
@@ -55,6 +55,7 @@ def _aws_provider_ready_for_create(provider):
         and provider.auth_header
         and provider.billing_source
         and provider.authentication
+        and not provider.status
         and not provider.koku_uuid
     ):
         return True
@@ -68,6 +69,7 @@ def _ocp_provider_ready_for_create(provider):
         and provider.name
         and provider.authentication
         and provider.auth_header
+        and not provider.status
         and not provider.koku_uuid
     ):
         return True
@@ -81,6 +83,7 @@ def _azure_provider_ready_for_create(provider):
         and provider.name
         and provider.auth_header
         and provider.billing_source
+        and not provider.status
         and not provider.koku_uuid
     ):
         billing_source = provider.billing_source.get("data_source", {})
@@ -102,6 +105,7 @@ def _gcp_provider_ready_for_create(provider):
         and provider.auth_header
         and provider.billing_source.get("data_source")
         and provider.authentication.get("credentials")
+        and not provider.status
         and not provider.koku_uuid
     ):
         return True

--- a/koku/sources/storage.py
+++ b/koku/sources/storage.py
@@ -171,7 +171,7 @@ APP_SETTINGS_SCREEN_MAP = {
 def source_settings_complete(provider):
     """Determine if the source application settings are complete."""
     LOG.info(f"SOURCE WHEN CHECKING IF SETTINGS ARE COMPLETE: {str(provider)}")
-    is provider.koku_uuid:
+    if provider.koku_uuid:
         screen_fn = APP_SETTINGS_SCREEN_MAP.get(provider.source_type)
         return screen_fn(provider)
     return False

--- a/koku/sources/storage.py
+++ b/koku/sources/storage.py
@@ -466,7 +466,9 @@ def add_provider_koku_uuid(source_id, koku_uuid):
         None
 
     """
+    LOG.info(f"Attempting to add provider uuid {str(koku_uuid)} to Source ID: {str(source_id)}")
     source = get_source(source_id, f"Source ID {source_id} does not exist.", LOG.error)
+    LOG.info(f"Source when attempting to add provider uuid: {str(source)}")
     if source and source.koku_uuid != koku_uuid:
         LOG.info(f"Adding provider uuid {str(koku_uuid)} to Source ID: {str(source_id)}")
         source.koku_uuid = koku_uuid

--- a/koku/sources/storage.py
+++ b/koku/sources/storage.py
@@ -61,7 +61,6 @@ def _aws_provider_ready_for_create(provider):
         and provider.name
         and provider.auth_header
         and aws_settings_ready(provider)
-        and not provider.pending_update
         and not provider.status
         and not provider.koku_uuid
     ):
@@ -583,7 +582,8 @@ def update_application_settings(source_id, settings):
             if instance.billing_source:
                 # Queue pending provider update if the billing source was previously
                 # populated and now has changed.
-                instance.pending_update = True
+                if instance.koku_uuid:
+                    instance.pending_update = True
                 instance.status = {}
             instance.billing_source = billing_source
             if updated_billing_source:

--- a/koku/sources/storage.py
+++ b/koku/sources/storage.py
@@ -170,7 +170,6 @@ APP_SETTINGS_SCREEN_MAP = {
 
 def source_settings_complete(provider):
     """Determine if the source application settings are complete."""
-    LOG.info(f"SOURCE WHEN CHECKING IF SETTINGS ARE COMPLETE: {str(provider)}")
     if provider.koku_uuid:
         screen_fn = APP_SETTINGS_SCREEN_MAP.get(provider.source_type)
         return screen_fn(provider)
@@ -299,7 +298,6 @@ def enqueue_source_update(source_id):
     """
     source = get_source(source_id, f"Unable to enqueue source update. Source ID {source_id} not found.", LOG.error)
     if source and source.koku_uuid and not source.pending_delete and not source.pending_update:
-        LOG.info(f"Pending Update Queued for Source ID: {str(source_id)}")
         source.pending_update = True
         source.save(update_fields=["pending_update"])
 
@@ -471,7 +469,6 @@ def add_provider_koku_uuid(source_id, koku_uuid):
     """
     LOG.info(f"Attempting to add provider uuid {str(koku_uuid)} to Source ID: {str(source_id)}")
     source = get_source(source_id, f"Source ID {source_id} does not exist.", LOG.error)
-    LOG.info(f"Source when attempting to add provider uuid: {str(source)}")
     if source and source.koku_uuid != koku_uuid:
         LOG.info(f"Adding provider uuid {str(koku_uuid)} to Source ID: {str(source_id)}")
         source.koku_uuid = koku_uuid
@@ -571,7 +568,7 @@ def _update_authentication(instance, authentication):
     return auth_copy
 
 
-def update_application_settings(source_id, settings):
+def update_application_settings(source_id, settings):  # noqa: C901
     """Store billing source update."""
     LOG.info(f"Found settings: {str(settings)}")
     billing_source = settings.get("billing_source")

--- a/koku/sources/test/api/test_source_status.py
+++ b/koku/sources/test/api/test_source_status.py
@@ -122,7 +122,7 @@ class SourcesStatusTest(IamTestCase):
                 source_id=1,
                 name="New AWS Mock Test Source",
                 source_type=Provider.PROVIDER_AWS,
-                authentication={},
+                authentication={"authentication": {"rolearn": "myarn"}},
                 billing_source={"bucket": "my-bucket"},
                 koku_uuid="",
                 offset=1,
@@ -143,7 +143,7 @@ class SourcesStatusTest(IamTestCase):
                 source_id=1,
                 name="New AWS Mock Test Source",
                 source_type=Provider.PROVIDER_AWS,
-                authentication={},
+                authentication={"authentication": {"rolearn": "myarn"}},
                 billing_source={"bucket": "my-bucket"},
                 koku_uuid="",
                 offset=1,
@@ -167,8 +167,15 @@ class SourcesStatusTest(IamTestCase):
             {
                 "name": "New Azure Mock Test Source",
                 "source_type": Provider.PROVIDER_AZURE,
-                "authentication": {"credentials": {"azure": "creds"}},
-                "billing_source": {"data_source": {"azure": "source"}},
+                "authentication": {
+                    "credentials": {
+                        "subscription_id": "subid",
+                        "client_id": "testid",
+                        "tenant_id": "tenant",
+                        "client_secret": "secret",
+                    }
+                },
+                "billing_source": {"data_source": {"resource_group": "rg", "storage_account": "sa"}},
                 "offset": 1,
             },
             {

--- a/koku/sources/test/api/test_source_status.py
+++ b/koku/sources/test/api/test_source_status.py
@@ -124,7 +124,7 @@ class SourcesStatusTest(IamTestCase):
                 source_type=Provider.PROVIDER_AWS,
                 authentication={"authentication": {"rolearn": "myarn"}},
                 billing_source={"bucket": "my-bucket"},
-                koku_uuid="",
+                koku_uuid="uuid",
                 offset=1,
             )
             json_data = {"source_id": 1}
@@ -145,7 +145,7 @@ class SourcesStatusTest(IamTestCase):
                 source_type=Provider.PROVIDER_AWS,
                 authentication={"authentication": {"rolearn": "myarn"}},
                 billing_source={"bucket": "my-bucket"},
-                koku_uuid="",
+                koku_uuid="uuid",
                 offset=1,
             )
             json_data = {"source_id": 1}

--- a/koku/sources/test/test_storage.py
+++ b/koku/sources/test/test_storage.py
@@ -59,6 +59,7 @@ class MockProvider:
         self.offset = offset
         self.pending_delete = pending_delete
         self.koku_uuid = koku_uuid
+        self.status = {}
 
 
 class SourcesStorageTest(TestCase):

--- a/koku/sources/test/test_storage.py
+++ b/koku/sources/test/test_storage.py
@@ -772,6 +772,42 @@ class SourcesStorageTest(TestCase):
         self.assertEqual(db_obj.authentication.get("subscription_id"), subscription_id)
         self.assertIsNone(db_obj.billing_source.get("data_source"))
 
+    def test_update_application_settings_billing_and_auth(self):
+        """Test to update application settings with both billing and auth."""
+        test_source_id = 3
+        subscription_id = "testsubid"
+        tenant_id = "testtenant"
+        client_id = "myclientid"
+        client_secret = "mysecret"
+        resource_group = "myrg"
+        storage_account = "mysa"
+        settings = {
+            "billing_source": {"data_source": {"resource_group": resource_group, "storage_account": storage_account}},
+            "authentication": {"credentials": {"subscription_id": subscription_id}},
+        }
+
+        azure_obj = Sources(
+            source_id=test_source_id,
+            auth_header=self.test_header,
+            offset=3,
+            authentication={
+                "credentials": {"client_id": client_id, "tenant_id": tenant_id, "client_secret": client_secret}
+            },
+            source_type=Provider.PROVIDER_AZURE,
+            name="Test AZURE Source",
+        )
+        azure_obj.save()
+
+        storage.update_application_settings(test_source_id, settings)
+        db_obj = Sources.objects.get(source_id=test_source_id)
+
+        self.assertEqual(db_obj.authentication.get("credentials").get("subscription_id"), subscription_id)
+        self.assertEqual(db_obj.authentication.get("credentials").get("client_secret"), client_secret)
+        self.assertEqual(db_obj.authentication.get("credentials").get("client_id"), client_id)
+        self.assertEqual(db_obj.authentication.get("credentials").get("tenant_id"), tenant_id)
+        self.assertEqual(db_obj.billing_source.get("data_source").get("resource_group"), resource_group)
+        self.assertEqual(db_obj.billing_source.get("data_source").get("storage_account"), storage_account)
+
     def test_save_status(self):
         """Test to verify source status is saved."""
         test_source_id = 3

--- a/koku/sources/test/test_storage.py
+++ b/koku/sources/test/test_storage.py
@@ -772,8 +772,8 @@ class SourcesStorageTest(TestCase):
         self.assertEqual(db_obj.authentication.get("subscription_id"), subscription_id)
         self.assertIsNone(db_obj.billing_source.get("data_source"))
 
-    def test_update_application_settings_billing_and_auth(self):
-        """Test to update application settings with both billing and auth."""
+    def test_update_application_settings_billing_and_auth_starting_with_auth(self):
+        """Test to update application settings with both billing and auth where auth already exists."""
         test_source_id = 3
         subscription_id = "testsubid"
         tenant_id = "testtenant"
@@ -798,6 +798,46 @@ class SourcesStorageTest(TestCase):
         )
         azure_obj.save()
 
+        storage.update_application_settings(test_source_id, settings)
+        db_obj = Sources.objects.get(source_id=test_source_id)
+
+        self.assertEqual(db_obj.authentication.get("credentials").get("subscription_id"), subscription_id)
+        self.assertEqual(db_obj.authentication.get("credentials").get("client_secret"), client_secret)
+        self.assertEqual(db_obj.authentication.get("credentials").get("client_id"), client_id)
+        self.assertEqual(db_obj.authentication.get("credentials").get("tenant_id"), tenant_id)
+        self.assertEqual(db_obj.billing_source.get("data_source").get("resource_group"), resource_group)
+        self.assertEqual(db_obj.billing_source.get("data_source").get("storage_account"), storage_account)
+
+    def test_update_application_settings_billing_and_auth_startingwith_billing(self):
+        """Test to update application settings with both billing and auth where billing already exists."""
+        test_source_id = 3
+        subscription_id = "testsubid"
+        tenant_id = "testtenant"
+        client_id = "myclientid"
+        client_secret = "mysecret"
+        resource_group = "myrg"
+        storage_account = "mysa"
+        settings = {
+            "billing_source": {"data_source": {"storage_account": storage_account}},
+            "authentication": {
+                "credentials": {
+                    "subscription_id": subscription_id,
+                    "client_id": client_id,
+                    "tenant_id": tenant_id,
+                    "client_secret": client_secret,
+                }
+            },
+        }
+
+        azure_obj = Sources(
+            source_id=test_source_id,
+            auth_header=self.test_header,
+            offset=3,
+            billing_source={"data_source": {"resource_group": resource_group}},
+            source_type=Provider.PROVIDER_AZURE,
+            name="Test AZURE Source",
+        )
+        azure_obj.save()
         storage.update_application_settings(test_source_id, settings)
         db_obj = Sources.objects.get(source_id=test_source_id)
 

--- a/koku/sources/test/test_storage.py
+++ b/koku/sources/test/test_storage.py
@@ -808,7 +808,7 @@ class SourcesStorageTest(TestCase):
         self.assertEqual(db_obj.billing_source.get("data_source").get("resource_group"), resource_group)
         self.assertEqual(db_obj.billing_source.get("data_source").get("storage_account"), storage_account)
 
-    def test_update_application_settings_billing_and_auth_startingwith_billing(self):
+    def test_update_application_settings_billing_and_auth_starting_with_billing(self):
         """Test to update application settings with both billing and auth where billing already exists."""
         test_source_id = 3
         subscription_id = "testsubid"


### PR DESCRIPTION
General stability work to minimize on redundant processing.

Extensive CRUD testing has been done in the QA OCP environment.
* CRUD with all source types, editing each field, verifying source status is correct
* Added duplicate accounts, verified source status.  Fixed duplicate accounts by editing
* Ran QE Sources crud automation
* Test PATCH flow and verified it could seamlessly transition to new app-extra flow
`195 passed, 9 skipped, 3064 deselected, 3 warnings in 541.91s (0:09:01)`