### PR TITLE
COST-721 Use redis for celery backend

### DIFF
--- a/koku/koku/settings.py
+++ b/koku/koku/settings.py
@@ -418,7 +418,7 @@ MASU_API_REPORT_DATA = f"{API_PATH_PREFIX}/v1/report_data/"
 RABBITMQ_HOST = os.getenv("RABBITMQ_HOST", "localhost")
 RABBITMQ_PORT = os.getenv("RABBITMQ_PORT", "5672")
 
-CELERY_BROKER_URL = f"amqp://{RABBITMQ_HOST}:{RABBITMQ_PORT}"
+CELERY_BROKER_URL = f"redis://{REDIS_HOST}:{REDIS_PORT}/{REDIS_DB}"
 CELERY_RESULTS_URL = f"redis://{REDIS_HOST}:{REDIS_PORT}/{REDIS_DB}"
 CELERY_IMPORTS = ("masu.processor.tasks", "masu.celery.tasks", "koku.metrics")
 CELERY_BROKER_POOL_LIMIT = None


### PR DESCRIPTION
## Summary
* Switch our celery broker backend to use redis. 
* This is step one, further cleanup of templates will follow. 

## Testing
Loaded test customer data locally with rabbit container removed to make sure we weren't somehow still using it. Everything ran successfully. APIs returned expected data. 