### PR TITLE
Add log message for tag rate calcs

### DIFF
--- a/koku/masu/database/ocp_report_db_accessor.py
+++ b/koku/masu/database/ocp_report_db_accessor.py
@@ -1672,6 +1672,8 @@ class OCPReportDBAccessor(ReportDBAccessorBase):
                         tag_rates_sql, tag_rates_sql_params = self.jinja_sql.prepare_query(
                             tag_rates_sql, tag_rates_sql_params
                         )
+                        msg = f"Running populate_tag_usage_costs SQL with params: {tag_rates_sql_params}"
+                        LOG.info(msg)
                         self._execute_raw_sql_query(
                             table_name, tag_rates_sql, start_date, end_date, bind_params=list(tag_rates_sql_params)
                         )
@@ -1757,6 +1759,8 @@ class OCPReportDBAccessor(ReportDBAccessorBase):
                     tag_rates_sql, tag_rates_sql_params = self.jinja_sql.prepare_query(
                         tag_rates_sql, tag_rates_sql_params
                     )
+                    msg = f"Running populate_tag_usage_default_costs SQL with params: {tag_rates_sql_params}"
+                    LOG.info(msg)
                     self._execute_raw_sql_query(
                         table_name, tag_rates_sql, start_date, end_date, bind_params=list(tag_rates_sql_params)
                     )


### PR DESCRIPTION
## Summary
This is just a small log statement to clear up some logs when tag rates are processed. 