### PR TITLE
Convert markup float values to Decimal

### DIFF
--- a/koku/masu/database/aws_report_db_accessor.py
+++ b/koku/masu/database/aws_report_db_accessor.py
@@ -7,6 +7,7 @@ import json
 import logging
 import pkgutil
 import uuid
+from decimal import Decimal
 
 from dateutil.parser import parse
 from django.conf import settings
@@ -486,6 +487,7 @@ class AWSReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
 
     def populate_markup_cost(self, provider_uuid, markup, start_date, end_date, bill_ids=None):
         """Set markup costs in the database."""
+        markup = Decimal(markup)
         with schema_context(self.schema):
             if bill_ids and start_date and end_date:
                 date_filters = {"usage_start__gte": start_date, "usage_start__lte": end_date}

--- a/koku/masu/database/azure_report_db_accessor.py
+++ b/koku/masu/database/azure_report_db_accessor.py
@@ -8,6 +8,7 @@ import logging
 import pkgutil
 import uuid
 from datetime import datetime
+from decimal import Decimal
 
 from dateutil.parser import parse
 from django.conf import settings
@@ -204,6 +205,7 @@ class AzureReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
 
     def populate_markup_cost(self, provider_uuid, markup, start_date, end_date, bill_ids=None):
         """Set markup costs in the database."""
+        markup = Decimal(markup)
         with schema_context(self.schema):
             if bill_ids and start_date and end_date:
                 date_filters = {"usage_start__gte": start_date, "usage_start__lte": end_date}

--- a/koku/masu/database/gcp_report_db_accessor.py
+++ b/koku/masu/database/gcp_report_db_accessor.py
@@ -7,6 +7,7 @@ import datetime
 import logging
 import pkgutil
 import uuid
+from decimal import Decimal
 from os import path
 
 from dateutil.parser import parse
@@ -277,6 +278,7 @@ class GCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
 
     def populate_markup_cost(self, markup, start_date, end_date, bill_ids=None):
         """Set markup costs in the database."""
+        markup = Decimal(markup)
         with schema_context(self.schema):
             if bill_ids and start_date and end_date:
                 for bill_id in bill_ids:

--- a/koku/masu/database/ocp_report_db_accessor.py
+++ b/koku/masu/database/ocp_report_db_accessor.py
@@ -833,6 +833,7 @@ class OCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
 
     def populate_markup_cost(self, markup, start_date, end_date, cluster_id):
         """Set markup cost for OCP including infrastructure cost markup."""
+        markup = Decimal(markup)
         with schema_context(self.schema):
             OCPUsageLineItemDailySummary.objects.filter(
                 cluster_id=cluster_id, usage_start__gte=start_date, usage_start__lte=end_date


### PR DESCRIPTION
While working on COST-444, markup tests were failing by a few cents. Converting the markup value to a Decimal before multiplying by usage and saving in the DB resolved the test failures.

Changes proposed in this PR:
* Convert markup to Decimal in each `populate_markup_cost` function.

Testing Instructions:
1. 
