### PR TITLE
Log unleash startup duration

### DIFF
--- a/koku/koku/celery.py
+++ b/koku/koku/celery.py
@@ -255,7 +255,12 @@ def init_worker(**kwargs):
     from koku.feature_flags import UNLEASH_CLIENT
 
     LOG.info("Initializing UNLEASH_CLIENT for celery worker.")
+    unleash_init_start = datetime.utcnow()
     UNLEASH_CLIENT.initialize_client()
+    LOG.info(
+        "UNLEASH_CLIENT initialized for celery worker in "
+        f"{(datetime.utcnow() - unleash_init_start).total_seconds()} seconds."
+    )
 
 
 @worker_process_shutdown.connect

--- a/koku/koku/test_celery_startup.py
+++ b/koku/koku/test_celery_startup.py
@@ -1,0 +1,22 @@
+"""Tests for celery startup."""
+from koku.celery import init_worker
+from masu.test import MasuTestCase
+
+
+class TestCeleryStartup(MasuTestCase):
+    """Test cases for Celery tasks."""
+
+    def test_unleash_init(self):
+        with self.assertLogs() as logger:
+            init_worker()
+            pre_found = post_found = False
+            for line in logger.output:
+                if not pre_found:
+                    pre_found = "Initializing UNLEASH_CLIENT for celery worker." in line
+                elif not post_found:
+                    post_found = "UNLEASH_CLIENT initialized for celery worker in" in line
+                else:
+                    break
+
+        self.assertTrue(pre_found, "Log pre-init not found")
+        self.assertTrue(post_found, "Log post-init not found")


### PR DESCRIPTION
Fixes [COST-2321](https://issues.redhat.com/browse/COST-2321)

Changes proposed in this PR:
* Log unleash duration to gather statistics in case adding unleash could possibly cause a timeout on worker init


Testing Instructions:
1. Start koku
2. Check worker logs for the message "UNLEASH_CLIENT initialized for celery worker in <n> seconds."

---
Additional Context:

None
