### PR TITLE
COST-1228: "no-project" ignores limit

### DIFF
--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -832,25 +832,12 @@ class ReportQueryHandler(QueryHandler):
             else:
                 rank = data.get("rank", 1)
 
-            LOG.info("\n")
-            LOG.info("data")
-            LOG.info(data)
-            LOG.info("limit")
-            LOG.info(self._limit)
             if rank > self._offset and rank <= self._limit + self._offset:
-                LOG.info("\n")
-                LOG.info("adding to ranked_list")
-                LOG.info("\n")
                 ranked_list.append(data)
             else:
                 others_list.append(data)
-                LOG.info("\n")
-                LOG.info("adding to others_list")
-                LOG.info("\n")
                 for column in self._mapper.sum_columns:
                     other_sums[column] += data.get(column) if data.get(column) else 0
-
-        LOG.info("---------------------")
 
         if other is not None and others_list and not is_offset:
             num_others = len(others_list)

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -703,16 +703,16 @@ class ReportQueryHandler(QueryHandler):
         except (DivisionByZero, ZeroDivisionError, InvalidOperation):
             return None
 
-    def set_missing_rank_value(self):
-        """Set the correct rank value if missing.
+    def check_missing_rank_value(self, rank_value):
+        """Check to see ranked values is missing.
 
-        Converts None in ranking to no-{group_by}
-        group
+        If it is missing, it converts it to no-{group_by}
 
-
+        rank_value: string or None value
         """
+        if rank_value:
+            return rank_value
         group_by_value = self._get_group_by()
-        # Convert None in ranking to no-{group_by}
         check_tag_group_by = is_grouped_by_tag(self.parameters)
         if check_tag_group_by:
             tag_value = check_tag_group_by[0].split(":")[1]
@@ -762,8 +762,7 @@ class ReportQueryHandler(QueryHandler):
         rankings = []
         for rank in ranks:
             rank_value = rank.get(group_by_value[0])
-            if not rank_value:
-                rank_value = self.set_missing_rank_value()
+            rank_value = self.check_missing_rank_value(rank_value)
             rankings.insert((rank.get("rank") - 1), rank_value)
 
         for query_return in data:
@@ -847,8 +846,7 @@ class ReportQueryHandler(QueryHandler):
 
             if ranks:
                 ranked_value = data.get(self._get_group_by()[0])
-                if not ranked_value:
-                    ranked_value = self.set_missing_rank_value()
+                ranked_value = self.check_missing_rank_value(ranked_value)
                 rank = ranks.index(ranked_value) + 1
                 data["rank"] = rank
             else:

--- a/koku/api/report/test/aws/tests_queries.py
+++ b/koku/api/report/test/aws/tests_queries.py
@@ -204,6 +204,28 @@ class AWSReportQueryTest(IamTestCase):
         out_data = handler._transform_data(groups, group_index, data)
         self.assertEqual(expected, out_data)
 
+    def test_transform_null_group_with_limit(self):
+        """Test transform data with null group value."""
+        url = "?filter[limit]=1"
+        query_params = self.mocked_query_params(url, AWSCostView)
+        handler = AWSReportQueryHandler(query_params)
+        groups = ["region"]
+        group_index = 0
+        data = {None: [{"region": "no-region", "units": "USD"}]}
+        expected = [{"region": "no-region", "values": [{"region": "no-region", "units": "USD"}]}]
+        out_data = handler._transform_data(groups, group_index, data)
+        self.assertEqual(expected, out_data)
+
+        data = {"us-east": [{"region": "us-east", "units": "USD"}]}
+        expected = [{"region": "us-east", "values": [{"region": "us-east", "units": "USD"}]}]
+        out_data = handler._transform_data(groups, group_index, data)
+        self.assertEqual(expected, out_data)
+
+        data = {None: {"region": "no-region", "units": "USD"}}
+        expected = [{"region": "no-region", "values": {"region": "no-region", "units": "USD"}}]
+        out_data = handler._transform_data(groups, group_index, data)
+        self.assertEqual(expected, out_data)
+
     def test_get_group_by_with_group_by_and_limit_params(self):
         """Test the _get_group_by method with limit and group by params."""
         expected = ["account"]


### PR DESCRIPTION
Fix issue with no-project ignoring limit.

Eva created some smoke tests for us to check to see if this is fixed: `test_api_ocp_filtered_top_no_project`

Smoke Results:
```
lib64/python3.6/site-packages/iqe_cost_management/tests/rest_api/v1/test_ocp_cost_reports.py::test_api_ocp_filtered_top_no_project[1]
=== 4 passed, 6561 deselected in 28.93s ====
```