### PR TITLE
[COST 1651]Add cluster alias support to resource-types/openshift-clusters API

### DIFF
--- a/koku/api/resource_types/openshift_clusters/view.py
+++ b/koku/api/resource_types/openshift_clusters/view.py
@@ -4,6 +4,7 @@
 #
 """View for Openshift clusters."""
 from django.db.models import F
+from django.db.models.functions.comparison import Coalesce
 from django.utils.decorators import method_decorator
 from django.views.decorators.vary import vary_on_headers
 from rest_framework import filters
@@ -18,12 +19,18 @@ from reporting.provider.ocp.models import OCPCostSummary
 class OCPClustersView(generics.ListAPIView):
     """API GET list view for Openshift clusters."""
 
-    queryset = OCPCostSummary.objects.annotate(**{"value": F("cluster_id")}).values("value").distinct()
+    queryset = (
+        OCPCostSummary.objects.annotate(
+            **{"value": F("cluster_id"), "ocp_cluster_alias": Coalesce(F("cluster_alias"), "cluster_id")}
+        )
+        .values("value", "ocp_cluster_alias")
+        .distinct()
+    )
     serializer_class = ResourceTypeSerializer
     permission_classes = [ResourceTypeAccessPermission]
     filter_backends = [filters.OrderingFilter, filters.SearchFilter]
-    ordering = ["value"]
-    search_fields = ["$value"]
+    ordering = ["value", "ocp_cluster_alias"]
+    search_fields = ["$value", "$ocp_cluster_alias"]
 
     @method_decorator(vary_on_headers(CACHE_RH_IDENTITY_HEADER))
     def list(self, request):

--- a/koku/api/resource_types/serializers.py
+++ b/koku/api/resource_types/serializers.py
@@ -9,5 +9,6 @@ from rest_framework import serializers
 class ResourceTypeSerializer(serializers.Serializer):
     """Serializer for resource-specific resource-type APIs."""
 
+    cluster_alias = serializers.CharField(source="ocp_cluster_alias", required=False)
     account_alias = serializers.CharField(source="alias", required=False)
     value = serializers.CharField()


### PR DESCRIPTION
This allows the users to search for OCP clusters Aliases and be able to see them being displayed on the endpoint.

Testing steps
1. Create and load test customer data
2. Go resource-types/openshift-clusters/ and confirm that both the cluster alias and cluster ID are visable.
3. Confirm search, adding ?search=AWS will return values with AWS in the name of the account alias, please confirm that this works.
