### PR TITLE
route kafka logs thru logger

### DIFF
--- a/koku/masu/external/kafka_msg_handler.py
+++ b/koku/masu/external/kafka_msg_handler.py
@@ -646,7 +646,8 @@ def get_consumer():  # pragma: no cover
             "queued.max.messages.kbytes": 1024,
             "enable.auto.commit": False,
             "max.poll.interval.ms": 1080000,  # 18 minutes
-        }
+        },
+        logger=LOG,
     )
     consumer.subscribe([HCCM_TOPIC])
     return consumer

--- a/koku/sources/kafka_listener.py
+++ b/koku/sources/kafka_listener.py
@@ -452,7 +452,8 @@ def get_consumer():
             "group.id": "hccm-sources",
             "queued.max.messages.kbytes": 1024,
             "enable.auto.commit": False,
-        }
+        },
+        logger=LOG,
     )
     consumer.subscribe([Config.SOURCES_TOPIC])
     return consumer


### PR DESCRIPTION
Currently, rdkafka prints directly to stdout instead of using our log handler. This PR re-routes kafka log messages through our handler which will enable Kibana to pick up these logs.


Below shows a comparison of the output for the same log message:
Previous behavior:
```
koku_listener     | %4|1616432526.766|MAXPOLL|rdkafka#consumer-1| [thrd:main]: Application maximum poll interval (100000ms) exceeded by 215ms (adjust max.poll.interval.ms for long-running message processing): leaving group
```

New behavior:
```
koku_listener     | [2021-03-22 16:56:34,811] WARNING None MAXPOLL [rdkafka#consumer-1] [thrd:main]: Application maximum poll interval (100000ms) exceeded by 161ms (adjust max.poll.interval.ms for long-running message processing): leaving group
```