### PR TITLE
move currencies from a json file into python code

### DIFF
--- a/koku/api/currency/currencies.py
+++ b/koku/api/currency/currencies.py
@@ -1,4 +1,11 @@
-[
+#
+# Copyright 2021 Red Hat Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+"""List of currencies."""
+# turn off black formatting
+# fmt: off
+CURRENCIES = [
     {
         "code": "AUD",
         "name": "Australian Dollar",
@@ -88,5 +95,6 @@
         "name": "South African Rand",
         "symbol": "R",
         "description": "ZAR (R) - South African Rand"
-    }
+    },
 ]
+# fmt: on

--- a/koku/api/currency/test/tests_views.py
+++ b/koku/api/currency/test/tests_views.py
@@ -3,31 +3,17 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 """Test the Metrics views."""
-import json
-import os
-from unittest.mock import patch
-
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from api.currency.view import load_currencies
+from api.currency.currencies import CURRENCIES
 from api.iam.test.iam_test_case import IamTestCase
-from koku import settings
-
-
-test_filename = os.path.join(settings.BASE_DIR, "..", "koku/api/currency/specs/currencies.json")
-
-
-def read_api_json():
-    """Read the openapi.json file out of the docs dir."""
-    return load_currencies(test_filename)
 
 
 class CurrencyViewTest(IamTestCase):
     """Tests for the metrics view."""
 
-    @patch("api.currency.view.load_currencies", return_value=read_api_json())
     def test_supported_currencies(self, _):
         """Test that a list GET call returns the supported currencies."""
         qs = "?limit=20"
@@ -38,27 +24,4 @@ class CurrencyViewTest(IamTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         data = response.data
-        with open(test_filename) as api_file:
-            expected = json.load(api_file)
-        self.assertEqual(data.get("data"), expected)
-
-    @patch("api.currency.view.load_currencies")
-    def test_supported_currencies_fnf_error(self, currency):
-        """Test that a list GET call with a FNF error returns 404."""
-        url = reverse("currency")
-        client = APIClient()
-        currency.side_effect = FileNotFoundError
-        response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-
-    def test_load_currencies(self):
-        """Test load currency function happy path."""
-        data = load_currencies(test_filename)
-        with open(test_filename) as api_file:
-            expected = json.load(api_file)
-        self.assertEqual(data, expected)
-
-    def test_load_currencies_fnf(self):
-        """Test file not found load_currencies."""
-        with self.assertRaises(FileNotFoundError):
-            load_currencies("doesnotexist.json")
+        self.assertEqual(data.get("data"), CURRENCIES)

--- a/koku/api/currency/test/tests_views.py
+++ b/koku/api/currency/test/tests_views.py
@@ -14,7 +14,7 @@ from api.iam.test.iam_test_case import IamTestCase
 class CurrencyViewTest(IamTestCase):
     """Tests for the metrics view."""
 
-    def test_supported_currencies(self, _):
+    def test_supported_currencies(self):
         """Test that a list GET call returns the supported currencies."""
         qs = "?limit=20"
         url = reverse("currency") + qs

--- a/koku/api/currency/view.py
+++ b/koku/api/currency/view.py
@@ -3,31 +3,15 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 """View for Currency."""
-import json
-import logging
-import os
-
 from rest_framework import permissions
-from rest_framework import status
 from rest_framework.decorators import api_view
 from rest_framework.decorators import permission_classes
 from rest_framework.decorators import renderer_classes
 from rest_framework.renderers import JSONRenderer
-from rest_framework.response import Response
 from rest_framework.settings import api_settings
 
 from api.common.pagination import ListPaginator
-from koku.settings import STATIC_ROOT
-
-
-CURRENCY_FILE_NAME = os.path.join(STATIC_ROOT, "currencies.json")
-LOG = logging.getLogger(__name__)
-
-
-def load_currencies(path):
-    """Obtain currency JSON data from file path."""
-    with open(path) as api_file:
-        return json.load(api_file)
+from api.currency.currencies import CURRENCIES
 
 
 @api_view(("GET",))
@@ -45,9 +29,4 @@ def get_currency(request):
         (Response): The report in a Response object
 
     """
-    try:
-        data = load_currencies(CURRENCY_FILE_NAME)
-        paginator = ListPaginator(data, request)
-        return paginator.paginated_response
-    except (FileNotFoundError, json.JSONDecodeError):
-        return Response(status=status.HTTP_404_NOT_FOUND)
+    return ListPaginator(CURRENCIES, request)

--- a/koku/api/currency/view.py
+++ b/koku/api/currency/view.py
@@ -29,4 +29,4 @@ def get_currency(request):
         (Response): The report in a Response object
 
     """
-    return ListPaginator(CURRENCIES, request)
+    return ListPaginator(CURRENCIES, request).paginated_response

--- a/koku/koku/settings.py
+++ b/koku/koku/settings.py
@@ -267,10 +267,7 @@ API_PATH_PREFIX = ENVIRONMENT.get_value("API_PATH_PREFIX", default="/api")
 STATIC_ROOT = os.path.join(BASE_DIR, "static")
 STATIC_URL = "{}/static/".format(API_PATH_PREFIX.rstrip("/"))
 
-STATICFILES_DIRS = [
-    os.path.join(BASE_DIR, "..", "docs/source/specs"),
-    os.path.join(BASE_DIR, "..", "koku/api/currency/specs"),
-]
+STATICFILES_DIRS = [os.path.join(BASE_DIR, "..", "docs/source/specs")]
 STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 
 INTERNAL_IPS = ["127.0.0.1"]


### PR DESCRIPTION
This PR moves the currencies into a Python dictionary instead of a json file. This drops the dependency of a static file and makes the api a little simpler.

```
GET http://localhost:8000/api/cost-management/v1/currency/

{
meta: {
count: 15
},
links: {
first: "/api/cost-management/v1/currency/?limit=10&offset=0",
next: "/api/cost-management/v1/currency/?limit=10&offset=10",
previous: null,
last: "/api/cost-management/v1/currency/?limit=10&offset=5"
},
data: [
{
code: "AUD",
name: "Australian Dollar",
symbol: "AU$",
description: "AUD (AU$) - Australian Dollar"
},
```

Smoke test:
```
$ iqe tests plugin cost_management -k test_api_pre_tenant_create_check

25 passed, 6626 deselected, 25 warnings in 5.90s
```
