### PR TITLE
Trino bugfix gcp labels

### DIFF
--- a/koku/masu/database/presto_sql/reporting_ocpusagelineitem_daily_summary.sql
+++ b/koku/masu/database/presto_sql/reporting_ocpusagelineitem_daily_summary.sql
@@ -230,19 +230,25 @@ SELECT uuid() as uuid,
     sua.storageclass,
     cast(sua.volume_labels as json) as volume_labels,
     (sua.persistentvolumeclaim_capacity_bytes *
-          power(2, -30)) as persistentvolumeclaim_capacity_gigabyte,
+        power(2, -30)) as persistentvolumeclaim_capacity_gigabyte,
     (sua.persistentvolumeclaim_capacity_byte_seconds /
-          (86400 *
-          cast(extract(day from last_day_of_month(date(sua.usage_start))) as integer) *
-          power(2, -30))) as persistentvolumeclaim_capacity_gigabyte_months,
+        (
+            86400 *
+            cast(extract(day from last_day_of_month(date(sua.usage_start))) as integer)
+        ) *
+        power(2, -30)) as persistentvolumeclaim_capacity_gigabyte_months,
     (sua.volume_request_storage_byte_seconds /
-          (86400 *
-          cast(extract(day from last_day_of_month(date(sua.usage_start))) as integer) *
-          power(2, -30))) as volume_request_storage_gigabyte_months,
+        (
+            86400 *
+            cast(extract(day from last_day_of_month(date(sua.usage_start))) as integer)
+        ) *
+        power(2, -30)) as volume_request_storage_gigabyte_months,
     (sua.persistentvolumeclaim_usage_byte_seconds /
-          (86400 *
-          cast(extract(day from last_day_of_month(date(sua.usage_start))) as integer) *
-          power(2, -30))) as persistentvolumeclaim_usage_gigabyte_months,
+        (
+            86400 *
+            cast(extract(day from last_day_of_month(date(sua.usage_start))) as integer)
+        ) *
+        power(2, -30)) as persistentvolumeclaim_usage_gigabyte_months,
     cast(sua.source_uuid as UUID) as source_uuid,
     JSON '{"cpu": 0.000000000, "memory": 0.000000000, "storage": 0.000000000}' as infrastructure_usage_cost
 FROM (

--- a/koku/masu/test/util/gcp/test_common.py
+++ b/koku/masu/test/util/gcp/test_common.py
@@ -132,15 +132,22 @@ class TestGCPUtils(MasuTestCase):
 
     def test_post_processor(self):
         """Test that data frame post processing succeeds."""
-        data = {"column.one": [1, 2, 3], "column.two": [4, 5, 6], "three": [7, 8, 9]}
-        expected_columns = ["column_one", "column_two", "three"]
+        data = {
+            "column.one": [1, 2, 3],
+            "column.two": [4, 5, 6],
+            "three": [7, 8, 9],
+            "labels": ['{"label_one": "value_one"}', '{"label_one": "value_two"}', '{"label_two": "value_three"}'],
+        }
+        expected_columns = ["column_one", "column_two", "labels", "three"]
 
         df = pd.DataFrame(data)
 
+        expected_tags = {"label_one", "label_two"}
         result_df = utils.gcp_post_processor(df)
-        if isinstance(result_df, tuple):
-            result_df, df_tag_keys = result_df
-            self.assertIsInstance(df_tag_keys, set)
+        self.assertIsInstance(result_df, tuple)
+        result_df, df_tag_keys = result_df
+        self.assertIsInstance(df_tag_keys, set)
+        self.assertEqual(df_tag_keys, expected_tags)
 
         result_columns = list(result_df)
         self.assertEqual(sorted(result_columns), sorted(expected_columns))

--- a/koku/masu/util/gcp/common.py
+++ b/koku/masu/util/gcp/common.py
@@ -107,7 +107,13 @@ def gcp_post_processor(data_frame):
         new_col_name = strip_characters_from_column_name(column)
         column_name_map[column] = new_col_name
     data_frame = data_frame.rename(columns=column_name_map)
-    return data_frame
+
+    label_set = set()
+    unique_labels = data_frame.labels.unique()
+    for label in unique_labels:
+        label_set.update(json.loads(label).keys())
+
+    return (data_frame, label_set)
 
 
 def get_column_converters():


### PR DESCRIPTION
## Summary
* Fix parens in OCP storage SQL
* Add entries for GCP enabled tags

## Testing
* OCP processing via Trino will succeed now.
* GCP will have enabled tag entries now.