### PR TITLE
Fixing openshift query set for ocp/gcp resource-type

### DIFF
--- a/koku/api/resource_types/gcp_projects/view.py
+++ b/koku/api/resource_types/gcp_projects/view.py
@@ -4,6 +4,7 @@
 #
 """View for GCP Projects."""
 from django.db.models import F
+from django.db.models.functions import Coalesce
 from django.utils.decorators import method_decorator
 from django.views.decorators.vary import vary_on_headers
 from rest_framework import filters
@@ -16,7 +17,7 @@ from api.common.permissions.gcp_access import GcpAccessPermission
 from api.common.permissions.gcp_access import GcpProjectPermission
 from api.resource_types.serializers import ResourceTypeSerializer
 from reporting.provider.gcp.models import GCPTopology
-from reporting.provider.gcp.openshift.models import OCPGCPCostLineItemProjectDailySummaryP
+from reporting.provider.gcp.openshift.models import OCPGCPCostSummaryByGCPProjectP
 
 
 class GCPProjectsView(generics.ListAPIView):
@@ -32,43 +33,6 @@ class GCPProjectsView(generics.ListAPIView):
     @method_decorator(vary_on_headers(CACHE_RH_IDENTITY_HEADER))
     def list(self, request):
         # Reads the users values for GCP project id and displays values related to what the user has access to
-        supported_query_params = ["search", "limit"]
-        error_message = {}
-        query_holder = None
-        # Test for only supported query_params
-        if self.request.query_params:
-            for key in self.request.query_params:
-                if key not in supported_query_params:
-                    error_message[key] = [{"Unsupported parameter"}]
-                    return Response(error_message, status=status.HTTP_400_BAD_REQUEST)
-        if request.user.admin:
-            return super().list(request)
-        if request.user.access:
-            gcp_account_access = request.user.access.get("gcp.account", {}).get("read", [])
-            gcp_project_access = request.user.access.get("gcp.project", {}).get("read", [])
-            # Checks if the access exists, and the user has wildcard access
-            query_holder = self.queryset
-            if gcp_project_access and gcp_project_access[0] != "*":
-                query_holder = query_holder.filter(project_id__in=gcp_project_access)
-            if gcp_account_access and gcp_account_access[0] != "*":
-                query_holder = query_holder.filter(account_id__in=gcp_account_access)
-        self.queryset = query_holder
-        return super().list(request)
-
-
-class OCPGCPNamespaceView(generics.ListAPIView):
-    queryset = (
-        OCPGCPCostLineItemProjectDailySummaryP.objects.annotate(**{"value": F("namespace")}).values("value").distinct()
-    )
-    serializer_class = ResourceTypeSerializer
-    permission_classes = [GcpProjectPermission | GcpAccessPermission]
-    filter_backends = [filters.OrderingFilter, filters.SearchFilter]
-    ordering = ["value"]
-    search_fields = ["$value"]
-
-    @method_decorator(vary_on_headers(CACHE_RH_IDENTITY_HEADER))
-    def list(self, request):
-        # Reads the users values for GCP project id and displays values related to what the user has access to
         supported_query_params = ["search", "limit", "openshift"]
         error_message = {}
         query_holder = None
@@ -78,6 +42,16 @@ class OCPGCPNamespaceView(generics.ListAPIView):
                 if key not in supported_query_params:
                     error_message[key] = [{"Unsupported parameter"}]
                     return Response(error_message, status=status.HTTP_400_BAD_REQUEST)
+                elif key == "openshift":
+                    openshift = self.request.query_params.get("openshift")
+                    if openshift == "true":
+                        self.queryset = (
+                            OCPGCPCostSummaryByGCPProjectP.objects.annotate(
+                                **{"value": F("project_id"), "project": Coalesce(F("project_name"), "project_id")}
+                            )
+                            .values("value", "project")
+                            .distinct()
+                        )
         if request.user.admin:
             return super().list(request)
         if request.user.access:

--- a/koku/api/resource_types/test/gcp_projects/test_views.py
+++ b/koku/api/resource_types/test/gcp_projects/test_views.py
@@ -74,7 +74,7 @@ class ResourceTypesViewTestGcpProjects(MasuTestCase):
             )
         # check that the expected is not zero
         self.assertTrue(expected)
-        url = reverse("gcp-gcp-projects")
+        url = reverse("gcp-projects")
         response = self.client.get(url, **self.headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         json_result = response.json()
@@ -122,7 +122,7 @@ class ResourceTypesViewTestGcpProjects(MasuTestCase):
             )
         # check that the expected is not zero
         self.assertTrue(expected)
-        url = reverse("gcp-gcp-projects")
+        url = reverse("gcp-projects")
         response = self.client.get(url, **self.headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         json_result = response.json()

--- a/koku/api/resource_types/view.py
+++ b/koku/api/resource_types/view.py
@@ -88,7 +88,7 @@ class ResourceTypeView(APIView):
             }
             gcp_project_dict = {
                 "value": "gcp.projects",
-                "path": "/api/cost-management/v1/resource-types/gcp-projectss/",
+                "path": "/api/cost-management/v1/resource-types/gcp-projects/",
                 "count": gcp_project_count,
             }
             cost_model_dict = {

--- a/koku/api/urls.py
+++ b/koku/api/urls.py
@@ -64,7 +64,6 @@ from api.views import OCPCpuView
 from api.views import OCPGCPCostForecastView
 from api.views import OCPGCPCostView
 from api.views import OCPGCPInstanceTypeView
-from api.views import OCPGCPNamespaceView
 from api.views import OCPGCPStorageView
 from api.views import OCPGCPTagView
 from api.views import OCPMemoryView
@@ -322,8 +321,7 @@ urlpatterns = [
     path("user-access/", UserAccessView.as_view(), name="user-access"),
     path("resource-types/aws-accounts/", AWSAccountView.as_view(), name="aws-accounts"),
     path("resource-types/gcp-accounts/", GCPAccountView.as_view(), name="gcp-accounts"),
-    path("resource-types/gcp-projects/", OCPGCPNamespaceView.as_view(), name="gcp-projects"),
-    path("resource-types/gcp-gcp-projects/", GCPProjectsView.as_view(), name="gcp-gcp-projects"),
+    path("resource-types/gcp-projects/", GCPProjectsView.as_view(), name="gcp-projects"),
     path("resource-types/gcp-regions/", GCPRegionView.as_view(), name="gcp-regions"),
     path("resource-types/gcp-services/", GCPServiceView.as_view(), name="gcp-services"),
     path(

--- a/koku/api/views.py
+++ b/koku/api/views.py
@@ -53,7 +53,6 @@ from api.resource_types.azure_subscription_guid.view import AzureSubscriptionGui
 from api.resource_types.cost_models.view import CostModelResourceTypesView
 from api.resource_types.gcp_accounts.view import GCPAccountView
 from api.resource_types.gcp_projects.view import GCPProjectsView
-from api.resource_types.gcp_projects.view import OCPGCPNamespaceView
 from api.resource_types.gcp_regions.view import GCPRegionView
 from api.resource_types.gcp_services.view import GCPServiceView
 from api.resource_types.openshift_clusters.view import OCPClustersView


### PR DESCRIPTION
Fixes [COST-2327](https://issues.redhat.com/browse/COST-2327)

Changes proposed in this PR:
* Switching confusing resource type naming convention from gcp-gcp-projects to gcp-projects
* Removing unneeded ocpgcp namespaces resource type
* Adding openshift=True option to gcp-projects queryset

Testing Instructions:
1. Ingest ocp on gcp data
2.  GET /api/cost-management/v1/resource-types/gcp-projects/?openshift=true

---
Additional Context:
