### PR TITLE
COST-1081: Exempting demo accounts from source checks with source-status API

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
         - prometheus_multiproc_dir=/tmp
         - API_PATH_PREFIX=${API_PATH_PREFIX-/api/cost-management}
         - GOOGLE_APPLICATION_CREDENTIALS=${GOOGLE_APPLICATION_CREDENTIALS}
-        - DEMO_ACCOUNTS=${DEMO_ACCOUNTS-{}}
+        - DEMO_ACCOUNTS
         - ACCOUNT_ENHANCED_METRICS=${ACCOUNT_ENHANCED_METRICS-False}
         - RUN_GUNICORN=${RUN_GUNICORN}
       privileged: true
@@ -259,7 +259,7 @@ services:
         - KOKU_CELERY_ENABLE_SENTRY
         - KOKU_CELERY_SENTRY_DSN
         - KOKU_SENTRY_ENVIRONMENT
-        - DEMO_ACCOUNTS=${DEMO_ACCOUNTS-{}}
+        - DEMO_ACCOUNTS
         - INITIAL_INGEST_OVERRIDE=${INITIAL_INGEST_OVERRIDE-False}
         - INITIAL_INGEST_NUM_MONTHS=${INITIAL_INGEST_NUM_MONTHS-2}
         - AUTO_DATA_INGEST=${AUTO_DATA_INGEST-True}
@@ -369,6 +369,7 @@ services:
         - SOURCES_KAFKA_PORT=${SOURCES_KAFKA_PORT-29092}
         - KOKU_SOURCES_CLIENT_PORT=${KOKU_SOURCES_CLIENT_PORT-9000}
         - GOOGLE_APPLICATION_CREDENTIALS=${GOOGLE_APPLICATION_CREDENTIALS}
+        - DEMO_ACCOUNTS
         - prometheus_multiproc_dir=/tmp
       privileged: true
       ports:

--- a/koku/sources/api/source_status.py
+++ b/koku/sources/api/source_status.py
@@ -17,6 +17,7 @@
 import logging
 import threading
 
+from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction
 from django.views.decorators.cache import never_cache
@@ -73,7 +74,8 @@ class SourceStatus:
         interface = ProviderAccessor(provider_type)
         error_obj = None
         try:
-            interface.cost_usage_source_ready(source_authentication, source_billing_source)
+            if self.source.account_id not in settings.DEMO_ACCOUNTS:
+                interface.cost_usage_source_ready(source_authentication, source_billing_source)
             self._set_provider_active_status(True)
         except ValidationError as validation_error:
             self._set_provider_active_status(False)


### PR DESCRIPTION
The DEMO_ACCOUNTS env contains the information for our nise populator service.  These accounts must skip the normal provider onboarding checks.  This change ensures that these accounts are not verified on the POST /source-status path.

**Testing**
1. With DEVELOPMENT=False set the DEMO_ACCOUNTS variable to a known account id.  Add a demo source (nise populator) and verify that source-status checks return avaiabile.

**Test Results**
[cost_1081_ut.txt](https://github.com/project-koku/koku/files/6025388/cost_1081_ut.txt)
