### PR TITLE
COST-1045: Supporting both GCP dataset id formats

### DIFF
--- a/koku/sources/api/view.py
+++ b/koku/sources/api/view.py
@@ -218,7 +218,11 @@ class SourcesViewSet(*MIXIN_LIST):
         response = super().list(request=request, args=args, kwargs=kwargs)
         _, tenant = self._get_account_and_tenant(request)
         for source in response.data["data"]:
-            if source.get("authentication", {}).get("credentials", {}).get("client_secret"):
+            if (
+                source.get("authentication")
+                and source.get("authentication").get("credentials")
+                and source.get("authentication").get("credentials").get("client_secret")
+            ):
                 del source["authentication"]["credentials"]["client_secret"]
             try:
                 manager = ProviderManager(source["uuid"])


### PR DESCRIPTION
GCP shows the Dataset ID two different ways in their BigQuery console.  It has added confusion to users onboarding GCP sources.  This change will support both formats:
* `dataset_name`
* `project:dataset_name`

**Testing**
1. Create a source with Dataset ID as the dataset name.  Verify it's successful
2. Create a source with Dataset ID as project:dataset.  Verify it's successful.
3. Create a source with Dataset ID as project:dataset where project is in correct.  Verify error
4. Create a source with a datset containing illegal characters.  Verify status is correct

**Test Results**
[cost_1045_ut.txt](https://github.com/project-koku/koku/files/5998909/cost_1045_ut.txt)
