### PR TITLE
GCP: Change to greater than for export time query.

### DIFF
--- a/koku/masu/external/downloader/gcp/gcp_report_downloader.py
+++ b/koku/masu/external/downloader/gcp/gcp_report_downloader.py
@@ -408,7 +408,7 @@ class GCPReportDownloader(ReportDownloaderBase, DownloaderInterface):
                 FROM {self.table_name}
                 WHERE DATE(_PARTITIONTIME) >= '{scan_start}'
                 AND DATE(_PARTITIONTIME) < '{scan_end}'
-                AND export_time >= '{last_export_time}'
+                AND export_time > '{last_export_time}'
                 """
             client = bigquery.Client()
             LOG.info(f"{query}")


### PR DESCRIPTION
## Description
I needed to remove the `or equal to` from our great than comparison in order to not duplicate cost during the day to day workflow. 

# Testing
*Step One: Setup the `DATE_OVERRIDE='2021-09-26'` environment variable.*
```
export DATA_OVERRIDE=2021-09-25
docker-compose up -d koku-worker
docker exec -it koku_koku-worker_1 bash -c "echo $DATE_OVERRIDE"
```
Make sure that the worker has the right date.
*Step Two: Upload source*
```
make gcp-source gcp_name=cody_test
```

*Step Three: Check the monthly results*

- Previous Month: http://localhost:8000/api/cost-management/v1/reports/gcp/costs/?filter[time_scope_value]=-2&filter[time_scope_units]=month&filter[resolution]=monthly
- Current Month: http://localhost:8000/api/cost-management/v1/reports/gcp/costs/?filter[time_scope_value]=-1&filter[time_scope_units]=month&filter[resolution]=monthly

```
previous: 315.2
current: 269.347526
```
*Step Four: Remove date override env*
(Follow commands in step one)

*Step Five: Redownload*
- http://127.0.0.1:5000/api/cost-management/v1/download/

*Step 6: Check Monthly values again*
```
previous: 315.2
current: 270.366098
```
*Step 7: Check masu endpoint to see if the cost is correct*

- http://127.0.0.1:5000/api/cost-management/v1/gcp_invoice_monthly_cost/?provider_uuid=ca8fec93-f35c-4b20-8f1f-65befa30da39
(replace with your provider_uuid)

```
{
    "monthly_invoice_cost_mapping": {
        "previous": 315.1999999999997,
        "current": 270.3660979999996
    }
}
```