### PR TITLE
Add the create_table flag via the listener

### DIFF
--- a/koku/masu/external/kafka_msg_handler.py
+++ b/koku/masu/external/kafka_msg_handler.py
@@ -545,6 +545,7 @@ def process_report(request_id, report):
         "request_id": request_id,
         "provider_type": "OCP",
         "start_date": date,
+        "create_table": True,
     }
     try:
         return _process_report_file(schema_name, provider_type, report_dict)


### PR DESCRIPTION
## Summary
In real envs where OpenShift is processed through the listener, the create_table flag was no being set, so we skip critical parts of OpenShift parquet processing.