### PR TITLE
COST-1045: Sources dataset update for downloader

### DIFF
--- a/koku/masu/external/downloader/gcp/gcp_report_downloader.py
+++ b/koku/masu/external/downloader/gcp/gcp_report_downloader.py
@@ -168,7 +168,7 @@ class GCPReportDownloader(ReportDownloaderBase, DownloaderInterface):
             "cost_type",
         ]
         self.table_name = ".".join(
-            [self.credentials.get("project_id"), self.data_source.get("dataset"), self.data_source.get("table_id")]
+            [self.credentials.get("project_id"), self._get_dataset_name(), self.data_source.get("table_id")]
         )
         self.scan_start, self.scan_end = self._generate_default_scan_range()
         try:
@@ -178,6 +178,12 @@ class GCPReportDownloader(ReportDownloaderBase, DownloaderInterface):
             msg = f"GCP source ({self._provider_uuid}) for {customer_name} is not reachable. Error: {str(ex)}"
             LOG.error(log_json(self.request_id, msg, self.context))
             raise GCPReportDownloaderError(str(ex))
+
+    def _get_dataset_name(self):
+        """Helper to get dataset ID when format is project:datasetName."""
+        if ":" in self.data_source.get("dataset"):
+            return self.data_source.get("dataset").split(":")[1]
+        return self.data_source.get("dataset")
 
     def _generate_default_scan_range(self, range_length=3):
         """

--- a/koku/masu/test/external/downloader/gcp/test_gcp_report_downloader.py
+++ b/koku/masu/test/external/downloader/gcp/test_gcp_report_downloader.py
@@ -280,3 +280,28 @@ class GCPReportDownloaderTest(MasuTestCase):
             os.remove(daily_file)
 
         os.remove(file_path)
+
+    def test_get_dataset_name(self):
+        """Test _get_dataset_name helper."""
+        project_id = FAKE.slug()
+        dataset_name = FAKE.slug()
+
+        datasets = [f"{project_id}:{dataset_name}", dataset_name]
+
+        for dataset in datasets:
+            billing_source = {"table_id": FAKE.slug(), "dataset": dataset}
+            credentials = {"project_id": project_id}
+
+            with patch("masu.external.downloader.gcp.gcp_report_downloader.GCPProvider"), patch(
+                "masu.external.downloader.gcp.gcp_report_downloader.GCPReportDownloader._generate_etag",
+                return_value=self.etag,
+            ):
+                with patch("masu.external.downloader.gcp.gcp_report_downloader.GCPProvider"):
+                    downloader = GCPReportDownloader(
+                        customer_name=FAKE.name(),
+                        data_source=billing_source,
+                        provider_uuid=uuid4(),
+                        credentials=credentials,
+                    )
+
+            self.assertEqual(downloader._get_dataset_name(), dataset_name)


### PR DESCRIPTION
Follow up to COST-1045.  The worker needs to adjust the dataset format.  I didn't want to change what was stored in the Sources model because it's better to stay in sync with what the platform stores.

**Testing**
Added GCP source with both formats and verified ingest was successful.