### PR TITLE
Fix issue with resummarizing gcp data.

### DIFF
--- a/koku/masu/database/gcp_report_db_accessor.py
+++ b/koku/masu/database/gcp_report_db_accessor.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 """Database accessor for GCP report data."""
+import datetime
 import logging
 import pkgutil
 import uuid
@@ -15,6 +16,7 @@ from jinjasql import JinjaSql
 from tenant_schemas.utils import schema_context
 
 from masu.database import GCP_REPORT_TABLE_MAP
+from masu.database.koku_database_access import mini_transaction_delete
 from masu.database.report_db_accessor_base import ReportDBAccessorBase
 from masu.external.date_accessor import DateAccessor
 from reporting.provider.gcp.models import GCPCostEntryBill
@@ -132,10 +134,6 @@ class GCPReportDBAccessor(ReportDBAccessorBase):
             (None)
 
         """
-        # For gcp in order to catch what we are calling cross over data
-        # we need to extend the end date by a couple of days. For more
-        # information see: https://issues.redhat.com/browse/COST-1771
-        end_date += relativedelta(days=2)
         table_name = self._table_map["line_item_daily"]
 
         daily_sql = pkgutil.get_data("masu.database", "sql/reporting_gcpcostentrylineitem_daily.sql")
@@ -183,10 +181,6 @@ class GCPReportDBAccessor(ReportDBAccessorBase):
             (None)
 
         """
-        # For gcp in order to catch what we are calling cross over data
-        # we need to extend the end date by a couple of days. For more
-        # information see: https://issues.redhat.com/browse/COST-1771
-        end_date += relativedelta(days=2)
         table_name = self._table_map["line_item_daily_summary"]
         summary_sql = pkgutil.get_data("masu.database", "sql/reporting_gcpcostentrylineitem_daily_summary.sql")
         summary_sql = summary_sql.decode("utf-8")
@@ -214,10 +208,16 @@ class GCPReportDBAccessor(ReportDBAccessorBase):
             (None)
 
         """
-        # For gcp in order to catch what we are calling cross over data
-        # we need to extend the end date by a couple of days. For more
-        # information see: https://issues.redhat.com/browse/COST-1771
-        end_date += relativedelta(days=2)
+        last_month_end = datetime.date.today().replace(day=1) - datetime.timedelta(days=1)
+        if end_date == last_month_end:
+
+            # For gcp in order to catch what we are calling cross over data
+            # we need to extend the end date by a couple of days. For more
+            # information see: https://issues.redhat.com/browse/COST-1771
+            new_end_date = end_date + relativedelta(days=2)
+            self.delete_line_item_daily_summary_entries_for_date_range(source_uuid, end_date, new_end_date)
+            end_date = new_end_date
+
         summary_sql = pkgutil.get_data("masu.database", "presto_sql/reporting_gcpcostentrylineitem_daily_summary.sql")
         summary_sql = summary_sql.decode("utf-8")
         uuid_str = str(uuid.uuid4()).replace("-", "_")
@@ -351,3 +351,20 @@ class GCPReportDBAccessor(ReportDBAccessorBase):
         self._execute_raw_sql_query(
             table_name, summary_sql, start_date, end_date, bind_params=list(summary_sql_params)
         )
+
+    def delete_line_item_daily_summary_entries_for_date_range(self, source_uuid, start_date, end_date, table=None):
+        invoice_month = start_date.strftime("%Y%m")
+        if table is None:
+            table = self.line_item_daily_summary_table
+        msg = f"Deleting records from {table} from {start_date} to {end_date} for invoice_month {invoice_month}"
+        LOG.info(msg)
+        select_query = table.objects.filter(
+            source_uuid=source_uuid,
+            usage_start__gte=start_date,
+            usage_start__lte=end_date,
+            invoice_month=invoice_month,
+        )
+        with schema_context(self.schema):
+            count, _ = mini_transaction_delete(select_query)
+        msg = f"Deleted {count} records from {table}"
+        LOG.info(msg)

--- a/koku/masu/database/gcp_report_db_accessor.py
+++ b/koku/masu/database/gcp_report_db_accessor.py
@@ -353,6 +353,17 @@ class GCPReportDBAccessor(ReportDBAccessorBase):
         )
 
     def delete_line_item_daily_summary_entries_for_date_range(self, source_uuid, start_date, end_date, table=None):
+        """Overwrite the parent class to include invoice month for gcp.
+
+        Args:
+            source_uuid (uuid): uuid of a given source
+            start_date (datetime): start range date
+            end_date (datetime): end range date
+            table (string): table name
+        """
+        # We want to include the invoice month in the delete to make sure we
+        # don't accidentially delete last month's data that flows into the
+        # next month
         invoice_month = start_date.strftime("%Y%m")
         if table is None:
             table = self.line_item_daily_summary_table


### PR DESCRIPTION
## Problem Description:
After running the gcp day to day test over the weekend we realized that our cost was off:
*Stage*:
```
2021-09-15: 30.26 
2021-09-16: 22.393603
2021-09-17: 16.39 
2021-09-18: 15.345999
2021-09-19: 15.367515
2021-09-20: 7.463555
```
After comparing with our *expected results*, we realized that some of the days cost were doubled:
```
2021-09-15: 15.13188  (doubled)
2021-09-16: 22.393603
2021-09-17: 8.196498 (doubled)
2021-09-18: 15.345999
2021-09-19: 15.367515
2021-09-20: 7.463555
```
After discussing the problem with Luke & Doug we decided to use turnpike to resummarize the 14th to 20th. Which created a gap in the data, so essentially the resummarization failed. After looking through the logs, I believe we started to understand why. During re-summary we realized that the range we were deleting and the range we were resummarizing didn't equal. 
*Deleting Range*:
```
[2021-09-20 18:35:41,047] INFO 5405d33f-2cd6-49c3-ba89-11a961351b2f Updating GCP report summary tables from parquet:
	Schema: acct6193296
	Provider: a9922338-ee8b-495d-bddf-25710c54faeb
	Dates: 2021-09-14 - 2021-09-19
[2021-09-20 18:35:41,070] INFO 5405d33f-2cd6-49c3-ba89-11a961351b2f Deleting records from <class 'reporting.provider.gcp.models.GCPCostEntryLineItemDailySummary'> from 2021-09-14 to 2021-09-19
```
*Summary Range*
```
AND usage_start_time >= TIMESTAMP '2021-09-14'
    AND usage_start_time < date_add('day', 1, TIMESTAMP '2021-09-21')
```
We resummarize up to the 20th. So we didn't delete that date in the summary table causing that day to be doubled. This bug was actually my fault, I added the change to bump the resummary end date by two days [here](https://github.com/project-koku/koku/pull/3098/files#diff-1477f4923c6c64b0cc0a78af7738c365d58ac4200fba76d2c6a57293f75f8f6aR138).The problem I was initially trying to solve with that addition was that when we are summarizing for the first time we were excluding cross over data. However, expanding all end dates by two was too big of a "hammer" for the problem at hand. I have refined it in this pull request to only happened if the end_date is the end of the last month for gcp. 

## How to reproduce the problem on main

1. Do an initial upload of the gcp dev account:
```
make gcp-source gcp_name=cody_test
```

2. After the initial upload check these endpoints and make sure they match the masu endpoint:
- http://localhost:8000/api/cost-management/v1/reports/gcp/costs/?filter[time_scope_value]=-2&filter[time_scope_units]=month&group_by[project]=*&filter[resolution]=monthly
- http://localhost:8000/api/cost-management/v1/reports/gcp/costs/?filter[time_scope_value]=-1&filter[time_scope_units]=month&group_by[project]=*&filter[resolution]=monthly

Masu Endpoint: 
-  http://127.0.0.1:5000/api/cost-management/v1/gcp_invoice_monthly_cost/?provider_uuid=09d8a6d0-5ce7-43fc-b142-1c8b1514ddf4
(replace with your provider_uuid)

3. After you check that they are the same, resummarize the data with internal masu endpoint:
- http://127.0.0.1:5000/api/cost-management/v1/report_data/?provider_uuid=8114721a-c8ed-4050-bbaa-ffe3e7580a48&start_date=2021-08-01&end_date=2021-09-20&schema=acct10001

You will notice that the previous month total is off because we accidentally deleted that data in the daily summary table without repopulating it because we were not taking invoice month into consideration during deletion in the same way were were doing during daily summary upload. 

## Steps to test
Same as the steps to reproduce, but for this pull request. The re-summarization should not result in data being off now. 

## Smoke Tests
https://ci.ext.devshift.net/job/project-koku-koku-pr-check/1443/#showFailuresLink