### PR TITLE
Set ulimits in presto to run on Linux

### DIFF
--- a/testing/compose_files/docker-compose-presto.yml
+++ b/testing/compose_files/docker-compose-presto.yml
@@ -80,6 +80,10 @@ services:
       - hive-metastore
     depends_on:
       - hive-metastore
+    ulimits:
+      nofile:
+        soft: 4096
+        hard: 4096
 
 networks:
  default:


### PR DESCRIPTION
I cannot run presto using Docker on Linux without setting ulimits to presto.

I am assuming this will work well on MacOS. If not, I will probably have to update README.md