### PR TITLE
Sources request exception

### DIFF
--- a/koku/sources/kafka_listener.py
+++ b/koku/sources/kafka_listener.py
@@ -50,6 +50,7 @@ from sources.kafka_message_processor import SourcesMessageError
 from sources.sources_http_client import SourceNotFoundError
 from sources.sources_http_client import SourcesHTTPClient
 from sources.sources_http_client import SourcesHTTPClientError
+from sources.sources_http_client import SourcesHTTPClientRequestError
 from sources.sources_provider_coordinator import SourcesProviderCoordinator
 from sources.sources_provider_coordinator import SourcesProviderCoordinatorError
 from sources.tasks import delete_source
@@ -314,8 +315,11 @@ def listen_for_messages(kaf_msg, consumer, application_source_id):  # noqa: C901
             LOG.warning(f"[listen_for_messages] {type(err).__name__}: {err}. Retrying...")
             SOURCES_HTTP_CLIENT_ERROR_COUNTER.inc()
             rewind_consumer_to_retry(consumer, tp)
-        except (SourcesMessageError, SourceNotFoundError) as error:
-            LOG.warning(f"[listen_for_messages] {type(error).__name__}: {error}. Skipping msg: {kaf_msg.value()}")
+        except SourcesHTTPClientRequestError as err:
+            LOG.warning(f"[listen_for_messages] {type(err).__name__}: {err}. Skipping msg: {kaf_msg.value()}")
+            consumer.commit()
+        except (SourcesMessageError, SourceNotFoundError) as err:
+            LOG.warning(f"[listen_for_messages] {type(err).__name__}: {err}. Skipping msg: {kaf_msg.value()}")
             consumer.commit()
         else:
             consumer.commit()

--- a/koku/sources/kafka_listener.py
+++ b/koku/sources/kafka_listener.py
@@ -50,7 +50,7 @@ from sources.kafka_message_processor import SourcesMessageError
 from sources.sources_http_client import SourceNotFoundError
 from sources.sources_http_client import SourcesHTTPClient
 from sources.sources_http_client import SourcesHTTPClientError
-from sources.sources_http_client import SourcesHTTPClientRequestError
+from sources.sources_http_client import SourcesHTTPClientInternalError
 from sources.sources_provider_coordinator import SourcesProviderCoordinator
 from sources.sources_provider_coordinator import SourcesProviderCoordinatorError
 from sources.tasks import delete_source
@@ -315,7 +315,7 @@ def listen_for_messages(kaf_msg, consumer, application_source_id):  # noqa: C901
             LOG.warning(f"[listen_for_messages] {type(err).__name__}: {err}. Retrying...")
             SOURCES_HTTP_CLIENT_ERROR_COUNTER.inc()
             rewind_consumer_to_retry(consumer, tp)
-        except SourcesHTTPClientRequestError as err:
+        except SourcesHTTPClientInternalError as err:
             LOG.warning(f"[listen_for_messages] {type(err).__name__}: {err}. Skipping msg: {kaf_msg.value()}")
             consumer.commit()
         except (SourcesMessageError, SourceNotFoundError) as err:

--- a/koku/sources/sources_http_client.py
+++ b/koku/sources/sources_http_client.py
@@ -99,7 +99,7 @@ class SourcesHTTPClient:
 
         if resp.status_code == 404:
             raise SourceNotFoundError(f"Status Code: {resp.status_code}. Response: {resp.text}")
-        if resp.status_code == 500:
+        elif resp.status_code == 500:
             raise SourcesHTTPClientInternalError(f"Status Code: {resp.status_code}. Response: {resp.text}")
         elif resp.status_code != 200:
             raise SourcesHTTPClientError(f"Status Code: {resp.status_code}. Response: {resp.text}")

--- a/koku/sources/sources_http_client.py
+++ b/koku/sources/sources_http_client.py
@@ -55,8 +55,8 @@ class SourcesHTTPClientError(Exception):
     pass
 
 
-class SourcesHTTPClientRequestError(Exception):
-    """Exception raised during SourcesHTTPClient request."""
+class SourcesHTTPClientInternalError(Exception):
+    """Internal error from sources-api."""
 
     pass
 
@@ -95,10 +95,12 @@ class SourcesHTTPClient:
         try:
             resp = requests.get(url, headers=self._identity_header)
         except RequestException as error:
-            raise SourcesHTTPClientRequestError(f"{error_msg}. Reason: {error}")
+            raise SourcesHTTPClientError(f"{error_msg}. Reason: {error}")
 
         if resp.status_code == 404:
             raise SourceNotFoundError(f"Status Code: {resp.status_code}. Response: {resp.text}")
+        if resp.status_code == 500:
+            raise SourcesHTTPClientInternalError(f"Status Code: {resp.status_code}. Response: {resp.text}")
         elif resp.status_code != 200:
             raise SourcesHTTPClientError(f"Status Code: {resp.status_code}. Response: {resp.text}")
 

--- a/koku/sources/sources_http_client.py
+++ b/koku/sources/sources_http_client.py
@@ -55,6 +55,12 @@ class SourcesHTTPClientError(Exception):
     pass
 
 
+class SourcesHTTPClientRequestError(Exception):
+    """Exception raised during SourcesHTTPClient request."""
+
+    pass
+
+
 class SourceNotFoundError(Exception):
     """SourceNotFound Error."""
 
@@ -89,7 +95,7 @@ class SourcesHTTPClient:
         try:
             resp = requests.get(url, headers=self._identity_header)
         except RequestException as error:
-            raise SourcesHTTPClientError(f"{error_msg}. Reason: {error}")
+            raise SourcesHTTPClientRequestError(f"{error_msg}. Reason: {error}")
 
         if resp.status_code == 404:
             raise SourceNotFoundError(f"Status Code: {resp.status_code}. Response: {resp.text}")

--- a/koku/sources/test/test_kafka_listener.py
+++ b/koku/sources/test/test_kafka_listener.py
@@ -364,15 +364,16 @@ class SourcesKafkaMsgHandlerTest(IamTestCase):
     def test_listen_for_messages_exceptions_no_retry(self):
         """Test listen_for_messages exceptions that do not cause a retry."""
         table = [
-            {"event": KAFKA_APPLICATION_CREATE, "value": b'{"this value is messeged up}'},
-            {"event": KAFKA_AUTHENTICATION_CREATE},
+            {"event": KAFKA_APPLICATION_CREATE, "value": b'{"this value is messeged up}', "status": 200},
+            {"event": KAFKA_AUTHENTICATION_CREATE, "status": 404},
+            {"event": KAFKA_AUTHENTICATION_CREATE, "status": 500},
         ]
         for test in table:
             with self.subTest(test=test):
                 with requests_mock.mock() as m:
                     m.get(
                         url=f"{MOCK_URL}/api/v1.0/{ENDPOINT_APPLICATION_TYPES}/{COST_MGMT_APP_TYPE_ID}/sources?filter[id]=1",  # noqa: E501
-                        status_code=404,
+                        status_code=test.get("status", 500),
                         json={},
                     )
                     msg = msg_generator(test.get("event"))

--- a/koku/sources/test/test_sources_http_client.py
+++ b/koku/sources/test/test_sources_http_client.py
@@ -40,6 +40,7 @@ from sources.sources_http_client import ENDPOINT_SOURCES
 from sources.sources_http_client import SourceNotFoundError
 from sources.sources_http_client import SourcesHTTPClient
 from sources.sources_http_client import SourcesHTTPClientError
+from sources.sources_http_client import SourcesHTTPClientRequestError
 
 faker = Faker()
 COST_MGMT_APP_TYPE_ID = 2
@@ -80,7 +81,7 @@ class SourcesHTTPClientTest(TestCase):
         client = SourcesHTTPClient(auth_header=Config.SOURCES_FAKE_HEADER, source_id=self.source_id)
         with requests_mock.mock() as m:
             m.get(url=MOCK_URL, exc=RequestException)
-            with self.assertRaises(SourcesHTTPClientError):
+            with self.assertRaises(SourcesHTTPClientRequestError):
                 client._get_network_response(MOCK_URL, "test error")
 
     def test_get_network_response_status_exception(self):

--- a/koku/sources/test/test_sources_http_client.py
+++ b/koku/sources/test/test_sources_http_client.py
@@ -40,7 +40,7 @@ from sources.sources_http_client import ENDPOINT_SOURCES
 from sources.sources_http_client import SourceNotFoundError
 from sources.sources_http_client import SourcesHTTPClient
 from sources.sources_http_client import SourcesHTTPClientError
-from sources.sources_http_client import SourcesHTTPClientRequestError
+from sources.sources_http_client import SourcesHTTPClientInternalError
 
 faker = Faker()
 COST_MGMT_APP_TYPE_ID = 2
@@ -81,13 +81,17 @@ class SourcesHTTPClientTest(TestCase):
         client = SourcesHTTPClient(auth_header=Config.SOURCES_FAKE_HEADER, source_id=self.source_id)
         with requests_mock.mock() as m:
             m.get(url=MOCK_URL, exc=RequestException)
-            with self.assertRaises(SourcesHTTPClientRequestError):
+            with self.assertRaises(SourcesHTTPClientError):
                 client._get_network_response(MOCK_URL, "test error")
 
     def test_get_network_response_status_exception(self):
         """Test get network response with invalid status responses."""
         client = SourcesHTTPClient(auth_header=Config.SOURCES_FAKE_HEADER, source_id=self.source_id)
-        table = [{"status": 404, "expected": SourceNotFoundError}, {"status": 403, "expected": SourcesHTTPClientError}]
+        table = [
+            {"status": 500, "expected": SourcesHTTPClientInternalError},
+            {"status": 404, "expected": SourceNotFoundError},
+            {"status": 403, "expected": SourcesHTTPClientError},
+        ]
         for test in table:
             with self.subTest(test=test):
                 with requests_mock.mock() as m:


### PR DESCRIPTION
CI is currently stuck in a retry loop where the sources-api is returning a 500 response. We should commit the kafka message and move on when we receive a 500.

This PR adds a new SourcesHTTPClientInternalError exception which is raised when we receive a 500 from the backend.