### PR TITLE
[COST-997] Bugfix: Remove sources API caching

### DIFF
--- a/koku/api/provider/provider_builder.py
+++ b/koku/api/provider/provider_builder.py
@@ -29,8 +29,6 @@ from api.models import User
 from api.provider.provider_manager import ProviderManager
 from api.provider.provider_manager import ProviderManagerError
 from api.provider.serializers import ProviderSerializer
-from koku.cache import invalidate_view_cache_for_tenant_and_cache_key
-from koku.cache import SOURCES_PREFIX
 from koku.middleware import IdentityHeaderMiddleware
 from sources.config import Config
 
@@ -139,7 +137,6 @@ class ProviderBuilder:
         try:
             if serializer.is_valid(raise_exception=True):
                 instance = serializer.save()
-                invalidate_view_cache_for_tenant_and_cache_key(tenant.schema_name, cache_key_prefix=SOURCES_PREFIX)
         except ValidationError as error:
             connection.set_schema_to_public()
             raise error
@@ -163,7 +160,6 @@ class ProviderBuilder:
         serializer = ProviderSerializer(instance=instance, data=json_data, partial=False, context=context)
         serializer.is_valid(raise_exception=True)
         serializer.save()
-        invalidate_view_cache_for_tenant_and_cache_key(tenant.schema_name, cache_key_prefix=SOURCES_PREFIX)
         connection.set_schema_to_public()
         return instance
 
@@ -179,5 +175,4 @@ class ProviderBuilder:
             LOG.info("Provider does not exist, skipping Provider delete.")
         else:
             manager.remove(user=user, from_sources=True)
-            invalidate_view_cache_for_tenant_and_cache_key(tenant.schema_name, cache_key_prefix=SOURCES_PREFIX)
         connection.set_schema_to_public()

--- a/koku/cost_models/view.py
+++ b/koku/cost_models/view.py
@@ -39,8 +39,6 @@ from api.common.permissions.cost_models_access import CostModelsAccessPermission
 from cost_models.cost_model_manager import CostModelManager
 from cost_models.models import CostModel
 from cost_models.serializers import CostModelSerializer
-from koku.cache import invalidate_view_cache_for_tenant_and_cache_key
-from koku.cache import SOURCES_PREFIX
 
 LOG = logging.getLogger(__name__)
 
@@ -152,7 +150,6 @@ class CostModelViewSet(viewsets.ModelViewSet):
     @method_decorator(never_cache)
     def create(self, request, *args, **kwargs):
         """Create a rate."""
-        invalidate_view_cache_for_tenant_and_cache_key(request.tenant.schema_name, cache_key_prefix=SOURCES_PREFIX)
         return super().create(request=request, args=args, kwargs=kwargs)
 
     @method_decorator(never_cache)
@@ -174,7 +171,6 @@ class CostModelViewSet(viewsets.ModelViewSet):
     def destroy(self, request, *args, **kwargs):
         """Delete a rate."""
         uuid = kwargs.get("uuid")
-        invalidate_view_cache_for_tenant_and_cache_key(request.tenant.schema_name, cache_key_prefix=SOURCES_PREFIX)
         try:
             manager = CostModelManager(cost_model_uuid=uuid)
         except CostModel.DoesNotExist:
@@ -185,5 +181,4 @@ class CostModelViewSet(viewsets.ModelViewSet):
 
     @method_decorator(never_cache)
     def update(self, request, *args, **kwargs):
-        invalidate_view_cache_for_tenant_and_cache_key(request.tenant.schema_name, cache_key_prefix=SOURCES_PREFIX)
         return super().update(request=request, args=args, kwargs=kwargs)

--- a/koku/sources/api/view.py
+++ b/koku/sources/api/view.py
@@ -23,7 +23,6 @@ from django.http import Http404
 from django.shortcuts import get_object_or_404
 from django.utils.decorators import method_decorator
 from django.utils.encoding import force_text
-from django.views.decorators.cache import cache_page
 from django.views.decorators.cache import never_cache
 from django_filters import FilterSet
 from django_filters.rest_framework import DjangoFilterBackend
@@ -47,8 +46,6 @@ from api.provider.models import Sources
 from api.provider.provider_builder import ProviderBuilder
 from api.provider.provider_manager import ProviderManager
 from api.provider.provider_manager import ProviderManagerError
-from koku.cache import invalidate_view_cache_for_tenant_and_cache_key
-from koku.cache import SOURCES_PREFIX
 from sources.api.serializers import AdminSourcesSerializer
 from sources.api.serializers import SourcesDependencyError
 from sources.api.serializers import SourcesSerializer
@@ -61,7 +58,6 @@ class DestroySourceMixin(mixins.DestroyModelMixin):
     @method_decorator(never_cache)
     def destroy(self, request, *args, **kwargs):
         """Delete a source."""
-        invalidate_view_cache_for_tenant_and_cache_key(request.tenant.schema_name, cache_key_prefix=SOURCES_PREFIX)
         source = self.get_object()
         manager = ProviderBuilder(request.user.identity_header.get("encoded"))
         for _ in range(5):
@@ -209,7 +205,6 @@ class SourcesViewSet(*MIXIN_LIST):
     @method_decorator(never_cache)
     def update(self, request, *args, **kwargs):
         """Update a Source."""
-        invalidate_view_cache_for_tenant_and_cache_key(request.tenant.schema_name, cache_key_prefix=SOURCES_PREFIX)
         try:
             return super().update(request=request, args=args, kwargs=kwargs)
         except (SourcesStorageError, ParseError) as error:
@@ -217,7 +212,7 @@ class SourcesViewSet(*MIXIN_LIST):
         except SourcesDependencyError as error:
             raise SourcesDependencyException(str(error))
 
-    @method_decorator(cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=SOURCES_PREFIX))
+    @method_decorator(never_cache)
     def list(self, request, *args, **kwargs):
         """Obtain the list of sources."""
         response = super().list(request=request, args=args, kwargs=kwargs)
@@ -243,7 +238,7 @@ class SourcesViewSet(*MIXIN_LIST):
                 ]
         return response
 
-    @method_decorator(cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=SOURCES_PREFIX))
+    @method_decorator(never_cache)
     def retrieve(self, request, *args, **kwargs):
         """Get a source."""
         response = super().retrieve(request=request, args=args, kwargs=kwargs)

--- a/koku/sources/test/api/test_view.py
+++ b/koku/sources/test/api/test_view.py
@@ -23,7 +23,6 @@ from unittest.mock import PropertyMock
 from uuid import uuid4
 
 import requests_mock
-from django.core.cache import caches
 from django.test.utils import override_settings
 from django.urls import reverse
 
@@ -72,11 +71,6 @@ class SourcesViewTests(IamTestCase):
 
         mock_url = PropertyMock(return_value="http://www.sourcesclient.com/api/v1/sources/")
         SourcesViewSet.url = mock_url
-
-    def tearDown(self):
-        """Tear down each test."""
-        cache = caches["default"]
-        cache.clear()
 
     def test_source_update(self):
         """Test the PATCH endpoint."""


### PR DESCRIPTION
## Summary
Our sources API caching is causing some problems, and doesn't account for the changes made to sources via the non-API pathed sources changes. Removing caching implementation as the benefit was marginal. We make significantly fewer calls to this API in the UI than we used to.