### PR TITLE
COST-1239: GCP project name is not being updated when changed.

### DIFF
--- a/koku/masu/database/gcp_report_db_accessor.py
+++ b/koku/masu/database/gcp_report_db_accessor.py
@@ -90,10 +90,13 @@ class GCPReportDBAccessor(ReportDBAccessorBase):
         """Make a mapping of projects to project objects."""
         table_name = GCPProject
         with schema_context(self.schema):
-            columns = ["account_id", "project_id", "id"]
+            columns = ["account_id", "project_id", "project_name", "id"]
             projects = self._get_db_obj_query(table_name, columns=columns).all()
 
-            return {(project["account_id"], project["project_id"]): project["id"] for project in projects}
+            return {
+                (project["account_id"], project["project_id"], project["project_name"]): project["id"]
+                for project in projects
+            }
 
     def get_lineitem_query_for_billid(self, bill_id):
         """Get the GCP cost entry line item for a given bill query."""

--- a/koku/masu/processor/gcp/gcp_report_processor.py
+++ b/koku/masu/processor/gcp/gcp_report_processor.py
@@ -248,7 +248,7 @@ class GCPReportProcessor(ReportProcessorBase):
         data = self._get_data_for_table(row, table_name._meta.db_table)
         data = report_db_accessor.clean_data(data, table_name._meta.db_table)
 
-        key = (data["account_id"], data["project_id"])
+        key = (data["account_id"], data["project_id"], data["project_name"])
         if key in self.processed_report.projects:
             return self.processed_report.projects[key]
 
@@ -256,8 +256,8 @@ class GCPReportProcessor(ReportProcessorBase):
             return self.existing_projects_map[key]
 
         with transaction.atomic():
-            project_id = report_db_accessor.insert_on_conflict_do_nothing(
-                table_name, data, conflict_columns=["project_id"]
+            project_id = report_db_accessor.insert_on_conflict_do_update(
+                table_name, data, conflict_columns=["project_id"], set_columns=list(data.keys())
             )
 
         self.processed_report.projects[key] = project_id

--- a/koku/masu/test/processor/gcp/test_gcp_report_processor.py
+++ b/koku/masu/test/processor/gcp/test_gcp_report_processor.py
@@ -153,6 +153,22 @@ class GCPReportProcessorTest(MasuTestCase):
         with schema_context(self.schema):
             self.assertTrue(GCPProject.objects.filter(id=project_id).exists())
 
+    def test_create_gcp_project_name_change(self):
+        """Test changing the project name will update in the table."""
+        project_id = fake.word()
+        project_info = {"project.id": project_id, "billing_account_id": fake.word(), "project.name": fake.word()}
+        expected_name = "BiggoStormsMixTape"
+        pt_id_1 = self.processor._get_or_create_gcp_project(project_info, self.accessor)
+        with schema_context(self.schema):
+            self.assertTrue(GCPProject.objects.filter(id=pt_id_1).exists())
+        project_info["project.name"] = expected_name
+        pt_id_2 = self.processor._get_or_create_gcp_project(project_info, self.accessor)
+        # Check that both calls return the same project table id
+        self.assertEqual(pt_id_1, pt_id_2)
+        with schema_context(self.schema):
+            p = GCPProject.objects.filter(project_id=project_id).first()
+            self.assertEqual(p.project_name, expected_name)
+
     def test_get_gcp_project(self):
         """Test calling _get_or_create_gcp_project on a project id that exists gets it."""
         project_id = fake.word()


### PR DESCRIPTION
Changes:
- Added the project name to the key so that way it wouldn't return the old value if name changes
- Whenever a project conflict happens now it will update instead of doing nothing
