### PR TITLE
convert data to stringData in koku-aws secret so that we do not need to b64 encode the values

### DIFF
--- a/.github/scripts/check_clowdapp.sh
+++ b/.github/scripts/check_clowdapp.sh
@@ -9,7 +9,7 @@ curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack
 changed=`git diff --name-only HEAD`
 
 if [[ $changed == *"clowdapp"* ]]; then
-  echo "clowdapp.yaml needs to be updated through kustomize."
+  echo "clowdapp.yaml cannot be directly modified. Update the base.yaml or the patch files and run `make clowdapp`."
   exit_code=1
 else
   echo "clowdapp.yaml is up to date."

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -1994,12 +1994,12 @@ objects:
   metadata:
     name: koku-secret
 - apiVersion: v1
-  data:
-    aws-access-key-id: ${AWS_ACCESS_KEY_ID_EPH}
-    aws-secret-access-key: ${AWS_SECRET_ACCESS_KEY_EPH}
   kind: Secret
   metadata:
     name: koku-aws
+  stringData:
+    aws-access-key-id: ${AWS_ACCESS_KEY_ID_EPH}
+    aws-secret-access-key: ${AWS_SECRET_ACCESS_KEY_EPH}
 - apiVersion: v1
   data:
     gcp-credentials: ${GCP_CREDENTIALS_EPH}
@@ -2223,11 +2223,11 @@ parameters:
 - displayName: AWS Access Key ID (Ephemeral)
   name: AWS_ACCESS_KEY_ID_EPH
   required: true
-  value: aW5zZXJ0LWJhc2U2NC1lbmNvZGVkLXZhbHVl
+  value: insert-string-value
 - displayName: AWS Secret Access Key (Ephemeral)
   name: AWS_SECRET_ACCESS_KEY_EPH
   required: true
-  value: aW5zZXJ0LWJhc2U2NC1lbmNvZGVkLXZhbHVl
+  value: insert-string-value
 - displayName: GCP Credentials (Ephemeral)
   name: GCP_CREDENTIALS_EPH
   required: true

--- a/deploy/kustomize/base/base.yaml
+++ b/deploy/kustomize/base/base.yaml
@@ -49,7 +49,7 @@ objects:
   kind: Secret # For ephemeral/local environment only
   metadata:
     name: koku-aws
-  data:
+  stringData:
     aws-access-key-id: "${AWS_ACCESS_KEY_ID_EPH}"
     aws-secret-access-key: "${AWS_SECRET_ACCESS_KEY_EPH}"
 - apiVersion: v1
@@ -287,11 +287,11 @@ parameters:
 - name: AWS_ACCESS_KEY_ID_EPH
   displayName: AWS Access Key ID (Ephemeral)
   required: true
-  value: aW5zZXJ0LWJhc2U2NC1lbmNvZGVkLXZhbHVl
+  value: insert-string-value
 - name: AWS_SECRET_ACCESS_KEY_EPH
   displayName: AWS Secret Access Key (Ephemeral)
   required: true
-  value: aW5zZXJ0LWJhc2U2NC1lbmNvZGVkLXZhbHVl
+  value: insert-string-value
 - name: GCP_CREDENTIALS_EPH
   displayName: GCP Credentials (Ephemeral)
   required: true

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -47,8 +47,8 @@ function run_smoke_tests() {
     oc get secret/koku-aws -o json -n ephemeral-base | jq -r '.data' > aws-creds.json
     oc get secret/koku-gcp -o json -n ephemeral-base | jq -r '.data' > gcp-creds.json
 
-    AWS_ACCESS_KEY_ID_EPH=$(jq -r '."aws-access-key-id"' < aws-creds.json)
-    AWS_SECRET_ACCESS_KEY_EPH=$(jq -r '."aws-secret-access-key"' < aws-creds.json)
+    AWS_ACCESS_KEY_ID_EPH=$(jq -r '."aws-access-key-id" | @base64d' < aws-creds.json)
+    AWS_SECRET_ACCESS_KEY_EPH=$(jq -r '."aws-secret-access-key" | @base64d' < aws-creds.json)
     GCP_CREDENTIALS_EPH=$(jq -r '."gcp-credentials"' < gcp-creds.json)
 
     bonfire deploy \


### PR DESCRIPTION
When deploying into the ephemeral cluster, this PR enables us to take our AWS credentials and put them directly into our bonfire configuration without needing to b64 encode the values first.

```
    AWS_ACCESS_KEY_ID_EPH: <access-key-id>
    AWS_SECRET_ACCESS_KEY_EPH:<access-secret-key>
```