### PR TITLE
remove hard coded git refs in pr_check

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -11,6 +11,8 @@ IMAGE="quay.io/cloudservices/koku"
 COMPONENTS="hive-metastore koku presto"  # specific components to deploy (optional, default: all)
 COMPONENTS_W_RESOURCES="hive-metastore koku presto"  # components which should preserve resource settings (optional, default: none)
 
+ARTIFACTS_DIR="$WORKSPACE/artifacts"
+
 export IQE_PLUGINS="cost_management"
 export IQE_MARKER_EXPRESSION="cost_smoke"
 export IQE_FILTER_EXPRESSION="test_api"
@@ -18,18 +20,29 @@ export IQE_CJI_TIMEOUT="2h"
 
 set -ex
 
+function get_pr_labels() {
+    mkdir -p $ARTIFACTS_DIR
+    curl -s -H "Accept: application/vnd.github.v3+json" https://api.github.com/search/issues\?q\=sha:$GIT_COMMIT | jq '.items[].labels[].name' > $ARTIFACTS_DIR/github_labels.txt
+}
+
+function check_for_labels() {
+    if [ -f $ARTIFACTS_DIR/github_labels.txt ]; then
+        egrep "$1" $ARTIFACTS_DIR/github_labels.txt &>/dev/null
+    fi
+}
+
+get_pr_labels
+
 # Install bonfire repo/initialize
 CICD_URL=https://raw.githubusercontent.com/RedHatInsights/bonfire/master/cicd
 curl -s $CICD_URL/bootstrap.sh > .cicd_bootstrap.sh && source .cicd_bootstrap.sh
 
-if $(curl -s -H "Accept: application/vnd.github.v3+json" https://api.github.com/search/issues\?q\=sha:$GIT_COMMIT |
-    jq '[.items[].labels[].name] | length > 0 and inside(["lgtm", "pr-check-build", "smoke-tests"])'); then
+if check_for_labels "lgtm|pr-check-build|smoke-tests"; then
 
     source $CICD_ROOT/build.sh
     # source $APP_ROOT/unit_test.sh
 
-    if $(curl -s -H "Accept: application/vnd.github.v3+json" https://api.github.com/search/issues\?q\=sha:$GIT_COMMIT |
-    jq '[.items[].labels[].name] | length > 0 and inside(["lgtm", "smoke-tests"])'); then
+    if check_for_labels "lgtm|smoke-tests"; then
 
         source ${CICD_ROOT}/_common_deploy_logic.sh
         export NAMESPACE=$(bonfire namespace reserve --duration 4)
@@ -46,12 +59,11 @@ if $(curl -s -H "Accept: application/vnd.github.v3+json" https://api.github.com/
             --source=appsre \
             --ref-env insights-stage \
             --set-template-ref ${APP_NAME}/${COMPONENT_NAME}=${GIT_COMMIT} \
-            --set-template-ref ${APP_NAME}/hive-metastore=e2d38d5cec970895e8591f46ef56d3688208bc34 \
-            --set-template-ref ${APP_NAME}/presto=7fde696eecd680ccb60cc5ba11359887997e48b1 \
             --set-image-tag ${IMAGE}=${IMAGE_TAG} \
             --namespace ${NAMESPACE} \
             ${COMPONENTS_ARG} \
             ${COMPONENTS_RESOURCES_ARG} \
+            --set-parameter rbac/MIN_REPLICAS=1 \
             --set-parameter koku/AWS_ACCESS_KEY_ID_EPH=${AWS_ACCESS_KEY_ID_EPH} \
             --set-parameter koku/AWS_SECRET_ACCESS_KEY_EPH=${AWS_SECRET_ACCESS_KEY_EPH} \
             --set-parameter koku/GCP_CREDENTIALS_EPH=${GCP_CREDENTIALS_EPH} \


### PR DESCRIPTION
- remove the hard-coded git-refs for hive and presto/trino
- clean up logic around getting github labels