### PR TITLE
fix collectstatic in build

### DIFF
--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -108,7 +108,7 @@ if should_collectstatic; then
       exit 1
     fi
 
-    if ! python $manage_file collectstatic --dry-run --noinput &> /dev/null; then
+    if ! python $manage_file collectstatic --dry-run --noinput; then
       echo "WARNING: could not run 'manage.py collectstatic'. To debug, run:"
       echo "    $ python $manage_file collectstatic --noinput"
       echo "Ignore this warning if you're not serving static files with Django."

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM registry.access.redhat.com/ubi8/python-38:latest
 ARG PIPENV_DEV=False
 ARG USER_ID=1000
 
+# needed for successful collectstatic
+ARG PROMETHEUS_MULTIPROC_DIR=/tmp
+
 ENV LC_ALL=en_US.UTF-8 \
     LANG=en_US.UTF-8 \
     PIP_NO_CACHE_DIR=off \


### PR DESCRIPTION
The `collectstatic` step was failing due to:
```
#11 70.75 ---> Collecting Django static files ...
#11 71.14 Traceback (most recent call last):
#11 71.14   File "./manage.py", line 15, in <module>
#11 71.14     execute_from_command_line(sys.argv)
#11 71.14   File "/opt/app-root/lib64/python3.8/site-packages/django/core/management/__init__.py", line 401, in execute_from_command_line
#11 71.14     utility.execute()
#11 71.14   File "/opt/app-root/lib64/python3.8/site-packages/django/core/management/__init__.py", line 345, in execute
#11 71.14     settings.INSTALLED_APPS
#11 71.14   File "/opt/app-root/lib64/python3.8/site-packages/django/conf/__init__.py", line 82, in __getattr__
#11 71.14     self._setup(name)
#11 71.14   File "/opt/app-root/lib64/python3.8/site-packages/django/conf/__init__.py", line 69, in _setup
#11 71.14     self._wrapped = Settings(settings_module)
#11 71.14   File "/opt/app-root/lib64/python3.8/site-packages/django/conf/__init__.py", line 170, in __init__
#11 71.14     mod = importlib.import_module(self.SETTINGS_MODULE)
#11 71.14   File "/usr/lib64/python3.8/importlib/__init__.py", line 127, in import_module
#11 71.14     return _bootstrap._gcd_import(name[level:], package, level)
#11 71.14   File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
#11 71.14   File "<frozen importlib._bootstrap>", line 991, in _find_and_load
#11 71.14   File "<frozen importlib._bootstrap>", line 961, in _find_and_load_unlocked
#11 71.14   File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
#11 71.14   File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
#11 71.14   File "<frozen importlib._bootstrap>", line 991, in _find_and_load
#11 71.14   File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
#11 71.14   File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
#11 71.14   File "<frozen importlib._bootstrap_external>", line 783, in exec_module
#11 71.14   File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
#11 71.14   File "/opt/app-root/src/koku/koku/__init__.py", line 2, in <module>
#11 71.14     from .celery import app as celery_app
#11 71.14   File "/opt/app-root/src/koku/koku/celery.py", line 16, in <module>
#11 71.14     from koku.probe_server import ProbeResponse
#11 71.14   File "/opt/app-root/src/koku/koku/probe_server.py", line 16, in <module>
#11 71.14     from masu.prometheus_stats import WORKER_REGISTRY
#11 71.14   File "/opt/app-root/src/koku/masu/prometheus_stats.py", line 13, in <module>
#11 71.14     multiprocess.MultiProcessCollector(WORKER_REGISTRY)
#11 71.14   File "/opt/app-root/lib64/python3.8/site-packages/prometheus_client/multiprocess.py", line 33, in __init__
#11 71.14     raise ValueError('env PROMETHEUS_MULTIPROC_DIR is not set or not a directory')
#11 71.14 ValueError: env PROMETHEUS_MULTIPROC_DIR is not set or not a directory
#11 71.19 WARNING: could not run 'manage.py collectstatic'. To debug, run:
#11 71.19     $ python ./manage.py collectstatic --noinput
```

This PR _unsilences_ errors during collectstatic since our app relies on the success of this step. The `.s2i/assemble` file was updated to exit with a non-zero exit code so that the build fails when static files are not collected. The `PROMETHEUS_MULTIPROC_DIR` arg was added to the Dockerfile to prevent the above error.