### PR TITLE
Fix cost distribution by grouping by data source.

### DIFF
--- a/koku/masu/database/presto_sql/reporting_ocpawscostlineitem_daily_summary.sql
+++ b/koku/masu/database/presto_sql/reporting_ocpawscostlineitem_daily_summary.sql
@@ -398,7 +398,7 @@ FROM (
     SELECT pds.aws_uuid,
         max(pds.cluster_id) as cluster_id,
         max(pds.cluster_alias) as cluster_alias,
-        max(pds.data_source) as data_source,
+        pds.data_source as data_source,
         pds.namespace,
         max(pds.node) as node,
         max(pds.persistentvolumeclaim) as persistentvolumeclaim,
@@ -439,7 +439,7 @@ FROM (
         ON pds.aws_uuid = r.aws_uuid
     LEFT JOIN postgres.{{schema | sqlsafe}}.reporting_awsaccountalias AS aa
         ON pds.usage_account_id = aa.account_id
-    GROUP BY pds.aws_uuid, pds.namespace
+    GROUP BY pds.aws_uuid, pds.namespace, pds.data_source
 ) as ocp_aws
 ;
 

--- a/koku/masu/database/presto_sql/reporting_ocpazurecostlineitem_daily_summary.sql
+++ b/koku/masu/database/presto_sql/reporting_ocpazurecostlineitem_daily_summary.sql
@@ -398,7 +398,7 @@ SELECT azure_uuid,
     cast(day(usage_start) as varchar) as day
 FROM (
     SELECT pds.azure_uuid,
-        max(pds.data_source) as data_source,
+        pds.data_source as data_source,
         max(pds.cluster_id) as cluster_id,
         max(pds.cluster_alias) as cluster_alias,
         pds.namespace,
@@ -438,7 +438,7 @@ FROM (
     FROM hive.{{schema | sqlsafe}}.reporting_ocpazurecostlineitem_project_daily_summary_temp AS pds
     JOIN cte_rankings as r
         ON pds.azure_uuid = r.azure_uuid
-    GROUP BY pds.azure_uuid, pds.namespace
+    GROUP BY pds.azure_uuid, pds.namespace, pds.data_source
 ) as ocp_azure
 ;
 


### PR DESCRIPTION
**Fixes:**

This pull request is to fix an issue we identified with how cost distribution was being handled for ocp on azure & ocp on aws. The problem is that inside of the sql we were doing a `max(data_source)` which was overwriting all data sources as either Storage or Pod depending on what the max was in the date range which was really throwing off the case statements we use for Cost Distribution.   
```
CASE WHEN resource_id_matched = TRUE AND data_source = 'Pod'
        THEN ({{pod_column | sqlsafe}} / {{cluster_column | sqlsafe}}) * pretax_cost * cast({{markup}} as decimal(24,9)) / project_rank / data_source_rank
        ELSE pretax_cost / project_rank / data_source_rank * cast({{markup}} as decimal(24,9))
    END as project_markup_cost,
```

Essentially, either the if was always getting hit, or the else was always getting hit.

**Changes proposed in this PR:**
this pr is to change the max into a group by option so that we can distribute the cost correctly for when the data source is a Pod, or ignore it probably when the data source is Storage for each row. 

Testing Instructions:
1. Smoke tests will be updated to verify this fix so that we can test it through the smoke test passing. 

