### PR TITLE
Update logic for operator_airgapped field 

### DIFF
--- a/koku/masu/external/downloader/ocp/ocp_report_downloader.py
+++ b/koku/masu/external/downloader/ocp/ocp_report_downloader.py
@@ -146,7 +146,7 @@ def process_cr(report_meta):
                 errors[case + "_error"] = case_info.get("error")
         manifest_info["operator_errors"] = errors or None
         manifest_info["cluster_channel"] = cr_status.get("clusterVersion")
-        manifest_info["operator_airgapped"] = cr_status.get("upload", {}).get("upload")
+        manifest_info["operator_airgapped"] = not cr_status.get("upload", {}).get("upload")
 
     return manifest_info
 

--- a/koku/masu/test/external/downloader/ocp/test_ocp_report_downloader.py
+++ b/koku/masu/test/external/downloader/ocp/test_ocp_report_downloader.py
@@ -277,7 +277,7 @@ class OCPReportDownloaderTest(MasuTestCase):
         expected_errors = {"prometheus_error": "fake error"}
         self.assertEqual(manifest.operator_version, version)
         self.assertEqual(manifest.operator_certified, False)
-        self.assertEqual(manifest.operator_airgapped, False)
+        self.assertEqual(manifest.operator_airgapped, True)
         self.assertEqual(manifest.cluster_channel, "stable-4.6")
         self.assertEqual(manifest.cluster_id, "4e009161-4f40-42c8-877c-3e59f6baea3d")
         self.assertEqual(manifest.operator_errors, expected_errors)


### PR DESCRIPTION
The koku-daily reports are finally coming in 🎉. However, this made me realize that I had switched the logic on the operator_airgapped field for the manifest. If the cr_status reports that the operator is uploading - airgapped should be False & vice versa. 