### PR TITLE
COST-2302 - improved logging when cluster id not in OCPCluster table

### DIFF
--- a/koku/masu/database/ocp_report_db_accessor.py
+++ b/koku/masu/database/ocp_report_db_accessor.py
@@ -2403,6 +2403,8 @@ class OCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
     def get_openshift_topology_for_provider(self, provider_uuid):
         """Return a dictionary with Cluster topology."""
         cluster = self.get_cluster_for_provider(provider_uuid)
+        if cluster is None:
+            return
         topology = {"cluster_id": cluster.cluster_id, "cluster_alias": cluster.cluster_alias}
         node_tuples = self.get_nodes_for_cluster(cluster.uuid)
         pvc_tuples = self.get_pvcs_for_cluster(cluster.uuid)

--- a/koku/masu/processor/parquet/ocp_cloud_parquet_report_processor.py
+++ b/koku/masu/processor/parquet/ocp_cloud_parquet_report_processor.py
@@ -135,6 +135,7 @@ class OCPCloudParquetReportProcessor(ParquetReportProcessor):
                 }
                 msg = "OCP cluster not found in OCPCluster table"
                 LOG.error(log_json(self.tracing_id, msg, ctx))
+                # TODO: THIS IS TEMPORARY. SHOULD BE REMOVED WHEN WE ARE FULLY MIGRATED TO TRINO
                 error = ParquetReportProcessorError("OCP cluster not found in OCPCluster table")
                 continue
             # Get matching tags
@@ -154,5 +155,6 @@ class OCPCloudParquetReportProcessor(ParquetReportProcessor):
                 self.create_ocp_on_cloud_parquet(
                     openshift_filtered_data_frame, parquet_base_filename, i, ocp_provider_uuid
                 )
+        # TODO: THIS IS TEMPORARY. SHOULD BE REMOVED WHEN WE ARE FULLY MIGRATED TO TRINO
         if error:
             raise error


### PR DESCRIPTION
Improves logging for [COST-2302](https://issues.redhat.com/browse/COST-2302)

Changes proposed in this PR:
* Log when the OCP cluster does not exist in the OCPCluster table.
* Interrupt `OCPCloudParquetReportProcessor.process` when the OCP cluster is not found in the OCPCluster table.

Testing Instructions:
1. with:
```
ENABLE_PARQUET_PROCESSING=False
ENABLE_TRINO_SOURCE_TYPE=GCP
```
2. Ingest test data `make create-test-customer` and `make load-test-customer-data`
3. In unleash, enable the trino account. Add `acct10001` to `cost-trino-processor`
4. Create and ingest more AWS data
5. Scan the koku-worker logs, and see:
```
koku-worker_1     | [2022-02-04 19:13:09,334] ERROR 550794d2-dfac-47a4-a26d-ebc47924f539 {'message': 'OCP cluster not found in OCPCluster table', 'tracing_id': '76d8277d-2145-4a52-90de-6cf6dfdbb3e9', 'ocp-provider-uuid': '08dc8cd9-95dd-42b4-8448-9304abbcdc60', 'infra-provider-uuid': '835821fb-e95b-4838-859a-d4640b12eaf9', 'infra-type': 'AWS-local'}
koku-worker_1     | [2022-02-04 19:13:09,352] ERROR 550794d2-dfac-47a4-a26d-ebc47924f539 {'message': 'OCP cluster not found in OCPCluster table', 'tracing_id': '76d8277d-2145-4a52-90de-6cf6dfdbb3e9', 'account': '10001', 'provider_uuid': '835821fb-e95b-4838-859a-d4640b12eaf9'}
koku-worker_1     | [2022-02-04 19:13:10,432] ERROR 550794d2-dfac-47a4-a26d-ebc47924f539 {'message': 'OCP cluster not found in OCPCluster table', 'tracing_id': '76d8277d-2145-4a52-90de-6cf6dfdbb3e9', 'account': '10001', 'provider_uuid': '835821fb-e95b-4838-859a-d4640b12eaf9'}
```

---
Additional Context:
The fix here should be temporary while we switch to Trino. This PR stops ocp-on-cloud processing when the OCP source has yet to send a new report to cost-management.