### PR TITLE
Update check_migration return value processing

### DIFF
--- a/koku/koku/celery.py
+++ b/koku/koku/celery.py
@@ -237,7 +237,9 @@ def wait_for_migrations(sender, instance, **kwargs):  # pragma: no cover
 
     httpd = start_probe_server(WorkerProbeServer)
 
-    while not check_migrations():
+    # This is a special case because check_migrations() returns three values
+    # True means migrations are up-to-date
+    while check_migrations() != True:  # noqa
         LOG.warning("Migrations not done. Sleeping")
         time.sleep(5)
 

--- a/koku/masu/management/commands/listener.py
+++ b/koku/masu/management/commands/listener.py
@@ -46,7 +46,9 @@ class Command(BaseCommand):
         """Initialize the prometheus exporter and koku-listener."""
         httpd = start_probe_server(ListenerProbeServer)
 
-        while not check_migrations():
+        # This is a special case because check_migrations() returns three values
+        # True means migrations are up-to-date
+        while check_migrations() != True:  # noqa
             LOG.warning("Migrations not done. Sleeping")
             time.sleep(5)
 

--- a/koku/sources/management/commands/sources.py
+++ b/koku/sources/management/commands/sources.py
@@ -52,7 +52,9 @@ class Command(BaseCommand):
         # Koku API server is responsible for running all database migrations. The sources client
         # server and kafka listener thread should only be started if migration execution is
         # complete.
-        while not check_migrations():
+        # This is a special case because check_migrations() returns three values
+        # True means migrations are up-to-date
+        while check_migrations() != True:  # noqa
             LOG.warning(f"Migrations not done. Sleeping {timeout} seconds.")
             time.sleep(timeout)
 

--- a/koku/sources/management/commands/sources_listener.py
+++ b/koku/sources/management/commands/sources_listener.py
@@ -53,7 +53,9 @@ class Command(BaseCommand):
         httpd = start_probe_server(SourcesProbeServer)
 
         timeout = 5
-        while not check_migrations():
+        # This is a special case because check_migrations() returns three values
+        # True means migrations are up-to-date
+        while check_migrations() != True:  # noqa
             LOG.warning(f"Migrations not done. Sleeping {timeout} seconds.")
             time.sleep(timeout)
 


### PR DESCRIPTION
## Jira Ticket

[COST-2182](https://issues.redhat.com/browse/COST-2182)

## Description

The old way of checking to see if migrations were up-to-date or not was a loop like this:

```python
while not check_migrations():
    sleep(5)
```

This does not work properly now that `check_migrations()` is no longer a function that only returns a bool. Since the `True` value is the only value indicating that migrations are up-to-date, the loops have been changed to:

```python
while check_migrations() != True:
    sleep(5)
```