### PR TITLE
Putting IBM behind the pre-release ENV

### DIFF
--- a/koku/api/user_access/test/test_view.py
+++ b/koku/api/user_access/test/test_view.py
@@ -418,10 +418,10 @@ class UserAccessViewTest(IamTestCase):
         }
     )
     @override_settings(ENABLE_PRERELEASE_FEATURES=True)
-    def test_ibm_view_account_wildcard(self):
-        """Test user-access view with ibm account read wildcard permission."""
+    def test_ibm_view_account_wildcard_with_pre_release_features(self):
+        """Test user-access view with ibm account read wildcard permission and pre_release env=true."""
         url = reverse("user-access")
-        import pdb; pdb.set_trace()
+
         response = self.client.get(url, **self.headers)
 
         self.assertEqual(len(response.data.get("data")), self.NUM_ACCESS_CLASSES)
@@ -430,6 +430,36 @@ class UserAccessViewTest(IamTestCase):
         self.assertTrue({"type": "ocp", "access": False} in response.data.get("data"))
         self.assertTrue({"type": "gcp", "access": False} in response.data.get("data"))
         self.assertTrue({"type": "ibm", "access": True} in response.data.get("data"))
+        self.assertTrue({"type": "azure", "access": False} in response.data.get("data"))
+        self.assertTrue({"type": "cost_model", "access": False} in response.data.get("data"))
+
+    @RbacPermissions(
+        {
+            "aws.account": {"read": []},
+            "aws.organizational_unit": {"read": []},
+            "gcp.account": {"read": []},
+            "gcp.project": {"read": []},
+            "ibm.account": {"read": ["*"]},
+            "azure.subscription_guid": {"read": []},
+            "openshift.cluster": {"read": []},
+            "openshift.node": {"read": []},
+            "openshift.project": {"read": []},
+            "cost_model": {"read": [], "write": []},
+        }
+    )
+    @override_settings(ENABLE_PRERELEASE_FEATURES=False)
+    def test_ibm_view_account_wildcard_with_pre_release_features_false(self):
+        """Test user-access view with ibm account read wildcard permission and pre_release env=false."""
+        url = reverse("user-access")
+
+        response = self.client.get(url, **self.headers)
+
+        self.assertEqual(len(response.data.get("data")), self.NUM_ACCESS_CLASSES)
+        self.assertTrue({"type": "any", "access": False} in response.data.get("data"))
+        self.assertTrue({"type": "aws", "access": False} in response.data.get("data"))
+        self.assertTrue({"type": "ocp", "access": False} in response.data.get("data"))
+        self.assertTrue({"type": "gcp", "access": False} in response.data.get("data"))
+        self.assertTrue({"type": "ibm", "access": False} in response.data.get("data"))
         self.assertTrue({"type": "azure", "access": False} in response.data.get("data"))
         self.assertTrue({"type": "cost_model", "access": False} in response.data.get("data"))
 
@@ -503,7 +533,8 @@ class UserAccessViewTest(IamTestCase):
         self.assertTrue({"type": "azure", "access": False} in response.data.get("data"))
         self.assertTrue({"type": "cost_model", "access": False} in response.data.get("data"))
 
-    def test_view_as_org_admin(self):
+    @override_settings(ENABLE_PRERELEASE_FEATURES=False)
+    def test_view_as_org_admin_prerelease_features_off(self):
         """Test user-access view as an org admin."""
         url = reverse("user-access")
         response = self.client.get(url, **self.headers)
@@ -513,7 +544,28 @@ class UserAccessViewTest(IamTestCase):
         self.assertTrue({"type": "aws", "access": True} in response.data.get("data"))
         self.assertTrue({"type": "ocp", "access": True} in response.data.get("data"))
         self.assertTrue({"type": "gcp", "access": True} in response.data.get("data"))
+
+        # IBM is a pre-release feature
+        self.assertTrue({"type": "ibm", "access": False} in response.data.get("data"))
+
+        self.assertTrue({"type": "azure", "access": True} in response.data.get("data"))
+        self.assertTrue({"type": "cost_model", "access": True} in response.data.get("data"))
+
+    @override_settings(ENABLE_PRERELEASE_FEATURES=True)
+    def test_view_as_org_admin_prerelease_features_on(self):
+        """Test user-access view as an org admin."""
+        url = reverse("user-access")
+        response = self.client.get(url, **self.headers)
+
+        self.assertEqual(len(response.data.get("data")), self.NUM_ACCESS_CLASSES)
+        self.assertTrue({"type": "any", "access": True} in response.data.get("data"))
+        self.assertTrue({"type": "aws", "access": True} in response.data.get("data"))
+        self.assertTrue({"type": "ocp", "access": True} in response.data.get("data"))
+        self.assertTrue({"type": "gcp", "access": True} in response.data.get("data"))
+
+        # IBM is a pre-release feature
         self.assertTrue({"type": "ibm", "access": True} in response.data.get("data"))
+
         self.assertTrue({"type": "azure", "access": True} in response.data.get("data"))
         self.assertTrue({"type": "cost_model", "access": True} in response.data.get("data"))
 

--- a/koku/api/user_access/test/test_view.py
+++ b/koku/api/user_access/test/test_view.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 """Test the UserAccess view."""
+from django.test.utils import override_settings
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
@@ -416,6 +417,7 @@ class UserAccessViewTest(IamTestCase):
             "cost_model": {"read": [], "write": []},
         }
     )
+    @override_settings(ENABLE_PRERELEASE_FEATURES=True)
     def test_ibm_view_account_wildcard(self):
         """Test user-access view with ibm account read wildcard permission."""
         url = reverse("user-access")

--- a/koku/api/user_access/test/test_view.py
+++ b/koku/api/user_access/test/test_view.py
@@ -421,6 +421,7 @@ class UserAccessViewTest(IamTestCase):
     def test_ibm_view_account_wildcard(self):
         """Test user-access view with ibm account read wildcard permission."""
         url = reverse("user-access")
+        import pdb; pdb.set_trace()
         response = self.client.get(url, **self.headers)
 
         self.assertEqual(len(response.data.get("data")), self.NUM_ACCESS_CLASSES)

--- a/koku/api/user_access/view.py
+++ b/koku/api/user_access/view.py
@@ -175,7 +175,9 @@ class UserAccessView(APIView):
         data = []
         for source_type in self._source_types:
             access_granted = False
-            access_granted = source_type.get("access_class")(user_access).access(admin_user, source_type.get("pre_release_feature"))
+            access_granted = source_type.get("access_class")(user_access).access(
+                admin_user, source_type.get("pre_release_feature")
+            )
             data.append({"type": source_type.get("type"), "access": access_granted})
 
         paginator = ListPaginator(data, request)

--- a/koku/api/user_access/view.py
+++ b/koku/api/user_access/view.py
@@ -163,7 +163,7 @@ class UserAccessView(APIView):
             )
             if source_accessor:
                 access_class = source_accessor.get("access_class")
-                if admin_user:
+                if admin_user == 'True':
                     access_granted = True
                 else:
                     access_granted = access_class(user_access).access
@@ -174,7 +174,7 @@ class UserAccessView(APIView):
         data = []
         for source_type in self._source_types:
             access_granted = False
-            if admin_user:
+            if admin_user == 'True':
                 access_granted = True
             else:
                 access_granted = source_type.get("access_class")(user_access).access

--- a/koku/api/user_access/view.py
+++ b/koku/api/user_access/view.py
@@ -60,13 +60,18 @@ class UIFeatureAccess:
         """Return the access value from the inner dict."""
         return self.access_dict.get(key1, {}).get(key2, default)
 
-    @property
-    def access(self):
+    def access(self, admin_user, pre_release_feature):
         """Access property returns whether the user has the requested access.
 
         Return:
             (bool)
         """
+        if pre_release_feature == True and settings.ENABLE_PRERELEASE_FEATURES == False:
+            return False
+
+        if admin_user:
+            return True
+
         for key in self.access_keys:
             if self._get_access_value(key, "read") or self._get_access_value(key, "write"):
                 return True
@@ -100,9 +105,7 @@ class GCPUserAccess(UIFeatureAccess):
 class IBMUserAccess(UIFeatureAccess):
     """Access to IBM UI Features."""
 
-    access_keys = ["disabled"]
-    if settings.ENABLE_PRERELEASE_FEATURES:
-        access_keys = ["ibm.account"]
+    access_keys = ["ibm.account"]
 
 
 class CostModelUserAccess(UIFeatureAccess):
@@ -130,7 +133,7 @@ class UserAccessView(APIView):
         {"type": "azure", "access_class": AzureUserAccess},
         {"type": "cost_model", "access_class": CostModelUserAccess},
         {"type": "gcp", "access_class": GCPUserAccess},
-        {"type": "ibm", "access_class": IBMUserAccess},
+        {"type": "ibm", "access_class": IBMUserAccess, "pre_release_feature": True},
         {"type": "ocp", "access_class": OCPUserAccess},
     ]
 
@@ -163,10 +166,8 @@ class UserAccessView(APIView):
             )
             if source_accessor:
                 access_class = source_accessor.get("access_class")
-                if admin_user:
-                    access_granted = True
-                else:
-                    access_granted = access_class(user_access).access
+                pre_release_feature = source_accessor.get("pre_release_feature")
+                access_granted = access_class(user_access).access(admin_user, pre_release_feature)
                 return Response({"data": access_granted})
             else:
                 return Response({f"Unknown source type: {source_type}"}, status=status.HTTP_400_BAD_REQUEST)
@@ -174,10 +175,7 @@ class UserAccessView(APIView):
         data = []
         for source_type in self._source_types:
             access_granted = False
-            if admin_user:
-                access_granted = True
-            else:
-                access_granted = source_type.get("access_class")(user_access).access
+            access_granted = source_type.get("access_class")(user_access).access(admin_user, source_type.get("pre_release_feature"))
             data.append({"type": source_type.get("type"), "access": access_granted})
 
         paginator = ListPaginator(data, request)

--- a/koku/api/user_access/view.py
+++ b/koku/api/user_access/view.py
@@ -66,7 +66,7 @@ class UIFeatureAccess:
         Return:
             (bool)
         """
-        if pre_release_feature == True and settings.ENABLE_PRERELEASE_FEATURES == False:
+        if pre_release_feature and not settings.ENABLE_PRERELEASE_FEATURES:
             return False
 
         if admin_user:

--- a/koku/api/user_access/view.py
+++ b/koku/api/user_access/view.py
@@ -148,8 +148,9 @@ class UserAccessView(APIView):
         query_params = request.query_params
         user_access = request.user.access
         admin_user = request.user.admin
+        LOG.info(f"TYPE admin_user: {type(admin_user)}")
         beta = request.user.beta
-        LOG.debug(f"User Access RBAC permissions: {str(user_access)}. Org Admin: {str(admin_user)}. Beta: {str(beta)}")
+        LOG.info(f"User Access RBAC permissions: {str(user_access)}. Org Admin: {str(admin_user)}. Beta: {str(beta)}")
 
         # only show pre-release features in approved environments
         flag = query_params.get("beta", "False")  # query_params are strings, not bools.

--- a/koku/api/user_access/view.py
+++ b/koku/api/user_access/view.py
@@ -152,9 +152,8 @@ class UserAccessView(APIView):
         user_access = request.user.access
         admin_user = request.user.admin
         beta = request.user.beta
-        LOG.info(f"User Access RBAC permissions: {str(user_access)}. Org Admin: {str(admin_user)}. Beta: {str(beta)}")
+        LOG.debug(f"User Access RBAC permissions: {str(user_access)}. Org Admin: {str(admin_user)}. Beta: {str(beta)}")
 
-        # only show pre-release features in approved environments
         flag = query_params.get("beta", "False")  # query_params are strings, not bools.
         if flag.lower() == "true" and not beta:
             return Response({"data": False})

--- a/koku/api/user_access/view.py
+++ b/koku/api/user_access/view.py
@@ -148,7 +148,6 @@ class UserAccessView(APIView):
         query_params = request.query_params
         user_access = request.user.access
         admin_user = request.user.admin
-        LOG.info(f"TYPE admin_user: {type(admin_user)}")
         beta = request.user.beta
         LOG.info(f"User Access RBAC permissions: {str(user_access)}. Org Admin: {str(admin_user)}. Beta: {str(beta)}")
 
@@ -164,7 +163,7 @@ class UserAccessView(APIView):
             )
             if source_accessor:
                 access_class = source_accessor.get("access_class")
-                if admin_user == 'True':
+                if admin_user:
                     access_granted = True
                 else:
                     access_granted = access_class(user_access).access
@@ -175,7 +174,7 @@ class UserAccessView(APIView):
         data = []
         for source_type in self._source_types:
             access_granted = False
-            if admin_user == 'True':
+            if admin_user:
                 access_granted = True
             else:
                 access_granted = source_type.get("access_class")(user_access).access

--- a/koku/api/user_access/view.py
+++ b/koku/api/user_access/view.py
@@ -16,6 +16,7 @@
 """View for UserAccess."""
 import logging
 
+from django.conf import settings
 from django.utils.decorators import method_decorator
 from django.views.decorators.vary import vary_on_headers
 from rest_framework import status
@@ -99,7 +100,9 @@ class GCPUserAccess(UIFeatureAccess):
 class IBMUserAccess(UIFeatureAccess):
     """Access to IBM UI Features."""
 
-    access_keys = ["ibm.account"]
+    access_keys = ["disabled"]
+    if settings.ENABLE_PRERELEASE_FEATURES:
+        access_keys = ["ibm.account"]
 
 
 class CostModelUserAccess(UIFeatureAccess):

--- a/koku/koku/settings.py
+++ b/koku/koku/settings.py
@@ -470,6 +470,9 @@ try:
 except JSONDecodeError:
     pass
 
+# Aids the UI in showing pre-release features in allowed environments.
+# see: koku.api.user_access.view
+ENABLE_PRERELEASE_FEATURES = ENVIRONMENT.bool("ENABLE_PRERELEASE_FEATURES", default=False)
 
 # Celery configuration
 

--- a/tox.ini
+++ b/tox.ini
@@ -35,8 +35,8 @@ deps =
 commands =
   /bin/sh {toxinidir}/scripts/check_postgres_running.sh
   /bin/sh {toxinidir}/scripts/create_test_db_user.sh
-  pipenv install --dev --ignore-pipfile
-  coverage run {toxinidir}/koku/manage.py test --noinput -v 2 {posargs: koku/}
+  #pipenv install --dev --ignore-pipfile
+  coverage run {toxinidir}/koku/manage.py test api.user_access.test
   coverage report --show-missing
 
 # The same tests as testenv, but run in parallel

--- a/tox.ini
+++ b/tox.ini
@@ -35,8 +35,8 @@ deps =
 commands =
   /bin/sh {toxinidir}/scripts/check_postgres_running.sh
   /bin/sh {toxinidir}/scripts/create_test_db_user.sh
-  #pipenv install --dev --ignore-pipfile
-  coverage run {toxinidir}/koku/manage.py test api.user_access.test.test_view.UserAccessViewTest.test_ibm_view_account_wildcard
+  pipenv install --dev --ignore-pipfile
+  coverage run {toxinidir}/koku/manage.py test --noinput -v 2 {posargs: koku/}
   coverage report --show-missing
 
 # The same tests as testenv, but run in parallel

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ commands =
   /bin/sh {toxinidir}/scripts/check_postgres_running.sh
   /bin/sh {toxinidir}/scripts/create_test_db_user.sh
   #pipenv install --dev --ignore-pipfile
-  coverage run {toxinidir}/koku/manage.py test api.user_access.test
+  coverage run {toxinidir}/koku/manage.py test api.user_access.test.test_view.UserAccessViewTest.test_ibm_view_account_wildcard
   coverage report --show-missing
 
 # The same tests as testenv, but run in parallel


### PR DESCRIPTION
We recently moved the user-access API to use URI `/beta` inspection.  This was done specifically for Cost Explorer.  IBM is also a beta feature but it's not something we want to show in production.  

This change will use the old `ENABLE_PRERELEASE_FEATURES` env to signal when pre-release features should be shown on a per-environment basis.

**Testing**
Testing change in QA environment.  Verify that:
* IBM is only visible in the `/beta` path when `ENABLE_PRERELEASE_FEATURES=True`
* Cost Explorer is visible in `/beta` path regardless of the state of `ENABLE_PRERELEASE_FEATURES`