### PR TITLE
fix aws tag enablement

### DIFF
--- a/koku/masu/database/sql/reporting_awscostentrylineitem_daily_summary.sql
+++ b/koku/masu/database/sql/reporting_awscostentrylineitem_daily_summary.sql
@@ -59,10 +59,7 @@ SELECT uuid_generate_v4() as uuid,
        p.region,
        p.instance_type,
        pr.unit,
-       case when ek.keys = '{}'::text[]
-                 then li.tags
-            else li.tags - public.array_subtract(array(select jsonb_object_keys(li.tags))::text[], ek.keys::text[])
-       end::jsonb as "aws_tags",
+       li.tags - public.array_subtract(array(select jsonb_object_keys(li.tags))::text[], ek.keys::text[]) as "aws_tags",
        sum(li.usage_amount) as usage_amount,
        max(li.normalization_factor) as normalization_factor,
        sum(li.normalized_usage_amount) as normalized_usage_amount,

--- a/koku/masu/database/sql/reporting_awstags_summary.sql
+++ b/koku/masu/database/sql/reporting_awstags_summary.sql
@@ -3,7 +3,7 @@ WITH cte_tag_value AS (
         value,
         li.cost_entry_bill_id,
         li.usage_account_id
-    FROM {{schema | sqlsafe}}.reporting_awscostentrylineitem_daily_summary AS li,
+    FROM {{schema | sqlsafe}}.reporting_awscostentrylineitem_daily AS li,
         jsonb_each_text(li.tags) labels
     WHERE li.usage_start >= {{start_date}}
         AND li.usage_start <= {{end_date}}


### PR DESCRIPTION
### **Jira ticket**
[COST-1599](https://issues.redhat.com/browse/COST-1599)

### **Description**
This PR addresses issue 2 and issue 3 reported in COST-1599

**issue 2 - aws tags enablement doesn't work after enabling some other tag**
- If we enable some aws tag and leave it enabled at the end of the run, we will not be able to enable any other aws tag in the next run.
- I believe that the problem is that **reporting_awstags_summary** table is created based on the **reporting_awscostentrylineitem_daily_summary** table, which contains **only enabled tags**,
- consequently, since the **reporting_awstags_summary** is used as a basis for settings - aws tags options, we can enable only already enabled tags

**issue 3 - disabled aws tags are visible in aws cost report**
- when we disable all aws tags, all aws tags are visible in cost reports
- if this is not intentional/feature, we should remove the condition (if there is no tag enabled, add all tags) from insert into select statement by which the **reporting_awscostentrylineitem_daily_summary** table is created
