### PR TITLE
[COST-2330] use the first value rather than the first index of the data frame

### DIFF
--- a/koku/masu/processor/parquet/ocp_cloud_parquet_report_processor.py
+++ b/koku/masu/processor/parquet/ocp_cloud_parquet_report_processor.py
@@ -113,7 +113,7 @@ class OCPCloudParquetReportProcessor(ParquetReportProcessor):
         if self._provider_type == Provider.PROVIDER_GCP:
             if data_frame.first_valid_index() is not None:
                 parquet_base_filename = (
-                    f"{data_frame['invoice_month'][0]}{parquet_base_filename[parquet_base_filename.find('_'):]}"
+                    f"{data_frame['invoice_month'].values[0]}{parquet_base_filename[parquet_base_filename.find('_'):]}"
                 )
         file_name = f"{parquet_base_filename}_{file_number}_{ocp_provider_uuid}{PARQUET_EXT}"
         file_path = f"{self.local_path}/{file_name}"


### PR DESCRIPTION
Fixes [COST-2330](https://issues.redhat.com/browse/COST-2330)

Changes proposed in this PR:
* instead of using the value of the first index for the invoice month, use the first actual value
*

Testing Instructions:
1. Revert this change or checkout main, have everything spun up in trino mode: `make docker-up-min-trino`
2. Remove the first index [of the dataframe here](https://github.com/project-koku/koku/blob/main/koku/masu/processor/parquet/ocp_cloud_parquet_report_processor.py#L113-L117) on line 115 after the if but before the filename adjustment
```
data_frame.drop(index=data_frame.index[0], 
                    axis=0, 
                    inplace=True)
```
3. Process some OCP data that matches gcp [this yaml (remove the .txt)](https://github.com/project-koku/koku/files/8063812/ocp_static_data.yml.txt) 
4. Example postman post for the ocp data (this started out taco cluster but i was tweakin stuff and swapped the a with a u): 
```
{
    "name": "tuco-cluster",
    "source_type": "OCP",
    "authentication": {
        "credentials": {
            "cluster_id": "tuco-cluster"
        }
    }
}
```
5. Process matching GCP data from bigquery, [this yaml (remove the .txt)](https://github.com/project-koku/koku/files/8063824/gcp_static_data.yml.txt) if you need help with this, ask corey
6.  Example GCP postman post:
```
{
    "name": "GCP index fail",
    "source_type": "GCP",
    "authentication": {
        "credentials": {
            "project_id": "<my-project-id>"
        }
    },
    "billing_source": {
        "data_source": {
            "dataset": "<my-dataset-name>"
        }
    }
}
```
7. You should see something like this in the logs (similar to what we saw in prod):
```
[2022-02-14 20:39:51,134] ERROR 061898ac-1325-4d3a-b29f-194ab677fe7f {'message': '0', 'tracing_id': 'e0ec9cad-ff1d-430c-ab23-b6ca135d8384:ffc0870c6450b92556898242f71785e4:202202', 'account': '10001', 'provider_uuid': 'e0ec9cad-ff1d-430c-ab23-b6ca135d8384'}
```
8. Repeat steps on this branch and processing will go smoothly

---
Additional Context:
