### PR TITLE
attempt workaround for codecov upload

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -86,4 +86,5 @@ jobs:
           file: ./coverage.xml
           flags: unittests
           name: Python-${{ matrix.python-version}}
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true


### PR DESCRIPTION
We can try adding a codecov token as a workaround for https://github.com/codecov/codecov-action/issues/330.

The docs clearly state that a token is not required for public repos:
![image](https://user-images.githubusercontent.com/19751919/121067321-e839f180-c798-11eb-841c-3d6f22dc718b.png)
but it's worth a try if it enables uploads again