### PR TITLE
add HCS queue to prometheus

### DIFF
--- a/koku/masu/prometheus_stats.py
+++ b/koku/masu/prometheus_stats.py
@@ -90,6 +90,10 @@ OCP_BACKLOG = Gauge(
     "ocp_backlog", "Number of celery tasks in the OCP queue", registry=WORKER_REGISTRY, multiprocess_mode="livesum"
 )
 
+HCS_BACKLOG = Gauge(
+    "hcs_backlog", "Number of celery tasks in the HCS queue", registry=WORKER_REGISTRY, multiprocess_mode="livesum"
+)
+
 QUEUES = {
     "download": DOWNLOAD_BACKLOG,
     "summary": SUMMARY_BACKLOG,
@@ -98,6 +102,7 @@ QUEUES = {
     "cost_model": COST_MODEL_BACKLOG,
     "celery": DEFAULT_BACKLOG,
     "ocp": OCP_BACKLOG,
+    "hcs": HCS_BACKLOG,
 }
 
 SOURCES_KAFKA_LOOP_RETRY = Counter(


### PR DESCRIPTION
Closes: https://issues.redhat.com/browse/COST-2132

In the original PR I missed a commit that made sure the queue was added to prometheus.

```
I tried it in stage env and the response for the "api/cost-management/v1/celery_queue_lengths/" endpoint request doesn't contain the "hcs" item

{
    "download": 0,
    "summary": 0,
    "priority": 0,
    "refresh": 0,
    "cost_model": 0,
    "celery": 0,
    "ocp": 0
} 
```
This is fixed in this PR

```
{
    "download": 0,
    "summary": 0,
    "priority": 0,
    "refresh": 0,
    "cost_model": 0,
    "celery": 0,
    "ocp": 0,
    "hcs": 0
}
```