### PR TITLE
use json.dumpms for proper escaping

### DIFF
--- a/koku/masu/database/ocp_report_db_accessor.py
+++ b/koku/masu/database/ocp_report_db_accessor.py
@@ -1655,7 +1655,7 @@ class OCPReportDBAccessor(ReportDBAccessorBase):
                     value_names = list(tag_vals.keys())
                     for val_name in value_names:
                         rate_value = tag_vals[val_name]
-                        key_value_pair = f'{{"{tag_key}": "{val_name}"}}'
+                        key_value_pair = json.dumps({tag_key: val_name})
                         tag_rates_sql = pkgutil.get_data("masu.database", sql_file)
                         tag_rates_sql = tag_rates_sql.decode("utf-8")
                         tag_rates_sql_params = {
@@ -1740,7 +1740,7 @@ class OCPReportDBAccessor(ReportDBAccessorBase):
                         continue
                     value_names = tag_vals.get("defined_keys", [])
                     for value_to_skip in value_names:
-                        key_value_pair.append(f'{{"{tag_key}": "{value_to_skip}"}}')
+                        key_value_pair.append(json.dumps({tag_key: value_to_skip}))
                     json.dumps(key_value_pair)
                     tag_rates_sql = pkgutil.get_data("masu.database", sql_file)
                     tag_rates_sql = tag_rates_sql.decode("utf-8")


### PR DESCRIPTION
## Jira ticket

[COST-1393](https://issues.redhat.com/browse/COST-1393)

## Description

JSON values are being used in tag usage costs processing. These JSON values were being built by hand using string manipulation. This change now uses  `json.dumps` for proper string escaping for JSON values in the data processing.

## Testing

Make tag based costs tag values something that would be originally not escaped properly like a string of two double-quote characters. (This is the value that caused the original production exception).