### PR TITLE
Update documentation links in Settings UI

### DIFF
--- a/koku/api/settings/utils.py
+++ b/koku/api/settings/utils.py
@@ -15,8 +15,6 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 """Utilities for Settings."""
-from koku.settings import OPENSHIFT_DOC_VERSION
-
 SETTINGS_PREFIX = "api.settings"
 OPENSHIFT_SETTINGS_PREFIX = f"{SETTINGS_PREFIX}.openshift"
 OPENSHIFT_TAG_MGMT_SETTINGS_PREFIX = f"{OPENSHIFT_SETTINGS_PREFIX}.tag-management"
@@ -78,8 +76,7 @@ def generate_doc_link(path):
     Args:
         (String) path - path to the documentation.
     """
-    prefix = f"https://access.redhat.com/documentation/en-us/openshift_container_platform/{OPENSHIFT_DOC_VERSION}/html"
-    return f"{prefix}/{path}"
+    return f"https://access.redhat.com/documentation/en-us/cost_management_service/2021/{path}"
 
 
 def create_dual_list_select(name, left_options=[], right_options=[], **kwargs):

--- a/koku/koku/settings.py
+++ b/koku/koku/settings.py
@@ -485,8 +485,6 @@ try:
 except JSONDecodeError:
     pass
 
-OPENSHIFT_DOC_VERSION = ENVIRONMENT.get_value("OPENSHIFT_DOC_VERSION", default="4.5")
-
 # Aids the UI in showing pre-release features in allowed environments.
 # see: koku.api.user_access.view
 ENABLE_PRERELEASE_FEATURES = ENVIRONMENT.bool("ENABLE_PRERELEASE_FEATURES", default=False)


### PR DESCRIPTION
Replace link prefix from https://access.redhat.com/documentation/en-us/openshift_container_platform to https://access.redhat.com/documentation/en-us/cost_management_service/2021

closes COST-977

//cc @dlabrecq @nlcwong @spank50 