### PR TITLE
unittest: end-of-month test fix

### DIFF
--- a/koku/api/report/serializers.py
+++ b/koku/api/report/serializers.py
@@ -402,8 +402,8 @@ class ParamSerializer(BaseSerializer):
                         and value.get("date") <= dh.today.date()
                     ):
                         continue
-                    error = "Order by date must be from {} to {}".format(
-                        materialized_view_month_start(dh).date(), dh.today.date()
+                    error[key] = _(
+                        f"Order-by date must be from {materialized_view_month_start(dh).date()} to {dh.today.date()}"
                     )
                     raise serializers.ValidationError(error)
 

--- a/koku/api/report/test/aws/openshift/test_ocp_aws_query_handler.py
+++ b/koku/api/report/test/aws/openshift/test_ocp_aws_query_handler.py
@@ -453,13 +453,13 @@ class OCPAWSQueryHandlerTest(IamTestCase):
         with self.assertRaises(ValidationError):
             self.mocked_query_params(url, OCPAWSCostView)
 
-    def test_aws_out_of_range_under_date(self):
-        wrong_date = DateHelper().today.date() - timedelta(days=91)
+    def test_ocp_aws_out_of_range_under_date(self):
+        wrong_date = DateHelper().today.date() - timedelta(months=3, days=1)
         url = f"?order_by[cost]=desc&order_by[date]={wrong_date}&group_by[service]=*"
         with self.assertRaises(ValidationError):
             self.mocked_query_params(url, OCPAWSCostView)
 
-    def test_aws_out_of_range_over_date(self):
+    def test_ocp_aws_out_of_range_over_date(self):
         wrong_date = DateHelper().today.date() + timedelta(days=1)
         url = f"?order_by[cost]=desc&order_by[date]={wrong_date}&group_by[service]=*"
         with self.assertRaises(ValidationError):

--- a/koku/api/report/test/aws/openshift/test_ocp_aws_query_handler.py
+++ b/koku/api/report/test/aws/openshift/test_ocp_aws_query_handler.py
@@ -7,7 +7,6 @@ import copy
 from datetime import datetime
 from datetime import timedelta
 
-from dateutil.relativedelta import relativedelta
 from rest_framework.exceptions import ValidationError
 from tenant_schemas.utils import tenant_context
 
@@ -18,6 +17,7 @@ from api.report.aws.openshift.view import OCPAWSInstanceTypeView
 from api.report.aws.openshift.view import OCPAWSStorageView
 from api.report.queries import check_view_filter_and_group_by_criteria
 from api.utils import DateHelper
+from api.utils import materialized_view_month_start
 from reporting.models import AWSCostEntryBill
 from reporting.models import OCPAWSComputeSummary
 from reporting.models import OCPAWSCostLineItemDailySummary
@@ -455,7 +455,7 @@ class OCPAWSQueryHandlerTest(IamTestCase):
             self.mocked_query_params(url, OCPAWSCostView)
 
     def test_ocp_aws_out_of_range_under_date(self):
-        wrong_date = DateHelper().today.date() - relativedelta(months=3, days=1)
+        wrong_date = materialized_view_month_start() - timedelta(days=1)
         url = f"?order_by[cost]=desc&order_by[date]={wrong_date}&group_by[service]=*"
         with self.assertRaises(ValidationError):
             self.mocked_query_params(url, OCPAWSCostView)

--- a/koku/api/report/test/aws/openshift/test_ocp_aws_query_handler.py
+++ b/koku/api/report/test/aws/openshift/test_ocp_aws_query_handler.py
@@ -7,6 +7,7 @@ import copy
 from datetime import datetime
 from datetime import timedelta
 
+from dateutil.relativedelta import relativedelta
 from rest_framework.exceptions import ValidationError
 from tenant_schemas.utils import tenant_context
 
@@ -454,7 +455,7 @@ class OCPAWSQueryHandlerTest(IamTestCase):
             self.mocked_query_params(url, OCPAWSCostView)
 
     def test_ocp_aws_out_of_range_under_date(self):
-        wrong_date = DateHelper().today.date() - timedelta(months=3, days=1)
+        wrong_date = DateHelper().today.date() - relativedelta(months=3, days=1)
         url = f"?order_by[cost]=desc&order_by[date]={wrong_date}&group_by[service]=*"
         with self.assertRaises(ValidationError):
             self.mocked_query_params(url, OCPAWSCostView)

--- a/koku/api/report/test/aws/tests_queries.py
+++ b/koku/api/report/test/aws/tests_queries.py
@@ -34,6 +34,7 @@ from api.report.test.aws.test_views import _calculate_accounts_and_subous
 from api.tags.aws.queries import AWSTagQueryHandler
 from api.tags.aws.view import AWSTagView
 from api.utils import DateHelper
+from api.utils import materialized_view_month_start
 from reporting.models import AWSComputeSummary
 from reporting.models import AWSComputeSummaryByAccount
 from reporting.models import AWSComputeSummaryByRegion
@@ -1893,7 +1894,7 @@ class AWSReportQueryTest(IamTestCase):
             self.mocked_query_params(url, AWSCostView)
 
     def test_aws_out_of_range_under_date(self):
-        wrong_date = DateHelper().today.date() - relativedelta(months=3, days=1)
+        wrong_date = materialized_view_month_start() - timedelta(days=1)
         url = f"?order_by[cost]=desc&order_by[date]={wrong_date}&group_by[service]=*"
         with self.assertRaises(ValidationError):
             self.mocked_query_params(url, AWSCostView)

--- a/koku/api/report/test/aws/tests_queries.py
+++ b/koku/api/report/test/aws/tests_queries.py
@@ -1893,7 +1893,7 @@ class AWSReportQueryTest(IamTestCase):
             self.mocked_query_params(url, AWSCostView)
 
     def test_aws_out_of_range_under_date(self):
-        wrong_date = DateHelper().today.date() - timedelta(months=3, days=1)
+        wrong_date = DateHelper().today.date() - relativedelta(months=3, days=1)
         url = f"?order_by[cost]=desc&order_by[date]={wrong_date}&group_by[service]=*"
         with self.assertRaises(ValidationError):
             self.mocked_query_params(url, AWSCostView)

--- a/koku/api/report/test/aws/tests_queries.py
+++ b/koku/api/report/test/aws/tests_queries.py
@@ -1893,7 +1893,7 @@ class AWSReportQueryTest(IamTestCase):
             self.mocked_query_params(url, AWSCostView)
 
     def test_aws_out_of_range_under_date(self):
-        wrong_date = DateHelper().today.date() - timedelta(days=91)
+        wrong_date = DateHelper().today.date() - timedelta(months=3, days=1)
         url = f"?order_by[cost]=desc&order_by[date]={wrong_date}&group_by[service]=*"
         with self.assertRaises(ValidationError):
             self.mocked_query_params(url, AWSCostView)

--- a/koku/api/report/test/azure/openshift/test_ocp_azure_query_handler.py
+++ b/koku/api/report/test/azure/openshift/test_ocp_azure_query_handler.py
@@ -27,6 +27,7 @@ from api.report.azure.openshift.view import OCPAzureCostView
 from api.report.azure.openshift.view import OCPAzureInstanceTypeView
 from api.report.azure.openshift.view import OCPAzureStorageView
 from api.utils import DateHelper
+from api.utils import materialized_view_month_start
 from reporting.models import AzureCostEntryBill
 from reporting.models import OCPAzureComputeSummary
 from reporting.models import OCPAzureCostLineItemDailySummary
@@ -1071,7 +1072,7 @@ class OCPAzureQueryHandlerTest(IamTestCase):
             self.mocked_query_params(url, OCPAzureCostView)
 
     def test_ocp_azure_out_of_range_under_date(self):
-        wrong_date = DateHelper().today.date() - relativedelta(months=3, days=1)
+        wrong_date = materialized_view_month_start() - timedelta(days=1)
         url = f"?order_by[cost]=desc&order_by[date]={wrong_date}&group_by[service_name]=*"
         with self.assertRaises(ValidationError):
             self.mocked_query_params(url, OCPAzureCostView)

--- a/koku/api/report/test/azure/openshift/test_ocp_azure_query_handler.py
+++ b/koku/api/report/test/azure/openshift/test_ocp_azure_query_handler.py
@@ -1071,7 +1071,7 @@ class OCPAzureQueryHandlerTest(IamTestCase):
             self.mocked_query_params(url, OCPAzureCostView)
 
     def test_ocp_azure_out_of_range_under_date(self):
-        wrong_date = DateHelper().today.date() - timedelta(months=3, days=1)
+        wrong_date = DateHelper().today.date() - relativedelta(months=3, days=1)
         url = f"?order_by[cost]=desc&order_by[date]={wrong_date}&group_by[service_name]=*"
         with self.assertRaises(ValidationError):
             self.mocked_query_params(url, OCPAzureCostView)

--- a/koku/api/report/test/azure/openshift/test_ocp_azure_query_handler.py
+++ b/koku/api/report/test/azure/openshift/test_ocp_azure_query_handler.py
@@ -1070,13 +1070,13 @@ class OCPAzureQueryHandlerTest(IamTestCase):
         with self.assertRaises(ValidationError):
             self.mocked_query_params(url, OCPAzureCostView)
 
-    def test_aws_out_of_range_under_date(self):
-        wrong_date = DateHelper().today.date() - timedelta(days=91)
+    def test_ocp_azure_out_of_range_under_date(self):
+        wrong_date = DateHelper().today.date() - timedelta(months=3, days=1)
         url = f"?order_by[cost]=desc&order_by[date]={wrong_date}&group_by[service_name]=*"
         with self.assertRaises(ValidationError):
             self.mocked_query_params(url, OCPAzureCostView)
 
-    def test_aws_out_of_range_over_date(self):
+    def test_ocp_azure_out_of_range_over_date(self):
         wrong_date = DateHelper().today.date() + timedelta(days=1)
         url = f"?order_by[cost]=desc&order_by[date]={wrong_date}&group_by[service_name]=*"
         with self.assertRaises(ValidationError):

--- a/koku/api/report/test/azure/tests_azure_query_handler.py
+++ b/koku/api/report/test/azure/tests_azure_query_handler.py
@@ -1267,7 +1267,7 @@ class AzureReportQueryHandlerTest(IamTestCase):
             self.mocked_query_params(url, AzureCostView)
 
     def test_azure_out_of_range_under_date(self):
-        wrong_date = DateHelper().today.date() - timedelta(months=3, days=1)
+        wrong_date = DateHelper().today.date() - relativedelta(months=3, days=1)
         url = f"?order_by[cost]=desc&order_by[date]={wrong_date}&group_by[service_name]=*"
         with self.assertRaises(ValidationError):
             self.mocked_query_params(url, AzureCostView)

--- a/koku/api/report/test/azure/tests_azure_query_handler.py
+++ b/koku/api/report/test/azure/tests_azure_query_handler.py
@@ -28,6 +28,7 @@ from api.report.azure.view import AzureStorageView
 from api.tags.azure.queries import AzureTagQueryHandler
 from api.tags.azure.view import AzureTagView
 from api.utils import DateHelper
+from api.utils import materialized_view_month_start
 from reporting.models import AzureComputeSummary
 from reporting.models import AzureCostEntryBill
 from reporting.models import AzureCostEntryLineItemDailySummary
@@ -1267,7 +1268,7 @@ class AzureReportQueryHandlerTest(IamTestCase):
             self.mocked_query_params(url, AzureCostView)
 
     def test_azure_out_of_range_under_date(self):
-        wrong_date = DateHelper().today.date() - relativedelta(months=3, days=1)
+        wrong_date = materialized_view_month_start() - timedelta(days=1)
         url = f"?order_by[cost]=desc&order_by[date]={wrong_date}&group_by[service_name]=*"
         with self.assertRaises(ValidationError):
             self.mocked_query_params(url, AzureCostView)

--- a/koku/api/report/test/azure/tests_azure_query_handler.py
+++ b/koku/api/report/test/azure/tests_azure_query_handler.py
@@ -1266,13 +1266,13 @@ class AzureReportQueryHandlerTest(IamTestCase):
         with self.assertRaises(ValidationError):
             self.mocked_query_params(url, AzureCostView)
 
-    def test_aws_out_of_range_under_date(self):
-        wrong_date = DateHelper().today.date() - timedelta(days=91)
+    def test_azure_out_of_range_under_date(self):
+        wrong_date = DateHelper().today.date() - timedelta(months=3, days=1)
         url = f"?order_by[cost]=desc&order_by[date]={wrong_date}&group_by[service_name]=*"
         with self.assertRaises(ValidationError):
             self.mocked_query_params(url, AzureCostView)
 
-    def test_aws_out_of_range_over_date(self):
+    def test_azure_out_of_range_over_date(self):
         wrong_date = DateHelper().today.date() + timedelta(days=1)
         url = f"?order_by[cost]=desc&order_by[date]={wrong_date}&group_by[service_name]=*"
         with self.assertRaises(ValidationError):

--- a/koku/api/report/test/gcp/tests_gcp_query_handler.py
+++ b/koku/api/report/test/gcp/tests_gcp_query_handler.py
@@ -25,6 +25,7 @@ from api.report.gcp.view import GCPCostView
 from api.report.gcp.view import GCPInstanceTypeView
 from api.report.gcp.view import GCPStorageView
 from api.utils import DateHelper
+from api.utils import materialized_view_month_start
 from reporting.models import GCPCostEntryBill
 from reporting.models import GCPCostEntryLineItemDailySummary
 from reporting.models import GCPCostSummary
@@ -1123,7 +1124,7 @@ class GCPReportQueryHandlerTest(IamTestCase):
             self.mocked_query_params(url, GCPCostView)
 
     def test_gcp_out_of_range_under_date(self):
-        wrong_date = DateHelper().today.date() - relativedelta(months=3, days=1)
+        wrong_date = materialized_view_month_start() - timedelta(days=1)
         url = f"?order_by[cost]=desc&order_by[date]={wrong_date}&group_by[service]=*"
         with self.assertRaises(ValidationError):
             self.mocked_query_params(url, GCPCostView)

--- a/koku/api/report/test/gcp/tests_gcp_query_handler.py
+++ b/koku/api/report/test/gcp/tests_gcp_query_handler.py
@@ -1122,13 +1122,13 @@ class GCPReportQueryHandlerTest(IamTestCase):
         with self.assertRaises(ValidationError):
             self.mocked_query_params(url, GCPCostView)
 
-    def test_aws_out_of_range_under_date(self):
-        wrong_date = DateHelper().today.date() - timedelta(days=91)
+    def test_gcp_out_of_range_under_date(self):
+        wrong_date = DateHelper().today.date() - timedelta(months=3, days=1)
         url = f"?order_by[cost]=desc&order_by[date]={wrong_date}&group_by[service]=*"
         with self.assertRaises(ValidationError):
             self.mocked_query_params(url, GCPCostView)
 
-    def test_aws_out_of_range_over_date(self):
+    def test_gcp_out_of_range_over_date(self):
         wrong_date = DateHelper().today.date() + timedelta(days=1)
         url = f"?order_by[cost]=desc&order_by[date]={wrong_date}&group_by[service]=*"
         with self.assertRaises(ValidationError):

--- a/koku/api/report/test/gcp/tests_gcp_query_handler.py
+++ b/koku/api/report/test/gcp/tests_gcp_query_handler.py
@@ -1123,7 +1123,7 @@ class GCPReportQueryHandlerTest(IamTestCase):
             self.mocked_query_params(url, GCPCostView)
 
     def test_gcp_out_of_range_under_date(self):
-        wrong_date = DateHelper().today.date() - timedelta(months=3, days=1)
+        wrong_date = DateHelper().today.date() - relativedelta(months=3, days=1)
         url = f"?order_by[cost]=desc&order_by[date]={wrong_date}&group_by[service]=*"
         with self.assertRaises(ValidationError):
             self.mocked_query_params(url, GCPCostView)

--- a/koku/api/report/test/ocp/test_ocp_query_handler.py
+++ b/koku/api/report/test/ocp/test_ocp_query_handler.py
@@ -10,7 +10,6 @@ from datetime import timedelta
 from decimal import Decimal
 from unittest.mock import patch
 
-from dateutil.relativedelta import relativedelta
 from django.db.models import Max
 from django.db.models.expressions import OrderBy
 from rest_framework.exceptions import ValidationError
@@ -26,6 +25,7 @@ from api.report.ocp.view import OCPVolumeView
 from api.tags.ocp.queries import OCPTagQueryHandler
 from api.tags.ocp.view import OCPTagView
 from api.utils import DateHelper
+from api.utils import materialized_view_month_start
 from reporting.models import OCPUsageLineItemDailySummary
 from reporting.provider.ocp.models import OCPUsageReportPeriod
 
@@ -644,7 +644,7 @@ class OCPReportQueryHandlerTest(IamTestCase):
             self.mocked_query_params(url, OCPCostView)
 
     def test_ocp_out_of_range_under_date(self):
-        wrong_date = DateHelper().today.date() - relativedelta(months=3, days=1)
+        wrong_date = materialized_view_month_start() - timedelta(days=1)
         url = f"?order_by[cost]=desc&order_by[date]={wrong_date}&group_by[project]=*"
         with self.assertRaises(ValidationError):
             self.mocked_query_params(url, OCPCostView)

--- a/koku/api/report/test/ocp/test_ocp_query_handler.py
+++ b/koku/api/report/test/ocp/test_ocp_query_handler.py
@@ -642,13 +642,13 @@ class OCPReportQueryHandlerTest(IamTestCase):
         with self.assertRaises(ValidationError):
             self.mocked_query_params(url, OCPCostView)
 
-    def test_aws_out_of_range_under_date(self):
-        wrong_date = DateHelper().today.date() - timedelta(days=91)
+    def test_ocp_out_of_range_under_date(self):
+        wrong_date = DateHelper().today.date() - timedelta(months=3, days=1)
         url = f"?order_by[cost]=desc&order_by[date]={wrong_date}&group_by[project]=*"
         with self.assertRaises(ValidationError):
             self.mocked_query_params(url, OCPCostView)
 
-    def test_aws_out_of_range_over_date(self):
+    def test_ocp_out_of_range_over_date(self):
         wrong_date = DateHelper().today.date() + timedelta(days=1)
         url = f"?order_by[cost]=desc&order_by[date]={wrong_date}&group_by[project]=*"
         with self.assertRaises(ValidationError):

--- a/koku/api/report/test/ocp/test_ocp_query_handler.py
+++ b/koku/api/report/test/ocp/test_ocp_query_handler.py
@@ -10,6 +10,7 @@ from datetime import timedelta
 from decimal import Decimal
 from unittest.mock import patch
 
+from dateutil.relativedelta import relativedelta
 from django.db.models import Max
 from django.db.models.expressions import OrderBy
 from rest_framework.exceptions import ValidationError
@@ -643,7 +644,7 @@ class OCPReportQueryHandlerTest(IamTestCase):
             self.mocked_query_params(url, OCPCostView)
 
     def test_ocp_out_of_range_under_date(self):
-        wrong_date = DateHelper().today.date() - timedelta(months=3, days=1)
+        wrong_date = DateHelper().today.date() - relativedelta(months=3, days=1)
         url = f"?order_by[cost]=desc&order_by[date]={wrong_date}&group_by[project]=*"
         with self.assertRaises(ValidationError):
             self.mocked_query_params(url, OCPCostView)


### PR DESCRIPTION
Update unit tests to use `materialized_view_month_start` and a time delta of 1 day rather than `timedelta` of 91 days.