### PR TITLE
COST-2066: Access denied during listing account aliases (pt2)

### DIFF
--- a/koku/masu/util/aws/common.py
+++ b/koku/masu/util/aws/common.py
@@ -20,7 +20,7 @@ from django.conf import settings
 from tenant_schemas.utils import schema_context
 
 from api.common import log_json
-from api.models import Provider
+from api.provider.models import Provider
 from masu.database.aws_report_db_accessor import AWSReportDBAccessor
 from masu.database.provider_db_accessor import ProviderDBAccessor
 from masu.processor import enable_trino_processing
@@ -163,6 +163,15 @@ def get_local_file_name(cur_key):
     return local_file_name
 
 
+def get_provider_uuid_from_arn(role_arn):
+    """Returns provider_uuid given the arn."""
+    aws_creds = {"role_arn": f"{role_arn}"}
+    query = Provider.objects.filter(authentication_id__credentials=aws_creds)
+    if query.first():
+        return query.first().uuid
+    return None
+
+
 def get_account_alias_from_role_arn(role_arn, session=None):
     """
     Get account ID for given RoleARN.
@@ -174,20 +183,32 @@ def get_account_alias_from_role_arn(role_arn, session=None):
         (String): Account ID
 
     """
+    provider_uuid = get_provider_uuid_from_arn(role_arn)
+    context_key = "aws_list_account_aliases"
     if not session:
         session = get_assume_role_session(role_arn)
     iam_client = session.client("iam")
 
     account_id = role_arn.split(":")[-2]
     alias = account_id
-    try:
-        alias_response = iam_client.list_account_aliases()
-        alias_list = alias_response.get("AccountAliases", [])
-        # Note: Boto3 docs states that you can only have one alias per account
-        # so the pop() should be ok...
-        alias = alias_list.pop() if alias_list else None
-    except ClientError as err:
-        LOG.info("Unable to list account aliases.  Reason: %s", str(err))
+
+    with ProviderDBAccessor(provider_uuid) as provider_accessor:
+        context = provider_accessor.get_additional_context()
+        list_aliases = context.get(context_key, True)
+
+    if list_aliases:
+        try:
+            # raise ClientError(operation_name="", error_response={})
+            alias_response = iam_client.list_account_aliases()
+            alias_list = alias_response.get("AccountAliases", [])
+            # Note: Boto3 docs states that you can only have one alias per account
+            # so the pop() should be ok...
+            alias = alias_list.pop() if alias_list else None
+        except ClientError as err:
+            LOG.info("Unable to list account aliases.  Reason: %s", str(err))
+            context[context_key] = False
+            with ProviderDBAccessor(provider_uuid) as provider_accessor:
+                provider_accessor.set_additional_context(context)
 
     return (account_id, alias)
 
@@ -203,21 +224,29 @@ def get_account_names_by_organization(role_arn, session=None):
         (list): Dictionaries of accounts with id, name keys
 
     """
+    context_key = "crawl_hierarchy"
+    provider_uuid = get_provider_uuid_from_arn(role_arn)
     if not session:
         session = get_assume_role_session(role_arn)
-    org_client = session.client("organizations")
     all_accounts = []
-    try:
-        paginator = org_client.get_paginator("list_accounts")
-        response_iterator = paginator.paginate()
-        for response in response_iterator:
-            accounts = response.get("Accounts", [])
-            for account in accounts:
-                account_id = account.get("Id")
-                name = account.get("Name")
-                all_accounts.append({"id": account_id, "name": name})
-    except ClientError as err:
-        LOG.info("Unable to list accounts using organization API.  Reason: %s", str(err))
+
+    with ProviderDBAccessor(provider_uuid) as provider_accessor:
+        context = provider_accessor.get_additional_context()
+        crawlable = context.get(context_key, True)
+
+    if crawlable:
+        try:
+            org_client = session.client("organizations")
+            paginator = org_client.get_paginator("list_accounts")
+            response_iterator = paginator.paginate()
+            for response in response_iterator:
+                accounts = response.get("Accounts", [])
+                for account in accounts:
+                    account_id = account.get("Id")
+                    name = account.get("Name")
+                    all_accounts.append({"id": account_id, "name": name})
+        except ClientError as err:
+            LOG.info("Unable to list accounts using organization API.  Reason: %s", str(err))
 
     return all_accounts
 

--- a/koku/masu/util/aws/common.py
+++ b/koku/masu/util/aws/common.py
@@ -198,7 +198,6 @@ def get_account_alias_from_role_arn(role_arn, session=None):
 
     if list_aliases:
         try:
-            # raise ClientError(operation_name="", error_response={})
             alias_response = iam_client.list_account_aliases()
             alias_list = alias_response.get("AccountAliases", [])
             # Note: Boto3 docs states that you can only have one alias per account


### PR DESCRIPTION
Fixes [COST-2066](https://issues.redhat.com/browse/COST-2066)

Changes proposed in this PR:
* If we fail to retrieve the account aliases we now update an additional context field in the database to say no longer attempt to download these aliases. 

Testing Instructions:

1. Add an AWS source and check for these logs:
```
koku-worker_1     | [2022-02-16 15:15:28,571] INFO 8ff3edb9-f338-4d81-aec2-6739e6c74c9b Unable to list account aliases.  Reason: An error occurred (AccessDenied) when calling the ListAccountAliases operation: User: ***** is not authorized to perform: iam:ListAccountAliases on resource: *
```

**Note 4 reviewers:** 
I updated the "no-org-unit" policy we used for last week's review to remove the account aliases that we used for last week.  So you can add the same source as last time to test this. 

2. After you see the log check the database:
```
postgres=# set search_path=public;
SET
postgres=# \x auto
Expanded display is used automatically.
postgres=# select * from api_provider;
-[ RECORD 1 ]----------+-------------------------------------
uuid                   | c4b38b2c-dcee-4664-a5fc-c9825e0a3922
name                   | QE AWS
type                   | AWS
setup_complete         | t
created_timestamp      | 2022-02-16 15:15:24.688443+00
data_updated_timestamp | 2022-02-16 15:16:11.880311+00
active                 | t
authentication_id      | 1
billing_source_id      | 1
created_by_id          | 1
customer_id            | 1
infrastructure_id      |
paused                 | f
additional_context     | {"aws_list_account_aliases": false}
```
3. Check the `additional_context` field on the sources endpoint:
```
additional_context": {
                "aws_list_account_aliases": false
            }
```
---

This finishes manual testing of the account alias portion of the pul request. However, I found where we should be checking if crawlable before listing accounts under an organization in this pull request as well. 

--- 
4. Attempt a crawler download:
http://localhost:5042/api/cost-management/v1/crawl_account_hierarchy/?provider_uuid=c4b38b2c-dcee-4664-a5fc-c9825e0a3922

5. Check the database & sources endpoint again

6. Trigger another run of `get_account_names_by_organization`:
```
(koku) bash-3.2$ make shell
>>> from masu.util.aws.common import get_account_names_by_organization
>>> role_arn = 'arn:aws:iam::account_number:role/your-role'
>>> get_account_names_by_organization(role_arn)
[2022-02-16 15:49:34,457] INFO None Unable to list accounts because organization is not crawlable.
[]
```
^^ This should now return an empty list with no error logs. 
