### PR TITLE
update pr_check.sh so that it fails if smokes were not run

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -70,8 +70,9 @@ function make_results_xml() {
 cat << EOF > $WORKSPACE/artifacts/junit-pr_check.xml
 <?xml version="1.0" encoding="UTF-8" ?>
 <testsuite id="pr_check" name="PR Check" tests="1" failures="1">
-    <testcase id="pr_check.${task_arr[$exit_code]}" name="${task_arr[$exit_code]}"/>
-    <failure type="${task_arr[$exit_code]}">"${error_arr[$exit_code]}"</failure>
+    <testcase id="pr_check.${task_arr[$exit_code]}" name="${task_arr[$exit_code]}">
+        <failure type="${task_arr[$exit_code]}">"${error_arr[$exit_code]}"</failure>
+    </testcase>
 </testsuite>
 EOF
 }


### PR DESCRIPTION
This updates our PR check script to fail when smokes are not run.

I've also updated things so that the script failure tells you why it failed:
![image](https://user-images.githubusercontent.com/19751919/131038139-21322841-c7b8-454c-9fa8-b5bb0205d155.png)

Without pr-check-build label:
![image](https://user-images.githubusercontent.com/19751919/131038185-cd6d4934-907e-4de5-bc7b-820da83cbb1c.png)

Without smokes label:
![image](https://user-images.githubusercontent.com/19751919/131038901-ab67ebbf-9a43-4521-97d9-1736512c5595.png)
