### PR TITLE
[COST-1568-Update] Aws Accounts endpoint now returns Account id if Account alias is null.

### DIFF
--- a/koku/api/resource_types/aws_accounts/view.py
+++ b/koku/api/resource_types/aws_accounts/view.py
@@ -4,6 +4,7 @@
 #
 """View for AWS accounts."""
 from django.db.models import F
+from django.db.models.functions import Coalesce
 from django.utils.decorators import method_decorator
 from django.views.decorators.vary import vary_on_headers
 from rest_framework import filters
@@ -20,7 +21,12 @@ class AWSAccountView(generics.ListAPIView):
 
     queryset = (
         AWSCostSummaryByAccount.objects.annotate(
-            **{"value": F("usage_account_id"), "alias": F("account_alias__account_alias")}
+            **(
+                {
+                    "value": F("usage_account_id"),
+                    "alias": Coalesce(F("account_alias__account_alias"), "usage_account_id"),
+                }
+            )
         )
         .values("value", "alias")
         .distinct()


### PR DESCRIPTION
Aws Account resource type endpoint can return null values for account_alias, this now changes the value to the account id instead if the account alias is null.

Steps to reproduce
1. load test customers data
2. Go to /resource-types/aws-accounts/  if any data was generated with a null in the account_alias, this should now display the account id EX account_alias = 9999999 account_id = 9999999 instead of account_alias = null account_id = 9999999.
