### PR TITLE
settings page: fix handling tags that contain dashes

### DIFF
--- a/koku/api/settings/settings.py
+++ b/koku/api/settings/settings.py
@@ -232,7 +232,7 @@ class Settings:
             # build a list of enabled tags for a given provider, removing the provider name prefix
             for enabled_tag in settings.get("enabled", []):
                 if enabled_tag.startswith(provider_name + tag_delimiter):
-                    enabled_tags_no_abbr.append(enabled_tag.split(tag_delimiter)[1])
+                    enabled_tags_no_abbr.append(enabled_tag.split(tag_delimiter, 1)[1])
 
             invalid_keys = [tag_key for tag_key in enabled_tags_no_abbr if tag_key not in available]
 

--- a/scripts/nise_ymls/ocp/ocp_on_premise.yml
+++ b/scripts/nise_ymls/ocp/ocp_on_premise.yml
@@ -18,18 +18,18 @@ generators:
                   cpu_limit: 1
                   mem_limit_gig: 4
                   pod_seconds: 3600
-                  labels: label_application:OpenCart|label_stage:Production|label_group:Marketing
+                  labels: label_application:OpenCart|label_stage:Production|label_group:Marketing|label_dashed-key-on-prem:dashed-value
               volumes:
                 - volume:
                   volume_name: pvc-volume_1
                   storage_class: gp2
                   volume_request_gig: 20
-                  labels: label_environment:Production|label_app:OpenCart|label_version:Production|label_storageclass:gold
+                  labels: label_environment:Production|label_app:OpenCart|label_version:Production|label_storageclass:gold|label_dashed-key-on-prem:dashed-value
                   volume_claims:
                   - volume_claim:
                     volume_claim_name: pod_name1_data
                     pod_name: pod_name1
-                    labels: label_environment:Production|label_app:OpenCart|label_version:Production|label_storageclass:gold
+                    labels: label_environment:Production|label_app:OpenCart|label_version:Production|label_storageclass:gold|label_dashed-key-on-prem:dashed-value
                     capacity_gig: 20
             Raleigh:
               pods:

--- a/scripts/nise_ymls/ocp_on_aws/aws_static_data.yml
+++ b/scripts/nise_ymls/ocp_on_aws/aws_static_data.yml
@@ -9,6 +9,7 @@ generators:
       region: us-east-1a
       tags:
         resourceTags/user:version: prod
+        resourceTags/user:dashed-key-on-aws: dashed-value
       instance_type:
         inst_type: m5.large
         vcpu: 2
@@ -27,6 +28,7 @@ generators:
       tags:
         resourceTags/user:environment: dev
         resourceTags/user:version: beta
+        resourceTags/user:dashed-key-on-aws: dashed-value
       instance_type:
         inst_type: m5.large
         vcpu: 2
@@ -45,6 +47,7 @@ generators:
       tags:
         resourceTags/user:environment: dev
         resourceTags/user:version: gamma
+        resourceTags/user:dashed-key-on-aws: dashed-value
       instance_type:
         inst_type: m5.large
         vcpu: 2
@@ -62,6 +65,7 @@ generators:
       region: us-east-1a
       tags:
         resourceTags/user:version: master
+        resourceTags/user:dashed-key-on-aws: dashed-value
       instance_type:
         inst_type: m5.large
         vcpu: 2

--- a/scripts/nise_ymls/ocp_on_aws/ocp_static_data.yml
+++ b/scripts/nise_ymls/ocp_on_aws/ocp_static_data.yml
@@ -20,7 +20,7 @@ generators:
                   cpu_limit: 1
                   mem_limit_gig: 4
                   pod_seconds: 3600
-                  labels: label_environment:dev|label_app:install-test|label_version:prod
+                  labels: label_environment:dev|label_app:install-test|label_version:prod|label_dashed-key-on-aws:dashed-value
                 - pod:
                   pod_name: pod_name1b
                   cpu_request: 1
@@ -28,18 +28,18 @@ generators:
                   cpu_limit: 1
                   mem_limit_gig: 4
                   pod_seconds: 3600
-                  labels: label_environment:alpha|label_app:install-test|label_version:prod|label_qa:approved
+                  labels: label_environment:alpha|label_app:install-test|label_version:prod|label_qa:approved|label_dashed-key-on-aws:dashed-value
               volumes:
                 - volume:
                   volume_name: pvc-volume_1
                   storage_class: gp2
                   volume_request_gig: 20
-                  labels: label_environment:dev|label_app:catalog|label_version:prod|label_storageclass:bravo
+                  labels: label_environment:dev|label_app:catalog|label_version:prod|label_storageclass:bravo|label_dashed-key-on-aws:dashed-value
                   volume_claims:
                   - volume_claim:
                     volume_claim_name: pod_name1_data
                     pod_name: pod_name1a
-                    labels: label_environment:dev|label_app:catalog|label_version:prod|label_storageclass:bravo
+                    labels: label_environment:dev|label_app:catalog|label_version:prod|label_storageclass:bravo|label_dashed-key-on-aws:dashed-value
                     capacity_gig: 20
             catalog:
               pods:

--- a/scripts/nise_ymls/ocp_on_azure/azure_static_data.yml
+++ b/scripts/nise_ymls/ocp_on_azure/azure_static_data.yml
@@ -9,6 +9,7 @@ generators:
       instance_id: '/subscriptions/99999999-9999-9999-9999-999999999999/resourceGroups/koku-99hqd-rg/providers/Microsoft.Compute/virtualMachines/azure_compute1'
       tags:
         version: Mars
+        dashed-key-on-azure: dashed-value
   - VMGenerator:
       start_date: {{start_date}}
       end_date: {{end_date}}
@@ -19,6 +20,7 @@ generators:
       tags:
         environment: Jupiter
         version: MilkyWay
+        dashed-key-on-azure: dashed-value
   - VMGenerator:
       start_date: {{start_date}}
       end_date: {{end_date}}
@@ -29,6 +31,7 @@ generators:
       tags:
         environment: Jupiter
         version: Andromeda
+        dashed-key-on-azure: dashed-value
   - VMGenerator:
       start_date: {{start_date}}
       end_date: {{end_date}}

--- a/scripts/nise_ymls/ocp_on_azure/ocp_static_data.yml
+++ b/scripts/nise_ymls/ocp_on_azure/ocp_static_data.yml
@@ -20,7 +20,7 @@ generators:
                   cpu_limit: 1
                   mem_limit_gig: 4
                   pod_seconds: 3600
-                  labels: label_environment:Jupiter|label_app:mobile|label_version:Mars
+                  labels: label_environment:Jupiter|label_app:mobile|label_version:Mars|label_dashed-key-on-azure:dashed-value
                 - pod:
                   pod_name: pod_name1b
                   cpu_request: 1
@@ -28,18 +28,18 @@ generators:
                   cpu_limit: 1
                   mem_limit_gig: 4
                   pod_seconds: 3600
-                  labels: label_environment:Jupiter|label_app:mobile|label_version:Mars|label_qa:approved
+                  labels: label_environment:Jupiter|label_app:mobile|label_version:Mars|label_qa:approved|label_dashed-key-on-azure:dashed-value
               volumes:
                 - volume:
                   volume_name: pvc-volume_1
                   storage_class: gp2
                   volume_request_gig: 20
-                  labels: label_environment:Jupiter|label_app:mobile|label_version:Mars|label_storageclass:Baldur
+                  labels: label_environment:Jupiter|label_app:mobile|label_version:Mars|label_storageclass:Baldur|label_dashed-key-on-azure:dashed-value
                   volume_claims:
                   - volume_claim:
                     volume_claim_name: pod_name1_data
                     pod_name: pod_name1a
-                    labels: label_environment:Jupiter|label_app:mobile|label_version:Mars|label_storageclass:Baldur
+                    labels: label_environment:Jupiter|label_app:mobile|label_version:Mars|label_storageclass:Baldur|label_dashed-key-on-azure:dashed-value
                     capacity_gig: 20
             news-site:
               pods:


### PR DESCRIPTION
The following POST to settings in Stage:
```
{api: {settings: {tag-management: {enabled: ["azure-cost", "azure-ms-resource-usage"]}}}}
```
is returning a 400 error with the following message:
```
{"errors":[{"detail":"Invalid tag keys provided: ms.","source":"settings","status":400}]}
```


This PR contains a fix for `dashed` tag keys and adds dashed tag keys to our Nise yamls.

Testing:
1. `make create-test-customer`
2. `make load-test-customer-data`
3. Go to a tags endpoint:
```
http://localhost:8000/api/cost-management/v1/tags/aws/

see this data:
    "data": [
        {
            "key": "dashed-key-on-aws",
            "values": [
                "dashed-value"
            ],
            "enabled": true
        },
```
4. make a POST to settings:
```
POST http://localhost:8000/api/cost-management/v1/settings/

{
    "api": {
        "settings": {
            "tag-management": {
                "enabled": [
                    "aws-dashed-key-on-aws"
                ]
            }
        }
    }
}
```
4. See a 200 response.