### PR TITLE
update sql token parser

### DIFF
--- a/koku/koku/database_exc.py
+++ b/koku/koku/database_exc.py
@@ -10,13 +10,19 @@ import os
 import re
 import traceback
 
-import psycopg2
 from django.db.utils import DatabaseError as DJDatabaseError
 from psycopg2.errors import DatabaseError
 from psycopg2.errors import DeadlockDetected
-from psycopg2.extras import RealDictCursor
 from sqlparse import parse as sql_parse
+from sqlparse.sql import Comparison
 from sqlparse.sql import Identifier
+from sqlparse.sql import IdentifierList
+from sqlparse.tokens import CTE
+from sqlparse.tokens import DML
+
+
+# import psycopg2
+# from psycopg2.extras import RealDictCursor
 
 
 LOG = logging.getLogger(__name__)
@@ -110,21 +116,53 @@ class ExtendedDBException(Exception):
         else:
             self.koku_exc_line = self.koku_exc_line_num = self.koku_exc_file = None
 
+    def get_tables_from_tokens(self, tokens, num_tokens, dml_type=None, seen_object=None, identifiers=None):  # noqa
+        if seen_object is None:
+            seen_object = set()
+        if identifiers is None:
+            identifiers = []
+
+        ix = 0
+        while ix < num_tokens:
+            tok = tokens[ix]
+            if tok.ttype in (CTE, DML):
+                dml_type = tok.ttype
+            elif isinstance(tok, Identifier):
+                tok_name = tok.get_real_name()
+                id_block = not bool(identifiers) or identifiers[-1].get_alias() != tok_name
+                if tok_name not in seen_object and id_block:
+                    identifiers.append(tok)
+                    seen_object.add(tok_name)
+                    if dml_type != CTE:
+                        self.query_tables.append(tok_name)
+
+            if dml_type == CTE and isinstance(tok, IdentifierList):
+                allow_idlist = True
+            else:
+                allow_idlist = not isinstance(tok, IdentifierList)
+            if tok.is_group and allow_idlist and not isinstance(tok, Comparison):
+                sub_tokens = tok.tokens
+                num_sub_tokens = len(sub_tokens)
+                if num_sub_tokens > 0:
+                    self.get_tables_from_tokens(
+                        sub_tokens, num_sub_tokens, dml_type=dml_type, seen_object=seen_object, identifiers=identifiers
+                    )
+
+            ix += 1
+
     def parse_exception(self):
         _frames = traceback.extract_tb(self.__traceback__)
         self.set_exception_frame_info(_frames)
         self.set_koku_exception_frame_info(_frames)
 
         self.formatted_tb = traceback.format_tb(self.__traceback__)
-        self.query_type = self.query_tables = None
+        self.query_type = None
+        self.query_tables = []
         if self.query:
-            parsed = sql_parse(self.query)
-            if parsed:
-                # Currently only looking at first statement
-                self.query_type = parsed[0].get_type()
-                self.query_tables = [
-                    token.get_name() for token in parsed[0].get_sublists() if isinstance(token, Identifier)
-                ]
+            parsed_tokens = sql_parse(self.query)
+            if parsed_tokens:
+                self.query_type = parsed_tokens[0].get_type()
+                self.get_tables_from_tokens(parsed_tokens, len(parsed_tokens))
 
     def get_extended_info(self):
         args_query = self.query[: self.query_limit] if self.query_limit else self.query
@@ -135,23 +173,23 @@ class ExtendedDBException(Exception):
             f"QUERY: {args_query}",
         ) + self.args
 
-    def connect(self, application_name="ExtendedInfoGetter"):
-        from koku.configurator import CONFIGURATOR
+    # def connect(self, application_name="ExtendedInfoGetter"):
+    #     from koku.configurator import CONFIGURATOR
 
-        if CONFIGURATOR.get_database_ca():
-            ssl_opts = {"sslmode": "verify-full", "sslrootcert": CONFIGURATOR.get_database_ca_file()}
-        else:
-            ssl_opts = {"sslmode": "prefer"}
+    #     if CONFIGURATOR.get_database_ca():
+    #         ssl_opts = {"sslmode": "verify-full", "sslrootcert": CONFIGURATOR.get_database_ca_file()}
+    #     else:
+    #         ssl_opts = {"sslmode": "prefer"}
 
-        return psycopg2.connect(
-            host=CONFIGURATOR.get_database_host(),
-            port=CONFIGURATOR.get_database_port(),
-            user=CONFIGURATOR.get_database_user(),
-            password=CONFIGURATOR.get_database_password(),
-            dbname=CONFIGURATOR.get_database_name(),
-            cursor_factory=RealDictCursor,
-            **ssl_opts,
-        )
+    #     return psycopg2.connect(
+    #         host=CONFIGURATOR.get_database_host(),
+    #         port=CONFIGURATOR.get_database_port(),
+    #         user=CONFIGURATOR.get_database_user(),
+    #         password=CONFIGURATOR.get_database_password(),
+    #         dbname=CONFIGURATOR.get_database_name(),
+    #         cursor_factory=RealDictCursor,
+    #         **ssl_opts,
+    #     )
 
 
 class ExtendedDeadlockDetected(ExtendedDBException):

--- a/koku/koku/test_database_exc.py
+++ b/koku/koku/test_database_exc.py
@@ -10,6 +10,7 @@ from django.db import connection
 from django.db import IntegrityError
 from psycopg2.errors import DeadlockDetected
 from psycopg2.errors import DivisionByZero
+from sqlparse import parse as sql_parse
 
 from . import database_exc as dbex
 from api.iam.test.iam_test_case import IamTestCase
@@ -79,6 +80,24 @@ class TestDatabaseExc(IamTestCase):
         dxc.__cause__ = DivisionByZero("Don't do it!")
         eexc = dbex.get_extended_exception_by_type(dxc)
         self.assertEqual(type(eexc), dbex.ExtendedDBException)
+
+    def test_tables_from_complex_query(self):
+        sql_buff = """
+insert into eek (id, name, data)
+select a.id, b.name, c.data
+  from table_a a
+  join table_b b
+    on b.a_id = a.id
+  left
+  join table_c c
+    on c.b_id = b.id;
+"""
+        expected_tables = ["eek", "table_a", "table_b", "table_c"]
+        tokens = sql_parse(sql_buff)
+        my_exc = dbex.ExtendedDBException(DivisionByZero("It's really bad!"))
+        my_exc.query_tables = []
+        my_exc.get_tables_from_tokens(tokens, len(tokens))
+        self.assertEqual(my_exc.query_tables, expected_tables)
 
     def test_excpetion_subclass(self):
         """Test that extended exception can resolve correctly by base exception class."""


### PR DESCRIPTION
This updates the tokens parsed from `sqlparse.parse()` to better get tables involved from more complex queries that are frequently used in the application.

## Testing

From `${KOKU_PATH}`:

1. `cd koku`
2. `python ./manage.py shell`
3. `from koku.database_exc import *`
4. `from psycopg2.errors import DivisionByZero`
5. `exc = ExtendedDBException(DivisionByZero("Oh Noes!"))`
6. `exc.query_tables = []`
7. `tokens = sql_parse("select * from table_a a join table_b b on b.a_id = a.id;")`
8. `exc.get_tables_from_tokens(tokens, len(tokens))`
9. `exc.query_tables == ["table_a", "table_b"]`
10. ctrl+d

The `tokens` variable will be a list of token objects as returned by sql_parse. So you can try it with a zero-length list if you'd like.