### PR TITLE
Update settings page so Cost Savings is visible in non dev mode

### DIFF
--- a/koku/api/settings/settings.py
+++ b/koku/api/settings/settings.py
@@ -206,8 +206,8 @@ class Settings:
         customer_specific_providers = Provider.objects.filter(customer=customer)
         has_aws_providers = customer_specific_providers.filter(type__icontains=Provider.PROVIDER_AWS).exists()
 
-        # cost_type plan settings TODO: only show in dev mode right now
-        if settings.DEVELOPMENT and has_aws_providers:
+        # cost_type plan settings
+        if has_aws_providers:
             cost_type_select_name = f'{"api.settings.cost_type"}'
             cost_type_text_context = (
                 "Select the preferred way of calculating upfront costs, either through savings "

--- a/koku/api/settings/test/tests_views.py
+++ b/koku/api/settings/test/tests_views.py
@@ -42,7 +42,7 @@ class SettingsViewTest(IamTestCase):
         primary_object = data[0]
         tg_mngmnt_subform_fields = primary_object.get("fields")
         self.assertIsNotNone(tg_mngmnt_subform_fields)
-        fields_len = 3
+        fields_len = 6
         self.assertEqual(len(tg_mngmnt_subform_fields), fields_len)
         for element in tg_mngmnt_subform_fields:
             component_name = element.get("component")


### PR DESCRIPTION
Closes: https://issues.redhat.com/browse/COST-2092

Update settings page to expose AWS Cost Savings settings

![Screen Shot 2021-11-19 at 10 08 45 AM](https://user-images.githubusercontent.com/57504257/142648572-61f868cd-7d29-49ab-a977-6bee7d77e258.png)

Database table before and after a changes are made via the settings page
![Screen Shot 2021-11-19 at 10 19 39 AM](https://user-images.githubusercontent.com/57504257/142648582-ae7b3fa4-c5d4-4476-9489-96c75531401b.png)

