### PR TITLE
COST-1450: Monthly rate to project cost distribution.

### DIFF
--- a/koku/api/report/ocp/provider_map.py
+++ b/koku/api/report/ocp/provider_map.py
@@ -622,15 +622,15 @@ class OCPProviderMap(ProviderMap):
                             ),
                             "sup_distributed": Sum(
                                 Coalesce(
-                                    KeyDecimalTransform("cpu", "supplementary_monthly_cost_json"),
+                                    KeyDecimalTransform("cpu", "supplementary_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(
-                                    KeyDecimalTransform("memory", "supplementary_monthly_cost_json"),
+                                    KeyDecimalTransform("memory", "supplementary_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(
-                                    KeyDecimalTransform("pvc", "supplementary_monthly_cost_json"),
+                                    KeyDecimalTransform("pvc", "supplementary_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                             ),
@@ -649,15 +649,15 @@ class OCPProviderMap(ProviderMap):
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(
-                                    KeyDecimalTransform("cpu", "supplementary_monthly_cost_json"),
+                                    KeyDecimalTransform("cpu", "supplementary_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(
-                                    KeyDecimalTransform("memory", "supplementary_monthly_cost_json"),
+                                    KeyDecimalTransform("memory", "supplementary_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(
-                                    KeyDecimalTransform("pvc", "supplementary_monthly_cost_json"),
+                                    KeyDecimalTransform("pvc", "supplementary_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(F("supplementary_monthly_cost"), Value(0, output_field=DecimalField()))
@@ -682,15 +682,15 @@ class OCPProviderMap(ProviderMap):
                             ),
                             "infra_distributed": Sum(
                                 Coalesce(
-                                    KeyDecimalTransform("cpu", "infrastructure_monthly_cost_json"),
+                                    KeyDecimalTransform("cpu", "infrastructure_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(
-                                    KeyDecimalTransform("memory", "infrastructure_monthly_cost_json"),
+                                    KeyDecimalTransform("memory", "infrastructure_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(
-                                    KeyDecimalTransform("pvc", "infrastructure_monthly_cost_json"),
+                                    KeyDecimalTransform("pvc", "infrastructure_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                             ),
@@ -717,15 +717,15 @@ class OCPProviderMap(ProviderMap):
                                     F("infrastructure_project_markup_cost"), Value(0, output_field=DecimalField())
                                 )
                                 + Coalesce(
-                                    KeyDecimalTransform("cpu", "infrastructure_monthly_cost_json"),
+                                    KeyDecimalTransform("cpu", "infrastructure_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(
-                                    KeyDecimalTransform("memory", "infrastructure_monthly_cost_json"),
+                                    KeyDecimalTransform("memory", "infrastructure_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(
-                                    KeyDecimalTransform("pvc", "infrastructure_monthly_cost_json"),
+                                    KeyDecimalTransform("pvc", "infrastructure_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(F("infrastructure_monthly_cost"), Value(0, output_field=DecimalField()))
@@ -765,27 +765,27 @@ class OCPProviderMap(ProviderMap):
                             ),
                             "cost_distributed": Sum(
                                 Coalesce(
-                                    KeyDecimalTransform("cpu", "supplementary_monthly_cost_json"),
+                                    KeyDecimalTransform("cpu", "supplementary_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(
-                                    KeyDecimalTransform("memory", "supplementary_monthly_cost_json"),
+                                    KeyDecimalTransform("memory", "supplementary_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(
-                                    KeyDecimalTransform("cpu", "infrastructure_monthly_cost_json"),
+                                    KeyDecimalTransform("cpu", "infrastructure_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(
-                                    KeyDecimalTransform("memory", "infrastructure_monthly_cost_json"),
+                                    KeyDecimalTransform("memory", "infrastructure_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(
-                                    KeyDecimalTransform("pvc", "supplementary_monthly_cost_json"),
+                                    KeyDecimalTransform("pvc", "supplementary_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(
-                                    KeyDecimalTransform("pvc", "infrastructure_monthly_cost_json"),
+                                    KeyDecimalTransform("pvc", "infrastructure_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                             ),
@@ -824,27 +824,27 @@ class OCPProviderMap(ProviderMap):
                                     F("infrastructure_project_markup_cost"), Value(0, output_field=DecimalField())
                                 )
                                 + Coalesce(
-                                    KeyDecimalTransform("cpu", "supplementary_monthly_cost_json"),
+                                    KeyDecimalTransform("cpu", "supplementary_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(
-                                    KeyDecimalTransform("memory", "supplementary_monthly_cost_json"),
+                                    KeyDecimalTransform("memory", "supplementary_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(
-                                    KeyDecimalTransform("cpu", "infrastructure_monthly_cost_json"),
+                                    KeyDecimalTransform("cpu", "infrastructure_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(
-                                    KeyDecimalTransform("memory", "infrastructure_monthly_cost_json"),
+                                    KeyDecimalTransform("memory", "infrastructure_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(
-                                    KeyDecimalTransform("pvc", "supplementary_monthly_cost_json"),
+                                    KeyDecimalTransform("pvc", "supplementary_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(
-                                    KeyDecimalTransform("pvc", "infrastructure_monthly_cost_json"),
+                                    KeyDecimalTransform("pvc", "infrastructure_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(F("supplementary_monthly_cost"), Value(0, output_field=DecimalField()))
@@ -871,15 +871,15 @@ class OCPProviderMap(ProviderMap):
                             ),
                             "sup_distributed": Sum(
                                 Coalesce(
-                                    KeyDecimalTransform("cpu", "supplementary_monthly_cost_json"),
+                                    KeyDecimalTransform("cpu", "supplementary_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(
-                                    KeyDecimalTransform("memory", "supplementary_monthly_cost_json"),
+                                    KeyDecimalTransform("memory", "supplementary_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(
-                                    KeyDecimalTransform("pvc", "supplementary_monthly_cost_json"),
+                                    KeyDecimalTransform("pvc", "supplementary_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                             ),
@@ -898,15 +898,15 @@ class OCPProviderMap(ProviderMap):
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(
-                                    KeyDecimalTransform("cpu", "supplementary_monthly_cost_json"),
+                                    KeyDecimalTransform("cpu", "supplementary_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(
-                                    KeyDecimalTransform("memory", "supplementary_monthly_cost_json"),
+                                    KeyDecimalTransform("memory", "supplementary_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(
-                                    KeyDecimalTransform("pvc", "supplementary_monthly_cost_json"),
+                                    KeyDecimalTransform("pvc", "supplementary_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(F("supplementary_monthly_cost"), Value(0, output_field=DecimalField()))
@@ -931,15 +931,15 @@ class OCPProviderMap(ProviderMap):
                             ),
                             "infra_distributed": Sum(
                                 Coalesce(
-                                    KeyDecimalTransform("cpu", "infrastructure_monthly_cost_json"),
+                                    KeyDecimalTransform("cpu", "infrastructure_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(
-                                    KeyDecimalTransform("memory", "infrastructure_monthly_cost_json"),
+                                    KeyDecimalTransform("memory", "infrastructure_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(
-                                    KeyDecimalTransform("pvc", "infrastructure_monthly_cost_json"),
+                                    KeyDecimalTransform("pvc", "infrastructure_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                             ),
@@ -963,15 +963,15 @@ class OCPProviderMap(ProviderMap):
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(
-                                    KeyDecimalTransform("cpu", "infrastructure_monthly_cost_json"),
+                                    KeyDecimalTransform("cpu", "infrastructure_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(
-                                    KeyDecimalTransform("memory", "infrastructure_monthly_cost_json"),
+                                    KeyDecimalTransform("memory", "infrastructure_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(
-                                    KeyDecimalTransform("pvc", "infrastructure_monthly_cost_json"),
+                                    KeyDecimalTransform("pvc", "infrastructure_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(
@@ -1014,27 +1014,27 @@ class OCPProviderMap(ProviderMap):
                             ),
                             "cost_distributed": Sum(
                                 Coalesce(
-                                    KeyDecimalTransform("cpu", "supplementary_monthly_cost_json"),
+                                    KeyDecimalTransform("cpu", "supplementary_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(
-                                    KeyDecimalTransform("memory", "supplementary_monthly_cost_json"),
+                                    KeyDecimalTransform("memory", "supplementary_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(
-                                    KeyDecimalTransform("cpu", "infrastructure_monthly_cost_json"),
+                                    KeyDecimalTransform("cpu", "infrastructure_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(
-                                    KeyDecimalTransform("memory", "infrastructure_monthly_cost_json"),
+                                    KeyDecimalTransform("memory", "infrastructure_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(
-                                    KeyDecimalTransform("pvc", "supplementary_monthly_cost_json"),
+                                    KeyDecimalTransform("pvc", "supplementary_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(
-                                    KeyDecimalTransform("pvc", "infrastructure_monthly_cost_json"),
+                                    KeyDecimalTransform("pvc", "infrastructure_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                             ),
@@ -1073,27 +1073,27 @@ class OCPProviderMap(ProviderMap):
                                     F("infrastructure_project_markup_cost"), Value(0, output_field=DecimalField())
                                 )
                                 + Coalesce(
-                                    KeyDecimalTransform("cpu", "supplementary_monthly_cost_json"),
+                                    KeyDecimalTransform("cpu", "supplementary_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(
-                                    KeyDecimalTransform("memory", "supplementary_monthly_cost_json"),
+                                    KeyDecimalTransform("memory", "supplementary_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(
-                                    KeyDecimalTransform("cpu", "infrastructure_monthly_cost_json"),
+                                    KeyDecimalTransform("cpu", "infrastructure_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(
-                                    KeyDecimalTransform("memory", "infrastructure_monthly_cost_json"),
+                                    KeyDecimalTransform("memory", "infrastructure_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(
-                                    KeyDecimalTransform("pvc", "supplementary_monthly_cost_json"),
+                                    KeyDecimalTransform("pvc", "supplementary_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(
-                                    KeyDecimalTransform("pvc", "infrastructure_monthly_cost_json"),
+                                    KeyDecimalTransform("pvc", "infrastructure_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(F("supplementary_monthly_cost"), Value(0, output_field=DecimalField()))
@@ -1138,27 +1138,27 @@ class OCPProviderMap(ProviderMap):
                                     F("infrastructure_project_markup_cost"), Value(0, output_field=DecimalField())
                                 )
                                 + Coalesce(
-                                    KeyDecimalTransform("cpu", "supplementary_monthly_cost_json"),
+                                    KeyDecimalTransform("cpu", "supplementary_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(
-                                    KeyDecimalTransform("memory", "supplementary_monthly_cost_json"),
+                                    KeyDecimalTransform("memory", "supplementary_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(
-                                    KeyDecimalTransform("cpu", "infrastructure_monthly_cost_json"),
+                                    KeyDecimalTransform("cpu", "infrastructure_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(
-                                    KeyDecimalTransform("memory", "infrastructure_monthly_cost_json"),
+                                    KeyDecimalTransform("memory", "infrastructure_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(
-                                    KeyDecimalTransform("pvc", "supplementary_monthly_cost_json"),
+                                    KeyDecimalTransform("pvc", "supplementary_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(
-                                    KeyDecimalTransform("pvc", "infrastructure_monthly_cost_json"),
+                                    KeyDecimalTransform("pvc", "infrastructure_project_monthly_cost"),
                                     Value(0, output_field=DecimalField()),
                                 )
                                 + Coalesce(F("supplementary_monthly_cost"), Value(0, output_field=DecimalField()))

--- a/koku/api/report/ocp/query_handler.py
+++ b/koku/api/report/ocp/query_handler.py
@@ -59,7 +59,6 @@ class OCPReportQueryHandler(ReportQueryHandler):
         }
         ocp_pack_definitions = copy.deepcopy(self._mapper.PACK_DEFINITIONS)
         ocp_pack_definitions["cost_groups"]["keys"] = ocp_pack_keys
-        self._mapper.PACK_DEFINITIONS = ocp_pack_definitions
 
         # super() needs to be called after _mapper and _limit is set
         super().__init__(parameters)
@@ -69,6 +68,7 @@ class OCPReportQueryHandler(ReportQueryHandler):
         if is_grouped_by_project(parameters) and parameters.report_type == "costs":
             self._report_type = parameters.report_type + "_by_project"
             self._mapper = OCPProviderMap(provider=self.provider, report_type=self._report_type)
+        self._mapper.PACK_DEFINITIONS = ocp_pack_definitions
 
     @property
     def annotations(self):

--- a/koku/masu/database/ocp_report_db_accessor.py
+++ b/koku/masu/database/ocp_report_db_accessor.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 """Database accessor for OCP report data."""
+import copy
 import datetime
 import json
 import logging
@@ -946,12 +947,57 @@ class OCPReportDBAccessor(ReportDBAccessorBase):
                     first_curr_month, first_next_month, cluster_id, cluster_alias, rate_type, rate_dict
                 )
 
+    def get_node_to_project_distribution(self, start_date, end_date, cluster_id, node_cost):
+        """Returns a list of dictionaries containing the distributed cost.
+
+        args:
+            start_date (datetime, str): The start_date to calculate monthly_cost.
+            end_date (datetime, str): The end_date to calculate monthly_cost.
+            cluster_id (str): The id of the cluster
+            cluster_cost (dec): The flat cost of the cluster
+
+        Node to Project Distribution:
+            - Node to project distribution is based on a per node scenario
+            - (node_cost) / (number of projects)
+
+        Return nested dictionaries:
+        - ex {'master_3': {'namespaces': ['openshift', 'kube-system'], 'distributed_cost': Decimal('500.0000000000')}
+
+        """
+        with schema_context(self.schema):
+            # TODO: cody, there may be a more effienct way to get the desired mapping from the django orm.
+            distributed_project_list = (
+                OCPUsageLineItemDailySummary.objects.filter(
+                    usage_start__gte=start_date, usage_start__lt=end_date, cluster_id=cluster_id
+                )
+                .filter(namespace__isnull=False)
+                .filter(node__isnull=False)
+                .values("namespace", "node")
+                .distinct()
+            )
+            node_mappings = {}
+            for project in distributed_project_list:
+                node_value = project.get("node")
+                namespace_value = project.get("namespace")
+                node_map = node_mappings.get(node_value)
+                if node_map:
+                    namespaces = copy.deepcopy(node_map.get("namespaces", []))
+                    namespaces.append(namespace_value)
+                    node_map["namespaces"] = namespaces
+                    node_map["distributed_cost"] = Decimal(node_cost) / Decimal(len(namespaces))
+                    node_mappings[node_value] = node_map
+                else:
+                    initial_map = {"namespaces": [namespace_value], "distributed_cost": Decimal(node_cost)}
+                    node_mappings[node_value] = initial_map
+        return node_mappings
+
     def upsert_monthly_node_cost_line_item(
         self, start_date, end_date, cluster_id, cluster_alias, rate_type, node_cost, distribution
     ):
         """Update or insert daily summary line item for node cost."""
         unique_nodes = self.get_distinct_nodes(start_date, end_date, cluster_id)
         report_period = self.get_usage_period_by_dates_and_cluster(start_date, end_date, cluster_id)
+        project_distrib_map = self.get_node_to_project_distribution(start_date, end_date, cluster_id, node_cost)
         with schema_context(self.schema):
             for node in unique_nodes:
                 line_item = OCPUsageLineItemDailySummary.objects.filter(
@@ -963,6 +1009,7 @@ class OCPReportDBAccessor(ReportDBAccessorBase):
                     monthly_cost_type="Node",
                     node=node,
                     data_source="Pod",
+                    namespace__isnull=True,
                 ).first()
                 if not line_item:
                     line_item = OCPUsageLineItemDailySummary(
@@ -984,6 +1031,46 @@ class OCPReportDBAccessor(ReportDBAccessorBase):
                     LOG.info("Node (%s) has a monthly supplemenarty cost of %s.", node, node_cost)
                     line_item.supplementary_monthly_cost_json = monthly_cost
                 line_item.save()
+            # How are we gonna handle distributing the node cost to the projects.
+            project_nodes = project_distrib_map.keys()
+            for project_node in project_nodes:
+                for namespace in project_distrib_map[project_node]["namespaces"]:
+                    distributed_cost = project_distrib_map[project_node]["distributed_cost"]
+                    project_line_item = OCPUsageLineItemDailySummary.objects.filter(
+                        usage_start=start_date,
+                        usage_end=start_date,
+                        report_period=report_period,
+                        cluster_id=cluster_id,
+                        cluster_alias=cluster_alias,
+                        monthly_cost_type="Node",
+                        node=project_node,
+                        namespace=namespace,
+                    ).first()
+                    if not project_line_item:
+                        project_line_item = OCPUsageLineItemDailySummary(
+                            uuid=uuid.uuid4(),
+                            usage_start=start_date,
+                            usage_end=start_date,
+                            report_period=report_period,
+                            cluster_id=cluster_id,
+                            cluster_alias=cluster_alias,
+                            monthly_cost_type="Node",
+                            node=project_node,
+                            namespace=namespace,
+                        )
+                    monthly_cost = self.generate_monthly_cost_json_object(distribution, distributed_cost)
+                    log_statement = (
+                        f"Distributing Node Cost to Project:\n"
+                        f" node ({project_node}) cost: {node_cost} \n"
+                        f" project ({namespace}) distributed cost: {distributed_cost}\n"
+                        f" distribution type: {distribution}\n"
+                    )
+                    if rate_type == metric_constants.INFRASTRUCTURE_COST_TYPE:
+                        project_line_item.infrastructure_project_monthly_cost = monthly_cost
+                    elif rate_type == metric_constants.SUPPLEMENTARY_COST_TYPE:
+                        project_line_item.supplementary_project_monthly_cost = monthly_cost
+                    project_line_item.save()
+                    LOG.info(log_statement)
 
     def tag_upsert_monthly_node_cost_line_item(  # noqa: C901
         self, start_date, end_date, cluster_id, cluster_alias, rate_type, rate_dict, distribution
@@ -1260,6 +1347,44 @@ class OCPReportDBAccessor(ReportDBAccessorBase):
         # node_to_cluster_ratio=Sum(node_column)/Sum(cluster_column)
         return distributed_node_list
 
+    def get_cluster_to_project_distribution(self, start_date, end_date, cluster_id, distribution, cluster_cost):
+        """Returns a list of dictionaries containing the distributed cost.
+
+        args:
+            start_date (datetime, str): The start_date to calculate monthly_cost.
+            end_date (datetime, str): The end_date to calculate monthly_cost.
+            cluster_id (str): The id of the cluster
+            cluster_cost (dec): The flat cost of the cluster
+            distribution: Choice of monthly distribution ex. (memory or cpu)
+
+        Project Distribution:
+            - Project distribution is a rolling window estimate of month to date.
+            - (project_usage / cluster_usage) x cluster_cost
+
+        Return list of dictionaries:
+        - ex [{'namespace': 'openshift', 'distributed_cost': Decimal('71.84')}
+
+        """
+        usage_column = "pod_usage_cpu_core_hours"
+        if "memory" in distribution:
+            usage_column = "pod_usage_memory_gigabyte_hours"
+
+        with schema_context(self.schema):
+            cluster_hours = (
+                OCPUsageLineItemDailySummary.objects.filter(
+                    usage_start__gte=start_date, usage_start__lt=end_date, cluster_id=cluster_id
+                ).aggregate(cluster_hours=Sum(usage_column))
+            ).get("cluster_hours")
+            distributed_project_list = (
+                OCPUsageLineItemDailySummary.objects.filter(
+                    usage_start__gte=start_date, usage_start__lt=end_date, cluster_id=cluster_id
+                )
+                .filter(namespace__isnull=False)
+                .values("namespace")
+                .annotate(distributed_cost=Sum(usage_column) / cluster_hours * cluster_cost)
+            )
+        return distributed_project_list
+
     def upsert_monthly_cluster_cost_line_item(
         self, start_date, end_date, cluster_id, cluster_alias, rate_type, cluster_cost, distribution
     ):
@@ -1288,7 +1413,7 @@ class OCPReportDBAccessor(ReportDBAccessorBase):
                 LOG.info("Distributing the cluster cost to nodes using %s distribution.", distribution)
                 for node_dikt in distribution_list:
                     node = node_dikt.get("node")
-                    distributed_cost = node_dikt.get("distributed_cost")
+                    distributed_cost = node_dikt.get("distributed_cost", Decimal(0))
                     line_item = OCPUsageLineItemDailySummary.objects.filter(
                         usage_start=start_date,
                         usage_end=start_date,
@@ -1298,6 +1423,7 @@ class OCPReportDBAccessor(ReportDBAccessorBase):
                         monthly_cost_type="Cluster",
                         node=node,
                         data_source="Pod",
+                        namespace__isnull=True,
                     ).first()
                     if not line_item:
                         line_item = OCPUsageLineItemDailySummary(
@@ -1324,6 +1450,51 @@ class OCPReportDBAccessor(ReportDBAccessorBase):
                         line_item.supplementary_monthly_cost_json = monthly_cost
                     LOG.info(log_statement)
                     line_item.save()
+            # Project Distribution
+            project_distribution_list = self.get_cluster_to_project_distribution(
+                start_date, end_date, cluster_id, distribution, cluster_cost
+            )
+            with schema_context(self.schema):
+                for project_dikt in project_distribution_list:
+                    namespace = project_dikt.get("namespace")
+                    distributed_cost = project_dikt.get("distributed_cost", Decimal(0))
+                    # I need to do a first, than an if not here.
+                    project_line_item = OCPUsageLineItemDailySummary.objects.filter(
+                        uuid=uuid.uuid4(),
+                        usage_start=start_date,
+                        usage_end=start_date,
+                        report_period=report_period,
+                        cluster_id=cluster_id,
+                        cluster_alias=cluster_alias,
+                        monthly_cost_type="Cluster",
+                        namespace=namespace,
+                        data_source="Pod",
+                    ).first()
+                    if not project_line_item:
+                        project_line_item = OCPUsageLineItemDailySummary(
+                            uuid=uuid.uuid4(),
+                            usage_start=start_date,
+                            usage_end=start_date,
+                            report_period=report_period,
+                            cluster_id=cluster_id,
+                            cluster_alias=cluster_alias,
+                            monthly_cost_type="Cluster",
+                            namespace=namespace,
+                            data_source="Pod",
+                        )
+                    monthly_cost = self.generate_monthly_cost_json_object(distribution, distributed_cost)
+                    log_statement = (
+                        f"Distributing Cluster Cost to Project:\n"
+                        f" cluster ({cluster_id}) cost: {cluster_cost} \n"
+                        f" project ({namespace}) distributed cost: {distributed_cost}\n"
+                        f" distribution type: {distribution}\n"
+                    )
+                    if rate_type == metric_constants.INFRASTRUCTURE_COST_TYPE:
+                        project_line_item.infrastructure_project_monthly_cost = monthly_cost
+                    elif rate_type == metric_constants.SUPPLEMENTARY_COST_TYPE:
+                        project_line_item.supplementary_project_monthly_cost = monthly_cost
+                    project_line_item.save()
+                    LOG.info(log_statement)
 
     def tag_upsert_monthly_pvc_cost_line_item(  # noqa: C901
         self, start_date, end_date, cluster_id, cluster_alias, rate_type, rate_dict
@@ -1419,6 +1590,8 @@ class OCPReportDBAccessor(ReportDBAccessorBase):
                     node=node,
                     data_source="Storage",
                     namespace=namespace,
+                    infrastructure_project_monthly_cost__isnull=True,
+                    supplementary_project_monthly_cost__isnull=True,
                 ).first()
                 if not line_item:
                     line_item = OCPUsageLineItemDailySummary(
@@ -1442,6 +1615,43 @@ class OCPReportDBAccessor(ReportDBAccessorBase):
                     LOG.info("PVC (%s) has a monthly supplemenarty cost of %s.", pvc, pvc_cost)
                     line_item.supplementary_monthly_cost_json = monthly_cost
                 line_item.save()
+                # PVC to project Distribution
+                project_line_item = OCPUsageLineItemDailySummary.objects.filter(
+                    usage_start=start_date,
+                    usage_end=start_date,
+                    report_period=report_period,
+                    cluster_id=cluster_id,
+                    cluster_alias=cluster_alias,
+                    monthly_cost_type="PVC",
+                    persistentvolumeclaim=pvc,
+                    node=node,
+                    namespace=namespace,
+                    data_source="Storage",
+                    infrastructure_monthly_cost__isnull=True,
+                    supplementary_monthly_cost__isnull=True,
+                ).first()
+                if not project_line_item:
+                    project_line_item = OCPUsageLineItemDailySummary(
+                        uuid=uuid.uuid4(),
+                        usage_start=start_date,
+                        usage_end=start_date,
+                        report_period=report_period,
+                        cluster_id=cluster_id,
+                        cluster_alias=cluster_alias,
+                        monthly_cost_type="PVC",
+                        persistentvolumeclaim=pvc,
+                        node=node,
+                        namespace=namespace,
+                        data_source="Storage",
+                    )
+                monthly_cost = self.generate_monthly_cost_json_object(metric_constants.PVC_DISTRIBUTION, pvc_cost)
+                if rate_type == metric_constants.INFRASTRUCTURE_COST_TYPE:
+                    LOG.info("PVC (%s) has a monthly project infrastructure cost of %s.", pvc, pvc_cost)
+                    project_line_item.infrastructure_project_monthly_cost = monthly_cost
+                elif rate_type == metric_constants.SUPPLEMENTARY_COST_TYPE:
+                    LOG.info("PVC (%s) has a monthly project supplemenarty cost of %s.", pvc, pvc_cost)
+                    project_line_item.supplementary_project_monthly_cost = monthly_cost
+                project_line_item.save()
 
     def tag_upsert_monthly_cluster_cost_line_item(  # noqa: C901
         self, start_date, end_date, cluster_id, cluster_alias, rate_type, rate_dict, distribution
@@ -1613,6 +1823,7 @@ class OCPReportDBAccessor(ReportDBAccessorBase):
             cost_filters = [
                 f"{rate_type.lower()}_monthly_cost__isnull",
                 f"{rate_type.lower()}_monthly_cost_json__isnull",
+                f"{rate_type.lower()}_project_monthly_cost__isnull",
             ]
             for cost_filter in cost_filters:
                 filters.update({cost_filter: False})

--- a/koku/masu/database/ocp_report_db_accessor.py
+++ b/koku/masu/database/ocp_report_db_accessor.py
@@ -1044,6 +1044,7 @@ class OCPReportDBAccessor(ReportDBAccessorBase):
                         monthly_cost_type="Node",
                         node=project_node,
                         namespace=namespace,
+                        data_source="Pod",
                     ).first()
                     if not project_line_item:
                         project_line_item = OCPUsageLineItemDailySummary(
@@ -1056,6 +1057,7 @@ class OCPReportDBAccessor(ReportDBAccessorBase):
                             monthly_cost_type="Node",
                             node=project_node,
                             namespace=namespace,
+                            data_source="Pod",
                         )
                     monthly_cost = self.generate_monthly_cost_json_object(distribution, distributed_cost)
                     log_statement = (

--- a/koku/masu/database/ocp_report_db_accessor.py
+++ b/koku/masu/database/ocp_report_db_accessor.py
@@ -965,7 +965,6 @@ class OCPReportDBAccessor(ReportDBAccessorBase):
 
         """
         with schema_context(self.schema):
-            # TODO: cody, there may be a more effienct way to get the desired mapping from the django orm.
             distributed_project_list = (
                 OCPUsageLineItemDailySummary.objects.filter(
                     usage_start__gte=start_date, usage_start__lt=end_date, cluster_id=cluster_id

--- a/koku/masu/database/ocp_report_db_accessor.py
+++ b/koku/masu/database/ocp_report_db_accessor.py
@@ -1458,9 +1458,7 @@ class OCPReportDBAccessor(ReportDBAccessorBase):
                 for project_dikt in project_distribution_list:
                     namespace = project_dikt.get("namespace")
                     distributed_cost = project_dikt.get("distributed_cost", Decimal(0))
-                    # I need to do a first, than an if not here.
                     project_line_item = OCPUsageLineItemDailySummary.objects.filter(
-                        uuid=uuid.uuid4(),
                         usage_start=start_date,
                         usage_end=start_date,
                         report_period=report_period,

--- a/koku/masu/database/ocp_report_db_accessor.py
+++ b/koku/masu/database/ocp_report_db_accessor.py
@@ -1626,8 +1626,8 @@ class OCPReportDBAccessor(ReportDBAccessorBase):
                     node=node,
                     namespace=namespace,
                     data_source="Storage",
-                    infrastructure_monthly_cost__isnull=True,
-                    supplementary_monthly_cost__isnull=True,
+                    infrastructure_monthly_cost_json__isnull=True,
+                    supplementary_monthly_cost_json__isnull=True,
                 ).first()
                 if not project_line_item:
                     project_line_item = OCPUsageLineItemDailySummary(

--- a/koku/masu/test/database/test_ocp_report_db_accessor.py
+++ b/koku/masu/test/database/test_ocp_report_db_accessor.py
@@ -696,7 +696,6 @@ class OCPReportDBAccessorTest(MasuTestCase):
             reports = self.accessor.get_reports()
             self.assertEquals(len(reports), OCPUsageReport.objects.count())
 
-    # TODO: Fix
     def test_populate_monthly_cost_node_infrastructure_cost(self):
         """Test that the monthly infrastructure cost row for nodes in the summary table is populated."""
         distribution_choices = [metric_constants.CPU_DISTRIBUTION, metric_constants.MEMORY_DISTRIBUTION]
@@ -768,7 +767,6 @@ class OCPReportDBAccessorTest(MasuTestCase):
                         )
                     self.assertEquals(sum(monthly_project_cost), expected_project_value)
 
-    # FIX:
     def test_populate_monthly_cost_node_supplementary_cost(self):
         """Test that the monthly supplementary cost row for nodes in the summary table is populated."""
         distribution_choices = [metric_constants.CPU_DISTRIBUTION, metric_constants.MEMORY_DISTRIBUTION]
@@ -1095,7 +1093,6 @@ class OCPReportDBAccessorTest(MasuTestCase):
                 self.assertEquals(pvc_project_cost, pvc_rate)
             self.assertEquals(sum(project_total), expected_project_total)
 
-    # TODO: cody, update
     def test_remove_monthly_cost(self):
         """Test that the monthly cost row in the summary table is removed."""
         distribution_choices = [metric_constants.CPU_DISTRIBUTION, metric_constants.MEMORY_DISTRIBUTION]

--- a/koku/masu/test/database/test_ocp_report_db_accessor.py
+++ b/koku/masu/test/database/test_ocp_report_db_accessor.py
@@ -724,10 +724,18 @@ class OCPReportDBAccessorTest(MasuTestCase):
                     .filter(usage_start=first_month, infrastructure_monthly_cost_json__isnull=False)
                     .all()
                 )
+                monthly_project_cost_rows = (
+                    self.accessor._get_db_obj_query(OCPUsageLineItemDailySummary)
+                    .filter(usage_start=first_month, infrastructure_project_monthly_cost__isnull=False)
+                    .all()
+                )
                 with schema_context(self.schema):
+                    # Test infrastructure monthly node distrbution
                     expected_count = (
                         OCPUsageLineItemDailySummary.objects.filter(
-                            report_period__provider_id=self.ocp_provider.uuid, usage_start__gte=start_date
+                            report_period__provider_id=self.ocp_provider.uuid,
+                            usage_start__gte=start_date,
+                            infrastructure_monthly_cost__isnull=False,
                         )
                         .values("node")
                         .distinct()
@@ -739,6 +747,24 @@ class OCPReportDBAccessorTest(MasuTestCase):
                             monthly_cost_row.infrastructure_monthly_cost_json.get(distribution), node_rate
                         )
 
+                    # Test infrastructure node to project distribution
+                    expected_project_value = expected_count * node_rate
+                    expected_project_count = (
+                        OCPUsageLineItemDailySummary.objects.filter(
+                            report_period__provider_id=self.ocp_provider.uuid,
+                            usage_start__gte=start_date,
+                            infrastructure_project_monthly_cost__isnull=False,
+                        )
+                        .values("node", "namespace")
+                        .distinct()
+                        .count()
+                    )
+                    self.assertEquals(monthly_project_cost_rows.count(), expected_project_count)
+                    monthly_project_cost = []
+                    for monthly_cost_row in monthly_cost_rows:
+                        monthly_project_cost.append(monthly_cost_row.infrastructure_monthly_cost.get(distribution))
+                    self.assertEquals(sum(monthly_project_cost), expected_project_value)
+
     def test_populate_monthly_cost_node_supplementary_cost(self):
         """Test that the monthly supplementary cost row for nodes in the summary table is populated."""
         distribution_choices = [metric_constants.CPU_DISTRIBUTION, metric_constants.MEMORY_DISTRIBUTION]
@@ -747,6 +773,7 @@ class OCPReportDBAccessorTest(MasuTestCase):
         end_date = dh.this_month_end
         first_month, _ = month_date_range_tuple(start_date)
         cluster_alias = "test_cluster_alias"
+
         for distribution in distribution_choices:
             with self.subTest(distribution=distribution):
                 self.cluster_id = self.ocp_provider.authentication.credentials.get("cluster_id")
@@ -766,10 +793,18 @@ class OCPReportDBAccessorTest(MasuTestCase):
                     .filter(usage_start=first_month, supplementary_monthly_cost_json__isnull=False)
                     .all()
                 )
+                monthly_project_cost_rows = (
+                    self.accessor._get_db_obj_query(OCPUsageLineItemDailySummary)
+                    .filter(usage_start=first_month, supplementary_project_monthly_cost__isnull=False)
+                    .all()
+                )
                 with schema_context(self.schema):
+                    # Test supplementary monthly node distrbution
                     expected_count = (
                         OCPUsageLineItemDailySummary.objects.filter(
-                            report_period__provider_id=self.ocp_provider.uuid, usage_start__gte=start_date
+                            report_period__provider_id=self.ocp_provider.uuid,
+                            usage_start__gte=start_date,
+                            supplementary_monthly_cost__isnull=False,
                         )
                         .values("node")
                         .distinct()
@@ -780,6 +815,24 @@ class OCPReportDBAccessorTest(MasuTestCase):
                         self.assertEquals(
                             monthly_cost_row.supplementary_monthly_cost_json.get(distribution), node_rate
                         )
+
+                    # Test supplementary node to project distribution
+                    expected_project_value = expected_count * node_rate
+                    expected_project_count = (
+                        OCPUsageLineItemDailySummary.objects.filter(
+                            report_period__provider_id=self.ocp_provider.uuid,
+                            usage_start__gte=start_date,
+                            supplementary_project_monthly_cost__isnull=False,
+                        )
+                        .values("node", "namespace")
+                        .distinct()
+                        .count()
+                    )
+                    self.assertEquals(monthly_project_cost_rows.count(), expected_project_count)
+                    monthly_project_cost = []
+                    for monthly_cost_row in monthly_cost_rows:
+                        monthly_project_cost.append(monthly_cost_row.supplementary_monthly_cost.get(distribution))
+                    self.assertEquals(sum(monthly_project_cost), expected_project_value)
 
     def test_populate_monthly_cost_cluster_infrastructure_cost(self):
         """Test that the monthly infrastructure cost row for clusters in the summary table is populated."""
@@ -809,13 +862,29 @@ class OCPReportDBAccessorTest(MasuTestCase):
                     .filter(usage_start=first_month, infrastructure_monthly_cost_json__isnull=False)
                     .all()
                 )
+
+                project_monthly_cost_rows = (
+                    self.accessor._get_db_obj_query(OCPUsageLineItemDailySummary)
+                    .filter(usage_start=first_month, infrastructure_project_monthly_cost__isnull=False)
+                    .all()
+                )
+
                 with schema_context(self.schema):
+                    # Test cluster to node distribution
                     sum_row_list = []
                     for monthly_cost_row in monthly_cost_rows:
                         sum_row_list.append(monthly_cost_row.infrastructure_monthly_cost_json.get(distribution))
                     #  handle small possible imprecision due to division
                     # eg. 56.99999999999999 != 57
                     self.assertTrue((cluster_rate - sum(sum_row_list)) < 0.001)
+
+                    # Test cluster to project distribution
+                    project_sum_list = []
+                    for p_monthly_cost_row in project_monthly_cost_rows:
+                        project_sum_list.append(
+                            p_monthly_cost_row.infrastructure_project_monthly_cost.get(distribution)
+                        )
+                    self.assertTrue((cluster_rate - sum(project_sum_list)) < 0.001)
 
     def test_populate_monthly_cost_cluster_supplementary_cost(self):
         """Test that the monthly infrastructure cost row for clusters in the summary table is populated."""
@@ -840,16 +909,32 @@ class OCPReportDBAccessorTest(MasuTestCase):
                     cluster_alias,
                     distribution,
                 )
+
                 monthly_cost_rows = (
                     self.accessor._get_db_obj_query(OCPUsageLineItemDailySummary)
                     .filter(usage_start=first_month, supplementary_monthly_cost_json__isnull=False)
                     .all()
                 )
+
+                project_monthly_cost_rows = (
+                    self.accessor._get_db_obj_query(OCPUsageLineItemDailySummary)
+                    .filter(usage_start=first_month, supplementary_project_monthly_cost__isnull=False)
+                    .all()
+                )
                 with schema_context(self.schema):
+                    # Test cluster to node distribution
                     sum_row_list = []
                     for monthly_cost_row in monthly_cost_rows:
                         sum_row_list.append(monthly_cost_row.supplementary_monthly_cost_json.get(distribution))
                     self.assertTrue((cluster_rate - sum(sum_row_list)) < 0.001)
+
+                    # Test cluster to project distribution
+                    project_sum_list = []
+                    for p_monthly_cost_row in project_monthly_cost_rows:
+                        project_sum_list.append(
+                            p_monthly_cost_row.supplementary_project_monthly_cost.get(distribution)
+                        )
+                    self.assertTrue((cluster_rate - sum(project_sum_list)) < 0.001)
 
     def test_populate_monthly_cost_pvc_infrastructure_cost(self):
         """Test that the monthly infrastructure cost row for PVC in the summary table is populated."""
@@ -880,7 +965,15 @@ class OCPReportDBAccessorTest(MasuTestCase):
             .filter(usage_start=first_month, infrastructure_monthly_cost_json__isnull=False)
             .all()
         )
+
+        project_monthly_cost_rows = (
+            self.accessor._get_db_obj_query(OCPUsageLineItemDailySummary)
+            .filter(usage_start=first_month, infrastructure_project_monthly_cost__isnull=False)
+            .all()
+        )
+
         with schema_context(self.schema):
+            # Test pvc to node distribution
             expected_count = (
                 OCPUsageLineItemDailySummary.objects.filter(
                     report_period__provider_id=self.ocp_provider.uuid,
@@ -896,6 +989,28 @@ class OCPReportDBAccessorTest(MasuTestCase):
                 self.assertEquals(
                     monthly_cost_row.infrastructure_monthly_cost_json.get(metric_constants.PVC_DISTRIBUTION), pvc_rate
                 )
+            # Test pvc to project distribution
+            expected_project_total = expected_count * pvc_rate
+            expected_project_count = (
+                OCPUsageLineItemDailySummary.objects.filter(
+                    report_period__provider_id=self.ocp_provider.uuid,
+                    usage_start__gte=start_date,
+                    persistentvolumeclaim__isnull=False,
+                    namespace__isnull=False,
+                )
+                .values("persistentvolumeclaim")
+                .distinct()
+                .count()
+            )
+            self.assertEquals(project_monthly_cost_rows.count(), expected_project_count)
+            project_total = []
+            for p_monthly_cost_row in project_monthly_cost_rows:
+                pvc_project_cost = p_monthly_cost_row.infrastructure_project_monthly_cost.get(
+                    metric_constants.PVC_DISTRIBUTION
+                )
+                project_total.append(pvc_project_cost)
+                self.assertEquals(pvc_project_cost, pvc_rate)
+            self.assertEquals(sum(project_total), expected_project_total)
 
     def test_populate_monthly_cost_pvc_supplementary_cost(self):
         """Test that the monthly supplementary cost row for PVC in the summary table is populated."""
@@ -926,7 +1041,15 @@ class OCPReportDBAccessorTest(MasuTestCase):
             .filter(usage_start=first_month, supplementary_monthly_cost_json__isnull=False)
             .all()
         )
+
+        project_monthly_cost_rows = (
+            self.accessor._get_db_obj_query(OCPUsageLineItemDailySummary)
+            .filter(usage_start=first_month, supplementary_project_monthly_cost__isnull=False)
+            .all()
+        )
+
         with schema_context(self.schema):
+            # Test pvc to node distribution
             expected_count = (
                 OCPUsageLineItemDailySummary.objects.filter(
                     report_period__provider_id=self.ocp_provider.uuid,
@@ -943,6 +1066,30 @@ class OCPReportDBAccessorTest(MasuTestCase):
                     monthly_cost_row.supplementary_monthly_cost_json.get(metric_constants.PVC_DISTRIBUTION), pvc_rate
                 )
 
+            # Test pvc to project distribution
+            expected_project_total = expected_count * pvc_rate
+            expected_project_count = (
+                OCPUsageLineItemDailySummary.objects.filter(
+                    report_period__provider_id=self.ocp_provider.uuid,
+                    usage_start__gte=start_date,
+                    persistentvolumeclaim__isnull=False,
+                    namespace__isnull=False,
+                )
+                .values("persistentvolumeclaim")
+                .distinct()
+                .count()
+            )
+            self.assertEquals(project_monthly_cost_rows.count(), expected_project_count)
+            project_total = []
+            for p_monthly_cost_row in project_monthly_cost_rows:
+                pvc_project_cost = p_monthly_cost_row.supplementary_project_monthly_cost.get(
+                    metric_constants.PVC_DISTRIBUTION
+                )
+                project_total.append(pvc_project_cost)
+                self.assertEquals(pvc_project_cost, pvc_rate)
+            self.assertEquals(sum(project_total), expected_project_total)
+
+    # TODO: cody, update
     def test_remove_monthly_cost(self):
         """Test that the monthly cost row in the summary table is removed."""
         distribution_choices = [metric_constants.CPU_DISTRIBUTION, metric_constants.MEMORY_DISTRIBUTION]
@@ -966,11 +1113,18 @@ class OCPReportDBAccessorTest(MasuTestCase):
                     .filter(usage_start=first_month, supplementary_monthly_cost_json__isnull=False)
                     .all()
                 )
+                project_monthly_rows = (
+                    self.accessor._get_db_obj_query(OCPUsageLineItemDailySummary)
+                    .filter(usage_start=first_month, supplementary_project_monthly_cost__isnull=False)
+                    .all()
+                )
                 with schema_context(self.schema):
                     self.assertTrue(monthly_cost_rows.exists())
+                    self.assertTrue(project_monthly_rows.exists())
                 self.accessor.remove_monthly_cost(start_date, first_next_month, self.cluster_id, cost_type)
                 with schema_context(self.schema):
                     self.assertFalse(monthly_cost_rows.exists())
+                    self.assertFalse(project_monthly_rows.exists())
 
     def test_remove_monthly_cost_no_data(self):
         """Test that an error isn't thrown when the monthly cost row has no data."""
@@ -1106,6 +1260,7 @@ select * from eek where val1 in {{report_period_ids}} ;
             for column in summary_columns:
                 self.assertIsNotNone(getattr(entry, column))
 
+    # TODO: Cody, update
     def test_upsert_monthly_cluster_cost_line_item_no_report_period(self):
         """Test that the cluster monthly costs are not updated when no report period  is found."""
         distribution_choices = [metric_constants.CPU_DISTRIBUTION, metric_constants.MEMORY_DISTRIBUTION]

--- a/koku/masu/test/database/test_ocp_report_db_accessor.py
+++ b/koku/masu/test/database/test_ocp_report_db_accessor.py
@@ -696,6 +696,7 @@ class OCPReportDBAccessorTest(MasuTestCase):
             reports = self.accessor.get_reports()
             self.assertEquals(len(reports), OCPUsageReport.objects.count())
 
+    # TODO: Fix
     def test_populate_monthly_cost_node_infrastructure_cost(self):
         """Test that the monthly infrastructure cost row for nodes in the summary table is populated."""
         distribution_choices = [metric_constants.CPU_DISTRIBUTION, metric_constants.MEMORY_DISTRIBUTION]
@@ -735,7 +736,7 @@ class OCPReportDBAccessorTest(MasuTestCase):
                         OCPUsageLineItemDailySummary.objects.filter(
                             report_period__provider_id=self.ocp_provider.uuid,
                             usage_start__gte=start_date,
-                            infrastructure_monthly_cost__isnull=False,
+                            infrastructure_monthly_cost_json__isnull=False,
                         )
                         .values("node")
                         .distinct()
@@ -761,10 +762,13 @@ class OCPReportDBAccessorTest(MasuTestCase):
                     )
                     self.assertEquals(monthly_project_cost_rows.count(), expected_project_count)
                     monthly_project_cost = []
-                    for monthly_cost_row in monthly_cost_rows:
-                        monthly_project_cost.append(monthly_cost_row.infrastructure_monthly_cost.get(distribution))
+                    for monthly_project_cost_row in monthly_project_cost_rows:
+                        monthly_project_cost.append(
+                            monthly_project_cost_row.infrastructure_project_monthly_cost.get(distribution)
+                        )
                     self.assertEquals(sum(monthly_project_cost), expected_project_value)
 
+    # FIX:
     def test_populate_monthly_cost_node_supplementary_cost(self):
         """Test that the monthly supplementary cost row for nodes in the summary table is populated."""
         distribution_choices = [metric_constants.CPU_DISTRIBUTION, metric_constants.MEMORY_DISTRIBUTION]
@@ -804,7 +808,7 @@ class OCPReportDBAccessorTest(MasuTestCase):
                         OCPUsageLineItemDailySummary.objects.filter(
                             report_period__provider_id=self.ocp_provider.uuid,
                             usage_start__gte=start_date,
-                            supplementary_monthly_cost__isnull=False,
+                            supplementary_monthly_cost_json__isnull=False,
                         )
                         .values("node")
                         .distinct()
@@ -830,8 +834,10 @@ class OCPReportDBAccessorTest(MasuTestCase):
                     )
                     self.assertEquals(monthly_project_cost_rows.count(), expected_project_count)
                     monthly_project_cost = []
-                    for monthly_cost_row in monthly_cost_rows:
-                        monthly_project_cost.append(monthly_cost_row.supplementary_monthly_cost.get(distribution))
+                    for monthly_project_cost_row in monthly_project_cost_rows:
+                        monthly_project_cost.append(
+                            monthly_project_cost_row.supplementary_project_monthly_cost.get(distribution)
+                        )
                     self.assertEquals(sum(monthly_project_cost), expected_project_value)
 
     def test_populate_monthly_cost_cluster_infrastructure_cost(self):

--- a/koku/reporting/provider/ocp/models.py
+++ b/koku/reporting/provider/ocp/models.py
@@ -320,8 +320,6 @@ class OCPUsageLineItemDailySummary(models.Model):
 
     supplementary_project_monthly_cost = JSONField(null=True)
 
-    supplementary_project_monthly_cost = JSONField(null=True)
-
     monthly_cost_type = models.TextField(null=True, choices=MONTHLY_COST_TYPES)
 
     source_uuid = models.UUIDField(unique=False, null=True)
@@ -693,10 +691,12 @@ class OCPCostSummaryByProject(models.Model):
     source_uuid = models.UUIDField(unique=False, null=True)
 
     infrastructure_monthly_cost = models.DecimalField(max_digits=33, decimal_places=15, null=True)
-    infrastructure_monthly_cost_json = JSONField(null=True)
 
     supplementary_monthly_cost = models.DecimalField(max_digits=33, decimal_places=15, null=True)
-    supplementary_monthly_cost_json = JSONField(null=True)
+
+    infrastructure_project_monthly_cost = JSONField(null=True)
+
+    supplementary_project_monthly_cost = JSONField(null=True)
 
 
 class OCPCostSummaryByNode(models.Model):

--- a/koku/reporting/provider/ocp/models.py
+++ b/koku/reporting/provider/ocp/models.py
@@ -309,12 +309,16 @@ class OCPUsageLineItemDailySummary(models.Model):
     infrastructure_monthly_cost = models.DecimalField(max_digits=33, decimal_places=15, null=True)
     infrastructure_monthly_cost_json = JSONField(null=True)
 
+    infrastructure_project_monthly_cost = JSONField(null=True)
+
     supplementary_usage_cost = JSONField(null=True)
 
     supplementary_monthly_cost = models.DecimalField(max_digits=33, decimal_places=15, null=True)
     supplementary_monthly_cost_json = JSONField(null=True)
 
     infrastructure_project_monthly_cost = JSONField(null=True)
+
+    supplementary_project_monthly_cost = JSONField(null=True)
 
     supplementary_project_monthly_cost = JSONField(null=True)
 

--- a/koku/reporting/provider/ocp/sql/views/_20210615/reporting_ocp_cost_summary_by_project_20210615.sql
+++ b/koku/reporting/provider/ocp/sql/views/_20210615/reporting_ocp_cost_summary_by_project_20210615.sql
@@ -24,13 +24,13 @@ CREATE MATERIALIZED VIEW reporting_ocp_cost_summary_by_project AS(
             'cpu', sum(((coalesce(supplementary_project_monthly_cost, '{"cpu": 0}'::jsonb))->>'cpu')::decimal),
             'memory', sum(((coalesce(supplementary_project_monthly_cost, '{"memory": 0}'::jsonb))->>'memory')::decimal),
             'pvc', sum(((coalesce(supplementary_project_monthly_cost, '{"pvc": 0}'::jsonb))->>'pvc')::decimal)
-        ) as supplementary_monthly_cost_json,
+        ) as supplementary_project_monthly_cost,
         sum(supplementary_monthly_cost) as supplementary_monthly_cost,
         json_build_object(
             'cpu', sum(((coalesce(infrastructure_project_monthly_cost, '{"cpu": 0}'::jsonb))->>'cpu')::decimal),
             'memory', sum(((coalesce(infrastructure_project_monthly_cost, '{"memory": 0}'::jsonb))->>'memory')::decimal),
             'pvc', sum(((coalesce(infrastructure_project_monthly_cost, '{"pvc": 0}'::jsonb))->>'pvc')::decimal)
-        ) as infrastructure_monthly_cost_json,
+        ) as infrastructure_project_monthly_cost,
         sum(infrastructure_monthly_cost) as infrastructure_monthly_cost,
         source_uuid
     FROM reporting_ocpusagelineitem_daily_summary


### PR DESCRIPTION
This pr follows along pretty closely to the design laid out in 
- https://issues.redhat.com/browse/COST-1450

# Background
This pr is to handle monthly rate cost distribution into the project. Each rate has different logic built around it. I can go into more detail about each algorthim I used and why. Additionally the project cost is saved into its own separate column in the summary table.

# Testing
How to test, you can now run `make load-test-customer-data` to populate openshift on premise cluster with a distribution cost. The default distribution is `cpu`, but you can change it to `memory` using the cost model example in this pr description: https://github.com/project-koku/koku/pull/2900

After you have successfully loaded the data you can now check out the ocp endpoints. You will notice that for the ocp endpoints we now have a new `distributed_cost` column:
```
"infrastructure": {
                "raw": {
                    "value": 1333.3458948441,
                    "units": "USD"
                },
                "markup": {
                    "value": 126.45735272621002,
                    "units": "USD"
                },
                "usage": {
                    "value": 0.0,
                    "units": "USD"
                },
                "distributed": {
                    "value": 17000.0,
                    "units": "USD"
                },
                "total": {
                    "value": 18459.80324757031,
                    "units": "USD"
                }
            },
```
Then we need to check the ocp endpoints with the `&group_by[project]=*`
 