### PR TITLE
COST-2295: switch public to private ports

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -438,11 +438,11 @@ objects:
             secretName: koku-gcp
       webServices:
         metrics:
-          enabled: false
+          enabled: true
         private:
           enabled: true
         public:
-          enabled: true
+          enabled: false
     - minReplicas: ${{SCHEDULER_MIN_REPLICAS}}
       name: clowder-scheduler
       podSpec:
@@ -715,11 +715,11 @@ objects:
             secretName: koku-gcp
       webServices:
         metrics:
-          enabled: false
+          enabled: true
         private:
           enabled: true
         public:
-          enabled: true
+          enabled: false
     - minReplicas: ${{SOURCES_LISTENER_MIN_REPLICAS}}
       name: clowder-sources-listener
       podSpec:

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -2511,7 +2511,7 @@ parameters:
   value: trino-coordinator
 - displayName: Presto/Trino port
   name: PRESTO_PORT
-  value: "8000"
+  value: "10000"
 - displayName: Prometheus Pushgateway
   name: PROMETHEUS_PUSHGATEWAY
   value: prometheus-pushgateway:9091

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -438,9 +438,9 @@ objects:
             secretName: koku-gcp
       webServices:
         metrics:
-          enabled: true
-        private:
           enabled: false
+        private:
+          enabled: true
         public:
           enabled: true
     - minReplicas: ${{SCHEDULER_MIN_REPLICAS}}
@@ -715,9 +715,9 @@ objects:
             secretName: koku-gcp
       webServices:
         metrics:
-          enabled: true
-        private:
           enabled: false
+        private:
+          enabled: true
         public:
           enabled: true
     - minReplicas: ${{SOURCES_LISTENER_MIN_REPLICAS}}

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -398,7 +398,7 @@ objects:
           failureThreshold: 5
           httpGet:
             path: ${API_PATH_PREFIX}/v1/status/?liveness
-            port: web
+            port: private
             scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 20
@@ -408,7 +408,7 @@ objects:
           failureThreshold: 5
           httpGet:
             path: ${API_PATH_PREFIX}/v1/status/
-            port: web
+            port: private
             scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 20
@@ -675,7 +675,7 @@ objects:
           failureThreshold: 5
           httpGet:
             path: ${API_PATH_PREFIX}/v1/status/?liveness
-            port: web
+            port: private
             scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 20
@@ -685,7 +685,7 @@ objects:
           failureThreshold: 5
           httpGet:
             path: ${API_PATH_PREFIX}/v1/status/
-            port: web
+            port: private
             scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 20

--- a/deploy/koku-cji.yaml
+++ b/deploy/koku-cji.yaml
@@ -65,7 +65,7 @@ parameters:
   value: trino-coordinator
 - displayName: Presto/Trino port
   name: PRESTO_PORT
-  value: "8000"
+  value: "10000"
 - displayName: Prometheus multiproc dir
   name: PROMETHEUS_DIR
   value: /tmp

--- a/deploy/kustomize/base/base.yaml
+++ b/deploy/kustomize/base/base.yaml
@@ -347,7 +347,7 @@ parameters:
   value: "trino-coordinator"
 - displayName: Presto/Trino port
   name: PRESTO_PORT
-  value: "8000"
+  value: "10000"
 
 - displayName: Prometheus Pushgateway
   name: PROMETHEUS_PUSHGATEWAY

--- a/deploy/kustomize/patches/masu.yaml
+++ b/deploy/kustomize/patches/masu.yaml
@@ -103,7 +103,7 @@
       livenessProbe:
         httpGet:
           path: ${API_PATH_PREFIX}/v1/status/?liveness
-          port: web
+          port: private
           scheme: HTTP
         initialDelaySeconds: 30
         periodSeconds: 20
@@ -113,7 +113,7 @@
       readinessProbe:
           httpGet:
             path: ${API_PATH_PREFIX}/v1/status/
-            port: web
+            port: private
             scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 20

--- a/deploy/kustomize/patches/masu.yaml
+++ b/deploy/kustomize/patches/masu.yaml
@@ -5,11 +5,11 @@
     minReplicas: ${{MASU_MIN_REPLICAS}}
     webServices:
       public:
-        enabled: true
+        enabled: false
       private:
         enabled: true
       metrics:
-        enabled: false
+        enabled: true
     podSpec:
       image: ${IMAGE}:${IMAGE_TAG}
       env:

--- a/deploy/kustomize/patches/masu.yaml
+++ b/deploy/kustomize/patches/masu.yaml
@@ -7,9 +7,9 @@
       public:
         enabled: true
       private:
-        enabled: false
-      metrics:
         enabled: true
+      metrics:
+        enabled: false
     podSpec:
       image: ${IMAGE}:${IMAGE_TAG}
       env:

--- a/deploy/kustomize/patches/sources-client.yaml
+++ b/deploy/kustomize/patches/sources-client.yaml
@@ -94,7 +94,7 @@
       livenessProbe:
         httpGet:
           path: ${API_PATH_PREFIX}/v1/status/?liveness
-          port: web
+          port: private
           scheme: HTTP
         initialDelaySeconds: 30
         periodSeconds: 20
@@ -104,7 +104,7 @@
       readinessProbe:
         httpGet:
           path: ${API_PATH_PREFIX}/v1/status/
-          port: web
+          port: private
           scheme: HTTP
         initialDelaySeconds: 30
         periodSeconds: 20

--- a/deploy/kustomize/patches/sources-client.yaml
+++ b/deploy/kustomize/patches/sources-client.yaml
@@ -7,9 +7,9 @@
       public:
         enabled: true
       private:
-        enabled: false
-      metrics:
         enabled: true
+      metrics:
+        enabled: false
     podSpec:
       image: ${IMAGE}:${IMAGE_TAG}
       env:

--- a/deploy/kustomize/patches/sources-client.yaml
+++ b/deploy/kustomize/patches/sources-client.yaml
@@ -5,11 +5,11 @@
     minReplicas: ${{SOURCES_CLIENT_MIN_REPLICAS}}
     webServices:
       public:
-        enabled: true
+        enabled: false
       private:
         enabled: true
       metrics:
-        enabled: false
+        enabled: true
     podSpec:
       image: ${IMAGE}:${IMAGE_TAG}
       env:

--- a/koku/gunicorn_conf.py
+++ b/koku/gunicorn_conf.py
@@ -12,7 +12,17 @@ ENVIRONMENT = environ.Env()
 
 SOURCES = ENVIRONMENT.bool("SOURCES", default=False)
 
-bind = "unix:/var/run/koku/gunicorn.sock"
+CLOWDER_PORT = "8000"
+if ENVIRONMENT.bool("CLOWDER_ENABLED", default=False):
+    from app_common_python import LoadedConfig
+
+    CLOWDER_PORT = LoadedConfig.publicPort
+
+    if ENVIRONMENT.bool("MASU", default=False) or ENVIRONMENT.bool("SOURCES", default=False):
+        CLOWDER_PORT = LoadedConfig.privatePort
+
+bind = f"0.0.0.0:{CLOWDER_PORT}"
+
 cpu_resources = ENVIRONMENT.int("POD_CPU_LIMIT", default=multiprocessing.cpu_count())
 workers = 1 if SOURCES else cpu_resources * 2 + 1
 

--- a/koku/koku/probe_server.py
+++ b/koku/koku/probe_server.py
@@ -23,6 +23,10 @@ if ENVIRONMENT.bool("CLOWDER_ENABLED", default=False):
 
     CLOWDER_METRICS_PORT = LoadedConfig.metricsPort
 
+SERVER_TYPE = "liveness/readiness/metrics"
+if ENVIRONMENT.bool("MASU", default=False) or ENVIRONMENT.bool("SOURCES", default=False):
+    SERVER_TYPE = "metrics"
+
 
 def start_probe_server(server_cls, logger=LOG):
     """Start the probe server."""
@@ -34,11 +38,11 @@ def start_probe_server(server_cls, logger=LOG):
         httpd.RequestHandlerClass.ready = False
         httpd.serve_forever()
 
-    logger.info("starting liveness/readiness probe server")
+    logger.info(f"starting {SERVER_TYPE} probe server")
     daemon = threading.Thread(name="probe_server", target=start_server)
     daemon.setDaemon(True)  # Set as a daemon so it will be killed once the main thread is dead.
     daemon.start()
-    logger.info(f"liveness/readiness probe server started on port {httpd.server_port}")
+    logger.info(f"{SERVER_TYPE} probe server started on port {httpd.server_port}")
 
     return httpd
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,16 +1,5 @@
 #!/bin/bash
 
 set -e
-
-if [[ -z "${ACG_CONFIG}" ]]; then
-    CLOWDER_PORT=8000
-else
-    if [ "$MASU" = true ] || [ "$SOURCES" = true ]; then
-        CLOWDER_PORT=$(python -c 'import app_common_python; print(app_common_python.LoadedConfig.privatePort)')
-    else
-        CLOWDER_PORT=$(python -c 'import app_common_python; print(app_common_python.LoadedConfig.publicPort)')
-    fi
-fi
-
 cd $APP_HOME
-gunicorn koku.wsgi --bind=0.0.0.0:$CLOWDER_PORT --access-logfile=- --config gunicorn_conf.py --preload
+gunicorn koku.wsgi --access-logfile=- --config gunicorn_conf.py --preload

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -5,7 +5,11 @@ set -e
 if [[ -z "${ACG_CONFIG}" ]]; then
     CLOWDER_PORT=8000
 else
-    CLOWDER_PORT=$(python -c 'import app_common_python; print(app_common_python.LoadedConfig.publicPort)')
+    if $MASU || $SOURCES; then
+        CLOWDER_PORT=$(python -c 'import app_common_python; print(app_common_python.LoadedConfig.privatePort)')
+    else
+        CLOWDER_PORT=$(python -c 'import app_common_python; print(app_common_python.LoadedConfig.publicPort)')
+    fi
 fi
 
 cd $APP_HOME

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -5,7 +5,7 @@ set -e
 if [[ -z "${ACG_CONFIG}" ]]; then
     CLOWDER_PORT=8000
 else
-    if $MASU || $SOURCES; then
+    if [ $MASU ] || [ $SOURCES ]; then
         CLOWDER_PORT=$(python -c 'import app_common_python; print(app_common_python.LoadedConfig.privatePort)')
     else
         CLOWDER_PORT=$(python -c 'import app_common_python; print(app_common_python.LoadedConfig.publicPort)')

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -5,7 +5,7 @@ set -e
 if [[ -z "${ACG_CONFIG}" ]]; then
     CLOWDER_PORT=8000
 else
-    if [ $MASU ] || [ $SOURCES ]; then
+    if [ "$MASU" = true ] || [ "$SOURCES" = true ]; then
         CLOWDER_PORT=$(python -c 'import app_common_python; print(app_common_python.LoadedConfig.privatePort)')
     else
         CLOWDER_PORT=$(python -c 'import app_common_python; print(app_common_python.LoadedConfig.publicPort)')


### PR DESCRIPTION
Fixes [COST-2295](https://issues.redhat.com/browse/COST-2295)

Changes proposed in this PR:
* convert from public to private port for masu and sources
* move the gunicorn `bind` setting into the gunicorn_conf.py file

Testing Instructions:
1. Run smokes

---
Additional context:
* Need this [MR](https://gitlab.cee.redhat.com/insights-qe/iqe-cost-management-plugin/-/merge_requests/1203) for all smokes to pass.

