### PR TITLE
Missing UNION, cluster alias as well as ID

### DIFF
--- a/koku/masu/database/gcp_report_db_accessor.py
+++ b/koku/masu/database/gcp_report_db_accessor.py
@@ -25,6 +25,7 @@ from masu.database import GCP_REPORT_TABLE_MAP
 from masu.database.koku_database_access import mini_transaction_delete
 from masu.database.report_db_accessor_base import ReportDBAccessorBase
 from masu.external.date_accessor import DateAccessor
+from masu.util.ocp.common import get_cluster_alias_from_cluster_id
 from reporting.provider.gcp.models import GCPCostEntryBill
 from reporting.provider.gcp.models import GCPCostEntryLineItem
 from reporting.provider.gcp.models import GCPCostEntryLineItemDaily
@@ -491,6 +492,8 @@ class GCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
             days_list, gcp_provider_uuid, openshift_provider_uuid, year, month
         )
 
+        cluster_alias = get_cluster_alias_from_cluster_id(cluster_id)
+
         # Default to cpu distribution
         pod_column = "pod_effective_usage_cpu_core_hours"
         cluster_column = "cluster_capacity_cpu_core_hours"
@@ -517,6 +520,7 @@ class GCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
             "pod_column": pod_column,
             "cluster_column": cluster_column,
             "cluster_id": cluster_id,
+            "cluster_alias": cluster_alias,
         }
         self._execute_presto_multipart_sql_query(self.schema, summary_sql, bind_params=summary_sql_params)
 

--- a/koku/masu/database/ocp_report_db_accessor.py
+++ b/koku/masu/database/ocp_report_db_accessor.py
@@ -2289,7 +2289,7 @@ class OCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
         """Get or create an entry in the OCP cluster table."""
         with schema_context(self.schema):
             cluster, created = OCPCluster.objects.get_or_create(
-                cluster_id=cluster_id, cluster_alias=cluster_id, provider=provider
+                cluster_id=cluster_id, cluster_alias=cluster_alias, provider=provider
             )
 
         if created:

--- a/koku/masu/database/presto_sql/gcp/openshift/reporting_ocpgcpcostlineitem_daily_summary.sql
+++ b/koku/masu/database/presto_sql/gcp/openshift/reporting_ocpgcpcostlineitem_daily_summary.sql
@@ -198,7 +198,8 @@ SELECT gcp.uuid as gcp_uuid,
 FROM hive.{{schema | sqlsafe}}.gcp_openshift_daily as gcp
 JOIN hive.{{ schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary as ocp
     ON date(gcp.usage_start_time) = ocp.usage_start
-        AND strpos(gcp.labels, 'kubernetes-io-cluster-{{cluster_id | sqlsafe}}') != 0 -- THIS IS THE SPECIFIC TO OCP ON GCP TAG MATCH
+        AND (strpos(gcp.labels, 'kubernetes-io-cluster-{{cluster_id | sqlsafe}}') != 0 -- THIS IS THE SPECIFIC TO OCP ON GCP TAG MATCH
+            OR strpos(gcp.labels, 'kubernetes-io-cluster-{{cluster_alias | sqlsafe}}') != 0)
 WHERE gcp.source = '{{gcp_source_uuid | sqlsafe}}'
     AND gcp.year = '{{year | sqlsafe}}'
     AND gcp.month = '{{month | sqlsafe}}'

--- a/koku/masu/database/presto_sql/reporting_ocpinfrastructure_provider_map.sql
+++ b/koku/masu/database/presto_sql/reporting_ocpinfrastructure_provider_map.sql
@@ -50,6 +50,10 @@
         {% endif %}
 {% endif %}
 
+{% if ocp_provider_uuid  %}
+    UNION
+{% endif %}
+
 {% if gcp_provider_uuid %}
     WITH cte_openshift_cluster_info AS (
     SELECT DISTINCT cluster_id,
@@ -61,6 +65,9 @@
     SELECT DISTINCT labels,
         source
     FROM hive.{{schema | sqlsafe}}.gcp_line_items_daily
+    WHERE source = '{{gcp_provider_uuid | sqlsafe}}'
+        AND year = '{{year | sqlsafe}}'
+        AND month = '{{month | sqlsafe}}'
     ),
     cte_label_keys AS (
     SELECT cast(json_parse(labels) as map(varchar, varchar)) as parsed_labels,
@@ -73,5 +80,6 @@
     FROM cte_label_keys as gcp
     INNER JOIN cte_openshift_cluster_info as ocp
         ON any_match(map_keys(gcp.parsed_labels), e -> e = 'kubernetes-io-cluster-' || ocp.cluster_id)
+            OR any_match(map_keys(gcp.parsed_labels), e -> e = 'kubernetes-io-cluster-' || ocp.cluster_alias)
             OR element_at(gcp.parsed_labels, 'openshift_cluster')  IN (ocp.cluster_id, ocp.cluster_alias)
 {% endif %}


### PR DESCRIPTION
Fixes [COST-####](https://issues.redhat.com/browse/COST-####)

Changes proposed in this PR:
* Use Cluster alias for tag matching in addition to cluster_id, after looking at kohls labels, we saw it can/will match on cluster alias so this change was made in the infrastructure matching SQL and the OCPGCP SQL.
* There was a UNION that should have been included in the infrastructure matching SQL

Testing Instructions:
1. Create some nise data that matches OCP on GCP, here are two files and two commands that will create some data with specific cluster id and alias's to match on.
2. [ocp_static_data.yml.txt](OCP YML, remove the .txt github doesnt let you upload ymls)
3. OCP nise command: `nise report ocp --static-report-file ocp_static_data.yml --ocp-cluster-id test-ocp-gcp-cluster --insights-upload testing/pvc_dir/insights_local`
4. [gcp_static_data.yml.txt](GCP YML, remove the .txt github doesnt let you upload ymls)
5. GCP nise command: `nise report gcp --gcp-bucket-name testing/local_providers/gcp_local_1 --static-report-file gcp_static_data.yml`
6. Create your OCP source specifying the cluster alias to be `my-cluster-alias` and the cluster-id to be `test-ocp-gcp-cluster`
7. Sample postman body for a post to `http://localhost:8000/api/cost-management/v1/sources/`  with this info to create the ocp source:
```
{
    "name": "my-cluster-alias",
    "source_type": "OCP",
    "authentication": {
        "credentials": {
            "cluster_id": "test-ocp-gcp-cluster"
        }
    }
}
```
8. Sample postman body for a post to `http://localhost:8000/api/cost-management/v1/sources/`  with this info to create the gcp source:
```
{
    "name": "my-ocpgcp-test",
    "source_type": "GCP-local",
    "authentication": {
        "credentials": {
            "project_id": "my-ocpgcp-test"
        }
    }, "billing_source": {
        "data_source": {"dataset": "numberone", "local_dir":"/tmp/gcp_local_bucket_1"}
        }
}
```
9. After these sources ingest, check the `reporting_ocp_clusters` table to verify the cluster id and alias are included
```
postgres=# select * from reporting_ocp_clusters ;
-[ RECORD 1 ]-+-------------------------------------
uuid          | cb903dc4-0a3b-423a-823c-4af2f998ca9d
cluster_id    | test-ocp-gcp-cluster
cluster_alias | my-cluster-alias
provider_id   | bcdefb7e-aaa3-448c-b88a-1d5a50849632
```
10. Check the OCP on GCP table to verify it matched on both alias and id:
```
postgres=# select distinct(tags) from reporting_ocpgcpcostlineitem_daily_summary_p;
[ RECORD 1 ]------------------------------------------------------------------------------------------------------------
tags | {"app": "winter", "version": "green", "environment": "clyde", "kubernetes-io-cluster-my-cluster-alias": "owned"}
[ RECORD 2 ]------------------------------------------------------------------------------------------------------------
tags | {"app": "spring", "version": "blue", "environment": "murphy", "kubernetes-io-cluster-my-cluster-alias": "owned"}
[ RECORD 3 ]------------------------------------------------------------------------------------------------------------
tags | {"app": "fall", "version": "red", "environment": "ruby", "kubernetes-io-cluster-test-ocp-gcp-cluster": "owned"}
[ RECORD 4 ]------------------------------------------------------------------------------------------------------------
tags | {"app": "snowdown", "version": "red", "environment": "ruby", "kubernetes-io-cluster-test-ocp-gcp-cluster": "owned"}
```

11. For the sake of being thorough, remove the two generators with the `kubernetes-io-cluster-test-ocp-gcp-cluster` tag (or change them, this is just making sure it will match only when cluster alias is available as well) and get a fresh db and repeat the steps and you should still see the cluster alias entries in the ocp gcp table:
```
postgres=# select distinct(tags) from reporting_ocpgcpcostlineitem_daily_summary_p;
[ RECORD 1 ]----------------------------------------------------------------------------------------------------------
tags | {"app": "winter", "version": "green", "environment": "clyde", "kubernetes-io-cluster-my-cluster-alias": "owned"}
[ RECORD 2 ]----------------------------------------------------------------------------------------------------------
tags | {"app": "spring", "version": "blue", "environment": "murphy", "kubernetes-io-cluster-my-cluster-alias": "owned"}
```
---
Additional Context:
