### PR TITLE
[COST-2275] - Fix OCP node capacity CTE in OCP Trino SQL

### DIFF
--- a/koku/masu/database/presto_sql/reporting_ocpusagelineitem_daily_summary.sql
+++ b/koku/masu/database/presto_sql/reporting_ocpusagelineitem_daily_summary.sql
@@ -119,26 +119,18 @@ cte_ocp_namespace_label_line_item_daily AS (
 ),
 -- Daily sum of cluster CPU and memory capacity
 cte_ocp_node_capacity AS (
-    SELECT date(nc.interval_start) as usage_start,
-        nc.node,
-        sum(nc.node_capacity_cpu_core_seconds) as node_capacity_cpu_core_seconds,
-        sum(nc.node_capacity_memory_byte_seconds) as node_capacity_memory_byte_seconds
-    FROM (
-        SELECT li.interval_start,
-            li.node,
-            max(li.node_capacity_cpu_core_seconds) as node_capacity_cpu_core_seconds,
-            max(li.node_capacity_memory_byte_seconds) as node_capacity_memory_byte_seconds
-        FROM hive.{{schema | sqlsafe}}.openshift_pod_usage_line_items_daily AS li
-        WHERE li.source = {{source}}
-            AND li.year = {{year}}
-            AND li.month = {{month}}
-            AND li.interval_start >= TIMESTAMP {{start_date}}
-            AND li.interval_start < date_add('day', 1, TIMESTAMP {{end_date}})
-        GROUP BY li.interval_start,
-            li.node
-    ) as nc
-    GROUP BY date(nc.interval_start),
-        nc.node
+    SELECT li.interval_start,
+        li.node,
+        sum(li.node_capacity_cpu_core_seconds) as node_capacity_cpu_core_seconds,
+        sum(li.node_capacity_memory_byte_seconds) as node_capacity_memory_byte_seconds
+    FROM hive.{{schema | sqlsafe}}.openshift_pod_usage_line_items_daily AS li
+    WHERE li.source = {{source}}
+        AND li.year = {{year}}
+        AND li.month = {{month}}
+        AND li.interval_start >= TIMESTAMP {{start_date}}
+        AND li.interval_start < date_add('day', 1, TIMESTAMP {{end_date}})
+    GROUP BY li.interval_start,
+        li.node
 ),
 cte_ocp_cluster_capacity AS (
     SELECT nc.usage_start,


### PR DESCRIPTION
Fixes [COST-2275](https://issues.redhat.com/browse/COST-2275)

Changes proposed in this PR:
* Adjust the node capacity common table expression to sum the results of the already aggregated daily values. This CTE was written around the hourly raw data and was not updated successfully when we switched to using the daily table.
*

Testing Instructions:
1. Ask SRE to run both forms of the SQL against a known cluster in prod.

[Smoke Tests](https://ci.ext.devshift.net/job/project-koku-koku-pr-check/3738/)

---
Additional Context:
