### PR TITLE
Localdev db ssl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,6 @@ testing/
 # Local OpenShift folders
 openshift.local.clusterup/
 scripts/openshift.local.clusterup/
+
+# Localdev Certs
+certs/

--- a/README.rst
+++ b/README.rst
@@ -175,10 +175,10 @@ If you see this error, run the following command (assuming you are at the projec
 
 If you need to run PostgreSQL using SSL for local development:
 
-1. Ensure that you have openssl installed.
-2. Ensure that you have the `KOKU_PATH` environment set to the koku source root directory.
-3. Execute `${KOKU_PATH}/scripts/genssc` and follow the prompts to create local a self-signed certificate for PostgreSQL.
-4. In the `docker-compose.yml` file, there are two commented sections labeled "PostgreSQL SSL". Follow the directions in these comments to enable the volume mounts and command options to use SSL.
+1. Ensure that you have ``openssl`` installed.
+2. Ensure that you have the ``KOKU_PATH`` environment set to the koku source root directory.
+3. Execute ``${KOKU_PATH}/scripts/genssc`` and follow the prompts to create local a self-signed certificate for PostgreSQL.
+4. In the ``docker-compose.yml`` file, there are two commented sections labeled "PostgreSQL SSL". Follow the directions in these comments to enable the volume mounts and command options to use SSL.
 
 See  https://access.redhat.com/containers/?tab=overview#/registry.access.redhat.com/rhel8/postgresql-12
 

--- a/README.rst
+++ b/README.rst
@@ -173,6 +173,13 @@ If you see this error, run the following command (assuming you are at the projec
 
     setfacl -m u:26:-wx ./pg_data
 
+If you need to run PostgreSQL using SSL for local development:
+
+1. Ensure that you have openssl installed.
+2. Ensure that you have the `KOKU_PATH` environment set to the koku source root directory.
+3. Execute `${KOKU_PATH}/scripts/genssc` and follow the prompts to create local a self-signed certificate for PostgreSQL.
+4. In the `docker-compose.yml` file, there are two commented sections labeled "PostgreSQL SSL". Follow the directions in these comments to enable the volume mounts and command options to use SSL.
+
 See  https://access.redhat.com/containers/?tab=overview#/registry.access.redhat.com/rhel8/postgresql-12
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,6 +125,9 @@ services:
     volumes:
       - ./pg_data:/var/lib/${DATABASE_DATA_DIR-postgresql}/data
       - ./pg_init:/docker-entrypoint-initdb.d
+      # PostgreSQL SSL: Un-comment the next two lines after running ./scripts/genssc to use sslmode in Postgres
+      # - ./certs/koku.crt:/etc/certs/koku.crt
+      # - ./certs/private/koku.key:/etc/certs/private/koku.key
     command:
       # This command give more precise control over the parameter settings
       # Included are loading the pg_stat_statements lib
@@ -132,6 +135,14 @@ services:
       # use of the autovacuum processes
       # The pg_init mount is still needed to enable the necesary extensions.
       - postgres
+      # PostgreSQL SSL: Run ./scripts/genssc to create self-signed cert and key files to support ssl
+      #                 Un-comment the three options below to utilize ssl mode and use the certificate and key
+      # - -c
+      # - ssl=on
+      # - -c
+      # - ssl_cert_file=/etc/certs/koku.crt
+      # - -c
+      # - ssl_key_file=/etc/certs/private/koku.key
       - -c
       - max_connections=1710
       - -c

--- a/scripts/genssc
+++ b/scripts/genssc
@@ -1,0 +1,59 @@
+#! /usr/bin/env sh
+#
+# Copyright 2021 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# This script will generate a self-signed certificate for development use of PostgreSQL SSL connections
+#
+
+if ! which openssl 1>/dev/null
+then
+    echo "ERROR: openssl is required" >&2
+    exit -1
+fi
+
+if [[ -z "${KOKU_PATH}" ]]
+then
+    echo "ERROR: Environment variable KOKU_PATH must be set" >&2
+    exit -1
+fi
+
+CERT_DIR="${KOKU_PATH}"/certs
+KEY_DIR="${KOKU_PATH}"/certs/private
+CERT_FILE="${CERT_DIR}"/koku.crt
+KEY_FILE="${KEY_DIR}"/koku.key
+CSR_FILE="${KEY_DIR}"/koku.csr
+
+[[ ! -d "${KEY_DIR}" ]] && mkdir -p "${KEY_DIR}" || true
+
+sudo rm -rf "${CERT_FILE}" "${KEY_FILE}" "${CSR_FILE}"
+
+openssl genrsa -out "${KEY_FILE}" 2048 && \
+openssl req -new -key "${KEY_FILE}" -out "${CSR_FILE}" -sha512 && \
+openssl x509 -req -days 3650 -in "${CSR_FILE}" -signkey "${KEY_FILE}" -out "${CERT_FILE}" -sha512
+RC=$?
+
+if [[ ${RC} -ne 0 ]]
+then
+    echo "Self-Signed Certificate creation failed!" >&2
+else
+    chmod ug+r "${CERT_FILE}"
+    chmod 0640 "${KEY_FILE}"
+    # Group id 101 is specific to the docker hub postgres image
+    sudo chown root:101 "${KEY_FILE}"
+    echo "Success!"
+fi
+
+exit $RC


### PR DESCRIPTION
## Description

Add a script to easily generate a self-signed cert for local development use of PostgreSQL with SSL support turned on.
Added options to `docker-compose.yml` to use the certificate and enable SSL support.

This is opt-in.