### PR TITLE
scripting updates - improve resilience, DRY up a few things

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,9 @@ OC_TEMPLATES = $(wildcard $(OC_TEMPLATE_DIR))
 
 # Docker compose specific file
 ifdef compose_file
-    DOCKER_COMPOSE = docker-compose -f $(compose_file)
+    DOCKER_COMPOSE = $(DOCKER)-compose -f $(compose_file)
 else
-	DOCKER_COMPOSE = docker-compose
+	DOCKER_COMPOSE = $(DOCKER)-compose
 endif
 
 # Platform differences
@@ -168,7 +168,7 @@ create-test-customer-no-sources: run-migrations docker-up-koku
 	$(PYTHON) $(TOPDIR)/scripts/create_test_customer.py --no-sources --bypass-api || echo "WARNING: create_test_customer failed unexpectedly!"
 
 load-test-customer-data:
-	$(TOPDIR)/scripts/load_test_customer_data.sh $(TOPDIR) $(start) $(end)
+	$(TOPDIR)/scripts/load_test_customer_data.sh $(start) $(end)
 	make load-aws-org-unit-tree
 
 load-aws-org-unit-tree:

--- a/scripts/create_test_customer.py
+++ b/scripts/create_test_customer.py
@@ -16,8 +16,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 """
-This script creates a customer and source in Koku for development and
-testing purposes.
+This script creates a customer and source in Koku for development and testing purposes.
 
 Configuration for this script is stored in a YAML file, using this syntax:
 
@@ -59,14 +58,26 @@ from yaml import safe_load
 
 BASEDIR = os.path.dirname(os.path.realpath(__file__))
 DEFAULT_CONFIG = BASEDIR + "/test_customer.yaml"
-SUPPORTED_SOURCES = ["AWS", "AWS-local", "Azure", "Azure-local", "OCP", "GCP-local", "GCP"]
+SUPPORTED_SOURCES_DB = ["AWS", "Azure", "OCP", "GCP"]
+SUPPORTED_SOURCES_API = SUPPORTED_SOURCES_DB + ["AWS-local", "Azure-local", "GCP-local"]
+
+SLEEP = 60
+
+
+def wallclock(func, *args, **kwargs):
+    """Measure time taken by func, print result."""
+    start = time.time()
+    returned = func(*args, **kwargs)
+    end = time.time()
+    print("{} took {:.3f} sec.".format(func.__name__, (end - start)))
+    return returned
 
 
 class KokuCustomerOnboarder:
     """Uses the Koku API and SQL to create an onboarded customer."""
 
     def __init__(self, conf):
-        """Constructor."""
+        """Class constructor."""
         self._config = conf
         self.customer = self._config.get("customer")
         self.koku = self._config.get("koku")
@@ -98,16 +109,18 @@ class KokuCustomerOnboarder:
         # Customer, User, and Tenant schema are lazy initialized
         # on any API request
         print("\nAdding customer...")
-        response = requests.get(self.endpoint_base + "reports/aws/costs/", headers=get_headers(self.auth_token))
+        response = wallclock(
+            requests.get, self.endpoint_base + "reports/azure/costs/", headers=get_headers(self.auth_token)
+        )
         print(f"Response: [{response.status_code}] {response.text}")
         if response.status_code not in [200, 201]:
-            time.sleep(60)
+            time.sleep(SLEEP)
 
     def create_source_api(self):
         """Create a Koku Source using the Koku API."""
         for source in self.customer.get("sources", []):
             source_type = source.get("source_type")
-            if source_type not in SUPPORTED_SOURCES:
+            if source_type not in SUPPORTED_SOURCES_API:
                 print(f"{source_type} is not a valid source type. Skipping.")
                 continue
 
@@ -119,10 +132,12 @@ class KokuCustomerOnboarder:
                 "billing_source": source.get("billing_source", {}),
             }
 
-            response = requests.post(self.endpoint_base + "sources/", headers=get_headers(self.auth_token), json=data)
+            response = wallclock(
+                requests.post, self.endpoint_base + "sources/", headers=get_headers(self.auth_token), json=data
+            )
             print(f"Response: [{response.status_code}] {response.reason}")
             if response.status_code not in [200, 201]:
-                time.sleep(60)
+                time.sleep(SLEEP)
 
     def create_provider_source(self, source_type):
         """Create a single provider, auth, and billing source in the DB."""
@@ -136,76 +151,76 @@ class KokuCustomerOnboarder:
         with psycopg2.connect(**dbinfo) as conn:
             cursor = conn.cursor()
 
-        if source_type.lower() == "aws":
-            source = "aws_source"
-        elif source_type.lower() == "ocp":
-            source = "ocp_source"
-        elif source_type.lower() == "azure":
-            source = "azure_source"
+        if source_type in SUPPORTED_SOURCES_DB:
+            source = "%s_source" % source_type.lower()
 
-        credentials = self.customer.get("sources").get(source).get("authentication").get("credentials", {})
-        data_source = self.customer.get("sources").get(source).get("billing_source").get("data_source", {})
+        for source_dict in self.customer.get("sources"):
+            if source not in source_dict.keys():
+                continue
+            credentials = source_dict.get("authentication").get("credentials", {})
+            data_source = source_dict.get("billing_source").get("data_source", {})
+            source_name = source_dict.get("source_name", source)
 
-        billing_sql = """
-            SELECT id FROM api_providerbillingsource
-            WHERE data_source = %s
+            billing_sql = """
+                SELECT id FROM api_providerbillingsource
+                WHERE data_source = %s
 
-        """
-        values = [json_dumps(data_source)]
-        cursor.execute(billing_sql, values)
-        billing_id = None
-        try:
-            billing_id = cursor.fetchone()
-            if billing_id:
-                billing_id = billing_id[0]
-        except psycopg2.ProgrammingError:
-            pass
-        finally:
-            if billing_id is None:
+            """
+            values = [json_dumps(data_source)]
+            cursor.execute(billing_sql, values)
+            billing_id = None
+            try:
+                billing_id = cursor.fetchone()
+                if billing_id:
+                    billing_id = billing_id[0]
+            except psycopg2.ProgrammingError:
+                pass
+            finally:
+                if billing_id is None:
 
-                billing_sql = """
-                    INSERT INTO api_providerbillingsource (uuid, data_source)
-                    VALUES (%s, %s)
-                    RETURNING id
-                    ;
-                """
-                values = [str(uuid4()), json_dumps(data_source)]
-                cursor.execute(billing_sql, values)
-                billing_id = cursor.fetchone()[0]
-        conn.commit()
+                    billing_sql = """
+                        INSERT INTO api_providerbillingsource (uuid, data_source)
+                        VALUES (%s, %s)
+                        RETURNING id
+                        ;
+                    """
+                    values = [str(uuid4()), json_dumps(data_source)]
+                    cursor.execute(billing_sql, values)
+                    billing_id = cursor.fetchone()[0]
+            conn.commit()
 
-        auth_sql = """
-            INSERT INTO api_providerauthentication (uuid,
-                                                    credentials)
-            VALUES (%s, %s)
-            RETURNING id
-            ;
-        """
-        values = [str(uuid4()), json_dumps(credentials)]
+            auth_sql = """
+                INSERT INTO api_providerauthentication (uuid,
+                                                        credentials)
+                VALUES (%s, %s)
+                RETURNING id
+                ;
+            """
+            values = [str(uuid4()), json_dumps(credentials)]
 
-        cursor.execute(auth_sql, values)
-        auth_id = cursor.fetchone()[0]
-        conn.commit()
+            cursor.execute(auth_sql, values)
+            auth_id = cursor.fetchone()[0]
+            conn.commit()
 
-        provider_sql = """
-            INSERT INTO api_provider (uuid, name, type, authentication_id, billing_source_id,
-                                    created_by_id, customer_id, setup_complete, active)
-            VALUES(%s, %s, %s, %s, %s, 1, 1, False, True)
-            RETURNING uuid
-            ;
-        """
-        values = [str(uuid4()), source, source_type, auth_id, billing_id]
+            provider_sql = """
+                INSERT INTO api_provider (uuid, name, type, authentication_id, billing_source_id,
+                                        created_by_id, customer_id, setup_complete, active)
+                VALUES(%s, %s, %s, %s, %s, 1, 1, False, True)
+                RETURNING uuid
+                ;
+            """
+            values = [str(uuid4()), source_name, source_type, auth_id, billing_id]
 
-        cursor.execute(provider_sql, values)
+            cursor.execute(provider_sql, values)
         conn.commit()
         conn.close()
 
     def create_sources_db(self, skip_sources):
         """Create a Koku source by inserting into the Koku DB."""
         if not skip_sources:
-            for source_type in ["AWS", "OCP", "Azure"]:
-                self.create_source_db(source_type)
-                print(f"Created {source_type} source.")
+            for source_type in SUPPORTED_SOURCES_DB:
+                print("Creating %s source..." % source_type)
+                wallclock(self.create_provider_source, source_type)
 
     def onboard(self):
         """Execute Koku onboarding steps."""
@@ -217,7 +232,7 @@ class KokuCustomerOnboarder:
 
 
 def get_headers(token):
-    """returns HTTP Token Auth header"""
+    """Return HTTP Token Auth header."""
     return {"x-rh-identity": token}
 
 


### PR DESCRIPTION
This PR adds some updates to our dev env scripting.

Change Summary:
- Update `Makefile` use of `docker-compose` to open the door for using `podman-compose`. This isn't 100% working, in that there's some additional details to work through with podman. But, adding almost-working support for podman doesn't adversely impact docker-compose users.

- `create_test_customer.py` got a few updates.
  - add `wallclock()` function to help expose ingestion timing issues.
  - define lists of source type constants that work with the API vs. the DB. DRY up those strings.
  - moved all sleeps to use a single variable.
  - fixed the `--bypass-api` flow so that it creates sources in the DB.  
  
- `load_test_customer.sh` also got several updates.
  - added a bunch of comments to document the script better
  - added `DEBUG` variable and function to print extra info only when `DEBUG=1`
  - fixed pathing logic so that we no longer need to pass a directory into the script; this script can now be executed from anywhere on your filesystem.
  - swapped out some `if/then` blocks for setting defaults at variable assignment time.
  - DRYed up the code for creating cost models
  - DRYed up the code for rendering nise static files