### PR TITLE
COST-1819: gcp fix invoice_month filter and other start of month test failures.

### DIFF
--- a/koku/api/report/test/aws/openshift/test_ocp_aws_query_handler.py
+++ b/koku/api/report/test/aws/openshift/test_ocp_aws_query_handler.py
@@ -4,7 +4,7 @@
 #
 """Test the Report Queries."""
 import copy
-from datetime import datetime
+import logging
 from datetime import timedelta
 
 from rest_framework.exceptions import ValidationError
@@ -28,6 +28,8 @@ from reporting.models import OCPAWSCostSummaryByService
 from reporting.models import OCPAWSDatabaseSummary
 from reporting.models import OCPAWSNetworkSummary
 from reporting.models import OCPAWSStorageSummary
+
+LOG = logging.getLogger(__name__)
 
 
 class OCPAWSQueryHandlerTestNoData(IamTestCase):
@@ -420,11 +422,8 @@ class OCPAWSQueryHandlerTest(IamTestCase):
     def test_ocp_aws_date_order_by_cost_desc(self):
         """Test execute_query with order by date for correct order of services."""
         # execute query
-        yesterday = datetime.utcnow() - timedelta(days=1)
-        # removes time from date
-        yesterday = datetime.date(yesterday)
+        yesterday = self.dh.yesterday.date()
         lst = []
-        matchinglists = False
         correctlst = []
         url = f"?order_by[cost]=desc&order_by[date]={yesterday}&group_by[service]=*"  # noqa: E501
         query_params = self.mocked_query_params(url, OCPAWSCostView)
@@ -437,16 +436,10 @@ class OCPAWSQueryHandlerTest(IamTestCase):
                 for service in element.get("services"):
                     correctlst.append(service.get("service"))
         for element in data:
-            # Check if there is any data in services
-            if element.get("services") > []:
-                for service in element.get("services"):
-                    lst.append(service.get("service"))
-                if correctlst == lst:
-                    matchinglists = True
-                else:
-                    matchinglists = False
-                lst = []
-        self.assertTrue(matchinglists)
+            for service in element.get("services"):
+                lst.append(service.get("service"))
+            self.assertEqual(correctlst, lst)
+            lst = []
 
     def test_ocp_aws_date_incorrect_date(self):
         wrong_date = "200BC"

--- a/koku/api/report/test/aws/tests_queries.py
+++ b/koku/api/report/test/aws/tests_queries.py
@@ -1859,11 +1859,8 @@ class AWSReportQueryTest(IamTestCase):
     def test_aws_date_order_by_cost_desc(self):
         """Test execute_query with order by date for correct order of services."""
         # execute query
-        yesterday = datetime.utcnow() - timedelta(days=1)
-        # removes time from date
-        yesterday = datetime.date(yesterday)
+        yesterday = self.dh.yesterday.date()
         lst = []
-        matchinglists = False
         correctlst = []
         url = f"?order_by[cost]=desc&order_by[date]={yesterday}&group_by[service]=*"  # noqa: E501
         query_params = self.mocked_query_params(url, AWSCostView)
@@ -1872,20 +1869,10 @@ class AWSReportQueryTest(IamTestCase):
         data = query_output.get("data")
         # test query output
         for element in data:
-            if element.get("date") == str(yesterday):
-                for service in element.get("services"):
-                    correctlst.append(service.get("service"))
-        for element in data:
-            # Check if there is any data in services
-            if element.get("services") > []:
-                for service in element.get("services"):
-                    lst.append(service.get("service"))
-                if correctlst == lst:
-                    matchinglists = True
-                else:
-                    matchinglists = False
-                lst = []
-        self.assertTrue(matchinglists)
+            for service in element.get("services"):
+                lst.append(service.get("service"))
+            self.assertEqual(correctlst, lst)
+            lst = []
 
     def test_aws_date_incorrect_date(self):
         wrong_date = "200BC"

--- a/koku/api/report/test/azure/openshift/test_ocp_azure_query_handler.py
+++ b/koku/api/report/test/azure/openshift/test_ocp_azure_query_handler.py
@@ -1037,11 +1037,8 @@ class OCPAzureQueryHandlerTest(IamTestCase):
     def test_ocp_azure_date_order_by_cost_desc(self):
         """Test execute_query with order by date for correct order of services."""
         # execute query
-        yesterday = datetime.utcnow() - timedelta(days=1)
-        # removes time from date
-        yesterday = datetime.date(yesterday)
+        yesterday = self.dh.yesterday.date()
         lst = []
-        matchinglists = False
         correctlst = []
         url = f"?order_by[cost]=desc&order_by[date]={yesterday}&group_by[service_name]=*"  # noqa: E501
         query_params = self.mocked_query_params(url, OCPAzureCostView)
@@ -1055,15 +1052,10 @@ class OCPAzureQueryHandlerTest(IamTestCase):
                     correctlst.append(service.get("service_name"))
         for element in data:
             # Check if there is any data in services
-            if element.get("service_names") > []:
-                for service in element.get("service_names"):
-                    lst.append(service.get("service_name"))
-                if correctlst == lst:
-                    matchinglists = True
-                else:
-                    matchinglists = False
-                lst = []
-        self.assertTrue(matchinglists)
+            for service in element.get("service_names"):
+                lst.append(service.get("service_name"))
+            self.assertEqual(correctlst, lst)
+            lst = []
 
     def test_ocp_azure_date_incorrect_date(self):
         wrong_date = "200BC"

--- a/koku/api/report/test/azure/tests_azure_query_handler.py
+++ b/koku/api/report/test/azure/tests_azure_query_handler.py
@@ -1233,11 +1233,8 @@ class AzureReportQueryHandlerTest(IamTestCase):
     def test_azure_date_order_by_cost_desc(self):
         """Test execute_query with order by date for correct order of services."""
         # execute query
-        yesterday = datetime.utcnow() - timedelta(days=1)
-        # removes time from date
-        yesterday = datetime.date(yesterday)
+        yesterday = self.dh.yesterday.date()
         lst = []
-        matchinglists = False
         correctlst = []
         url = f"?order_by[cost]=desc&order_by[date]={yesterday}&group_by[service_name]=*"  # noqa: E501
         query_params = self.mocked_query_params(url, AzureCostView)
@@ -1251,15 +1248,10 @@ class AzureReportQueryHandlerTest(IamTestCase):
                     correctlst.append(service.get("service_name"))
         for element in data:
             # Check if there is any data in services
-            if element.get("service_names") > []:
-                for service in element.get("service_names"):
-                    lst.append(service.get("service_name"))
-                if correctlst == lst:
-                    matchinglists = True
-                else:
-                    matchinglists = False
-                lst = []
-        self.assertTrue(matchinglists)
+            for service in element.get("service_names"):
+                lst.append(service.get("service_name"))
+            self.assertEqual(correctlst, lst)
+            lst = []
 
     def test_azure_date_incorrect_date(self):
         wrong_date = "200BC"

--- a/koku/api/report/test/gcp/tests_gcp_query_handler.py
+++ b/koku/api/report/test/gcp/tests_gcp_query_handler.py
@@ -1089,11 +1089,8 @@ class GCPReportQueryHandlerTest(IamTestCase):
     def test_gcp_date_order_by_cost_desc(self):
         """Test execute_query with order by date for correct order of services."""
         # execute query
-        yesterday = datetime.utcnow() - timedelta(days=1)
-        # removes time from date
-        yesterday = datetime.date(yesterday)
+        yesterday = self.dh.yesterday.date()
         lst = []
-        matchinglists = False
         correctlst = []
         url = f"?order_by[cost]=desc&order_by[date]={yesterday}&group_by[service]=*"  # noqa: E501
         query_params = self.mocked_query_params(url, GCPCostView)
@@ -1106,16 +1103,10 @@ class GCPReportQueryHandlerTest(IamTestCase):
                 for service in element.get("services"):
                     correctlst.append(service.get("service"))
         for element in data:
-            # Check if there is any data in services
-            if element.get("services") > []:
-                for service in element.get("services"):
-                    lst.append(service.get("service"))
-                if correctlst == lst:
-                    matchinglists = True
-                else:
-                    matchinglists = False
-                lst = []
-        self.assertTrue(matchinglists)
+            for service in element.get("services"):
+                lst.append(service.get("service"))
+            self.assertEqual(correctlst, lst)
+            lst = []
 
     def test_gcp_date_incorrect_date(self):
         wrong_date = "200BC"

--- a/koku/api/report/test/ocp/test_ocp_query_handler.py
+++ b/koku/api/report/test/ocp/test_ocp_query_handler.py
@@ -5,7 +5,6 @@
 """Test the Report Queries."""
 import logging
 from collections import defaultdict
-from datetime import datetime
 from datetime import timedelta
 from decimal import Decimal
 from unittest.mock import patch
@@ -608,11 +607,8 @@ class OCPReportQueryHandlerTest(IamTestCase):
     def test_ocp_date_order_by_cost_desc(self):
         """Test execute_query with order by date for correct order of services."""
         # execute query
-        yesterday = datetime.utcnow() - timedelta(days=1)
-        # removes time from date
-        yesterday = datetime.date(yesterday)
+        yesterday = self.dh.yesterday.date()
         lst = []
-        matchinglists = False
         correctlst = []
         url = f"?order_by[cost]=desc&order_by[date]={yesterday}&group_by[project]=*"  # noqa: E501
         query_params = self.mocked_query_params(url, OCPCostView)
@@ -620,22 +616,16 @@ class OCPReportQueryHandlerTest(IamTestCase):
         query_output = handler.execute_query()
         data = query_output.get("data")
         # test query output
-        # test query output
         for element in data:
             if element.get("date") == str(yesterday):
                 for service in element.get("projects"):
                     correctlst.append(service.get("project"))
         for element in data:
             # Check if there is any data in services
-            if element.get("projects") > []:
-                for service in element.get("projects"):
-                    lst.append(service.get("project"))
-                if correctlst == lst:
-                    matchinglists = True
-                else:
-                    matchinglists = False
-                lst = []
-        self.assertTrue(matchinglists)
+            for service in element.get("projects"):
+                lst.append(service.get("project"))
+            self.assertEqual(correctlst, lst)
+            lst = []
 
     def test_gcp_date_incorrect_date(self):
         wrong_date = "200BC"

--- a/koku/api/utils.py
+++ b/koku/api/utils.py
@@ -276,8 +276,11 @@ class DateHelper:
         Returns:
             List of invoice months.
         """
+        # Add a little buffer to end date for beginning of the month
+        # searches for invoice_month for dates < end_date
+        end_range = end + timedelta(1)
         invoice_months = []
-        for day in range((end - start).days):
+        for day in range((end_range - start).days):
             invoice_month = (start + timedelta(day)).strftime("%Y%m")
             if invoice_month not in invoice_months:
                 invoice_months.append(invoice_month)


### PR DESCRIPTION
So, a while back I wrote a function to filter by the invoice_month for the GCP endpoint, that function was only checking dates that are < end_date, since the end date was sept. 1 it wasn't including September as an invoice month causing all of the September endpoints to return zero. 

Additionally,  I fixed some unit tests related to COST-1076. An if condition was not getting met so it was not overwriting the default variable causing a fake failure to see if the test passed or failed. 