### PR TITLE
Update the version map with the latest releases

### DIFF
--- a/koku/masu/external/downloader/ocp/ocp_report_downloader.py
+++ b/koku/masu/external/downloader/ocp/ocp_report_downloader.py
@@ -117,8 +117,15 @@ def process_cr(report_meta):
     """
     LOG.info(log_json(report_meta.get("tracing_id"), "Processing the manifest"))
     operator_versions = {
-        "f73a992e7b2fc19028b31c7fb87963ae19bba251": "koku-metrics-operator:v0.9.8",
+        "084bca2e1c48caab18c237453c17ceef61747fe2": "costmanagement-metrics-operator:1.1.3",
+        "77ec351f8d332796dc522e5623f1200c2fab4042": "costmanagement-metrics-operator:1.1.4",
+        "6f10d07e3af3ea4f073d4ffda9019d8855f52e7f": "costmanagement-metrics-operator:1.1.0",
         "fd764dcd7e9b993025f3e05f7cd674bb32fad3be": "costmanagement-metrics-operator:1.0.0",
+        "3430d17b8ad52ee912fc816da6ed31378fd28367": "koku-metrics-operator:v1.1.3",
+        "02f315aa5a7f0bf5adecd3668b0a769799b54be8": "koku-metrics-operator:v1.1.2",
+        "7c413e966e2ec0a709f5a25cbf5a487c646306d1": "koku-metrics-operator:v1.1.1",
+        "12b9463a9501f8e9acecbfa4f7e7ae7509d559fa": "koku-metrics-operator:v1.1.4",
+        "f73a992e7b2fc19028b31c7fb87963ae19bba251": "koku-metrics-operator:v0.9.8",
         "d37e6d6fd90d65b0d6794347f5fe00a472ce9d33": "koku-metrics-operator:v0.9.7",
         "1019682a6aa1eeb7533724b07d98cfb54dbe0e94": "koku-metrics-operator:v0.9.6",
         "513e7dffddb6ecc090b9e8f20a2fba2fe8ec6053": "koku-metrics-operator:v0.9.5",


### PR DESCRIPTION
Follow on to [COST-2009](https://issues.redhat.com/browse/COST-2009) and other operator releases

Changes proposed in this PR:
* Update the operator versions map with the new commits mapped to which release it was 

Testing Instructions:
1. You could test this by uploading a manifest locally and adding print statements for the version/ - this is mainly to update our koku-daily reports/ tableau boards. 

---
Additional Context:
Today during the program call I realized our tableau boards for the operator version were replaced with a different color and it made me remember that this map exists and we need to update it after operator releases. 
