### PR TITLE
Don't do tag matching if already resource matched

### DIFF
--- a/koku/masu/database/presto_sql/reporting_ocpawscostlineitem_daily_summary.sql
+++ b/koku/masu/database/presto_sql/reporting_ocpawscostlineitem_daily_summary.sql
@@ -31,7 +31,7 @@ INSERT INTO postgres.{{schema | sqlsafe}}.reporting_ocpawscostlineitem_project_d
     tags,
     source_uuid
 )
-WITH cte_ocp_on_aws_joined AS (
+WITH cte_ocp_on_aws_resource_id_joined AS (
     SELECT aws.uuid as aws_id,
         max(nullif(aws.lineitem_resourceid, '')) as resource_id,
         max(aws.lineitem_usagestartdate) as usage_start,
@@ -78,8 +78,67 @@ WITH cte_ocp_on_aws_joined AS (
     JOIN postgres.{{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary as ocp
         ON aws.lineitem_usagestartdate = ocp.usage_start
             AND (
-                (aws.lineitem_resourceid = ocp.resource_id AND ocp.data_source = 'Pod')
-                    OR json_extract_scalar(aws.resourcetags, '$.openshift_project') = lower(ocp.namespace)
+                aws.lineitem_resourceid = ocp.resource_id
+                    AND ocp.data_source = 'Pod'
+            )
+    WHERE aws.source = '{{aws_source_uuid | sqlsafe}}'
+        AND aws.year = '{{year | sqlsafe}}'
+        AND aws.month = '{{month | sqlsafe}}'
+        AND aws.lineitem_usagestartdate >= TIMESTAMP '{{start_date | sqlsafe}}'
+        AND aws.lineitem_usagestartdate < date_add('day', 1, TIMESTAMP '{{end_date | sqlsafe}}')
+        AND ocp.report_period_id = {{report_period_id | sqlsafe}}
+        AND ocp.usage_start >= date('{{start_date | sqlsafe}}')
+        AND ocp.usage_start <= date('{{end_date | sqlsafe}}')
+    GROUP BY aws.uuid, ocp.namespace, ocp.data_source
+),
+cte_ocp_on_aws_tag_joined AS (
+    SELECT aws.uuid as aws_id,
+        max(nullif(aws.lineitem_resourceid, '')) as resource_id,
+        max(aws.lineitem_usagestartdate) as usage_start,
+        max(aws.lineitem_usagestartdate) as usage_end,
+        max(nullif(aws.lineitem_productcode, '')) as product_code,
+        max(nullif(aws.product_productfamily, '')) as product_family,
+        max(nullif(aws.product_instancetype, '')) as instance_type,
+        max(aws.lineitem_usageaccountid) as usage_account_id,
+        max(nullif(aws.lineitem_availabilityzone, '')) as availability_zone,
+        max(nullif(aws.product_region, '')) as region,
+        max(nullif(aws.pricing_unit, '')) as unit,
+        max(aws.lineitem_usageamount) as usage_amount,
+        max(nullif(aws.lineitem_currencycode, '')) as currency_code,
+        max(aws.lineitem_unblendedcost) as unblended_cost,
+        max(aws.resourcetags) as tags,
+        max(aws.resource_id_matched) as resource_id_matched,
+        max(ocp.report_period_id) as report_period_id,
+        max(ocp.cluster_id) as cluster_id,
+        max(ocp.cluster_alias) as cluster_alias,
+        ocp.namespace,
+        ocp.data_source,
+        max(ocp.node) as node,
+        max(json_format(ocp.pod_labels)) as pod_labels,
+        sum(ocp.pod_usage_cpu_core_hours) as pod_usage_cpu_core_hours,
+        sum(ocp.pod_request_cpu_core_hours) as pod_request_cpu_core_hours,
+        sum(ocp.pod_limit_cpu_core_hours) as pod_limit_cpu_core_hours,
+        sum(ocp.pod_usage_memory_gigabyte_hours) as pod_usage_memory_gigabyte_hours,
+        sum(ocp.pod_request_memory_gigabyte_hours) as pod_request_memory_gigabyte_hours,
+        max(ocp.node_capacity_cpu_cores) as node_capacity_cpu_cores,
+        max(ocp.node_capacity_cpu_core_hours) as node_capacity_cpu_core_hours,
+        max(ocp.node_capacity_memory_gigabytes) as node_capacity_memory_gigabytes,
+        max(ocp.node_capacity_memory_gigabyte_hours) as node_capacity_memory_gigabyte_hours,
+        max(ocp.cluster_capacity_cpu_core_hours) as cluster_capacity_cpu_core_hours,
+        max(ocp.cluster_capacity_memory_gigabyte_hours) as cluster_capacity_memory_gigabyte_hours,
+        max(ocp.persistentvolumeclaim) as persistentvolumeclaim,
+        max(ocp.persistentvolume) as persistentvolume,
+        max(ocp.storageclass) as storageclass,
+        max(json_format(volume_labels)) as volume_labels,
+        max(ocp.persistentvolumeclaim_capacity_gigabyte) as persistentvolumeclaim_capacity_gigabyte,
+        max(ocp.persistentvolumeclaim_capacity_gigabyte_months) as persistentvolumeclaim_capacity_gigabyte_months,
+        sum(ocp.volume_request_storage_gigabyte_months) as volume_request_storage_gigabyte_months,
+        sum(ocp.persistentvolumeclaim_usage_gigabyte_months) as persistentvolumeclaim_usage_gigabyte_months
+    FROM hive.{{schema | sqlsafe}}.aws_openshift_daily as aws
+    JOIN postgres.{{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary as ocp
+        ON aws.lineitem_usagestartdate = ocp.usage_start
+            AND (
+                json_extract_scalar(aws.resourcetags, '$.openshift_project') = lower(ocp.namespace)
                     OR json_extract_scalar(aws.resourcetags, '$.openshift_node') = lower(ocp.node)
                     OR json_extract_scalar(aws.resourcetags, '$.openshift_cluster') IN (lower(ocp.cluster_id), lower(ocp.cluster_alias))
                     OR (aws.matched_tag != '' AND any_match(split(aws.matched_tag, ','), x->strpos(json_format(ocp.pod_labels), replace(x, ' ')) != 0))
@@ -94,6 +153,18 @@ WITH cte_ocp_on_aws_joined AS (
         AND ocp.usage_start >= date('{{start_date | sqlsafe}}')
         AND ocp.usage_start <= date('{{end_date | sqlsafe}}')
     GROUP BY aws.uuid, ocp.namespace, ocp.data_source
+),
+cte_ocp_on_aws_joined AS (
+    SELECT *
+    FROM cte_ocp_on_aws_resource_id_joined
+
+    UNION
+
+    SELECT tag.*
+    FROM cte_ocp_on_aws_tag_joined as tag
+    LEFT JOIN cte_ocp_on_aws_resource_id_joined as rid
+        ON tag.aws_id = rid.aws_id
+    WHERE rid.aws_id IS NULL
 ),
 cte_project_counts AS (
     SELECT aws_id,

--- a/koku/masu/database/presto_sql/reporting_ocpazurecostlineitem_daily_summary.sql
+++ b/koku/masu/database/presto_sql/reporting_ocpazurecostlineitem_daily_summary.sql
@@ -28,7 +28,7 @@ INSERT INTO postgres.{{schema | sqlsafe}}.reporting_ocpazurecostlineitem_project
     tags,
     source_uuid
 )
-WITH cte_ocp_on_azure_joined AS (
+WITH cte_ocp_on_azure_resource_id_joined AS (
     SELECT azure.uuid as azure_id,
         max(split_part(coalesce(resourceid, instanceid), '/', 9)) as resource_id,
         max(coalesce(date, usagedatetime)) as usage_start,
@@ -90,7 +90,78 @@ WITH cte_ocp_on_azure_joined AS (
             AND (
                 (split_part(coalesce(azure.resourceid, azure.instanceid), '/', 9) = ocp.node AND ocp.data_source = 'Pod')
                     OR (split_part(coalesce(azure.resourceid, azure.instanceid), '/', 9) = ocp.persistentvolume AND ocp.data_source = 'Storage')
-                    OR json_extract_scalar(azure.tags, '$.openshift_project') = lower(ocp.namespace)
+            )
+    WHERE azure.source = '{{azure_source_uuid | sqlsafe}}'
+        AND azure.year = '{{year | sqlsafe}}'
+        AND azure.month = '{{month | sqlsafe}}'
+        AND coalesce(azure.date, azure.usagedatetime) >= TIMESTAMP '{{start_date | sqlsafe}}'
+        AND coalesce(azure.date, azure.usagedatetime) < date_add('day', 1, TIMESTAMP '{{end_date | sqlsafe}}')
+        AND ocp.report_period_id = {{report_period_id | sqlsafe}}
+        AND ocp.usage_start >= date('{{start_date | sqlsafe}}')
+        AND ocp.usage_start <= date('{{end_date | sqlsafe}}')
+    GROUP BY azure.uuid, ocp.namespace, ocp.data_source
+),
+cte_ocp_on_azure_tag_joined AS (
+    SELECT azure.uuid as azure_id,
+        max(split_part(coalesce(resourceid, instanceid), '/', 9)) as resource_id,
+        max(coalesce(date, usagedatetime)) as usage_start,
+        max(coalesce(date, usagedatetime)) as usage_end,
+        max(json_extract_scalar(json_parse(azure.additionalinfo), '$.ServiceType')) as instance_type,
+        max(coalesce(subscriptionid, subscriptionguid)) as subscription_guid,
+        max(azure.resourcelocation) as resource_location,
+
+        max(CASE
+            WHEN split_part(unitofmeasure, ' ', 2) != '' AND NOT (unitofmeasure = '100 Hours' AND metercategory='Virtual Machines')
+                THEN cast(split_part(unitofmeasure, ' ', 1) as integer)
+            ELSE 1
+            END) as multiplier,
+        max(CASE
+            WHEN split_part(unitofmeasure, ' ', 2) = 'Hours'
+                THEN  'Hrs'
+            WHEN split_part(unitofmeasure, ' ', 2) = 'GB/Month'
+                THEN  'GB-Mo'
+            WHEN split_part(unitofmeasure, ' ', 2) != ''
+                THEN  split_part(unitofmeasure, ' ', 2)
+            ELSE unitofmeasure
+        END) as unit_of_measure,
+
+        max(cast(coalesce(azure.quantity, azure.usagequantity) as decimal(24,9))) as usage_quantity,
+        max(cast(coalesce(azure.costinbillingcurrency, azure.pretaxcost) as decimal(24,9))) as pretax_cost,
+        max(coalesce(billingcurrencycode, currency)) as currency,
+        max(azure.resource_id_matched) as resource_id_matched,
+        max(azure.tags) as tags,
+        max(azure.servicename) as service_name,
+        max(ocp.report_period_id) as report_period_id,
+        max(ocp.cluster_id) as cluster_id,
+        max(ocp.cluster_alias) as cluster_alias,
+        ocp.namespace,
+        ocp.data_source,
+        max(ocp.node) as node,
+        max(json_format(ocp.pod_labels)) as pod_labels,
+        sum(ocp.pod_usage_cpu_core_hours) as pod_usage_cpu_core_hours,
+        sum(ocp.pod_request_cpu_core_hours) as pod_request_cpu_core_hours,
+        sum(ocp.pod_limit_cpu_core_hours) as pod_limit_cpu_core_hours,
+        sum(ocp.pod_usage_memory_gigabyte_hours) as pod_usage_memory_gigabyte_hours,
+        sum(ocp.pod_request_memory_gigabyte_hours) as pod_request_memory_gigabyte_hours,
+        max(ocp.node_capacity_cpu_cores) as node_capacity_cpu_cores,
+        max(ocp.node_capacity_cpu_core_hours) as node_capacity_cpu_core_hours,
+        max(ocp.node_capacity_memory_gigabytes) as node_capacity_memory_gigabytes,
+        max(ocp.node_capacity_memory_gigabyte_hours) as node_capacity_memory_gigabyte_hours,
+        max(ocp.cluster_capacity_cpu_core_hours) as cluster_capacity_cpu_core_hours,
+        max(ocp.cluster_capacity_memory_gigabyte_hours) as cluster_capacity_memory_gigabyte_hours,
+        max(ocp.persistentvolumeclaim) as persistentvolumeclaim,
+        max(ocp.persistentvolume) as persistentvolume,
+        max(ocp.storageclass) as storageclass,
+        max(json_format(volume_labels)) as volume_labels,
+        max(ocp.persistentvolumeclaim_capacity_gigabyte) as persistentvolumeclaim_capacity_gigabyte,
+        max(ocp.persistentvolumeclaim_capacity_gigabyte_months) as persistentvolumeclaim_capacity_gigabyte_months,
+        sum(ocp.volume_request_storage_gigabyte_months) as volume_request_storage_gigabyte_months,
+        sum(ocp.persistentvolumeclaim_usage_gigabyte_months) as persistentvolumeclaim_usage_gigabyte_months
+    FROM hive.{{schema | sqlsafe}}.azure_openshift_daily as azure
+    JOIN postgres.{{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary as ocp
+        ON coalesce(azure.date, azure.usagedatetime) = ocp.usage_start
+            AND (
+                    json_extract_scalar(azure.tags, '$.openshift_project') = lower(ocp.namespace)
                     OR json_extract_scalar(azure.tags, '$.openshift_node') = lower(ocp.node)
                     OR json_extract_scalar(azure.tags, '$.openshift_cluster') IN (lower(ocp.cluster_id), lower(ocp.cluster_alias))
                     OR (azure.matched_tag != '' AND any_match(split(azure.matched_tag, ','), x->strpos(json_format(ocp.pod_labels), replace(x, ' ')) != 0))
@@ -105,6 +176,18 @@ WITH cte_ocp_on_azure_joined AS (
         AND ocp.usage_start >= date('{{start_date | sqlsafe}}')
         AND ocp.usage_start <= date('{{end_date | sqlsafe}}')
     GROUP BY azure.uuid, ocp.namespace, ocp.data_source
+),
+cte_ocp_on_azure_joined AS (
+    SELECT *
+    FROM cte_ocp_on_azure_resource_id_joined
+
+    UNION
+
+    SELECT tag.*
+    FROM cte_ocp_on_azure_tag_joined as tag
+    LEFT JOIN cte_ocp_on_azure_resource_id_joined as rid
+        ON tag.azure_id = rid.azure_id
+    WHERE rid.azure_id IS NULL
 ),
 cte_project_counts AS (
     SELECT azure_id,

--- a/koku/masu/processor/report_summary_updater.py
+++ b/koku/masu/processor/report_summary_updater.py
@@ -174,6 +174,8 @@ class ReportSummaryUpdater:
         try:
             if self.trino_enabled and self._provider.type in Provider.OPENSHIFT_ON_CLOUD_PROVIDER_LIST:
                 self._ocp_cloud_updater.update_summary_tables(start_date, end_date)
+            elif not self.trino_enabled:
+                self._ocp_cloud_updater.update_summary_tables(start_date, end_date)
         except Exception as ex:
             raise ReportSummaryUpdaterCloudError(str(ex))
 

--- a/koku/masu/processor/report_summary_updater.py
+++ b/koku/masu/processor/report_summary_updater.py
@@ -192,7 +192,8 @@ class ReportSummaryUpdater:
         start_date, end_date = self._updater.update_summary_tables(start_date, end_date)
 
         try:
-            self._ocp_cloud_updater.update_summary_tables(start_date, end_date)
+            if self._provider.type in Provider.OPENSHIFT_ON_CLOUD_PROVIDER_LIST:
+                self._ocp_cloud_updater.update_summary_tables(start_date, end_date)
         except Exception as ex:
             raise ReportSummaryUpdaterCloudError(str(ex))
 

--- a/koku/masu/processor/report_summary_updater.py
+++ b/koku/masu/processor/report_summary_updater.py
@@ -5,6 +5,7 @@
 """Update reporting summary tables."""
 import datetime
 import logging
+from functools import cached_property
 
 from api.common import log_json
 from api.models import Provider
@@ -75,6 +76,11 @@ class ReportSummaryUpdater:
         msg = f"Starting report data summarization for provider uuid: {self._provider.uuid}."
         LOG.info(log_json(self._tracing_id, msg))
 
+    @cached_property
+    def trino_enabled(self):
+        """Return whether the source is enabled for Trino processing."""
+        return enable_trino_processing(self._provider_uuid, self._provider.type, self._schema)
+
     def _set_updater(self):
         """
         Create the report summary updater object.
@@ -89,45 +95,19 @@ class ReportSummaryUpdater:
 
         """
         if self._provider.type in (Provider.PROVIDER_AWS, Provider.PROVIDER_AWS_LOCAL):
-            report_summary_updater = (
-                AWSReportParquetSummaryUpdater
-                if enable_trino_processing(
-                    self._provider_uuid, self._provider.type, self._provider.customer.schema_name
-                )
-                else AWSReportSummaryUpdater
-            )
+            report_summary_updater = AWSReportParquetSummaryUpdater if self.trino_enabled else AWSReportSummaryUpdater
         elif self._provider.type in (Provider.PROVIDER_AZURE, Provider.PROVIDER_AZURE_LOCAL):
             report_summary_updater = (
-                AzureReportParquetSummaryUpdater
-                if enable_trino_processing(
-                    self._provider_uuid, self._provider.type, self._provider.customer.schema_name
-                )
-                else AzureReportSummaryUpdater
+                AzureReportParquetSummaryUpdater if self.trino_enabled else AzureReportSummaryUpdater
             )
         elif self._provider.type in (Provider.PROVIDER_OCP,):
-            report_summary_updater = (
-                OCPReportParquetSummaryUpdater
-                if enable_trino_processing(
-                    self._provider_uuid, self._provider.type, self._provider.customer.schema_name
-                )
-                else OCPReportSummaryUpdater
-            )
+            report_summary_updater = OCPReportParquetSummaryUpdater if self.trino_enabled else OCPReportSummaryUpdater
         elif self._provider.type in (Provider.PROVIDER_GCP, Provider.PROVIDER_GCP_LOCAL):
-            report_summary_updater = (
-                GCPReportParquetSummaryUpdater
-                if enable_trino_processing(
-                    self._provider_uuid, self._provider.type, self._provider.customer.schema_name
-                )
-                else GCPReportSummaryUpdater
-            )
+            report_summary_updater = GCPReportParquetSummaryUpdater if self.trino_enabled else GCPReportSummaryUpdater
         else:
             return (None, None)
 
-        ocp_cloud_updater = (
-            OCPCloudParquetReportSummaryUpdater
-            if enable_trino_processing(self._provider_uuid, self._provider.type, self._provider.customer.schema_name)
-            else OCPCloudReportSummaryUpdater
-        )
+        ocp_cloud_updater = OCPCloudParquetReportSummaryUpdater if self.trino_enabled else OCPCloudReportSummaryUpdater
 
         LOG.info(f"Set report_summary_updater = {report_summary_updater.__name__}")
         return (
@@ -192,7 +172,7 @@ class ReportSummaryUpdater:
         start_date, end_date = self._updater.update_summary_tables(start_date, end_date)
 
         try:
-            if self._provider.type in Provider.OPENSHIFT_ON_CLOUD_PROVIDER_LIST:
+            if self.trino_enabled and self._provider.type in Provider.OPENSHIFT_ON_CLOUD_PROVIDER_LIST:
                 self._ocp_cloud_updater.update_summary_tables(start_date, end_date)
         except Exception as ex:
             raise ReportSummaryUpdaterCloudError(str(ex))


### PR DESCRIPTION
## Summary
This separates out the resource id matching and tag matching for OCP on Cloud, and only considers tag matches rows that have not already been resource id matched.