### PR TITLE
Adding enhanced labelling to pr_Check

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -14,7 +14,6 @@ ARTIFACTS_DIR="$WORKSPACE/artifacts"
 
 export IQE_PLUGINS="cost_management"
 export IQE_MARKER_EXPRESSION="cost_smoke"
-export IQE_FILTER_EXPRESSION="test_api"
 export IQE_CJI_TIMEOUT="90m"
 
 set -ex
@@ -40,6 +39,7 @@ function run_unit_tests() {
 
 function run_smoke_tests() {
     run_trino_smoke_tests
+    run_test_filter_expression
     source ${CICD_ROOT}/_common_deploy_logic.sh
     export NAMESPACE=$(bonfire namespace reserve --duration 2)
 
@@ -77,6 +77,35 @@ function run_trino_smoke_tests() {
     if check_for_labels "trino-smoke-tests"
     then
         ENABLE_PARQUET_PROCESSING="true"
+    fi
+}
+
+function run_test_filter_expression {
+    if check_for_labels "aws"
+    then
+        export IQE_FILTER_EXPRESSION="test_api_aws or test_api_ocp_on_aws or test_api_cost_model_ocp_on_aws"
+    elif check_for_labels "azure"
+    then
+        export IQE_FILTER_EXPRESSION="test_api_azure or test_api_ocp_on_azure or test_api_cost_model_ocp_on_azure"
+    elif check_for_labels "gcp"
+    then
+        export IQE_FILTER_EXPRESSION="test_api_gcp or test_api_ocp_on_gcp or test_api_cost_model_ocp_on_gcp"
+    elif check_for_labels "ocp"
+    then
+        export IQE_FILTER_EXPRESSION="test_api_ocp or test_api_cost_model_ocp"
+    elif check_for_labels "hot-fix"
+    then
+        export IQE_FILTER_EXPRESSION="test_api"
+        export IQE_MARKER_EXPRESSION="outage"
+    elif check_for_labels "cost-models"
+    then
+        export IQE_FILTER_EXPRESSION="test_api_cost_model or test_api_ocp_source_upload_service"
+    elif check_for_labels "full-run"
+    then
+        export IQE_FILTER_EXPRESSION="test_api"
+    else
+        export IQE_FILTER_EXPRESSION="test_api"
+        export IQE_MARKER_EXPRESSION="cost_required"
     fi
 }
 

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -39,7 +39,6 @@ function run_unit_tests() {
 
 function run_smoke_tests() {
     run_trino_smoke_tests
-    run_test_filter_expression
     source ${CICD_ROOT}/_common_deploy_logic.sh
     export NAMESPACE=$(bonfire namespace reserve --duration 2)
 
@@ -97,7 +96,7 @@ function run_test_filter_expression {
     then
         export IQE_FILTER_EXPRESSION="test_api"
         export IQE_MARKER_EXPRESSION="outage"
-    elif check_for_labels "cost-models-smoke-tests"
+    elif check_for_labels "cost-model-smoke-tests"
     then
         export IQE_FILTER_EXPRESSION="test_api_cost_model or test_api_ocp_source_upload_service"
     elif check_for_labels "full-run-smoke-tests"
@@ -145,6 +144,9 @@ then
     exit_code=1
 else
     # Install bonfire repo/initialize
+    run_test_filter_expression
+    echo $IQE_MARKER_EXPRESSION
+    echo $IQE_FILTER_EXPRESSION
     CICD_URL=https://raw.githubusercontent.com/RedHatInsights/bonfire/master/cicd
     curl -s $CICD_URL/bootstrap.sh > .cicd_bootstrap.sh && source .cicd_bootstrap.sh
     echo "creating PR image"

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -139,7 +139,7 @@ curl -s -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos
 
 
 # check if this PR is labeled to build the test image
-if ! [[ check_for_labels == 'lgtm' ]] || [[ check_for_labels == 'pr-check-build' ]] || [[ check_for_labels == *'smoke-tests' ]]
+if ! check_for_labels 'lgtm|pr-check-build|*smoke-tests'
 then
     echo "PR check skipped"
     exit_code=1
@@ -154,7 +154,7 @@ fi
 
 if [[ $exit_code == 0 ]]; then
     # check if this PR is labeled to run smoke tests
-    if ! [[ check_for_labels == 'lgtm' ]] || [[ check_for_labels == *'smoke-tests' ]]
+    if ! check_for_labels 'lgtm|*smoke-tests'
     then
         echo "PR smoke tests skipped"
         exit_code=2

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -81,31 +81,35 @@ function run_trino_smoke_tests() {
 }
 
 function run_test_filter_expression {
-    if check_for_labels "aws"
+    if check_for_labels "aws-smoke-tests"
     then
         export IQE_FILTER_EXPRESSION="test_api_aws or test_api_ocp_on_aws or test_api_cost_model_ocp_on_aws"
-    elif check_for_labels "azure"
+    elif check_for_labels "azure-smoke-tests"
     then
         export IQE_FILTER_EXPRESSION="test_api_azure or test_api_ocp_on_azure or test_api_cost_model_ocp_on_azure"
-    elif check_for_labels "gcp"
+    elif check_for_labels "gcp-smoke-tests"
     then
         export IQE_FILTER_EXPRESSION="test_api_gcp or test_api_ocp_on_gcp or test_api_cost_model_ocp_on_gcp"
-    elif check_for_labels "ocp"
+    elif check_for_labels "ocp-smoke-tests"
     then
         export IQE_FILTER_EXPRESSION="test_api_ocp or test_api_cost_model_ocp"
-    elif check_for_labels "hot-fix"
+    elif check_for_labels "hot-fix-smoke-tests"
     then
         export IQE_FILTER_EXPRESSION="test_api"
         export IQE_MARKER_EXPRESSION="outage"
-    elif check_for_labels "cost-models"
+    elif check_for_labels "cost-models-smoke-tests"
     then
         export IQE_FILTER_EXPRESSION="test_api_cost_model or test_api_ocp_source_upload_service"
-    elif check_for_labels "full-run"
+    elif check_for_labels "full-run-smoke-tests"
     then
         export IQE_FILTER_EXPRESSION="test_api"
-    else
+    elif check_for_labels "smoke-tests"
+    then
         export IQE_FILTER_EXPRESSION="test_api"
         export IQE_MARKER_EXPRESSION="cost_required"
+    else
+        echo "PR smoke tests skipped"
+        exit_code=2
     fi
 }
 
@@ -135,7 +139,7 @@ curl -s -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos
 
 
 # check if this PR is labeled to build the test image
-if ! check_for_labels "lgtm|pr-check-build|smoke-tests"
+if ! [[ check_for_labels == 'lgtm' ]] || [[ check_for_labels == 'pr-check-build' ]] || [[ check_for_labels == *'smoke-tests' ]]
 then
     echo "PR check skipped"
     exit_code=1
@@ -150,7 +154,7 @@ fi
 
 if [[ $exit_code == 0 ]]; then
     # check if this PR is labeled to run smoke tests
-    if ! check_for_labels "lgtm|smoke-tests"
+    if ! [[ check_for_labels == 'lgtm' ]] || [[ check_for_labels == *'smoke-tests' ]]
     then
         echo "PR smoke tests skipped"
         exit_code=2

--- a/unit_test.sh
+++ b/unit_test.sh
@@ -88,4 +88,9 @@ cat << EOF > $WORKSPACE/artifacts/junit-dummy.xml
 </testsuite>
 EOF
 
-exit $result
+if [ $result -ne 0 ]; then
+  echo '====================================='
+  echo '====  ✖ ERROR: UNIT TEST FAILED  ===='
+  echo '====================================='
+  exit 1
+fi


### PR DESCRIPTION
Hopefully this will give as some improved labelling methods for running pr_check jobs.

This adds 7 new labels plus a new _default_ bare minimal test suite.

List of labels and usage:
- `aws-smoke-tests` This will run all aws and ocp on aws tests
- `azure-smoke-tests` This will run all aws and ocp on azure tests
- `gcp-smoke-tests` This will run all gcp and ocp on gcp tests
- `cost-model-smoke-tests` This will run all cost-model tests
- `full-run-smoke-tests` This runs all smoke tests (basically what we used to have by default)
- `hot-fix-smoke-tests` This runs that absolute minimal tests to get an urgent bug-fix to production
- `smoke-tests` Original label, this will now run new cost_required marker, this is going to run the bare minimal amount of tests across the board that _should_ be run on all pr's as minimum.

One thing to note here is these labels are not really going to be stackable, we could change this in the future but it might be a pain to manage. That said this breakout _should_ cover most if not all cases. If you are changing something that touches multiple source types then there's a good chance it will affect all of them so full-test should be used. 


#### Note ####
I also had to update the unit_test.sh after some changes in bonfire that caught me out while testing this.