### PR TITLE
collect currency.json into static directory

### DIFF
--- a/koku/api/currency/test/tests_views.py
+++ b/koku/api/currency/test/tests_views.py
@@ -19,10 +19,16 @@ from koku import settings
 test_filename = os.path.join(settings.BASE_DIR, "..", "koku/api/currency/specs/currencies.json")
 
 
+def read_api_json():
+    """Read the openapi.json file out of the docs dir."""
+    return load_currencies(test_filename)
+
+
 class CurrencyViewTest(IamTestCase):
     """Tests for the metrics view."""
 
-    def test_supported_currencies(self):
+    @patch("api.currency.view.load_currencies", return_value=read_api_json())
+    def test_supported_currencies(self, _):
         """Test that a list GET call returns the supported currencies."""
         qs = "?limit=20"
         url = reverse("currency") + qs

--- a/koku/api/currency/test/tests_views.py
+++ b/koku/api/currency/test/tests_views.py
@@ -4,15 +4,19 @@
 #
 """Test the Metrics views."""
 import json
+import os
 from unittest.mock import patch
 
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from api.currency.view import CURRENCY_FILE_NAME
 from api.currency.view import load_currencies
 from api.iam.test.iam_test_case import IamTestCase
+from koku import settings
+
+
+test_filename = os.path.join(settings.BASE_DIR, "..", "koku/api/currency/specs/currencies.json")
 
 
 class CurrencyViewTest(IamTestCase):
@@ -28,7 +32,7 @@ class CurrencyViewTest(IamTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         data = response.data
-        with open(CURRENCY_FILE_NAME) as api_file:
+        with open(test_filename) as api_file:
             expected = json.load(api_file)
         self.assertEqual(data.get("data"), expected)
 
@@ -43,8 +47,8 @@ class CurrencyViewTest(IamTestCase):
 
     def test_load_currencies(self):
         """Test load currency function happy path."""
-        data = load_currencies(CURRENCY_FILE_NAME)
-        with open(CURRENCY_FILE_NAME) as api_file:
+        data = load_currencies(test_filename)
+        with open(test_filename) as api_file:
             expected = json.load(api_file)
         self.assertEqual(data, expected)
 

--- a/koku/api/currency/view.py
+++ b/koku/api/currency/view.py
@@ -5,6 +5,7 @@
 """View for Currency."""
 import json
 import logging
+import os
 
 from rest_framework import permissions
 from rest_framework import status
@@ -16,18 +17,17 @@ from rest_framework.response import Response
 from rest_framework.settings import api_settings
 
 from api.common.pagination import ListPaginator
+from koku.settings import STATIC_ROOT
 
 
-CURRENCY_FILE_NAME = "koku/api/currency/specs/currencies.json"
-
+CURRENCY_FILE_NAME = os.path.join(STATIC_ROOT, "currencies.json")
 LOG = logging.getLogger(__name__)
 
 
 def load_currencies(path):
     """Obtain currency JSON data from file path."""
     with open(path) as api_file:
-        data = json.load(api_file)
-        return data
+        return json.load(api_file)
 
 
 @api_view(("GET",))

--- a/koku/koku/settings.py
+++ b/koku/koku/settings.py
@@ -267,7 +267,10 @@ API_PATH_PREFIX = ENVIRONMENT.get_value("API_PATH_PREFIX", default="/api")
 STATIC_ROOT = os.path.join(BASE_DIR, "static")
 STATIC_URL = "{}/static/".format(API_PATH_PREFIX.rstrip("/"))
 
-STATICFILES_DIRS = [os.path.join(BASE_DIR, "..", "docs/source/specs")]
+STATICFILES_DIRS = [
+    os.path.join(BASE_DIR, "..", "docs/source/specs"),
+    os.path.join(BASE_DIR, "..", "koku/api/currency/specs"),
+]
 STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 
 INTERNAL_IPS = ["127.0.0.1"]


### PR DESCRIPTION
The `currency.json` file wasn't being found in the container. This PR collects the `currency.json` file into the static directory, and fetches the file from there.

Running in the ephemeral cluster:
![api/currency/)](https://user-images.githubusercontent.com/19751919/132560728-7ab9184c-3e93-4461-8dad-5abf1c65cb2e.png)
