### PR TITLE
write `metrics_check` method for workers

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -144,7 +144,11 @@ objects:
         - mountPath: /etc/gcp
           name: gcp-credentials
           readOnly: true
+        - mountPath: ${PROMETHEUS_DIR}
+          name: prometheus-data
         volumes:
+        - emptyDir: {}
+          name: prometheus-data
         - name: gcp-credentials
           secret:
             items:
@@ -265,12 +269,16 @@ objects:
             cpu: ${LISTENER_CPU_REQUEST}
             memory: ${LISTENER_MEMORY_REQUEST}
         volumeMounts:
+        - mountPath: ${PROMETHEUS_DIR}
+          name: prometheus-data
         - mountPath: /var/tmp/masu/
           name: koku-listener-data
         - mountPath: /etc/gcp
           name: gcp-credentials
           readOnly: true
         volumes:
+        - emptyDir: {}
+          name: prometheus-data
         - emptyDir: {}
           name: koku-listener-data
         - name: gcp-credentials
@@ -407,7 +415,11 @@ objects:
         - mountPath: /etc/gcp
           name: gcp-credentials
           readOnly: true
+        - mountPath: ${PROMETHEUS_DIR}
+          name: prometheus-data
         volumes:
+        - emptyDir: {}
+          name: prometheus-data
         - name: gcp-credentials
           secret:
             items:
@@ -664,7 +676,11 @@ objects:
         - mountPath: /etc/gcp
           name: gcp-credentials
           readOnly: true
+        - mountPath: ${PROMETHEUS_DIR}
+          name: prometheus-data
         volumes:
+        - emptyDir: {}
+          name: prometheus-data
         - name: gcp-credentials
           secret:
             items:
@@ -786,7 +802,11 @@ objects:
         - mountPath: /etc/gcp
           name: gcp-credentials
           readOnly: true
+        - mountPath: ${PROMETHEUS_DIR}
+          name: prometheus-data
         volumes:
+        - emptyDir: {}
+          name: prometheus-data
         - name: gcp-credentials
           secret:
             items:
@@ -943,7 +963,11 @@ objects:
         - mountPath: /etc/gcp
           name: gcp-credentials
           readOnly: true
+        - mountPath: ${PROMETHEUS_DIR}
+          name: prometheus-data
         volumes:
+        - emptyDir: {}
+          name: prometheus-data
         - emptyDir: {}
           name: koku-worker-data
         - name: gcp-credentials
@@ -1102,7 +1126,11 @@ objects:
         - mountPath: /etc/gcp
           name: gcp-credentials
           readOnly: true
+        - mountPath: ${PROMETHEUS_DIR}
+          name: prometheus-data
         volumes:
+        - emptyDir: {}
+          name: prometheus-data
         - emptyDir: {}
           name: koku-worker-data
         - name: gcp-credentials
@@ -1261,7 +1289,11 @@ objects:
         - mountPath: /etc/gcp
           name: gcp-credentials
           readOnly: true
+        - mountPath: ${PROMETHEUS_DIR}
+          name: prometheus-data
         volumes:
+        - emptyDir: {}
+          name: prometheus-data
         - emptyDir: {}
           name: koku-worker-data
         - name: gcp-credentials
@@ -1420,7 +1452,11 @@ objects:
         - mountPath: /etc/gcp
           name: gcp-credentials
           readOnly: true
+        - mountPath: ${PROMETHEUS_DIR}
+          name: prometheus-data
         volumes:
+        - emptyDir: {}
+          name: prometheus-data
         - emptyDir: {}
           name: koku-worker-data
         - name: gcp-credentials
@@ -1579,7 +1615,11 @@ objects:
         - mountPath: /etc/gcp
           name: gcp-credentials
           readOnly: true
+        - mountPath: ${PROMETHEUS_DIR}
+          name: prometheus-data
         volumes:
+        - emptyDir: {}
+          name: prometheus-data
         - emptyDir: {}
           name: koku-worker-data
         - name: gcp-credentials
@@ -1738,7 +1778,11 @@ objects:
         - mountPath: /etc/gcp
           name: gcp-credentials
           readOnly: true
+        - mountPath: ${PROMETHEUS_DIR}
+          name: prometheus-data
         volumes:
+        - emptyDir: {}
+          name: prometheus-data
         - emptyDir: {}
           name: koku-worker-data
         - name: gcp-credentials
@@ -1897,7 +1941,11 @@ objects:
         - mountPath: /etc/gcp
           name: gcp-credentials
           readOnly: true
+        - mountPath: ${PROMETHEUS_DIR}
+          name: prometheus-data
         volumes:
+        - emptyDir: {}
+          name: prometheus-data
         - emptyDir: {}
           name: koku-worker-data
         - name: gcp-credentials

--- a/deploy/kustomize/patches/koku.yaml
+++ b/deploy/kustomize/patches/koku.yaml
@@ -140,7 +140,11 @@
       - name: gcp-credentials
         mountPath: /etc/gcp
         readOnly: true
+      - name: prometheus-data
+        mountPath: ${PROMETHEUS_DIR}
       volumes:
+      - name: prometheus-data
+        emptyDir: {}
       - name: gcp-credentials
         secret:
           secretName: koku-gcp

--- a/deploy/kustomize/patches/listener.yaml
+++ b/deploy/kustomize/patches/listener.yaml
@@ -115,12 +115,16 @@
           cpu: ${LISTENER_CPU_REQUEST}
           memory: ${LISTENER_MEMORY_REQUEST}
       volumeMounts:
-      - mountPath: /var/tmp/masu/
-        name: koku-listener-data
+      - name: prometheus-data
+        mountPath: ${PROMETHEUS_DIR}
+      - name: koku-listener-data
+        mountPath: /var/tmp/masu/
       - name: gcp-credentials
         mountPath: /etc/gcp
         readOnly: true
       volumes:
+      - name: prometheus-data
+        emptyDir: {}
       - name: koku-listener-data
         emptyDir: {}
       - name: gcp-credentials

--- a/deploy/kustomize/patches/masu.yaml
+++ b/deploy/kustomize/patches/masu.yaml
@@ -129,7 +129,11 @@
       - name: gcp-credentials
         mountPath: /etc/gcp
         readOnly: true
+      - name: prometheus-data
+        mountPath: ${PROMETHEUS_DIR}
       volumes:
+      - name: prometheus-data
+        emptyDir: {}
       - name: gcp-credentials
         secret:
           secretName: koku-gcp

--- a/deploy/kustomize/patches/sources-client.yaml
+++ b/deploy/kustomize/patches/sources-client.yaml
@@ -114,7 +114,11 @@
       - name: gcp-credentials
         mountPath: /etc/gcp
         readOnly: true
+      - name: prometheus-data
+        mountPath: ${PROMETHEUS_DIR}
       volumes:
+      - name: prometheus-data
+        emptyDir: {}
       - name: gcp-credentials
         secret:
           secretName: koku-gcp

--- a/deploy/kustomize/patches/sources-listener.yaml
+++ b/deploy/kustomize/patches/sources-listener.yaml
@@ -116,7 +116,11 @@
       - name: gcp-credentials
         mountPath: /etc/gcp
         readOnly: true
+      - name: prometheus-data
+        mountPath: ${PROMETHEUS_DIR}
       volumes:
+      - name: prometheus-data
+        emptyDir: {}
       - name: gcp-credentials
         secret:
           secretName: koku-gcp

--- a/deploy/kustomize/patches/worker-celery.yaml
+++ b/deploy/kustomize/patches/worker-celery.yaml
@@ -152,7 +152,11 @@
       - name: gcp-credentials
         mountPath: /etc/gcp
         readOnly: true
+      - name: prometheus-data
+        mountPath: ${PROMETHEUS_DIR}
       volumes:
+      - name: prometheus-data
+        emptyDir: {}
       - name: koku-worker-data
         emptyDir: {}
       - name: gcp-credentials

--- a/deploy/kustomize/patches/worker-cost-model.yaml
+++ b/deploy/kustomize/patches/worker-cost-model.yaml
@@ -152,7 +152,11 @@
       - name: gcp-credentials
         mountPath: /etc/gcp
         readOnly: true
+      - name: prometheus-data
+        mountPath: ${PROMETHEUS_DIR}
       volumes:
+      - name: prometheus-data
+        emptyDir: {}
       - name: koku-worker-data
         emptyDir: {}
       - name: gcp-credentials

--- a/deploy/kustomize/patches/worker-download.yaml
+++ b/deploy/kustomize/patches/worker-download.yaml
@@ -152,7 +152,11 @@
       - name: gcp-credentials
         mountPath: /etc/gcp
         readOnly: true
+      - name: prometheus-data
+        mountPath: ${PROMETHEUS_DIR}
       volumes:
+      - name: prometheus-data
+        emptyDir: {}
       - name: koku-worker-data
         emptyDir: {}
       - name: gcp-credentials

--- a/deploy/kustomize/patches/worker-ocp.yaml
+++ b/deploy/kustomize/patches/worker-ocp.yaml
@@ -152,7 +152,11 @@
       - name: gcp-credentials
         mountPath: /etc/gcp
         readOnly: true
+      - name: prometheus-data
+        mountPath: ${PROMETHEUS_DIR}
       volumes:
+      - name: prometheus-data
+        emptyDir: {}
       - name: koku-worker-data
         emptyDir: {}
       - name: gcp-credentials

--- a/deploy/kustomize/patches/worker-priority.yaml
+++ b/deploy/kustomize/patches/worker-priority.yaml
@@ -152,7 +152,11 @@
       - name: gcp-credentials
         mountPath: /etc/gcp
         readOnly: true
+      - name: prometheus-data
+        mountPath: ${PROMETHEUS_DIR}
       volumes:
+      - name: prometheus-data
+        emptyDir: {}
       - name: koku-worker-data
         emptyDir: {}
       - name: gcp-credentials

--- a/deploy/kustomize/patches/worker-refresh.yaml
+++ b/deploy/kustomize/patches/worker-refresh.yaml
@@ -152,7 +152,11 @@
       - name: gcp-credentials
         mountPath: /etc/gcp
         readOnly: true
+      - name: prometheus-data
+        mountPath: ${PROMETHEUS_DIR}
       volumes:
+      - name: prometheus-data
+        emptyDir: {}
       - name: koku-worker-data
         emptyDir: {}
       - name: gcp-credentials

--- a/deploy/kustomize/patches/worker-summary.yaml
+++ b/deploy/kustomize/patches/worker-summary.yaml
@@ -152,7 +152,11 @@
       - name: gcp-credentials
         mountPath: /etc/gcp
         readOnly: true
+      - name: prometheus-data
+        mountPath: ${PROMETHEUS_DIR}
       volumes:
+      - name: prometheus-data
+        emptyDir: {}
       - name: koku-worker-data
         emptyDir: {}
       - name: gcp-credentials

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,8 @@ services:
         - ENABLE_TRINO_SOURCE_TYPE
       privileged: true
       ports:
-          - 8000:8000
+        - 8000:8000
+        - 8001:9000
       volumes:
         - '.:/koku/'
       links:
@@ -106,7 +107,8 @@ services:
         - RETAIN_NUM_MONTHS=${RETAIN_NUM_MONTHS-3}
       privileged: true
       ports:
-          - 5000:8000
+        - 5000:8000
+        - 5001:9000
       volumes:
         - '.:/koku/'
       links:
@@ -120,7 +122,7 @@ services:
     container_name: koku_redis
     image: redis:5.0.4
     ports:
-      - "6379:6379"
+      - 6379:6379
 
   db:
     container_name: koku_db
@@ -130,7 +132,7 @@ services:
     - POSTGRES_USER=${DATABASE_USER-postgres}
     - POSTGRES_PASSWORD=${DATABASE_PASSWORD-postgres}
     ports:
-      - "15432:5432"
+      - 15432:5432
     volumes:
       - ./pg_data:/var/lib/${DATABASE_DATA_DIR-postgresql}/data
       - ./pg_init:/docker-entrypoint-initdb.d
@@ -200,7 +202,7 @@ services:
     - PGADMIN_DEFAULT_EMAIL=${PGADMIN_EMAIL-postgres}
     - PGADMIN_DEFAULT_PASSWORD=${PGADMIN_PASSWORD-postgres}
     ports:
-    - "${PGADMIN_PORT-8432}:80"
+      - "${PGADMIN_PORT-8432}:80"
     volumes:
       - ./pgadmin_servers.json:/pgadmin4/servers.json
 
@@ -210,7 +212,7 @@ services:
         context: grafana
         dockerfile: Dockerfile-grafana
     ports:
-        - 3001:3000
+      - 3001:3000
     links:
         - db
     depends_on:
@@ -225,13 +227,13 @@ services:
           - RABBITMQ_DEFAULT_USER=guest
           - RABBITMQ_DEFAULT_PASS=guest
       ports:
-          - "${RABBITMQ_PORT-5674}:5672"
+        - "${RABBITMQ_PORT-5674}:5672"
 
   koku-worker:
       hostname: koku-worker-1
       image: koku_base
       working_dir: /koku/koku
-      entrypoint: ['watchmedo', 'auto-restart', '--directory=./', '--pattern=*.py', '--recursive', '--', 'celery', '-A', 'koku', 'worker', '-l', 'info', '-Q', 'celery,download,ocp,priority,summary,cost_model,refresh']
+      entrypoint: ['watchmedo', 'auto-restart', '--directory=./koku', '--pattern=*.py', '--ignore-patterns=*test*', '--recursive', '--', 'celery', '-A', 'koku', 'worker', '-l', 'info', '-Q', 'celery,download,ocp,priority,summary,cost_model,refresh']
       environment:
         - AWS_ACCESS_KEY_ID
         - AWS_SECRET_ACCESS_KEY
@@ -281,6 +283,8 @@ services:
         - MAX_CELERY_TASKS_PER_WORKER=${MAX_CELERY_TASKS_PER_WORKER-10}
         - RETAIN_NUM_MONTHS=${RETAIN_NUM_MONTHS-3}
       privileged: true
+      ports:
+        - 6001:9000
       volumes:
         - '.:/koku'
         - './testing:/testing'
@@ -346,7 +350,7 @@ services:
         - ENABLE_TRINO_SOURCE_TYPE
       privileged: true
       ports:
-          - "9988:9999"
+        - 7001:9000
       volumes:
         - '.:/koku'
       links:
@@ -362,7 +366,7 @@ services:
       image: koku_base
       restart: on-failure:25
       working_dir: /koku/
-      entrypoint: ['watchmedo', 'auto-restart', '--directory=./', '--pattern=*.py', '--recursive', '--', /koku/run_sources.sh]
+      entrypoint: ['watchmedo', 'auto-restart', '--directory=./koku', '--pattern=*.py', '--ignore-patterns=*test*', '--recursive', '--', /koku/run_sources.sh]
       environment:
         - DATABASE_SERVICE_NAME=POSTGRES_SQL
         - DATABASE_ENGINE=postgresql
@@ -392,7 +396,8 @@ services:
         - GUNICORN_THREADS=${GUNICORN_THREADS-False}
       privileged: true
       ports:
-          - 4000:8080
+        - 4000:8000
+        - 4001:9000
       volumes:
         - '.:/koku'
       links:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -233,7 +233,7 @@ services:
       hostname: koku-worker-1
       image: koku_base
       working_dir: /koku/koku
-      entrypoint: ['watchmedo', 'auto-restart', '--directory=./koku', '--pattern=*.py', '--ignore-patterns=*test*', '--recursive', '--', 'celery', '-A', 'koku', 'worker', '-l', 'info', '-Q', 'celery,download,ocp,priority,summary,cost_model,refresh']
+      entrypoint: ['watchmedo', 'auto-restart', '--directory=./', '--pattern=*.py', '--ignore-patterns=*test*', '--recursive', '--', 'celery', '-A', 'koku', 'worker', '-l', 'info', '-Q', 'celery,download,ocp,priority,summary,cost_model,refresh']
       environment:
         - AWS_ACCESS_KEY_ID
         - AWS_SECRET_ACCESS_KEY
@@ -284,7 +284,7 @@ services:
         - RETAIN_NUM_MONTHS=${RETAIN_NUM_MONTHS-3}
       privileged: true
       ports:
-        - 6001:9000
+        - 6001-6020:9000
       volumes:
         - '.:/koku'
         - './testing:/testing'
@@ -350,7 +350,7 @@ services:
         - ENABLE_TRINO_SOURCE_TYPE
       privileged: true
       ports:
-        - 7001:9000
+        - 7001-7020:9000
       volumes:
         - '.:/koku'
       links:

--- a/koku/koku/celery.py
+++ b/koku/koku/celery.py
@@ -172,10 +172,10 @@ app.conf.beat_schedule["source_status_beat"] = {
 app.conf.beat_schedule["db_metrics"] = {"task": "koku.metrics.collect_metrics", "schedule": crontab(hour=1, minute=0)}
 
 # Collect queue metrics.
-app.conf.beat_schedule["queue_metrics"] = {
-    "task": "masu.celery.tasks.collect_queue_metrics",
-    "schedule": crontab(hour="*/1", minute=0),
-}
+# app.conf.beat_schedule["queue_metrics"] = {
+#     "task": "masu.celery.tasks.collect_queue_metrics",
+#     "schedule": crontab(hour="*/1", minute=0),
+# }
 
 
 # optionally specify the weekday and time you would like the clean volume task to run

--- a/koku/koku/celery.py
+++ b/koku/koku/celery.py
@@ -1,8 +1,9 @@
 """Celery configuration for the Koku project."""
-import datetime
 import logging
 import os
 import time
+from datetime import datetime
+from datetime import timedelta
 
 from celery import Celery
 from celery import Task
@@ -45,6 +46,21 @@ class LoggingCelery(Celery):
 class WorkerProbeServer(ProbeServer):  # pragma: no cover
     """HTTP server for liveness/readiness probes."""
 
+    _collector = lambda *args: None  # noqa: E731
+    _last_query_time = datetime.min
+
+    @classmethod
+    def update_last_query_time(cls, value):
+        """Update the last query time."""
+        cls._last_query_time = value
+
+    def metrics_check(self):
+        """Get the metrics."""
+        if datetime.now() - timedelta(minutes=1) > self._last_query_time:
+            self.update_last_query_time(datetime.now())
+            self._collector()
+        super(ProbeServer, self).do_GET()
+
     def readiness_check(self):
         """Set the readiness check response."""
         status = 424
@@ -84,7 +100,7 @@ app.conf.worker_max_tasks_per_child = MAX_CELERY_TASKS_PER_WORKER
 # Toggle to enable/disable scheduled checks for new reports.
 if ENVIRONMENT.bool("SCHEDULE_REPORT_CHECKS", default=False):
     # The interval to scan for new reports.
-    REPORT_CHECK_INTERVAL = datetime.timedelta(minutes=ENVIRONMENT.int("SCHEDULE_CHECK_INTERVAL", default=60))
+    REPORT_CHECK_INTERVAL = timedelta(minutes=ENVIRONMENT.int("SCHEDULE_CHECK_INTERVAL", default=60))
 
     CHECK_REPORT_UPDATES_DEF = {
         "task": "masu.celery.tasks.check_report_updates",
@@ -198,6 +214,7 @@ CELERY_INSPECT = app.control.inspect()
 def wait_for_migrations(sender, instance, **kwargs):  # pragma: no cover
     """Wait for migrations to complete before completing worker startup."""
     from .database import check_migrations
+    from masu.celery.tasks import collect_queue_metrics
 
     httpd = start_probe_server(WorkerProbeServer)
 
@@ -206,6 +223,7 @@ def wait_for_migrations(sender, instance, **kwargs):  # pragma: no cover
         time.sleep(5)
 
     httpd.RequestHandlerClass.ready = True  # Set `ready` to true to indicate migrations are done.
+    httpd.RequestHandlerClass._collector = collect_queue_metrics
 
 
 def is_task_currently_running(task_name, task_id, check_args=None):

--- a/koku/koku/probe_server.py
+++ b/koku/koku/probe_server.py
@@ -68,7 +68,7 @@ class ProbeServer(ABC, MetricsHandler):
         elif self.path == "/readyz":
             self.readiness_check()
         elif self.path == "/metrics":
-            super().do_GET()
+            self.metrics_check()
         else:
             self.default_response()
 
@@ -83,6 +83,10 @@ class ProbeServer(ABC, MetricsHandler):
     def liveness_check(self):
         """Set the liveness check response."""
         self._write_response(ProbeResponse(200, "ok"))
+
+    def metrics_check(self):
+        """Get the metrics."""
+        super().do_GET()
 
     @abstractmethod
     def readiness_check(self):

--- a/koku/masu/api/running_celery_tasks.py
+++ b/koku/masu/api/running_celery_tasks.py
@@ -42,4 +42,5 @@ def running_celery_tasks(request):
 def celery_queue_lengths(request):
     """Get the length of the celery queues."""
     queue_len = collect_queue_metrics()
+    LOG.info(f"Celery queue backlog info: {queue_len}")
     return Response(queue_len)

--- a/koku/masu/celery/tasks.py
+++ b/koku/masu/celery/tasks.py
@@ -13,7 +13,6 @@ from botocore.exceptions import ClientError
 from celery.exceptions import MaxRetriesExceededError
 from django.conf import settings
 from django.utils import timezone
-from prometheus_client import push_to_gateway
 from tenant_schemas.utils import schema_context
 
 from api.dataexport.models import DataExportRequest
@@ -24,7 +23,6 @@ from api.models import Provider
 from api.provider.models import Sources
 from api.utils import DateHelper
 from koku import celery_app
-from koku.metrics import REGISTRY
 from masu.config import Config
 from masu.database.report_manifest_db_accessor import ReportManifestDBAccessor
 from masu.external.accounts.hierarchy.aws.aws_org_unit_crawler import AWSOrgUnitCrawler
@@ -342,17 +340,5 @@ def collect_queue_metrics(self):
             length = conn.default_channel.client.llen(queue)
             queue_len[queue] = length
             gauge.set(length)
-    LOG.info("Celery queue backlog info: ")
-    LOG.info(queue_len)
-    LOG.debug("Pushing stats to gateway: %s", settings.PROMETHEUS_PUSHGATEWAY)
-    try:
-        push_to_gateway(
-            settings.PROMETHEUS_PUSHGATEWAY, job="masu.celery.tasks.collect_queue_metrics", registry=REGISTRY
-        )
-    except OSError as exc:
-        LOG.error("Problem reaching pushgateway: %s", exc)
-        try:
-            self.update_state(state="FAILURE", meta={"result": str(exc), "traceback": str(exc.__traceback__)})
-        except TypeError as err:
-            LOG.error("The following error occurred: %s " % err)
+    LOG.debug(f"Celery queue backlog info: {queue_len}")
     return queue_len

--- a/koku/masu/prometheus_stats.py
+++ b/koku/masu/prometheus_stats.py
@@ -50,14 +50,42 @@ KAFKA_CONNECTION_ERRORS_COUNTER = Counter(
 
 CELERY_ERRORS_COUNTER = Counter("celery_errors", "Number of celery errors", registry=WORKER_REGISTRY)
 
-DOWNLOAD_BACKLOG = Gauge("download_backlog", "Number of celery tasks in the download queue", registry=WORKER_REGISTRY)
-SUMMARY_BACKLOG = Gauge("summary_backlog", "Number of celery tasks in the summary queue", registry=WORKER_REGISTRY)
-PRIORITY_BACKLOG = Gauge("priority_backlog", "Number of celery tasks in the priority queue", registry=WORKER_REGISTRY)
-REFRESH_BACKLOG = Gauge("refresh_backlog", "Number of celery tasks in the refresh queue", registry=WORKER_REGISTRY)
-COST_MODEL_BACKLOG = Gauge(
-    "cost_model_backlog", "Number of celery tasks in the cost model queue", registry=WORKER_REGISTRY
+DOWNLOAD_BACKLOG = Gauge(
+    "download_backlog",
+    "Number of celery tasks in the download queue",
+    registry=WORKER_REGISTRY,
+    multiprocess_mode="livesum",
 )
-DEFAULT_BACKLOG = Gauge("default_backlog", "Number of celery tasks in the default queue", registry=WORKER_REGISTRY)
+SUMMARY_BACKLOG = Gauge(
+    "summary_backlog",
+    "Number of celery tasks in the summary queue",
+    registry=WORKER_REGISTRY,
+    multiprocess_mode="livesum",
+)
+PRIORITY_BACKLOG = Gauge(
+    "priority_backlog",
+    "Number of celery tasks in the priority queue",
+    registry=WORKER_REGISTRY,
+    multiprocess_mode="livesum",
+)
+REFRESH_BACKLOG = Gauge(
+    "refresh_backlog",
+    "Number of celery tasks in the refresh queue",
+    registry=WORKER_REGISTRY,
+    multiprocess_mode="livesum",
+)
+COST_MODEL_BACKLOG = Gauge(
+    "cost_model_backlog",
+    "Number of celery tasks in the cost model queue",
+    registry=WORKER_REGISTRY,
+    multiprocess_mode="livesum",
+)
+DEFAULT_BACKLOG = Gauge(
+    "default_backlog",
+    "Number of celery tasks in the default queue",
+    registry=WORKER_REGISTRY,
+    multiprocess_mode="livesum",
+)
 QUEUES = {
     "download": DOWNLOAD_BACKLOG,
     "summary": SUMMARY_BACKLOG,

--- a/koku/masu/test/celery/test_tasks.py
+++ b/koku/masu/test/celery/test_tasks.py
@@ -279,12 +279,10 @@ class TestCeleryTasks(MasuTestCase):
             self.assertIn(expected_log_msg, captured_logs.output[0])
 
     @patch("masu.celery.tasks.celery_app")
-    @patch("masu.celery.tasks.push_to_gateway")
-    def test_collect_queue_len(self, mock_celery_app, mock_push):
+    def test_collect_queue_len(self, mock_celery_app):
         """Test that the collect queue len function runs correctly."""
         mock_celery_app.pool.acquire(block=True).default_channel.client.llen.return_value = 2
-        mock_push.return_value = True
-        with self.assertLogs("masu.celery.tasks", "INFO") as captured_logs:
+        with self.assertLogs("masu.celery.tasks", "DEBUG") as captured_logs:
             tasks.collect_queue_metrics()
             expected_log_msg = "Celery queue backlog info: "
             self.assertIn(expected_log_msg, captured_logs.output[0])


### PR DESCRIPTION
Adding the metrics server introduced a couple of issues with the way metrics were scraped. 
1. With the way celery creates processes, multiples of the same metrics were being collected within a single pod, and these were being pushed with `pid` in the prom metric, generating results like:
```


{container="koku-clowder-worker-ocp",endpoint="metrics",instance="10.128.17.96:9000",job="koku-clowder-worker-ocp",namespace="hccm-prod",pid="1",pod="koku-clowder-worker-ocp-786fff9bc4-kgpcr",service="koku-clowder-worker-ocp"} | 0
{container="koku-clowder-worker-ocp",endpoint="metrics",instance="10.128.17.96:9000",job="koku-clowder-worker-ocp",namespace="hccm-prod",pid="101",pod="koku-clowder-worker-ocp-786fff9bc4-kgpcr",service="koku-clowder-worker-ocp"} | 0
{container="koku-clowder-worker-ocp",endpoint="metrics",instance="10.128.17.96:9000",job="koku-clowder-worker-ocp",namespace="hccm-prod",pid="103",pod="koku-clowder-worker-ocp-786fff9bc4-kgpcr",service="koku-clowder-worker-ocp"} | 0
{container="koku-clowder-worker-ocp",endpoint="metrics",instance="10.128.17.96:9000",job="koku-clowder-worker-ocp",namespace="hccm-prod",pid="105",pod="koku-clowder-worker-ocp-786fff9bc4-kgpcr",service="koku-clowder-worker-ocp"} | 0
```

I'm hoping that adding `multiprocess_mode="livesum"` to these gauges will remedy this issue. This should sum all the processes into a single metric and push to prometheus without the `pid` field.

2. With multiple `celery-worker` pods running, any one of these could pick up the metrics collection task. When this task collects the metrics, prometheus scrapes those gauges for that pod. The next time the task runs, it could be collected by a different pod. This does not recount the metrics for the first pod. In this case, the metrics from the first read are essentially "stuck" in prometheus.

The fix for this issue is to have _every_ pod count these gauges and serve them to prometheus. With this method, we will need to update the Prometheus Rules to aggregate all the results from the pods.

This PR also adds an emptyDir to each pod for the `prometheus_multiproc_dir` to use.