### PR TITLE
OCP processing: replace `info` with `debug` logging

### DIFF
--- a/koku/masu/database/ocp_report_db_accessor.py
+++ b/koku/masu/database/ocp_report_db_accessor.py
@@ -1027,10 +1027,10 @@ class OCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
                     )
                 monthly_cost = self.generate_monthly_cost_json_object(distribution, node_cost)
                 if rate_type == metric_constants.INFRASTRUCTURE_COST_TYPE:
-                    LOG.info("Node (%s) has a monthly infrastructure cost of %s.", node, node_cost)
+                    LOG.debug("Node (%s) has a monthly infrastructure cost of %s.", node, node_cost)
                     line_item.infrastructure_monthly_cost_json = monthly_cost
                 elif rate_type == metric_constants.SUPPLEMENTARY_COST_TYPE:
-                    LOG.info("Node (%s) has a monthly supplemenarty cost of %s.", node, node_cost)
+                    LOG.debug("Node (%s) has a monthly supplemenarty cost of %s.", node, node_cost)
                     line_item.supplementary_monthly_cost_json = monthly_cost
                 line_item.save()
             # How are we gonna handle distributing the node cost to the projects.
@@ -1130,7 +1130,7 @@ class OCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
                                     )
                                 node_cost = rate_value
                                 if rate_type == metric_constants.INFRASTRUCTURE_COST_TYPE:
-                                    LOG.info("Node (%s) has a monthly infrastructure cost of %s.", node, rate_value)
+                                    LOG.debug("Node (%s) has a monthly infrastructure cost of %s.", node, rate_value)
                                     if line_item.infrastructure_monthly_cost_json:
                                         node_cost = (
                                             line_item.infrastructure_monthly_cost_json.get(distribution, 0)
@@ -1139,7 +1139,7 @@ class OCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
                                     monthly_cost = self.generate_monthly_cost_json_object(distribution, node_cost)
                                     line_item.infrastructure_monthly_cost_json = monthly_cost
                                 elif rate_type == metric_constants.SUPPLEMENTARY_COST_TYPE:
-                                    LOG.info("Node (%s) has a monthly supplemenarty cost of %s.", node, rate_value)
+                                    LOG.debug("Node (%s) has a monthly supplemenarty cost of %s.", node, rate_value)
                                     if line_item.supplementary_monthly_cost_json:
                                         node_cost = (
                                             line_item.supplementary_monthly_cost_json.get(distribution, 0) + rate_value
@@ -1557,7 +1557,7 @@ class OCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
                                     )
                                 pvc_cost = rate_value
                                 if rate_type == metric_constants.INFRASTRUCTURE_COST_TYPE:
-                                    LOG.info("PVC (%s) has a monthly infrastructure cost of %s.", pvc, rate_value)
+                                    LOG.debug("PVC (%s) has a monthly infrastructure cost of %s.", pvc, rate_value)
                                     if line_item.infrastructure_monthly_cost_json:
                                         pvc_cost = (
                                             line_item.infrastructure_monthly_cost_json.get(distribution, 0)
@@ -1566,7 +1566,7 @@ class OCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
                                     monthly_cost = self.generate_monthly_cost_json_object(distribution, pvc_cost)
                                     line_item.infrastructure_monthly_cost_json = monthly_cost
                                 elif rate_type == metric_constants.SUPPLEMENTARY_COST_TYPE:
-                                    LOG.info("PVC (%s) has a monthly supplemenarty cost of %s.", pvc, rate_value)
+                                    LOG.debug("PVC (%s) has a monthly supplemenarty cost of %s.", pvc, rate_value)
                                     if line_item.supplementary_monthly_cost_json:
                                         pvc_cost = (
                                             line_item.supplementary_monthly_cost_json.get(distribution, 0) + rate_value
@@ -1611,10 +1611,10 @@ class OCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
                     )
                 monthly_cost = self.generate_monthly_cost_json_object(metric_constants.PVC_DISTRIBUTION, pvc_cost)
                 if rate_type == metric_constants.INFRASTRUCTURE_COST_TYPE:
-                    LOG.info("PVC (%s) has a monthly infrastructure cost of %s.", pvc, pvc_cost)
+                    LOG.debug("PVC (%s) has a monthly infrastructure cost of %s.", pvc, pvc_cost)
                     line_item.infrastructure_monthly_cost_json = monthly_cost
                 elif rate_type == metric_constants.SUPPLEMENTARY_COST_TYPE:
-                    LOG.info("PVC (%s) has a monthly supplemenarty cost of %s.", pvc, pvc_cost)
+                    LOG.debug("PVC (%s) has a monthly supplemenarty cost of %s.", pvc, pvc_cost)
                     line_item.supplementary_monthly_cost_json = monthly_cost
                 line_item.save()
                 # PVC to project Distribution
@@ -1648,10 +1648,10 @@ class OCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
                     )
                 monthly_cost = self.generate_monthly_cost_json_object(metric_constants.PVC_DISTRIBUTION, pvc_cost)
                 if rate_type == metric_constants.INFRASTRUCTURE_COST_TYPE:
-                    LOG.info("PVC (%s) has a monthly project infrastructure cost of %s.", pvc, pvc_cost)
+                    LOG.debug("PVC (%s) has a monthly project infrastructure cost of %s.", pvc, pvc_cost)
                     project_line_item.infrastructure_project_monthly_cost = monthly_cost
                 elif rate_type == metric_constants.SUPPLEMENTARY_COST_TYPE:
-                    LOG.info("PVC (%s) has a monthly project supplemenarty cost of %s.", pvc, pvc_cost)
+                    LOG.debug("PVC (%s) has a monthly project supplemenarty cost of %s.", pvc, pvc_cost)
                     project_line_item.supplementary_project_monthly_cost = monthly_cost
                 project_line_item.save()
 
@@ -1704,7 +1704,7 @@ class OCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
                                     )
                                 cluster_cost = rate_value
                                 if rate_type == metric_constants.INFRASTRUCTURE_COST_TYPE:
-                                    LOG.info(
+                                    LOG.debug(
                                         "Cluster (%s) has a monthly infrastructure cost of %s from tag rates.",
                                         cluster_id,
                                         rate_value,
@@ -1717,7 +1717,7 @@ class OCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
                                     monthly_cost = self.generate_monthly_cost_json_object(distribution, cluster_cost)
                                     line_item.infrastructure_monthly_cost_json = monthly_cost
                                 elif rate_type == metric_constants.SUPPLEMENTARY_COST_TYPE:
-                                    LOG.info(
+                                    LOG.debug(
                                         "Cluster (%s) has a monthly supplemenarty cost of %s from tag rates.",
                                         cluster_id,
                                         rate_value,
@@ -1786,7 +1786,7 @@ class OCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
                             )
                         cluster_cost = tag_default
                         if rate_type == metric_constants.INFRASTRUCTURE_COST_TYPE:
-                            LOG.info(
+                            LOG.debug(
                                 "Cluster (%s) has a default monthly infrastructure cost of %s.",
                                 cluster_id,
                                 tag_default,
@@ -1798,7 +1798,7 @@ class OCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
                             monthly_cost = self.generate_monthly_cost_json_object(distribution, cluster_cost)
                             line_item.infrastructure_monthly_cost_json = monthly_cost
                         elif rate_type == metric_constants.SUPPLEMENTARY_COST_TYPE:
-                            LOG.info(
+                            LOG.debug(
                                 "Cluster (%s) has a default monthly supplemenarty cost of %s.", cluster_id, tag_default
                             )
                             if line_item.supplementary_monthly_cost_json:


### PR DESCRIPTION
This PR replaces unnecessary INFO logs with DEBUG logs.