### PR TITLE
prcheck use pullid so forks work

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -92,7 +92,7 @@ EOF
 }
 
 # check if this commit is out of date with the branch
-latest_commit=$(curl -s -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/project-koku/koku/commits/$ghprbSourceBranch | jq -r '.sha')
+latest_commit=$(curl -s -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/project-koku/koku/pulls/$ghprbPullId | jq -r '.head.sha')
 if [[ $latest_commit != $ghprbActualCommit ]]
 then
     exit_code=3


### PR DESCRIPTION
Checks the pull request commit instead of branch commit so forks work.