### PR TITLE
[COST-2265] - Use the true max of rankings for OCP on AWS

### DIFF
--- a/koku/masu/database/presto_sql/reporting_ocpawscostlineitem_daily_summary.sql
+++ b/koku/masu/database/presto_sql/reporting_ocpawscostlineitem_daily_summary.sql
@@ -427,7 +427,7 @@ FROM (
         ON pds.aws_uuid = r.aws_uuid
     LEFT JOIN postgres.{{schema | sqlsafe}}.reporting_awsaccountalias AS aa
         ON pds.usage_account_id = aa.account_id
-    GROUP BY aws_uuid, namespace
+    GROUP BY pds.aws_uuid, pds.namespace
 ) as ocp_aws
 ;
 

--- a/koku/masu/database/presto_sql/reporting_ocpawscostlineitem_daily_summary.sql
+++ b/koku/masu/database/presto_sql/reporting_ocpawscostlineitem_daily_summary.sql
@@ -325,6 +325,13 @@ INSERT INTO hive.{{schema | sqlsafe}}.reporting_ocpawscostlineitem_project_daily
     month,
     day
 )
+WITH cte_rankings AS (
+    SELECT pds.aws_uuid,
+        max(pds.data_source_rank) as data_source_rank,
+        max(pds.project_rank) as project_rank
+    FROM hive.{{schema | sqlsafe}}.reporting_ocpawscostlineitem_project_daily_summary_temp AS pds
+    GROUP BY aws_uuid
+)
 SELECT aws_uuid,
     cluster_id,
     cluster_alias,
@@ -412,10 +419,12 @@ FROM (
         max(pds.pod_labels) as pod_labels,
         max(pds.volume_labels) as volume_labels,
         max(pds.tags) as tags,
-        max(pds.project_rank) as project_rank,
-        max(pds.data_source_rank) as data_source_rank,
+        max(r.project_rank) as project_rank,
+        max(r.data_source_rank) as data_source_rank,
         max(pds.resource_id_matched) as resource_id_matched
     FROM hive.{{schema | sqlsafe}}.reporting_ocpawscostlineitem_project_daily_summary_temp AS pds
+    JOIN cte_rankings as r
+        ON pds.aws_uuid = r.aws_uuid
     LEFT JOIN postgres.{{schema | sqlsafe}}.reporting_awsaccountalias AS aa
         ON pds.usage_account_id = aa.account_id
     GROUP BY aws_uuid, namespace


### PR DESCRIPTION
Fixes [COST-2265](https://issues.redhat.com/browse/COST-2265)

Changes proposed in this PR:
* Apply bugfix to use true max ranking for each AWS item

Testing Instructions:
1. Run standard load test customer data flow

---
Additional Context:
Already applied for OCP on Azure in https://github.com/project-koku/koku/pull/3333