### PR TITLE
[COST-1474] ignore messages without x-rh-identity header

### DIFF
--- a/koku/sources/kafka_listener.py
+++ b/koku/sources/kafka_listener.py
@@ -294,7 +294,7 @@ def listen_for_messages(kaf_msg, consumer, application_source_id):  # noqa: C901
     try:
         try:
             msg_processor = create_msg_processor(kaf_msg, application_source_id)
-            if msg_processor and msg_processor.source_id:
+            if msg_processor and msg_processor.source_id and msg_processor.auth_header:
                 tp = TopicPartition(Config.SOURCES_TOPIC, msg_processor.partition, msg_processor.offset)
                 if not msg_processor.msg_for_cost_mgmt():
                     LOG.info("Event not associated with cost-management.")

--- a/koku/sources/kafka_message_processor.py
+++ b/koku/sources/kafka_message_processor.py
@@ -89,9 +89,9 @@ class KafkaMessageProcessor:
         self.cost_mgmt_id = cost_mgmt_id
         self.offset = msg.offset()
         self.partition = msg.partition()
-        header = extract_from_header(msg.headers(), KAFKA_HDR_RH_IDENTITY)
-        if header is None:
-            msg = f"[KafkaMessageProcessor] missing `{KAFKA_HDR_RH_IDENTITY}``: {msg.value}"
+        self.auth_header = extract_from_header(msg.headers(), KAFKA_HDR_RH_IDENTITY)
+        if self.auth_header is None:
+            msg = f"[KafkaMessageProcessor] missing `{KAFKA_HDR_RH_IDENTITY}`: {str(self.value)}"
             LOG.warning(msg)
             raise SourcesMessageError(msg)
         self.source_id = None

--- a/koku/sources/kafka_message_processor.py
+++ b/koku/sources/kafka_message_processor.py
@@ -89,7 +89,11 @@ class KafkaMessageProcessor:
         self.cost_mgmt_id = cost_mgmt_id
         self.offset = msg.offset()
         self.partition = msg.partition()
-        self.auth_header = extract_from_header(msg.headers(), KAFKA_HDR_RH_IDENTITY)
+        header = extract_from_header(msg.headers(), KAFKA_HDR_RH_IDENTITY)
+        if header is None:
+            msg = f"[KafkaMessageProcessor] missing `{KAFKA_HDR_RH_IDENTITY}``: {msg.value}"
+            LOG.warning(msg)
+            raise SourcesMessageError(msg)
         self.source_id = None
 
     def __repr__(self):
@@ -315,7 +319,7 @@ def extract_from_header(headers, header_type):
                     continue
                 else:
                     return item.decode("ascii")
-    return "unknown"
+    return None
 
 
 def create_msg_processor(msg, cost_mgmt_id):

--- a/koku/sources/kafka_message_processor.py
+++ b/koku/sources/kafka_message_processor.py
@@ -91,7 +91,7 @@ class KafkaMessageProcessor:
         self.partition = msg.partition()
         self.auth_header = extract_from_header(msg.headers(), KAFKA_HDR_RH_IDENTITY)
         if self.auth_header is None:
-            msg = f"[KafkaMessageProcessor] missing `{KAFKA_HDR_RH_IDENTITY}`: {str(self.value)}"
+            msg = f"[KafkaMessageProcessor] missing `{KAFKA_HDR_RH_IDENTITY}`: {msg.headers()}"
             LOG.warning(msg)
             raise SourcesMessageError(msg)
         self.source_id = None

--- a/koku/sources/test/test_kafka_listener.py
+++ b/koku/sources/test/test_kafka_listener.py
@@ -364,8 +364,9 @@ class SourcesKafkaMsgHandlerTest(IamTestCase):
     def test_listen_for_messages_exceptions_no_retry(self):
         """Test listen_for_messages exceptions that do not cause a retry."""
         table = [
-            {"event": KAFKA_APPLICATION_CREATE, "value": b'{"this value is messeged up}'},
-            {"event": KAFKA_AUTHENTICATION_CREATE},
+            {"event": KAFKA_APPLICATION_CREATE, "header": True, "value": b'{"this value is messeged up}'},
+            {"event": KAFKA_APPLICATION_DESTROY, "header": False},
+            {"event": KAFKA_AUTHENTICATION_CREATE, "header": True},
         ]
         for test in table:
             with self.subTest(test=test):
@@ -376,6 +377,8 @@ class SourcesKafkaMsgHandlerTest(IamTestCase):
                         json={},
                     )
                     msg = msg_generator(test.get("event"))
+                    if not test.get("header"):
+                        msg = msg_generator(test.get("event"), header=None)
                     if test.get("value"):
                         msg._value = test.get("value")
                     mock_consumer = MockKafkaConsumer([msg])

--- a/koku/sources/test/test_kafka_message_processor.py
+++ b/koku/sources/test/test_kafka_message_processor.py
@@ -79,7 +79,7 @@ SOURCE_TYPE_IDS_MAP = {
 }
 
 
-def msg_generator(event_type, topic=None, offset=None, value=None):
+def msg_generator(event_type, topic=None, offset=None, value=None, header=Config.SOURCES_FAKE_HEADER):
     test_value = '{"id":1,"source_id":1,"application_type_id":2}'
     if value:
         test_value = json.dumps(value)
@@ -87,7 +87,7 @@ def msg_generator(event_type, topic=None, offset=None, value=None):
         topic=topic or "platform.sources.event-stream",
         offset=offset or 5,
         event_type=event_type,
-        auth_header=Config.SOURCES_FAKE_HEADER,
+        auth_header=header,
         value=bytes(test_value, encoding="utf-8"),
     )
 


### PR DESCRIPTION
This PR fixes an issue in the sources integration. If we received a kafka message that did not contain a header, we were still trying to process the message when we should have ignored it. This PR ignores missing-header messages.