### PR TITLE
Trino aws bugfix empty tags

### DIFF
--- a/koku/masu/test/util/aws/test_common.py
+++ b/koku/masu/test/util/aws/test_common.py
@@ -384,6 +384,22 @@ class TestAWSUtils(MasuTestCase):
         for column in PRESTO_REQUIRED_COLUMNS:
             self.assertIn(column.replace("-", "_").replace("/", "_").replace(":", "_").lower(), columns)
 
+    def test_aws_post_processor_empty_tags(self):
+        """Test that missing columns in a report end up in the data frame."""
+        column_one = "column_one"
+        column_two = "column_two"
+        column_three = "column-three"
+        column_four = "resourceTags/System:key"
+        data = {column_one: [1, 2], column_two: [3, 4], column_three: [5, 6], column_four: ["value_1", "value_2"]}
+        data_frame = pd.DataFrame.from_dict(data)
+
+        processed_data_frame = utils.aws_post_processor(data_frame)
+        if isinstance(processed_data_frame, tuple):
+            processed_data_frame, df_tag_keys = processed_data_frame
+            self.assertIsInstance(df_tag_keys, set)
+
+        self.assertFalse(processed_data_frame["resourcetags"].isna().values.any())
+
 
 class AwsArnTest(TestCase):
     """AwnArn class test case."""

--- a/koku/masu/util/aws/common.py
+++ b/koku/masu/util/aws/common.py
@@ -369,6 +369,7 @@ def aws_post_processor(data_frame):
     resource_tags_dict = tag_df.apply(
         lambda row: {scrub_resource_col_name(column): value for column, value in row.items() if value}, axis=1
     )
+    resource_tags_dict.where(resource_tags_dict.notna(), lambda _: [{}], inplace=True)
 
     data_frame["resourceTags"] = resource_tags_dict.apply(json.dumps)
     # Make sure we have entries for our required columns


### PR DESCRIPTION
## Summary
Our trino SQL fails for AWS when no user defined tags are sent through the cost and usage report. This changes a `NaN` value to an empty dict for the empty tags and allows us to fully process and summarize.