### PR TITLE
[COST-1623]Gcp Services is returning the wrong value

### DIFF
--- a/koku/api/resource_types/gcp_services/view.py
+++ b/koku/api/resource_types/gcp_services/view.py
@@ -19,7 +19,7 @@ class GCPServiceView(generics.ListAPIView):
     """API GET list view for GCP Services by ID."""
 
     queryset = (
-        GCPCostSummaryByService.objects.annotate(**{"value": F("service_id")})
+        GCPCostSummaryByService.objects.annotate(**{"value": F("service_alias")})
         .values("value")
         .distinct()
         .filter(service_id__isnull=False)


### PR DESCRIPTION
GCP-Services endpoint was returning account id, this has been changed to account alias to better help the customer understand what service is being displayed.

Testing steps 
1. Load test data
2.  Go to /resource-types/gcp-services/ and check to see if the data is returning aliases EX "Compute Engine" or " Cloud storage"
