### PR TITLE
add start_date and end_date parameters to org unit endpoint.

### DIFF
--- a/koku/api/organizations/queries.py
+++ b/koku/api/organizations/queries.py
@@ -79,10 +79,12 @@ class OrgQueryHandler(QueryHandler):
         """
         super().__init__(parameters)
         # _set_start_and_end_dates must be called after super and before _get_filter
-        self._set_start_and_end_dates()
+        if not self.parameters.get("start_date") and not self.parameters.get("end_date"):
+            self._set_start_and_end_dates()
         # super() needs to be called before calling _get_filter()
         self.query_filter = self._get_filter()
 
+    # deprecated
     def _set_start_and_end_dates(self):
         """Set start and end dates.
 

--- a/koku/api/organizations/serializers.py
+++ b/koku/api/organizations/serializers.py
@@ -21,6 +21,8 @@ from api.report.serializers import add_operator_specified_fields
 from api.report.serializers import handle_invalid_fields
 from api.report.serializers import StringOrListField
 from api.report.serializers import validate_field
+from api.utils import DateHelper
+from api.utils import materialized_view_month_start
 
 AWS_FILTER_OP_FIELDS = ["org_unit_id"]
 
@@ -33,8 +35,8 @@ class FilterSerializer(serializers.Serializer):
     TIME_UNIT_CHOICES = (("day", "day"), ("month", "month"))
 
     resolution = serializers.ChoiceField(choices=RESOLUTION_CHOICES, required=False)
-    time_scope_value = serializers.ChoiceField(choices=TIME_CHOICES, required=False)
-    time_scope_units = serializers.ChoiceField(choices=TIME_UNIT_CHOICES, required=False)
+    time_scope_value = serializers.ChoiceField(choices=TIME_CHOICES, required=False)  # deprecated
+    time_scope_units = serializers.ChoiceField(choices=TIME_UNIT_CHOICES, required=False)  # deprecated
     limit = serializers.IntegerField(required=False, min_value=1)
     offset = serializers.IntegerField(required=False, min_value=0)
 
@@ -95,6 +97,10 @@ class OrgQueryParamSerializer(serializers.Serializer):
     limit = serializers.IntegerField(required=False, min_value=1)
     offset = serializers.IntegerField(required=False, min_value=0)
 
+    # DateField defaults: format='iso-8601', input_formats=['iso-8601']
+    start_date = serializers.DateField(required=False)
+    end_date = serializers.DateField(required=False)
+
     def validate(self, data):
         """Validate incoming data.
 
@@ -106,8 +112,49 @@ class OrgQueryParamSerializer(serializers.Serializer):
             (ValidationError): if field inputs are invalid
 
         """
+        super().validate(data)
         handle_invalid_fields(self, data)
+
+        start_date = data.get("start_date")
+        end_date = data.get("end_date")
+        time_scope_value = data.get("filter", {}).get("time_scope_value")
+        time_scope_units = data.get("filter", {}).get("time_scope_units")
+
+        if (start_date or end_date) and (time_scope_value or time_scope_units):
+            error = {
+                "error": (
+                    "The parameters [start_date, end_date] may not be ",
+                    "used with the filters [time_scope_value, time_scope_units]",
+                )
+            }
+            raise serializers.ValidationError(error)
+
+        if (start_date and not end_date) or (end_date and not start_date):
+            error = {"error": "The parameters [start_date, end_date] must both be defined."}
+            raise serializers.ValidationError(error)
+
+        if start_date and end_date and (start_date > end_date):
+            error = {"error": "start_date must be a date that is before end_date."}
+            raise serializers.ValidationError(error)
+
         return data
+
+    def validate_start_date(self, value):
+        """Validate that the start_date is within the expected range."""
+        dh = DateHelper()
+        if value >= materialized_view_month_start(dh).date() and value <= dh.today.date():
+            return value
+
+        error = "Parameter start_date must be from {} to {}".format(dh.last_month_start.date(), dh.today.date())
+        raise serializers.ValidationError(error)
+
+    def validate_end_date(self, value):
+        """Validate that the end_date is within the expected range."""
+        dh = DateHelper()
+        if value >= materialized_view_month_start(dh).date() and value <= dh.today.date():
+            return value
+        error = "Parameter end_date must be from {} to {}".format(dh.last_month_start.date(), dh.today.date())
+        raise serializers.ValidationError(error)
 
 
 class AWSOrgQueryParamSerializer(OrgQueryParamSerializer):

--- a/koku/api/organizations/test/test_serializers.py
+++ b/koku/api/organizations/test/test_serializers.py
@@ -21,6 +21,9 @@ from rest_framework import serializers
 
 from api.organizations.serializers import AWSOrgFilterSerializer
 from api.organizations.serializers import FilterSerializer
+from api.organizations.serializers import OrgQueryParamSerializer
+from api.utils import DateHelper
+from api.utils import materialized_view_month_start
 
 
 class FilterSerializerTest(TestCase):
@@ -100,3 +103,81 @@ class AWSFilterSerializerTest(TestCase):
             filter_params["type"] = tag_type
             serializer = AWSOrgFilterSerializer(data=filter_params)
             self.assertFalse(serializer.is_valid())
+
+
+class OrgQueryParamSerializerTest(TestCase):
+    """Tests for the handling query parameter parsing serializer."""
+
+    def test_parse_query_params_success(self):
+        """Test parse of a query params successfully."""
+        query_params = {
+            "filter": {"resolution": "daily", "time_scope_value": "-10", "time_scope_units": "day"},
+            "limit": "5",
+            "offset": "3",
+        }
+        serializer = OrgQueryParamSerializer(data=query_params)
+        self.assertTrue(serializer.is_valid())
+
+    def test_query_params_invalid_fields(self):
+        """Test parse of query params for invalid fields."""
+        query_params = {"invalid": "invalid"}
+        serializer = OrgQueryParamSerializer(data=query_params)
+        with self.assertRaises(serializers.ValidationError):
+            serializer.is_valid(raise_exception=True)
+
+    def test_parse_filter_dates_valid(self):
+        """Test parse of a filter date-based param should succeed."""
+        dh = DateHelper()
+        scenarios = [
+            {"start_date": dh.yesterday.date(), "end_date": dh.today.date()},
+            {"start_date": dh.this_month_start.date(), "end_date": dh.yesterday.date()},
+            {
+                "start_date": dh.last_month_end.date(),
+                "end_date": dh.this_month_start.date(),
+                "filter": {"resolution": "monthly"},
+            },
+            {
+                "start_date": dh.last_month_start.date(),
+                "end_date": dh.last_month_end.date(),
+                "filter": {"resolution": "monthly"},
+            },
+        ]
+
+        for params in scenarios:
+            with self.subTest(params=params):
+                serializer = OrgQueryParamSerializer(data=params)
+                self.assertTrue(serializer.is_valid(raise_exception=True))
+
+    def test_parse_filter_dates_invalid(self):
+        """Test parse of invalid data for filter date-based param should not succeed."""
+        dh = DateHelper()
+        scenarios = [
+            {"start_date": dh.today.date()},
+            {"end_date": dh.today.date()},
+            {"start_date": dh.yesterday.date(), "end_date": dh.tomorrow.date()},
+            {"start_date": dh.n_days_ago(materialized_view_month_start(dh), 1).date(), "end_date": dh.today.date()},
+            {"start_date": dh.today.date(), "end_date": dh.this_month_start.date()},
+            {"start_date": "llamas", "end_date": dh.yesterday.date()},
+            {"start_date": dh.yesterday.date(), "end_date": "alpacas"},
+            {"start_date": "llamas", "end_date": "alpacas"},
+            {
+                "start_date": dh.last_month_start.date(),
+                "end_date": dh.last_month_end.date(),
+                "filter": {"time_scope_units": "day"},
+            },
+            {
+                "start_date": dh.last_month_start.date(),
+                "end_date": dh.last_month_end.date(),
+                "filter": {"time_scope_value": "-1"},
+            },
+            {
+                "start_date": dh.last_month_start.date(),
+                "end_date": dh.last_month_end.date(),
+                "filter": {"time_scope_units": "day", "time_scope_value": "-1"},
+            },
+        ]
+
+        for params in scenarios:
+            with self.subTest(params=params):
+                serializer = OrgQueryParamSerializer(data=params)
+                self.assertFalse(serializer.is_valid())


### PR DESCRIPTION
This adds `start_date` and `end_date` query parameters to the OrgUnits endpoint. This is a follow-on to PR #2656 

Functional testing:
```
~/tests.sh
+ ENDPOINT=/organizations/aws
++ date +%Y-%m-%d
+ TODAY=2021-02-19
++ date -d '2021-02-19 +1 days' +%Y-%m-%d
+ TOMORROW=2021-02-20
++ date -d '2021-02-19 -1 month' +%Y-%m-01
+ FIRST_OF_LAST_MONTH=2021-01-01
+ curl -g 'http://localhost:8000/api/cost-management/v1/organizations/aws/?filter[time_scope_units]=day&filter[time_scope_value]=-30&filter[resolution]=daily'
{"meta":{"count":6,"filter":{"resolution":"daily","time_scope_value":"-30","time_scope_units":"day"},"key_only":false,"group_by":{},"order_by":{},"access":{}},"links":{"first":"/api/cost-management/v1/organizations/aws/?filter%5Bresolution%5D=daily&filter%5Btime_scope_units%5D=day&filter%5Btime_scope_value%5D=-30&limit=100&offset=0","next":null,"previous":null,"last":"/api/cost-management/v1/organizations/aws/?filter%5Bresolution%5D=daily&filter%5Btime_scope_units%5D=day&filter%5Btime_scope_value%5D=-30&limit=100&offset=0"},"data":[{"org_unit_id":"OU_001","org_unit_name":"Dept OU_001 (Rename)","org_unit_path":"R_001&OU_001","level":1,"sub_orgs":["OU_005"],"accounts":["account 001","account 002"]},{"org_unit_id":"OU_002","org_unit_name":"Dept OU_002","org_unit_path":"R_001&OU_002","level":1,"sub_orgs":["OU_003"],"accounts":[]},{"org_unit_id":"OU_003","org_unit_name":"Dept OU_003","org_unit_path":"R_001&OU_002&OU_003","level":2,"sub_orgs":[],"accounts":["account 003"]},{"org_unit_id":"OU_004","org_unit_name":"Dept OU_004","org_unit_path":"R_001&OU_004","level":1,"sub_orgs":[],"accounts":["account 004"]},{"org_unit_id":"OU_005","org_unit_name":"Dept OU_005","org_unit_path":"R_001&OU_001&OU_005","level":2,"sub_orgs":[],"accounts":["account 005"]},{"org_unit_id":"R_001","org_unit_name":"Root","org_unit_path":"R_001","level":0,"sub_orgs":["OU_002","OU_004","OU_001"],"accounts":["Root A Test"]}]}+ echo ''

+ curl -g 'http://localhost:8000/api/cost-management/v1/organizations/aws/?start_date=2021-01-01&end_date=2021-02-19&filter[resolution]=daily'
{"meta":{"count":6,"filter":{"resolution":"daily","time_scope_value":"-10","time_scope_units":"day"},"key_only":false,"start_date":"2021-01-01","end_date":"2021-02-19","group_by":{},"order_by":{},"access":{}},"links":{"first":"/api/cost-management/v1/organizations/aws/?end_date=2021-02-19&filter%5Bresolution%5D=daily&limit=100&offset=0&start_date=2021-01-01","next":null,"previous":null,"last":"/api/cost-management/v1/organizations/aws/?end_date=2021-02-19&filter%5Bresolution%5D=daily&limit=100&offset=0&start_date=2021-01-01"},"data":[{"org_unit_id":"OU_001","org_unit_name":"Dept OU_001 (Rename)","org_unit_path":"R_001&OU_001","level":1,"sub_orgs":["OU_005"],"accounts":["account 001","account 002"]},{"org_unit_id":"OU_002","org_unit_name":"Dept OU_002","org_unit_path":"R_001&OU_002","level":1,"sub_orgs":["OU_003"],"accounts":[]},{"org_unit_id":"OU_003","org_unit_name":"Dept OU_003","org_unit_path":"R_001&OU_002&OU_003","level":2,"sub_orgs":[],"accounts":["account 003"]},{"org_unit_id":"OU_004","org_unit_name":"Dept OU_004","org_unit_path":"R_001&OU_004","level":1,"sub_orgs":[],"accounts":["account 004"]},{"org_unit_id":"OU_005","org_unit_name":"Dept OU_005","org_unit_path":"R_001&OU_001&OU_005","level":2,"sub_orgs":[],"accounts":["account 005"]},{"org_unit_id":"R_001","org_unit_name":"Root","org_unit_path":"R_001","level":0,"sub_orgs":["OU_002","OU_004","OU_001"],"accounts":["Root A Test"]}]}+ echo ''

+ curl -g 'http://localhost:8000/api/cost-management/v1/organizations/aws/?start_date=2021-01-01'
{"error":["The parameters [start_date, end_date] must both be defined."]}+ echo ''

+ curl -g 'http://localhost:8000/api/cost-management/v1/organizations/aws/?end_date=2021-02-19'
{"error":["The parameters [start_date, end_date] must both be defined."]}+ echo ''

+ curl -g 'http://localhost:8000/api/cost-management/v1/organizations/aws/?start_date=2021-01-01&end_date=2021-02-20&filter[resolution]=daily'
{"end_date":["Parameter end_date must be from 2021-01-01 to 2021-02-19"]}+ echo ''

+ curl -g 'http://localhost:8000/api/cost-management/v1/organizations/aws/?start_date=2021-02-20&end_date=2021-02-19&filter[resolution]=daily'
{"start_date":["Parameter start_date must be from 2021-01-01 to 2021-02-19"]}+ echo ''

+ curl -g 'http://localhost:8000/api/cost-management/v1/organizations/aws/?start_date=2021-02-19&end_date=2021-01-01&filter[resolution]=daily'
{"error":["start_date must be a date that is before end_date."]}+ echo ''

+ curl -g 'http://localhost:8000/api/cost-management/v1/organizations/aws/?start_date=1970-01-01&end_date=2021-02-19&filter[resolution]=daily'
{"start_date":["Parameter start_date must be from 2021-01-01 to 2021-02-19"]}+ echo ''

```