### PR TITLE
COST-1736: No data for ocp on aws/azure in stage.

### DIFF
--- a/koku/masu/processor/ocp/ocp_cloud_parquet_summary_updater.py
+++ b/koku/masu/processor/ocp/ocp_cloud_parquet_summary_updater.py
@@ -47,8 +47,8 @@ class OCPCloudParquetReportSummaryUpdater(OCPCloudReportSummaryUpdater):
             #     end_date,
             # )
 
-            cluster_id = get_cluster_id_from_provider(openshift_provider_uuid)
-            aws_bills = aws_get_bills_from_provider(aws_provider_uuid, self._schema, start_date, end_date)
+            # cluster_id = get_cluster_id_from_provider(openshift_provider_uuid)
+            # aws_bills = aws_get_bills_from_provider(aws_provider_uuid, self._schema, start_date, end_date)
             aws_bill_ids = [str(bill.id) for bill in aws_bills]
             current_aws_bill_id = aws_bills.first().id if aws_bills else None
             current_ocp_report_period_id = report_period.id
@@ -107,8 +107,8 @@ class OCPCloudParquetReportSummaryUpdater(OCPCloudReportSummaryUpdater):
             #     end_date,
             # )
 
-            cluster_id = get_cluster_id_from_provider(openshift_provider_uuid)
-            azure_bills = azure_get_bills_from_provider(azure_provider_uuid, self._schema, start_date, end_date)
+            # cluster_id = get_cluster_id_from_provider(openshift_provider_uuid)
+            # azure_bills = azure_get_bills_from_provider(azure_provider_uuid, self._schema, start_date, end_date)
             azure_bill_ids = [str(bill.id) for bill in azure_bills]
             current_azure_bill_id = azure_bills.first().id if azure_bills else None
             current_ocp_report_period_id = report_period.id

--- a/koku/masu/processor/ocp/ocp_cloud_parquet_summary_updater.py
+++ b/koku/masu/processor/ocp/ocp_cloud_parquet_summary_updater.py
@@ -47,8 +47,6 @@ class OCPCloudParquetReportSummaryUpdater(OCPCloudReportSummaryUpdater):
             #     end_date,
             # )
 
-            # cluster_id = get_cluster_id_from_provider(openshift_provider_uuid)
-            # aws_bills = aws_get_bills_from_provider(aws_provider_uuid, self._schema, start_date, end_date)
             aws_bill_ids = [str(bill.id) for bill in aws_bills]
             current_aws_bill_id = aws_bills.first().id if aws_bills else None
             current_ocp_report_period_id = report_period.id
@@ -107,8 +105,6 @@ class OCPCloudParquetReportSummaryUpdater(OCPCloudReportSummaryUpdater):
             #     end_date,
             # )
 
-            # cluster_id = get_cluster_id_from_provider(openshift_provider_uuid)
-            # azure_bills = azure_get_bills_from_provider(azure_provider_uuid, self._schema, start_date, end_date)
             azure_bill_ids = [str(bill.id) for bill in azure_bills]
             current_azure_bill_id = azure_bills.first().id if azure_bills else None
             current_ocp_report_period_id = report_period.id


### PR DESCRIPTION
### Problem Definition
https://github.com/project-koku/koku/pull/2950/files

The pull request above introduced [extraneous calls](https://github.com/project-koku/koku/blob/e6f1216a6299e4492f03f37796af07808b827dac/koku/masu/processor/ocp/ocp_cloud_parquet_summary_updater.py#L50-L51) to get the cluster id and the bill ids. The new additional calls are causing the schema to loose its context resulting in the following error for ocp on aws and ocp on azure:

```
koku-worker_1 | [2021-08-04 15:45:04,941] INFO 2ce439d5-c48e-4b68-9835-efec06eac0be {'message': 'Failed to correlate OpenShift metrics for provider: 4e1b48c6-f507-4ca7-a143-8c8fd64bc428. Error: relation "reporting_azurecostentrybill" does not exist\nLINE 1: ..."reporting_azurecostentrybill"."provider_id" FROM "reporting...\n ^\n', 'tracing_id': 'b5266403-aab8-4a7a-a37f-55e7e24bde2f'
```

## Testing
Switch your environment over to use Trino. After that build and bring up the server and populate it with the load test customer:
```
make docker-presto-down-all && make docker-up-min-presto-no-build
(wait til finished)
make create-test-customer
(wait til finished)
make load-test-customer-data
```
Then check the daily summary table for ocp on aws/azure and see that we now have data populated. 
