### PR TITLE
Also exclude zero'd costs

### DIFF
--- a/koku/masu/database/sql/reporting_ocpawscostlineitem_daily_summary.sql
+++ b/koku/masu/database/sql/reporting_ocpawscostlineitem_daily_summary.sql
@@ -3,6 +3,7 @@ WHERE usage_start >= {{start_date}}::date
     AND usage_start <= {{end_date}}::date
     AND cluster_id = {{cluster_id}}
     AND infrastructure_raw_cost IS NOT NULL
+    AND infrastructure_raw_cost != 0
 ;
 
 -- The Python Jinja string variable subsitutions aws_where_clause and ocp_where_clause

--- a/koku/masu/database/sql/reporting_ocpazurecostlineitem_daily_summary.sql
+++ b/koku/masu/database/sql/reporting_ocpazurecostlineitem_daily_summary.sql
@@ -3,6 +3,7 @@ WHERE usage_start >= {{start_date}}::date
     AND usage_start <= {{end_date}}::date
     AND cluster_id = {{cluster_id}}
     AND infrastructure_raw_cost IS NOT NULL
+    AND infrastructure_raw_cost != 0
 ;
 
 CREATE TEMPORARY TABLE matched_tags_{{uuid | sqlsafe}} AS (


### PR DESCRIPTION
## Summary
This also excluded rows with zero cost (not just NULLs) when deleting OCP on Cloud infra cost from the OCP daily summary table.