### PR TITLE
COST-2324: Handle AWS access denied errors downloading from S3

### DIFF
--- a/koku/masu/external/downloader/aws/aws_report_downloader.py
+++ b/koku/masu/external/downloader/aws/aws_report_downloader.py
@@ -129,8 +129,17 @@ class AWSReportDownloader(ReportDownloaderBase, DownloaderInterface):
         """
         size_ok = False
 
-        s3fileobj = self.s3_client.get_object(Bucket=self.report.get("S3Bucket"), Key=s3key)
-        size = int(s3fileobj.get("ContentLength", -1))
+        try:
+            s3fileobj = self.s3_client.get_object(Bucket=self.report.get("S3Bucket"), Key=s3key)
+            size = int(s3fileobj.get("ContentLength", -1))
+        except ClientError as ex:
+            if ex.response["Error"]["Code"] == "AccessDenied":
+                msg = "Unable to access S3 Bucket {}: (AccessDenied)".format(self.report.get("S3Bucket"))
+                LOG.info(log_json(self.tracing_id, msg, self.context))
+                raise AWSReportDownloaderAccessDenied(msg)
+            msg = f"Error downloading file: Error: {str(ex)}"
+            LOG.error(log_json(self.tracing_id, msg, self.context))
+            raise AWSReportDownloaderError(str(ex))
 
         if size < 0:
             raise AWSReportDownloaderError(f"Invalid size for S3 object: {s3fileobj}")

--- a/koku/masu/external/downloader/aws/aws_report_downloader.py
+++ b/koku/masu/external/downloader/aws/aws_report_downloader.py
@@ -35,6 +35,10 @@ class AWSReportDownloaderNoFileError(Exception):
     """AWS Report Downloader error for missing file."""
 
 
+class AWSReportDownloaderAccessDenied(Exception):
+    """AWS Report Downloader error for access denied."""
+
+
 class AWSReportDownloader(ReportDownloaderBase, DownloaderInterface):
     """
     AWS Cost and Usage Report Downloader.
@@ -237,7 +241,10 @@ class AWSReportDownloader(ReportDownloaderBase, DownloaderInterface):
                 msg = "Unable to find {} in S3 Bucket: {}".format(s3_filename, self.report.get("S3Bucket"))
                 LOG.info(log_json(self.tracing_id, msg, self.context))
                 raise AWSReportDownloaderNoFileError(msg)
-
+            if ex.response["Error"]["Code"] == "AccessDenied":
+                msg = "Unable to access S3 Bucket {}: (AccessDenied)".format(self.report.get("S3Bucket"))
+                LOG.info(log_json(self.tracing_id, msg, self.context))
+                raise AWSReportDownloaderAccessDenied(msg)
             msg = f"Error downloading file: Error: {str(ex)}"
             LOG.error(log_json(self.tracing_id, msg, self.context))
             raise AWSReportDownloaderError(str(ex))

--- a/koku/masu/external/downloader/aws/aws_report_downloader.py
+++ b/koku/masu/external/downloader/aws/aws_report_downloader.py
@@ -35,10 +35,6 @@ class AWSReportDownloaderNoFileError(Exception):
     """AWS Report Downloader error for missing file."""
 
 
-class AWSReportDownloaderAccessDenied(Exception):
-    """AWS Report Downloader error for access denied."""
-
-
 class AWSReportDownloader(ReportDownloaderBase, DownloaderInterface):
     """
     AWS Cost and Usage Report Downloader.
@@ -136,7 +132,7 @@ class AWSReportDownloader(ReportDownloaderBase, DownloaderInterface):
             if ex.response["Error"]["Code"] == "AccessDenied":
                 msg = "Unable to access S3 Bucket {}: (AccessDenied)".format(self.report.get("S3Bucket"))
                 LOG.info(log_json(self.tracing_id, msg, self.context))
-                raise AWSReportDownloaderAccessDenied(msg)
+                raise AWSReportDownloaderNoFileError(msg)
             msg = f"Error downloading file: Error: {str(ex)}"
             LOG.error(log_json(self.tracing_id, msg, self.context))
             raise AWSReportDownloaderError(str(ex))
@@ -253,7 +249,7 @@ class AWSReportDownloader(ReportDownloaderBase, DownloaderInterface):
             if ex.response["Error"]["Code"] == "AccessDenied":
                 msg = "Unable to access S3 Bucket {}: (AccessDenied)".format(self.report.get("S3Bucket"))
                 LOG.info(log_json(self.tracing_id, msg, self.context))
-                raise AWSReportDownloaderAccessDenied(msg)
+                raise AWSReportDownloaderNoFileError(msg)
             msg = f"Error downloading file: Error: {str(ex)}"
             LOG.error(log_json(self.tracing_id, msg, self.context))
             raise AWSReportDownloaderError(str(ex))

--- a/koku/masu/test/external/downloader/aws/test_aws_report_downloader.py
+++ b/koku/masu/test/external/downloader/aws/test_aws_report_downloader.py
@@ -21,7 +21,6 @@ from masu.exceptions import MasuProviderError
 from masu.external import AWS_REGIONS
 from masu.external.date_accessor import DateAccessor
 from masu.external.downloader.aws.aws_report_downloader import AWSReportDownloader
-from masu.external.downloader.aws.aws_report_downloader import AWSReportDownloaderAccessDenied
 from masu.external.downloader.aws.aws_report_downloader import AWSReportDownloaderError
 from masu.external.downloader.aws.aws_report_downloader import AWSReportDownloaderNoFileError
 from masu.external.report_downloader import ReportDownloader
@@ -306,7 +305,7 @@ class AWSReportDownloaderTest(MasuTestCase):
         downloader.s3_client = fake_client
 
         fakekey = self.fake.file_path(depth=random.randint(1, 5), extension=random.choice(["json", "csv.gz"]))
-        with self.assertRaises(AWSReportDownloaderAccessDenied):
+        with self.assertRaises(AWSReportDownloaderNoFileError):
             downloader._check_size(fakekey, check_inflate=False)
 
     @patch("masu.util.aws.common.get_assume_role_session", return_value=FakeSession)
@@ -404,7 +403,7 @@ class AWSReportDownloaderTest(MasuTestCase):
         downloader = AWSReportDownloader(self.fake_customer_name, self.credentials, self.data_source)
         downloader.s3_client = fake_client
 
-        with self.assertRaises(AWSReportDownloaderAccessDenied):
+        with self.assertRaises(AWSReportDownloaderNoFileError):
             downloader.download_file(self.fake.file_path())
 
     def test_remove_manifest_file(self):

--- a/koku/masu/test/external/downloader/aws/test_aws_report_downloader.py
+++ b/koku/masu/test/external/downloader/aws/test_aws_report_downloader.py
@@ -312,7 +312,7 @@ class AWSReportDownloaderTest(MasuTestCase):
     @patch("masu.util.aws.common.get_assume_role_session", return_value=FakeSession)
     def test_check_size_fail_unknown_error(self, fake_session):
         """Test _check_size fails if there report has no size."""
-        fake_response = {"Error": {"Unknown": "Unknown"}}
+        fake_response = {"Error": {"Code": "Unknown"}}
         fake_client = Mock()
         fake_client.get_object.side_effect = ClientError(fake_response, "masu-test")
 


### PR DESCRIPTION
Fixes [COST-2324](https://issues.redhat.com/browse/COST-2324)

Changes proposed in this PR:
* This pull request is to handle access denied errors when trying to download the csv from the S3 bucket.

Testing Instructions:
1. Add the same source that we used for the previous AWS permissions issues. (If you don't know the source details, feel free to reach out to me.)

I updated the policy permissions on that source to trigger the Access Denied when attempting to download the file from the S3 bucket. 

- Check the logs:
```
koku-worker_1     | [2022-02-16 22:12:43,460] INFO f68277fc-57cf-4a39-9541-1dc5d526fddb {'message': 'Unable to access S3 Bucket bucket-name-here: (AccessDenied)', 'tracing_id': 'no_tracing_id', 'provider_uuid': UUID('10424d1f-ccab-4add-ab22-f35211913126'), 'provider_type': 'AWS', 'account': '10001'}
```

---
Additional Context:
