### PR TITLE
switch out get_task_logger for standard logger

### DIFF
--- a/koku/api/common/pagination.py
+++ b/koku/api/common/pagination.py
@@ -25,7 +25,7 @@ from api import API_VERSION
 from api.utils import DateHelper
 
 PATH_INFO = "PATH_INFO"
-logger = logging.getLogger(__name__)
+LOG = logging.getLogger(__name__)
 
 
 class StandardResultsSetPagination(LimitOffsetPagination):
@@ -47,7 +47,7 @@ class StandardResultsSetPagination(LimitOffsetPagination):
                 path_link = "{}{}"
                 url = path_link.format(path[:path_api_index], link[local_api_index:])
             except ValueError:
-                logger.warning(f'Unable to rewrite link as "{version}" was not found.')
+                LOG.warning(f'Unable to rewrite link as "{version}" was not found.')
         return url
 
     def get_first_link(self):

--- a/koku/api/dataexport/syncer/__init__.py
+++ b/koku/api/dataexport/syncer/__init__.py
@@ -1,4 +1,5 @@
 """Data export syncer."""
+import logging
 from abc import ABC
 from abc import abstractmethod
 from datetime import timedelta
@@ -6,7 +7,6 @@ from itertools import product
 
 import boto3
 from botocore.exceptions import ClientError
-from celery.utils.log import get_task_logger
 from dateutil.rrule import DAILY
 from dateutil.rrule import MONTHLY
 from dateutil.rrule import rrule
@@ -15,7 +15,7 @@ from django.utils.translation import gettext as _
 
 from api.provider.models import Provider
 
-LOG = get_task_logger(__name__)
+LOG = logging.getLogger(__name__)
 
 
 class SyncedFileInColdStorageError(Exception):

--- a/koku/api/dataexport/uploader/__init__.py
+++ b/koku/api/dataexport/uploader/__init__.py
@@ -6,7 +6,7 @@ from abc import abstractmethod
 import boto3
 from django.conf import settings
 
-logger = logging.getLogger(__name__)
+LOG = logging.getLogger(__name__)
 
 
 class UploaderInterface(ABC):
@@ -51,11 +51,11 @@ class AwsS3Uploader(UploaderInterface):
 
         """
         if settings.ENABLE_S3_ARCHIVING:
-            logger.info("uploading %s to s3://%s/%s", local_path, self.s3_bucket_name, remote_path)
+            LOG.info("uploading %s to s3://%s/%s", local_path, self.s3_bucket_name, remote_path)
             try:
                 self.s3_client.upload_file(local_path, self.s3_bucket_name, remote_path)
             except Exception as e:
-                logger.exception(
+                LOG.exception(
                     "Failed to upload %s to s3://%s/%s due to %s(%s)",
                     local_path,
                     self.s3_bucket_name,
@@ -64,6 +64,6 @@ class AwsS3Uploader(UploaderInterface):
                     str(e),
                 )
                 raise e
-            logger.info("finished uploading %s to s3://%s/%s", local_path, self.s3_bucket_name, remote_path)
+            LOG.info("finished uploading %s to s3://%s/%s", local_path, self.s3_bucket_name, remote_path)
         else:
-            logger.info("Skipping upload of %s to %s; upload feature is disabled", local_path, self.s3_bucket_name)
+            LOG.info("Skipping upload of %s to %s; upload feature is disabled", local_path, self.s3_bucket_name)

--- a/koku/api/status/models.py
+++ b/koku/api/status/models.py
@@ -24,7 +24,7 @@ import sys
 from api import API_VERSION
 from koku.rbac import RbacService
 
-logger = logging.getLogger(__name__)
+LOG = logging.getLogger(__name__)
 
 
 class Status:
@@ -78,21 +78,21 @@ class Status:
 
     def startup(self):
         """Log startup information."""
-        logger.info("Platform:")
+        LOG.info("Platform:")
         for name, value in self.platform_info.items():
-            logger.info("%s - %s ", name, value)
+            LOG.info("%s - %s ", name, value)
 
-        logger.info("Python: %s", self.python_version)
+        LOG.info("Python: %s", self.python_version)
         module_list = []
         for mod, version in self.modules.items():
             module_list.append(f"{mod} - {version}")
 
         if module_list:
-            logger.info("Modules: %s", ", ".join(module_list))
+            LOG.info("Modules: %s", ", ".join(module_list))
         else:
-            logger.info("Modules: None")
-        logger.info("Commit: %s", self.commit)
-        logger.info("API Version: %s", self.api_version)
+            LOG.info("Modules: None")
+        LOG.info("Commit: %s", self.commit)
+        LOG.info("API Version: %s", self.api_version)
 
     @property
     def rbac_cache_ttl(self):

--- a/koku/api/status/tests_status.py
+++ b/koku/api/status/tests_status.py
@@ -99,7 +99,7 @@ class StatusModelTest(TestCase):
         result = self.status_info.modules
         self.assertEqual(result, expected)
 
-    @patch("api.status.models.logger.info")
+    @patch("api.status.models.LOG.info")
     def test_startup_with_modules(self, mock_logger):
         """Test the startup method with a module list."""
         self.status_info.startup()

--- a/koku/koku/celery.py
+++ b/koku/koku/celery.py
@@ -16,7 +16,7 @@ from koku import sentry  # noqa: F401
 from koku.env import ENVIRONMENT
 
 
-LOGGER = logging.getLogger(__name__)
+LOG = logging.getLogger(__name__)
 
 
 class LogErrorsTask(Task):  # pragma: no cover
@@ -24,7 +24,7 @@ class LogErrorsTask(Task):  # pragma: no cover
 
     def on_failure(self, exc, task_id, args, kwargs, einfo):
         """Log exceptions when a celery task fails."""
-        LOGGER.exception("Task failed: %s", exc, exc_info=exc)
+        LOG.exception("Task failed: %s", exc, exc_info=exc)
         super().on_failure(exc, task_id, args, kwargs, einfo)
 
 
@@ -42,10 +42,10 @@ class LoggingCelery(Celery):
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "koku.settings")
 
-LOGGER.info("Starting celery.")
+LOG.info("Starting celery.")
 # Setup the database for use in Celery
 django.setup()
-LOGGER.info("Database configured.")
+LOG.info("Database configured.")
 
 # 'app' is the recommended convention from celery docs
 # following this for ease of comparison to reference implementation
@@ -54,7 +54,7 @@ app = LoggingCelery(
 )
 app.config_from_object("django.conf:settings", namespace="CELERY")
 
-LOGGER.info("Celery autodiscover tasks.")
+LOG.info("Celery autodiscover tasks.")
 
 # Toggle to enable/disable scheduled checks for new reports.
 if ENVIRONMENT.bool("SCHEDULE_REPORT_CHECKS", default=False):
@@ -170,7 +170,7 @@ def wait_for_migrations(sender, instance, **kwargs):  # pragma: no cover
     from .database import check_migrations
 
     while not check_migrations():
-        LOGGER.warning("Migrations not done. Sleeping")
+        LOG.warning("Migrations not done. Sleeping")
         time.sleep(5)
 
 
@@ -179,7 +179,7 @@ def is_task_currently_running(task_name, task_id, check_args=None):
     try:
         active_dict = CELERY_INSPECT.active()
     except OperationalError:
-        LOGGER.warning("Cannot connect to RabbitMQ.")
+        LOG.warning("Cannot connect to RabbitMQ.")
         return False
     active_tasks = []
     for task_list in active_dict.values():

--- a/koku/koku/metrics.py
+++ b/koku/koku/metrics.py
@@ -15,9 +15,9 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 """Prometheus metrics."""
+import logging
 import time
 
-from celery.utils.log import get_task_logger
 from django.conf import settings
 from django.db import connection
 from django.db import InterfaceError
@@ -29,7 +29,7 @@ from prometheus_client import push_to_gateway
 
 from .celery import app
 
-LOG = get_task_logger(__name__)
+LOG = logging.getLogger(__name__)
 REGISTRY = CollectorRegistry()
 DB_CONNECTION_ERRORS_COUNTER = Counter("db_connection_errors", "Number of DB connection errors", registry=REGISTRY)
 PGSQL_GAUGE = Gauge("postgresql_schema_size_bytes", "PostgreSQL DB Size (bytes)", ["schema"], registry=REGISTRY)

--- a/koku/masu/api/download.py
+++ b/koku/masu/api/download.py
@@ -15,8 +15,6 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 """View for temporary force download endpoint."""
-import logging
-
 from django.views.decorators.cache import never_cache
 from rest_framework.decorators import api_view
 from rest_framework.decorators import permission_classes
@@ -26,8 +24,6 @@ from rest_framework.response import Response
 from rest_framework.settings import api_settings
 
 from masu.celery.tasks import check_report_updates
-
-logger = logging.getLogger(__name__)
 
 
 @never_cache

--- a/koku/masu/api/upload_normalized_data.py
+++ b/koku/masu/api/upload_normalized_data.py
@@ -1,6 +1,4 @@
 """View to force the `upload_normalized_data` task to run."""
-import logging
-
 from django.views.decorators.cache import never_cache
 from rest_framework import status
 from rest_framework.decorators import api_view
@@ -11,8 +9,6 @@ from rest_framework.response import Response
 from rest_framework.settings import api_settings
 
 from masu.celery import tasks
-
-logger = logging.getLogger(__name__)
 
 
 @never_cache

--- a/koku/masu/celery/tasks.py
+++ b/koku/masu/celery/tasks.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 """Asynchronous tasks."""
+import logging
 import math
 import os
 from datetime import datetime
@@ -22,7 +23,6 @@ from datetime import timedelta
 
 from botocore.exceptions import ClientError
 from celery.exceptions import MaxRetriesExceededError
-from celery.utils.log import get_task_logger
 from django.conf import settings
 from django.utils import timezone
 
@@ -43,7 +43,7 @@ from masu.processor.tasks import autovacuum_tune_schema
 from masu.processor.tasks import vacuum_schema
 from masu.util.aws.common import get_s3_resource
 
-LOG = get_task_logger(__name__)
+LOG = logging.getLogger(__name__)
 _DB_FETCH_BATCH_SIZE = 2000
 
 

--- a/koku/masu/database/report_manifest_db_accessor.py
+++ b/koku/masu/database/report_manifest_db_accessor.py
@@ -15,7 +15,8 @@
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 """Report manifest database accessor for cost usage reports."""
-from celery.utils.log import get_task_logger
+import logging
+
 from django.db.models import F
 from django.db.models.expressions import Window
 from django.db.models.functions import RowNumber
@@ -26,7 +27,7 @@ from masu.external.date_accessor import DateAccessor
 from reporting_common.models import CostUsageReportManifest
 from reporting_common.models import CostUsageReportStatus
 
-LOG = get_task_logger(__name__)
+LOG = logging.getLogger(__name__)
 
 
 class ReportManifestDBAccessor(KokuDBAccess):

--- a/koku/masu/processor/_tasks/download.py
+++ b/koku/masu/processor/_tasks/download.py
@@ -15,8 +15,9 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 """Asynchronous tasks."""
+import logging
+
 import psutil
-from celery.utils.log import get_task_logger
 
 import masu.prometheus_stats as worker_stats
 from api.common import log_json
@@ -27,7 +28,7 @@ from masu.external.report_downloader import ReportDownloader
 from masu.external.report_downloader import ReportDownloaderError
 from masu.processor.worker_cache import WorkerCache
 
-LOG = get_task_logger(__name__)
+LOG = logging.getLogger(__name__)
 
 
 # disabled until the program flow stabilizes a bit more

--- a/koku/masu/processor/_tasks/process.py
+++ b/koku/masu/processor/_tasks/process.py
@@ -15,10 +15,10 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 """Asynchronous tasks."""
+import logging
 from os import path
 
 import psutil
-from celery.utils.log import get_task_logger
 
 from masu.database.provider_db_accessor import ProviderDBAccessor
 from masu.database.report_manifest_db_accessor import ReportManifestDBAccessor
@@ -27,7 +27,7 @@ from masu.processor.report_processor import ReportProcessor
 from masu.processor.report_processor import ReportProcessorDBError
 from masu.processor.report_processor import ReportProcessorError
 
-LOG = get_task_logger(__name__)
+LOG = logging.getLogger(__name__)
 
 
 def _process_report_file(schema_name, provider, report_dict):

--- a/koku/masu/processor/_tasks/remove_expired.py
+++ b/koku/masu/processor/_tasks/remove_expired.py
@@ -15,11 +15,11 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 """Remove expired data asynchronous tasks."""
-from celery.utils.log import get_task_logger
+import logging
 
 from masu.processor.expired_data_remover import ExpiredDataRemover
 
-LOG = get_task_logger(__name__)
+LOG = logging.getLogger(__name__)
 
 
 def _remove_expired_data(schema_name, provider, simulate, provider_uuid=None, line_items_only=False):

--- a/koku/masu/processor/tasks.py
+++ b/koku/masu/processor/tasks.py
@@ -17,13 +17,13 @@
 """Asynchronous tasks."""
 import datetime
 import json
+import logging
 import os
 from decimal import Decimal
 from decimal import InvalidOperation
 
 import ciso8601
 from celery import chain
-from celery.utils.log import get_task_logger
 from dateutil import parser
 from django.db import connection
 from django.db.utils import IntegrityError
@@ -61,7 +61,7 @@ from reporting.models import OCP_ON_AWS_MATERIALIZED_VIEWS
 from reporting.models import OCP_ON_AZURE_MATERIALIZED_VIEWS
 from reporting.models import OCP_ON_INFRASTRUCTURE_MATERIALIZED_VIEWS
 
-LOG = get_task_logger(__name__)
+LOG = logging.getLogger(__name__)
 
 GET_REPORT_FILES_QUEUE = "download"
 OCP_QUEUE = "ocp"


### PR DESCRIPTION
This PR is simply for consistency sake. It replaces the Celery `get_task_logger` with the standard `logging.getLogger`.