### PR TITLE
Check a single and list of filters to apply contains

### DIFF
--- a/koku/api/report/test/all/openshift/test_query_handler.py
+++ b/koku/api/report/test/all/openshift/test_query_handler.py
@@ -205,3 +205,18 @@ class OCPAllQueryHandlerTest(IamTestCase):
         handler.set_access_filters(access, filt, filters)
         expected = [QueryFilter(field=field, operation="contains", parameter=access)]
         self.assertEqual(filters._filters, expected)
+
+    @RbacPermissions({"openshift.project": {"read": ["analytics"]}})
+    def test_set_access_filters_with_array_field_and_list(self):
+        """Test that a filter is correctly set for arrays."""
+
+        query_params = self.mocked_query_params("?filter[project]=analytics", OCPAllCostView)
+        # the mocked query parameters dont include the key from the url so it needs to be added
+        handler = OCPAllReportQueryHandler(query_params)
+        field = "namespace"
+        access = ["analytics"]
+        filt = [{"field": field}]
+        filters = QueryFilterCollection()
+        handler.set_access_filters(access, filt, filters)
+        expected = [QueryFilter(field=field, operation="contains", parameter=access)]
+        self.assertEqual(filters._filters, expected)


### PR DESCRIPTION
## Jira ticket

[COST-776](https://issues.redhat.com/browse/COST-776)

## Description

SQL is being rendered in such a way as to generate `array_col` in (array_parameter)` which is failing. After discussing with Andrew regarding his original fix on #2604 I saw that the contains modification was only being applied to a single filter vs filters in a list. This change will apply his fix to any filter whether single or in a list.

## Testing

Failing url in production was `http://koku.hccm-prod.svc.cluster.local/api/cost-management/v1/forecasts/openshift/infrastructures/all/costs/?limit=31`

So this request should pass with no namespace filters, a single namespace filter, and a list of namespace filters.

## Note

You may want to use split diff to view changes.