### PR TITLE
COST-1289: Handling OCP on Cloud exceptions so infrastructure completes processing.

### DIFF
--- a/koku/masu/processor/report_summary_updater.py
+++ b/koku/masu/processor/report_summary_updater.py
@@ -44,6 +44,12 @@ class ReportSummaryUpdaterError(Exception):
     pass
 
 
+class ReportSummaryUpdaterCloudError(Exception):
+    """Report Summary Updater Cloud Error."""
+
+    pass
+
+
 class ReportSummaryUpdater:
     """Update reporting summary tables."""
 
@@ -183,24 +189,9 @@ class ReportSummaryUpdater:
 
         start_date, end_date = self._updater.update_summary_tables(start_date, end_date)
 
-        self._ocp_cloud_updater.update_summary_tables(start_date, end_date)
-
-        invalidate_view_cache_for_tenant_and_source_type(self._schema, self._provider.type)
-
-    def update_cost_summary_table(self, start_date, end_date):
-        """
-        Update cost summary tables.
-
-        Args:
-            start_date (str, datetime): When to start.
-            end_date (str, datetime): When to end.
-
-        Returns:
-            None
-
-        """
-        start_date, end_date = self._format_dates(start_date, end_date)
-
-        self._ocp_cloud_updater.update_cost_summary_table(start_date, end_date)
+        try:
+            self._ocp_cloud_updater.update_summary_tables(start_date, end_date)
+        except Exception as ex:
+            raise ReportSummaryUpdaterCloudError(str(ex))
 
         invalidate_view_cache_for_tenant_and_source_type(self._schema, self._provider.type)

--- a/koku/masu/processor/tasks.py
+++ b/koku/masu/processor/tasks.py
@@ -52,6 +52,7 @@ from masu.processor.cost_model_cost_updater import CostModelCostUpdater
 from masu.processor.report_processor import ReportProcessorDBError
 from masu.processor.report_processor import ReportProcessorError
 from masu.processor.report_summary_updater import ReportSummaryUpdater
+from masu.processor.report_summary_updater import ReportSummaryUpdaterCloudError
 from masu.processor.worker_cache import WorkerCache
 from reporting.models import AWS_MATERIALIZED_VIEWS
 from reporting.models import AZURE_MATERIALIZED_VIEWS
@@ -373,6 +374,8 @@ def update_summary_tables(  # noqa: C901
         updater = ReportSummaryUpdater(schema_name, provider_uuid, manifest_id)
         start_date, end_date = updater.update_daily_tables(start_date, end_date)
         updater.update_summary_tables(start_date, end_date)
+    except ReportSummaryUpdaterCloudError as ex:
+        LOG.info(f"Failed to correlate OpenShift metrics for provider: {str(provider_uuid)}. Error: {str(ex)}")
     except Exception as ex:
         if not synchronous:
             worker_cache.release_single_task(task_name, cache_args)

--- a/koku/masu/test/processor/test_tasks.py
+++ b/koku/masu/test/processor/test_tasks.py
@@ -1220,10 +1220,7 @@ class TestWorkerCacheThrottling(MasuTestCase):
         mock_summary,
         mock_delay,
     ):
-        """Test that the worker cache is used."""
-        task_name = "masu.processor.tasks.update_summary_tables"
-        cache_args = [self.schema]
-
+        """Test that the update_summary_table cloud exception is caught."""
         start_date = DateHelper().this_month_start
         end_date = DateHelper().this_month_end
         mock_daily.return_value = start_date, end_date

--- a/koku/masu/test/processor/test_tasks.py
+++ b/koku/masu/test/processor/test_tasks.py
@@ -54,6 +54,7 @@ from masu.processor._tasks.download import _get_report_files
 from masu.processor._tasks.process import _process_report_file
 from masu.processor.expired_data_remover import ExpiredDataRemover
 from masu.processor.report_processor import ReportProcessorError
+from masu.processor.report_summary_updater import ReportSummaryUpdaterCloudError
 from masu.processor.tasks import autovacuum_tune_schema
 from masu.processor.tasks import get_report_files
 from masu.processor.tasks import normalize_table_options
@@ -80,7 +81,6 @@ from reporting.models import GCP_MATERIALIZED_VIEWS
 from reporting.models import OCP_MATERIALIZED_VIEWS
 from reporting_common.models import CostUsageReportStatus
 
-# from koku.api.utils import DateHelper
 
 LOG = logging.getLogger(__name__)
 
@@ -1198,6 +1198,44 @@ class TestWorkerCacheThrottling(MasuTestCase):
             update_summary_tables(self.schema, Provider.PROVIDER_AWS, self.aws_provider_uuid, start_date, end_date)
             mock_delay.assert_not_called()
             self.assertFalse(self.single_task_is_running(task_name, cache_args))
+
+    @patch("masu.processor.tasks.update_summary_tables.s")
+    @patch("masu.processor.tasks.ReportSummaryUpdater.update_summary_tables")
+    @patch("masu.processor.tasks.ReportSummaryUpdater.update_daily_tables")
+    @patch("masu.processor.tasks.chain")
+    @patch("masu.processor.tasks.refresh_materialized_views")
+    @patch("masu.processor.tasks.update_cost_model_costs")
+    @patch("masu.processor.tasks.WorkerCache.release_single_task")
+    @patch("masu.processor.tasks.WorkerCache.lock_single_task")
+    @patch("masu.processor.worker_cache.CELERY_INSPECT")
+    def test_update_summary_tables_cloud_summary_error(
+        self,
+        mock_inspect,
+        mock_lock,
+        mock_release,
+        mock_update_cost,
+        mock_refresh,
+        mock_chain,
+        mock_daily,
+        mock_summary,
+        mock_delay,
+    ):
+        """Test that the worker cache is used."""
+        task_name = "masu.processor.tasks.update_summary_tables"
+        cache_args = [self.schema]
+
+        start_date = DateHelper().this_month_start
+        end_date = DateHelper().this_month_end
+        mock_daily.return_value = start_date, end_date
+        mock_summary.side_effect = ReportSummaryUpdaterCloudError
+        expected = "Failed to correlate"
+        with self.assertLogs("masu.processor.tasks", level="INFO") as logger:
+            update_summary_tables(self.schema, Provider.PROVIDER_AWS, self.aws_provider_uuid, start_date, end_date)
+            statement_found = False
+            for log in logger.output:
+                if expected in log:
+                    statement_found = True
+            self.assertTrue(statement_found)
 
     @patch("masu.processor.tasks.update_cost_model_costs.s")
     @patch("masu.processor.tasks.WorkerCache.release_single_task")


### PR DESCRIPTION
OCP to Cloud cost correlation summary failures should not prevent the individual cloud and OCP sources from completing processing.  This change will introduce a new exception type that will be caught by the update_summary_tables celery task.

**Testing**
1. Add an OCP source and ingest data.
2. Add a test Exception to force error during OCP correlation Cloud processing.  Add a cooresponding AWS source such that OCP is running on AWS.  Verify exception is caught and AWS processing completes.

**Test Results**
[cost_1289_ut.txt](https://github.com/project-koku/koku/files/6320202/cost_1289_ut.txt)
