### PR TITLE
[COST-1063][COST-1165] More priority cost model updates

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -385,6 +385,7 @@ services:
         - GOOGLE_APPLICATION_CREDENTIALS=${GOOGLE_APPLICATION_CREDENTIALS}
         - DEMO_ACCOUNTS
         - prometheus_multiproc_dir=/tmp
+        - AUTO_DATA_INGEST=${AUTO_DATA_INGEST-True}
       privileged: true
       ports:
           - 4000:8080

--- a/koku/cost_models/cost_model_manager.py
+++ b/koku/cost_models/cost_model_manager.py
@@ -73,6 +73,7 @@ class CostModelManager:
 
         providers_to_delete = set(current_providers_for_instance).difference(provider_uuids)
         providers_to_create = set(provider_uuids).difference(current_providers_for_instance)
+        all_providers = set(current_providers_for_instance).union(provider_uuids)
 
         for provider_uuid in providers_to_delete:
             CostModelMap.objects.filter(provider_uuid=provider_uuid, cost_model=self._model).delete()
@@ -89,8 +90,8 @@ class CostModelManager:
 
         start_date = DateHelper().this_month_start.strftime("%Y-%m-%d")
         end_date = DateHelper().today.strftime("%Y-%m-%d")
-        for provider_uuid in provider_uuids:
-            # Update cost-model costs for each provider, on every update/PUT
+        for provider_uuid in all_providers:
+            # Update cost-model costs for each provider, on every PUT/DELETE
             try:
                 provider = Provider.objects.get(uuid=provider_uuid)
             except Provider.DoesNotExist:

--- a/koku/cost_models/test/test_cost_model_manager.py
+++ b/koku/cost_models/test/test_cost_model_manager.py
@@ -94,8 +94,9 @@ class CostModelManagerTest(IamTestCase):
 
         with tenant_context(self.tenant):
             manager = CostModelManager()
-            with patch("cost_models.cost_model_manager.chain"):
+            with patch("cost_models.cost_model_manager.chain") as mock_chain:
                 cost_model_obj = manager.create(**data)
+                mock_chain.return_value.apply_async.assert_called()
             self.assertIsNotNone(cost_model_obj.uuid)
             for rate in cost_model_obj.rates:
                 self.assertEqual(rate.get("metric", {}).get("name"), metric)
@@ -131,8 +132,9 @@ class CostModelManagerTest(IamTestCase):
 
         with tenant_context(self.tenant):
             manager = CostModelManager()
-            with patch("cost_models.cost_model_manager.chain"):
+            with patch("cost_models.cost_model_manager.chain") as mock_chain:
                 cost_model_obj = manager.create(**data)
+                mock_chain.return_value.apply_async.assert_called()
 
             cost_model_map = CostModelMap.objects.filter(provider_uuid=provider_uuid)
             self.assertIsNotNone(cost_model_map)
@@ -177,8 +179,9 @@ class CostModelManagerTest(IamTestCase):
 
         with tenant_context(self.tenant):
             manager = CostModelManager()
-            with patch("cost_models.cost_model_manager.chain"):
+            with patch("cost_models.cost_model_manager.chain") as mock_chain:
                 cost_model_obj = manager.create(**data)
+                mock_chain.return_value.apply_async.assert_called()
             self.assertIsNotNone(cost_model_obj.uuid)
             for rate in cost_model_obj.rates:
                 self.assertEqual(rate.get("metric", {}).get("name"), metric)
@@ -209,8 +212,9 @@ class CostModelManagerTest(IamTestCase):
         cost_model_obj = None
         with tenant_context(self.tenant):
             manager = CostModelManager()
-            with patch("cost_models.cost_model_manager.chain"):
+            with patch("cost_models.cost_model_manager.chain") as mock_chain:
                 cost_model_obj = manager.create(**data)
+                mock_chain.return_value.apply_async.assert_not_called()
 
             cost_model_map = CostModelMap.objects.filter(cost_model=cost_model_obj)
             self.assertEqual(len(cost_model_map), 0)
@@ -225,8 +229,9 @@ class CostModelManagerTest(IamTestCase):
         # Add provider to existing cost model
         with tenant_context(self.tenant):
             manager = CostModelManager(cost_model_uuid=cost_model_obj.uuid)
-            with patch("cost_models.cost_model_manager.chain"):
+            with patch("cost_models.cost_model_manager.chain") as mock_chain:
                 manager.update_provider_uuids(provider_uuids=[provider_uuid])
+                mock_chain.return_value.apply_async.assert_called()
 
             cost_model_map = CostModelMap.objects.filter(cost_model=cost_model_obj)
             self.assertIsNotNone(cost_model_map)
@@ -236,8 +241,9 @@ class CostModelManagerTest(IamTestCase):
         # Add provider again to existing cost model.  Verify there is still only 1 item in map
         with tenant_context(self.tenant):
             manager = CostModelManager(cost_model_uuid=cost_model_obj.uuid)
-            with patch("cost_models.cost_model_manager.chain"):
+            with patch("cost_models.cost_model_manager.chain") as mock_chain:
                 manager.update_provider_uuids(provider_uuids=[provider_uuid])
+                mock_chain.return_value.apply_async.assert_called()
 
             cost_model_map = CostModelMap.objects.filter(cost_model=cost_model_obj)
             self.assertIsNotNone(cost_model_map)
@@ -247,8 +253,9 @@ class CostModelManagerTest(IamTestCase):
         # Remove provider from existing rate
         with tenant_context(self.tenant):
             manager = CostModelManager(cost_model_uuid=cost_model_obj.uuid)
-            with patch("cost_models.cost_model_manager.chain"):
+            with patch("cost_models.cost_model_manager.chain") as mock_chain:
                 manager.update_provider_uuids(provider_uuids=[])
+                mock_chain.return_value.apply_async.assert_called()
 
             cost_model_map = CostModelMap.objects.filter(cost_model=cost_model_obj)
             self.assertEqual(len(cost_model_map), 0)

--- a/koku/cost_models/test/tests_view.py
+++ b/koku/cost_models/test/tests_view.py
@@ -231,13 +231,15 @@ class CostModelViewTests(IamTestCase):
         response = client.get(url, **self.headers)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-    def test_update_cost_model_success(self):
+    @patch("cost_models.cost_model_manager.chain")
+    def test_update_cost_model_success(self, _):
         """Test that we can update an existing rate."""
         new_value = round(Decimal(random.random()), 6)
         self.fake_data["rates"][0]["tiered_rates"][0]["value"] = new_value
 
-        cost_model = CostModel.objects.first()
-        url = reverse("cost-models-detail", kwargs={"uuid": cost_model.uuid})
+        with tenant_context(self.tenant):
+            cost_model = CostModel.objects.first()
+            url = reverse("cost-models-detail", kwargs={"uuid": cost_model.uuid})
         client = APIClient()
         response = client.put(url, self.fake_data, format="json", **self.headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK)


### PR DESCRIPTION
## Summary
- To keep the OCP worker processing the normal task flow, switch to using the priority queue for all API/UI driven cost model update calls.
- Queue cost model cost update for any update operation, regardless of source add/delete from cost model.
- Queue cost model cost update for cost model delete operations.