### PR TITLE
Cost 1885 tags in csvs

### DIFF
--- a/koku/api/report/azure/query_handler.py
+++ b/koku/api/report/azure/query_handler.py
@@ -48,6 +48,7 @@ class AzureReportQueryHandler(ReportQueryHandler):
 
         self.group_by_options = self._mapper.provider_map.get("group_by_options")
         self._limit = parameters.get_filter("limit")
+        self.is_csv_output = parameters.accept_type and "text/csv" in parameters.accept_type
 
         # super() needs to be called after _mapper and _limit is set
         super().__init__(parameters)
@@ -154,8 +155,6 @@ class AzureReportQueryHandler(ReportQueryHandler):
             if self._delta:
                 query_data = self.add_deltas(query_data, query_sum)
 
-            is_csv_output = self.parameters.accept_type and "text/csv" in self.parameters.accept_type
-
             def check_if_valid_date_str(date_str):
                 """Check to see if a valid date has been passed in."""
                 import ciso8601
@@ -195,7 +194,7 @@ class AzureReportQueryHandler(ReportQueryHandler):
                 # &order_by[cost]=desc&order_by[date]=2021-08-02
                 query_data = self.order_by(query_data, query_order_by)
 
-            if is_csv_output:
+            if self.is_csv_output:
                 if self._limit:
                     data = self._ranked_list(list(query_data))
                 else:

--- a/koku/api/report/gcp/query_handler.py
+++ b/koku/api/report/gcp/query_handler.py
@@ -191,8 +191,6 @@ class GCPReportQueryHandler(ReportQueryHandler):
             if self._delta:
                 query_data = self.add_deltas(query_data, query_sum)
 
-            is_csv_output = self.parameters.accept_type and "text/csv" in self.parameters.accept_type
-
             def check_if_valid_date_str(date_str):
                 """Check to see if a valid date has been passed in."""
                 import ciso8601
@@ -232,7 +230,7 @@ class GCPReportQueryHandler(ReportQueryHandler):
                 # &order_by[cost]=desc&order_by[date]=2021-08-02
                 query_data = self.order_by(query_data, query_order_by)
 
-            if is_csv_output:
+            if self.is_csv_output:
                 if self._limit:
                     data = self._ranked_list(list(query_data))
                 else:

--- a/koku/api/report/ocp/query_handler.py
+++ b/koku/api/report/ocp/query_handler.py
@@ -37,6 +37,7 @@ class OCPReportQueryHandler(ReportQueryHandler):
         self._mapper = OCPProviderMap(provider=self.provider, report_type=parameters.report_type)
         self.group_by_options = self._mapper.provider_map.get("group_by_options")
         self._limit = parameters.get_filter("limit")
+        self.is_csv_output = parameters.accept_type and "text/csv" in parameters.accept_type
 
         # We need to overwrite the default pack definitions with these
         # Order of the keys matters in how we see it in the views.
@@ -149,7 +150,6 @@ class OCPReportQueryHandler(ReportQueryHandler):
 
             if self._delta:
                 query_data = self.add_deltas(query_data, query_sum)
-            is_csv_output = self.parameters.accept_type and "text/csv" in self.parameters.accept_type
 
             def check_if_valid_date_str(date_str):
                 """Check to see if a valid date has been passed in."""
@@ -189,7 +189,7 @@ class OCPReportQueryHandler(ReportQueryHandler):
             else:
                 query_data = self.order_by(query_data, query_order_by)
 
-            if is_csv_output:
+            if self.is_csv_output:
                 if self._limit:
                     data = self._ranked_list(list(query_data))
                 else:

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -392,7 +392,7 @@ class ReportQueryHandler(QueryHandler):
         if self.is_csv_output:
             add_tags = True
             for entry in group_by:
-                if "tag" in entry:
+                if self._mapper.tag_column in entry:
                     # There is already a specific tag group_by
                     add_tags = False
             if add_tags:

--- a/koku/api/report/test/aws/tests_queries.py
+++ b/koku/api/report/test/aws/tests_queries.py
@@ -842,12 +842,21 @@ class AWSReportQueryTest(IamTestCase):
         self.assertIsNotNone(data)
         self.assertIsNotNone(total_cost_total)
         self.assertAlmostEqual(total_cost_total.get("value", {}), self.calculate_total(handler), 6)
-
+        with tenant_context(self.tenant):
+            tag_count = (
+                AWSCostEntryLineItemDailySummary.objects.filter(account_alias__account_alias=self.account_alias)
+                .values(handler._mapper.tag_column)
+                .distinct()
+                .count()
+            )
         cmonth_str = DateHelper().this_month_start.strftime("%Y-%m")
-        self.assertEqual(len(data), 1)
+        self.assertEqual(len(data), tag_count)
+        accounts = set()
         for data_item in data:
+            accounts.add(data_item.get("alias"))
             month = data_item.get("date")
             self.assertEqual(month, cmonth_str)
+        self.assertEqual(len(accounts), 1)
 
     def test_execute_query_w_delta(self):
         """Test grouped by deltas."""

--- a/koku/api/report/test/azure/tests_azure_query_handler.py
+++ b/koku/api/report/test/azure/tests_azure_query_handler.py
@@ -678,7 +678,7 @@ class AzureReportQueryHandlerTest(IamTestCase):
         """Test execute_query for current month on monthly by subscription_guid with limt as csv."""
         mock_accept.return_value = "text/csv"
 
-        url = "?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[limit]=2&group_by[subscription_guid]=*"  # noqa: E501
+        url = "?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[limit]=1&group_by[subscription_guid]=*"  # noqa: E501
         query_params = self.mocked_query_params(url, AzureCostView)
         handler = AzureReportQueryHandler(query_params)
         query_output = handler.execute_query()
@@ -695,11 +695,19 @@ class AzureReportQueryHandlerTest(IamTestCase):
         self.assertIsNotNone(result_cost_total)
         self.assertEqual(result_cost_total, expected_cost_total)
 
+        with tenant_context(self.tenant):
+            tag_count = (
+                AzureCostEntryLineItemDailySummary.objects.values(handler._mapper.tag_column).distinct().count()
+            )
+
         cmonth_str = self.dh.this_month_start.strftime("%Y-%m")
-        self.assertEqual(len(data), 1)
+        self.assertEqual(len(data), tag_count)
+        subs = set()
         for data_item in data:
+            subs.add(data_item.get("subscription_guid"))
             month = data_item.get("date")
             self.assertEqual(month, cmonth_str)
+        self.assertEqual(len(subs), 1)
 
     def test_execute_query_w_delta(self):
         """Test grouped by deltas."""

--- a/koku/api/report/test/gcp/tests_gcp_query_handler.py
+++ b/koku/api/report/test/gcp/tests_gcp_query_handler.py
@@ -586,7 +586,7 @@ class GCPReportQueryHandlerTest(IamTestCase):
         """Test execute_query for current month on monthly by account with limt as csv."""
         mock_accept.return_value = "text/csv"
 
-        url = "?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[limit]=2&group_by[account]=*"  # noqa: E501
+        url = "?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[limit]=1&group_by[account]=*"  # noqa: E501
         query_params = self.mocked_query_params(url, GCPCostView)
         handler = GCPReportQueryHandler(query_params)
         query_output = handler.execute_query()
@@ -600,11 +600,17 @@ class GCPReportQueryHandlerTest(IamTestCase):
         self.assertIsNotNone(total.get("cost"))
         self.assertEqual(total.get("cost", {}).get("total").get("value"), current_totals["cost_total"])
 
+        with tenant_context(self.tenant):
+            tag_count = GCPCostEntryLineItemDailySummary.objects.values(handler._mapper.tag_column).distinct().count()
+
         cmonth_str = self.dh.this_month_start.strftime("%Y-%m")
-        self.assertEqual(len(data), 1)
+        self.assertEqual(len(data), tag_count)
+        accounts = set()
         for data_item in data:
+            accounts.add(data_item.get("account"))
             month = data_item.get("date")
             self.assertEqual(month, cmonth_str)
+        self.assertEqual(len(accounts), 1)
 
     def test_execute_query_w_delta(self):
         """Test grouped by deltas."""


### PR DESCRIPTION
## Summary
This will add an implicit group by for tags to our reports APIs when exporting CSV data. This will force tags to be included in the CSV. For now it is not optional. 