### PR TITLE
Update learn more link for tag settings

### DIFF
--- a/koku/api/settings/tag_management.py
+++ b/koku/api/settings/tag_management.py
@@ -139,7 +139,9 @@ class TagManagementSettings:
             + " Changes will be reflected within 24 hours. <link>Learn more</link>"
         )
         doc_link = dict(
-            href=generate_doc_link("managing_cost_data_using_tagging/configuring_tags_and_labels_in_cost_management")
+            href=generate_doc_link(
+                "html-single/managing_cost_data_using_tagging/index#assembly-configuring-tags-and-labels-in-cost-management"
+            )
         )
         tag_key_text = create_plain_text_with_doc(tag_key_text_name, tag_key_text_context, doc_link)
         components = []

--- a/koku/api/settings/tag_management.py
+++ b/koku/api/settings/tag_management.py
@@ -140,7 +140,8 @@ class TagManagementSettings:
         )
         doc_link = dict(
             href=generate_doc_link(
-                "html-single/managing_cost_data_using_tagging/index#assembly-configuring-tags-and-labels-in-cost-management"
+                "html-single/managing_cost_data_using_tagging/index"
+                + "#assembly-configuring-tags-and-labels-in-cost-management"
             )
         )
         tag_key_text = create_plain_text_with_doc(tag_key_text_name, tag_key_text_context, doc_link)

--- a/koku/api/settings/utils.py
+++ b/koku/api/settings/utils.py
@@ -76,7 +76,7 @@ def generate_doc_link(path):
     Args:
         (String) path - path to the documentation.
     """
-    return f"https://access.redhat.com/documentation/en-us/cost_management_service/2021/html/{path}"
+    return f"https://access.redhat.com/documentation/en-us/cost_management_service/2021/{path}"
 
 
 def create_dual_list_select(name, left_options=[], right_options=[], **kwargs):


### PR DESCRIPTION
Doc URLs changed; thus, we need to update learn more link for tag settings.

https://issues.redhat.com/browse/COST-1312