### PR TITLE
Disable ACCOUNT_ENHANCED_METRICS due to high cardinality impacts

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -2165,7 +2165,7 @@ parameters:
 - description: Flag to use account enhanced prometheus metrics
   displayName: Account Enhanced Metrics
   name: ACCOUNT_ENHANCED_METRICS
-  value: "True"
+  value: "False"
 - description: Flag to enable/disable caching
   displayName: cached views
   name: CACHED_VIEWS_DISABLED


### PR DESCRIPTION
Don't enable ACCOUNT_ENHANCED_METRICS due to high cardinality impacts

* Disable metrics tags with accounts