### PR TITLE
fix model bakery tags update

### DIFF
--- a/koku/api/report/test/util/model_bakery_loader.py
+++ b/koku/api/report/test/util/model_bakery_loader.py
@@ -347,7 +347,6 @@ class ModelBakeryDataLoader(DataLoader):
             daily_summary_recipe = "api.report.test.util.ocp_on_aws_daily_summary"
             project_summary_pod_recipe = "api.report.test.util.ocp_on_aws_project_daily_summary_pod"
             project_summary_storage_recipe = "api.report.test.util.ocp_on_aws_project_daily_summary_storage"
-            # tags_update_method = partial(AWSReportDBAccessor(self.schema).populate_ocp_on_aws_tags_summary_table)
             dbaccessor, tags_update_method = AWSReportDBAccessor, "populate_ocp_on_aws_tags_summary_table"
             with schema_context(self.schema):
                 account_alias = random.choice(list(AWSAccountAlias.objects.all()))
@@ -356,14 +355,12 @@ class ModelBakeryDataLoader(DataLoader):
             daily_summary_recipe = "api.report.test.util.ocp_on_azure_daily_summary"
             project_summary_pod_recipe = "api.report.test.util.ocp_on_azure_project_daily_summary_pod"
             project_summary_storage_recipe = "api.report.test.util.ocp_on_azure_project_daily_summary_storage"
-            # tags_update_method = partial(AzureReportDBAccessor(self.schema).populate_ocp_on_azure_tags_summary_table)
             dbaccessor, tags_update_method = AzureReportDBAccessor, "populate_ocp_on_azure_tags_summary_table"
             unique_fields = {"currency": self.currency, "subscription_guid": self.faker.uuid4()}
         elif provider_type in (Provider.PROVIDER_GCP, Provider.PROVIDER_GCP_LOCAL):
             daily_summary_recipe = "api.report.test.util.ocp_on_gcp_daily_summary"
             project_summary_pod_recipe = "api.report.test.util.ocp_on_gcp_project_daily_summary_pod"
             project_summary_storage_recipe = "api.report.test.util.ocp_on_gcp_project_daily_summary_storage"
-            # tags_update_method = partial(GCPReportDBAccessor(self.schema).populate_ocp_on_gcp_tags_summary_table)
             dbaccessor, tags_update_method = GCPReportDBAccessor, "populate_ocp_on_gcp_tags_summary_table"
             unique_fields = {
                 "currency": self.currency,

--- a/koku/api/report/test/util/model_bakery_loader.py
+++ b/koku/api/report/test/util/model_bakery_loader.py
@@ -6,7 +6,6 @@
 import logging
 import random
 from datetime import timedelta
-from functools import partial
 from itertools import cycle
 from itertools import product
 
@@ -348,7 +347,8 @@ class ModelBakeryDataLoader(DataLoader):
             daily_summary_recipe = "api.report.test.util.ocp_on_aws_daily_summary"
             project_summary_pod_recipe = "api.report.test.util.ocp_on_aws_project_daily_summary_pod"
             project_summary_storage_recipe = "api.report.test.util.ocp_on_aws_project_daily_summary_storage"
-            tags_update_method = partial(AWSReportDBAccessor(self.schema).populate_ocp_on_aws_tags_summary_table)
+            # tags_update_method = partial(AWSReportDBAccessor(self.schema).populate_ocp_on_aws_tags_summary_table)
+            dbaccessor, tags_update_method = AWSReportDBAccessor, "populate_ocp_on_aws_tags_summary_table"
             with schema_context(self.schema):
                 account_alias = random.choice(list(AWSAccountAlias.objects.all()))
             unique_fields = {"currency_code": self.currency, "account_alias": account_alias}
@@ -356,13 +356,15 @@ class ModelBakeryDataLoader(DataLoader):
             daily_summary_recipe = "api.report.test.util.ocp_on_azure_daily_summary"
             project_summary_pod_recipe = "api.report.test.util.ocp_on_azure_project_daily_summary_pod"
             project_summary_storage_recipe = "api.report.test.util.ocp_on_azure_project_daily_summary_storage"
-            tags_update_method = partial(AzureReportDBAccessor(self.schema).populate_ocp_on_azure_tags_summary_table)
+            # tags_update_method = partial(AzureReportDBAccessor(self.schema).populate_ocp_on_azure_tags_summary_table)
+            dbaccessor, tags_update_method = AzureReportDBAccessor, "populate_ocp_on_azure_tags_summary_table"
             unique_fields = {"currency": self.currency, "subscription_guid": self.faker.uuid4()}
         elif provider_type in (Provider.PROVIDER_GCP, Provider.PROVIDER_GCP_LOCAL):
             daily_summary_recipe = "api.report.test.util.ocp_on_gcp_daily_summary"
             project_summary_pod_recipe = "api.report.test.util.ocp_on_gcp_project_daily_summary_pod"
             project_summary_storage_recipe = "api.report.test.util.ocp_on_gcp_project_daily_summary_storage"
-            tags_update_method = partial(GCPReportDBAccessor(self.schema).populate_ocp_on_gcp_tags_summary_table)
+            # tags_update_method = partial(GCPReportDBAccessor(self.schema).populate_ocp_on_gcp_tags_summary_table)
+            dbaccessor, tags_update_method = GCPReportDBAccessor, "populate_ocp_on_gcp_tags_summary_table"
             unique_fields = {
                 "currency": self.currency,
                 "account_id": self.faker.pystr_format(string_format="####################"),
@@ -415,7 +417,8 @@ class ModelBakeryDataLoader(DataLoader):
                         _quantity=len(self.tags),
                         **unique_fields,
                     )
-
-        tags_update_method([bill.id for bill in bills], self.first_start_date, self.last_end_date)
+        with dbaccessor(self.schema) as accessor:
+            cls_method = getattr(accessor, tags_update_method)
+            cls_method([bill.id for bill in bills], self.first_start_date, self.last_end_date)
 
         refresh_materialized_views(self.schema, provider_type, provider_uuid=provider.uuid, synchronous=True)


### PR DESCRIPTION
The ocp-on-cloud tags summary updater was not resetting the schema to public which caused the additional test Tenant creation to fail. This PR uses a context manager to update the tags which resets the schema when done.