### PR TITLE
enable running smoke tests on trino for pr-check

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -9,6 +9,8 @@ IMAGE="quay.io/cloudservices/koku"
 COMPONENTS="hive-metastore koku presto"  # specific components to deploy (optional, default: all)
 COMPONENTS_W_RESOURCES="hive-metastore koku presto"  # components which should preserve resource settings (optional, default: none)
 
+ENABLE_PARQUET_PROCESSING="false"
+
 ARTIFACTS_DIR="$WORKSPACE/artifacts"
 
 export IQE_PLUGINS="cost_management"
@@ -38,6 +40,7 @@ function run_unit_tests() {
 }
 
 function run_smoke_tests() {
+    run_trino_smoke_tests
     source ${CICD_ROOT}/_common_deploy_logic.sh
     export NAMESPACE=$(bonfire namespace reserve --duration 4)
 
@@ -61,9 +64,17 @@ function run_smoke_tests() {
         --set-parameter koku/AWS_ACCESS_KEY_ID_EPH=${AWS_ACCESS_KEY_ID_EPH} \
         --set-parameter koku/AWS_SECRET_ACCESS_KEY_EPH=${AWS_SECRET_ACCESS_KEY_EPH} \
         --set-parameter koku/GCP_CREDENTIALS_EPH=${GCP_CREDENTIALS_EPH} \
+        --set-parameter koku/ENABLE_PARQUET_PROCESSING=${ENABLE_PARQUET_PROCESSING} \
         --timeout 600
 
     source $CICD_ROOT/cji_smoke_test.sh
+}
+
+function run_trino_smoke_tests() {
+    if check_for_labels "trino-smoke-tests"
+    then
+        ENABLE_PARQUET_PROCESSING="true"
+    fi
 }
 
 function make_results_xml() {


### PR DESCRIPTION
This PR enables running smoke tests on Trino by adding the label `trino-smoke-tests`.