### PR TITLE
[COST-1237] Only call account labeler when reports processing

### DIFF
--- a/koku/masu/processor/orchestrator.py
+++ b/koku/masu/processor/orchestrator.py
@@ -244,7 +244,7 @@ class Orchestrator:
                     if account_number:
                         LOG.info("Account: %s Label: %s updated.", account_number, label)
 
-        return async_result
+        return
 
     def remove_expired_report_data(self, simulate=False, line_items_only=False):
         """

--- a/koku/masu/processor/orchestrator.py
+++ b/koku/masu/processor/orchestrator.py
@@ -212,6 +212,7 @@ class Orchestrator:
 
         """
         for account in self._polling_accounts:
+            accounts_labeled = False
             provider_uuid = account.get("provider_uuid")
             report_months = self.get_reports(provider_uuid)
             for month in report_months:
@@ -233,7 +234,7 @@ class Orchestrator:
                     continue
 
                 # update labels
-                if reports_tasks_queued:
+                if reports_tasks_queued and not accounts_labeled:
                     LOG.info("Running AccountLabel to get account aliases.")
                     labeler = AccountLabel(
                         auth=account.get("credentials"),
@@ -241,6 +242,7 @@ class Orchestrator:
                         provider_type=account.get("provider_type"),
                     )
                     account_number, label = labeler.get_label_details()
+                    accounts_labeled = True
                     if account_number:
                         LOG.info("Account: %s Label: %s updated.", account_number, label)
 

--- a/koku/masu/processor/orchestrator.py
+++ b/koku/masu/processor/orchestrator.py
@@ -135,7 +135,9 @@ class Orchestrator:
                 assembly_id - (String): UUID identifying report file
                 compression - (String): Report compression format
                 files       - ([{"key": full_file_path "local_file": "local file name"}]): List of report files.
+            (Boolaen) - Whether we are processing this manifest
         """
+        reports_tasks_queued = False
         downloader = ReportDownloader(
             customer_name=customer_name,
             credentials=credentials,
@@ -189,9 +191,10 @@ class Orchestrator:
             LOG.info("Download queued - schema_name: %s.", schema_name)
 
         if report_tasks:
+            reports_tasks_queued = True
             async_id = chord(report_tasks, summarize_reports.s())()
             LOG.info(f"Manifest Processing Async ID: {async_id}")
-        return manifest
+        return manifest, reports_tasks_queued
 
     def prepare(self):
         """
@@ -218,7 +221,7 @@ class Orchestrator:
                 )
                 account["report_month"] = month
                 try:
-                    self.start_manifest_processing(**account)
+                    _, reports_tasks_queued = self.start_manifest_processing(**account)
                 except ReportDownloaderError as err:
                     LOG.warning(f"Unable to download manifest for provider: {provider_uuid}. Error: {str(err)}.")
                     continue
@@ -231,14 +234,16 @@ class Orchestrator:
                     continue
 
                 # update labels
-                labeler = AccountLabel(
-                    auth=account.get("credentials"),
-                    schema=account.get("schema_name"),
-                    provider_type=account.get("provider_type"),
-                )
-                account_number, label = labeler.get_label_details()
-                if account_number:
-                    LOG.info("Account: %s Label: %s updated.", account_number, label)
+                if reports_tasks_queued:
+                    LOG.info("Running AccountLabel to get account aliases.")
+                    labeler = AccountLabel(
+                        auth=account.get("credentials"),
+                        schema=account.get("schema_name"),
+                        provider_type=account.get("provider_type"),
+                    )
+                    account_number, label = labeler.get_label_details()
+                    if account_number:
+                        LOG.info("Account: %s Label: %s updated.", account_number, label)
 
         return async_result
 

--- a/koku/masu/test/processor/test_orchestrator.py
+++ b/koku/masu/test/processor/test_orchestrator.py
@@ -228,7 +228,7 @@ class OrchestratorTest(MasuTestCase):
 
     @patch("masu.processor.worker_cache.CELERY_INSPECT")
     @patch("masu.processor.orchestrator.AccountLabel", spec=True)
-    @patch("masu.processor.orchestrator.Orchestrator.start_manifest_processing", return_value=True)
+    @patch("masu.processor.orchestrator.Orchestrator.start_manifest_processing", return_value=([], True))
     def test_prepare_w_manifest_processing_successful(self, mock_task, mock_labeler, mock_inspect):
         """Test that Orchestrator.prepare() works when manifest processing is successful."""
         mock_labeler().get_label_details.return_value = (True, True)


### PR DESCRIPTION
## Summary
We currently run the account labeler every time we check for a manifest, even when there is no new information. It's very slow and could easily be done just when there are new reports to process. 

## Testing

1. Ingest our AWS account
2. See `Running AccountLabel to get account aliases.` logged.
3. Run /download endpoint again. 
4. No logged message for the account labeler. 