### PR TITLE
[COST 1501] Fix wildcard returning null, and filter no longer removes alias.

### DIFF
--- a/koku/api/resource_types/aws_accounts/view.py
+++ b/koku/api/resource_types/aws_accounts/view.py
@@ -59,7 +59,8 @@ class AWSAccountView(generics.ListAPIView):
             return super().list(request)
         elif request.user.access:
             user_access = request.user.access.get("aws.account", {}).get("read", [])
-
-        self.queryset = self.queryset.values("value").filter(usage_account_id__in=user_access)
+        if user_access and user_access[0] == "*":
+            return super().list(request)
+        self.queryset = self.queryset.filter(usage_account_id__in=user_access)
 
         return super().list(request)

--- a/koku/api/resource_types/aws_org_unit/view.py
+++ b/koku/api/resource_types/aws_org_unit/view.py
@@ -38,5 +38,7 @@ class AWSOrganizationalUnitView(generics.ListAPIView):
             return super().list(request)
         elif request.user.access:
             user_access = request.user.access.get("aws.organizational_unit", {}).get("read", [])
-        self.queryset = self.queryset.values("value").filter(org_unit_id__in=user_access)
+        if user_access and user_access[0] == "*":
+            return super().list(request)
+        self.queryset = self.queryset.filter(org_unit_id__in=user_access)
         return super().list(request)

--- a/koku/api/resource_types/aws_regions/view.py
+++ b/koku/api/resource_types/aws_regions/view.py
@@ -38,5 +38,7 @@ class AWSAccountRegionView(generics.ListAPIView):
             return super().list(request)
         elif request.user.access:
             user_access = request.user.access.get("aws.account", {}).get("read", [])
-        self.queryset = self.queryset.values("value").filter(usage_account_id__in=user_access)
+        if user_access and user_access[0] == "*":
+            return super().list(request)
+        self.queryset = self.queryset.filter(usage_account_id__in=user_access)
         return super().list(request)

--- a/koku/api/resource_types/aws_services/view.py
+++ b/koku/api/resource_types/aws_services/view.py
@@ -38,5 +38,7 @@ class AWSServiceView(generics.ListAPIView):
             return super().list(request)
         elif request.user.access:
             user_access = request.user.access.get("aws.account", {}).get("read", [])
-        self.queryset = self.queryset.values("value").filter(usage_account_id__in=user_access)
+        if user_access and user_access[0] == "*":
+            return super().list(request)
+        self.queryset = self.queryset.filter(usage_account_id__in=user_access)
         return super().list(request)

--- a/koku/api/resource_types/azure_regions/view.py
+++ b/koku/api/resource_types/azure_regions/view.py
@@ -47,5 +47,7 @@ class AzureRegionView(generics.ListAPIView):
             return super().list(request)
         elif request.user.access:
             user_access = request.user.access.get("azure.subscription_guid", {}).get("read", [])
-        self.queryset = self.queryset.values("value").filter(subscription_guid__in=user_access)
+        if user_access and user_access[0] == "*":
+            return super().list(request)
+        self.queryset = self.queryset.filter(subscription_guid__in=user_access)
         return super().list(request)

--- a/koku/api/resource_types/azure_services/view.py
+++ b/koku/api/resource_types/azure_services/view.py
@@ -48,5 +48,7 @@ class AzureServiceView(generics.ListAPIView):
             return super().list(request)
         elif request.user.access:
             user_access = request.user.access.get("azure.subscription_guid", {}).get("read", [])
-        self.queryset = self.queryset.values("value").filter(subscription_guid__in=user_access)
+        if user_access and user_access[0] == "*":
+            return super().list(request)
+        self.queryset = self.queryset.filter(subscription_guid__in=user_access)
         return super().list(request)

--- a/koku/api/resource_types/azure_subscription_guid/view.py
+++ b/koku/api/resource_types/azure_subscription_guid/view.py
@@ -45,6 +45,8 @@ class AzureSubscriptionGuidView(generics.ListAPIView):
             return super().list(request)
         elif request.user.access:
             user_access = request.user.access.get("azure.subscription_guid", {}).get("read", [])
-        self.queryset = self.queryset.values("value").filter(subscription_guid__in=user_access)
+        if user_access and user_access[0] == "*":
+            return super().list(request)
+        self.queryset = self.queryset.filter(subscription_guid__in=user_access)
 
         return super().list(request)

--- a/koku/api/resource_types/gcp_accounts/view.py
+++ b/koku/api/resource_types/gcp_accounts/view.py
@@ -33,5 +33,7 @@ class GCPAccountView(generics.ListAPIView):
             return super().list(request)
         elif request.user.access:
             user_access = request.user.access.get("gcp.account", {}).get("read", [])
-        self.queryset = self.queryset.values("value").filter(account_id__in=user_access)
+        if user_access and user_access[0] == "*":
+            return super().list(request)
+        self.queryset = self.queryset.filter(account_id__in=user_access)
         return super().list(request)

--- a/koku/api/resource_types/gcp_projects/view.py
+++ b/koku/api/resource_types/gcp_projects/view.py
@@ -33,5 +33,7 @@ class GCPProjectsView(generics.ListAPIView):
             return super().list(request)
         if request.user.access:
             user_access = request.user.access.get("gcp.project", {}).get("read", [])
-        self.queryset = self.queryset.values("value").filter(project_id__in=user_access)
+        if user_access and user_access[0] == "*":
+            return super().list(request)
+        self.queryset = self.queryset.filter(project_id__in=user_access)
         return super().list(request)

--- a/koku/api/resource_types/gcp_regions/view.py
+++ b/koku/api/resource_types/gcp_regions/view.py
@@ -38,5 +38,7 @@ class GCPRegionView(generics.ListAPIView):
             return super().list(request)
         elif request.user.access:
             user_access = request.user.access.get("gcp.account", {}).get("read", [])
-        self.queryset = self.queryset.values("value").filter(account_id__in=user_access)
+        if user_access and user_access[0] == "*":
+            return super().list(request)
+        self.queryset = self.queryset.filter(account_id__in=user_access)
         return super().list(request)

--- a/koku/api/resource_types/gcp_services/view.py
+++ b/koku/api/resource_types/gcp_services/view.py
@@ -38,5 +38,7 @@ class GCPServiceView(generics.ListAPIView):
             return super().list(request)
         elif request.user.access:
             user_access = request.user.access.get("gcp.account", {}).get("read", [])
-        self.queryset = self.queryset.values("value").filter(account_id__in=user_access)
+        if user_access and user_access[0] == "*":
+            return super().list(request)
+        self.queryset = self.queryset.filter(account_id__in=user_access)
         return super().list(request)

--- a/koku/api/resource_types/openshift_clusters/view.py
+++ b/koku/api/resource_types/openshift_clusters/view.py
@@ -39,7 +39,9 @@ class OCPClustersView(generics.ListAPIView):
         user_access = []
         if request.user.admin:
             return super().list(request)
-        elif request.user.access:
+        if request.user.access:
             user_access = request.user.access.get("openshift.cluster", {}).get("read", [])
-        self.queryset = self.queryset.values("value").filter(cluster_id__in=user_access)
+        if user_access and user_access[0] == "*":
+            return super().list(request)
+        self.queryset = self.queryset.filter(cluster_id__in=user_access)
         return super().list(request)

--- a/koku/api/resource_types/openshift_nodes/view.py
+++ b/koku/api/resource_types/openshift_nodes/view.py
@@ -38,5 +38,7 @@ class OCPNodesView(generics.ListAPIView):
             return super().list(request)
         elif request.user.access:
             user_access = request.user.access.get("openshift.node", {}).get("read", [])
-        self.queryset = self.queryset.values("value").filter(node__in=user_access)
+        if user_access and user_access[0] == "*":
+            return super().list(request)
+        self.queryset = self.queryset.filter(node__in=user_access)
         return super().list(request)

--- a/koku/api/resource_types/openshift_projects/view.py
+++ b/koku/api/resource_types/openshift_projects/view.py
@@ -38,5 +38,7 @@ class OCPProjectsView(generics.ListAPIView):
             return super().list(request)
         elif request.user.access:
             user_access = request.user.access.get("openshift.project", {}).get("read", [])
-        self.queryset = self.queryset.values("value").filter(namespace__in=user_access)
+        if user_access and user_access[0] == "*":
+            return super().list(request)
+        self.queryset = self.queryset.filter(namespace__in=user_access)
         return super().list(request)

--- a/koku/api/resource_types/test/tests_views.py
+++ b/koku/api/resource_types/test/tests_views.py
@@ -198,3 +198,61 @@ class ResourceTypesViewTest(IamTestCase):
         self.assertIsNotNone(json_result.get("data"))
         self.assertIsInstance(json_result.get("data"), list)
         self.assertEqual(json_result.get("data"), [])
+
+    @RbacPermissions({"aws.account": {"read": ["1234"]}, "aws.organizational_unit": {"read": ["1234"]}})
+    def test_rbacpermissions_aws_account_data_returns_null(self):
+        """Test that Aws endpoints accept valid Aws permissions."""
+        for endpoint in self.ENDPOINTS_AWS:
+            with self.subTest(endpoint=endpoint):
+                url = reverse(endpoint)
+                response = self.client.get(url, **self.headers)
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+                json_result = response.json()
+                self.assertIsNotNone(json_result.get("data"))
+                self.assertIsInstance(json_result.get("data"), list)
+                self.assertEqual(json_result.get("data"), [])
+
+    @RbacPermissions({"azure.subscription_guid": {"read": ["1234"]}})
+    def test_rbacpermissions_azure_account_data_returns_null(self):
+        """Test that OpenShift endpoints accept valid OpenShift permissions."""
+        for endpoint in self.ENDPOINTS_AZURE:
+            with self.subTest(endpoint=endpoint):
+                url = reverse(endpoint)
+                response = self.client.get(url, **self.headers)
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+                json_result = response.json()
+                self.assertIsNotNone(json_result.get("data"))
+                self.assertIsInstance(json_result.get("data"), list)
+                self.assertEqual(json_result.get("data"), [])
+
+    @RbacPermissions({"gcp.account": {"read": ["1234"]}, "gcp.project": {"read": ["1234"]}})
+    def test_rbacpermissions_aws_account_data_wildcard(self):
+        """Test that OpenShift endpoints accept valid OpenShift permissions."""
+        for endpoint in self.ENDPOINTS_GCP:
+            with self.subTest(endpoint=endpoint):
+                url = reverse(endpoint)
+                response = self.client.get(url, **self.headers)
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+                json_result = response.json()
+                self.assertIsNotNone(json_result.get("data"))
+                self.assertIsInstance(json_result.get("data"), list)
+                self.assertEqual(json_result.get("data"), [])
+
+    @RbacPermissions(
+        {
+            "openshift.cluster": {"read": ["1234"]},
+            "openshift.project": {"read": ["1234"]},
+            "openshift.node": {"read": ["1234"]},
+        }
+    )
+    def test_rbacpermissions_openshift_data_returns_empty_list(self):
+        """Test that OpenShift endpoints accept valid OpenShift permissions."""
+        for endpoint in self.ENDPOINTS_OPENSHIFT:
+            with self.subTest(endpoint=endpoint):
+                url = reverse(endpoint)
+                response = self.client.get(url, **self.headers)
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+                json_result = response.json()
+                self.assertIsNotNone(json_result.get("data"))
+                self.assertIsInstance(json_result.get("data"), list)
+                self.assertEqual(json_result.get("data"), [])


### PR DESCRIPTION
This fix lets accounts with wildcard access to see all data with rbac, while also return alias as well as the value in the endpoint if the endpoint returns alias.

Smokes

```
- FAILED lib64/python3.6/site-packages/iqe_cost_management/tests/black_box/test_prod_status.py::test_api_pre_tenant_create_check[/openapi.json] - iqe_cost_management_api.exceptions.ApiException...
FAILED lib64/python3.6/site-packages/iqe_cost_management/tests/rest_api/v1/test_azure_cost_reports.py::test_api_azure_cost_tag_validate_keys_visible - AssertionError: Failing from https://iss...
FAILED lib64/python3.6/site-packages/iqe_cost_management/tests/rest_api/v1/test_cost_model.py::test_api_cost_model_sorting[-source_type] - AssertionError: Sorted cost models don't match expec...
FAILED lib64/python3.6/site-packages/iqe_cost_management/tests/rest_api/v1/test_gcp_cost_reports.py::test_api_gcp_cost_order_by_name_pagination - AssertionError: Failing from https://issues.r...
FAILED lib64/python3.6/site-packages/iqe_cost_management/tests/rest_api/v1/test_user.py::test_api_settings_gcp_tag_enablement - iqe_cost_management_api.exceptions.ApiException: (400)
```