### PR TITLE
Add back rank columns to table defs.

### DIFF
--- a/koku/masu/database/presto_sql/gcp/openshift/reporting_ocpgcpcostlineitem_daily_summary.sql
+++ b/koku/masu/database/presto_sql/gcp/openshift/reporting_ocpgcpcostlineitem_daily_summary.sql
@@ -42,7 +42,9 @@ CREATE TABLE IF NOT EXISTS hive.{{schema | sqlsafe}}.reporting_ocpgcpcostlineite
     cluster_capacity_cpu_core_hours double,
     cluster_capacity_memory_gigabyte_hours double,
     volume_labels varchar,
-    tags varchar
+    tags varchar,
+    project_rank integer,
+    data_source_rank integer
 ) WITH(format = 'PARQUET')
 ;
 
@@ -89,6 +91,8 @@ CREATE TABLE IF NOT EXISTS hive.{{schema | sqlsafe}}.reporting_ocpgcpcostlineite
     cluster_capacity_memory_gigabyte_hours double,
     volume_labels varchar,
     tags varchar,
+    project_rank integer,
+    data_source_rank integer,
     gcp_source varchar,
     ocp_source varchar,
     year varchar,

--- a/koku/masu/database/presto_sql/reporting_ocpawscostlineitem_daily_summary.sql
+++ b/koku/masu/database/presto_sql/reporting_ocpawscostlineitem_daily_summary.sql
@@ -40,6 +40,8 @@ CREATE TABLE IF NOT EXISTS hive.{{schema | sqlsafe}}.reporting_ocpawscostlineite
     pod_labels varchar,
     volume_labels varchar,
     tags varchar,
+    project_rank integer,
+    data_source_rank integer,
     resource_id_matched boolean
 ) WITH(format = 'PARQUET')
 ;
@@ -75,6 +77,8 @@ CREATE TABLE IF NOT EXISTS hive.{{schema | sqlsafe}}.reporting_ocpawscostlineite
     project_markup_cost double,
     pod_labels varchar,
     tags varchar,
+    project_rank integer,
+    data_source_rank integer,
     aws_source varchar,
     ocp_source varchar,
     year varchar,

--- a/koku/masu/database/presto_sql/reporting_ocpazurecostlineitem_daily_summary.sql
+++ b/koku/masu/database/presto_sql/reporting_ocpazurecostlineitem_daily_summary.sql
@@ -38,6 +38,8 @@ CREATE TABLE IF NOT EXISTS hive.{{schema | sqlsafe}}.reporting_ocpazurecostlinei
     pod_labels varchar,
     volume_labels varchar,
     tags varchar,
+    project_rank integer,
+    data_source_rank integer,
     resource_id_matched boolean
 ) WITH(format = 'PARQUET')
 ;
@@ -70,6 +72,8 @@ CREATE TABLE IF NOT EXISTS hive.{{schema | sqlsafe}}.reporting_ocpazurecostlinei
     project_markup_cost double,
     pod_labels varchar,
     tags varchar,
+    project_rank integer,
+    data_source_rank integer,
     azure_source varchar,
     ocp_source varchar,
     year varchar,


### PR DESCRIPTION

---
Additional Context: Adds back the already defined columns to hive tables to avoid the need for a migration. That column successfully populates with the SQL as-is, just has NULL values. 
