### PR TITLE
COST-1308: Handle no source_type when checking source status

### DIFF
--- a/koku/sources/storage.py
+++ b/koku/sources/storage.py
@@ -171,7 +171,7 @@ APP_SETTINGS_SCREEN_MAP = {
 def source_settings_complete(provider):
     """Determine if the source application settings are complete."""
     screen_fn = APP_SETTINGS_SCREEN_MAP.get(provider.source_type)
-    return screen_fn(provider)
+    return screen_fn(provider) if screen_fn else False
 
 
 def load_providers_to_create():


### PR DESCRIPTION
`provider.source_type` can be None if there is an out of order delete record in the database.  This change returns `False` for that condition