### PR TITLE
clowdapp: remove duplicate sentry env variables

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -1890,14 +1890,6 @@ parameters:
   displayName: Source Types to be processed with Trino
   name: ENABLE_TRINO_SOURCE_TYPE
   value: ""
-- description: Enable API Sentry
-  displayName: Enable API Sentry
-  name: ENABLE_API_SENTRY
-  value: "false"
-- description: Enable Celery Sentry
-  displayName: Enable Celery Sentry
-  name: ENABLE_CELERY_SENTRY
-  value: "false"
 - description: Scheduler check interval
   displayName: Scheduler check interval
   name: SCHEDULE_CHECK_INTERVAL

--- a/deploy/kustomize/base/base.yaml
+++ b/deploy/kustomize/base/base.yaml
@@ -190,15 +190,6 @@ parameters:
   name: ENABLE_TRINO_SOURCE_TYPE
   value: ""
 
-- description: Enable API Sentry
-  displayName: Enable API Sentry
-  name: ENABLE_API_SENTRY
-  value: "false"
-- description: Enable Celery Sentry
-  displayName: Enable Celery Sentry
-  name: ENABLE_CELERY_SENTRY
-  value: "false"
-
 - description: Scheduler check interval
   displayName: Scheduler check interval
   name: SCHEDULE_CHECK_INTERVAL


### PR DESCRIPTION
`ENABLE_API_SENTRY` and `ENABLE_CELERY_SENTRY` were duplicated in the `parameters`. This PR removes the duplicates.