### PR TITLE
OCP log statement for summary start and end dates

### DIFF
--- a/koku/masu/external/kafka_msg_handler.py
+++ b/koku/masu/external/kafka_msg_handler.py
@@ -507,6 +507,9 @@ def summarize_manifest(report_meta):
                 "manifest_id": manifest_id,
             }
             if start_date and end_date:
+                LOG.info(
+                    f"Summarizing OCP reports from {str(start_date)}-{str(end_date)} for provider: {provider_uuid}"
+                )
                 report_meta["start"] = start_date
                 report_meta["end"] = end_date
             async_id = summarize_reports.delay([report_meta])


### PR DESCRIPTION
This log statement will tell us which operator the OCP cluster is using.  The start and end dates are present only in the manifests generated in the new operator. 