### PR TITLE
[COST-1784] Delete ocp on cloud parquet too

### DIFF
--- a/koku/masu/processor/parquet/ocp_cloud_parquet_report_processor.py
+++ b/koku/masu/processor/parquet/ocp_cloud_parquet_report_processor.py
@@ -11,43 +11,28 @@ from tenant_schemas.utils import schema_context
 
 from api.provider.models import Provider
 from api.utils import DateHelper
-from masu.config import Config
 from masu.database.aws_report_db_accessor import AWSReportDBAccessor
 from masu.database.azure_report_db_accessor import AzureReportDBAccessor
 from masu.database.ocp_report_db_accessor import OCPReportDBAccessor
 from masu.database.report_manifest_db_accessor import ReportManifestDBAccessor
 from masu.processor.ocp.ocp_cloud_updater_base import OCPCloudUpdaterBase
+from masu.processor.parquet.parquet_report_processor import OPENSHIFT_REPORT_TYPE
 from masu.processor.parquet.parquet_report_processor import PARQUET_EXT
 from masu.processor.parquet.parquet_report_processor import ParquetReportProcessor
 from masu.util.aws.common import match_openshift_resources_and_labels as aws_match_openshift_resources_and_labels
 from masu.util.azure.common import match_openshift_resources_and_labels as azure_match_openshift_resources_and_labels
-from masu.util.common import get_path_prefix
 
 
 LOG = logging.getLogger(__name__)
-REPORT_TYPE = "openshift"
 
 
 class OCPCloudParquetReportProcessor(ParquetReportProcessor):
     """Parquet report processor for OCP on Cloud infrastructure data."""
 
     @property
-    def parquet_ocp_on_cloud_path_s3(self):
-        """The path in the S3 bucket where Parquet files are loaded."""
-        return get_path_prefix(
-            self.account,
-            self.provider_type,
-            self.provider_uuid,
-            self.start_date,
-            Config.PARQUET_DATA_TYPE,
-            report_type=REPORT_TYPE,
-            daily=True,
-        )
-
-    @property
     def report_type(self):
         """Report OCP on Cloud report type."""
-        return REPORT_TYPE
+        return OPENSHIFT_REPORT_TYPE
 
     @property
     def ocp_on_cloud_data_processor(self):

--- a/koku/masu/processor/parquet/parquet_report_processor.py
+++ b/koku/masu/processor/parquet/parquet_report_processor.py
@@ -50,6 +50,7 @@ CSV_EXT = ".csv"
 PARQUET_EXT = ".parquet"
 
 DAILY_FILE_TYPE = "daily"
+OPENSHIFT_REPORT_TYPE = "openshift"
 
 COLUMN_CONVERTERS = {
     Provider.PROVIDER_AWS: aws_column_converters,
@@ -234,6 +235,19 @@ class ParquetReportProcessor:
         )
 
     @property
+    def parquet_ocp_on_cloud_path_s3(self):
+        """The path in the S3 bucket where Parquet files are loaded."""
+        return get_path_prefix(
+            self.account,
+            self.provider_type,
+            self.provider_uuid,
+            self.start_date,
+            Config.PARQUET_DATA_TYPE,
+            report_type=OPENSHIFT_REPORT_TYPE,
+            daily=True,
+        )
+
+    @property
     def local_path(self):
         local_path = f"{Config.TMP_DIR}/{self.account}/{self.provider_uuid}"
         Path(local_path).mkdir(parents=True, exist_ok=True)
@@ -324,6 +338,9 @@ class ParquetReportProcessor:
             )
             remove_files_not_in_set_from_s3_bucket(
                 self.tracing_id, self.parquet_daily_path_s3, self.manifest_id, self.error_context
+            )
+            remove_files_not_in_set_from_s3_bucket(
+                self.tracing_id, self.parquet_ocp_on_cloud_path_s3, self.manifest_id, self.error_context
             )
             manifest_accessor.mark_s3_parquet_cleared(manifest)
 

--- a/koku/masu/test/processor/parquet/test_ocp_cloud_parquet_report_processor.py
+++ b/koku/masu/test/processor/parquet/test_ocp_cloud_parquet_report_processor.py
@@ -14,7 +14,7 @@ from masu.database.azure_report_db_accessor import AzureReportDBAccessor
 from masu.database.ocp_report_db_accessor import OCPReportDBAccessor
 from masu.processor.ocp.ocp_cloud_updater_base import OCPCloudUpdaterBase
 from masu.processor.parquet.ocp_cloud_parquet_report_processor import OCPCloudParquetReportProcessor
-from masu.processor.parquet.ocp_cloud_parquet_report_processor import REPORT_TYPE
+from masu.processor.parquet.parquet_report_processor import OPENSHIFT_REPORT_TYPE
 from masu.processor.parquet.parquet_report_processor import PARQUET_EXT
 from masu.test import MasuTestCase
 from masu.util.aws.common import match_openshift_resources_and_labels
@@ -45,11 +45,11 @@ class TestOCPCloudParquetReportProcessor(MasuTestCase):
 
     def test_parquet_ocp_on_cloud_path_s3(self):
         """Test that the path is set properly."""
-        self.assertIn(REPORT_TYPE, self.report_processor.parquet_ocp_on_cloud_path_s3)
+        self.assertIn(OPENSHIFT_REPORT_TYPE, self.report_processor.parquet_ocp_on_cloud_path_s3)
 
     def test_report_type(self):
         """Test that the report type is set properly."""
-        self.assertEqual(REPORT_TYPE, self.report_processor.report_type)
+        self.assertEqual(OPENSHIFT_REPORT_TYPE, self.report_processor.report_type)
 
     def test_ocp_on_cloud_data_processor(self):
         """Test that the processor is properly set."""
@@ -132,7 +132,8 @@ class TestOCPCloudParquetReportProcessor(MasuTestCase):
     def test_determin_s3_path(self):
         """Test that we return the OCP on cloud path."""
         self.assertEqual(
-            self.report_processor._determin_s3_path(REPORT_TYPE), self.report_processor.parquet_ocp_on_cloud_path_s3
+            self.report_processor._determin_s3_path(OPENSHIFT_REPORT_TYPE),
+            self.report_processor.parquet_ocp_on_cloud_path_s3,
         )
         self.assertIsNone(self.report_processor._determin_s3_path("incorrect"))
 

--- a/koku/masu/util/azure/common.py
+++ b/koku/masu/util/azure/common.py
@@ -188,7 +188,7 @@ def match_openshift_resources_and_labels(data_frame, cluster_topology, matched_t
         resource_id_df = data_frame["instanceid"]
 
     LOG.info("Matching OpenShift on Azure by resource ID.")
-    resource_id_matched = resource_id_df.isin(matchable_resources)
+    resource_id_matched = resource_id_df.str.contains("|".join(matchable_resources))
     data_frame["resource_id_matched"] = resource_id_matched
 
     tags = data_frame["tags"]


### PR DESCRIPTION
## Summary
* When we process AWS or Azure data, we delete previous parquet files for the month. We were not doing this for ocp on Cloud parquet files, causing duplication. This will delete these files before reprocessing the month. 
* Fixes OCP on Azure resource ID matching using string contains instead of isin

## Testing
Ran make-load-test-customer-data several times before making this change and had a parquet file from each run in the daily/openshift parquet path for AWS. Made this change and re-ran resulting in a single file covering the entire month's costs. 