### PR TITLE
Remove order_by

### DIFF
--- a/koku/api/report/aws/query_handler.py
+++ b/koku/api/report/aws/query_handler.py
@@ -361,7 +361,7 @@ class AWSReportQueryHandler(ReportQueryHandler):
             if self._mapper.usage_units_key:
                 units_fallback = self._mapper.report_type_map.get("usage_units_fallback")
                 sum_annotations["usage_units"] = Coalesce(self._mapper.usage_units_key, Value(units_fallback))
-            sum_query = query.annotate(**sum_annotations)
+            sum_query = query.annotate(**sum_annotations).order_by()
             units_value = sum_query.values("cost_units").first().get("cost_units", cost_units_fallback)
             sum_units = {"cost_units": units_value}
             if self._mapper.usage_units_key:

--- a/koku/api/report/azure/query_handler.py
+++ b/koku/api/report/azure/query_handler.py
@@ -105,7 +105,7 @@ class AzureReportQueryHandler(ReportQueryHandler):
             if self._mapper.usage_units_key:
                 units_fallback = self._mapper.report_type_map.get("usage_units_fallback")
                 sum_annotations["usage_units"] = Coalesce(self._mapper.usage_units_key, Value(units_fallback))
-            sum_query = query.annotate(**sum_annotations)
+            sum_query = query.annotate(**sum_annotations).order_by()
 
             units_value = sum_query.values("cost_units").first().get("cost_units", cost_units_fallback)
             sum_units = {"cost_units": units_value}

--- a/koku/api/report/gcp/query_handler.py
+++ b/koku/api/report/gcp/query_handler.py
@@ -141,7 +141,7 @@ class GCPReportQueryHandler(ReportQueryHandler):
             if self._mapper.usage_units_key:
                 units_fallback = self._mapper.report_type_map.get("usage_units_fallback")
                 sum_annotations["usage_units"] = Coalesce(self._mapper.usage_units_key, Value(units_fallback))
-            sum_query = query.annotate(**sum_annotations)
+            sum_query = query.annotate(**sum_annotations).order_by()
 
             units_value = sum_query.values("cost_units").first().get("cost_units", cost_units_fallback)
             sum_units = {"cost_units": units_value}


### PR DESCRIPTION
## Jira Ticket

[COST-1606](https://issues.redhat.com/browse/COST-1606)

## Description

When getting the cost unit in the query handler, a `ORDER BY` clause was being emitted causing a lot of extra processing time in the database.

This change removes the `ORDER BY` clause.

## Smoke Tests

[Console Output](https://ci.ext.devshift.net/job/project-koku-koku-pr-check/1705/console)

### Summary

```
17:37:49 =========================== short test summary info ============================
17:37:49 FAILED lib64/python3.6/site-packages/iqe_cost_management/tests/rest_api/v1/test__ocp_cost_reports.py::test_api_ocp_cost_filtered_total_match_group_by_total
17:37:49 FAILED lib64/python3.6/site-packages/iqe_cost_management/tests/rest_api/v1/test_gcp_cost_reports.py::test_api_gcp_cost_filtered_top_order_by_name[services-asc-last-month-daily]
17:37:49 FAILED lib64/python3.6/site-packages/iqe_cost_management/tests/rest_api/v1/test_gcp_cost_reports.py::test_api_gcp_cost_filtered_top_order_by_name[services-asc-last-month]
17:37:49 FAILED lib64/python3.6/site-packages/iqe_cost_management/tests/rest_api/v1/test_gcp_cost_reports.py::test_api_gcp_cost_filtered_top_order_by_name[services-desc-last-month-daily]
17:37:49 FAILED lib64/python3.6/site-packages/iqe_cost_management/tests/rest_api/v1/test_gcp_cost_reports.py::test_api_gcp_cost_filtered_top_order_by_name[services-desc-last-month]
17:37:49 FAILED lib64/python3.6/site-packages/iqe_cost_management/tests/rest_api/v1/test_gcp_cost_reports.py::test_api_gcp_cost_filtered_top_order_by_name[projects-asc-last-month-daily]
17:37:49 FAILED lib64/python3.6/site-packages/iqe_cost_management/tests/rest_api/v1/test_gcp_cost_reports.py::test_api_gcp_cost_filtered_top_order_by_name[projects-asc-last-month]
17:37:49 FAILED lib64/python3.6/site-packages/iqe_cost_management/tests/rest_api/v1/test_gcp_cost_reports.py::test_api_gcp_cost_filtered_top_order_by_name[projects-desc-last-month-daily]
17:37:49 FAILED lib64/python3.6/site-packages/iqe_cost_management/tests/rest_api/v1/test_gcp_cost_reports.py::test_api_gcp_cost_filtered_top_order_by_name[projects-desc-last-month]
17:37:49 FAILED lib64/python3.6/site-packages/iqe_cost_management/tests/rest_api/v1/test_gcp_cost_reports.py::test_api_gcp_cost_filtered_top_order_by_name[regions-asc-last-month-daily]
17:37:49 FAILED lib64/python3.6/site-packages/iqe_cost_management/tests/rest_api/v1/test_gcp_cost_reports.py::test_api_gcp_cost_filtered_top_order_by_name[regions-asc-last-month]
17:37:49 FAILED lib64/python3.6/site-packages/iqe_cost_management/tests/rest_api/v1/test_gcp_cost_reports.py::test_api_gcp_cost_filtered_top_order_by_name[regions-desc-last-month-daily]
17:37:49 FAILED lib64/python3.6/site-packages/iqe_cost_management/tests/rest_api/v1/test_gcp_cost_reports.py::test_api_gcp_cost_filtered_top_order_by_name[regions-desc-last-month]
17:37:49 FAILED lib64/python3.6/site-packages/iqe_cost_management/tests/rest_api/v1/test_gcp_cost_reports.py::test_api_gcp_cost_filtered_top_order_by_name[accounts-asc-last-month-daily]
17:37:49 FAILED lib64/python3.6/site-packages/iqe_cost_management/tests/rest_api/v1/test_gcp_cost_reports.py::test_api_gcp_cost_filtered_top_order_by_name[accounts-asc-last-month]
17:37:49 FAILED lib64/python3.6/site-packages/iqe_cost_management/tests/rest_api/v1/test_gcp_cost_reports.py::test_api_gcp_cost_filtered_top_order_by_name[accounts-desc-last-month-daily]
17:37:49 FAILED lib64/python3.6/site-packages/iqe_cost_management/tests/rest_api/v1/test_gcp_cost_reports.py::test_api_gcp_cost_filtered_top_order_by_name[accounts-desc-last-month]
17:37:49 FAILED lib64/python3.6/site-packages/iqe_cost_management/tests/rest_api/v1/test_gcp_cost_reports.py::test_api_gcp_cost_data_pagination_limit
17:37:49 FAILED lib64/python3.6/site-packages/iqe_cost_management/tests/rest_api/v1/test_gcp_instance_reports.py::test_api_gcp_instance_deltas_daily
17:37:49 FAILED lib64/python3.6/site-packages/iqe_cost_management/tests/rest_api/v1/test_gcp_instance_reports.py::test_api_gcp_instance_or_group_bys_daily[instance_types]
17:37:49 FAILED lib64/python3.6/site-packages/iqe_cost_management/tests/rest_api/v1/test_gcp_instance_reports.py::test_api_gcp_instance_or_group_bys_daily[regions]
17:37:49 FAILED lib64/python3.6/site-packages/iqe_cost_management/tests/rest_api/v1/test_gcp_storage_reports.py::test_api_gcp_storage_or_group_bys_daily[service_names]
17:37:49 FAILED lib64/python3.6/site-packages/iqe_cost_management/tests/rest_api/v1/test_gcp_storage_reports.py::test_api_gcp_storage_or_group_bys_daily[regions]
17:37:49 FAILED lib64/python3.6/site-packages/iqe_cost_management/tests/rest_api/v1/test_source.py::test_api_gcp_source_raw_calc
17:37:49 FAILED lib64/python3.6/site-packages/iqe_cost_management/tests/rest_api/v1/test_source.py::test_api_ocp_sources_shared_rates_recalculation
17:37:49 FAILED lib64/python3.6/site-packages/iqe_cost_management/tests/rest_api/v1/test_tagging.py::test_api_aws_tag_key_endpoint
17:37:49 FAILED lib64/python3.6/site-packages/iqe_cost_management/tests/rest_api/v1/test_user.py::test_api_settings_ocp_tag_enablement
17:37:49 FAILED lib64/python3.6/site-packages/iqe_cost_management/tests/rest_api/v1/test_user.py::test_api_settings_azure_tag_enablement
17:37:49 FAILED lib64/python3.6/site-packages/iqe_cost_management/tests/rest_api/v1/test_user.py::test_api_settings_gcp_tag_enablement
17:37:49 FAILED lib64/python3.6/site-packages/iqe_cost_management/tests/rest_api/v1/test_user.py::test_api_settings_aws_tag_enablement
17:37:49 = 30 failed, 5057 passed, 172 skipped, 862 deselected, 5 warnings in 1755.42s (0:29:15) =
```