### PR TITLE
Fix tag pre processing for non-trio tag enablement.

### DIFF
--- a/koku/masu/database/sql/reporting_awscostentrylineitem_daily_summary.sql
+++ b/koku/masu/database/sql/reporting_awscostentrylineitem_daily_summary.sql
@@ -15,6 +15,7 @@ WHERE li.usage_start >= {{start_date}}
 WITH cte_enabled_keys AS (
     select coalesce(array_agg(key), '{}'::text[])::text[] as keys
         from {{schema | sqlsafe}}.reporting_awsenabledtagkeys
+     where enabled = true
 )
 INSERT INTO {{schema | sqlsafe}}.reporting_awscostentrylineitem_daily_summary (
     uuid,


### PR DESCRIPTION
This pr is to fix the smoke tests for tag enablement: `test_api_settings_aws_tag_enablement` related to changes made here: https://github.com/project-koku/koku/pull/2797