### PR TITLE
Add extended DB exception processing to _execute_raw_sql_query

### DIFF
--- a/koku/koku/database_exc.py
+++ b/koku/koku/database_exc.py
@@ -30,7 +30,7 @@ LOG = logging.getLogger(__name__)
 
 def get_driver_exception(db_exception):
     if isinstance(db_exception, DJDatabaseError):
-        return db_exception.__cause__
+        return db_exception.__cause__ or db_exception.__context__
     else:
         return db_exception
 
@@ -41,7 +41,10 @@ class ExtendedDBException(Exception):
     def __init__(self, db_exception, query_limit=128):
         _db_exception = get_driver_exception(db_exception)
         if not isinstance(_db_exception, DatabaseError):
-            raise TypeError("This wrapper class only works on type <psycopg2.errors.DatabaseError>")
+            raise TypeError(
+                "This wrapper class only works on type <psycopg2.errors.DatabaseError> "
+                + f"(Got {type(_db_exception).__name__})"
+            )
         self.query_limit = query_limit
         self.ingest_exception(_db_exception)
         self.parse_exception()


### PR DESCRIPTION
## Jira Ticket

[COST-2221](https://issues.redhat.com/browse/COST-2221)

## Description

We've been seeing more DeadlockDetected exceptions in a different location. This change will add extended DB exception processing to calls of `_execute_raw_sql_query` in the `ReportDBAccessorBase` class