### PR TITLE
Update Masu port

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ PYDIR	= koku
 KOKU_SERVER = $(shell echo "${KOKU_API_HOST:-localhost}")
 KOKU_SERVER_PORT = $(shell echo "${KOKU_API_PORT:-8000}")
 MASU_SERVER = $(shell echo "${MASU_SERVICE_HOST:-localhost}")
-MASU_SERVER_PORT = $(shell echo "${MASU_SERVICE_PORT:-5000}")
+MASU_SERVER_PORT = $(shell echo "${MASU_SERVICE_PORT:-5042}")
 DOCKER := $(shell which docker 2>/dev/null || which podman 2>/dev/null)
 scale = 1
 
@@ -518,7 +518,7 @@ endif
 	mkdir -p testing/pvc_dir/insights_local
 	nise report ocp --ocp-cluster-id $(cluster_id) --insights-upload testing/pvc_dir/insights_local --static-report-file $(srf_yaml)
 	curl -d '{"name": "$(ocp_name)", "source_type": "OCP", "authentication": {"credentials": {"cluster_id": "$(cluster_id)"}}}' -H "Content-Type: application/json" -X POST http://0.0.0.0:8000/api/cost-management/v1/sources/
-# From here you can hit the http://127.0.0.1:5000/api/cost-management/v1/download/ endpoint to start running masu.
+# From here you can hit the http://127.0.0.1:5042/api/cost-management/v1/download/ endpoint to start running masu.
 # After masu has run these endpoints should have data in them: (v1/reports/openshift/memory, v1/reports/openshift/compute/, v1/reports/openshift/volumes/)
 
 aws-source:

--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,7 @@ Run AWS Scenario
     make aws-source aws_name=AWS-SOURCE-001 bucket=cost-usage-bucket
 
 2. Verify source exists by visiting http://127.0.0.1:8000/api/cost-management/v1/sources/?name=AWS-SOURCE-001
-3. Trigger MASU processing by visiting http://127.0.0.1:5000/api/cost-management/v1/download/
+3. Trigger MASU processing by visiting http://127.0.0.1:5042/api/cost-management/v1/download/
 4. Wait for processing to complete
 5. Verify data existing using AWS API endpoints
 
@@ -128,7 +128,7 @@ Run OCP Scenario
     make ocp-source-from-yaml cluster_id=my_test_cluster srf_yaml=../nise/example_ocp_static_data.yml ocp_name=my_ocp_name
 
 2. Verify provider exists by visiting http://127.0.0.1:8000/api/cost-management/v1/sources/?name=my_ocp_name
-3. Trigger MASU processing by visiting http://127.0.0.1:5000/api/cost-management/v1/download/
+3. Trigger MASU processing by visiting http://127.0.0.1:5042/api/cost-management/v1/download/
 4. Wait for processing to complete
 5. Verify data exists using API endpoints
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,7 +113,7 @@ services:
       - UNLEASH_LOG_LEVEL=${UNLEASH_LOG_LEVEL-WARNING}
     privileged: true
     ports:
-      - 5000:8000
+      - 5042:8000
       - 5001:9000
     volumes:
       - '.:/koku/'

--- a/docs/source/aws.rst
+++ b/docs/source/aws.rst
@@ -28,7 +28,7 @@ You should receive a 200 range response confirming that the Source was created.
 Trigger Masu
 =============
 
-Send a GET request to ``http://<your_host>:5000/api/cost-management/v1/download/`` That will trigger the worker to load the data into the DB.
+Send a GET request to ``http://<your_host>:5042/api/cost-management/v1/download/`` That will trigger the worker to load the data into the DB.
 
 You may want to check the logs to see if the loading is occuring:
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -65,5 +65,5 @@ Masu can alternatively be deployed with Docker Compose:
 Follow the steps above to start the Koku API with Docker Compose
 
 Start masu services: ``masu_branch> make docker-up``
-To trigger Masu to process data, send a GET request to http://<baseUrl>:5000/api/cost-management/v1/download/
+To trigger Masu to process data, send a GET request to http://<baseUrl>:5042/api/cost-management/v1/download/
 You may want to see Masu logs using `docker logs koku_worker -f`

--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -78,7 +78,7 @@ settings.local.yaml::
         azure_dir: /tmp/local_container
         masu:
           path: api/cost-management/v1
-          port: 5000
+          port: 5042
           hostname: masu-hccm.apps-crc.testing
           scheme: http
       main:

--- a/testing/compose_files/docker-compose-multilistener.yml
+++ b/testing/compose_files/docker-compose-multilistener.yml
@@ -92,7 +92,7 @@ services:
 
       privileged: true
       ports:
-          - 5000:8000
+          - 5042:8000
       volumes:
         - './../..:/koku/'
       links:

--- a/testing/compose_files/docker-compose-multiworker-make.yml
+++ b/testing/compose_files/docker-compose-multiworker-make.yml
@@ -92,7 +92,7 @@ services:
 
       privileged: true
       ports:
-          - 5000:8000
+          - 5042:8000
       volumes:
         - ${KOKU_PATH}/:/koku/
       links:

--- a/testing/compose_files/docker-compose-multiworker.yml
+++ b/testing/compose_files/docker-compose-multiworker.yml
@@ -95,7 +95,7 @@ services:
 
       privileged: true
       ports:
-          - 5000:8000
+          - 5042:8000
       volumes:
         - './../..:/koku/'
       links:

--- a/testing/compose_files/docker-compose-multiworkerlistener.yml
+++ b/testing/compose_files/docker-compose-multiworkerlistener.yml
@@ -91,7 +91,7 @@ services:
 
       privileged: true
       ports:
-          - 5000:8000
+          - 5042:8000
       volumes:
         - './../..:/koku/'
       links:

--- a/testing/conf/settings.local.yaml
+++ b/testing/conf/settings.local.yaml
@@ -9,7 +9,7 @@ local:
       masu:
         config:
           path: api/cost-management/v1
-          port: 5000
+          port: 5042
           hostname: localhost
           scheme: http
   SOURCES:


### PR DESCRIPTION
In the new apple update for Monterey the apple control center now utilizes port 5000 so it was decided to move internal endpoints from port 5000 to 5042. This should update the endpoints to port 5042 as well as update the docs.

Testing Instructions:
```
1. Bring any currently running docker containers down
2. Pull and checkout branch
3. Bring docker containers back up 
4. test internal endpoints:
http://127.0.0.1:5000/api/cost-management/v1/download/ 
    -should no longer work
http://127.0.0.1:5042/api/cost-management/v1/download/
    -should be the new endpoint that works
```