### PR TITLE
[COST-1348] Option for timing request/response time in django

### DIFF
--- a/koku/koku/settings.py
+++ b/koku/koku/settings.py
@@ -122,6 +122,7 @@ if ACCOUNT_ENHANCED_METRICS:
 ### Middleware setup
 MIDDLEWARE = [
     PROMETHEUS_BEFORE_MIDDLEWARE,
+    "koku.middleware.RequestTimingMiddleware",
     "corsheaders.middleware.CorsMiddleware",
     "koku.middleware.DisableCSRF",
     "django.middleware.security.SecurityMiddleware",


### PR DESCRIPTION
## Summary
This would add time to the logged message when we produce a response for an API call. 

Ex. 

```
[2021-04-28 16:37:54,290] INFO None {'method': 'GET', 'path': '/api/cost-management/v1/sources/', 'status': 200, 'request_id': None, 'account': '10001', 'username': 'user_dev', 'is_admin': 'True', 'response_time': '217.31 ms'}
```