### PR TITLE
COST-1197: removing time scope deprecated comments

### DIFF
--- a/koku/api/organizations/queries.py
+++ b/koku/api/organizations/queries.py
@@ -84,7 +84,6 @@ class OrgQueryHandler(QueryHandler):
         # super() needs to be called before calling _get_filter()
         self.query_filter = self._get_filter()
 
-    # deprecated
     def _set_start_and_end_dates(self):
         """Set start and end dates.
 

--- a/koku/api/organizations/serializers.py
+++ b/koku/api/organizations/serializers.py
@@ -36,8 +36,8 @@ class FilterSerializer(serializers.Serializer):
     TIME_UNIT_CHOICES = (("day", "day"), ("month", "month"))
 
     resolution = serializers.ChoiceField(choices=RESOLUTION_CHOICES, required=False)
-    time_scope_value = serializers.ChoiceField(choices=TIME_CHOICES, required=False)  # deprecated
-    time_scope_units = serializers.ChoiceField(choices=TIME_UNIT_CHOICES, required=False)  # deprecated
+    time_scope_value = serializers.ChoiceField(choices=TIME_CHOICES, required=False)
+    time_scope_units = serializers.ChoiceField(choices=TIME_UNIT_CHOICES, required=False)
     limit = serializers.IntegerField(required=False, min_value=1)
     offset = serializers.IntegerField(required=False, min_value=0)
 

--- a/koku/api/report/serializers.py
+++ b/koku/api/report/serializers.py
@@ -209,8 +209,8 @@ class FilterSerializer(BaseSerializer):
     TIME_UNIT_CHOICES = (("day", "day"), ("month", "month"))
 
     resolution = serializers.ChoiceField(choices=RESOLUTION_CHOICES, required=False)
-    time_scope_value = serializers.ChoiceField(choices=TIME_CHOICES, required=False)  # deprecated
-    time_scope_units = serializers.ChoiceField(choices=TIME_UNIT_CHOICES, required=False)  # deprecated
+    time_scope_value = serializers.ChoiceField(choices=TIME_CHOICES, required=False)
+    time_scope_units = serializers.ChoiceField(choices=TIME_UNIT_CHOICES, required=False)
 
     resource_scope = StringOrListField(child=serializers.CharField(), required=False)
     limit = serializers.IntegerField(required=False, min_value=1)

--- a/koku/api/tags/queries.py
+++ b/koku/api/tags/queries.py
@@ -96,7 +96,6 @@ class TagQueryHandler(QueryHandler):
         filters.add(QueryFilter(field="key", operation="exact", parameter=self.key))
         return self.query_filter & filters.compose()
 
-    # deprecated
     def _set_start_and_end_dates(self):
         """Set start and end dates.
 

--- a/koku/api/tags/serializers.py
+++ b/koku/api/tags/serializers.py
@@ -41,8 +41,8 @@ class FilterSerializer(serializers.Serializer):
     key = StringOrListField(required=False)
     value = StringOrListField(required=False)
     resolution = serializers.ChoiceField(choices=RESOLUTION_CHOICES, required=False)
-    time_scope_value = serializers.ChoiceField(choices=TIME_CHOICES, required=False)  # deprecated
-    time_scope_units = serializers.ChoiceField(choices=TIME_UNIT_CHOICES, required=False)  # deprecated
+    time_scope_value = serializers.ChoiceField(choices=TIME_CHOICES, required=False)
+    time_scope_units = serializers.ChoiceField(choices=TIME_UNIT_CHOICES, required=False)
     limit = serializers.IntegerField(required=False, min_value=1)
     offset = serializers.IntegerField(required=False, min_value=0)
 


### PR DESCRIPTION
time scope parameters will be used for the foreseeable future in all non cost exporter UI