### PR TITLE
Fix migration to not fail on missing env vars

### DIFF
--- a/koku/koku/settings.py
+++ b/koku/koku/settings.py
@@ -237,6 +237,11 @@ DATABASES = {"default": database.config()}
 
 DATABASE_ROUTERS = ("tenant_schemas.routers.TenantSyncRouter",)
 
+# Hive DB variables
+HIVE_DATABASE_USER = ENVIRONMENT.get_value("HIVE_DATABASE_USER", default="hive")
+HIVE_DATABASE_NAME = ENVIRONMENT.get_value("HIVE_DATABASE_NAME", default="hive")
+HIVE_DATABASE_PASSWORD = ENVIRONMENT.get_value("HIVE_DATABASE_PASSWORD", default="hive")
+
 #
 TENANT_MODEL = "api.Tenant"
 


### PR DESCRIPTION
## Summary
This puts our env var references in settings.py and allows the migration to run if these vars have not been set. 