### PR TITLE
Restore development workflow for creating real gcp sources locally

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -117,6 +117,7 @@ services:
       - UNLEASH_HOST=${UNLEASH_HOST-unleash}
       - UNLEASH_PORT=${UNLEASH_PORT-4242}
       - UNLEASH_LOG_LEVEL=${UNLEASH_LOG_LEVEL-WARNING}
+      - GOOGLE_APPLICATION_CREDENTIALS=${GOOGLE_APPLICATION_CREDENTIALS-}
     ports:
       - 5042:8000
       - 5001:9000
@@ -126,6 +127,7 @@ services:
       - './db_functions:/koku/db_functions'
       - './scripts:/koku/scripts'
       - './run_server.sh:/koku/run_server.sh'
+      - './testing/gcp_auth_json/:/testing/gcp_auth_json/'
     depends_on:
       - koku-base
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,7 @@ services:
       - './db_functions:/koku/db_functions'
       - './scripts:/koku/scripts'
       - './run_server.sh:/koku/run_server.sh'
+      - './testing/gcp_auth_json/:/testing/gcp_auth_json/'
     depends_on:
       - koku-base
 

--- a/testing/gcp_auth_json/.gitignore
+++ b/testing/gcp_auth_json/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
Fixes Development workflow for GCP

Some dockerfile changes were made a while back that reduced the number of files we were adding to our docker image. Which is great! However, it broke the development workflow for the make command that creates a real GCP source for you. We tend to use a real source to verify and debug GCP related issues. 

Therefore if you currently do:
```
make gcp-source gcp_name=CodyTest
``` 
on main you will get error message like: 
```
File /path/gcp-auth.json was not found..
```

Therefore, this pr creates a dedicated place for the gcp auth json file to live that is mapped to the required container so that real GCP sources can be added again locally.  

---

### Testing Instructions:

1. Add the gcp auth json to the correct directory. 
2. Update the .env dir to point to new path location inside of the container:
```
GOOGLE_APPLICATION_CREDENTIALS=/testing/gcp_auth_json/your_file_name.json
```
4. If this is your first time adding a real gcp source locally you will also need the dataset & project env vars:
```
GCP_DATASET='ctsa'
GCP_PROJECT_ID='sasdf'
```
5. Ensure that your pipenv has the newly updated the google creds path:
```
printenv | grep GOOGLE
```
6. Create the real gcp source:
```
make gcp-source gcp_name=CodyTest
``` 

Note: If you don't have gcp auth json file, feel free to reach out to me and I can help with that. 
