### PR TITLE
COST-1250: Add others count to metadata and remove it from name

### DIFF
--- a/koku/api/common/pagination.py
+++ b/koku/api/common/pagination.py
@@ -198,8 +198,6 @@ class ReportRankedPagination(ReportPagination):
         self.request = request
         self.limit = self.get_limit(request)
         self.offset = self.get_offset(request)
-        LOG.info("\n\n\nqueryset")
-        LOG.info(queryset)
         return queryset
 
 

--- a/koku/api/common/pagination.py
+++ b/koku/api/common/pagination.py
@@ -135,6 +135,10 @@ class ReportPagination(StandardResultsSetPagination):
 
     default_limit = 100
 
+    def __init__(self, params):
+        """Set the parameters."""
+        self.others = params.get("others")
+
     def get_count(self, queryset):
         """Determine a report data's count."""
         return len(queryset.get("data", []))
@@ -162,8 +166,10 @@ class ReportPagination(StandardResultsSetPagination):
     def get_paginated_response(self, data):
         """Override pagination output."""
         paginated_data = data.pop("data", [])
+        filter_limit = data.get("filter", {}).get("limit", 0)
+        self.others = self.others - filter_limit
         response = {
-            "meta": {"count": self.count},
+            "meta": {"count": self.count, "others": self.others},
             "links": {
                 "first": self.get_first_link(),
                 "next": self.get_next_link(),
@@ -192,7 +198,8 @@ class ReportRankedPagination(ReportPagination):
         self.request = request
         self.limit = self.get_limit(request)
         self.offset = self.get_offset(request)
-
+        LOG.info("\n\n\nqueryset")
+        LOG.info(queryset)
         return queryset
 
 

--- a/koku/api/common/pagination.py
+++ b/koku/api/common/pagination.py
@@ -135,9 +135,9 @@ class ReportPagination(StandardResultsSetPagination):
 
     default_limit = 100
 
-    def __init__(self, params):
+    def __init__(self):
         """Set the parameters."""
-        self.others = params.get("others")
+        self.others = None
 
     def get_count(self, queryset):
         """Determine a report data's count."""
@@ -167,9 +167,12 @@ class ReportPagination(StandardResultsSetPagination):
         """Override pagination output."""
         paginated_data = data.pop("data", [])
         filter_limit = data.get("filter", {}).get("limit", 0)
-        self.others = self.others - filter_limit
+        meta = {"count": self.count}
+        if self.others:
+            self.others = self.others - filter_limit
+            meta["others"] = self.others
         response = {
-            "meta": {"count": self.count, "others": self.others},
+            "meta": meta,
             "links": {
                 "first": self.get_first_link(),
                 "next": self.get_next_link(),

--- a/koku/api/common/pagination.py
+++ b/koku/api/common/pagination.py
@@ -212,6 +212,7 @@ class OrgUnitPagination(ReportPagination):
         self.limit = params.get("limit", 10)
         self.offset = params.get("offset", 0)
         self.count = 0
+        self.others = None
 
     def paginate_queryset(self, dataset, request, view=None):
         """Override queryset pagination."""

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -654,7 +654,7 @@ class ReportQueryHandler(QueryHandler):
                         line_data[field] = f"no-{field}"
                 sorted_data = sorted(
                     sorted_data,
-                    key=lambda entry: (bool(re.match(r"[0-9]+\sothers", entry[field].lower())), entry[field].lower()),
+                    key=lambda entry: (bool(re.match(r"other*", entry[field].lower())), entry[field].lower()),
                     reverse=reverse,
                 )
         return sorted_data

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -831,10 +831,10 @@ class ReportQueryHandler(QueryHandler):
 
         if other is not None and others_list and not is_offset:
             num_others = len(others_list)
-            others_label = f"{num_others} Others"
+            others_label = "Others"
 
             if num_others == 1:
-                others_label = f"{num_others} Other"
+                others_label = "Other"
 
             other.update(other_sums)
             other["rank"] = self._limit + 1

--- a/koku/api/report/test/aws/openshift/tests_views.py
+++ b/koku/api/report/test/aws/openshift/tests_views.py
@@ -219,6 +219,10 @@ class OCPAWSReportViewTest(IamTestCase):
 
         self.assertIn("nodes", data.get("data")[0])
 
+        # assert the others count is correct
+        meta = data.get("meta")
+        self.assertEqual(meta.get("others"), 2)
+
         # Check if limit returns the correct number of results, and
         # that the totals add up properly
         for item in data.get("data"):
@@ -227,7 +231,7 @@ class OCPAWSReportViewTest(IamTestCase):
                 projects = item.get("nodes")
                 self.assertTrue(len(projects) <= 2)
                 if len(projects) == 2:
-                    self.assertEqual(projects[1].get("node"), "2 Others")
+                    self.assertEqual(projects[1].get("node"), "Others")
                     usage_total = projects[0].get("values")[0].get("usage", {}).get("value") + projects[1].get(
                         "values"
                     )[0].get("usage", {}).get("value")

--- a/koku/api/report/test/aws/tests_queries.py
+++ b/koku/api/report/test/aws/tests_queries.py
@@ -994,8 +994,8 @@ class AWSReportQueryTest(IamTestCase):
             {"account": "1", "account_alias": "1", "total": 5, "rank": 1},
             {"account": "2", "account_alias": "2", "total": 4, "rank": 2},
             {
-                "account": "2 Others",
-                "account_alias": "2 Others",
+                "account": "Others",
+                "account_alias": "Others",
                 "total": 5,
                 "rank": 3,
                 "cost_total": 0,
@@ -1020,7 +1020,7 @@ class AWSReportQueryTest(IamTestCase):
         expected = [
             {"service": "1", "total": 5, "rank": 1},
             {"service": "2", "total": 4, "rank": 2},
-            {"service": "2 Others", "total": 5, "rank": 3, "cost_total": 0, "infra_total": 0, "sup_total": 0},
+            {"service": "Others", "total": 5, "rank": 3, "cost_total": 0, "infra_total": 0, "sup_total": 0},
         ]
         ranked_list = handler._ranked_list(data_list)
         self.assertEqual(ranked_list, expected)
@@ -1103,7 +1103,7 @@ class AWSReportQueryTest(IamTestCase):
                 "date": "2000-01-01",
                 "infra_total": 0.03,
                 "rank": 3,
-                "service": "2 Others",
+                "service": "Others",
                 "sup_total": 0.05,
             },
             {
@@ -1127,7 +1127,7 @@ class AWSReportQueryTest(IamTestCase):
                 "date": "2000-01-02",
                 "infra_total": 0.03,
                 "rank": 3,
-                "service": "2 Others",
+                "service": "Others",
                 "sup_total": 0.05,
             },
             {
@@ -1151,7 +1151,7 @@ class AWSReportQueryTest(IamTestCase):
                 "date": "2000-01-03",
                 "infra_total": 0.02,
                 "rank": 3,
-                "service": "2 Others",
+                "service": "Others",
                 "sup_total": 0.03,
             },
         ]

--- a/koku/api/report/test/azure/openshift/test_ocp_azure_query_handler.py
+++ b/koku/api/report/test/azure/openshift/test_ocp_azure_query_handler.py
@@ -753,14 +753,7 @@ class OCPAzureQueryHandlerTest(IamTestCase):
         expected = [
             {"subscription_guid": "1", "total": 5, "rank": 1},
             {"subscription_guid": "2", "total": 4, "rank": 2},
-            {
-                "subscription_guid": "2 Others",
-                "total": 5,
-                "rank": 3,
-                "cost_total": 0,
-                "sup_total": 0,
-                "infra_total": 0,
-            },
+            {"subscription_guid": "Others", "total": 5, "rank": 3, "cost_total": 0, "sup_total": 0, "infra_total": 0},
         ]
         ranked_list = handler._ranked_list(data_list)
         self.assertEqual(ranked_list, expected)
@@ -780,7 +773,7 @@ class OCPAzureQueryHandlerTest(IamTestCase):
         expected = [
             {"service_name": "1", "total": 5, "rank": 1},
             {"service_name": "2", "total": 4, "rank": 2},
-            {"service_name": "2 Others", "total": 5, "rank": 3, "cost_total": 0, "sup_total": 0, "infra_total": 0},
+            {"service_name": "Others", "total": 5, "rank": 3, "cost_total": 0, "sup_total": 0, "infra_total": 0},
         ]
         ranked_list = handler._ranked_list(data_list)
         self.assertEqual(ranked_list, expected)

--- a/koku/api/report/test/azure/tests_azure_query_handler.py
+++ b/koku/api/report/test/azure/tests_azure_query_handler.py
@@ -863,14 +863,7 @@ class AzureReportQueryHandlerTest(IamTestCase):
         expected = [
             {"subscription_guid": "1", "total": 5, "rank": 1},
             {"subscription_guid": "2", "total": 4, "rank": 2},
-            {
-                "subscription_guid": "2 Others",
-                "total": 5,
-                "rank": 3,
-                "cost_total": 0,
-                "infra_total": 0,
-                "sup_total": 0,
-            },
+            {"subscription_guid": "Others", "total": 5, "rank": 3, "cost_total": 0, "infra_total": 0, "sup_total": 0},
         ]
         ranked_list = handler._ranked_list(data_list)
         self.assertEqual(ranked_list, expected)
@@ -889,7 +882,7 @@ class AzureReportQueryHandlerTest(IamTestCase):
         expected = [
             {"service_name": "1", "total": 5, "rank": 1},
             {"service_name": "2", "total": 4, "rank": 2},
-            {"service_name": "2 Others", "total": 5, "rank": 3, "cost_total": 0, "infra_total": 0, "sup_total": 0},
+            {"service_name": "Others", "total": 5, "rank": 3, "cost_total": 0, "infra_total": 0, "sup_total": 0},
         ]
         ranked_list = handler._ranked_list(data_list)
         self.assertEqual(ranked_list, expected)

--- a/koku/api/report/test/gcp/tests_gcp_query_handler.py
+++ b/koku/api/report/test/gcp/tests_gcp_query_handler.py
@@ -751,8 +751,8 @@ class GCPReportQueryHandlerTest(IamTestCase):
             {"account": "1", "total": 5, "rank": 1},
             {"account": "2", "total": 4, "rank": 2},
             {
-                "account": "2 Others",
-                "account_alias": "2 Others",
+                "account": "Others",
+                "account_alias": "Others",
                 "total": 5,
                 "rank": 3,
                 "cost_total": 0,
@@ -779,7 +779,7 @@ class GCPReportQueryHandlerTest(IamTestCase):
             {"service_alias": "1", "total": 5, "rank": 1},
             {"service_alias": "2", "total": 4, "rank": 2},
             {
-                "service": "2 Others",
+                "service": "Others",
                 "service_alias": "1",
                 "total": 5,
                 "rank": 3,

--- a/koku/api/report/test/ocp/tests_views.py
+++ b/koku/api/report/test/ocp/tests_views.py
@@ -460,6 +460,10 @@ class OCPReportViewTest(IamTestCase):
 
         self.assertIn("nodes", data.get("data")[0])
 
+        # assert the others count is correct
+        meta = data.get("meta")
+        self.assertEqual(meta.get("others"), num_nodes - 1)
+
         # Check if limit returns the correct number of results, and
         # that the totals add up properly
         for item in data.get("data"):
@@ -467,7 +471,7 @@ class OCPReportViewTest(IamTestCase):
                 date = item.get("date")
                 nodes = item.get("nodes")
                 self.assertEqual(len(nodes), 2)
-                self.assertEqual(nodes[1].get("node"), f"{num_nodes-1} Others")
+                self.assertEqual(nodes[1].get("node"), "Others")
                 usage_total = nodes[0].get("values")[0].get("usage", {}).get("value") + nodes[1].get("values")[0].get(
                     "usage", {}
                 ).get("value")

--- a/koku/api/report/view.py
+++ b/koku/api/report/view.py
@@ -45,7 +45,7 @@ def get_paginator(filter_query_params, count, group_by_params=False):
         paginator = OrgUnitPagination(filter_query_params)
     else:
         if "offset" in filter_query_params:
-            paginator = ReportRankedPagination(filter_query_params)
+            paginator = ReportRankedPagination()
             paginator.count = count
             paginator.others = count
         else:

--- a/koku/api/report/view.py
+++ b/koku/api/report/view.py
@@ -47,8 +47,10 @@ def get_paginator(filter_query_params, count, group_by_params=False):
         if "offset" in filter_query_params:
             paginator = ReportRankedPagination(filter_query_params)
             paginator.count = count
+            paginator.others = count
         else:
-            paginator = ReportPagination(filter_query_params)
+            paginator = ReportPagination()
+            paginator.others = count
     return paginator
 
 
@@ -177,9 +179,7 @@ class ReportView(APIView):
                     error = {"details": _("Unit conversion failed.")}
                     raise ValidationError(error)
 
-        filter_params = params.parameters.get("filter", {})
-        filter_params["others"] = max_rank
-        paginator = get_paginator(filter_params, max_rank, request.query_params)
+        paginator = get_paginator(params.parameters.get("filter", {}), max_rank, request.query_params)
         paginated_result = paginator.paginate_queryset(output, request)
         LOG.debug(f"DATA: {output}")
         return paginator.get_paginated_response(paginated_result)

--- a/koku/api/report/view.py
+++ b/koku/api/report/view.py
@@ -45,10 +45,10 @@ def get_paginator(filter_query_params, count, group_by_params=False):
         paginator = OrgUnitPagination(filter_query_params)
     else:
         if "offset" in filter_query_params:
-            paginator = ReportRankedPagination()
+            paginator = ReportRankedPagination(filter_query_params)
             paginator.count = count
         else:
-            paginator = ReportPagination()
+            paginator = ReportPagination(filter_query_params)
     return paginator
 
 
@@ -177,7 +177,9 @@ class ReportView(APIView):
                     error = {"details": _("Unit conversion failed.")}
                     raise ValidationError(error)
 
-        paginator = get_paginator(params.parameters.get("filter", {}), max_rank, request.query_params)
+        filter_params = params.parameters.get("filter", {})
+        filter_params["others"] = max_rank
+        paginator = get_paginator(filter_params, max_rank, request.query_params)
         paginated_result = paginator.paginate_queryset(output, request)
         LOG.debug(f"DATA: {output}")
         return paginator.get_paginated_response(paginated_result)

--- a/koku/api/report/view.py
+++ b/koku/api/report/view.py
@@ -43,6 +43,7 @@ def get_paginator(filter_query_params, count, group_by_params=False):
         "group_by[org_unit_id]" in group_by_params or "group_by[or:org_unit_id]" in group_by_params
     ):
         paginator = OrgUnitPagination(filter_query_params)
+        paginator.others = count
     else:
         if "offset" in filter_query_params:
             paginator = ReportRankedPagination()


### PR DESCRIPTION
This PR does two things: 
- Adds a field called `others` to the metadata with the count of others
- Removes the count of others from the name 
----
#### Testing: 
1.  Create data: 
```
make docker-reinitdb-with-sources
make load-test-customer-data 
```
2. Hit an endpoint like http://127.0.0.1:8000/api/cost-management/v1/reports/openshift/costs/?group_by[project]=*&filter[limit]=2 and look at the response: 
```
{
    "meta": {
        "count": 10,
        "others": 52,   <<<<<<<<<< notice others count added to metadata 
        "filter": {
            "limit": 2
        },
        "group_by": {
            "project": [
                "*"
            ]
        },

```
and 
```
{
    "project": "Others", <<<<<< count removed from name 
    "values": [
        {
            "date": "2021-04-13",
            "project": "Others",
            "clusters": [
                "Test OCP on Premises"
            ],
            "cost": {
                "raw": {
                    "value": 0.0,
                    "units": "USD"
                },
                "markup": {
                    "value": 0.0,
```
----
#### Smoke test results 
```
=============== 32 failed, 5885 passed, 110 skipped, 538 deselected in 3069.52s (0:51:09) ============
```
