### PR TITLE
add minio port for console access

### DIFF
--- a/testing/compose_files/docker-compose-presto.yml
+++ b/testing/compose_files/docker-compose-presto.yml
@@ -12,7 +12,8 @@ services:
       MINIO_ROOT_PASSWORD: kokuminiosecret
     ports:
       - 9000:9000
-    command: server /data
+      - 9090:9090
+    command: server /data --console-address ":9090"
     volumes:
       - ./../../.trino/parquet_data:/data
 

--- a/testing/compose_files/docker-compose-trino.yml
+++ b/testing/compose_files/docker-compose-trino.yml
@@ -12,7 +12,8 @@ services:
       MINIO_ROOT_PASSWORD: kokuminiosecret
     ports:
       - 9000:9000
-    command: server /data
+      - 9090:9090
+    command: server /data --console-address ":9090"
     volumes:
       - ./../../.trino/parquet_data:/data
 


### PR DESCRIPTION
testing:
1. make docker-up-min
2. make docker-trino-up
3. point browser to `http://localhost:9090`
4. log in with user `kokuminioaccess` and password: `kokuminiosecret`