### PR TITLE
skip processing/writing empty data frames to parquet

### DIFF
--- a/koku/masu/processor/parquet/parquet_report_processor.py
+++ b/koku/masu/processor/parquet/parquet_report_processor.py
@@ -403,22 +403,23 @@ class ParquetReportProcessor:
                 csv_filename, converters=csv_converters, chunksize=settings.PARQUET_PROCESSING_BATCH_SIZE, **kwargs
             ) as reader:
                 for i, data_frame in enumerate(reader):
-                    if not data_frame.empty:
-                        parquet_filename = f"{parquet_base_filename}_{i}{PARQUET_EXT}"
-                        parquet_file = f"{self.local_path}/{parquet_filename}"
-                        if self.post_processor:
-                            data_frame = self.post_processor(data_frame)
-                            if isinstance(data_frame, tuple):
-                                data_frame, data_frame_tag_keys = data_frame
-                                LOG.info(f"Updating unique keys with {len(data_frame_tag_keys)} keys")
-                                unique_keys.update(data_frame_tag_keys)
-                                LOG.info(f"Total unique keys for file {len(unique_keys)}")
-                        if self.daily_data_processor is not None:
-                            daily_data_frames.append(self.daily_data_processor(data_frame))
+                    if data_frame.empty:
+                        continue
+                    parquet_filename = f"{parquet_base_filename}_{i}{PARQUET_EXT}"
+                    parquet_file = f"{self.local_path}/{parquet_filename}"
+                    if self.post_processor:
+                        data_frame = self.post_processor(data_frame)
+                        if isinstance(data_frame, tuple):
+                            data_frame, data_frame_tag_keys = data_frame
+                            LOG.info(f"Updating unique keys with {len(data_frame_tag_keys)} keys")
+                            unique_keys.update(data_frame_tag_keys)
+                            LOG.info(f"Total unique keys for file {len(unique_keys)}")
+                    if self.daily_data_processor is not None:
+                        daily_data_frames.append(self.daily_data_processor(data_frame))
 
-                        success = self._write_parquet_to_file(parquet_file, parquet_filename, data_frame)
-                        if not success:
-                            return parquet_base_filename, daily_data_frames, False
+                    success = self._write_parquet_to_file(parquet_file, parquet_filename, data_frame)
+                    if not success:
+                        return parquet_base_filename, daily_data_frames, False
             if self.create_table and not self.presto_table_exists.get(self.report_type):
                 self.create_parquet_table(parquet_file)
             create_enabled_keys(self._schema_name, self.enabled_tags_model, unique_keys)


### PR DESCRIPTION
Fixes [COST-####](https://issues.redhat.com/browse/COST-####)

Changes proposed in this PR:
* We don't need to do any processing on empty data frames or add them to our list of daily data frames to be processed in openshift on cloud 


Testing Instructions:
1. Spin everything up in trino, for example: `make docker-up-min-trino`
2. Send a bigquery (OCP on or just GCP, either is fine) GCP source made with nise, if you need help doing this, ask Corey 
3. If you are on main, you will see a few extra parquet files in minio (http://localhost:9090/login) that don't actually contain any data
4. On this branch, you will not see the empty files in minio since we did not process/try to write them to parquet


---
Additional Context: 
