### PR TITLE
[COST-2204] handle Hour unit for Azure

### DIFF
--- a/koku/masu/database/presto_sql/reporting_azurecostentrylineitem_daily_summary.sql
+++ b/koku/masu/database/presto_sql/reporting_azurecostentrylineitem_daily_summary.sql
@@ -36,7 +36,7 @@ WITH cte_line_items AS (
             ELSE 1
             END as multiplier,
         CASE
-            WHEN split_part(unitofmeasure, ' ', 2) = 'Hours'
+            WHEN split_part(unitofmeasure, ' ', 2) IN ('Hours', 'Hour')
                 THEN  'Hrs'
             WHEN split_part(unitofmeasure, ' ', 2) = 'GB/Month'
                 THEN  'GB-Mo'

--- a/koku/masu/database/sql/reporting_azurecostentrylineitem_daily_summary.sql
+++ b/koku/masu/database/sql/reporting_azurecostentrylineitem_daily_summary.sql
@@ -60,7 +60,7 @@ CREATE TEMPORARY TABLE reporting_azurecostentrylineitem_daily_summary_{{uuid | s
                 ELSE 1::integer
                 END as multiplier,
             CASE
-                WHEN split_part(m.unit_of_measure, ' ', 2) = 'Hours'
+                WHEN split_part(m.unit_of_measure, ' ', 2) IN ('Hours', 'Hour')
                     THEN  'Hrs'
                 WHEN split_part(m.unit_of_measure, ' ', 2) = 'GB/Month'
                     THEN  'GB-Mo'


### PR DESCRIPTION
Our azure dev account has units of measure that are `1 Hour` which isn't being converted to `Hrs` in our SQL like the unit `Hours` is. This addresses that.

Testing:

1. On Main, spin things up (trino or non, this affects both) and load in our azure dev account
2. Go to the instance types endpoint and see no data: http://localhost:8000/api/cost-management/v1/reports/azure/instance-types/
3. Check the DB and see that there is no data in the compute partable but we do have instance type entries in the daily summary table:
          - `SELECT * FROM reporting_azure_compute_summary_p;`
          -  `SELECT instance_type, unit_of_measure FROM reporting_azurecostentrylineitem_daily_summary WHERE instance_type IS NOT NULL;`
4. Checkout this branch and process the azure dev account again
5.  Go to the instance types endpoint and see data this time: http://localhost:8000/api/cost-management/v1/reports/azure/instance-types/
6. Check the DB and see there is now data in the compute partable: `SELECT * FROM reporting_azure_compute_summary_p;`