### PR TITLE
add schema to partable sql

### DIFF
--- a/koku/masu/database/sql/azure/reporting_azure_compute_summary_p.sql
+++ b/koku/masu/database/sql/azure/reporting_azure_compute_summary_p.sql
@@ -4,7 +4,7 @@ WHERE usage_start >= {{start_date}}::date
     AND source_uuid = {{source_uuid}}
 ;
 
-INSERT INTO {{schema_name | sqlsafe}}.reporting_azure_compute_summary_p (
+INSERT INTO {{schema | sqlsafe}}.reporting_azure_compute_summary_p (
     id,
     usage_start,
     usage_end,
@@ -42,7 +42,7 @@ INSERT INTO {{schema_name | sqlsafe}}.reporting_azure_compute_summary_p (
             SUM(pretax_cost) AS pretax_cost,
             SUM(markup_cost) AS markup_cost,
             MAX(currency) AS currency
-        FROM {{schema_name | sqlsafe}}.reporting_azurecostentrylineitem_daily_summary
+        FROM {{schema | sqlsafe}}.reporting_azurecostentrylineitem_daily_summary
         WHERE usage_start >= {{start_date}}::date
             AND usage_start <= {{end_date}}::date
             AND source_uuid = {{source_uuid}}
@@ -61,7 +61,7 @@ INSERT INTO {{schema_name | sqlsafe}}.reporting_azure_compute_summary_p (
                 subscription_guid,
                 instance_type,
                 UNNEST(instance_ids) AS instance_id
-            FROM {{schema_name | sqlsafe}}.reporting_azurecostentrylineitem_daily_summary
+            FROM {{schema | sqlsafe}}.reporting_azurecostentrylineitem_daily_summary
             WHERE usage_start >= {{start_date}}::date
                 AND usage_start <= {{end_date}}::date
                 AND source_uuid = {{source_uuid}}

--- a/koku/masu/database/sql/azure/reporting_azure_compute_summary_p.sql
+++ b/koku/masu/database/sql/azure/reporting_azure_compute_summary_p.sql
@@ -4,7 +4,7 @@ WHERE usage_start >= {{start_date}}::date
     AND source_uuid = {{source_uuid}}
 ;
 
-INSERT INTO reporting_azure_compute_summary_p (
+INSERT INTO {{schema_name | sqlsafe}}.reporting_azure_compute_summary_p (
     id,
     usage_start,
     usage_end,
@@ -42,7 +42,7 @@ INSERT INTO reporting_azure_compute_summary_p (
             SUM(pretax_cost) AS pretax_cost,
             SUM(markup_cost) AS markup_cost,
             MAX(currency) AS currency
-        FROM reporting_azurecostentrylineitem_daily_summary
+        FROM {{schema_name | sqlsafe}}.reporting_azurecostentrylineitem_daily_summary
         WHERE usage_start >= {{start_date}}::date
             AND usage_start <= {{end_date}}::date
             AND source_uuid = {{source_uuid}}
@@ -61,7 +61,7 @@ INSERT INTO reporting_azure_compute_summary_p (
                 subscription_guid,
                 instance_type,
                 UNNEST(instance_ids) AS instance_id
-            FROM reporting_azurecostentrylineitem_daily_summary
+            FROM {{schema_name | sqlsafe}}.reporting_azurecostentrylineitem_daily_summary
             WHERE usage_start >= {{start_date}}::date
                 AND usage_start <= {{end_date}}::date
                 AND source_uuid = {{source_uuid}}

--- a/koku/masu/database/sql/azure/reporting_azure_cost_summary_by_account_p.sql
+++ b/koku/masu/database/sql/azure/reporting_azure_cost_summary_by_account_p.sql
@@ -4,7 +4,7 @@ WHERE usage_start >= {{start_date}}::date
     AND source_uuid = {{source_uuid}}
 ;
 
-INSERT INTO {{schema_name | sqlsafe}}.reporting_azure_cost_summary_by_account_p (
+INSERT INTO {{schema | sqlsafe}}.reporting_azure_cost_summary_by_account_p (
     id,
     usage_start,
     usage_end,
@@ -22,7 +22,7 @@ INSERT INTO {{schema_name | sqlsafe}}.reporting_azure_cost_summary_by_account_p 
         sum(markup_cost) as markup_cost,
         max(currency) as currency,
         {{source_uuid}}::uuid as source_uuid
-    FROM {{schema_name | sqlsafe}}.reporting_azurecostentrylineitem_daily_summary
+    FROM {{schema | sqlsafe}}.reporting_azurecostentrylineitem_daily_summary
     WHERE usage_start >= {{start_date}}::date
         AND usage_start <= {{end_date}}::date
         AND source_uuid = {{source_uuid}}

--- a/koku/masu/database/sql/azure/reporting_azure_cost_summary_by_account_p.sql
+++ b/koku/masu/database/sql/azure/reporting_azure_cost_summary_by_account_p.sql
@@ -4,7 +4,7 @@ WHERE usage_start >= {{start_date}}::date
     AND source_uuid = {{source_uuid}}
 ;
 
-INSERT INTO reporting_azure_cost_summary_by_account_p (
+INSERT INTO {{schema_name | sqlsafe}}.reporting_azure_cost_summary_by_account_p (
     id,
     usage_start,
     usage_end,
@@ -22,7 +22,7 @@ INSERT INTO reporting_azure_cost_summary_by_account_p (
         sum(markup_cost) as markup_cost,
         max(currency) as currency,
         {{source_uuid}}::uuid as source_uuid
-    FROM reporting_azurecostentrylineitem_daily_summary
+    FROM {{schema_name | sqlsafe}}.reporting_azurecostentrylineitem_daily_summary
     WHERE usage_start >= {{start_date}}::date
         AND usage_start <= {{end_date}}::date
         AND source_uuid = {{source_uuid}}

--- a/koku/masu/database/sql/azure/reporting_azure_cost_summary_by_location_p.sql
+++ b/koku/masu/database/sql/azure/reporting_azure_cost_summary_by_location_p.sql
@@ -4,7 +4,7 @@ WHERE usage_start >= {{start_date}}::date
     AND source_uuid = {{source_uuid}}
 ;
 
-INSERT INTO reporting_azure_cost_summary_by_location_p (
+INSERT INTO {{schema_name | sqlsafe}}.reporting_azure_cost_summary_by_location_p (
     id,
     usage_start,
     usage_end,
@@ -24,7 +24,7 @@ INSERT INTO reporting_azure_cost_summary_by_location_p (
         sum(markup_cost) as markup_cost,
         max(currency) as currency,
         {{source_uuid}}::uuid as source_uuid
-    FROM reporting_azurecostentrylineitem_daily_summary
+    FROM {{schema_name | sqlsafe}}.reporting_azurecostentrylineitem_daily_summary
     WHERE usage_start >= {{start_date}}::date
         AND usage_start <= {{end_date}}::date
         AND source_uuid = {{source_uuid}}

--- a/koku/masu/database/sql/azure/reporting_azure_cost_summary_by_location_p.sql
+++ b/koku/masu/database/sql/azure/reporting_azure_cost_summary_by_location_p.sql
@@ -4,7 +4,7 @@ WHERE usage_start >= {{start_date}}::date
     AND source_uuid = {{source_uuid}}
 ;
 
-INSERT INTO {{schema_name | sqlsafe}}.reporting_azure_cost_summary_by_location_p (
+INSERT INTO {{schema | sqlsafe}}.reporting_azure_cost_summary_by_location_p (
     id,
     usage_start,
     usage_end,
@@ -24,7 +24,7 @@ INSERT INTO {{schema_name | sqlsafe}}.reporting_azure_cost_summary_by_location_p
         sum(markup_cost) as markup_cost,
         max(currency) as currency,
         {{source_uuid}}::uuid as source_uuid
-    FROM {{schema_name | sqlsafe}}.reporting_azurecostentrylineitem_daily_summary
+    FROM {{schema | sqlsafe}}.reporting_azurecostentrylineitem_daily_summary
     WHERE usage_start >= {{start_date}}::date
         AND usage_start <= {{end_date}}::date
         AND source_uuid = {{source_uuid}}

--- a/koku/masu/database/sql/azure/reporting_azure_cost_summary_by_service_p.sql
+++ b/koku/masu/database/sql/azure/reporting_azure_cost_summary_by_service_p.sql
@@ -4,7 +4,7 @@ WHERE usage_start >= {{start_date}}::date
     AND source_uuid = {{source_uuid}}
 ;
 
-INSERT INTO {{schema_name | sqlsafe}}.reporting_azure_cost_summary_by_service_p (
+INSERT INTO {{schema | sqlsafe}}.reporting_azure_cost_summary_by_service_p (
     id,
     usage_start,
     usage_end,
@@ -24,7 +24,7 @@ INSERT INTO {{schema_name | sqlsafe}}.reporting_azure_cost_summary_by_service_p 
         sum(markup_cost) as markup_cost,
         max(currency) as currency,
         {{source_uuid}}::uuid as source_uuid
-    FROM {{schema_name | sqlsafe}}.reporting_azurecostentrylineitem_daily_summary
+    FROM {{schema | sqlsafe}}.reporting_azurecostentrylineitem_daily_summary
     WHERE usage_start >= {{start_date}}::date
         AND usage_start <= {{end_date}}::date
         AND source_uuid = {{source_uuid}}

--- a/koku/masu/database/sql/azure/reporting_azure_cost_summary_by_service_p.sql
+++ b/koku/masu/database/sql/azure/reporting_azure_cost_summary_by_service_p.sql
@@ -4,7 +4,7 @@ WHERE usage_start >= {{start_date}}::date
     AND source_uuid = {{source_uuid}}
 ;
 
-INSERT INTO reporting_azure_cost_summary_by_service_p (
+INSERT INTO {{schema_name | sqlsafe}}.reporting_azure_cost_summary_by_service_p (
     id,
     usage_start,
     usage_end,
@@ -24,7 +24,7 @@ INSERT INTO reporting_azure_cost_summary_by_service_p (
         sum(markup_cost) as markup_cost,
         max(currency) as currency,
         {{source_uuid}}::uuid as source_uuid
-    FROM reporting_azurecostentrylineitem_daily_summary
+    FROM {{schema_name | sqlsafe}}.reporting_azurecostentrylineitem_daily_summary
     WHERE usage_start >= {{start_date}}::date
         AND usage_start <= {{end_date}}::date
         AND source_uuid = {{source_uuid}}

--- a/koku/masu/database/sql/azure/reporting_azure_cost_summary_p.sql
+++ b/koku/masu/database/sql/azure/reporting_azure_cost_summary_p.sql
@@ -4,7 +4,7 @@ WHERE usage_start >= {{start_date}}::date
     AND source_uuid = {{source_uuid}}
 ;
 
-INSERT INTO reporting_azure_cost_summary_p (
+INSERT INTO {{schema_name | sqlsafe}}.reporting_azure_cost_summary_p (
     id,
     usage_start,
     usage_end,
@@ -20,7 +20,7 @@ INSERT INTO reporting_azure_cost_summary_p (
         sum(markup_cost) as markup_cost,
         max(currency) as currency,
         {{source_uuid}}::uuid as source_uuid
-    FROM reporting_azurecostentrylineitem_daily_summary
+    FROM {{schema_name | sqlsafe}}.reporting_azurecostentrylineitem_daily_summary
     WHERE usage_start >= {{start_date}}::date
         AND usage_start <= {{end_date}}::date
         AND source_uuid = {{source_uuid}}

--- a/koku/masu/database/sql/azure/reporting_azure_cost_summary_p.sql
+++ b/koku/masu/database/sql/azure/reporting_azure_cost_summary_p.sql
@@ -4,7 +4,7 @@ WHERE usage_start >= {{start_date}}::date
     AND source_uuid = {{source_uuid}}
 ;
 
-INSERT INTO {{schema_name | sqlsafe}}.reporting_azure_cost_summary_p (
+INSERT INTO {{schema | sqlsafe}}.reporting_azure_cost_summary_p (
     id,
     usage_start,
     usage_end,
@@ -20,7 +20,7 @@ INSERT INTO {{schema_name | sqlsafe}}.reporting_azure_cost_summary_p (
         sum(markup_cost) as markup_cost,
         max(currency) as currency,
         {{source_uuid}}::uuid as source_uuid
-    FROM {{schema_name | sqlsafe}}.reporting_azurecostentrylineitem_daily_summary
+    FROM {{schema | sqlsafe}}.reporting_azurecostentrylineitem_daily_summary
     WHERE usage_start >= {{start_date}}::date
         AND usage_start <= {{end_date}}::date
         AND source_uuid = {{source_uuid}}

--- a/koku/masu/database/sql/azure/reporting_azure_database_summary_p.sql
+++ b/koku/masu/database/sql/azure/reporting_azure_database_summary_p.sql
@@ -4,7 +4,7 @@ WHERE usage_start >= {{start_date}}::date
     AND source_uuid = {{source_uuid}}
 ;
 
-INSERT INTO {{schema_name | sqlsafe}}.reporting_azure_database_summary_p (
+INSERT INTO {{schema | sqlsafe}}.reporting_azure_database_summary_p (
     id,
     usage_start,
     usage_end,
@@ -28,7 +28,7 @@ INSERT INTO {{schema_name | sqlsafe}}.reporting_azure_database_summary_p (
         sum(markup_cost) as markup_cost,
         max(currency) as currency,
         {{source_uuid}}::uuid as source_uuid
-    FROM {{schema_name | sqlsafe}}.reporting_azurecostentrylineitem_daily_summary
+    FROM {{schema | sqlsafe}}.reporting_azurecostentrylineitem_daily_summary
     WHERE service_name IN ('Cosmos DB','Cache for Redis') OR service_name ILIKE '%%database%%'
         AND usage_start >= {{start_date}}::date
         AND usage_start <= {{end_date}}::date

--- a/koku/masu/database/sql/azure/reporting_azure_database_summary_p.sql
+++ b/koku/masu/database/sql/azure/reporting_azure_database_summary_p.sql
@@ -4,7 +4,7 @@ WHERE usage_start >= {{start_date}}::date
     AND source_uuid = {{source_uuid}}
 ;
 
-INSERT INTO reporting_azure_database_summary_p (
+INSERT INTO {{schema_name | sqlsafe}}.reporting_azure_database_summary_p (
     id,
     usage_start,
     usage_end,
@@ -28,7 +28,7 @@ INSERT INTO reporting_azure_database_summary_p (
         sum(markup_cost) as markup_cost,
         max(currency) as currency,
         {{source_uuid}}::uuid as source_uuid
-    FROM reporting_azurecostentrylineitem_daily_summary
+    FROM {{schema_name | sqlsafe}}.reporting_azurecostentrylineitem_daily_summary
     WHERE service_name IN ('Cosmos DB','Cache for Redis') OR service_name ILIKE '%%database%%'
         AND usage_start >= {{start_date}}::date
         AND usage_start <= {{end_date}}::date

--- a/koku/masu/database/sql/azure/reporting_azure_network_summary_p.sql
+++ b/koku/masu/database/sql/azure/reporting_azure_network_summary_p.sql
@@ -4,7 +4,7 @@ WHERE usage_start >= {{start_date}}::date
     AND source_uuid = {{source_uuid}}
 ;
 
-INSERT INTO reporting_azure_network_summary_p (
+INSERT INTO {{schema_name | sqlsafe}}.reporting_azure_network_summary_p (
     id,
     usage_start,
     usage_end,
@@ -28,7 +28,7 @@ INSERT INTO reporting_azure_network_summary_p (
         sum(markup_cost) as markup_cost,
         max(currency) as currency,
         {{source_uuid}}::uuid as source_uuid
-    FROM reporting_azurecostentrylineitem_daily_summary
+    FROM {{schema_name | sqlsafe}}.reporting_azurecostentrylineitem_daily_summary
     WHERE service_name IN ('Virtual Network','VPN','DNS','Traffic Manager','ExpressRoute','Load Balancer','Application Gateway')
         AND usage_start >= {{start_date}}::date
         AND usage_start <= {{end_date}}::date

--- a/koku/masu/database/sql/azure/reporting_azure_network_summary_p.sql
+++ b/koku/masu/database/sql/azure/reporting_azure_network_summary_p.sql
@@ -4,7 +4,7 @@ WHERE usage_start >= {{start_date}}::date
     AND source_uuid = {{source_uuid}}
 ;
 
-INSERT INTO {{schema_name | sqlsafe}}.reporting_azure_network_summary_p (
+INSERT INTO {{schema | sqlsafe}}.reporting_azure_network_summary_p (
     id,
     usage_start,
     usage_end,
@@ -28,7 +28,7 @@ INSERT INTO {{schema_name | sqlsafe}}.reporting_azure_network_summary_p (
         sum(markup_cost) as markup_cost,
         max(currency) as currency,
         {{source_uuid}}::uuid as source_uuid
-    FROM {{schema_name | sqlsafe}}.reporting_azurecostentrylineitem_daily_summary
+    FROM {{schema | sqlsafe}}.reporting_azurecostentrylineitem_daily_summary
     WHERE service_name IN ('Virtual Network','VPN','DNS','Traffic Manager','ExpressRoute','Load Balancer','Application Gateway')
         AND usage_start >= {{start_date}}::date
         AND usage_start <= {{end_date}}::date

--- a/koku/masu/database/sql/azure/reporting_azure_storage_summary_p.sql
+++ b/koku/masu/database/sql/azure/reporting_azure_storage_summary_p.sql
@@ -4,7 +4,7 @@ WHERE usage_start >= {{start_date}}::date
     AND source_uuid = {{source_uuid}}
 ;
 
-INSERT INTO {{schema_name | sqlsafe}}.reporting_azure_storage_summary_p (
+INSERT INTO {{schema | sqlsafe}}.reporting_azure_storage_summary_p (
     id,
     usage_start,
     usage_end,
@@ -28,7 +28,7 @@ INSERT INTO {{schema_name | sqlsafe}}.reporting_azure_storage_summary_p (
         sum(markup_cost) as markup_cost,
         max(currency) as currency,
         {{source_uuid}}::uuid as source_uuid
-    FROM {{schema_name | sqlsafe}}.reporting_azurecostentrylineitem_daily_summary
+    FROM {{schema | sqlsafe}}.reporting_azurecostentrylineitem_daily_summary
     WHERE service_name LIKE '%%Storage%%'
         AND unit_of_measure = 'GB-Mo'
         AND usage_start >= {{start_date}}::date

--- a/koku/masu/database/sql/azure/reporting_azure_storage_summary_p.sql
+++ b/koku/masu/database/sql/azure/reporting_azure_storage_summary_p.sql
@@ -4,7 +4,7 @@ WHERE usage_start >= {{start_date}}::date
     AND source_uuid = {{source_uuid}}
 ;
 
-INSERT INTO reporting_azure_storage_summary_p (
+INSERT INTO {{schema_name | sqlsafe}}.reporting_azure_storage_summary_p (
     id,
     usage_start,
     usage_end,
@@ -28,7 +28,7 @@ INSERT INTO reporting_azure_storage_summary_p (
         sum(markup_cost) as markup_cost,
         max(currency) as currency,
         {{source_uuid}}::uuid as source_uuid
-    FROM reporting_azurecostentrylineitem_daily_summary
+    FROM {{schema_name | sqlsafe}}.reporting_azurecostentrylineitem_daily_summary
     WHERE service_name LIKE '%%Storage%%'
         AND unit_of_measure = 'GB-Mo'
         AND usage_start >= {{start_date}}::date

--- a/koku/masu/database/sql/gcp/reporting_gcp_compute_summary_by_account_p.sql
+++ b/koku/masu/database/sql/gcp/reporting_gcp_compute_summary_by_account_p.sql
@@ -5,7 +5,7 @@ WHERE usage_start >= {{start_date}}::date
     AND invoice_month = {{invoice_month}}
 ;
 
-INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_compute_summary_by_account_p (
+INSERT INTO {{schema | sqlsafe}}.reporting_gcp_compute_summary_by_account_p (
     id,
     usage_start,
     usage_end,
@@ -33,7 +33,7 @@ INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_compute_summary_by_account_p
         max(source_uuid::text)::uuid as source_uuid,
         invoice_month,
         SUM(credit_amount) AS credit_amount
-    FROM {{schema_name | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
+    FROM {{schema | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
     WHERE usage_start >= {{start_date}}::date
         AND usage_start <= {{end_date}}::date
         AND source_uuid = {{source_uuid}}

--- a/koku/masu/database/sql/gcp/reporting_gcp_compute_summary_by_account_p.sql
+++ b/koku/masu/database/sql/gcp/reporting_gcp_compute_summary_by_account_p.sql
@@ -5,7 +5,7 @@ WHERE usage_start >= {{start_date}}::date
     AND invoice_month = {{invoice_month}}
 ;
 
-INSERT INTO reporting_gcp_compute_summary_by_account_p (
+INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_compute_summary_by_account_p (
     id,
     usage_start,
     usage_end,
@@ -33,7 +33,7 @@ INSERT INTO reporting_gcp_compute_summary_by_account_p (
         max(source_uuid::text)::uuid as source_uuid,
         invoice_month,
         SUM(credit_amount) AS credit_amount
-    FROM reporting_gcpcostentrylineitem_daily_summary
+    FROM {{schema_name | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
     WHERE usage_start >= {{start_date}}::date
         AND usage_start <= {{end_date}}::date
         AND source_uuid = {{source_uuid}}

--- a/koku/masu/database/sql/gcp/reporting_gcp_compute_summary_by_project_p.sql
+++ b/koku/masu/database/sql/gcp/reporting_gcp_compute_summary_by_project_p.sql
@@ -5,7 +5,7 @@ WHERE usage_start >= {{start_date}}::date
     AND invoice_month = {{invoice_month}}
 ;
 
-INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_compute_summary_by_project_p (
+INSERT INTO {{schema | sqlsafe}}.reporting_gcp_compute_summary_by_project_p (
     id,
     usage_start,
     usage_end,
@@ -37,7 +37,7 @@ INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_compute_summary_by_project_p
         max(source_uuid::text)::uuid as source_uuid,
         invoice_month,
         SUM(credit_amount) AS credit_amount
-    FROM {{schema_name | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
+    FROM {{schema | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
     WHERE usage_start >= {{start_date}}::date
         AND usage_start <= {{end_date}}::date
         AND source_uuid = {{source_uuid}}

--- a/koku/masu/database/sql/gcp/reporting_gcp_compute_summary_by_project_p.sql
+++ b/koku/masu/database/sql/gcp/reporting_gcp_compute_summary_by_project_p.sql
@@ -5,7 +5,7 @@ WHERE usage_start >= {{start_date}}::date
     AND invoice_month = {{invoice_month}}
 ;
 
-INSERT INTO reporting_gcp_compute_summary_by_project_p (
+INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_compute_summary_by_project_p (
     id,
     usage_start,
     usage_end,
@@ -37,7 +37,7 @@ INSERT INTO reporting_gcp_compute_summary_by_project_p (
         max(source_uuid::text)::uuid as source_uuid,
         invoice_month,
         SUM(credit_amount) AS credit_amount
-    FROM reporting_gcpcostentrylineitem_daily_summary
+    FROM {{schema_name | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
     WHERE usage_start >= {{start_date}}::date
         AND usage_start <= {{end_date}}::date
         AND source_uuid = {{source_uuid}}

--- a/koku/masu/database/sql/gcp/reporting_gcp_compute_summary_by_region_p.sql
+++ b/koku/masu/database/sql/gcp/reporting_gcp_compute_summary_by_region_p.sql
@@ -5,7 +5,7 @@ WHERE usage_start >= {{start_date}}::date
     AND invoice_month = {{invoice_month}}
 ;
 
-INSERT INTO reporting_gcp_compute_summary_by_region_p (
+INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_compute_summary_by_region_p (
     id,
     usage_start,
     usage_end,
@@ -35,7 +35,7 @@ INSERT INTO reporting_gcp_compute_summary_by_region_p (
         max(source_uuid::text)::uuid as source_uuid,
         invoice_month,
         SUM(credit_amount) AS credit_amount
-    FROM reporting_gcpcostentrylineitem_daily_summary
+    FROM {{schema_name | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
     WHERE usage_start >= {{start_date}}::date
         AND usage_start <= {{end_date}}::date
         AND source_uuid = {{source_uuid}}

--- a/koku/masu/database/sql/gcp/reporting_gcp_compute_summary_by_region_p.sql
+++ b/koku/masu/database/sql/gcp/reporting_gcp_compute_summary_by_region_p.sql
@@ -5,7 +5,7 @@ WHERE usage_start >= {{start_date}}::date
     AND invoice_month = {{invoice_month}}
 ;
 
-INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_compute_summary_by_region_p (
+INSERT INTO {{schema | sqlsafe}}.reporting_gcp_compute_summary_by_region_p (
     id,
     usage_start,
     usage_end,
@@ -35,7 +35,7 @@ INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_compute_summary_by_region_p 
         max(source_uuid::text)::uuid as source_uuid,
         invoice_month,
         SUM(credit_amount) AS credit_amount
-    FROM {{schema_name | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
+    FROM {{schema | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
     WHERE usage_start >= {{start_date}}::date
         AND usage_start <= {{end_date}}::date
         AND source_uuid = {{source_uuid}}

--- a/koku/masu/database/sql/gcp/reporting_gcp_compute_summary_by_service_p.sql
+++ b/koku/masu/database/sql/gcp/reporting_gcp_compute_summary_by_service_p.sql
@@ -5,7 +5,7 @@ WHERE usage_start >= {{start_date}}::date
     AND invoice_month = {{invoice_month}}
 ;
 
-INSERT INTO reporting_gcp_compute_summary_by_service_p (
+INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_compute_summary_by_service_p (
     id,
     usage_start,
     usage_end,
@@ -37,7 +37,7 @@ INSERT INTO reporting_gcp_compute_summary_by_service_p (
         max(source_uuid::text)::uuid as source_uuid,
         invoice_month,
         SUM(credit_amount) AS credit_amount
-    FROM reporting_gcpcostentrylineitem_daily_summary
+    FROM {{schema_name | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
     WHERE usage_start >= {{start_date}}::date
         AND usage_start <= {{end_date}}::date
         AND source_uuid = {{source_uuid}}

--- a/koku/masu/database/sql/gcp/reporting_gcp_compute_summary_by_service_p.sql
+++ b/koku/masu/database/sql/gcp/reporting_gcp_compute_summary_by_service_p.sql
@@ -5,7 +5,7 @@ WHERE usage_start >= {{start_date}}::date
     AND invoice_month = {{invoice_month}}
 ;
 
-INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_compute_summary_by_service_p (
+INSERT INTO {{schema | sqlsafe}}.reporting_gcp_compute_summary_by_service_p (
     id,
     usage_start,
     usage_end,
@@ -37,7 +37,7 @@ INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_compute_summary_by_service_p
         max(source_uuid::text)::uuid as source_uuid,
         invoice_month,
         SUM(credit_amount) AS credit_amount
-    FROM {{schema_name | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
+    FROM {{schema | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
     WHERE usage_start >= {{start_date}}::date
         AND usage_start <= {{end_date}}::date
         AND source_uuid = {{source_uuid}}

--- a/koku/masu/database/sql/gcp/reporting_gcp_compute_summary_p.sql
+++ b/koku/masu/database/sql/gcp/reporting_gcp_compute_summary_p.sql
@@ -5,7 +5,7 @@ WHERE usage_start >= {{start_date}}::date
     AND invoice_month = {{invoice_month}}
 ;
 
-INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_compute_summary_p (
+INSERT INTO {{schema | sqlsafe}}.reporting_gcp_compute_summary_p (
     id,
     usage_start,
     usage_end,
@@ -31,7 +31,7 @@ INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_compute_summary_p (
         source_uuid,
         invoice_month,
         SUM(credit_amount) AS credit_amount
-    FROM {{schema_name | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
+    FROM {{schema | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
     WHERE usage_start >= {{start_date}}::date
         AND usage_start <= {{end_date}}::date
         AND source_uuid = {{source_uuid}}

--- a/koku/masu/database/sql/gcp/reporting_gcp_compute_summary_p.sql
+++ b/koku/masu/database/sql/gcp/reporting_gcp_compute_summary_p.sql
@@ -5,7 +5,7 @@ WHERE usage_start >= {{start_date}}::date
     AND invoice_month = {{invoice_month}}
 ;
 
-INSERT INTO reporting_gcp_compute_summary_p (
+INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_compute_summary_p (
     id,
     usage_start,
     usage_end,
@@ -31,7 +31,7 @@ INSERT INTO reporting_gcp_compute_summary_p (
         source_uuid,
         invoice_month,
         SUM(credit_amount) AS credit_amount
-    FROM reporting_gcpcostentrylineitem_daily_summary
+    FROM {{schema_name | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
     WHERE usage_start >= {{start_date}}::date
         AND usage_start <= {{end_date}}::date
         AND source_uuid = {{source_uuid}}

--- a/koku/masu/database/sql/gcp/reporting_gcp_cost_summary_by_account_p.sql
+++ b/koku/masu/database/sql/gcp/reporting_gcp_cost_summary_by_account_p.sql
@@ -5,7 +5,7 @@ WHERE usage_start >= {{start_date}}::date
     AND invoice_month = {{invoice_month}}
 ;
 
-INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_cost_summary_by_account_p (
+INSERT INTO {{schema | sqlsafe}}.reporting_gcp_cost_summary_by_account_p (
     id,
     usage_start,
     usage_end,
@@ -27,7 +27,7 @@ INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_cost_summary_by_account_p (
         max(source_uuid::text)::uuid as source_uuid,
         invoice_month,
         SUM(credit_amount) AS credit_amount
-    FROM {{schema_name | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
+    FROM {{schema | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
     WHERE usage_start >= {{start_date}}::date
         AND usage_start <= {{end_date}}::date
         AND source_uuid = {{source_uuid}}

--- a/koku/masu/database/sql/gcp/reporting_gcp_cost_summary_by_account_p.sql
+++ b/koku/masu/database/sql/gcp/reporting_gcp_cost_summary_by_account_p.sql
@@ -5,7 +5,7 @@ WHERE usage_start >= {{start_date}}::date
     AND invoice_month = {{invoice_month}}
 ;
 
-INSERT INTO reporting_gcp_cost_summary_by_account_p (
+INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_cost_summary_by_account_p (
     id,
     usage_start,
     usage_end,
@@ -27,7 +27,7 @@ INSERT INTO reporting_gcp_cost_summary_by_account_p (
         max(source_uuid::text)::uuid as source_uuid,
         invoice_month,
         SUM(credit_amount) AS credit_amount
-    FROM reporting_gcpcostentrylineitem_daily_summary
+    FROM {{schema_name | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
     WHERE usage_start >= {{start_date}}::date
         AND usage_start <= {{end_date}}::date
         AND source_uuid = {{source_uuid}}

--- a/koku/masu/database/sql/gcp/reporting_gcp_cost_summary_by_project_p.sql
+++ b/koku/masu/database/sql/gcp/reporting_gcp_cost_summary_by_project_p.sql
@@ -5,7 +5,7 @@ WHERE usage_start >= {{start_date}}::date
     AND invoice_month = {{invoice_month}}
 ;
 
-INSERT INTO reporting_gcp_cost_summary_by_project_p (
+INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_cost_summary_by_project_p (
     id,
     usage_start,
     usage_end,
@@ -31,7 +31,7 @@ INSERT INTO reporting_gcp_cost_summary_by_project_p (
         account_id,
         invoice_month,
         SUM(credit_amount) AS credit_amount
-    FROM reporting_gcpcostentrylineitem_daily_summary
+    FROM {{schema_name | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
     WHERE usage_start >= {{start_date}}::date
         AND usage_start <= {{end_date}}::date
         AND source_uuid = {{source_uuid}}

--- a/koku/masu/database/sql/gcp/reporting_gcp_cost_summary_by_project_p.sql
+++ b/koku/masu/database/sql/gcp/reporting_gcp_cost_summary_by_project_p.sql
@@ -5,7 +5,7 @@ WHERE usage_start >= {{start_date}}::date
     AND invoice_month = {{invoice_month}}
 ;
 
-INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_cost_summary_by_project_p (
+INSERT INTO {{schema | sqlsafe}}.reporting_gcp_cost_summary_by_project_p (
     id,
     usage_start,
     usage_end,
@@ -31,7 +31,7 @@ INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_cost_summary_by_project_p (
         account_id,
         invoice_month,
         SUM(credit_amount) AS credit_amount
-    FROM {{schema_name | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
+    FROM {{schema | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
     WHERE usage_start >= {{start_date}}::date
         AND usage_start <= {{end_date}}::date
         AND source_uuid = {{source_uuid}}

--- a/koku/masu/database/sql/gcp/reporting_gcp_cost_summary_by_region_p.sql
+++ b/koku/masu/database/sql/gcp/reporting_gcp_cost_summary_by_region_p.sql
@@ -5,7 +5,7 @@ WHERE usage_start >= {{start_date}}::date
     AND invoice_month = {{invoice_month}}
 ;
 
-INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_cost_summary_by_region_p (
+INSERT INTO {{schema | sqlsafe}}.reporting_gcp_cost_summary_by_region_p (
     id,
     usage_start,
     usage_end,
@@ -29,7 +29,7 @@ INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_cost_summary_by_region_p (
         max(source_uuid::text)::uuid as source_uuid,
         invoice_month,
         SUM(credit_amount) AS credit_amount
-    FROM {{schema_name | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
+    FROM {{schema | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
     WHERE usage_start >= {{start_date}}::date
         AND usage_start <= {{end_date}}::date
         AND source_uuid = {{source_uuid}}

--- a/koku/masu/database/sql/gcp/reporting_gcp_cost_summary_by_region_p.sql
+++ b/koku/masu/database/sql/gcp/reporting_gcp_cost_summary_by_region_p.sql
@@ -5,7 +5,7 @@ WHERE usage_start >= {{start_date}}::date
     AND invoice_month = {{invoice_month}}
 ;
 
-INSERT INTO reporting_gcp_cost_summary_by_region_p (
+INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_cost_summary_by_region_p (
     id,
     usage_start,
     usage_end,
@@ -29,7 +29,7 @@ INSERT INTO reporting_gcp_cost_summary_by_region_p (
         max(source_uuid::text)::uuid as source_uuid,
         invoice_month,
         SUM(credit_amount) AS credit_amount
-    FROM reporting_gcpcostentrylineitem_daily_summary
+    FROM {{schema_name | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
     WHERE usage_start >= {{start_date}}::date
         AND usage_start <= {{end_date}}::date
         AND source_uuid = {{source_uuid}}

--- a/koku/masu/database/sql/gcp/reporting_gcp_cost_summary_by_service_p.sql
+++ b/koku/masu/database/sql/gcp/reporting_gcp_cost_summary_by_service_p.sql
@@ -5,7 +5,7 @@ WHERE usage_start >= {{start_date}}::date
     AND invoice_month = {{invoice_month}}
 ;
 
-INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_cost_summary_by_service_p (
+INSERT INTO {{schema | sqlsafe}}.reporting_gcp_cost_summary_by_service_p (
     id,
     usage_start,
     usage_end,
@@ -31,7 +31,7 @@ INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_cost_summary_by_service_p (
         max(source_uuid::text)::uuid as source_uuid,
         invoice_month,
         SUM(credit_amount) AS credit_amount
-    FROM {{schema_name | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
+    FROM {{schema | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
     WHERE usage_start >= {{start_date}}::date
         AND usage_start <= {{end_date}}::date
         AND source_uuid = {{source_uuid}}

--- a/koku/masu/database/sql/gcp/reporting_gcp_cost_summary_by_service_p.sql
+++ b/koku/masu/database/sql/gcp/reporting_gcp_cost_summary_by_service_p.sql
@@ -5,7 +5,7 @@ WHERE usage_start >= {{start_date}}::date
     AND invoice_month = {{invoice_month}}
 ;
 
-INSERT INTO reporting_gcp_cost_summary_by_service_p (
+INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_cost_summary_by_service_p (
     id,
     usage_start,
     usage_end,
@@ -31,7 +31,7 @@ INSERT INTO reporting_gcp_cost_summary_by_service_p (
         max(source_uuid::text)::uuid as source_uuid,
         invoice_month,
         SUM(credit_amount) AS credit_amount
-    FROM reporting_gcpcostentrylineitem_daily_summary
+    FROM {{schema_name | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
     WHERE usage_start >= {{start_date}}::date
         AND usage_start <= {{end_date}}::date
         AND source_uuid = {{source_uuid}}

--- a/koku/masu/database/sql/gcp/reporting_gcp_cost_summary_p.sql
+++ b/koku/masu/database/sql/gcp/reporting_gcp_cost_summary_p.sql
@@ -5,7 +5,7 @@ WHERE usage_start >= {{start_date}}::date
     AND invoice_month = {{invoice_month}}
 ;
 
-INSERT INTO reporting_gcp_cost_summary_p (
+INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_cost_summary_p (
     id,
     usage_start,
     usage_end,
@@ -25,7 +25,7 @@ INSERT INTO reporting_gcp_cost_summary_p (
         source_uuid,
         invoice_month,
         SUM(credit_amount) AS credit_amount
-    FROM reporting_gcpcostentrylineitem_daily_summary
+    FROM {{schema_name | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
     WHERE usage_start >= {{start_date}}::date
         AND usage_start <= {{end_date}}::date
         AND source_uuid = {{source_uuid}}

--- a/koku/masu/database/sql/gcp/reporting_gcp_cost_summary_p.sql
+++ b/koku/masu/database/sql/gcp/reporting_gcp_cost_summary_p.sql
@@ -5,7 +5,7 @@ WHERE usage_start >= {{start_date}}::date
     AND invoice_month = {{invoice_month}}
 ;
 
-INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_cost_summary_p (
+INSERT INTO {{schema | sqlsafe}}.reporting_gcp_cost_summary_p (
     id,
     usage_start,
     usage_end,
@@ -25,7 +25,7 @@ INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_cost_summary_p (
         source_uuid,
         invoice_month,
         SUM(credit_amount) AS credit_amount
-    FROM {{schema_name | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
+    FROM {{schema | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
     WHERE usage_start >= {{start_date}}::date
         AND usage_start <= {{end_date}}::date
         AND source_uuid = {{source_uuid}}

--- a/koku/masu/database/sql/gcp/reporting_gcp_database_summary_p.sql
+++ b/koku/masu/database/sql/gcp/reporting_gcp_database_summary_p.sql
@@ -5,7 +5,7 @@ WHERE usage_start >= {{start_date}}::date
     AND invoice_month = {{invoice_month}}
 ;
 
-INSERT INTO reporting_gcp_database_summary_p (
+INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_database_summary_p (
     id,
     usage_start,
     usage_end,
@@ -35,7 +35,7 @@ INSERT INTO reporting_gcp_database_summary_p (
         service_alias,
         invoice_month,
         SUM(credit_amount) AS credit_amount
-    FROM reporting_gcpcostentrylineitem_daily_summary
+    FROM {{schema_name | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
     WHERE (service_alias LIKE '%%SQL%%'
         OR service_alias LIKE '%%Spanner%%'
         OR service_alias LIKE '%%Bigtable%%'

--- a/koku/masu/database/sql/gcp/reporting_gcp_database_summary_p.sql
+++ b/koku/masu/database/sql/gcp/reporting_gcp_database_summary_p.sql
@@ -5,7 +5,7 @@ WHERE usage_start >= {{start_date}}::date
     AND invoice_month = {{invoice_month}}
 ;
 
-INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_database_summary_p (
+INSERT INTO {{schema | sqlsafe}}.reporting_gcp_database_summary_p (
     id,
     usage_start,
     usage_end,
@@ -35,7 +35,7 @@ INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_database_summary_p (
         service_alias,
         invoice_month,
         SUM(credit_amount) AS credit_amount
-    FROM {{schema_name | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
+    FROM {{schema | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
     WHERE (service_alias LIKE '%%SQL%%'
         OR service_alias LIKE '%%Spanner%%'
         OR service_alias LIKE '%%Bigtable%%'

--- a/koku/masu/database/sql/gcp/reporting_gcp_network_summary_p.sql
+++ b/koku/masu/database/sql/gcp/reporting_gcp_network_summary_p.sql
@@ -5,7 +5,7 @@ WHERE usage_start >= {{start_date}}::date
     AND invoice_month = {{invoice_month}}
 ;
 
-INSERT INTO reporting_gcp_network_summary_p (
+INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_network_summary_p (
     id,
     usage_start,
     usage_end,
@@ -35,7 +35,7 @@ INSERT INTO reporting_gcp_network_summary_p (
         service_alias,
         invoice_month,
         SUM(credit_amount) AS credit_amount
-    FROM reporting_gcpcostentrylineitem_daily_summary
+    FROM {{schema_name | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
     WHERE (service_alias LIKE '%%Network%%'
         OR service_alias LIKE '%%VPC%%'
         OR service_alias LIKE '%%Firewall%%'

--- a/koku/masu/database/sql/gcp/reporting_gcp_network_summary_p.sql
+++ b/koku/masu/database/sql/gcp/reporting_gcp_network_summary_p.sql
@@ -5,7 +5,7 @@ WHERE usage_start >= {{start_date}}::date
     AND invoice_month = {{invoice_month}}
 ;
 
-INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_network_summary_p (
+INSERT INTO {{schema | sqlsafe}}.reporting_gcp_network_summary_p (
     id,
     usage_start,
     usage_end,
@@ -35,7 +35,7 @@ INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_network_summary_p (
         service_alias,
         invoice_month,
         SUM(credit_amount) AS credit_amount
-    FROM {{schema_name | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
+    FROM {{schema | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
     WHERE (service_alias LIKE '%%Network%%'
         OR service_alias LIKE '%%VPC%%'
         OR service_alias LIKE '%%Firewall%%'

--- a/koku/masu/database/sql/gcp/reporting_gcp_storage_summary_by_account_p.sql
+++ b/koku/masu/database/sql/gcp/reporting_gcp_storage_summary_by_account_p.sql
@@ -5,7 +5,7 @@ WHERE usage_start >= {{start_date}}::date
     AND invoice_month = {{invoice_month}}
 ;
 
-INSERT INTO reporting_gcp_storage_summary_by_account_p (
+INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_storage_summary_by_account_p (
     id,
     usage_start,
     usage_end,
@@ -31,7 +31,7 @@ INSERT INTO reporting_gcp_storage_summary_by_account_p (
         max(source_uuid::text)::uuid as source_uuid,
         invoice_month,
         SUM(credit_amount) AS credit_amount
-    FROM reporting_gcpcostentrylineitem_daily_summary
+    FROM {{schema_name | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
     WHERE usage_start >= {{start_date}}::date
         AND usage_start <= {{end_date}}::date
         AND source_uuid = {{source_uuid}}

--- a/koku/masu/database/sql/gcp/reporting_gcp_storage_summary_by_account_p.sql
+++ b/koku/masu/database/sql/gcp/reporting_gcp_storage_summary_by_account_p.sql
@@ -5,7 +5,7 @@ WHERE usage_start >= {{start_date}}::date
     AND invoice_month = {{invoice_month}}
 ;
 
-INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_storage_summary_by_account_p (
+INSERT INTO {{schema | sqlsafe}}.reporting_gcp_storage_summary_by_account_p (
     id,
     usage_start,
     usage_end,
@@ -31,7 +31,7 @@ INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_storage_summary_by_account_p
         max(source_uuid::text)::uuid as source_uuid,
         invoice_month,
         SUM(credit_amount) AS credit_amount
-    FROM {{schema_name | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
+    FROM {{schema | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
     WHERE usage_start >= {{start_date}}::date
         AND usage_start <= {{end_date}}::date
         AND source_uuid = {{source_uuid}}

--- a/koku/masu/database/sql/gcp/reporting_gcp_storage_summary_by_project_p.sql
+++ b/koku/masu/database/sql/gcp/reporting_gcp_storage_summary_by_project_p.sql
@@ -5,7 +5,7 @@ WHERE usage_start >= {{start_date}}::date
     AND invoice_month = {{invoice_month}}
 ;
 
-INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_storage_summary_by_project_p (
+INSERT INTO {{schema | sqlsafe}}.reporting_gcp_storage_summary_by_project_p (
     id,
     usage_start,
     usage_end,
@@ -35,7 +35,7 @@ INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_storage_summary_by_project_p
         max(source_uuid::text)::uuid as source_uuid,
         invoice_month,
         SUM(credit_amount) AS credit_amount
-    FROM {{schema_name | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
+    FROM {{schema | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
     WHERE usage_start >= {{start_date}}::date
         AND usage_start <= {{end_date}}::date
         AND source_uuid = {{source_uuid}}

--- a/koku/masu/database/sql/gcp/reporting_gcp_storage_summary_by_project_p.sql
+++ b/koku/masu/database/sql/gcp/reporting_gcp_storage_summary_by_project_p.sql
@@ -5,7 +5,7 @@ WHERE usage_start >= {{start_date}}::date
     AND invoice_month = {{invoice_month}}
 ;
 
-INSERT INTO reporting_gcp_storage_summary_by_project_p (
+INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_storage_summary_by_project_p (
     id,
     usage_start,
     usage_end,
@@ -35,7 +35,7 @@ INSERT INTO reporting_gcp_storage_summary_by_project_p (
         max(source_uuid::text)::uuid as source_uuid,
         invoice_month,
         SUM(credit_amount) AS credit_amount
-    FROM reporting_gcpcostentrylineitem_daily_summary
+    FROM {{schema_name | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
     WHERE usage_start >= {{start_date}}::date
         AND usage_start <= {{end_date}}::date
         AND source_uuid = {{source_uuid}}

--- a/koku/masu/database/sql/gcp/reporting_gcp_storage_summary_by_region_p.sql
+++ b/koku/masu/database/sql/gcp/reporting_gcp_storage_summary_by_region_p.sql
@@ -5,7 +5,7 @@ WHERE usage_start >= {{start_date}}::date
     AND invoice_month = {{invoice_month}}
 ;
 
-INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_storage_summary_by_region_p (
+INSERT INTO {{schema | sqlsafe}}.reporting_gcp_storage_summary_by_region_p (
     id,
     usage_start,
     usage_end,
@@ -33,7 +33,7 @@ INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_storage_summary_by_region_p 
         max(source_uuid::text)::uuid as source_uuid,
         invoice_month,
         SUM(credit_amount) AS credit_amount
-    FROM {{schema_name | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
+    FROM {{schema | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
     WHERE usage_start >= {{start_date}}::date
         AND usage_start <= {{end_date}}::date
         AND source_uuid = {{source_uuid}}

--- a/koku/masu/database/sql/gcp/reporting_gcp_storage_summary_by_region_p.sql
+++ b/koku/masu/database/sql/gcp/reporting_gcp_storage_summary_by_region_p.sql
@@ -5,7 +5,7 @@ WHERE usage_start >= {{start_date}}::date
     AND invoice_month = {{invoice_month}}
 ;
 
-INSERT INTO reporting_gcp_storage_summary_by_region_p (
+INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_storage_summary_by_region_p (
     id,
     usage_start,
     usage_end,
@@ -33,7 +33,7 @@ INSERT INTO reporting_gcp_storage_summary_by_region_p (
         max(source_uuid::text)::uuid as source_uuid,
         invoice_month,
         SUM(credit_amount) AS credit_amount
-    FROM reporting_gcpcostentrylineitem_daily_summary
+    FROM {{schema_name | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
     WHERE usage_start >= {{start_date}}::date
         AND usage_start <= {{end_date}}::date
         AND source_uuid = {{source_uuid}}

--- a/koku/masu/database/sql/gcp/reporting_gcp_storage_summary_by_service_p.sql
+++ b/koku/masu/database/sql/gcp/reporting_gcp_storage_summary_by_service_p.sql
@@ -5,7 +5,7 @@ WHERE usage_start >= {{start_date}}::date
     AND invoice_month = {{invoice_month}}
 ;
 
-INSERT INTO reporting_gcp_storage_summary_by_service_p (
+INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_storage_summary_by_service_p (
     id,
     usage_start,
     usage_end,
@@ -35,7 +35,7 @@ INSERT INTO reporting_gcp_storage_summary_by_service_p (
         max(source_uuid::text)::uuid as source_uuid,
         invoice_month,
         SUM(credit_amount) AS credit_amount
-    FROM reporting_gcpcostentrylineitem_daily_summary
+    FROM {{schema_name | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
     WHERE usage_start >= {{start_date}}::date
         AND usage_start <= {{end_date}}::date
         AND source_uuid = {{source_uuid}}

--- a/koku/masu/database/sql/gcp/reporting_gcp_storage_summary_by_service_p.sql
+++ b/koku/masu/database/sql/gcp/reporting_gcp_storage_summary_by_service_p.sql
@@ -5,7 +5,7 @@ WHERE usage_start >= {{start_date}}::date
     AND invoice_month = {{invoice_month}}
 ;
 
-INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_storage_summary_by_service_p (
+INSERT INTO {{schema | sqlsafe}}.reporting_gcp_storage_summary_by_service_p (
     id,
     usage_start,
     usage_end,
@@ -35,7 +35,7 @@ INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_storage_summary_by_service_p
         max(source_uuid::text)::uuid as source_uuid,
         invoice_month,
         SUM(credit_amount) AS credit_amount
-    FROM {{schema_name | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
+    FROM {{schema | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
     WHERE usage_start >= {{start_date}}::date
         AND usage_start <= {{end_date}}::date
         AND source_uuid = {{source_uuid}}

--- a/koku/masu/database/sql/gcp/reporting_gcp_storage_summary_p.sql
+++ b/koku/masu/database/sql/gcp/reporting_gcp_storage_summary_p.sql
@@ -5,7 +5,7 @@ WHERE usage_start >= {{start_date}}::date
     AND invoice_month = {{invoice_month}}
 ;
 
-INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_storage_summary_p (
+INSERT INTO {{schema | sqlsafe}}.reporting_gcp_storage_summary_p (
     id,
     usage_start,
     usage_end,
@@ -29,7 +29,7 @@ INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_storage_summary_p (
         source_uuid,
         invoice_month,
         SUM(credit_amount) AS credit_amount
-    FROM {{schema_name | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
+    FROM {{schema | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
     WHERE usage_start >= {{start_date}}::date
         AND usage_start <= {{end_date}}::date
         AND source_uuid = {{source_uuid}}

--- a/koku/masu/database/sql/gcp/reporting_gcp_storage_summary_p.sql
+++ b/koku/masu/database/sql/gcp/reporting_gcp_storage_summary_p.sql
@@ -5,7 +5,7 @@ WHERE usage_start >= {{start_date}}::date
     AND invoice_month = {{invoice_month}}
 ;
 
-INSERT INTO reporting_gcp_storage_summary_p (
+INSERT INTO {{schema_name | sqlsafe}}.reporting_gcp_storage_summary_p (
     id,
     usage_start,
     usage_end,
@@ -29,7 +29,7 @@ INSERT INTO reporting_gcp_storage_summary_p (
         source_uuid,
         invoice_month,
         SUM(credit_amount) AS credit_amount
-    FROM reporting_gcpcostentrylineitem_daily_summary
+    FROM {{schema_name | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary
     WHERE usage_start >= {{start_date}}::date
         AND usage_start <= {{end_date}}::date
         AND source_uuid = {{source_uuid}}


### PR DESCRIPTION
This PR adds `{{schema | sqlsafe}}` to the INSERT and SELECT statements for the Azure and GCP partable sql. We currently do this for AWS and OCP, so we should do the same thing for these providers.