### PR TITLE
Exclude blank resource ids in ocp aws matching

### DIFF
--- a/koku/masu/database/presto_sql/reporting_ocpawscostlineitem_daily_summary.sql
+++ b/koku/masu/database/presto_sql/reporting_ocpawscostlineitem_daily_summary.sql
@@ -184,10 +184,12 @@ SELECT aws.uuid as aws_uuid,
         AND aws.month = {{month}}
         AND aws.lineitem_usagestartdate >= TIMESTAMP '{{start_date | sqlsafe}}'
         AND aws.lineitem_usagestartdate < date_add('day', 1, TIMESTAMP '{{end_date | sqlsafe}}')
+        AND (aws.lineitem_resourceid IS NOT NULL AND aws.lineitem_resourceid != '')
         AND ocp.source = '{{ocp_source_uuid | sqlsafe}}'
         AND ocp.year = {{year}}
         AND ocp.month = {{month}}
         AND ocp.day IN ({{days}})
+        AND (ocp.resource_id IS NOT NULL AND ocp.resource_id != '')
     GROUP BY aws.uuid, ocp.namespace
 ;
 


### PR DESCRIPTION
## Summary
This will exclude null or blank resource ids from matching in our OCP on AWS Trino SQL. 

## Testing

Ran count query against prod schema to get counts

Ran without null/blank check
```
SELECT count(*) 
FROM hive.{schema}.aws_openshift_daily as aws
JOIN hive.{schema}.reporting_ocpusagelineitem_daily_summary as ocp
    ON aws.lineitem_usagestartdate = ocp.usage_start
        AND aws.lineitem_resourceid = ocp.resource_id
WHERE aws.year = '2021'
    AND aws.month = '12'
    AND aws.lineitem_usagestartdate = TIMESTAMP '2021-12-05' 
    AND ocp.year = '2021'
    AND ocp.month = '12'
    AND ocp.day = '5'
;
...
   _col0   
-----------
 150,277,762 
(1 row)
```

Ran with null/blank check
```
SELECT count(*) 
FROM hive.{schema}.aws_openshift_daily as aws
JOIN hive.{schema}.reporting_ocpusagelineitem_daily_summary as ocp
    ON aws.lineitem_usagestartdate = ocp.usage_start
        AND aws.lineitem_resourceid = ocp.resource_id
        AND (aws.lineitem_resourceid IS NOT NULL and aws.lineitem_resourceid != '')
        AND (ocp.resource_id IS NOT NULL and ocp.resource_id != '')
WHERE aws.year = '2021'
    AND aws.month = '12'
    AND aws.lineitem_usagestartdate = TIMESTAMP '2021-12-05' 
    AND ocp.year = '2021'
    AND ocp.month = '12'
    AND ocp.day = '5'
;

...
 _col0 
-------
 27,534 
(1 row)
```