### PR TITLE
reroute masu-api tasks to priority worker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -324,7 +324,7 @@ _koku-wait:
 docker-up:
 	$(DOCKER_COMPOSE) up --build -d
 
-docker-up-no-build:
+docker-up-no-build: docker-up-db
 	$(DOCKER_COMPOSE) up -d
 
 docker-up-min:

--- a/koku/masu/api/report_data.py
+++ b/koku/masu/api/report_data.py
@@ -28,11 +28,11 @@ from rest_framework.response import Response
 from rest_framework.settings import api_settings
 
 from masu.database.provider_db_accessor import ProviderDBAccessor
-from masu.processor.tasks import OCP_QUEUE
+from masu.processor.tasks import PRIORITY_QUEUE
+from masu.processor.tasks import QUEUE_LIST
 from masu.processor.tasks import remove_expired_data
 from masu.processor.tasks import update_all_summary_tables
 from masu.processor.tasks import update_summary_tables
-from masu.processor.tasks import UPDATE_SUMMARY_TABLES_QUEUE
 
 LOG = logging.getLogger(__name__)
 REPORT_DATA_KEY = "Report Data Task ID"
@@ -53,9 +53,13 @@ def report_data(request):
         schema_name = params.get("schema")
         start_date = params.get("start_date")
         end_date = params.get("end_date")
+        queue_name = params.get("queue", default=PRIORITY_QUEUE)
         if provider_uuid is None and provider_type is None:
             errmsg = "provider_uuid or provider_type must be supplied as a parameter."
-            return Response({"Error": errmsg}, status=400)
+            return Response({"Error": errmsg}, status=status.HTTP_400_BAD_REQUEST)
+        if queue_name not in QUEUE_LIST:
+            errmsg = f"'queue' must be one of {QUEUE_LIST}."
+            return Response({"Error": errmsg}, status=status.HTTP_400_BAD_REQUEST)
 
         if provider_uuid == "*":
             all_providers = True
@@ -70,7 +74,6 @@ def report_data(request):
             return Response({"Error": errmsg}, status=status.HTTP_400_BAD_REQUEST)
 
         if not all_providers:
-            queue_name = OCP_QUEUE if provider and provider.lower() == "ocp" else None
             if schema_name is None:
                 errmsg = "schema is a required parameter."
                 return Response({"Error": errmsg}, status=status.HTTP_400_BAD_REQUEST)
@@ -85,7 +88,7 @@ def report_data(request):
 
             async_result = update_summary_tables.s(
                 schema_name, provider, provider_uuid, start_date, end_date, queue_name=queue_name
-            ).apply_async(queue=queue_name or UPDATE_SUMMARY_TABLES_QUEUE)
+            ).apply_async(queue=queue_name or PRIORITY_QUEUE)
         else:
             async_result = update_all_summary_tables.delay(start_date, end_date)
         return Response({REPORT_DATA_KEY: str(async_result)})

--- a/koku/masu/api/report_data.py
+++ b/koku/masu/api/report_data.py
@@ -53,7 +53,7 @@ def report_data(request):
         schema_name = params.get("schema")
         start_date = params.get("start_date")
         end_date = params.get("end_date")
-        queue_name = params.get("queue", default=PRIORITY_QUEUE)
+        queue_name = params.get("queue") or PRIORITY_QUEUE
         if provider_uuid is None and provider_type is None:
             errmsg = "provider_uuid or provider_type must be supplied as a parameter."
             return Response({"Error": errmsg}, status=status.HTTP_400_BAD_REQUEST)

--- a/koku/masu/api/update_cost_model_costs.py
+++ b/koku/masu/api/update_cost_model_costs.py
@@ -51,7 +51,7 @@ def update_cost_model_costs(request):
     default_end_date = DateHelper().today.strftime("%Y-%m-%d")
     start_date = params.get("start_date", default=default_start_date)
     end_date = params.get("end_date", default=default_end_date)
-    queue_name = params.get("queue", default=PRIORITY_QUEUE)
+    queue_name = params.get("queue") or PRIORITY_QUEUE
 
     if provider_uuid is None or schema_name is None:
         errmsg = "provider_uuid and schema_name are required parameters."

--- a/koku/masu/api/update_cost_model_costs.py
+++ b/koku/masu/api/update_cost_model_costs.py
@@ -29,6 +29,8 @@ from rest_framework.settings import api_settings
 
 from api.provider.models import Provider
 from api.utils import DateHelper
+from masu.processor.tasks import PRIORITY_QUEUE
+from masu.processor.tasks import QUEUE_LIST
 from masu.processor.tasks import refresh_materialized_views
 from masu.processor.tasks import update_cost_model_costs as cost_task
 
@@ -49,9 +51,13 @@ def update_cost_model_costs(request):
     default_end_date = DateHelper().today.strftime("%Y-%m-%d")
     start_date = params.get("start_date", default=default_start_date)
     end_date = params.get("end_date", default=default_end_date)
+    queue_name = params.get("queue", default=PRIORITY_QUEUE)
 
     if provider_uuid is None or schema_name is None:
         errmsg = "provider_uuid and schema_name are required parameters."
+        return Response({"Error": errmsg}, status=status.HTTP_400_BAD_REQUEST)
+    if queue_name not in QUEUE_LIST:
+        errmsg = f"'queue' must be one of {QUEUE_LIST}."
         return Response({"Error": errmsg}, status=status.HTTP_400_BAD_REQUEST)
 
     try:
@@ -61,8 +67,10 @@ def update_cost_model_costs(request):
 
     LOG.info("Calling update_cost_model_costs async task.")
     async_result = chain(
-        cost_task.s(schema_name, provider_uuid, start_date, end_date),
-        refresh_materialized_views.si(schema_name, provider.type, provider_uuid=provider_uuid),
+        cost_task.s(schema_name, provider_uuid, start_date, end_date, queue_name=queue_name).set(queue=queue_name),
+        refresh_materialized_views.si(
+            schema_name, provider.type, provider_uuid=provider_uuid, queue_name=queue_name
+        ).set(queue=queue_name),
     ).apply_async()
 
     return Response({"Update Cost Model Cost Task ID": str(async_result)})

--- a/koku/masu/processor/orchestrator.py
+++ b/koku/masu/processor/orchestrator.py
@@ -208,7 +208,6 @@ class Orchestrator:
             (celery.result.AsyncResult) Async result for download request.
 
         """
-        async_result = None
         for account in self._polling_accounts:
             provider_uuid = account.get("provider_uuid")
             report_months = self.get_reports(provider_uuid)
@@ -239,8 +238,7 @@ class Orchestrator:
                 account_number, label = labeler.get_label_details()
                 if account_number:
                     LOG.info("Account: %s Label: %s updated.", account_number, label)
-
-        return async_result
+        return
 
     def remove_expired_report_data(self, simulate=False, line_items_only=False):
         """

--- a/koku/masu/processor/tasks.py
+++ b/koku/masu/processor/tasks.py
@@ -65,12 +65,24 @@ LOG = get_task_logger(__name__)
 
 GET_REPORT_FILES_QUEUE = "download"
 OCP_QUEUE = "ocp"
+PRIORITY_QUEUE = "priority"
 REFRESH_MATERIALIZED_VIEWS_QUEUE = "reporting"
 REMOVE_EXPIRED_DATA_QUEUE = "remove_expired"
 SUMMARIZE_REPORTS_QUEUE = "process"
 UPDATE_COST_MODEL_COSTS_QUEUE = "reporting"
 UPDATE_SUMMARY_TABLES_QUEUE = "reporting"
-PRIORITY_QUEUE = "priority"
+
+# any additional queues should be added to this list
+QUEUE_LIST = [
+    GET_REPORT_FILES_QUEUE,
+    OCP_QUEUE,
+    PRIORITY_QUEUE,
+    REFRESH_MATERIALIZED_VIEWS_QUEUE,
+    REMOVE_EXPIRED_DATA_QUEUE,
+    SUMMARIZE_REPORTS_QUEUE,
+    UPDATE_COST_MODEL_COSTS_QUEUE,
+    UPDATE_SUMMARY_TABLES_QUEUE,
+]
 
 
 def record_all_manifest_files(manifest_id, report_files):

--- a/koku/masu/test/api/test_report_data.py
+++ b/koku/masu/test/api/test_report_data.py
@@ -148,7 +148,7 @@ class ReportDataTests(TestCase):
     @patch("koku.middleware.MASU", return_value=True)
     @patch("masu.api.report_data.update_summary_tables")
     def test_get_report_data_invalid_queue(self, mock_update, _):
-        """Test GET report_data endpoint returns a 400 for invalid provider_uuid."""
+        """Test GET report_data endpoint returns a 400 for invalid queue."""
         start_date = datetime.date.today()
         params = {
             "start_date": start_date,

--- a/koku/masu/test/api/test_report_data.py
+++ b/koku/masu/test/api/test_report_data.py
@@ -25,6 +25,8 @@ from django.urls import reverse
 
 from api.models import Provider
 from masu.processor.tasks import OCP_QUEUE
+from masu.processor.tasks import PRIORITY_QUEUE
+from masu.processor.tasks import QUEUE_LIST
 
 
 @override_settings(ROOT_URLCONF="masu.urls")
@@ -57,7 +59,7 @@ class ReportDataTests(TestCase):
             params["provider_uuid"],
             str(params["start_date"]),
             None,
-            queue_name=None,
+            queue_name=PRIORITY_QUEUE,
         )
 
     @patch("koku.middleware.MASU", return_value=True)
@@ -72,6 +74,7 @@ class ReportDataTests(TestCase):
             "schema": "acct10001",
             "start_date": start_date,
             "provider_uuid": "6e212746-484a-40cd-bba0-09a19d132d64",
+            "queue": "ocp",
         }
         expected_key = "Report Data Task ID"
 
@@ -134,6 +137,27 @@ class ReportDataTests(TestCase):
         }
         expected_key = "Error"
         expected_message = "Unable to determine provider type."
+
+        response = self.client.get(reverse("report_data"), params)
+        body = response.json()
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(expected_key, body)
+        self.assertEqual(body[expected_key], expected_message)
+
+    @patch("koku.middleware.MASU", return_value=True)
+    @patch("masu.api.report_data.update_summary_tables")
+    def test_get_report_data_invalid_queue(self, mock_update, _):
+        """Test GET report_data endpoint returns a 400 for invalid provider_uuid."""
+        start_date = datetime.date.today()
+        params = {
+            "start_date": start_date,
+            "schema": "acct10001",
+            "provider_uuid": "6e212746-484a-40cd-bba0-09a19d132ddd",
+            "queue": "not-a-real-queue",
+        }
+        expected_key = "Error"
+        expected_message = f"'queue' must be one of {QUEUE_LIST}."
 
         response = self.client.get(reverse("report_data"), params)
         body = response.json()
@@ -208,7 +232,7 @@ class ReportDataTests(TestCase):
             params["provider_uuid"],
             str(params["start_date"]),
             str(params["end_date"]),
-            queue_name=None,
+            queue_name=PRIORITY_QUEUE,
         )
 
     @patch("koku.middleware.MASU", return_value=True)
@@ -236,7 +260,7 @@ class ReportDataTests(TestCase):
             None,
             str(params["start_date"]),
             str(params["end_date"]),
-            queue_name=None,
+            queue_name=PRIORITY_QUEUE,
         )
 
     @patch("koku.middleware.MASU", return_value=True)

--- a/koku/masu/test/api/test_update_cost_model_costs.py
+++ b/koku/masu/test/api/test_update_cost_model_costs.py
@@ -21,6 +21,8 @@ from django.test import TestCase
 from django.test.utils import override_settings
 from django.urls import reverse
 
+from masu.processor.tasks import QUEUE_LIST
+
 
 @override_settings(ROOT_URLCONF="masu.urls")
 class UpdateCostModelCostTest(TestCase):
@@ -68,6 +70,21 @@ class UpdateCostModelCostTest(TestCase):
         params = {"provider_uuid": "3c6e687e-1a09-4a05-970c-2ccf44b0952e"}
         expected_key = "Error"
         expected_message = "provider_uuid and schema_name are required parameters."
+
+        response = self.client.get(reverse("update_cost_model_costs"), params)
+        body = response.json()
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(expected_key, body)
+        self.assertEqual(body[expected_key], expected_message)
+
+    @patch("koku.middleware.MASU", return_value=True)
+    @patch("masu.api.update_cost_model_costs.cost_task")
+    def test_get_update_cost_model_costs_invalid_queue(self, mock_update, _):
+        """Test GET report_data endpoint returns a 400 for invalid queue."""
+        params = {"provider_uuid": "3c6e687e-1a09-4a05-970c-2ccf44b0952e"}
+        expected_key = "Error"
+        expected_message = f"'queue' must be one of {QUEUE_LIST}."
 
         response = self.client.get(reverse("update_cost_model_costs"), params)
         body = response.json()

--- a/koku/masu/test/api/test_update_cost_model_costs.py
+++ b/koku/masu/test/api/test_update_cost_model_costs.py
@@ -78,11 +78,17 @@ class UpdateCostModelCostTest(TestCase):
         self.assertIn(expected_key, body)
         self.assertEqual(body[expected_key], expected_message)
 
+    @patch("masu.api.update_cost_model_costs.Provider")
     @patch("koku.middleware.MASU", return_value=True)
     @patch("masu.api.update_cost_model_costs.cost_task")
-    def test_get_update_cost_model_costs_invalid_queue(self, mock_update, _):
+    def test_get_update_cost_model_costs_invalid_queue(self, mock_update, _, __):
         """Test GET report_data endpoint returns a 400 for invalid queue."""
-        params = {"provider_uuid": "3c6e687e-1a09-4a05-970c-2ccf44b0952e"}
+        params = {
+            "schema": "acct10001",
+            "provider_uuid": "3c6e687e-1a09-4a05-970c-2ccf44b0952e",
+            "start_date": "01-03-2010",
+            "queue": "This-aint-a-real-queue",
+        }
         expected_key = "Error"
         expected_message = f"'queue' must be one of {QUEUE_LIST}."
 

--- a/testing/compose_files/docker-compose-priority-ocp-normal-workers.yml
+++ b/testing/compose_files/docker-compose-priority-ocp-normal-workers.yml
@@ -1,0 +1,424 @@
+version: '3'
+
+services:
+  koku-base:
+    image: koku_base
+    build:
+      context: ./../..
+      dockerfile: Dockerfile-env
+
+  koku-server:
+    container_name: koku-server
+    image: koku_base
+    working_dir: /koku
+    entrypoint:
+      - /koku/run_server.sh
+    environment:
+      - DATABASE_SERVICE_NAME=POSTGRES_SQL
+      - DATABASE_ENGINE=postgresql
+      - DATABASE_NAME=${DATABASE_NAME-postgres}
+      - POSTGRES_SQL_SERVICE_HOST=db
+      - POSTGRES_SQL_SERVICE_PORT=5432
+      - DATABASE_USER=${DATABASE_USER-postgres}
+      - DATABASE_PASSWORD=${DATABASE_PASSWORD-postgres}
+      - KOKU_SOURCES_CLIENT_HOST=${KOKU_SOURCES_CLIENT_HOST-sources-client}
+      - KOKU_SOURCES_CLIENT_PORT=${KOKU_SOURCES_CLIENT_PORT-9000}
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - DJANGO_READ_DOT_ENV_FILE=True
+      - DEVELOPMENT=${DEVELOPMENT-True}
+      - DJANGO_DEBUG=${DJANGO_DEBUG-True}
+      - RBAC_SERVICE_HOST=${RBAC_SERVICE_HOST-rbac-server}
+      - RBAC_SERVICE_PORT=${RBAC_SERVICE_PORT-9000}
+      - RBAC_SERVICE_PATH=${RBAC_SERVICE_PATH-/r/insights/platform/rbac/v1/access/}
+      - REDIS_HOST=${REDIS_HOST-redis}
+      - REDIS_PORT=${REDIS_PORT-6379}
+      - MASU_SERVICE_HOST=${MASU_SERVICE_HOST-masu-server}
+      - MASU_SERVICE_PORT=${MASU_SERVICE_PORT-8000}
+      - RBAC_CACHE_TTL
+      - MASU_SECRET_KEY=abc
+      - prometheus_multiproc_dir=/tmp
+      - API_PATH_PREFIX=${API_PATH_PREFIX-/api/cost-management}
+      - GOOGLE_APPLICATION_CREDENTIALS=${GOOGLE_APPLICATION_CREDENTIALS}
+      - DEMO_ACCOUNTS=${DEMO_ACCOUNTS-{}}
+      - ACCOUNT_ENHANCED_METRICS=${ACCOUNT_ENHANCED_METRICS-False}
+      - ENABLE_TRINO_SOURCES
+
+    privileged: true
+    ports:
+        - 8000:8000
+    volumes:
+      - './../..:/koku/'
+    links:
+      - db
+      - redis
+      - masu-server
+      - sources-client
+    depends_on:
+      - koku-base
+      - db
+
+  masu-server:
+    container_name: masu-server
+    image: koku_base
+    working_dir: /koku
+    entrypoint:
+      - /koku/run_internal.sh
+    environment:
+      - MASU=True
+      - DATABASE_SERVICE_NAME=POSTGRES_SQL
+      - DATABASE_ENGINE=postgresql
+      - DATABASE_NAME=${DATABASE_NAME-postgres}
+      - POSTGRES_SQL_SERVICE_HOST=db
+      - POSTGRES_SQL_SERVICE_PORT=5432
+      - DATABASE_USER=${DATABASE_USER-postgres}
+      - DATABASE_PASSWORD=${DATABASE_PASSWORD-postgres}
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - DJANGO_READ_DOT_ENV_FILE=True
+      - DEVELOPMENT=${DEVELOPMENT-True}
+      - DJANGO_DEBUG=${DJANGO_DEBUG-True}
+      - RBAC_SERVICE_HOST=${RBAC_SERVICE_HOST-rbac-server}
+      - RBAC_SERVICE_PORT=${RBAC_SERVICE_PORT-9000}
+      - RBAC_SERVICE_PATH=${RBAC_SERVICE_PATH-/r/insights/platform/rbac/v1/access/}
+      - REDIS_HOST=${REDIS_HOST-redis}
+      - REDIS_PORT=${REDIS_PORT-6379}
+      - MASU_SERVICE_HOST=${MASU_SERVICE_HOST-masu-server}
+      - MASU_SERVICE_PORT=${MASU_SERVICE_PORT-8000}
+      - RBAC_CACHE_TTL
+      - MASU_SECRET_KEY=abc
+      - prometheus_multiproc_dir=/tmp
+      - API_PATH_PREFIX=${API_PATH_PREFIX-/api/cost-management}
+      - ACCOUNT_ENHANCED_METRICS=${ACCOUNT_ENHANCED_METRICS-False}
+      - ENABLE_TRINO_SOURCES
+
+    privileged: true
+    ports:
+        - 5000:8000
+    volumes:
+      - './../..:/koku/'
+    links:
+      - db
+      - redis
+    depends_on:
+      - koku-base
+      - db
+
+  redis:
+    container_name: koku-redis
+    image: redis:5.0.4
+    ports:
+      - "6379:6379"
+
+  db:
+    container_name: koku-db
+    image: postgres:12
+    environment:
+    - POSTGRES_DB=${DATABASE_NAME-postgres}
+    - POSTGRES_USER=${DATABASE_USER-postgres}
+    - POSTGRES_PASSWORD=${DATABASE_PASSWORD-postgres}
+    ports:
+      - "15432:5432"
+    volumes:
+      - ./../../pg_data:/var/lib/${DATABASE_DATA_DIR-postgresql}/data
+      - ./../../pg_init:/docker-entrypoint-initdb.d
+    command:
+      # This command give more precise control over the parameter settings
+      # Included are loading the pg_stat_statements lib
+      # as well as autovacuum settings that are designed to make more efficient
+      # use of the autovacuum processes
+      # The pg_init mount is still needed to enable the necesary extensions.
+      - postgres
+      - -c
+      - max_connections=1710
+      - -c
+      - shared_preload_libraries=pg_stat_statements
+      - -c
+      - autovacuum_max_workers=8
+      - -c
+      - autovacuum_vacuum_cost_limit=4800
+      - -c
+      - autovacuum_vacuum_cost_delay=10
+      - -c
+      - idle_in_transaction_session_timeout=30000
+      - -c
+      - pg_stat_statements.max=2000
+      - -c
+      - pg_stat_statements.save=off
+      - -c
+      - pg_stat_statements.track_utility=off
+      - -c
+      - track_activity_query_size=2048
+      - -c
+      - log_min_error_statement=error
+      - -c
+      - log_min_duration_statement=2000
+      - -c
+      - track_functions=pl
+
+  koku-worker-ocp:
+    container_name: koku-worker-ocp
+    hostname: koku-worker-ocp
+    image: koku_base
+    working_dir: /koku/koku
+    entrypoint: ['watchmedo', 'auto-restart', '--directory=./', '--pattern=*.py', '--recursive', '--', 'celery', '-A', 'koku', 'worker', '-l', 'info', '-Q', 'ocp']
+    environment:
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - DATABASE_SERVICE_NAME=POSTGRES_SQL
+      - DATABASE_ENGINE=postgresql
+      - DATABASE_NAME=${DATABASE_NAME-postgres}
+      - POSTGRES_SQL_SERVICE_HOST=db
+      - POSTGRES_SQL_SERVICE_PORT=5432
+      - DATABASE_USER=${DATABASE_USER-postgres}
+      - DATABASE_PASSWORD=${DATABASE_PASSWORD-postgres}
+      - DEVELOPMENT=${DEVELOPMENT-True}
+      - LOG_LEVEL=INFO
+      - DJANGO_SETTINGS_MODULE=koku.settings
+      - MASU_SECRET_KEY=abc
+      - prometheus_multiproc_dir=/tmp
+      - PROMETHEUS_PUSHGATEWAY=${PROMETHEUS_PUSHGATEWAY-pushgateway:9091}
+      - ENABLE_S3_ARCHIVING=${ENABLE_S3_ARCHIVING-False}
+      - ENABLE_PARQUET_PROCESSING=${ENABLE_PARQUET_PROCESSING-False}
+      - S3_BUCKET_NAME=${S3_BUCKET_NAME-koku-bucket}
+      - S3_BUCKET_PATH=${S3_BUCKET_PATH-data_archive}
+      - S3_ENDPOINT
+      - S3_ACCESS_KEY
+      - S3_SECRET
+      - PVC_DIR=${PVC_DIR-/testing/pvc_dir}
+      - GOOGLE_APPLICATION_CREDENTIALS=${GOOGLE_APPLICATION_CREDENTIALS}
+      - KOKU_CELERY_ENABLE_SENTRY
+      - KOKU_CELERY_SENTRY_DSN
+      - KOKU_SENTRY_ENVIRONMENT
+      - DEMO_ACCOUNTS
+      - INITIAL_INGEST_OVERRIDE=${INITIAL_INGEST_OVERRIDE-False}
+      - INITIAL_INGEST_NUM_MONTHS=${INITIAL_INGEST_NUM_MONTHS-2}
+      - AUTO_DATA_INGEST=${AUTO_DATA_INGEST-True}
+      - REPORT_PROCESSING_BATCH_SIZE=${REPORT_PROCESSING_BATCH_SIZE-100000}
+      - REPORT_PROCESSING_TIMEOUT_HOURS=${REPORT_PROCESSING_TIMEOUT_HOURS-2}
+      - PRESTO_HOST=${PRESTO_HOST-presto}
+      - PRESTO_PORT=${PRESTO_PORT-8080}
+      - DATE_OVERRIDE
+      - MASU_DEBUG
+      - ENABLE_TRINO_SOURCES
+    privileged: true
+    volumes:
+      - './../..:/koku/'
+    links:
+        - redis
+    depends_on:
+        - koku-base
+        - redis
+
+  koku-worker-1:
+    container_name: koku-worker-1
+    hostname: koku-worker-1-fsfsgr
+    image: koku_base
+    working_dir: /koku/koku
+    entrypoint: ['watchmedo', 'auto-restart', '--directory=./', '--pattern=*.py', '--recursive', '--', 'celery', '-A', 'koku', 'worker', '-l', 'info', '-Q', 'celery,download,remove_expired,reporting,process,upload,customer_data_sync,delete_archived_data,query_upload']
+    environment:
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - DATABASE_SERVICE_NAME=POSTGRES_SQL
+      - DATABASE_ENGINE=postgresql
+      - DATABASE_NAME=${DATABASE_NAME-postgres}
+      - POSTGRES_SQL_SERVICE_HOST=db
+      - POSTGRES_SQL_SERVICE_PORT=5432
+      - DATABASE_USER=${DATABASE_USER-postgres}
+      - DATABASE_PASSWORD=${DATABASE_PASSWORD-postgres}
+      - REDIS_HOST=${REDIS_HOST-redis}
+      - REDIS_PORT=${REDIS_PORT-6379}
+      - DEVELOPMENT=${DEVELOPMENT-True}
+      - LOG_LEVEL=INFO
+      - DJANGO_SETTINGS_MODULE=koku.settings
+      - MASU_SECRET_KEY=abc
+      - prometheus_multiproc_dir=/tmp
+      - PROMETHEUS_PUSHGATEWAY=${PROMETHEUS_PUSHGATEWAY-pushgateway:9091}
+      - ENABLE_S3_ARCHIVING=${ENABLE_S3_ARCHIVING-False}
+      - ENABLE_PARQUET_PROCESSING=${ENABLE_PARQUET_PROCESSING-False}
+      - S3_BUCKET_NAME=${S3_BUCKET_NAME-koku-bucket}
+      - S3_BUCKET_PATH=${S3_BUCKET_PATH-data_archive}
+      - S3_ENDPOINT
+      - S3_ACCESS_KEY
+      - S3_SECRET
+      - PVC_DIR=${PVC_DIR-/testing/pvc_dir}
+      - GOOGLE_APPLICATION_CREDENTIALS=${GOOGLE_APPLICATION_CREDENTIALS}
+      - KOKU_CELERY_ENABLE_SENTRY
+      - KOKU_CELERY_SENTRY_DSN
+      - KOKU_SENTRY_ENVIRONMENT
+      - DEMO_ACCOUNTS=${DEMO_ACCOUNTS-{}}
+      - INITIAL_INGEST_OVERRIDE=${INITIAL_INGEST_OVERRIDE-False}
+      - INITIAL_INGEST_NUM_MONTHS=${INITIAL_INGEST_NUM_MONTHS-2}
+      - AUTO_DATA_INGEST=${AUTO_DATA_INGEST-True}
+      - REPORT_PROCESSING_BATCH_SIZE=${REPORT_PROCESSING_BATCH_SIZE-100000}
+      - REPORT_PROCESSING_TIMEOUT_HOURS=${REPORT_PROCESSING_TIMEOUT_HOURS-2}
+      - ENABLE_TRINO_SOURCES
+    privileged: true
+    volumes:
+      - './../..:/koku'
+      - './../../testing:/testing'
+      - './../../testing/local_providers/azure_local:/tmp/local_container'
+      - './../../testing/local_providers/aws_local:/tmp/local_bucket'
+      - './../../testing/local_providers/aws_local_0:/tmp/local_bucket_0'
+      - './../../testing/local_providers/aws_local_1:/tmp/local_bucket_1'
+      - './../../testing/local_providers/aws_local_2:/tmp/local_bucket_2'
+      - './../../testing/local_providers/aws_local_3:/tmp/local_bucket_3'
+      - './../../testing/local_providers/aws_local_4:/tmp/local_bucket_4'
+      - './../../testing/local_providers/aws_local_5:/tmp/local_bucket_5'
+      - './../../testing/local_providers/insights_local:/var/tmp/masu/insights_local'
+    links:
+        - redis
+    depends_on:
+        - redis
+        - koku-base
+
+  priority-worker:
+    container_name: priority-worker
+    hostname: priority-worker
+    image: koku_base
+    working_dir: /koku/koku
+    entrypoint: ['watchmedo', 'auto-restart', '--directory=./', '--pattern=*.py', '--recursive', '--', 'celery', '-A', 'koku', 'worker', '-l', 'info', '-Q', 'priority']
+    environment:
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - DATABASE_SERVICE_NAME=POSTGRES_SQL
+      - DATABASE_ENGINE=postgresql
+      - DATABASE_NAME=${DATABASE_NAME-postgres}
+      - POSTGRES_SQL_SERVICE_HOST=db
+      - POSTGRES_SQL_SERVICE_PORT=5432
+      - DATABASE_USER=${DATABASE_USER-postgres}
+      - DATABASE_PASSWORD=${DATABASE_PASSWORD-postgres}
+      - DEVELOPMENT=${DEVELOPMENT-True}
+      - LOG_LEVEL=INFO
+      - DJANGO_SETTINGS_MODULE=koku.settings
+      - MASU_SECRET_KEY=abc
+      - prometheus_multiproc_dir=/tmp
+      - PROMETHEUS_PUSHGATEWAY=${PROMETHEUS_PUSHGATEWAY-pushgateway:9091}
+      - ENABLE_S3_ARCHIVING=${ENABLE_S3_ARCHIVING-False}
+      - ENABLE_PARQUET_PROCESSING=${ENABLE_PARQUET_PROCESSING-False}
+      - S3_BUCKET_NAME=${S3_BUCKET_NAME-koku-bucket}
+      - S3_BUCKET_PATH=${S3_BUCKET_PATH-data_archive}
+      - S3_ENDPOINT
+      - S3_ACCESS_KEY
+      - S3_SECRET
+      - PVC_DIR=${PVC_DIR-/testing/pvc_dir}
+      - GOOGLE_APPLICATION_CREDENTIALS=${GOOGLE_APPLICATION_CREDENTIALS}
+      - KOKU_CELERY_ENABLE_SENTRY
+      - KOKU_CELERY_SENTRY_DSN
+      - KOKU_SENTRY_ENVIRONMENT
+      - DEMO_ACCOUNTS
+      - INITIAL_INGEST_OVERRIDE=${INITIAL_INGEST_OVERRIDE-False}
+      - INITIAL_INGEST_NUM_MONTHS=${INITIAL_INGEST_NUM_MONTHS-2}
+      - AUTO_DATA_INGEST=${AUTO_DATA_INGEST-True}
+      - REPORT_PROCESSING_BATCH_SIZE=${REPORT_PROCESSING_BATCH_SIZE-100000}
+      - REPORT_PROCESSING_TIMEOUT_HOURS=${REPORT_PROCESSING_TIMEOUT_HOURS-2}
+      - PRESTO_HOST=${PRESTO_HOST-presto}
+      - PRESTO_PORT=${PRESTO_PORT-8080}
+      - DATE_OVERRIDE
+      - MASU_DEBUG
+    volumes:
+      - './../..:/koku'
+      - './../../testing:/testing'
+      - './../../testing/local_providers/azure_local:/tmp/local_container'
+      - './../../testing/local_providers/aws_local:/tmp/local_bucket'
+      - './../../testing/local_providers/aws_local_0:/tmp/local_bucket_0'
+      - './../../testing/local_providers/aws_local_1:/tmp/local_bucket_1'
+      - './../../testing/local_providers/aws_local_2:/tmp/local_bucket_2'
+      - './../../testing/local_providers/aws_local_3:/tmp/local_bucket_3'
+      - './../../testing/local_providers/aws_local_4:/tmp/local_bucket_4'
+      - './../../testing/local_providers/aws_local_5:/tmp/local_bucket_5'
+      - './../../testing/local_providers/insights_local:/var/tmp/masu/insights_local'
+    privileged: true
+    links:
+      - redis
+    depends_on:
+      - koku-base
+      - redis
+
+  koku-listener:
+    container_name: koku-listener
+    image: koku_base
+    working_dir: /koku/
+    entrypoint: ['python', 'koku/manage.py', 'listener']
+    environment:
+      - DATABASE_SERVICE_NAME=POSTGRES_SQL
+      - POSTGRES_SQL_SERVICE_HOST=db
+      - POSTGRES_SQL_SERVICE_PORT=5432
+      - DATABASE_ENGINE=postgresql
+      - DATABASE_NAME=${DATABASE_NAME-postgres}
+      - DATABASE_HOST=db
+      - DATABASE_PORT=5432
+      - DATABASE_USER=${DATABASE_USER-postgres}
+      - DATABASE_PASSWORD=${DATABASE_PASSWORD-postgres}
+      - MASU_SECRET_KEY=abc
+      - INSIGHTS_KAFKA_HOST=kafka
+      - INSIGHTS_KAFKA_PORT=29092
+      - KAFKA_CONNECT=True
+      - prometheus_multiproc_dir=/tmp
+      - MASU_DATE_OVERRIDE
+      - MASU_DEBUG
+      - LOG_LEVEL=INFO
+      - INITIAL_INGEST_NUM_MONTHS=1
+      - PYTHONPATH=/koku/koku
+      - ENABLE_S3_ARCHIVING=${ENABLE_S3_ARCHIVING-False}
+      - ENABLE_PARQUET_PROCESSING=${ENABLE_PARQUET_PROCESSING-False}
+      - S3_BUCKET_NAME=${S3_BUCKET_NAME-koku-bucket}
+      - S3_BUCKET_PATH=${S3_BUCKET_PATH-data_archive}
+      - S3_ENDPOINT
+      - S3_ACCESS_KEY
+      - S3_SECRET
+      - ENABLE_TRINO_SOURCES
+    privileged: true
+    ports:
+        - "9988:9999"
+    volumes:
+      - './../..:/koku'
+    links:
+      - db
+      - redis
+    depends_on:
+      - koku-base
+      - db
+
+  sources-client:
+    container_name: sources_client
+    image: koku_base
+    restart: on-failure:25
+    working_dir: /koku/
+    entrypoint:
+      - /koku/run_sources.sh
+    environment:
+      - DATABASE_SERVICE_NAME=POSTGRES_SQL
+      - DATABASE_ENGINE=postgresql
+      - DATABASE_NAME=${DATABASE_NAME-postgres}
+      - POSTGRES_SQL_SERVICE_HOST=db
+      - POSTGRES_SQL_SERVICE_PORT=5432
+      - DATABASE_USER=${DATABASE_USER-postgres}
+      - DATABASE_PASSWORD=${DATABASE_PASSWORD-postgres}
+      - KOKU_API_HOST=${KOKU_API_HOST-koku-server}
+      - KOKU_API_PORT=${KOKU_API_PORT-8000}
+      - KOKU_API_PATH_PREFIX=${KOKU_API_PATH_PREFIX-/api/cost-management/v1}
+      - SOURCES_API_HOST=${SOURCES_API_HOST-sources-server}
+      - SOURCES_API_PORT=${SOURCES_API_PORT-3000}
+      - REDIS_HOST=${REDIS_HOST-redis}
+      - REDIS_PORT=${REDIS_PORT-6379}
+      - SOURCES_KAFKA_HOST=${SOURCES_KAFKA_HOST-kafka}
+      - SOURCES_KAFKA_PORT=${SOURCES_KAFKA_PORT-29092}
+      - KOKU_SOURCES_CLIENT_PORT=${KOKU_SOURCES_CLIENT_PORT-9000}
+      - prometheus_multiproc_dir=/tmp
+    privileged: true
+    ports:
+        - 4000:8080
+        - 4050:9000
+    volumes:
+      - './../..:/koku'
+    links:
+      - db
+      - redis
+    depends_on:
+      - koku-base
+
+networks:
+ default:
+   external:
+     name: koku_default


### PR DESCRIPTION
1. Reroute `update_cost_model_costs` and `report_data` (for specific providers/schema) masu-api tasks to the priority worker
2. add a `queue` query parameter so that we can select which queue to send the work, if we so choose. We check to make sure the queue exists, else we return a 400 (if this check did not exist, the task won't run).

Testing:
1. spin up the queues:
``` 
export compose_file=testing/compose_files/docker-compose-priority-ocp-normal-workers.yml
make docker-up-no-build
```
2. add a source and ingest data
3. make some masu-api calls:
```
http://localhost:5000/api/cost-management/v1/report_data/?provider_uuid=eb976c07-e455-447b-99b0-1e67f6782541&schema=acct10001&start_date=2021-03-01

See work performed in priority-worker

http://localhost:5000/api/cost-management/v1/report_data/?provider_uuid=eb976c07-e455-447b-99b0-1e67f6782541&schema=acct10001&start_date=2021-03-01&queue=ocp

see work performed in koku-worker-ocp

http://localhost:5000/api/cost-management/v1/report_data/?provider_uuid=eb976c07-e455-447b-99b0-1e67f6782541&schema=acct10001&start_date=2021-03-01&queue=reporting

see work performed in koku-worker-1

http://localhost:5000/api/cost-management/v1/report_data/?provider_uuid=eb976c07-e455-447b-99b0-1e67f6782541&schema=acct10001&start_date=2021-03-01&queue=not-a-real-queue

see 400 Bad Request:
{
    "Error": "'queue' must be one of ['download', 'ocp', 'priority', 'reporting', 'remove_expired', 'process', 'reporting', 'reporting']."
}
```
4. add a cost-model
5. do the same tests with the masu `/update_cost_model_costs` endpoint. Verify the work is done on the correct worker.
6. unset exported compose_file:
```
unset compose_file
```