### PR TITLE
Only get user-defined tags from AWS

### DIFF
--- a/koku/masu/processor/aws/aws_report_processor.py
+++ b/koku/masu/processor/aws/aws_report_processor.py
@@ -262,7 +262,7 @@ class AWSReportProcessor(ReportProcessorBase):
 
         return {column_map[key]: value for key, value in row.items() if key in column_map}
 
-    def _process_tags(self, row, tag_prefix="resourceTags"):
+    def _process_tags(self, row, tag_prefix="resourceTags/user"):
         """Return a JSON string of AWS resource tags.
 
         Args:


### PR DESCRIPTION
## Summary
This would filter out AWS system tags that come in the cost and usage report and only process user-defined tags. 