### PR TITLE
COST-1331: Disable start/end date being used with delta.

### DIFF
--- a/koku/api/report/serializers.py
+++ b/koku/api/report/serializers.py
@@ -346,6 +346,10 @@ class ParamSerializer(BaseSerializer):
             }
             raise serializers.ValidationError(error)
 
+        if data.get("delta") and (data.get("start_date") or data.get("end_date")):
+            error = {"error": "Delta calculation is not supported with start_date and end_date parameters."}
+            raise serializers.ValidationError(error)
+
         if (start_date and not end_date) or (end_date and not start_date):
             error = {"error": "The parameters [start_date, end_date] must both be defined."}
             raise serializers.ValidationError(error)
@@ -356,10 +360,6 @@ class ParamSerializer(BaseSerializer):
 
         if data.get("filter", {}).get("resolution") == "monthly" and (data.get("start_date") or data.get("end_date")):
             error = {"error": "Monthly resolution is not supported with start_date and end_date parameters."}
-            raise serializers.ValidationError(error)
-
-        if data.get("delta") and (data.get("start_date") or data.get("end_date")):
-            error = {"error": "Delta calculation is not supported with start_date and end_date parameters."}
             raise serializers.ValidationError(error)
 
         return data

--- a/koku/api/report/serializers.py
+++ b/koku/api/report/serializers.py
@@ -358,6 +358,10 @@ class ParamSerializer(BaseSerializer):
             error = {"error": "Monthly resolution is not supported with start_date and end_date parameters."}
             raise serializers.ValidationError(error)
 
+        if data.get("delta") and (data.get("start_date") or data.get("end_date")):
+            error = {"error": "Delta calculation is not supported with start_date and end_date parameters."}
+            raise serializers.ValidationError(error)
+
         return data
 
     def validate_order_by(self, value):

--- a/koku/api/report/serializers.py
+++ b/koku/api/report/serializers.py
@@ -346,10 +346,6 @@ class ParamSerializer(BaseSerializer):
             }
             raise serializers.ValidationError(error)
 
-        if data.get("delta") and (data.get("start_date") or data.get("end_date")):
-            error = {"error": "Delta calculation is not supported with start_date and end_date parameters."}
-            raise serializers.ValidationError(error)
-
         if (start_date and not end_date) or (end_date and not start_date):
             error = {"error": "The parameters [start_date, end_date] must both be defined."}
             raise serializers.ValidationError(error)
@@ -360,6 +356,10 @@ class ParamSerializer(BaseSerializer):
 
         if data.get("filter", {}).get("resolution") == "monthly" and (data.get("start_date") or data.get("end_date")):
             error = {"error": "Monthly resolution is not supported with start_date and end_date parameters."}
+            raise serializers.ValidationError(error)
+
+        if data.get("delta") and (data.get("start_date") or data.get("end_date")):
+            error = {"error": "Delta calculation is not supported with start_date and end_date parameters."}
             raise serializers.ValidationError(error)
 
         return data

--- a/koku/api/report/test/aws/test_views.py
+++ b/koku/api/report/test/aws/test_views.py
@@ -602,3 +602,11 @@ class AWSReportViewTest(IamTestCase):
             url = reverse("reports-aws-instance-type") + qs
             response = self.client.get(url, **self.headers)
             self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_start_end_parameters_with_delta(self):
+        """Test that a validation error is raised for monthly resolution with start/end parameters."""
+        qs_list = ["?start_date=2021-04-01&end_date=2021-04-13&delta=cost"]
+        for qs in qs_list:
+            url = reverse("reports-aws-instance-type") + qs
+            response = self.client.get(url, **self.headers)
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/koku/api/report/test/aws/test_views.py
+++ b/koku/api/report/test/aws/test_views.py
@@ -605,7 +605,11 @@ class AWSReportViewTest(IamTestCase):
 
     def test_start_end_parameters_with_delta(self):
         """Test that a validation error is raised for monthly resolution with start/end parameters."""
-        qs_list = ["?start_date=2021-04-01&end_date=2021-04-13&delta=cost"]
+        qs_list = [
+            "?start_date=2021-04-01&end_date=2021-04-13&delta=usage",
+            "?start_date=2021-04-01&delta=usage",
+            "?end_date=2021-04-13&delta=usage",
+        ]
         for qs in qs_list:
             url = reverse("reports-aws-instance-type") + qs
             response = self.client.get(url, **self.headers)

--- a/koku/api/report/test/tests_serializers.py
+++ b/koku/api/report/test/tests_serializers.py
@@ -26,6 +26,7 @@ from api.report.aws.serializers import FilterSerializer
 from api.report.aws.serializers import GroupBySerializer
 from api.report.aws.serializers import OrderBySerializer
 from api.report.aws.serializers import QueryParamSerializer
+from api.report.serializers import ParamSerializer
 from api.utils import DateHelper
 from api.utils import materialized_view_month_start
 
@@ -594,21 +595,6 @@ class QueryParamSerializerTest(TestCase):
                     serializer = QueryParamSerializer(data=params)
                     serializer.is_valid(raise_exception=True)
 
-    def test_parse_filter_dates_invalid_delta(self):
-        """Test parse of a filter date-based param with monthly presolution should not succeed."""
-        dh = DateHelper()
-        scenarios = [
-            {"start_date": dh.last_month_end.date(), "end_date": dh.this_month_start.date(), "delta": "cost"},
-            {"start_date": materialized_view_month_start().date(), "end_date": dh.today.date(), "delta": "cost"},
-        ]
-
-        for params in scenarios:
-            with self.subTest(params=params):
-                with self.assertRaises(ValidationError):
-                    serializer = QueryParamSerializer(data=params)
-                    self.assertFalse(serializer.is_valid())
-                    serializer.is_valid(raise_exception=True)
-
     def test_parse_filter_dates_invalid(self):
         """Test parse of invalid data for filter date-based param should not succeed."""
         dh = DateHelper()
@@ -647,3 +633,16 @@ class QueryParamSerializerTest(TestCase):
             with self.subTest(params=params):
                 serializer = QueryParamSerializer(data=params)
                 self.assertFalse(serializer.is_valid())
+
+
+class ParamSerializerTest(TestCase):
+    """Tests for the handling query parameter parsing serializer."""
+
+    def test_parse_filter_dates_invalid_delta(self):
+        """Test parse of a filter date-based param with monthly presolution should not succeed."""
+        dh = DateHelper()
+        params = {"start_date": dh.last_month_end.date(), "end_date": dh.this_month_start.date(), "delta": "cost"}
+        with self.assertRaises(ValidationError):
+            serializer = ParamSerializer(data=params)
+            self.assertFalse(serializer.is_valid())
+            serializer.is_valid(raise_exception=True)

--- a/koku/api/report/test/tests_serializers.py
+++ b/koku/api/report/test/tests_serializers.py
@@ -595,6 +595,21 @@ class QueryParamSerializerTest(TestCase):
                     serializer = QueryParamSerializer(data=params)
                     serializer.is_valid(raise_exception=True)
 
+    def test_parse_filter_dates_invalid_delta_pairing(self):
+        """Test parse of a filter date-based param with monthly presolution should not succeed."""
+        dh = DateHelper()
+        scenarios = [
+            {"end_date": dh.this_month_start.date(), "delta": "cost"},
+            {"start_date": materialized_view_month_start().date(), "delta": "cost"},
+            {"start_date": materialized_view_month_start().date(), "end_date": dh.today.date(), "delta": "cost"},
+        ]
+
+        for params in scenarios:
+            with self.subTest(params=params):
+                with self.assertRaises(ValidationError):
+                    serializer = QueryParamSerializer(data=params)
+                    serializer.is_valid(raise_exception=True)
+
     def test_parse_filter_dates_invalid(self):
         """Test parse of invalid data for filter date-based param should not succeed."""
         dh = DateHelper()

--- a/koku/api/report/test/tests_serializers.py
+++ b/koku/api/report/test/tests_serializers.py
@@ -594,6 +594,20 @@ class QueryParamSerializerTest(TestCase):
                     serializer = QueryParamSerializer(data=params)
                     serializer.is_valid(raise_exception=True)
 
+    def test_parse_filter_dates_invalid_delta(self):
+        """Test parse of a filter date-based param with monthly presolution should not succeed."""
+        dh = DateHelper()
+        scenarios = [
+            {"start_date": dh.last_month_end.date(), "end_date": dh.this_month_start.date(), "delta": "cost"},
+            {"start_date": materialized_view_month_start().date(), "end_date": dh.today.date(), "delta": "cost"},
+        ]
+
+        for params in scenarios:
+            with self.subTest(params=params):
+                with self.assertRaises(ValidationError):
+                    serializer = QueryParamSerializer(data=params)
+                    serializer.is_valid(raise_exception=True)
+
     def test_parse_filter_dates_invalid(self):
         """Test parse of invalid data for filter date-based param should not succeed."""
         dh = DateHelper()

--- a/koku/api/report/test/tests_serializers.py
+++ b/koku/api/report/test/tests_serializers.py
@@ -606,6 +606,7 @@ class QueryParamSerializerTest(TestCase):
             with self.subTest(params=params):
                 with self.assertRaises(ValidationError):
                     serializer = QueryParamSerializer(data=params)
+                    self.assertFalse(serializer.is_valid())
                     serializer.is_valid(raise_exception=True)
 
     def test_parse_filter_dates_invalid(self):


### PR DESCRIPTION
Disable the ability to use delta when start/end date is also being used.
Example url:
- http://127.0.0.1:8000/api/cost-management/v1/reports/aws/costs/?start_date=2021-04-01&end_date=2021-04-22&delta=cost

We are also going to need to update smoke tests:
`test_api_aws_cost_deltas_daily_date_range`

Issue: https://issues.redhat.com/browse/COST-1331

--- 

Trying to make the codecov patch happy. 