### PR TITLE
Revert "Cost 2312 always log db pid"

### DIFF
--- a/koku/api/common/__init__.py
+++ b/koku/api/common/__init__.py
@@ -1,5 +1,4 @@
 # noqa
-from django.db import connection
 from django.utils.translation import ugettext as _
 
 RH_IDENTITY_HEADER = "HTTP_X_RH_IDENTITY"
@@ -16,8 +15,6 @@ def error_obj(key, message):
 
 def log_json(tracing_id, message, context={}):
     """Create JSON object for logging data."""
-    if connection.connection and not connection.connection.closed:
-        message = f"DBPID_{connection.connection.get_backend_pid()} {message}"
     stmt = {"message": message, "tracing_id": tracing_id}
     stmt.update(context)
     return stmt

--- a/koku/api/iam/test/iam_test_case.py
+++ b/koku/api/iam/test/iam_test_case.py
@@ -189,21 +189,6 @@ class IamTestCase(TestCase):
         query_params = QueryParameters(m_request, view)
         return query_params
 
-    def _regex_search(self, regex, iterable):
-        return any(bool(regex.search(elem)) for elem in iterable)
-
-    def assertRegexIn(self, regex, iterable, message=None):
-        found = self._regex_search(regex, iterable)
-        if message is None:
-            message = f'"{regex.pattern}" was not found in {iterable}'
-        self.assertTrue(found, message)
-
-    def assertRegexNotIn(self, regex, iterable, message=None):
-        found = self._regex_search(regex, iterable)
-        if message is None:
-            message = f'"{regex.pattern}" was found in {iterable}'
-        self.assertFalse(found, message)
-
 
 class RbacPermissions:
     """A decorator class for running tests with a custom identity.

--- a/koku/api/status/test_status.py
+++ b/koku/api/status/test_status.py
@@ -4,7 +4,6 @@
 #
 """Test the status API."""
 import logging
-import re
 from collections import namedtuple
 from unittest.mock import ANY
 from unittest.mock import Mock
@@ -42,15 +41,6 @@ class StatusModelTest(TestCase):
         """Create test case setup."""
         super().setUp()
         Tenant.objects.get_or_create(schema_name="public")
-
-    def _regex_search(self, regex, iterable):
-        return any(bool(regex.search(elem)) for elem in iterable)
-
-    def assertRegexIn(self, regex, iterable, message=None):
-        found = self._regex_search(regex, iterable)
-        if message is None:
-            message = f'"{regex.pattern}" was not found in {iterable}'
-        self.assertTrue(found, message)
 
     @override_settings(GIT_COMMIT="buildnum")
     def test_commit(self):
@@ -97,11 +87,11 @@ class StatusModelTest(TestCase):
     def test_startup_without_modules(self, mock_mods):
         """Test the startup method without a module list."""
         mock_mods.return_value = {}
-        expected = re.compile(r"INFO:api.status.models:.*Modules: None")
+        expected = "INFO:api.status.models:Modules: None"
 
         with self.assertLogs("api.status.models", level="INFO") as logger:
             self.status_info.startup()
-            self.assertRegexIn(expected, logger.output)
+            self.assertIn(expected, logger.output)
 
 
 class StatusViewTest(TestCase):

--- a/koku/koku/settings.py
+++ b/koku/koku/settings.py
@@ -21,24 +21,11 @@ from json import JSONDecodeError
 from boto3.session import Session
 from botocore.exceptions import ClientError
 from corsheaders.defaults import default_headers
-from django.db import connection
 
 from . import database
 from . import sentry
 from .configurator import CONFIGURATOR
 from .env import ENVIRONMENT
-
-
-# New logging method
-def koku_log(self, level, msg, args, **kwargs):
-    if connection.connection and not connection.connection.closed:
-        msg = f"DBPID_{connection.connection.get_backend_pid()} {msg}"
-    self._log_o(level, msg, args, **kwargs)
-
-
-# Taint the logging.Logger class
-setattr(logging.Logger, "_log_o", logging.Logger._log)
-setattr(logging.Logger, "_log", koku_log)
 
 
 # Database

--- a/koku/koku/test_cache.py
+++ b/koku/koku/test_cache.py
@@ -5,7 +5,6 @@
 """Test view caching functions."""
 import logging
 import random
-import re
 
 from django.core.cache import caches
 from django.test.utils import override_settings
@@ -170,11 +169,11 @@ class KokuCacheTest(IamTestCase):
 
         # test for log warning on invalid source type
         with self.assertLogs() as captured:
-            result = re.compile("unable to invalidate cache, bogus is not a valid source type")
+            result = "unable to invalidate cache, bogus is not a valid source type"
             source_types = ["bogus"]
             invalidate_view_cache_for_tenant_and_source_types(self.schema_name, source_types)
             self.assertEqual(len(captured.records), 1)
-            self.assertRegexIn(result, captured.output)
+            self.assertEqual(captured.records[0].getMessage(), result)
 
     def test_invalidate_view_cache_for_tenant_and_all_source_type(self):
         """Test that all views for a all source types and tenant are invalidated."""

--- a/koku/koku/test_delete_sql.py
+++ b/koku/koku/test_delete_sql.py
@@ -2,7 +2,6 @@
 # Copyright 2021 Red Hat Inc.
 # SPDX-License-Identifier: Apache-2.0
 #
-import re
 import uuid
 from datetime import datetime
 
@@ -95,17 +94,17 @@ class TestDeleteSQL(IamTestCase):
         )
         pocp.save()
 
-        expected1 = re.compile(r"DEBUG:koku.database:.*Level 1: delete records from OCPUsageReportPeriod")
-        expected2 = re.compile(r"DEBUG:koku.database:.*SKIPPING RELATION OCPUsageLineItemDailySummary by directive")
-        expected3 = re.compile(r"DEBUG:koku.database:.*SKIPPING RELATION OCPUsageLineItem by directive")
+        expected1 = "DEBUG:koku.database:Level 1: delete records from OCPUsageReportPeriod"
+        expected2 = "DEBUG:koku.database:SKIPPING RELATION OCPUsageLineItemDailySummary by directive"
+        expected3 = "DEBUG:koku.database:SKIPPING RELATION OCPUsageLineItem by directive"
         skip_models = [kdb.get_model("OCPUsageLineItemDailySummary"), kdb.get_model("OCPUsageLineItem")]
         query = Provider.objects.filter(pk=pocp.pk)
         with self.assertLogs("koku.database", level="DEBUG") as _logger:
             with schema_context(c.schema_name):
                 kdb.cascade_delete(Provider, query, skip_relations=skip_models)
-            self.assertRegexIn(expected1, _logger.output)
-            self.assertRegexIn(expected2, _logger.output)
-            self.assertRegexIn(expected3, _logger.output)
+            self.assertIn(expected1, _logger.output)
+            self.assertIn(expected2, _logger.output)
+            self.assertIn(expected3, _logger.output)
 
         with schema_context(c.schema_name):
             self.assertEqual(OCPUsageReportPeriod.objects.filter(pk=pocp.pk).count(), 0)
@@ -187,25 +186,25 @@ class TestDeleteSQL(IamTestCase):
             gcpceb.save()
             ocpurp.save()
 
-        expected = re.compile(r"DEBUG:koku.database:.*Level 1: delete records from AWSCostEntryBill")
+        expected = "DEBUG:koku.database:Level 1: delete records from AWSCostEntryBill"
         with self.assertLogs("koku.database", level="DEBUG") as _logger:
             paws.delete()
-            self.assertRegexIn(expected, _logger.output)
+            self.assertIn(expected, _logger.output)
 
-        expected = re.compile(r"DEBUG:koku.database:.*Level 1: delete records from AzureCostEntryBill")
+        expected = "DEBUG:koku.database:Level 1: delete records from AzureCostEntryBill"
         with self.assertLogs("koku.database", level="DEBUG") as _logger:
             pazure.delete()
-            self.assertRegexIn(expected, _logger.output)
+            self.assertIn(expected, _logger.output)
 
-        expected = re.compile(r"DEBUG:koku.database:.*Level 1: delete records from GCPCostEntryBill")
+        expected = "DEBUG:koku.database:Level 1: delete records from GCPCostEntryBill"
         with self.assertLogs("koku.database", level="DEBUG") as _logger:
             pgcp.delete()
-            self.assertRegexIn(expected, _logger.output)
+            self.assertIn(expected, _logger.output)
 
-        expected = re.compile(r"DEBUG:koku.database:.*Level 1: delete records from OCPUsageReportPeriod")
+        expected = "DEBUG:koku.database:Level 1: delete records from OCPUsageReportPeriod"
         with self.assertLogs("koku.database", level="DEBUG") as _logger:
             pocp.delete()
-            self.assertRegexIn(expected, _logger.output)
+            self.assertIn(expected, _logger.output)
 
         with schema_context(c.schema_name):
             self.assertEqual(AWSCostEntryBill.objects.filter(pk=awsceb.pk).count(), 0)
@@ -253,10 +252,10 @@ class TestDeleteSQL(IamTestCase):
         with schema_context(c.schema_name):
             awsceb.save()
 
-        expected = re.compile(r"DEBUG:koku.database:.*Setting constaints to execute immediately")
+        expected = "DEBUG:koku.database:Setting constaints to execute immediately"
         with self.assertLogs("koku.database", level="DEBUG") as _logger:
             paws.delete()
-            self.assertRegexIn(expected, _logger.output)
+            self.assertIn(expected, _logger.output)
 
         with schema_context(c.schema_name):
             self.assertEqual(AWSCostEntryBill.objects.filter(pk=awsceb.pk).count(), 0)
@@ -316,18 +315,18 @@ class TestDeleteSQL(IamTestCase):
             )
             awsceli.save()
 
-        expected = re.compile(r"DEBUG:koku.database:.*SKIPPING RELATION AWSCostEntryLineItem by directive")
-        expected2 = re.compile(r"DEBUG:koku.database:.*SKIPPING RELATION GCPCostEntryLineItem by directive")
-        expected3 = re.compile(r"DEBUG:koku.database:.*SKIPPING RELATION OCPUsageLineItem by directive")
-        expected4 = re.compile(r"DEBUG:koku.database:.*SKIPPING RELATION OCPStorageLineItem by directive")
-        expected5 = re.compile(r"DEBUG:koku.database:.*SKIPPING RELATION OCPNodeLabelLineItem by directive")
+        expected = "DEBUG:koku.database:SKIPPING RELATION AWSCostEntryLineItem by directive"
+        expected2 = "DEBUG:koku.database:SKIPPING RELATION GCPCostEntryLineItem by directive"
+        expected3 = "DEBUG:koku.database:SKIPPING RELATION OCPUsageLineItem by directive"
+        expected4 = "DEBUG:koku.database:SKIPPING RELATION OCPStorageLineItem by directive"
+        expected5 = "DEBUG:koku.database:SKIPPING RELATION OCPNodeLabelLineItem by directive"
         with self.assertLogs("koku.database", level="DEBUG") as _logger:
             paws.delete()
-            self.assertRegexIn(expected, _logger.output)
-            self.assertRegexIn(expected2, _logger.output)
-            self.assertRegexIn(expected3, _logger.output)
-            self.assertRegexIn(expected4, _logger.output)
-            self.assertRegexIn(expected5, _logger.output)
+            self.assertIn(expected, _logger.output)
+            self.assertIn(expected2, _logger.output)
+            self.assertIn(expected3, _logger.output)
+            self.assertIn(expected4, _logger.output)
+            self.assertIn(expected5, _logger.output)
 
         with schema_context(c.schema_name):
             self.assertEqual(AWSCostEntryBill.objects.filter(pk=awsceb.pk).count(), 0)

--- a/koku/masu/test/api/test_status.py
+++ b/koku/masu/test/api/test_status.py
@@ -32,15 +32,6 @@ class StatusAPITest(TestCase):
         super().setUp()
         logging.disable(logging.NOTSET)
 
-    def _regex_search(self, regex, iterable):
-        return any(bool(regex.search(elem)) for elem in iterable)
-
-    def assertRegexIn(self, regex, iterable, message=None):
-        found = self._regex_search(regex, iterable)
-        if message is None:
-            message = f'"{regex.pattern}" was not found in {iterable}'
-        self.assertTrue(found, message)
-
     @patch("masu.api.status.ApplicationStatus.celery_status", new_callable=PropertyMock)
     def test_status(self, mock_celery):
         """Test the status endpoint."""
@@ -142,11 +133,11 @@ class StatusAPITest(TestCase):
     def test_startup_without_modules(self, mock_mods, mock_celery):
         """Test the startup method without a module list."""
         mock_mods.return_value = {}
-        expected = re.compile(r"INFO:masu.api.status:.*Modules: None")
+        expected = "INFO:masu.api.status:Modules: None"
 
         with self.assertLogs("masu.api.status", level="INFO") as logger:
             ApplicationStatus().startup()
-            self.assertRegexIn(expected, logger.output)
+            self.assertIn(expected, logger.output)
 
     @patch("masu.api.status.celery_app")
     @patch("masu.external.date_accessor.DateAccessor.today")
@@ -155,31 +146,31 @@ class StatusAPITest(TestCase):
         mock_date_string = "2018-07-25 10:41:59.993536"
         mock_date_obj = datetime.strptime(mock_date_string, "%Y-%m-%d %H:%M:%S.%f")
         mock_date.return_value = mock_date_obj
-        expected = re.compile(f"INFO:masu.api.status:.*Current Date: {mock_date.return_value}")
+        expected = f"INFO:masu.api.status:Current Date: {mock_date.return_value}"
         with self.assertLogs("masu.api.status", level="INFO") as logger:
             ApplicationStatus().startup()
-            self.assertRegexIn(expected, logger.output)
+            self.assertIn(str(expected), logger.output)
 
     @patch("masu.api.status.celery_app")
     def test_get_debug(self, mock_celery):
         """Test the startup method for debug state."""
-        expected = re.compile(r"INFO:masu.api.status:.*DEBUG enabled: {}".format(str(False)))
+        expected = "INFO:masu.api.status:DEBUG enabled: {}".format(str(False))
         with self.assertLogs("masu.api.status", level="INFO") as logger:
             ApplicationStatus().startup()
-            self.assertRegexIn(expected, logger.output)
+            self.assertIn(str(expected), logger.output)
 
     @patch("masu.api.status.celery_app")
     def test_startup_has_celery_status(self, mock_celery):
         """Test celery status is in startup() output."""
         expected_status = {"Status": "OK"}
-        expected = re.compile(f"INFO:masu.api.status:.*Celery Status: {expected_status}")
+        expected = f"INFO:masu.api.status:Celery Status: {expected_status}"
 
         mock_control = mock_celery.control
         mock_control.inspect.return_value.stats.return_value = expected_status
 
         with self.assertLogs("masu.api.status", level="INFO") as logger:
             ApplicationStatus().startup()
-            self.assertRegexIn(expected, logger.output)
+            self.assertIn(expected, logger.output)
 
     @patch("masu.api.status.celery_app")
     def test_celery_status(self, mock_celery):
@@ -228,7 +219,7 @@ class StatusAPITest(TestCase):
     @patch("masu.api.status.celery_app")
     def test_database_status(self, mock_celery):
         """Test that fetching database status works."""
-        expected = re.compile(r"INFO:masu.api.status:.*Database: \[\{.*postgres.*\}\]")
+        expected = re.compile(r"INFO:masu.api.status:Database: \[{.*postgres.*}\]")
         with self.assertLogs("masu.api.status", level="INFO") as logger:
             ApplicationStatus().startup()
             results = None
@@ -240,13 +231,13 @@ class StatusAPITest(TestCase):
     @patch("masu.api.status.celery_app")
     def test_database_status_fail(self, mock_celery):
         """Test that fetching database handles errors."""
-        expected = re.compile(r"WARNING:masu.api.status:.*Unable to connect to DB:")
+        expected = "WARNING:masu.api.status:Unable to connect to DB: "
         with patch("django.db.backends.utils.CursorWrapper") as mock_cursor:
             mock_cursor = mock_cursor.return_value.__enter__.return_value
             mock_cursor.execute.side_effect = InterfaceError()
             with self.assertLogs("masu.api.status", level="INFO") as logger:
                 ApplicationStatus().startup()
-                self.assertRegexIn(expected, logger.output)
+                self.assertIn(expected, logger.output)
 
     @patch("masu.api.status.celery_app")
     def test_get_celery_queue_data(self, mock_celery):

--- a/koku/masu/test/processor/aws/test_aws_report_parquet_processor.py
+++ b/koku/masu/test/processor/aws/test_aws_report_parquet_processor.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 """Test the AWSReportParquetProcessor."""
-import re
 from unittest.mock import patch
 
 from tenant_schemas.utils import schema_context
@@ -97,14 +96,14 @@ class AWSReportProcessorParquetTest(MasuTestCase):
         bill_date = DateHelper().next_month_start
         pg_table = self.processor.postgres_summary_table._meta.db_table
         table_name = f"{pg_table}_{bill_date.strftime('%Y_%m')}"
-        expected_log = re.compile(
-            "INFO:masu.processor.report_parquet_processor_base:.*"
-            + f"Created a new partition for {pg_table} : {table_name}"
+        expected_log = (
+            f"INFO:masu.processor.report_parquet_processor_base:"
+            f"Created a new partition for {pg_table} : {table_name}"
         )
 
         with self.assertLogs("masu.processor.report_parquet_processor_base", level="INFO") as logger:
             self.processor.get_or_create_postgres_partition(bill_date)
-            self.assertRegexIn(expected_log, logger.output)
+            self.assertIn(expected_log, logger.output)
 
         with schema_context(self.schema):
             self.assertNotEqual(PartitionedTable.objects.filter(table_name=table_name).count(), 0)

--- a/koku/masu/test/processor/aws/test_aws_report_parquet_summary_updater.py
+++ b/koku/masu/test/processor/aws/test_aws_report_parquet_summary_updater.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 """Test the AWSReportParquetSummaryUpdater."""
-import re
 from datetime import timedelta
 from unittest.mock import patch
 
@@ -65,14 +64,14 @@ class AWSReportParquetSummaryUpdaterTest(MasuTestCase):
         end_str = self.dh.this_month_end.isoformat()
         expected_start, expected_end = self.updater._get_sql_inputs(start_str, end_str)
 
-        expected_log = re.compile(
-            "INFO:masu.processor.aws.aws_report_parquet_summary_updater:.*"
-            + f"update_daily_tables for: {expected_start}-{expected_end}"
+        expected_log = (
+            "INFO:masu.processor.aws.aws_report_parquet_summary_updater:"
+            f"update_daily_tables for: {expected_start}-{expected_end}"
         )
 
         with self.assertLogs("masu.processor.aws.aws_report_parquet_summary_updater", level="INFO") as logger:
             start, end = self.updater.update_daily_tables(start_str, end_str)
-            self.assertRegexIn(expected_log, logger.output)
+            self.assertIn(expected_log, logger.output)
         self.assertEqual(start, expected_start)
         self.assertEqual(end, expected_end)
 

--- a/koku/masu/test/processor/aws/test_aws_report_processor.py
+++ b/koku/masu/test/processor/aws/test_aws_report_processor.py
@@ -11,7 +11,6 @@ import json
 import logging
 import os
 import random
-import re
 import shutil
 import tempfile
 from unittest.mock import Mock
@@ -172,18 +171,17 @@ class AWSReportProcessorTest(MasuTestCase):
 
         bill_date = self.manifest.billing_period_start_datetime.date()
 
-        expected = re.compile(
-            f"INFO:masu.processor.report_processor_base:.*Processing bill starting on {bill_date}.\n"
-            + " Processing entire month.\n"
-            + f" schema_name: {self.schema},\n"
-            + f" provider_uuid: {self.aws_provider_uuid},\n"
-            + f" manifest_id: {self.manifest.id}",
-            flags=re.MULTILINE,
+        expected = (
+            f"INFO:masu.processor.report_processor_base:Processing bill starting on {bill_date}.\n"
+            f" Processing entire month.\n"
+            f" schema_name: {self.schema},\n"
+            f" provider_uuid: {self.aws_provider_uuid},\n"
+            f" manifest_id: {self.manifest.id}"
         )
         logging.disable(logging.NOTSET)  # We are currently disabling all logging below CRITICAL in masu/__init__.py
         with self.assertLogs("masu.processor.report_processor_base", level="INFO") as logger:
             processor.process()
-            self.assertRegexIn(expected, logger.output)
+            self.assertIn(expected, logger.output)
 
         for table_name in self.report_tables:
             table = getattr(report_schema, table_name)
@@ -222,15 +220,15 @@ class AWSReportProcessorTest(MasuTestCase):
                 count = table.objects.count()
             counts[table_name] = count
 
-        expected = re.compile(
-            "INFO:masu.processor.aws.aws_report_processor:.*"
-            + f"Skip processing for file: {base_name} and "
-            + f"schema: {self.schema} as it was not found on disk."
+        expected = (
+            "INFO:masu.processor.aws.aws_report_processor:"
+            f"Skip processing for file: {base_name} and "
+            f"schema: {self.schema} as it was not found on disk."
         )
         logging.disable(logging.NOTSET)  # We are currently disabling all logging below CRITICAL in masu/__init__.py
         with self.assertLogs("masu.processor.aws.aws_report_processor", level="INFO") as logger:
             processor.process()
-            self.assertRegexIn(expected, logger.output)
+            self.assertIn(expected, logger.output)
 
     def test_process_gzip(self):
         """Test the processing of a gzip compressed file."""

--- a/koku/masu/test/processor/azure/test_azure_report_parquet_summary_updater.py
+++ b/koku/masu/test/processor/azure/test_azure_report_parquet_summary_updater.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 """Test the AzureReportParquetSummaryUpdater."""
-import re
 from datetime import timedelta
 from unittest.mock import patch
 
@@ -65,14 +64,14 @@ class AzureReportParquetSummaryUpdaterTest(MasuTestCase):
         end_str = self.dh.this_month_end.isoformat()
         expected_start, expected_end = self.updater._get_sql_inputs(start_str, end_str)
 
-        expected_log = re.compile(
-            "INFO:masu.processor.azure.azure_report_parquet_summary_updater:.*"
-            + f"update_daily_tables for: {expected_start}-{expected_end}"
+        expected_log = (
+            "INFO:masu.processor.azure.azure_report_parquet_summary_updater:"
+            f"update_daily_tables for: {expected_start}-{expected_end}"
         )
 
         with self.assertLogs("masu.processor.azure.azure_report_parquet_summary_updater", level="INFO") as logger:
             start, end = self.updater.update_daily_tables(start_str, end_str)
-            self.assertRegexIn(expected_log, logger.output)
+            self.assertIn(expected_log, logger.output)
         self.assertEqual(start, expected_start)
         self.assertEqual(end, expected_end)
 

--- a/koku/masu/test/processor/gcp/test_gcp_report_parquet_processor.py
+++ b/koku/masu/test/processor/gcp/test_gcp_report_parquet_processor.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 """Test the GCPReportParquetProcessor."""
-import re
 from unittest.mock import patch
 
 from tenant_schemas.utils import schema_context
@@ -91,14 +90,14 @@ class GCPReportProcessorParquetTest(MasuTestCase):
         bill_date = DateHelper().next_month_start
         pg_table = self.processor.postgres_summary_table._meta.db_table
         table_name = f"{pg_table}_{bill_date.strftime('%Y_%m')}"
-        expected_log = re.compile(
-            "INFO:masu.processor.report_parquet_processor_base:.*"
-            + f"Created a new partition for {pg_table} : {table_name}"
+        expected_log = (
+            f"INFO:masu.processor.report_parquet_processor_base:"
+            f"Created a new partition for {pg_table} : {table_name}"
         )
 
         with self.assertLogs("masu.processor.report_parquet_processor_base", level="INFO") as logger:
             self.processor.get_or_create_postgres_partition(bill_date)
-            self.assertRegexIn(expected_log, logger.output)
+            self.assertIn(expected_log, logger.output)
 
         with schema_context(self.schema):
             self.assertNotEqual(PartitionedTable.objects.filter(table_name=table_name).count(), 0)

--- a/koku/masu/test/processor/gcp/test_gcp_report_parquet_summary_updater.py
+++ b/koku/masu/test/processor/gcp/test_gcp_report_parquet_summary_updater.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 """Test the GCPReportParquetSummaryUpdater."""
-import re
 from datetime import timedelta
 from unittest.mock import patch
 
@@ -65,14 +64,14 @@ class GCPReportParquetSummaryUpdaterTest(MasuTestCase):
         end_str = self.dh.this_month_end.isoformat()
         expected_start, expected_end = self.updater._get_sql_inputs(start_str, end_str)
 
-        expected_log = re.compile(
-            "INFO:masu.processor.gcp.gcp_report_parquet_summary_updater:.*"
-            + f"update_daily_tables for: {expected_start}-{expected_end}"
+        expected_log = (
+            "INFO:masu.processor.gcp.gcp_report_parquet_summary_updater:"
+            f"update_daily_tables for: {expected_start}-{expected_end}"
         )
 
         with self.assertLogs("masu.processor.gcp.gcp_report_parquet_summary_updater", level="INFO") as logger:
             start, end = self.updater.update_daily_tables(start_str, end_str)
-            self.assertRegexIn(expected_log, logger.output)
+            self.assertIn(expected_log, logger.output)
         self.assertEqual(start, expected_start)
         self.assertEqual(end, expected_end)
 

--- a/koku/masu/test/processor/ocp/test_ocp_report_parquet_summary_updater.py
+++ b/koku/masu/test/processor/ocp/test_ocp_report_parquet_summary_updater.py
@@ -4,7 +4,6 @@
 #
 """Test the OCPReportProcessor."""
 import datetime
-import re
 from unittest.mock import patch
 
 from api.utils import DateHelper
@@ -103,13 +102,13 @@ class OCPReportSummaryUpdaterTest(MasuTestCase):
         end_date = start_date
         start_date_str = start_date.strftime("%Y-%m-%d")
         end_date_str = end_date.strftime("%Y-%m-%d")
-        expected = re.compile(
-            "INFO:masu.processor.ocp.ocp_report_parquet_summary_updater:.*"
-            + f"NO-OP update_daily_tables for: {start_date_str}-{end_date_str}"
+        expected = (
+            "INFO:masu.processor.ocp.ocp_report_parquet_summary_updater:"
+            "NO-OP update_daily_tables for: %s-%s" % (start_date_str, end_date_str)
         )
         with self.assertLogs("masu.processor.ocp.ocp_report_parquet_summary_updater", level="INFO") as _logger:
             self.updater.update_daily_tables(start_date_str, end_date_str)
-            self.assertRegexIn(expected, _logger.output)
+            self.assertIn(expected, _logger.output)
 
     @patch(
         "masu.processor.ocp.ocp_report_parquet_summary_updater.OCPReportDBAccessor."

--- a/koku/masu/test/processor/test_orchestrator.py
+++ b/koku/masu/test/processor/test_orchestrator.py
@@ -5,7 +5,6 @@
 """Test the Orchestrator object."""
 import logging
 import random
-import re
 from unittest.mock import patch
 
 import faker
@@ -68,7 +67,7 @@ class OrchestratorTest(MasuTestCase):
             }
         ]
 
-    @patch("masu.processor.worker_cache.CELERY_INSPECT")  # noqa: C901
+    @patch("masu.processor.worker_cache.CELERY_INSPECT")
     def test_initializer(self, mock_inspect):  # noqa: C901
         """Test to init."""
         orchestrator = Orchestrator()
@@ -168,6 +167,7 @@ class OrchestratorTest(MasuTestCase):
         expected_results = [{"account_payer_id": "999999999", "billing_period_start": "2018-06-24 15:47:33.052509"}]
         mock_remover.return_value = expected_results
 
+        expected = "INFO:masu.processor.orchestrator:Expired data removal queued - schema_name: acct10001, Task ID: {}"
         # unset disabling all logging below CRITICAL from masu/__init__.py
         logging.disable(logging.NOTSET)
         with self.assertLogs("masu.processor.orchestrator", level="INFO") as logger:
@@ -176,11 +176,7 @@ class OrchestratorTest(MasuTestCase):
             self.assertTrue(results)
             self.assertEqual(len(results), 5)
             async_id = results.pop().get("async_id")
-            expected = re.compile(
-                "INFO:masu.processor.orchestrator:.*"
-                + f"Expired data removal queued - schema_name: acct10001, Task ID: {async_id}"
-            )
-            self.assertRegexIn(expected, logger.output)
+            self.assertIn(expected.format(async_id), logger.output)
 
     @patch("masu.processor.worker_cache.CELERY_INSPECT")
     @patch.object(AccountsAccessor, "get_accounts")

--- a/koku/masu/test/processor/test_report_parquet_processor_base.py
+++ b/koku/masu/test/processor/test_report_parquet_processor_base.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 """Test the ReportParquetProcessorBase."""
-import re
 import shutil
 import tempfile
 import uuid
@@ -116,38 +115,38 @@ class ReportParquetProcessorBaseTest(MasuTestCase):
     @patch("masu.processor.report_parquet_processor_base.ReportParquetProcessorBase._execute_sql")
     def test_sync_hive_partitions(self, mock_execute):
         """Test that hive partitions are synced."""
-        expected_log = re.compile(
-            "INFO:masu.processor.report_parquet_processor_base:.*"
-            fr"CALL system.sync_partition_metadata\('{self.processor._schema_name}', "
-            fr"'{self.processor._table_name}', 'FULL'\)"
+        expected_log = (
+            "INFO:masu.processor.report_parquet_processor_base:"
+            f"CALL system.sync_partition_metadata('{self.processor._schema_name}', "
+            f"'{self.processor._table_name}', 'FULL')"
         )
         with self.assertLogs("masu.processor.report_parquet_processor_base", level="INFO") as logger:
             self.processor.sync_hive_partitions()
-            self.assertRegexIn(expected_log, logger.output)
+            self.assertIn(expected_log, logger.output)
 
     @patch("masu.processor.report_parquet_processor_base.ReportParquetProcessorBase._execute_sql")
     def test_schema_exists(self, mock_execute):
         """Test that hive partitions are synced."""
-        expected_log = re.compile("INFO:masu.processor.report_parquet_processor_base:.*Checking for schema")
+        expected_log = "INFO:masu.processor.report_parquet_processor_base:" "Checking for schema"
         with self.assertLogs("masu.processor.report_parquet_processor_base", level="INFO") as logger:
             self.processor.schema_exists()
-            self.assertRegexIn(expected_log, logger.output)
+            self.assertIn(expected_log, logger.output)
 
     @patch("masu.processor.report_parquet_processor_base.ReportParquetProcessorBase._execute_sql")
     def test_table_exists(self, mock_execute):
         """Test that hive partitions are synced."""
-        expected_log = re.compile("INFO:masu.processor.report_parquet_processor_base:.*Checking for table")
+        expected_log = "INFO:masu.processor.report_parquet_processor_base:" "Checking for table"
         with self.assertLogs("masu.processor.report_parquet_processor_base", level="INFO") as logger:
             self.processor.table_exists()
-            self.assertRegexIn(expected_log, logger.output)
+            self.assertIn(expected_log, logger.output)
 
     @patch("masu.processor.report_parquet_processor_base.ReportParquetProcessorBase._execute_sql")
     def test_create_schema(self, mock_execute):
         """Test that hive partitions are synced."""
-        expected_log = re.compile(
-            "INFO:masu.processor.report_parquet_processor_base:.*"
-            + f"Create Trino/Hive schema SQL: CREATE SCHEMA IF NOT EXISTS acct{self.account}"
+        expected_log = (
+            "INFO:masu.processor.report_parquet_processor_base:"
+            f"Create Trino/Hive schema SQL: CREATE SCHEMA IF NOT EXISTS acct{self.account}"
         )
         with self.assertLogs("masu.processor.report_parquet_processor_base", level="INFO") as logger:
             self.processor.create_schema()
-            self.assertRegexIn(expected_log, logger.output)
+            self.assertIn(expected_log, logger.output)

--- a/koku/masu/test/processor/test_tasks.py
+++ b/koku/masu/test/processor/test_tasks.py
@@ -6,7 +6,6 @@
 import json
 import logging
 import os
-import re
 import shutil
 import tempfile
 import time
@@ -498,14 +497,13 @@ class TestRemoveExpiredDataTasks(MasuTestCase):
         expected_results = [{"account_payer_id": "999999999", "billing_period_start": "2018-06-24 15:47:33.052509"}]
         fake_remover.return_value = expected_results
 
-        re_expected_results = re.sub(r"([\[\{\}\]])", r"\\\1", str(expected_results))
-        expected = re.compile(f"INFO:masu.processor._tasks.remove_expired:.*Expired Data:\n {re_expected_results}")
+        expected = "INFO:masu.processor._tasks.remove_expired:Expired Data:\n {}"
 
         # disable logging override set in masu/__init__.py
         logging.disable(logging.NOTSET)
         with self.assertLogs("masu.processor._tasks.remove_expired") as logger:
             remove_expired_data(schema_name=self.schema, provider=Provider.PROVIDER_AWS, simulate=True)
-            self.assertRegexIn(expected, logger.output)
+            self.assertIn(expected.format(str(expected_results)), logger.output)
 
 
 class TestUpdateSummaryTablesTask(MasuTestCase):
@@ -783,10 +781,10 @@ class TestUpdateSummaryTablesTask(MasuTestCase):
         """Test that the vacuum schema task runs."""
         logging.disable(logging.NOTSET)
         mock_conn.cursor.return_value.__enter__.return_value.fetchall.return_value = [("table",)]
-        expected = re.compile(r"INFO:masu.processor.tasks:.*VACUUM ANALYZE acct10001.table")
+        expected = "INFO:masu.processor.tasks:VACUUM ANALYZE acct10001.table"
         with self.assertLogs("masu.processor.tasks", level="INFO") as logger:
             vacuum_schema(self.schema)
-            self.assertRegexIn(expected, logger.output)
+            self.assertIn(expected, logger.output)
 
     @patch("masu.processor.tasks.connection")
     def test_autovacuum_tune_schema_default_table(self, mock_conn):
@@ -798,49 +796,44 @@ class TestUpdateSummaryTablesTask(MasuTestCase):
             del os.environ["AUTOVACUUM_TUNING"]
 
         mock_conn.cursor.return_value.__enter__.return_value.fetchall.return_value = [("cost_model", 20000000, {})]
-        expected = re.compile(
-            "INFO:masu.processor.tasks:.*ALTER TABLE "
-            + r"acct10001.cost_model set \(autovacuum_vacuum_scale_factor = 0.01\);"
+        expected = (
+            "INFO:masu.processor.tasks:ALTER TABLE acct10001.cost_model set (autovacuum_vacuum_scale_factor = 0.01);"
         )
         with self.assertLogs("masu.processor.tasks", level="INFO") as logger:
             autovacuum_tune_schema(self.schema)
-            self.assertRegexIn(expected, logger.output)
+            self.assertIn(expected, logger.output)
 
         mock_conn.cursor.return_value.__enter__.return_value.fetchall.return_value = [("cost_model", 2000000, {})]
-        expected = re.compile(
-            "INFO:masu.processor.tasks:.*ALTER TABLE "
-            + r"acct10001.cost_model set \(autovacuum_vacuum_scale_factor = 0.02\);"
+        expected = (
+            "INFO:masu.processor.tasks:ALTER TABLE acct10001.cost_model set (autovacuum_vacuum_scale_factor = 0.02);"
         )
         with self.assertLogs("masu.processor.tasks", level="INFO") as logger:
             autovacuum_tune_schema(self.schema)
-            self.assertRegexIn(expected, logger.output)
+            self.assertIn(expected, logger.output)
 
         mock_conn.cursor.return_value.__enter__.return_value.fetchall.return_value = [("cost_model", 200000, {})]
-        expected = re.compile(
-            "INFO:masu.processor.tasks:.*ALTER TABLE "
-            + r"acct10001.cost_model set \(autovacuum_vacuum_scale_factor = 0.05\);"
+        expected = (
+            "INFO:masu.processor.tasks:ALTER TABLE acct10001.cost_model set (autovacuum_vacuum_scale_factor = 0.05);"
         )
         with self.assertLogs("masu.processor.tasks", level="INFO") as logger:
             autovacuum_tune_schema(self.schema)
-            self.assertRegexIn(expected, logger.output)
+            self.assertIn(expected, logger.output)
 
         mock_conn.cursor.return_value.__enter__.return_value.fetchall.return_value = [
             ("cost_model", 200000, {"autovacuum_vacuum_scale_factor": Decimal("0.05")})
         ]
-        expected = re.compile("INFO:masu.processor.tasks:.*Altered autovacuum_vacuum_scale_factor on 0 tables")
+        expected = "INFO:masu.processor.tasks:Altered autovacuum_vacuum_scale_factor on 0 tables"
         with self.assertLogs("masu.processor.tasks", level="INFO") as logger:
             autovacuum_tune_schema(self.schema)
-            self.assertRegexIn(expected, logger.output)
+            self.assertIn(expected, logger.output)
 
         mock_conn.cursor.return_value.__enter__.return_value.fetchall.return_value = [
             ("cost_model", 20000, {"autovacuum_vacuum_scale_factor": Decimal("0.02")})
         ]
-        expected = re.compile(
-            r"INFO:masu.processor.tasks:.*ALTER TABLE acct10001.cost_model reset \(autovacuum_vacuum_scale_factor\);"
-        )
+        expected = "INFO:masu.processor.tasks:ALTER TABLE acct10001.cost_model reset (autovacuum_vacuum_scale_factor);"
         with self.assertLogs("masu.processor.tasks", level="INFO") as logger:
             autovacuum_tune_schema(self.schema)
-            self.assertRegexIn(expected, logger.output)
+            self.assertIn(expected, logger.output)
 
     @patch("masu.processor.tasks.connection")
     def test_autovacuum_tune_schema_custom_table(self, mock_conn):
@@ -850,49 +843,44 @@ class TestUpdateSummaryTablesTask(MasuTestCase):
         os.environ["AUTOVACUUM_TUNING"] = json.dumps(scale_table)
 
         mock_conn.cursor.return_value.__enter__.return_value.fetchall.return_value = [("cost_model", 20000000, {})]
-        expected = re.compile(
-            "INFO:masu.processor.tasks:.*ALTER TABLE acct10001.cost_model "
-            + r"set \(autovacuum_vacuum_scale_factor = 0.0001\);"
+        expected = (
+            "INFO:masu.processor.tasks:ALTER TABLE acct10001.cost_model set (autovacuum_vacuum_scale_factor = 0.0001);"
         )
         with self.assertLogs("masu.processor.tasks", level="INFO") as logger:
             autovacuum_tune_schema(self.schema)
-            self.assertRegexIn(expected, logger.output)
+            self.assertIn(expected, logger.output)
 
         mock_conn.cursor.return_value.__enter__.return_value.fetchall.return_value = [("cost_model", 2000000, {})]
-        expected = re.compile(
-            "INFO:masu.processor.tasks:.*ALTER TABLE acct10001.cost_model "
-            + r"set \(autovacuum_vacuum_scale_factor = 0.004\);"
+        expected = (
+            "INFO:masu.processor.tasks:ALTER TABLE acct10001.cost_model set (autovacuum_vacuum_scale_factor = 0.004);"
         )
         with self.assertLogs("masu.processor.tasks", level="INFO") as logger:
             autovacuum_tune_schema(self.schema)
-            self.assertRegexIn(expected, logger.output)
+            self.assertIn(expected, logger.output)
 
         mock_conn.cursor.return_value.__enter__.return_value.fetchall.return_value = [("cost_model", 200000, {})]
-        expected = re.compile(
-            "INFO:masu.processor.tasks:.*ALTER TABLE acct10001.cost_model "
-            + r"set \(autovacuum_vacuum_scale_factor = 0.011\);"
+        expected = (
+            "INFO:masu.processor.tasks:ALTER TABLE acct10001.cost_model set (autovacuum_vacuum_scale_factor = 0.011);"
         )
         with self.assertLogs("masu.processor.tasks", level="INFO") as logger:
             autovacuum_tune_schema(self.schema)
-            self.assertRegexIn(expected, logger.output)
+            self.assertIn(expected, logger.output)
 
         mock_conn.cursor.return_value.__enter__.return_value.fetchall.return_value = [
             ("cost_model", 200000, {"autovacuum_vacuum_scale_factor": Decimal("0.011")})
         ]
-        expected = re.compile("INFO:masu.processor.tasks:.*Altered autovacuum_vacuum_scale_factor on 0 tables")
+        expected = "INFO:masu.processor.tasks:Altered autovacuum_vacuum_scale_factor on 0 tables"
         with self.assertLogs("masu.processor.tasks", level="INFO") as logger:
             autovacuum_tune_schema(self.schema)
-            self.assertRegexIn(expected, logger.output)
+            self.assertIn(expected, logger.output)
 
         mock_conn.cursor.return_value.__enter__.return_value.fetchall.return_value = [
             ("cost_model", 20000, {"autovacuum_vacuum_scale_factor": Decimal("0.004")})
         ]
-        expected = re.compile(
-            r"INFO:masu.processor.tasks:.*ALTER TABLE acct10001.cost_model reset \(autovacuum_vacuum_scale_factor\);"
-        )
+        expected = "INFO:masu.processor.tasks:ALTER TABLE acct10001.cost_model reset (autovacuum_vacuum_scale_factor);"
         with self.assertLogs("masu.processor.tasks", level="INFO") as logger:
             autovacuum_tune_schema(self.schema)
-            self.assertRegexIn(expected, logger.output)
+            self.assertIn(expected, logger.output)
 
         del os.environ["AUTOVACUUM_TUNING"]
 
@@ -908,21 +896,20 @@ class TestUpdateSummaryTablesTask(MasuTestCase):
         mock_conn.cursor.return_value.__enter__.return_value.fetchall.return_value = [
             ("cost_model", 200000, {"autovacuum_vacuum_scale_factor": Decimal("0.04")})
         ]
-        expected = re.compile("INFO:masu.processor.tasks:.*Altered autovacuum_vacuum_scale_factor on 0 tables")
+        expected = "INFO:masu.processor.tasks:Altered autovacuum_vacuum_scale_factor on 0 tables"
         with self.assertLogs("masu.processor.tasks", level="INFO") as logger:
             autovacuum_tune_schema(self.schema)
-            self.assertRegexIn(expected, logger.output)
+            self.assertIn(expected, logger.output)
 
         mock_conn.cursor.return_value.__enter__.return_value.fetchall.return_value = [
             ("cost_model", 200000, {"autovacuum_vacuum_scale_factor": Decimal("0.06")})
         ]
-        expected = re.compile(
-            "INFO:masu.processor.tasks:.*ALTER TABLE "
-            + r"acct10001.cost_model set \(autovacuum_vacuum_scale_factor = 0.05\);"
+        expected = (
+            "INFO:masu.processor.tasks:ALTER TABLE acct10001.cost_model set (autovacuum_vacuum_scale_factor = 0.05);"
         )
         with self.assertLogs("masu.processor.tasks", level="INFO") as logger:
             autovacuum_tune_schema(self.schema)
-            self.assertRegexIn(expected, logger.output)
+            self.assertIn(expected, logger.output)
 
     @patch("masu.processor.tasks.connection")
     def test_autovacuum_tune_schema_invalid_setting(self, mock_conn):
@@ -937,13 +924,12 @@ class TestUpdateSummaryTablesTask(MasuTestCase):
         mock_conn.cursor.return_value.__enter__.return_value.fetchall.return_value = [
             ("cost_model", 20000000, {"autovacuum_vacuum_scale_factor": ""})
         ]
-        expected = re.compile(
-            "INFO:masu.processor.tasks:.*ALTER TABLE "
-            + r"acct10001.cost_model set \(autovacuum_vacuum_scale_factor = 0.01\);"
+        expected = (
+            "INFO:masu.processor.tasks:ALTER TABLE acct10001.cost_model set (autovacuum_vacuum_scale_factor = 0.01);"
         )
         with self.assertLogs("masu.processor.tasks", level="INFO") as logger:
             autovacuum_tune_schema(self.schema)
-            self.assertRegexIn(expected, logger.output)
+            self.assertIn(expected, logger.output)
 
     def test_autovacuum_tune_schema_normalize(self):
         """Test that the autovacuum tuning runs."""

--- a/koku/masu/test/util/ocp/test_common.py
+++ b/koku/masu/test/util/ocp/test_common.py
@@ -8,7 +8,6 @@ import datetime
 import json
 import os
 import random
-import re
 import shutil
 import tempfile
 from unittest.mock import patch
@@ -244,9 +243,9 @@ class OCPUtilTests(MasuTestCase):
         with tempfile.TemporaryDirectory() as manifest_path:
             manifest_file = f"{manifest_path}/manifest.json"
             with self.assertLogs("masu.util.ocp.common", level="INFO") as logger:
-                expected = re.compile(f"INFO:masu.util.ocp.common:.*No manifest available at {manifest_file}")
+                expected = f"INFO:masu.util.ocp.common:No manifest available at {manifest_file}"
                 utils.get_report_details(manifest_path)
-                self.assertRegexIn(expected, logger.output)
+                self.assertIn(expected, logger.output)
 
             with open(manifest_file, "w") as f:
                 data = {"key": "value"}
@@ -256,6 +255,6 @@ class OCPUtilTests(MasuTestCase):
             with patch("masu.util.ocp.common.open") as mock_open:
                 mock_open.side_effect = OSError
                 with self.assertLogs("masu.util.ocp.common", level="INFO") as logger:
-                    expected = re.compile("ERROR:masu.util.ocp.common:.*Unable to extract manifest data")
+                    expected = "ERROR:masu.util.ocp.common:Unable to extract manifest data"
                     utils.get_report_details(manifest_path)
-                    self.assertRegexIn(expected, logger.output)
+                    self.assertIn(expected, logger.output[0])

--- a/koku/sources/test/api/test_source_status.py
+++ b/koku/sources/test/api/test_source_status.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 """Test the Sources Status HTTP Client."""
-import re
 from unittest.mock import create_autospec
 from unittest.mock import patch
 from uuid import uuid4
@@ -608,5 +607,5 @@ class SourcesStatusTest(IamTestCase):
             status_obj = SourceStatus(source_id)
             with self.assertLogs("sources.api.source_status", level="INFO") as logger:
                 status_obj.status()
-                expected = re.compile(f"INFO:sources.api.source_status:.*No provider found for Source ID: {source_id}")
-                self.assertRegexIn(expected, logger.output)
+                expected = f"INFO:sources.api.source_status:No provider found for Source ID: {source_id}"
+                self.assertIn(expected, logger.output)


### PR DESCRIPTION
We ran into an issue during the last stage release where: 
```
  File "/opt/koku/koku/koku/settings.py", line 34, in koku_log
    if connection.connection and not connection.connection.closed:
```

We need to revert this pr so we can continue to debug the issue while still being able to do stage releases.