### PR TITLE
sources: fix applications/authentications queries

### DIFF
--- a/koku/sources/kafka_message_processor.py
+++ b/koku/sources/kafka_message_processor.py
@@ -164,7 +164,7 @@ class KafkaMessageProcessor:
         sources_network = self.get_sources_client()
 
         try:
-            data_source = {"data_source": sources_network.get_data_source(source_type)}
+            data_source = {"data_source": sources_network.get_data_source(source_type, self.cost_mgmt_id)}
         except SourcesHTTPClientError as error:
             LOG.info(f"[save_billing_source] billing info not available for source_id: {self.source_id}")
             sources_network.set_source_status(error)

--- a/koku/sources/kafka_message_processor.py
+++ b/koku/sources/kafka_message_processor.py
@@ -136,7 +136,7 @@ class KafkaMessageProcessor:
         sources_network = self.get_sources_client()
 
         try:
-            authentication = {"credentials": sources_network.get_credentials(source_type)}
+            authentication = {"credentials": sources_network.get_credentials(source_type, self.cost_mgmt_id)}
         except SourcesHTTPClientError as error:
             LOG.info(f"[save_credentials] authentication info not available for source_id: {self.source_id}")
             sources_network.set_source_status(error)

--- a/koku/sources/sources_http_client.py
+++ b/koku/sources/sources_http_client.py
@@ -157,22 +157,22 @@ class SourcesHTTPClient:
             )
         return {k: app_settings.get(k) for k in required_extras}
 
-    def get_credentials(self, source_type):
+    def get_credentials(self, source_type, app_type_id):
         """Get the source credentials."""
         if source_type not in self.credential_map.keys():
             msg = f"[get_credentials] unexpected source type: {source_type}"
             LOG.error(msg)
             raise SourcesHTTPClientError(msg)
-        return self.credential_map.get(source_type)()
+        return self.credential_map.get(source_type)(app_type_id)
 
-    def _get_ocp_credentials(self):
+    def _get_ocp_credentials(self, _):
         """Get the OCP cluster_id from the source."""
         source_details = self.get_source_details()
         if source_details.get("source_ref"):
             return {"cluster_id": source_details.get("source_ref")}
         raise SourcesHTTPClientError("Unable to find Cluster ID")
 
-    def _get_aws_credentials(self):
+    def _get_aws_credentials(self, _):
         """Get the roleARN from Sources Authentication service."""
         auth_type = AUTH_TYPES.get(Provider.PROVIDER_AWS)
         authentications_url = (
@@ -200,7 +200,7 @@ class SourcesHTTPClient:
 
         raise SourcesHTTPClientError(f"Unable to get AWS roleARN for Source: {self._source_id}")
 
-    def _get_gcp_credentials(self):
+    def _get_gcp_credentials(self, _):
         """Get the GCP credentials from Sources Authentication service."""
         auth_type = AUTH_TYPES.get(Provider.PROVIDER_GCP)
         authentications_url = (
@@ -216,10 +216,10 @@ class SourcesHTTPClient:
 
         raise SourcesHTTPClientError(f"Unable to get GCP credentials for Source: {self._source_id}")
 
-    def _get_azure_credentials(self):
+    def _get_azure_credentials(self, app_type_id):
         """Get the Azure Credentials from Sources Authentication service."""
         # get subscription_id from applications extra
-        url = f"{self._base_url}/{ENDPOINT_APPLICATIONS}?source_id={self._source_id}"
+        url = f"{self._base_url}/{ENDPOINT_APPLICATIONS}?source_id={self._source_id}&application_type_id={app_type_id}"
         app_response = self._get_network_response(url, "Unable to get Azure credentials")
         app_data = (app_response.get("data") or [None])[0]
         if not app_data:

--- a/koku/sources/sources_http_client.py
+++ b/koku/sources/sources_http_client.py
@@ -166,7 +166,7 @@ class SourcesHTTPClient:
 
     def _get_aws_credentials(self):
         """Get the roleARN from Sources Authentication service."""
-        authentications_url = f"{self._base_url}/{ENDPOINT_AUTHENTICATIONS}?source_id={self._source_id}"
+        authentications_url = f"{self._base_url}/{ENDPOINT_AUTHENTICATIONS}?source_id={self._source_id}&authtype=arn"
         auth_response = self._get_network_response(authentications_url, "Unable to get AWS RoleARN")
         auth_data = (auth_response.get("data") or [None])[0]
         if not auth_data:

--- a/koku/sources/sources_http_client.py
+++ b/koku/sources/sources_http_client.py
@@ -135,13 +135,15 @@ class SourcesHTTPClient:
             raise SourcesHTTPClientError("source type name not found")
         return source_types_data.get("name")
 
-    def get_data_source(self, source_type):
+    def get_data_source(self, source_type, app_type_id):
         """Get the data_source settings from Sources."""
         if source_type not in APP_EXTRA_FIELD_MAP.keys():
             msg = f"[get_data_source] Unexpected source type: {source_type}"
             LOG.error(msg)
             raise SourcesHTTPClientError(msg)
-        application_url = f"{self._base_url}/{ENDPOINT_APPLICATIONS}?source_id={self._source_id}"
+        application_url = (
+            f"{self._base_url}/{ENDPOINT_APPLICATIONS}?source_id={self._source_id}&application_type_id={app_type_id}"
+        )
         applications_response = self._get_network_response(application_url, "Unable to get application settings")
         applications_data = (applications_response.get("data") or [None])[0]
         if not applications_data:

--- a/koku/sources/sources_http_client.py
+++ b/koku/sources/sources_http_client.py
@@ -30,6 +30,12 @@ APP_EXTRA_FIELD_MAP = {
     Provider.PROVIDER_GCP: ["dataset"],
     Provider.PROVIDER_GCP_LOCAL: ["dataset"],
 }
+AUTH_TYPES = {
+    Provider.PROVIDER_OCP: "token",
+    Provider.PROVIDER_AWS: "arn",
+    Provider.PROVIDER_AZURE: "tenant_id_client_id_client_secret",
+    Provider.PROVIDER_GCP: "project_id_service_account_json",
+}
 ENDPOINT_APPLICATIONS = "applications"
 ENDPOINT_APPLICATION_TYPES = "application_types"
 ENDPOINT_AUTHENTICATIONS = "authentications"
@@ -166,7 +172,10 @@ class SourcesHTTPClient:
 
     def _get_aws_credentials(self):
         """Get the roleARN from Sources Authentication service."""
-        authentications_url = f"{self._base_url}/{ENDPOINT_AUTHENTICATIONS}?source_id={self._source_id}&authtype=arn"
+        auth_type = AUTH_TYPES.get(Provider.PROVIDER_AWS)
+        authentications_url = (
+            f"{self._base_url}/{ENDPOINT_AUTHENTICATIONS}?source_id={self._source_id}&authtype={auth_type}"
+        )
         auth_response = self._get_network_response(authentications_url, "Unable to get AWS RoleARN")
         auth_data = (auth_response.get("data") or [None])[0]
         if not auth_data:
@@ -191,7 +200,10 @@ class SourcesHTTPClient:
 
     def _get_gcp_credentials(self):
         """Get the GCP credentials from Sources Authentication service."""
-        authentications_url = f"{self._base_url}/{ENDPOINT_AUTHENTICATIONS}?source_id={self._source_id}"
+        auth_type = AUTH_TYPES.get(Provider.PROVIDER_GCP)
+        authentications_url = (
+            f"{self._base_url}/{ENDPOINT_AUTHENTICATIONS}?source_id={self._source_id}&authtype={auth_type}"
+        )
         auth_response = self._get_network_response(authentications_url, "Unable to get GCP credentials")
         auth_data = (auth_response.get("data") or [None])[0]
         if not auth_data:
@@ -213,7 +225,10 @@ class SourcesHTTPClient:
         subscription_id = app_data.get("extra", {}).get("subscription_id")
 
         # get client and tenant ids
-        authentications_url = f"{self._base_url}/{ENDPOINT_AUTHENTICATIONS}?source_id={self._source_id}"
+        auth_type = AUTH_TYPES.get(Provider.PROVIDER_AZURE)
+        authentications_url = (
+            f"{self._base_url}/{ENDPOINT_AUTHENTICATIONS}?source_id={self._source_id}&authtype={auth_type}"
+        )
         auth_response = self._get_network_response(authentications_url, "Unable to get Azure credentials")
         auth_data = (auth_response.get("data") or [None])[0]
         if not auth_data:

--- a/koku/sources/test/test_kafka_message_processor.py
+++ b/koku/sources/test/test_kafka_message_processor.py
@@ -311,7 +311,7 @@ class KafkaMessageProcessorTest(IamTestCase):
     def test_save_billing_source(self):
         """Test save billing source calls add_provider_sources_billing_info."""
 
-        def side_effect_func(arg):
+        def side_effect_func(arg, _):
             """Helper func to mock client.get_data_source call."""
             values = {  # add new sources here
                 Provider.PROVIDER_AWS: self.valid_billing.get(Provider.PROVIDER_AWS),

--- a/koku/sources/test/test_sources_http_client.py
+++ b/koku/sources/test/test_sources_http_client.py
@@ -266,7 +266,7 @@ class SourcesHTTPClientTest(TestCase):
             m.get(
                 f"{MOCK_URL}/api/v1.0/{ENDPOINT_SOURCES}/{self.source_id}", status_code=200, json={"source_ref": uuid}
             )
-            creds = client._get_ocp_credentials()
+            creds = client._get_ocp_credentials(COST_MGMT_APP_TYPE_ID)
             self.assertEqual(creds.get("cluster_id"), uuid)
 
     def test__get_ocp_credentials_missing_cluster_id(self):
@@ -277,7 +277,7 @@ class SourcesHTTPClientTest(TestCase):
                 f"{MOCK_URL}/api/v1.0/{ENDPOINT_SOURCES}/{self.source_id}", status_code=200, json={"source_ref": None}
             )
             with self.assertRaises(SourcesHTTPClientError):
-                client._get_ocp_credentials()
+                client._get_ocp_credentials(COST_MGMT_APP_TYPE_ID)
 
     def test_get_aws_credentials_username(self):
         """Test to get AWS Role ARN from authentication service from username."""
@@ -290,7 +290,7 @@ class SourcesHTTPClientTest(TestCase):
                 status_code=200,
                 json={"data": [{"id": resource_id, "username": self.authentication}]},
             )
-            creds = client._get_aws_credentials()
+            creds = client._get_aws_credentials(COST_MGMT_APP_TYPE_ID)
             self.assertEqual(creds.get("role_arn"), self.authentication)
 
     def test_get_aws_credentials_internal_endpoint(self):
@@ -319,7 +319,7 @@ class SourcesHTTPClientTest(TestCase):
         with requests_mock.mock() as m:
             for resp in responses:
                 m.get(resp.get("url"), status_code=resp.get("status"), json=resp.get("json"))
-            response = client._get_aws_credentials()
+            response = client._get_aws_credentials(COST_MGMT_APP_TYPE_ID)
             self.assertEqual(response.get("role_arn"), self.authentication)
 
     def test_get_aws_credentials_errors(self):
@@ -337,7 +337,7 @@ class SourcesHTTPClientTest(TestCase):
                         json={"data": test},
                     )
                     with self.assertRaises(SourcesHTTPClientError):
-                        client._get_aws_credentials()
+                        client._get_aws_credentials(COST_MGMT_APP_TYPE_ID)
 
             resource_id = 2
             m.get(
@@ -354,7 +354,7 @@ class SourcesHTTPClientTest(TestCase):
                 json={"authtype": "arn"},
             )
             with self.assertRaises(SourcesHTTPClientError):
-                client._get_aws_credentials()
+                client._get_aws_credentials(COST_MGMT_APP_TYPE_ID)
 
     def test_get_gcp_credentials_username(self):
         """Test to get project id from authentication service from username."""
@@ -367,7 +367,7 @@ class SourcesHTTPClientTest(TestCase):
                 status_code=200,
                 json={"data": [{"id": resource_id, "username": self.authentication}]},
             )
-            creds = client._get_gcp_credentials()
+            creds = client._get_gcp_credentials(COST_MGMT_APP_TYPE_ID)
             self.assertEqual(creds.get("project_id"), self.authentication)
 
     def test_get_gcp_credentials_errors(self):
@@ -385,7 +385,7 @@ class SourcesHTTPClientTest(TestCase):
                         json={"data": test},
                     )
                     with self.assertRaises(SourcesHTTPClientError):
-                        client._get_gcp_credentials()
+                        client._get_gcp_credentials(COST_MGMT_APP_TYPE_ID)
 
     def test_get_azure_credentials(self):
         """Test to get Azure credentials from authentication service."""
@@ -431,7 +431,7 @@ class SourcesHTTPClientTest(TestCase):
                 status_code=200,
                 json={"password": authentication},
             )
-            response = client._get_azure_credentials()
+            response = client._get_azure_credentials(COST_MGMT_APP_TYPE_ID)
             self.assertDictEqual(
                 response,
                 {
@@ -540,10 +540,10 @@ class SourcesHTTPClientTest(TestCase):
                         json=internal.get("json"),
                     )
                     if all([app.get("valid"), auth.get("valid"), internal.get("valid")]):
-                        self.assertIsNotNone(client._get_azure_credentials())
+                        self.assertIsNotNone(client._get_azure_credentials(COST_MGMT_APP_TYPE_ID))
                     else:
                         with self.assertRaises(SourcesHTTPClientError):
-                            client._get_azure_credentials()
+                            client._get_azure_credentials(COST_MGMT_APP_TYPE_ID)
 
     def test_build_status_header(self):
         """Test build status header success and failure."""

--- a/koku/sources/test/test_sources_http_client.py
+++ b/koku/sources/test/test_sources_http_client.py
@@ -211,7 +211,8 @@ class SourcesHTTPClientTest(TestCase):
             with self.subTest(test=test):
                 with requests_mock.mock() as m:
                     m.get(
-                        f"{MOCK_URL}/api/v1.0/{ENDPOINT_APPLICATIONS}?source_id={self.source_id}",
+                        f"{MOCK_URL}/api/v1.0/{ENDPOINT_APPLICATIONS}?"
+                        f"source_id={self.source_id}&application_type_id={COST_MGMT_APP_TYPE_ID}",
                         status_code=200,
                         json={"data": [test.get("json")]},
                     )
@@ -227,7 +228,8 @@ class SourcesHTTPClientTest(TestCase):
             with self.subTest(test=(source_type, json)):
                 with requests_mock.mock() as m:
                     m.get(
-                        f"{MOCK_URL}/api/v1.0/{ENDPOINT_APPLICATIONS}?source_id={self.source_id}",
+                        f"{MOCK_URL}/api/v1.0/{ENDPOINT_APPLICATIONS}?"
+                        f"source_id={self.source_id}&application_type_id={COST_MGMT_APP_TYPE_ID}",
                         status_code=200,
                         json={"data": json},
                     )
@@ -243,7 +245,8 @@ class SourcesHTTPClientTest(TestCase):
             with self.subTest(test=(source_type, json)):
                 with requests_mock.mock() as m:
                     m.get(
-                        f"{MOCK_URL}/api/v1.0/{ENDPOINT_APPLICATIONS}?source_id={self.source_id}",
+                        f"{MOCK_URL}/api/v1.0/{ENDPOINT_APPLICATIONS}?"
+                        f"source_id={self.source_id}&application_type_id={COST_MGMT_APP_TYPE_ID}",
                         status_code=200,
                         json={"data": json},
                     )
@@ -410,7 +413,8 @@ class SourcesHTTPClientTest(TestCase):
         client = SourcesHTTPClient(auth_header=Config.SOURCES_FAKE_HEADER, source_id=self.source_id)
         with requests_mock.mock() as m:
             m.get(
-                f"{MOCK_URL}/api/v1.0/{ENDPOINT_APPLICATIONS}?source_id={self.source_id}",
+                f"{MOCK_URL}/api/v1.0/{ENDPOINT_APPLICATIONS}?"
+                f"source_id={self.source_id}&application_type_id={COST_MGMT_APP_TYPE_ID}",
                 status_code=200,
                 json={"data": [applications_reponse]},
             )
@@ -516,7 +520,8 @@ class SourcesHTTPClientTest(TestCase):
             with self.subTest(test=(app, auth, internal)):
                 with requests_mock.mock() as m:
                     m.get(
-                        f"{MOCK_URL}/api/v1.0/{ENDPOINT_APPLICATIONS}?source_id={self.source_id}",
+                        f"{MOCK_URL}/api/v1.0/{ENDPOINT_APPLICATIONS}?"
+                        f"source_id={self.source_id}&application_type_id={COST_MGMT_APP_TYPE_ID}",
                         status_code=200,
                         json={"data": [app.get("json")]},
                     )

--- a/koku/sources/test/test_sources_http_client.py
+++ b/koku/sources/test/test_sources_http_client.py
@@ -216,7 +216,7 @@ class SourcesHTTPClientTest(TestCase):
                         status_code=200,
                         json={"data": [test.get("json")]},
                     )
-                    response = client.get_data_source(test.get("source-type"))
+                    response = client.get_data_source(test.get("source-type"), COST_MGMT_APP_TYPE_ID)
                     self.assertDictEqual(response, test.get("expected"))
 
     def test_get_data_source_errors(self):
@@ -234,7 +234,7 @@ class SourcesHTTPClientTest(TestCase):
                         json={"data": json},
                     )
                     with self.assertRaises(SourcesHTTPClientError):
-                        client.get_data_source(source_type)
+                        client.get_data_source(source_type, COST_MGMT_APP_TYPE_ID)
 
     def test_get_data_source_errors_invalid_extras(self):
         """Test to get application settings errors. Check last SourcesHTTPClientError in get_data_source"""
@@ -251,10 +251,10 @@ class SourcesHTTPClientTest(TestCase):
                         json={"data": json},
                     )
                     if source_type == Provider.PROVIDER_OCP:  # ocp should always return empty dict
-                        self.assertDictEqual(client.get_data_source(source_type), {})
+                        self.assertDictEqual(client.get_data_source(source_type, COST_MGMT_APP_TYPE_ID), {})
                     else:
                         with self.assertRaises(SourcesHTTPClientError):
-                            client.get_data_source(source_type)
+                            client.get_data_source(source_type, COST_MGMT_APP_TYPE_ID)
 
     # maybe insert get_credentials tests. maybe mock the specific get_creds call and assert they were called
 

--- a/koku/sources/test/test_sources_http_client.py
+++ b/koku/sources/test/test_sources_http_client.py
@@ -281,7 +281,7 @@ class SourcesHTTPClientTest(TestCase):
         with requests_mock.mock() as m:
             resource_id = 2
             m.get(
-                f"{MOCK_URL}/api/v1.0/{ENDPOINT_AUTHENTICATIONS}?source_id={self.source_id}",
+                f"{MOCK_URL}/api/v1.0/{ENDPOINT_AUTHENTICATIONS}?source_id={self.source_id}&authtype=arn",
                 status_code=200,
                 json={"data": [{"id": resource_id, "username": self.authentication}]},
             )

--- a/koku/sources/test/test_sources_http_client.py
+++ b/koku/sources/test/test_sources_http_client.py
@@ -20,6 +20,7 @@ from api.provider.models import Sources
 from sources.config import Config
 from sources.kafka_listener import storage_callback
 from sources.sources_http_client import APP_EXTRA_FIELD_MAP
+from sources.sources_http_client import AUTH_TYPES
 from sources.sources_http_client import ENDPOINT_APPLICATION_TYPES
 from sources.sources_http_client import ENDPOINT_APPLICATIONS
 from sources.sources_http_client import ENDPOINT_AUTHENTICATIONS
@@ -277,11 +278,12 @@ class SourcesHTTPClientTest(TestCase):
 
     def test_get_aws_credentials_username(self):
         """Test to get AWS Role ARN from authentication service from username."""
+        auth_type = AUTH_TYPES.get(Provider.PROVIDER_AWS)
         client = SourcesHTTPClient(auth_header=Config.SOURCES_FAKE_HEADER, source_id=self.source_id)
         with requests_mock.mock() as m:
             resource_id = 2
             m.get(
-                f"{MOCK_URL}/api/v1.0/{ENDPOINT_AUTHENTICATIONS}?source_id={self.source_id}&authtype=arn",
+                f"{MOCK_URL}/api/v1.0/{ENDPOINT_AUTHENTICATIONS}?source_id={self.source_id}&authtype={auth_type}",
                 status_code=200,
                 json={"data": [{"id": resource_id, "username": self.authentication}]},
             )
@@ -290,11 +292,15 @@ class SourcesHTTPClientTest(TestCase):
 
     def test_get_aws_credentials_internal_endpoint(self):
         """Test to get AWS Role ARN from authentication service from internal endpoint."""
+        auth_type = AUTH_TYPES.get(Provider.PROVIDER_AWS)
         client = SourcesHTTPClient(auth_header=Config.SOURCES_FAKE_HEADER, source_id=self.source_id)
         resource_id = 2
         responses = [
             {
-                "url": f"{MOCK_URL}/api/v1.0/{ENDPOINT_AUTHENTICATIONS}?source_id={self.source_id}",
+                "url": (
+                    f"{MOCK_URL}/api/v1.0/{ENDPOINT_AUTHENTICATIONS}?"
+                    f"source_id={self.source_id}&authtype={auth_type}"
+                ),
                 "status": 200,
                 "json": {"data": [{"id": resource_id}]},
             },
@@ -315,13 +321,15 @@ class SourcesHTTPClientTest(TestCase):
 
     def test_get_aws_credentials_errors(self):
         """Test to get AWS Role ARN exceptions."""
+        auth_type = AUTH_TYPES.get(Provider.PROVIDER_AWS)
         client = SourcesHTTPClient(auth_header=Config.SOURCES_FAKE_HEADER, source_id=self.source_id)
         with requests_mock.mock() as m:
             json_data = [None, []]
             for test in json_data:
                 with self.subTest(test=test):
                     m.get(
-                        f"{MOCK_URL}/api/v1.0/{ENDPOINT_AUTHENTICATIONS}?source_id={self.source_id}",
+                        f"{MOCK_URL}/api/v1.0/{ENDPOINT_AUTHENTICATIONS}?"
+                        f"source_id={self.source_id}&authtype={auth_type}",
                         status_code=200,
                         json={"data": test},
                     )
@@ -330,7 +338,7 @@ class SourcesHTTPClientTest(TestCase):
 
             resource_id = 2
             m.get(
-                f"{MOCK_URL}/api/v1.0/{ENDPOINT_AUTHENTICATIONS}?source_id={self.source_id}",
+                f"{MOCK_URL}/api/v1.0/{ENDPOINT_AUTHENTICATIONS}?source_id={self.source_id}&authtype={auth_type}",
                 status_code=200,
                 json={"data": [{"id": resource_id}]},
             )
@@ -347,11 +355,12 @@ class SourcesHTTPClientTest(TestCase):
 
     def test_get_gcp_credentials_username(self):
         """Test to get project id from authentication service from username."""
+        auth_type = AUTH_TYPES.get(Provider.PROVIDER_GCP)
         client = SourcesHTTPClient(auth_header=Config.SOURCES_FAKE_HEADER, source_id=self.source_id)
         with requests_mock.mock() as m:
             resource_id = 2
             m.get(
-                f"{MOCK_URL}/api/v1.0/{ENDPOINT_AUTHENTICATIONS}?source_id={self.source_id}",
+                f"{MOCK_URL}/api/v1.0/{ENDPOINT_AUTHENTICATIONS}?source_id={self.source_id}&authtype={auth_type}",
                 status_code=200,
                 json={"data": [{"id": resource_id, "username": self.authentication}]},
             )
@@ -360,13 +369,15 @@ class SourcesHTTPClientTest(TestCase):
 
     def test_get_gcp_credentials_errors(self):
         """Test to get project id exceptions."""
+        auth_type = AUTH_TYPES.get(Provider.PROVIDER_GCP)
         client = SourcesHTTPClient(auth_header=Config.SOURCES_FAKE_HEADER, source_id=self.source_id)
         with requests_mock.mock() as m:
             json_data = [None, [], [{"no-username": "empty"}]]
             for test in json_data:
                 with self.subTest(test=test):
                     m.get(
-                        f"{MOCK_URL}/api/v1.0/{ENDPOINT_AUTHENTICATIONS}?source_id={self.source_id}",
+                        f"{MOCK_URL}/api/v1.0/{ENDPOINT_AUTHENTICATIONS}?"
+                        f"source_id={self.source_id}&authtype={auth_type}",
                         status_code=200,
                         json={"data": test},
                     )
@@ -395,6 +406,7 @@ class SourcesHTTPClientTest(TestCase):
             "extra": {"azure": {"tenant_id": tenent_id}},
         }
 
+        auth_type = AUTH_TYPES.get(Provider.PROVIDER_AZURE)
         client = SourcesHTTPClient(auth_header=Config.SOURCES_FAKE_HEADER, source_id=self.source_id)
         with requests_mock.mock() as m:
             m.get(
@@ -403,7 +415,7 @@ class SourcesHTTPClientTest(TestCase):
                 json={"data": [applications_reponse]},
             )
             m.get(
-                f"{MOCK_URL}/api/v1.0/{ENDPOINT_AUTHENTICATIONS}?source_id={self.source_id}",
+                f"{MOCK_URL}/api/v1.0/{ENDPOINT_AUTHENTICATIONS}?source_id={self.source_id}&authtype={auth_type}",
                 status_code=200,
                 json={"data": [authentications_response]},
             )
@@ -496,6 +508,7 @@ class SourcesHTTPClientTest(TestCase):
             {"valid": True, "json": {"password": authentication}},
         ]
 
+        auth_type = AUTH_TYPES.get(Provider.PROVIDER_AZURE)
         client = SourcesHTTPClient(auth_header=Config.SOURCES_FAKE_HEADER, source_id=self.source_id)
         for app, auth, internal in product(
             applications_reponse_table, authentications_response_table, internal_response_table
@@ -508,7 +521,8 @@ class SourcesHTTPClientTest(TestCase):
                         json={"data": [app.get("json")]},
                     )
                     m.get(
-                        f"{MOCK_URL}/api/v1.0/{ENDPOINT_AUTHENTICATIONS}?source_id={self.source_id}",
+                        f"{MOCK_URL}/api/v1.0/{ENDPOINT_AUTHENTICATIONS}?"
+                        f"source_id={self.source_id}&authtype={auth_type}",
                         status_code=200,
                         json={"data": [auth.get("json")]},
                     )


### PR DESCRIPTION
The applications and authentication queries need to be more specific because more than 1 app/auth can be associated with 1 source.  
- adds an `auth_type` filter to the authentication query.
- adds an `app-type-id` filter to the applications query.