### PR TITLE
For deletes use direct reference to month column

### DIFF
--- a/koku/masu/database/aws_report_db_accessor.py
+++ b/koku/masu/database/aws_report_db_accessor.py
@@ -387,7 +387,7 @@ class AWSReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
                     WHERE aws_source = '{aws_source}'
                     AND ocp_source = '{ocp_source}'
                     AND year = '{year}'
-                    AND lpad(month, 2, '0') = '{month}'
+                    AND (month = replace(ltrim(replace('{{month}}', '0', ' ')),' ', '0') OR month = '{{month}}')
                     AND day = '{day}';"""
                 final_sql_list.append(sql)
             final_sql = "".join(final_sql_list)

--- a/koku/masu/database/aws_report_db_accessor.py
+++ b/koku/masu/database/aws_report_db_accessor.py
@@ -387,7 +387,7 @@ class AWSReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
                     WHERE aws_source = '{aws_source}'
                     AND ocp_source = '{ocp_source}'
                     AND year = '{year}'
-                    AND (month = replace(ltrim(replace('{{month}}', '0', ' ')),' ', '0') OR month = '{{month}}')
+                    AND (month = replace(ltrim(replace('{month}', '0', ' ')),' ', '0') OR month = '{month}')
                     AND day = '{day}';"""
                 final_sql_list.append(sql)
             final_sql = "".join(final_sql_list)

--- a/koku/masu/database/ocp_report_db_accessor.py
+++ b/koku/masu/database/ocp_report_db_accessor.py
@@ -653,7 +653,7 @@ class OCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
                 DELETE FROM hive.{self.schema}.{table}
                 WHERE source = '{source}'
                 AND year = '{year}'
-                AND lpad(month, 2, '0') = '{month}'
+                AND (month = replace(ltrim(replace('{{month}}', '0', ' ')),' ', '0') OR month = '{{month}}')
                 AND day = '{day}';
                 """
                 final_sql_list.append(sql)

--- a/koku/masu/database/ocp_report_db_accessor.py
+++ b/koku/masu/database/ocp_report_db_accessor.py
@@ -653,7 +653,7 @@ class OCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
                 DELETE FROM hive.{self.schema}.{table}
                 WHERE source = '{source}'
                 AND year = '{year}'
-                AND (month = replace(ltrim(replace('{{month}}', '0', ' ')),' ', '0') OR month = '{{month}}')
+                AND (month = replace(ltrim(replace('{month}', '0', ' ')),' ', '0') OR month = '{month}')
                 AND day = '{day}';
                 """
                 final_sql_list.append(sql)


### PR DESCRIPTION
## Summary
For some reason Trino/Hive can't recognize the month partition column inside a function call. This changes to reference the month column directly and does the manipulation on the string instead. 