### PR TITLE
COST-1091: fix forecasting on last day of the month

### DIFF
--- a/koku/forecast/forecast.py
+++ b/koku/forecast/forecast.py
@@ -89,7 +89,7 @@ class Forecast:
                 # We have access constraints, but no view to accomodate, default to daily summary table
                 self.cost_summary_table = self.provider_map.query_table
 
-        self.forecast_days_required = (self.dh.this_month_end - self.dh.yesterday).days
+        self.forecast_days_required = max((self.dh.this_month_end - self.dh.yesterday).days, 2)
 
         # forecasts use a rolling window
         self.query_range = (self.dh.n_days_ago(self.dh.yesterday, 30), self.dh.yesterday)

--- a/koku/forecast/test/tests_forecast.py
+++ b/koku/forecast/test/tests_forecast.py
@@ -96,7 +96,7 @@ class AWSForecastTest(IamTestCase):
                 "today": dh.today,
                 "yesterday": dh.yesterday,
                 "this_month_end": dh.this_month_end,
-                "expected": (dh.this_month_end - dh.yesterday).days,
+                "expected": max((dh.this_month_end - dh.yesterday).days, 2),
             },
             {
                 "today": datetime(2000, 1, 1, 0, 0, 0, 0),
@@ -108,7 +108,7 @@ class AWSForecastTest(IamTestCase):
                 "today": datetime(2000, 1, 31, 0, 0, 0, 0),
                 "yesterday": datetime(2000, 1, 30, 0, 0, 0, 0),
                 "this_month_end": datetime(2000, 1, 31, 0, 0, 0, 0),
-                "expected": 1,
+                "expected": 2,
             },
         ]
 
@@ -365,6 +365,16 @@ class AWSForecastTest(IamTestCase):
                                 self.assertGreaterEqual(float(pval), 0)
                     # test that the results always stop at the end of the month.
                     self.assertEqual(results[-1].get("date"), dh.this_month_end.date())
+
+    def test_predict_end_of_month(self):
+        """COST-1091: Test that predict() returns empty list on the last day of a month."""
+        scenario = [(date(2000, 1, 31), 1.5)]
+
+        params = self.mocked_query_params("?", AWSCostForecastView)
+        instance = AWSForecast(params)
+
+        out = instance._predict(scenario)
+        self.assertEqual(out, [])
 
     def test_set_access_filter_with_list(self):
         """


### PR DESCRIPTION
This fixes the forecasting bug described in COST-1091.

The issue was with the list of values we calculate for the future prediction. On the last day of the month, `self.forecast_days_required` is 1, which results in us using a 1-value list in `wls_predictions_std`.

Now, `self.forecast_days_required` will never be less than 2, which is the bare minimum that `wls_predictions_std` needs to function without raising this exception.