### PR TITLE
[COST-1238] targeted download api

### DIFF
--- a/koku/masu/api/download.py
+++ b/koku/masu/api/download.py
@@ -36,5 +36,8 @@ logger = logging.getLogger(__name__)
 @renderer_classes(tuple(api_settings.DEFAULT_RENDERER_CLASSES))
 def download_report(request):
     """Return download file async task ID."""
-    async_download_result = check_report_updates.delay()
+    params = request.query_params
+    provider_uuid = params.get("provider_uuid")
+    bill_date = params.get("bill_date")
+    async_download_result = check_report_updates.delay(provider_uuid=provider_uuid, bill_date=bill_date)
     return Response({"Download Request Task ID": str(async_download_result)})

--- a/koku/masu/external/date_accessor.py
+++ b/koku/masu/external/date_accessor.py
@@ -127,3 +127,14 @@ class DateAccessor:
             calculated_month = current_month + relativedelta(months=-month)
             months.append(calculated_month.date())
         return months
+
+    def get_billing_month_start(self, in_date):
+        """Return the start of the month for the input."""
+
+        if isinstance(in_date, str):
+            out_date = parser.parse(in_date).replace(day=1).date()
+        elif isinstance(in_date, datetime):
+            out_date = in_date.replace(day=1).date()
+        else:
+            out_date = in_date.replace(day=1)
+        return out_date

--- a/koku/masu/openapi.json
+++ b/koku/masu/openapi.json
@@ -66,7 +66,30 @@
             "Download"
           ]
         },
-        "parameters": []
+        "parameters": [
+          {
+            "name": "provider_uuid",
+            "in": "query",
+            "description": "The provider UUID",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "83ee048e-3c1d-43ef-b945-108225ae52f4"
+            }
+          },
+          {
+            "name": "bill_date",
+            "in": "query",
+            "description": "The month's data to download",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "example": "2019-01-01"
+            }
+          }
+        ]
       },
       "/enabled_tags/": {
         "get": {

--- a/koku/masu/processor/orchestrator.py
+++ b/koku/masu/processor/orchestrator.py
@@ -47,7 +47,7 @@ class Orchestrator:
 
     """
 
-    def __init__(self, billing_source=None, provider_uuid=None):
+    def __init__(self, billing_source=None, provider_uuid=None, bill_date=None):
         """
         Orchestrator for processing.
 
@@ -57,6 +57,7 @@ class Orchestrator:
         """
         self._accounts, self._polling_accounts = self.get_accounts(billing_source, provider_uuid)
         self.worker_cache = WorkerCache()
+        self.bill_date = bill_date
 
     @staticmethod
     def get_accounts(billing_source=None, provider_uuid=None):
@@ -93,8 +94,7 @@ class Orchestrator:
 
         return all_accounts, polling_accounts
 
-    @staticmethod
-    def get_reports(provider_uuid):
+    def get_reports(self, provider_uuid):
         """
         Get months for provider to process.
 
@@ -107,6 +107,9 @@ class Orchestrator:
         """
         with ProviderDBAccessor(provider_uuid=provider_uuid) as provider_accessor:
             reports_processed = provider_accessor.get_setup_complete()
+
+        if self.bill_date:
+            return [DateAccessor().get_billing_month_start(self.bill_date)]
 
         if Config.INGEST_OVERRIDE or not reports_processed:
             number_of_months = Config.INITIAL_INGEST_NUM_MONTHS

--- a/koku/masu/test/api/test_download.py
+++ b/koku/masu/test/api/test_download.py
@@ -47,3 +47,10 @@ class DownloadAPIViewTest(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("Download Request Task ID", body)
+
+        url_w_params = url + "?provider_uuid=1&bill_date=2021-04-01"
+        response = self.client.get(url_w_params)
+        body = response.json()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Download Request Task ID", body)

--- a/koku/masu/test/external/test_date_accessor.py
+++ b/koku/masu/test/external/test_date_accessor.py
@@ -21,6 +21,7 @@ import dateutil
 import pytz
 from faker import Faker
 
+from api.utils import DateHelper
 from masu.config import Config
 from masu.external.date_accessor import DateAccessor
 from masu.external.date_accessor import DateAccessorError
@@ -161,3 +162,16 @@ class DateAccessorTest(MasuTestCase):
 
         with self.assertRaises(DateAccessorError):
             accessor.today_with_timezone(string_tz)
+
+    def test_get_billing_month_start(self):
+        """Test that a proper datetime is returend for bill month."""
+        dh = DateHelper()
+        accessor = DateAccessor()
+        expected = dh.this_month_start.date()
+        today = dh.today
+        str_input = str(today)
+        datetime_input = today
+        date_input = today.date()
+        self.assertEqual(accessor.get_billing_month_start(str_input), expected)
+        self.assertEqual(accessor.get_billing_month_start(datetime_input), expected)
+        self.assertEqual(accessor.get_billing_month_start(date_input), expected)

--- a/koku/masu/test/processor/test_orchestrator.py
+++ b/koku/masu/test/processor/test_orchestrator.py
@@ -22,6 +22,7 @@ from unittest.mock import patch
 import faker
 
 from api.models import Provider
+from api.utils import DateHelper
 from masu.config import Config
 from masu.external.accounts_accessor import AccountsAccessor
 from masu.external.accounts_accessor import AccountsAccessorError
@@ -345,3 +346,9 @@ class OrchestratorTest(MasuTestCase):
 
         Config.INGEST_OVERRIDE = False
         Config.INITIAL_INGEST_NUM_MONTHS = initial_month_qty
+
+        dh = DateHelper()
+        expected = [dh.this_month_start.date()]
+        orchestrator = Orchestrator(bill_date=dh.today)
+        result = orchestrator.get_reports(self.aws_provider_uuid)
+        self.assertEqual(result, expected)


### PR DESCRIPTION
## Summary 
Allow the masu download API to work for a given source and billing period. 

## Testing
1. Hit http://127.0.0.1:5000/api/cost-management/v1/download/ and see normal behavior
2. http://127.0.0.1:5000/api/cost-management/v1/download/?provider_uuid={uuid} and see 2 month download check for just that source
3. http://127.0.0.1:5000/api/cost-management/v1/download/?provider_uuid={uuid}&bill_date=2021-03-01 and see 1 month download check for just that source and specified month.