### PR TITLE
Fix gcp export bug on multiworker

### DIFF
--- a/koku/masu/database/report_manifest_db_accessor.py
+++ b/koku/masu/database/report_manifest_db_accessor.py
@@ -206,12 +206,3 @@ class ReportManifestDBAccessor(KokuDBAccess):
         manifests = CostUsageReportManifest.objects.filter(**filters).all()
         max_export = manifests.aggregate(Max("export_time"))
         return max_export.get("export_time__max")
-
-    def update_export_time_for_manifest(self, key, new_export_time):
-        """Given a file name update the export time for the manifest."""
-        record = CostUsageReportStatus.objects.filter(report_name=key).first()
-        if record:
-            manifest_id = record.manifest_id
-            manifest = self.get_manifest_by_id(manifest_id)
-            manifest.export_time = new_export_time
-            manifest.save()

--- a/koku/masu/external/downloader/gcp/gcp_report_downloader.py
+++ b/koku/masu/external/downloader/gcp/gcp_report_downloader.py
@@ -358,7 +358,7 @@ class GCPReportDownloader(ReportDownloaderBase, DownloaderInterface):
                     export_query = f"""
                     SELECT max(export_time) FROM {self.table_name}
                     WHERE DATE(_PARTITIONTIME) >= '{bill_start}'
-                    AND DATE(_PARTITIONTIME) < '{dh.today}'
+                    AND DATE(_PARTITIONTIME) < '{dh.today.date()}'
                     """
                     eq_result = client.query(export_query).result()
                     for row in eq_result:

--- a/koku/masu/external/downloader/gcp/gcp_report_downloader.py
+++ b/koku/masu/external/downloader/gcp/gcp_report_downloader.py
@@ -350,11 +350,6 @@ class GCPReportDownloader(ReportDownloaderBase, DownloaderInterface):
                 processed_files = manifest_accessor.number_of_files_processed(record.manifest_id)
                 if (total_files - 1) == processed_files:
                     client = bigquery.Client()
-                    # TODO: Put more thought into if the end parameter should be the
-                    # scan_end or today. If we do scan_end we have to think about
-                    # all the reports downloading in random order. Whereas today
-                    # is more of contant. Plus we only update on the last manifest
-                    # anyway.
                     export_query = f"""
                     SELECT max(export_time) FROM {self.table_name}
                     WHERE DATE(_PARTITIONTIME) >= '{bill_start}'


### PR DESCRIPTION
# Problem Description 
Did I just create a bug? maybe 😬 😂 

So, I ran the export time change in stage and I didn't think about the idea of their being more than one download worker :facepalm: What is happening is that that I grab the `max export_time` from our manifests data for the bill date to use in bigquery. However, since the jobs don't run in order the `2021-09-16` range is running before `2021-09-11` range causing gaps in the initial ingest:
<img width="388" alt="multi-worker" src="https://user-images.githubusercontent.com/16995455/134621641-91019dec-0d0f-4916-a838-59b0accee41c.png">

-----

After giving the problem some thought, the solution I came up is to not update the export time for the manifest until we are on the last report in the manifest. That way we don't accidentally skip data.  

# How to reproduce
On main bring up the multi workers and then upload the dev gcp account.
```
make docker-presto-down-all && make docker-up-min-presto-no-build scale=4
make gcp-source gcp_name=cody_test
```
*Note:* The `make docker-up-min-presto-no-build scale=4` might fail the first time but if you just run it again it will work. 

After you upload the source you can look at the daily view and see that some days are missing data due to multiworker timing.

# How to test
Same steps to reproduce but for this pr. If you want to verify that your cost is being calculated for the time period you can use these three links:
- [internal masu endpoint](http://127.0.0.1:5000/api/cost-management/v1/gcp_invoice_monthly_cost/?provider_uuid=52a921ca-bdb2-4919-85db-e2b942fe60f6)
This endpoint grabs the expected monthly cost from the bigquery console. 
- [Previous month](http://localhost:8000/api/cost-management/v1/reports/gcp/costs/?filter[time_scope_value]=-2&filter[time_scope_units]=month&filter[resolution]=monthly)
- [Current month](http://localhost:8000/api/cost-management/v1/reports/gcp/costs/?filter[time_scope_value]=-1&filter[time_scope_units]=month&filter[resolution]=monthly) 
