### PR TITLE
GCP: Fix issue with day to day flow overwriting parquet files.

### DIFF
--- a/koku/masu/external/downloader/gcp/gcp_report_downloader.py
+++ b/koku/masu/external/downloader/gcp/gcp_report_downloader.py
@@ -351,7 +351,7 @@ class GCPReportDownloader(ReportDownloaderBase, DownloaderInterface):
         """
         Logic to set export_time in the manifest.
         """
-        today = DateAccessor().today().date() + relativedelta(days=1)
+        tomorrow = DateAccessor().today().date() + relativedelta(days=1)
         bill_start = ciso8601.parse_datetime(scan_start).date().replace(day=1)
         with ReportManifestDBAccessor() as manifest_accessor:
             last_export_time = manifest_accessor.get_max_export_time_for_manifests(self._provider_uuid, bill_start)
@@ -365,7 +365,7 @@ class GCPReportDownloader(ReportDownloaderBase, DownloaderInterface):
                     export_query = f"""
                     SELECT max(export_time) FROM {self.table_name}
                     WHERE DATE(_PARTITIONTIME) >= '{bill_start}'
-                    AND DATE(_PARTITIONTIME) < '{today}'
+                    AND DATE(_PARTITIONTIME) < '{tomorrow}'
                     """
                     eq_result = client.query(export_query).result()
                     for row in eq_result:

--- a/koku/masu/external/downloader/gcp/gcp_report_downloader.py
+++ b/koku/masu/external/downloader/gcp/gcp_report_downloader.py
@@ -268,6 +268,9 @@ class GCPReportDownloader(ReportDownloaderBase, DownloaderInterface):
                 end_of_month = end_of_month.date()
             if end_of_month < self.scan_end:
                 self.scan_end = end_of_month
+            today = DateAccessor().today().date()
+            if today < end_of_month:
+                self.scan_end = today
 
         invoice_month = self.scan_start.strftime("%Y%m")
         bill_date = self.scan_start.replace(day=1)
@@ -348,7 +351,7 @@ class GCPReportDownloader(ReportDownloaderBase, DownloaderInterface):
         """
         Logic to set export_time in the manifest.
         """
-        today = DateAccessor().today().date()
+        today = DateAccessor().today().date() + relativedelta(days=1)
         bill_start = ciso8601.parse_datetime(scan_start).date().replace(day=1)
         with ReportManifestDBAccessor() as manifest_accessor:
             last_export_time = manifest_accessor.get_max_export_time_for_manifests(self._provider_uuid, bill_start)

--- a/koku/masu/external/downloader/gcp/gcp_report_downloader.py
+++ b/koku/masu/external/downloader/gcp/gcp_report_downloader.py
@@ -38,7 +38,9 @@ DATA_DIR = Config.TMP_DIR
 LOG = logging.getLogger(__name__)
 
 
-def create_daily_archives(tracing_id, account, provider_uuid, filename, filepath, manifest_id, start_date, context={}):
+def create_daily_archives(
+    tracing_id, account, provider_uuid, filename, filepath, manifest_id, start_date, last_export_time, context={}
+):
     """
     Create daily CSVs from incoming report and archive to S3.
 
@@ -52,7 +54,11 @@ def create_daily_archives(tracing_id, account, provider_uuid, filename, filepath
         start_date (Datetime): The start datetime of incoming report
         context (Dict): Logging context dictionary
     """
+    download_hash = None
     daily_file_names = []
+    if last_export_time:
+        download_hash = hashlib.md5(str(last_export_time).encode())
+        download_hash = download_hash.hexdigest()
     if settings.ENABLE_S3_ARCHIVING or enable_trino_processing(provider_uuid, Provider.PROVIDER_GCP, account):
         dh = DateHelper()
         directory = os.path.dirname(filepath)
@@ -78,7 +84,10 @@ def create_daily_archives(tracing_id, account, provider_uuid, filename, filepath
             for daily_data in daily_data_frames:
                 day = daily_data.get("date")
                 df = daily_data.get("data_frame")
-                day_file = f"{invoice_month}_{day}.csv"
+                if download_hash:
+                    day_file = f"{invoice_month}_{day}_{download_hash}.csv"
+                else:
+                    day_file = f"{invoice_month}_{day}.csv"
                 day_filepath = f"{directory}/{day_file}"
                 df.to_csv(day_filepath, index=False, header=True)
                 copy_local_report_file_to_s3_bucket(
@@ -339,7 +348,7 @@ class GCPReportDownloader(ReportDownloaderBase, DownloaderInterface):
         """
         Logic to set export_time in the manifest.
         """
-        dh = DateHelper()
+        today = DateAccessor().today().date()
         bill_start = ciso8601.parse_datetime(scan_start).date().replace(day=1)
         with ReportManifestDBAccessor() as manifest_accessor:
             last_export_time = manifest_accessor.get_max_export_time_for_manifests(self._provider_uuid, bill_start)
@@ -353,7 +362,7 @@ class GCPReportDownloader(ReportDownloaderBase, DownloaderInterface):
                     export_query = f"""
                     SELECT max(export_time) FROM {self.table_name}
                     WHERE DATE(_PARTITIONTIME) >= '{bill_start}'
-                    AND DATE(_PARTITIONTIME) < '{dh.today.date()}'
+                    AND DATE(_PARTITIONTIME) < '{today}'
                     """
                     eq_result = client.query(export_query).result()
                     for row in eq_result:
@@ -448,6 +457,7 @@ class GCPReportDownloader(ReportDownloaderBase, DownloaderInterface):
             full_local_path,
             manifest_id,
             start_date,
+            last_export_time,
             self.context,
         )
 


### PR DESCRIPTION
During the daily download for GCP the parquet files are being overwritten cause they have the same name. However, this change is to use the `last_export_time` in the file naming convention for daily files to insure they don't overwrite what is previously there.  
# Testing
*Step One: Setup the `DATE_OVERRIDE='2021-09-25'` environment variable.*
```
export DATA_OVERRIDE=2021-09-25
docker-compose up -d koku-worker
docker exec -it koku_koku-worker_1 bash -c "echo $DATE_OVERRIDE"
```
Make sure that the worker has the right date.
*Step Two: Upload source*
```
make gcp-source gcp_name=cody_test
```

*Step Three: Check the monthly results*

- Previous Month: http://localhost:8000/api/cost-management/v1/reports/gcp/costs/?filter[time_scope_value]=-2&filter[time_scope_units]=month&filter[resolution]=monthly
- Current Month: http://localhost:8000/api/cost-management/v1/reports/gcp/costs/?filter[time_scope_value]=-1&filter[time_scope_units]=month&filter[resolution]=monthly

```
previous: 315.2
current:  267.484843
```
*Step Four: Remove date override env*
(Follow commands in step one)

*Step Five: Redownload*
- http://127.0.0.1:5000/api/cost-management/v1/download/

*Step 6: Check Monthly values again*
```
previous: 315.2
current:  269.347526
```
*Step 7: Check masu endpoint to see if the cost is correct*

- http://127.0.0.1:5000/api/cost-management/v1/gcp_invoice_monthly_cost/?provider_uuid=ca8fec93-f35c-4b20-8f1f-65befa30da39
(replace with your provider_uuid)

```
{
    "monthly_invoice_cost_mapping": {
        "previous": 315.1999999999997,
        "current": 269.24924899999957
    }
}
```
----
Note: The cost is slightly different between masu internal and our endpoint and I think that may have to do with the `DATE_OVERRIDE= ` functionality in general through. Like in the real world, there will never be data for the `max_export` time beyond "today" during the initial download. However, since we are replacing today with the DATE_OVERRIDE, I think some rows are bleeding into the initial download that shouldn't technically be there yet.

## Smoke Test:
[Jenkins Build](https://ci.ext.devshift.net/job/project-koku-koku-pr-check/1542/)