### PR TITLE
unleash: add worker_process_shutdown method to destroy client

### DIFF
--- a/koku/koku/celery.py
+++ b/koku/koku/celery.py
@@ -10,6 +10,7 @@ from celery import Task
 from celery.schedules import crontab
 from celery.signals import celeryd_after_setup
 from celery.signals import worker_process_init
+from celery.signals import worker_process_shutdown
 from django.conf import settings
 from kombu.exceptions import OperationalError
 
@@ -233,6 +234,14 @@ def init_worker(**kwargs):
 
     LOG.info("Initializing UNLEASH_CLIENT for celery worker.")
     UNLEASH_CLIENT.initialize_client()
+
+
+@worker_process_shutdown.connect
+def shutdown_worker(**kwargs):
+    from koku.feature_flags import UNLEASH_CLIENT
+
+    LOG.info("Shutting down UNLEASH_CLIENT for celery worker.")
+    UNLEASH_CLIENT.destroy()
 
 
 def is_task_currently_running(task_name, task_id, check_args=None):


### PR DESCRIPTION
When a forked-worker shuts down, we need to destroy the background processes that unleash starts. This PR taps into the `worker_process_shutdown` signal to run the `destroy` command.

Note: the [celery docs](https://docs.celeryproject.org/en/stable/userguide/signals.html#worker-process-shutdown) mention that this method is not _guaranteed_ to run when a work shuts down. But of the signals available, this is likely the only one that will run within the forked-worker when the worker is shutting down. We _must_ call this `destroy` in the forked-worker process, else the background process won't be stopped. If this signal is not run, then we may still leave behind processes, but something is better than nothing here.

Some testing:
1. `make create-test-customer`
2. `make load-test-customer-data`
3. observe the worker logs. Saw this fly by which is exactly what we need to happen:
```
koku-worker_1     | [2021-10-08 15:25:59,477] INFO None Shutting down UNLEASH_CLIENT for celery worker.
koku-worker_1     | [2021-10-08 15:25:59,477: INFO/ForkPoolWorker-4] Shutting down UNLEASH_CLIENT for celery worker.
koku-worker_1     | [2021-10-08 15:26:00,209] INFO None Initializing UNLEASH_CLIENT for celery worker.
koku-worker_1     | [2021-10-08 15:26:00,209: INFO/ForkPoolWorker-5] Initializing UNLEASH_CLIENT for celery worker.
```