### PR TITLE
[COST-1998] - `json.dump(key)` in case the key contains a dict

### DIFF
--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -14,6 +14,7 @@ from decimal import Decimal
 from decimal import DivisionByZero
 from decimal import InvalidOperation
 from itertools import groupby
+from json import dumps as json_dumps
 from urllib.parse import quote_plus
 
 from django.db.models import F
@@ -967,7 +968,7 @@ class ReportQueryHandler(QueryHandler):
             date = date + date_delta
             row["date"] = self.date_to_string(date)
             key = tuple(row[key] for key in query_group_by)
-            previous_dict[str(key)] = row[self._delta]
+            previous_dict[json_dumps(key)] = row[self._delta]
 
         return previous_dict
 
@@ -1016,7 +1017,7 @@ class ReportQueryHandler(QueryHandler):
         previous_dict = self._create_previous_totals(previous_query, delta_group_by)
         for row in query_data:
             key = tuple(row[key] for key in delta_group_by)
-            previous_total = previous_dict.get(str(key)) or 0
+            previous_total = previous_dict.get(json_dumps(key)) or 0
             current_total = row.get(self._delta) or 0
             row["delta_value"] = current_total - previous_total
             row["delta_percent"] = self._percent_delta(current_total, previous_total)


### PR DESCRIPTION
Exporting a CSV with deltas is resulting in a `Internal Server Error` because we are trying to use a dictionary as a key in another dictionary which Python doesn't allow. Actual error:
```
Traceback (most recent call last):
....
  File "/koku/koku/api/report/view.py", line 156, in get
    output = handler.execute_query()
  File "/koku/koku/api/report/ocp/query_handler.py", line 152, in execute_query
    query_data = self.add_deltas(query_data, query_sum)
  File "/koku/koku/api/report/ocp/query_handler.py", line 282, in add_deltas
    return super().add_deltas(query_data, query_sum)
  File "/koku/koku/api/report/queries.py", line 1019, in add_deltas
    previous_total = previous_dict.get(key) or 0
TypeError: unhashable type: 'dict'
```

Testing (I did this with Trino running):
1. make create-test-customer
2. make load-test-customer-data
3. make the following request:
```
curl --location -g --request GET 'http://localhost:8000/api/cost-management/v1/reports/openshift/costs/?delta=cost&filter[resolution]=monthly&filter[time_scope_value]=-1&group_by[project]=*&limit=0' \
--header 'Accept: text/csv' \
--header 'Content-Type: text/csv'
```
4. Get data in return