### PR TITLE
Turn off release notes cronjob and remove `current commit` from notes

### DIFF
--- a/.github/scripts/get_description.sh
+++ b/.github/scripts/get_description.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
 cat > release_body.md << EOF
-### Current commit: \<insert-commit-hash\>
-
 ### Summary:
 
 TODO: insert summary

--- a/.github/scripts/get_description.sh
+++ b/.github/scripts/get_description.sh
@@ -7,5 +7,5 @@ TODO: insert summary
 
 ### Changes:
 
-$(git log $(git tag --list | tail -1)..main --pretty=format:'* %h - %s')
+$(git log $(git tag --list | tail -1)..${RELEASE_COMMIT} --pretty=format:'* %h - %s')
 EOF

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -1,8 +1,6 @@
 name: pre release
 
 on:
-  schedule:
-    - cron:  '30 12 * * FRI'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -2,22 +2,29 @@ name: pre release
 
 on:
   workflow_dispatch:
+    inputs:
+      commit:
+        description: 'Release commit'
+        required: true
 
 jobs:
   pre-release:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Set variables
       run: echo "::set-output name=TAG_VERSION::r.$(date +%Y.%m.%d)"
       id: variable-setter
-    - name: Remove old remote-tracking references no longer on remote
-      run: git fetch --prune --unshallow
+    - name: set the release commit
+      run: echo "RELEASE_COMMIT=${{ github.event.inputs.commit }}" >> $GITHUB_ENV
     - name: Create release body file
       run: bash .github/scripts/get_description.sh
-    - uses: ncipollo/release-action@v1
-      with:
-        bodyFile: release_body.md
-        prerelease: true
-        tag: ${{ steps.variable-setter.outputs.TAG_VERSION }}
-        token: ${{ secrets.GITHUB_TOKEN }}
+    - run: cat release_body.md
+    # - uses: ncipollo/release-action@v1
+    #   with:
+    #     bodyFile: release_body.md
+    #     prerelease: true
+    #     tag: ${{ steps.variable-setter.outputs.TAG_VERSION }}
+    #     token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -21,10 +21,10 @@ jobs:
       run: echo "RELEASE_COMMIT=${{ github.event.inputs.commit }}" >> $GITHUB_ENV
     - name: Create release body file
       run: bash .github/scripts/get_description.sh
-    - run: cat release_body.md
-    # - uses: ncipollo/release-action@v1
-    #   with:
-    #     bodyFile: release_body.md
-    #     prerelease: true
-    #     tag: ${{ steps.variable-setter.outputs.TAG_VERSION }}
-    #     token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: ncipollo/release-action@v1
+      with:
+        bodyFile: release_body.md
+        commit: ${{ github.event.inputs.commit }}
+        prerelease: true
+        tag: ${{ steps.variable-setter.outputs.TAG_VERSION }}
+        token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- disable the cronjob
- remove "Current commit" from the notes
- require the commit-hash to be passed into the manual trigger