### PR TITLE
Fixing log message spacing

### DIFF
--- a/koku/masu/external/kafka_msg_handler.py
+++ b/koku/masu/external/kafka_msg_handler.py
@@ -287,7 +287,7 @@ def extract_payload(url, request_id, context={}):  # noqa: C901
         log_json(
             request_id,
             f"Payload with the request id {request_id} from cluster {cluster_id}"
-            + f"is part of the report with manifest id {manifest_uuid}",
+            + f" is part of the report with manifest id {manifest_uuid}",
         )
     )
     if context:


### PR DESCRIPTION
Minor log message fix, while investigating an Openshift issue I noticed there is no space between the cluster id and the word is. See below:

Before:
`cluster bec17195d0fcis part of the report with manifest id 0cd84d9e`

After:
`cluster bec17195d0fc is part of the report with manifest id 0cd84d9e`