### PR TITLE
COST-1341: Fix no attribute bug in provider db accessor.

### DIFF
--- a/koku/masu/database/provider_db_accessor.py
+++ b/koku/masu/database/provider_db_accessor.py
@@ -135,7 +135,10 @@ class ProviderDBAccessor(KokuDBAccess):
                     example: {"bucket": "my-s3-cur-bucket"}
 
         """
-        return self.provider.billing_source.data_source
+        data_source = None
+        if self.provider and self.provider.billing_source:
+            data_source = self.provider.billing_source.data_source
+        return data_source
 
     def get_setup_complete(self):
         """

--- a/koku/masu/database/provider_db_accessor.py
+++ b/koku/masu/database/provider_db_accessor.py
@@ -119,7 +119,10 @@ class ProviderDBAccessor(KokuDBAccess):
                     example: {"role_arn": "arn:aws:iam::111111111111:role/CostManagement"}
 
         """
-        return self.provider.authentication.credentials
+        credentials = None
+        if self.provider and self.provider.authentication:
+            credentials = self.provider.authentication.credentials
+        return credentials
 
     def get_data_source(self):
         """

--- a/koku/masu/test/database/test_provider_db_accessor.py
+++ b/koku/masu/test/database/test_provider_db_accessor.py
@@ -79,7 +79,7 @@ class ProviderDBAccessorTest(MasuTestCase):
 
     def test_get_data_source_no_data_source(self):
         """Test provider data_source getter."""
-        uuid = self.gcp_provider_uuid
+        uuid = self.unkown_test_provider_uuid
         with ProviderDBAccessor(uuid) as accessor:
             self.assertIsNone(accessor.get_data_source())
 

--- a/koku/masu/test/database/test_provider_db_accessor.py
+++ b/koku/masu/test/database/test_provider_db_accessor.py
@@ -77,6 +77,12 @@ class ProviderDBAccessorTest(MasuTestCase):
         with ProviderDBAccessor(uuid) as accessor:
             self.assertEqual(expected_data_source, accessor.get_data_source())
 
+    def test_get_data_source_no_data_source(self):
+        """Test provider data_source getter."""
+        uuid = self.gcp_provider_uuid
+        with ProviderDBAccessor(uuid) as accessor:
+            self.assertIsNone(accessor.get_data_source())
+
     def test_get_customer_uuid(self):
         """Test provider billing_source getter."""
         expected_uuid = None

--- a/koku/masu/test/util/ocp/test_common.py
+++ b/koku/masu/test/util/ocp/test_common.py
@@ -11,6 +11,7 @@ from uuid import UUID
 
 import pandas as pd
 
+from api.provider.models import Provider
 from masu.config import Config
 from masu.database import OCP_REPORT_TABLE_MAP
 from masu.database.ocp_report_db_accessor import OCPReportDBAccessor
@@ -43,6 +44,16 @@ class OCPUtilTests(MasuTestCase):
         """Test that the cluster ID is returned from OCP provider."""
         cluster_id = utils.get_cluster_id_from_provider(self.ocp_test_provider_uuid)
         self.assertIsNotNone(cluster_id)
+
+    def test_get_cluster_id_with_no_authentication(self):
+        """Test that a None is correctly returned if authentication is not present."""
+        # Remove test provider authentication
+        Provider.objects.filter(uuid=self.ocp_test_provider_uuid).update(authentication=None)
+        ocp_provider = Provider.objects.get(uuid=self.ocp_test_provider_uuid)
+        self.assertIsNone(ocp_provider.authentication)
+        # Assert if authentication is empty we return none instead of an error
+        cluster_id = utils.get_cluster_id_from_provider(self.ocp_test_provider_uuid)
+        self.assertIsNone(cluster_id)
 
     def test_get_cluster_id_from_non_ocp_provider(self):
         """Test that None is returned when getting cluster ID on non-OCP provider."""

--- a/koku/masu/util/ocp/common.py
+++ b/koku/masu/util/ocp/common.py
@@ -198,7 +198,9 @@ def get_cluster_id_from_provider(provider_uuid):
         return cluster_id
 
     with ProviderDBAccessor(provider_uuid=provider_uuid) as provider_accessor:
-        cluster_id = provider_accessor.get_credentials().get("cluster_id")
+        credentials = provider_accessor.get_credentials()
+        if credentials:
+            cluster_id = credentials.get("cluster_id")
 
     return cluster_id
 


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/COST-1341

The error we were seeing:
```
  File "/opt/app-root/src/koku/masu/util/ocp/common.py", line 213, in get_cluster_id_from_provider
    cluster_id = provider_accessor.get_credentials().get("cluster_id")
  File "/opt/app-root/src/koku/masu/database/provider_db_accessor.py", line 134, in get_credentials
    return self.provider.authentication.credentials
AttributeError: 'NoneType' object has no attribute 'credentials'
```

I added some conditionals, then wrote up a unittest that forces a none  in the authentication to confirm.