### PR TITLE
Adding old endpoint to not break the UI

### DIFF
--- a/koku/api/urls.py
+++ b/koku/api/urls.py
@@ -322,6 +322,8 @@ urlpatterns = [
     path("resource-types/aws-accounts/", AWSAccountView.as_view(), name="aws-accounts"),
     path("resource-types/gcp-accounts/", GCPAccountView.as_view(), name="gcp-accounts"),
     path("resource-types/gcp-projects/", GCPProjectsView.as_view(), name="gcp-projects"),
+    # TODO gcp-gcp-projects should be removed after UI is pushed to prod.
+    path("resource-types/gcp-gcp-projects/", GCPProjectsView.as_view(), name="gcp-gcp-projects"),
     path("resource-types/gcp-regions/", GCPRegionView.as_view(), name="gcp-regions"),
     path("resource-types/gcp-services/", GCPServiceView.as_view(), name="gcp-services"),
     path(


### PR DESCRIPTION
Fixes [COST-2327]

Changes proposed in this PR:
* Adding gcp-gcp-projects endpoint back in so it can be deprecated correctly once the UI is updated.

Testing Instructions:
1. Load GCP data
GET http://localhost:8000/api/cost-management/v1/resource-types/gcp-gcp-projects/

