### PR TITLE
COST-2154: Individually drop partitions on managed tables to prevent errors.

### DIFF
--- a/koku/masu/database/aws_report_db_accessor.py
+++ b/koku/masu/database/aws_report_db_accessor.py
@@ -368,18 +368,18 @@ class AWSReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
     def delete_ocp_on_aws_hive_partition_by_day(self, days, aws_source, ocp_source, year, month):
         """Deletes partitions individually for each day in days list."""
         table = self._table_map["ocp_on_aws_project_daily_summary"]
-        LOG.info(
-            "Deleting partitions for the following: \n\tSchema: %s "
-            "\n\tOCP Source: %s \n\tAWS Source: %s \n\tTable: %s \n\tYear-Month: %s-%s \n\tDays: %s",
-            self.schema,
-            ocp_source,
-            aws_source,
-            table,
-            year,
-            month,
-            days,
-        )
         if self.table_exists_trino(table):
+            LOG.info(
+                "Deleting partitions for the following: \n\tSchema: %s "
+                "\n\tOCP Source: %s \n\tAWS Source: %s \n\tTable: %s \n\tYear-Month: %s-%s \n\tDays: %s",
+                self.schema,
+                ocp_source,
+                aws_source,
+                table,
+                year,
+                month,
+                days,
+            )
             final_sql_list = []
             for day in days:
                 sql = f"""

--- a/koku/masu/database/aws_report_db_accessor.py
+++ b/koku/masu/database/aws_report_db_accessor.py
@@ -365,6 +365,34 @@ class AWSReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
             summary_sql, summary_sql_params = self.jinja_sql.prepare_query(summary_sql, sql_params)
             self._execute_raw_sql_query(table_name, summary_sql, bind_params=list(summary_sql_params))
 
+    def delete_ocp_on_aws_hive_partition_by_day(self, days, aws_source, ocp_source, year, month):
+        """Deletes partitions individually for each day in days list."""
+        table = self._table_map["ocp_on_aws_project_daily_summary"]
+        LOG.info(
+            "Deleting partitions for the following: \n\tSchema: %s "
+            "\n\tOCP Source: %s \n\tAWS Source: %s \n\tTable: %s \n\tYear-Month: %s-%s \n\tDays: %s",
+            self.schema,
+            ocp_source,
+            aws_source,
+            table,
+            year,
+            month,
+            days,
+        )
+        if self.table_exists_trino(table):
+            final_sql_list = []
+            for day in days:
+                sql = f"""
+                DELETE FROM hive.{self.schema}.{table}
+                    WHERE aws_source = '{aws_source}'
+                    AND ocp_source = '{ocp_source}'
+                    AND year = '{year}'
+                    AND month = '{month}'
+                    AND day = '{day}';"""
+                final_sql_list.append(sql)
+            final_sql = "".join(final_sql_list)
+            self._execute_presto_multipart_sql_query(self.schema, final_sql)
+
     def populate_ocp_on_aws_cost_daily_summary_presto(
         self,
         start_date,
@@ -387,8 +415,14 @@ class AWSReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
 
         """
         # Default to cpu distribution
+        year = start_date.strftime("%Y")
+        month = start_date.strftime("%m")
         days = DateHelper().list_days(start_date, end_date)
         days_str = "','".join([str(day.day) for day in days])
+        days_list = [str(day.day) for day in days]
+        self.delete_ocp_on_aws_hive_partition_by_day(
+            days_list, aws_provider_uuid, openshift_provider_uuid, year, month
+        )
 
         pod_column = "pod_usage_cpu_core_hours"
         cluster_column = "cluster_capacity_cpu_core_hours"
@@ -401,8 +435,8 @@ class AWSReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
         summary_sql_params = {
             "schema": self.schema,
             "start_date": start_date,
-            "year": start_date.strftime("%Y"),
-            "month": start_date.strftime("%m"),
+            "year": year,
+            "month": month,
             "days": days_str,
             "end_date": end_date,
             "aws_source_uuid": aws_provider_uuid,

--- a/koku/masu/database/ocp_report_db_accessor.py
+++ b/koku/masu/database/ocp_report_db_accessor.py
@@ -636,17 +636,17 @@ class OCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
     def delete_ocp_hive_partition_by_day(self, days, source, year, month):
         """Deletes partitions individually for each day in days list."""
         table = self._table_map["line_item_daily_summary"]
-        LOG.info(
-            "Deleting partitions for the following: \n\tSchema: %s "
-            "\n\tOCP Source: %s \n\tTable: %s \n\tYear-Month: %s-%s \n\tDays: %s",
-            self.schema,
-            source,
-            table,
-            year,
-            month,
-            days,
-        )
         if self.table_exists_trino(table):
+            LOG.info(
+                "Deleting partitions for the following: \n\tSchema: %s "
+                "\n\tOCP Source: %s \n\tTable: %s \n\tYear-Month: %s-%s \n\tDays: %s",
+                self.schema,
+                source,
+                table,
+                year,
+                month,
+                days,
+            )
             final_sql_list = []
             for day in days:
                 sql = f"""

--- a/koku/masu/database/presto_sql/reporting_ocpawscostlineitem_daily_summary.sql
+++ b/koku/masu/database/presto_sql/reporting_ocpawscostlineitem_daily_summary.sql
@@ -86,16 +86,6 @@ CREATE TABLE IF NOT EXISTS hive.{{schema | sqlsafe}}.reporting_ocpawscostlineite
 DELETE FROM hive.{{schema | sqlsafe}}.reporting_ocpawscostlineitem_project_daily_summary_temp
 ;
 
-DELETE
-FROM hive.{{schema | sqlsafe}}.reporting_ocpawscostlineitem_project_daily_summary
-WHERE aws_source = '{{aws_source_uuid | sqlsafe}}'
-    AND ocp_source = '{{ocp_source_uuid | sqlsafe}}'
-    AND year = {{year}}
-    AND month = {{month}}
-    AND day IN ({{days}})
-
-;
-
 -- Direct resource_id matching
 INSERT INTO hive.{{schema | sqlsafe}}.reporting_ocpawscostlineitem_project_daily_summary_temp (
     aws_uuid,

--- a/koku/masu/database/presto_sql/reporting_ocpusagelineitem_daily_summary.sql
+++ b/koku/masu/database/presto_sql/reporting_ocpusagelineitem_daily_summary.sql
@@ -44,15 +44,6 @@ CREATE TABLE IF NOT EXISTS hive.{{schema | sqlsafe}}.reporting_ocpusagelineitem_
 ) WITH(format = 'PARQUET', partitioned_by=ARRAY['source', 'year', 'month', 'day'])
 ;
 
-
-DELETE
-FROM hive.{{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary
-WHERE source = {{source}}
-    AND year = {{year}}
-    AND month = {{month}}
-    AND day IN ({{days}})
-;
-
 INSERT INTO hive.{{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary (
     uuid,
     report_period_id,

--- a/koku/masu/test/database/test_aws_report_db_accessor.py
+++ b/koku/masu/test/database/test_aws_report_db_accessor.py
@@ -992,8 +992,9 @@ class AWSReportDBAccessorTest(MasuTestCase):
         )
         mock_presto.assert_called()
 
+    @patch("masu.database.aws_report_db_accessor.AWSReportDBAccessor.delete_ocp_on_aws_hive_partition_by_day")
     @patch("masu.database.aws_report_db_accessor.AWSReportDBAccessor._execute_presto_multipart_sql_query")
-    def test_populate_ocp_on_aws_cost_daily_summary_presto(self, mock_presto):
+    def test_populate_ocp_on_aws_cost_daily_summary_presto(self, mock_presto, mock_delete):
         """Test that we construst our SQL and query using Presto."""
         dh = DateHelper()
         start_date = dh.this_month_start.date()
@@ -1020,8 +1021,9 @@ class AWSReportDBAccessorTest(MasuTestCase):
         )
         mock_presto.assert_called()
 
+    @patch("masu.database.aws_report_db_accessor.AWSReportDBAccessor.delete_ocp_on_aws_hive_partition_by_day")
     @patch("masu.database.aws_report_db_accessor.AWSReportDBAccessor._execute_presto_multipart_sql_query")
-    def test_populate_ocp_on_aws_cost_daily_summary_presto_memory_distribution(self, mock_presto):
+    def test_populate_ocp_on_aws_cost_daily_summary_presto_memory_distribution(self, mock_presto, mock_delete):
         """Test that we construst our SQL and query using Presto."""
         dh = DateHelper()
         start_date = dh.this_month_start.date()

--- a/koku/masu/test/database/test_aws_report_db_accessor.py
+++ b/koku/masu/test/database/test_aws_report_db_accessor.py
@@ -1021,6 +1021,16 @@ class AWSReportDBAccessorTest(MasuTestCase):
         )
         mock_presto.assert_called()
 
+    @patch("masu.database.aws_report_db_accessor.AWSReportDBAccessor.table_exists_trino")
+    @patch("masu.database.aws_report_db_accessor.AWSReportDBAccessor._execute_presto_multipart_sql_query")
+    def test_delete_partition_by_day(self, mock_presto, mock_table_exists):
+        """Test delete partition by day."""
+        # Mostly to make testcov happy
+        mock_table_exists.side_effect = [True, None]
+        self.accessor.delete_ocp_on_aws_hive_partition_by_day(["01", "02"], "1234uid", "5678uid", "2021", "12")
+        self.accessor.delete_ocp_on_aws_hive_partition_by_day(["01", "02"], "1234uid", "5678uid", "2021", "12")
+        mock_presto.assert_called_once()
+
     @patch("masu.database.aws_report_db_accessor.AWSReportDBAccessor.delete_ocp_on_aws_hive_partition_by_day")
     @patch("masu.database.aws_report_db_accessor.AWSReportDBAccessor._execute_presto_multipart_sql_query")
     def test_populate_ocp_on_aws_cost_daily_summary_presto_memory_distribution(self, mock_presto, mock_delete):


### PR DESCRIPTION
## Testing
### How to replicate the issue:
Step One: Populate the database
```
make create-test-customer
make load-test-customer-data
```
Once you have populated the database you can switch over to the main branch and hit the report data endpoints for the AWS source & the OCP source. 
Report Data URL Example:
- http://127.0.0.1:5042/api/cost-management/v1/report_data/?provider_uuid=bf176dc8-b4d0-46c7-8fce-61f739cb599d&start_date=2021-12-01&end_date=2021-12-10&schema=acct10001

You will notice the following error: 
```
koku-worker_1     | trino.exceptions.TrinoExternalError: TrinoExternalError(type=EXTERNAL, name=HIVE_METASTORE_ERROR, message="The transaction didn't commit cleanly. 
All operations other than the following delete operations were completed: 
drop partition acct10001.reporting_ocpusagelineitem_daily_summary [bf176dc8-b4d0-46c7-8fce-61f739cb599d, 2021, 12, 7];
```
### How to verify:
If you switch back to this branch and hit the same report data urls, you should no longer see the errors in the logs. 

Pay particular attention to the following new log format:
```
koku-worker_1     | [2021-12-13 19:35:29,920] INFO 7c590795-5d53-48be-8e96-f8627b5dd5cb Deleting partitions for the following:
koku-worker_1     | 	Schema: acct10001
koku-worker_1     | 	OCP Source: bf176dc8-b4d0-46c7-8fce-61f739cb599d
koku-worker_1     | 	Table: reporting_ocpusagelineitem_daily_summary
koku-worker_1     | 	Year-Month: 2021-12
koku-worker_1     | 	Days: ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10']
```
Additionally, while using the report data endpoint if you choose a start and end date that does not go up to today, you can check the modified timestamp for the files in your time range to see if they were updated under the `acct10001.db` inside of minio.

For instance in my example url I went up until the 10th of December. 
Timestamp for the 10th day: `Mon Dec 13 2021 14:17:02 GMT-0500`
Timestamp for the 11th day: `Mon Dec 13 2021 13:08:46 GMT-0500`

Proving that partition files were only updated for the range of the files provided through the report_data endpoint.
