### PR TITLE
Script to show latest migrations by sha

### DIFF
--- a/scripts/show_migrations
+++ b/scripts/show_migrations
@@ -1,66 +1,135 @@
-#!/usr/bin/env bash
-
-TMPFILE=/tmp/_migrations.txt
-GITERR=/tmp/_git_err
-_RESTORE=$(git show -s --format="%H")
-_DIR_RESTORE=$(pwd)
-
-function handle_restore
-{
-    rm -f ${TMPFILE}
-    rm -f ${GITERR}
-    git checkout -q ${_RESTORE}
-    cd ${_DIR_RESTORE}
-}
+#!/usr/bin/env python
+import argparse
+import os
+import re
+import shutil
+import subprocess
+import sys
 
 
-trap "handle_restore" EXIT
-
-cd ${KOKU_PATH}
-git fetch -q
-
-printf "\n"
-
-if [[ -z "$1" || "$1" == "-h" || "$1" == "--help" || "$1" == "-help" ]]
-then
-    printf "\nUsage:\n"
-    printf "\t%s <sha> [<sha> ...]\n\n" ${0##*/}
-    printf "Needs an env var set:\n"
-    printf "\texport KOKU_PATH=/path/to/koku/repo\n\n\n"
-    exit 0
-fi
+GIT = shutil.which("git")
+MIGRATIONS = re.compile(r".+migrations/[0-9]+.*\.py")
+MIGRATION = re.compile("/migrations/(.+)")
+VERBOSE = 0
+MINIMAL = 1
+QUIET = 2
 
 
-sha=$1
-shift
+def resolve_repo_root():
+    script_path = os.path.abspath(sys.argv[0])
+    return os.path.dirname(script_path)
 
-while [[ -n "${sha}" ]]
-do
-    printf "Checking out sha %s\n" "${sha}"
-    git checkout -q ${sha} 2>${GITERR}
-    if [[ $? -ne 0 ]]
-    then
-        _rc=$?
-        cat ${GITERR} 1>&2
-        handle_restore
-        exit $?
-    fi
-    printf "%s:\n" "${sha}" >>${TMPFILE}
 
-    for mig_dir in $(find ${KOKU_PATH}/koku -type d -name migrations | sort)
-    do
-        ls -1 ${mig_dir}/[0-9]*.py | tail -1 >>${TMPFILE}
-    done
-    [[ ${#} -ge 1 ]] && printf -- "------------------\n" >>${TMPFILE}
+def get_migration_info(sha):
+    ls_command = [GIT, "ls-tree", "--full-tree", "-r", sha]
+    buff = None
+    with subprocess.Popen(ls_command, stdout=subprocess.PIPE) as git_process:
+        buff = git_process.stdout.read().decode("utf-8")
 
-    sha=$1
-    shift
-done
+    return buff
 
-printf "\n===========================================\n\n"
 
-cat ${TMPFILE}
+def parse_migration_info(buff):
+    migrations = MIGRATIONS.findall(buff)
+    return migrations
 
-printf "\n===========================================\n\n"
 
-handle_restore
+def get_latest_migrations(migrations):
+    latest_migrations = {}
+    for migration in migrations:
+        info, path = migration.split("\t")
+        obj_id = info.split(" ")[-1]
+        app, _, migration_file = path.split(os.path.sep)[-3:]
+        migration_number = migration_file[:4]
+        latest_migrations.setdefault(app, {})[migration_number] = {"obj_id": obj_id, "file": migration_file}
+
+    return latest_migrations
+
+
+def get_sha_migrations(sha):
+    return get_latest_migrations(parse_migration_info(get_migration_info(sha)))
+
+
+def compare_sha_migrations(old_sha, new_sha):
+    new_app_migrations = {}
+    new_migrations_files = {}
+    changed_migrations = {}
+    old_sha_migrations = get_sha_migrations(old_sha)
+    new_sha_migrations = get_sha_migrations(new_sha)
+
+    new_apps = sorted(set(new_sha_migrations).difference(set(old_sha_migrations)))
+    if new_apps:
+        for new_app in new_apps:
+            new_app_migrations.setdefault(new_app, []).extend(
+                m["file"] for _, m in new_sha_migrations[new_app].items()
+            )
+
+    for app in sorted(old_sha_migrations):
+        old_migrations = old_sha_migrations[app]
+        new_migrations = new_sha_migrations[app]
+        for migration_number in sorted(set(list(old_migrations) + list(new_migrations))):
+            if migration_number in new_migrations and migration_number not in old_migrations:
+                new_migrations_files.setdefault(app, []).append(new_migrations[migration_number]["file"])
+            elif migration_number in new_migrations and migration_number in old_migrations:
+                if old_migrations.get(migration_number).get("obj_id") != new_migrations[migration_number]["obj_id"]:
+                    changed_migrations.setdefault(app, []).append(new_migrations[migration_number]["file"])
+
+    return new_app_migrations, new_migrations_files, changed_migrations
+
+
+def print_migrations(migrations):
+    for app in migrations:
+        print(f"\t{app}:")
+        for migration_file in migrations[app]:
+            print(f"\t\t{migration_file}")
+
+
+def handle_migration_compare(old_sha, new_sha, quiet=VERBOSE):
+    if not quiet:
+        print(f"\nComparing migrations:\nold sha: {old_sha}\nnew sha {new_sha}")
+    new_app_migrations, new_migrations, changed_migrations = compare_sha_migrations(old_sha, new_sha)
+    if new_app_migrations or new_migrations or changed_migrations:
+        if changed_migrations and not new_app_migrations and not new_migrations:
+            migration_action_msg = "Migrations may need to be run"
+            rc = 2
+        else:
+            migration_action_msg = "Migrations ** should ** be run"
+            rc = 1
+
+        if not quiet:
+            if new_app_migrations:
+                print("New apps were created:")
+                print_migrations(new_app_migrations)
+
+            if new_migrations:
+                print("New migrations were created:")
+                print_migrations(new_migrations)
+
+            if changed_migrations:
+                print("Migrations changed between shas")
+                print_migrations(changed_migrations)
+
+        if quiet < QUIET:
+            print(f"\n{migration_action_msg}\n\n")
+    else:
+        if quiet < QUIET:
+            print("No migrations to be run.")
+        rc = 0
+
+    return rc
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-o", "--old-sha", type=str, dest="old_sha", metavar="OLD", required=True, help="Earlier sha")
+    parser.add_argument("-n", "--new-sha", type=str, dest="new_sha", metavar="NEW", required=True, help="Later sha")
+    parser.add_argument(
+        "-s", "--short", action="store_true", dest="short", default=False, required=False, help="Minimal output"
+    )
+    parser.add_argument(
+        "-q", "--quiet", action="store_true", dest="quiet", default=False, required=False, help="No output"
+    )
+    args = parser.parse_args()
+    args.short |= args.quiet
+
+    sys.exit(handle_migration_compare(args.old_sha, args.new_sha, quiet=int(args.short) + int(args.quiet)))

--- a/scripts/show_migrations
+++ b/scripts/show_migrations
@@ -86,7 +86,7 @@ def print_migrations(migrations):
 
 def handle_migration_compare(old_sha, new_sha, quiet=VERBOSE):
     if not quiet:
-        print(f"\nComparing migrations:\nold sha: {old_sha}\nnew sha {new_sha}")
+        print(f"\nComparing migrations:\nold sha: {old_sha}\nnew sha: {new_sha}\n")
     new_app_migrations, new_migrations, changed_migrations = compare_sha_migrations(old_sha, new_sha)
     if new_app_migrations or new_migrations or changed_migrations:
         if changed_migrations and not new_app_migrations and not new_migrations:

--- a/scripts/show_migrations
+++ b/scripts/show_migrations
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+TMPFILE=/tmp/_migrations.txt
+GITERR=/tmp/_git_err
+_RESTORE=$(git rev-parse HEAD)
+_DIR_RESTORE=$(pwd)
+
+function handle_restore
+{
+    rm -f ${TMPFILE}
+    rm -f ${GITERR}
+    git checkout -q ${_RESTORE}
+    cd ${_DIR_RESTORE}
+}
+
+
+trap "handle_restore" EXIT
+
+cd ${KOKU_PATH}
+git fetch -q
+
+printf "\n"
+
+if [[ -z "$1" || "$1" == "-h" || "$1" == "--help" || "$1" == "-help" ]]
+then
+    printf "\nUsage:\n"
+    printf "\t%s <sha> [<sha> ...]\n\n" ${0##*/}
+    printf "Needs an env var set:\n"
+    printf "\texport KOKU_PATH=/path/to/koku/repo\n\n\n"
+    exit 0
+fi
+
+
+sha=$1
+shift
+
+while [[ -n "${sha}" ]]
+do
+    printf "Checking out sha %s\n" "${sha}"
+    git checkout -q ${sha} 2>${GITERR}
+    if [[ $? -ne 0 ]]
+    then
+        _rc=$?
+        cat ${GITERR} 1>&2
+        handle_restore
+        exit $?
+    fi
+    printf "%s:\n" "${sha}" >>${TMPFILE}
+
+    for mig_dir in $(find ${KOKU_PATH}/koku -type d -name migrations | sort)
+    do
+        ls -1 ${mig_dir}/[0-9]*.py | tail -1 >>${TMPFILE}
+    done
+    [[ ${#} -ge 1 ]] && printf -- "------------------\n" >>${TMPFILE}
+
+    sha=$1
+    shift
+done
+
+printf "\n===========================================\n\n"
+
+cat ${TMPFILE}
+
+printf "\n===========================================\n\n"
+
+handle_restore

--- a/scripts/show_migrations
+++ b/scripts/show_migrations
@@ -2,7 +2,7 @@
 
 TMPFILE=/tmp/_migrations.txt
 GITERR=/tmp/_git_err
-_RESTORE=$(git rev-parse HEAD)
+_RESTORE=$(git show -s --format="%H")
 _DIR_RESTORE=$(pwd)
 
 function handle_restore


### PR DESCRIPTION
## Description

This change introduces a new helper script for developers on release duty.

This script is `scripts/show_migrations`

### Usage

```
usage: show_migrations [-h] -o OLD -n NEW [-s] [-q]

optional arguments:
  -h, --help            show this help message and exit
  -o OLD, --old-sha OLD
                        Earlier sha
  -n NEW, --new-sha NEW
                        Later sha
  -s, --short           Minimal output
  -q, --quiet           No output
```

On successful completion, the script will exit to shell with the following values:

* 0 (zero) no migration run needed
* 1 migrations should be run
* 2 migrations may need to be run (migration numbers matched, but object ids have changed)

### Utilization

The intended use of this script is to compare the prior release sha to the sha of the current release to see if the migration files are different. This will indicate that a DB migration CJI should be run.

## Example

```bash
./scripts/show_migrations -o f6436e9786f8d2cd0a086c5ff39c2b090409c043 -n main 

Comparing migrations:
old sha: f6436e9786f8d2cd0a086c5ff39c2b090409c043
new sha main
New migrations were created:
	api:
		0030_auto_20201007_1403.py
		0031_clone_schema.py
		0032_presto_delete_log_trigger_func.py
		0033_sources_name_text.py
		0034_remove_sources_endpoint_id.py
		0035_reapply_partition_and_clone_func.py
		0036_reapply_check_migrations_func.py
		0037_auto_20210223_2136.py
		0038_drop_app_needs_migrations_func.py
		0039_create_hive_db.py
		0040_auto_20210318_1514.py
		0041_array_subtract_dbfunc.py
		0042_reapply_clone_func.py
		0043_apply_turbo_schema_clone_func.py
		0044_auto_20210505_1747.py
		0045_update_django_migration_sequences.py
		0046_jsonb_sha256_text.py
		0047_update_django_migration_sequences.py
		0048_new_partition_manager_func.py
		0049_auto_20210818_2208.py
		0050_exchangerates.py
		0051_reapply_partition_trigger_func.py
		0052_sources_provider.py
		0053_additional_context.py
	cost_models:
		0003_auto_20210615_2011.py
		0004_auto_20210903_1559.py
	reporting:
		0190_ocp_on_all_partitioned_models.py
		0191_currencysettings.py
		0192_gcp_bigquery_partition.py
		0193_gcptopology.py
		0194_awscostentrylineitemdailysummary_savingsplan_effective_cost.py
		0195_ocpall_add_source_fk.py
		0196_ocpall_cvt_matview_to_part.py
		0197_usersettings.py
		0198_aws_matviews_to_partables.py
		0199_aws_perspective_colname_idx.py
		0200_ocpgcp_partables.py
		0201_ocp_partables.py
		0202_azure_partables.py
		0203_auto_20211108_1626.py
		0204_auto_20211110_2118.py
		0205_ocpall_perspective_db_defaults.py
		0206_auto_20211115_1322.py
		0207_auto_20211115_2234.py
		0208_savingsplan_markup_fields.py
		0209_gcp_partables.py
		0210_ocpaws_partables.py
		0211_ocpaz_partables.py
		0212_auto_20211203_1640.py
		0213_delete_mat_views.py
		0214_ocpgcp_unitusage.py
		0215_ocpaws_ocpazure_summary_partables.py
		0216_drop_old_aws_partables.py
		0217_auto_20220124_1634.py
		0218_rm_unused_gcp_partables.py
	reporting_common:
		0027_auto_20210412_1731.py
		0028_costusagereportmanifest_operator_version.py
		0029_costusagereportmanifest_operator_info.py
		0030_costusagereportmanifest_cluster_id.py
		0031_costusagereportmanifest_export_time.py
Migrations changed between shas
	api:
		0001_initial.py
	cost_models:
		0001_initial.py
		0002_auto_20210318_1514.py
	reporting:
		0001_initial-from-template.py
	reporting_common:
		0001_initial.py

Migrations ** should ** be run

```
