### PR TITLE
COST-1252: bugfix ranked grouping

### DIFF
--- a/koku/masu/test/util/test_hash.py
+++ b/koku/masu/test/util/test_hash.py
@@ -18,6 +18,7 @@
 import hashlib
 import random
 import string
+from unittest.mock import patch
 
 from masu.exceptions import HasherError
 from masu.test import MasuTestCase
@@ -71,6 +72,16 @@ class HasherUtilTests(MasuTestCase):
     def test_unsupported_algorithm(self):
         """Test that an exception is raised for unsupported algorithms."""
         bad_algorithm = "zuul"
+
+        with self.assertRaises(HasherError):
+            Hasher(hash_function=bad_algorithm)
+
+    @patch("masu.util.hash.hashlib", spec=hashlib)
+    def test_guaranteed_algorithms(self, mock_hashlib):
+        """Test that an exception is raised for a guaranteed algorithm."""
+        bad_algorithm = "test_hash_function"
+        mock_hashlib.algorithms_guaranteed = [bad_algorithm]
+        mock_hashlib.test_hash_function = None
 
         with self.assertRaises(HasherError):
             Hasher(hash_function=bad_algorithm)

--- a/koku/masu/util/hash.py
+++ b/koku/masu/util/hash.py
@@ -59,13 +59,12 @@ class Hasher:
             errmsg = f"{hash_function} requires length to be set"
             raise HasherError(errmsg)
 
-        try:
-            self._hash_function = getattr(hashlib, hash_function)
-        except AttributeError:
+        self._hash_function = getattr(hashlib, hash_function, None)
+
+        if not self._hash_function:
+            errmsg = f"{hash_function} is not currently supported."
             if hash_function in hashlib.algorithms_guaranteed:
                 errmsg = f"{hash_function} needs Hasher implementation."
-                raise HasherError(errmsg)
-            errmsg = f"{hash_function} is not currently supported."
             raise HasherError(errmsg)
 
     def hash_string_to_hex(self, string):


### PR DESCRIPTION
This fixed ranked grouping. I neglected to handle the case where the group-by key isn't in the grouping list. So, we're getting KeyErrors when the key is missing. This PR fixes that.

Also, there is a small change made to the Hasher class. This slightly improves testability without altering function. This was done to make CodeCov happy.

Functional testing:
```
curl -g -I 'http://localhost:8000/api/cost-management/v1/reports/openshift/costs/?group_by[project]=*&order_by[project]=asc&filter[limit]=10' 
HTTP/1.1 200 OK
Date: Wed, 07 Apr 2021 15:31:54 GMT
Server: WSGIServer/0.2 CPython/3.8.6
Content-Type: application/json
Vary: X_RH_IDENTITY, Accept, Origin
Allow: GET, HEAD, OPTIONS
Expires: Wed, 07 Apr 2021 16:31:54 GMT
Cache-Control: max-age=3600
X-Frame-Options: DENY
Content-Length: 15143
X-Content-Type-Options: nosniff
Referrer-Policy: same-origin
```
Full response: [output.txt](https://github.com/project-koku/koku/files/6272791/output.txt)
