### PR TITLE
[COST-2191] Fix hive table duplication

### DIFF
--- a/koku/masu/database/aws_report_db_accessor.py
+++ b/koku/masu/database/aws_report_db_accessor.py
@@ -387,7 +387,7 @@ class AWSReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
                     WHERE aws_source = '{aws_source}'
                     AND ocp_source = '{ocp_source}'
                     AND year = '{year}'
-                    AND month = '{month}'
+                    AND lpad(month, 2, '0') = '{month}'
                     AND day = '{day}';"""
                 final_sql_list.append(sql)
             final_sql = "".join(final_sql_list)

--- a/koku/masu/database/ocp_report_db_accessor.py
+++ b/koku/masu/database/ocp_report_db_accessor.py
@@ -653,7 +653,7 @@ class OCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
                 DELETE FROM hive.{self.schema}.{table}
                 WHERE source = '{source}'
                 AND year = '{year}'
-                AND month = '{month}'
+                AND lpad(month, 2, '0') = '{month}'
                 AND day = '{day}';
                 """
                 final_sql_list.append(sql)

--- a/koku/masu/database/presto_sql/reporting_ocpawscostlineitem_daily_summary.sql
+++ b/koku/masu/database/presto_sql/reporting_ocpawscostlineitem_daily_summary.sql
@@ -86,8 +86,6 @@ CREATE TABLE IF NOT EXISTS hive.{{schema | sqlsafe}}.reporting_ocpawscostlineite
 DELETE FROM hive.{{schema | sqlsafe}}.reporting_ocpawscostlineitem_project_daily_summary_temp
 ;
 
-DELETE FROM hive.{{schema | sqlsafe}}.reporting_ocpawscostlineitem_project_daily_summary
-;
 
 -- Direct resource_id matching
 INSERT INTO hive.{{schema | sqlsafe}}.reporting_ocpawscostlineitem_project_daily_summary_temp (
@@ -498,7 +496,4 @@ WHERE aws_source = '{{aws_source_uuid | sqlsafe}}'
 ;
 
 DELETE FROM hive.{{schema | sqlsafe}}.reporting_ocpawscostlineitem_project_daily_summary_temp
-;
-
-DELETE FROM hive.{{schema | sqlsafe}}.reporting_ocpawscostlineitem_project_daily_summary
 ;

--- a/koku/masu/database/presto_sql/reporting_ocpawscostlineitem_daily_summary.sql
+++ b/koku/masu/database/presto_sql/reporting_ocpawscostlineitem_daily_summary.sql
@@ -86,7 +86,6 @@ CREATE TABLE IF NOT EXISTS hive.{{schema | sqlsafe}}.reporting_ocpawscostlineite
 DELETE FROM hive.{{schema | sqlsafe}}.reporting_ocpawscostlineitem_project_daily_summary_temp
 ;
 
-
 -- Direct resource_id matching
 INSERT INTO hive.{{schema | sqlsafe}}.reporting_ocpawscostlineitem_project_daily_summary_temp (
     aws_uuid,

--- a/koku/masu/database/presto_sql/reporting_ocpawscostlineitem_daily_summary.sql
+++ b/koku/masu/database/presto_sql/reporting_ocpawscostlineitem_daily_summary.sql
@@ -86,6 +86,9 @@ CREATE TABLE IF NOT EXISTS hive.{{schema | sqlsafe}}.reporting_ocpawscostlineite
 DELETE FROM hive.{{schema | sqlsafe}}.reporting_ocpawscostlineitem_project_daily_summary_temp
 ;
 
+DELETE FROM hive.{{schema | sqlsafe}}.reporting_ocpawscostlineitem_project_daily_summary
+;
+
 -- Direct resource_id matching
 INSERT INTO hive.{{schema | sqlsafe}}.reporting_ocpawscostlineitem_project_daily_summary_temp (
     aws_uuid,
@@ -495,4 +498,7 @@ WHERE aws_source = '{{aws_source_uuid | sqlsafe}}'
 ;
 
 DELETE FROM hive.{{schema | sqlsafe}}.reporting_ocpawscostlineitem_project_daily_summary_temp
+;
+
+DELETE FROM hive.{{schema | sqlsafe}}.reporting_ocpawscostlineitem_project_daily_summary
 ;


### PR DESCRIPTION
We missed another lpad, great find Andrew!

On main, load in some ocp on aws data, I did this with `make create-test-customer`  and make `load-test-customer-data` for simplicity. Check your OCP cost and your OCP on AWS cost and note the values:

OCP on AWS: http://localhost:8000/api/cost-management/v1/reports/openshift/infrastructures/aws/costs/

```
"total": {
            "infrastructure": {
                "raw": {
                    "value": 322.2119261194527,
                    "units": "USD"
                },
                "markup": {
                    "value": 32.221192611945284,
                    "units": "USD"
                },
                "usage": {
                    "value": 0.0,
                    "units": "USD"
                },
                "total": {
                    "value": 354.433118731398,
                    "units": "USD"
                }
            },
```

Resummarize with the masu report data endpoint: http://localhost:5042/api/cost-management/v1/report_data/?provider_type=AWS-local&provider_uuid=0f7413a1-6a03-4ce6-8994-cb5f90770e85&start_date=2022-01-01&schema=acct10001

See that your OCP on AWS cost has close to doubled:
```
"infrastructure": {
                "raw": {
                    "value": 642.9525044092351,
                    "units": "USD"
                },
                "markup": {
                    "value": 64.29525044092351,
                    "units": "USD"
                },
                "usage": {
                    "value": 0.0,
                    "units": "USD"
                },
                "total": {
                    "value": 707.2477548501586,
                    "units": "USD"
                }
            },
```
Checkout this branch and do it again and it should be good with no duplicated data