### PR TITLE
[COST-2304] - cleanup trino migration script

### DIFF
--- a/scripts/job_script.sh
+++ b/scripts/job_script.sh
@@ -2,4 +2,4 @@
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-${SCRIPT_DIR}/copy_ocp_aws_azure_data.py 4
+${SCRIPT_DIR}/migrate_trino.py


### PR DESCRIPTION
[COST-2304](https://issues.redhat.com/browse/COST-2304)

Changes proposed in this PR:
* cleanup the trino migration script
* run each sql statement in its own context/connection - with auto-commit enabled (which is the default behavior), exiting the `with` statement forces the commit

Testing Instructions:
1. Spin up 0b432b9e85318f8bc4bf4fcc3c9662aecbb4d4bc in ephemeral
2. Ingest some OCP data
3. Run the CJI
4. Inspect trino:
  * `openshift_pod_usage_line_items_daily` and `reporting_ocpawscostlineitem_project_daily_summary_temp` no longer exist
  * `reporting_ocpusagelineitem_daily_summary` contain new columns:
```
trino:acct0369233> describe reporting_ocpusagelineitem_daily_summary;
                     Column                     |  Type   |     Extra     | Comment 
------------------------------------------------+---------+---------------+---------
 uuid                                           | varchar |               |         
...
 pod_effective_usage_memory_gigabyte_hours      | double  |               |         
 pod_effective_usage_cpu_core_hours             | double  |               |         
```

