### PR TITLE
Fix Hive Delete for OCP on AWS/Azure

### DIFF
--- a/koku/masu/database/aws_report_db_accessor.py
+++ b/koku/masu/database/aws_report_db_accessor.py
@@ -369,7 +369,7 @@ class AWSReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
 
     def delete_ocp_on_aws_hive_partition_by_day(self, days, aws_source, ocp_source, year, month):
         """Deletes partitions individually for each day in days list."""
-        table = self._table_map["ocp_on_aws_project_daily_summary"]
+        table = "reporting_ocpawscostlineitem_project_daily_summary"
         retries = settings.HIVE_PARTITION_DELETE_RETRIES
         if self.table_exists_trino(table):
             LOG.info(

--- a/koku/masu/database/azure_report_db_accessor.py
+++ b/koku/masu/database/azure_report_db_accessor.py
@@ -325,7 +325,7 @@ class AzureReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
 
     def delete_ocp_on_azure_hive_partition_by_day(self, days, az_source, ocp_source, year, month):
         """Deletes partitions individually for each day in days list."""
-        table = self._table_map["ocp_on_azure_project_daily_summary"]
+        table = "reporting_ocpazurecostlineitem_project_daily_summary"
         retries = settings.HIVE_PARTITION_DELETE_RETRIES
         if self.table_exists_trino(table):
             LOG.info(


### PR DESCRIPTION
This change decouples the hive delete from our table map and fixes an issue where the table name was incorrect causing the hive tables to not get cleared out properly.

Fixes [COST-####](https://issues.redhat.com/browse/COST-####)

Changes proposed in this PR:
* Decouple hive delete from the table map
* Put the correct table name in the hive delete function

Testing Instructions:
1. Load some ocp on aws/azure data ON MAIN (or with this change reverted), such as with make test customer data: `make create-test-customer` followed by `make load-test-customer-data`
2. Check your cost on the OCP on AWS/ OCP on Azure endpoints (examples will be aws): `http://localhost:8000/api/cost-management/v1/reports/openshift/infrastructures/aws/costs/`
3. See and note your total cost, in my case `323.10`
4. Resummarize your aws source with masu, filling in your appropriate provider uuid: `http://localhost:5042/api/cost-management/v1/report_data/?provider_type=AWS-local&provider_uuid=501faf96-5504-4c62-9951-b94e6cd5da0f&start_date=2022-01-01&schema=acct10001`
5. Hit the aws cost endpoint from 2 and compare the amounts: `646.20` vs `323.10` is exactly double
6. Resummarize again and hit the endpoint from 2 again and it will have gone up by the same amount again: `969.30`
7. Checkout this branch or un-revert this change and resummarize again and check the cost and you should see it return to normal


---
Additional Context: 
