### PR TITLE
Safe ORM attribute access

### DIFF
--- a/koku/masu/external/accounts/db/cur_accounts_db.py
+++ b/koku/masu/external/accounts/db/cur_accounts_db.py
@@ -18,7 +18,7 @@ class CURAccountsDB(CURAccountsInterface):
     def get_account_information(provider):
         """Return account information in dictionary."""
         return {
-            "customer_name": provider.customer.schema_name,
+            "customer_name": getattr(provider.customer, "schema_name", None),
             "credentials": getattr(provider.authentication, "credentials", None),
             "data_source": getattr(provider.billing_source, "data_source", None),
             "provider_type": provider.type,

--- a/koku/masu/external/accounts/db/cur_accounts_db.py
+++ b/koku/masu/external/accounts/db/cur_accounts_db.py
@@ -19,10 +19,10 @@ class CURAccountsDB(CURAccountsInterface):
         """Return account information in dictionary."""
         return {
             "customer_name": provider.customer.schema_name,
-            "credentials": provider.authentication.credentials,
-            "data_source": provider.billing_source.data_source,
+            "credentials": getattr(provider.authentication, "credentials", None),
+            "data_source": getattr(provider.billing_source, "data_source", None),
             "provider_type": provider.type,
-            "schema_name": provider.customer.schema_name,
+            "schema_name": getattr(provider.customer, "schema_name", None),
             "provider_uuid": provider.uuid,
         }
 

--- a/koku/masu/test/external/accounts/db/test_cur_accounts_db.py
+++ b/koku/masu/test/external/accounts/db/test_cur_accounts_db.py
@@ -11,6 +11,24 @@ from masu.test import MasuTestCase
 class CURAccountsDBTest(MasuTestCase):
     """Test Cases for the CURAccountsDB object."""
 
+    def test_handle_missing_foreign_data(self):
+        p = Provider.objects.first()
+        p.customer = None
+        p.billing_source = None
+        p.authentication = None
+        exc = None
+
+        try:
+            info = CURAccountsDB.get_account_information(p)
+        except Exception as e:
+            exc = e
+
+        self.assertIsNone(exc)
+        self.assertIsNone(info["customer_name"])
+        self.assertIsNone(info["credentials"])
+        self.assertIsNone(info["data_source"])
+        self.assertIsNone(info["schema_name"])
+
     def test_get_accounts_from_source(self):
         """Test to get all accounts."""
         accounts = CURAccountsDB().get_accounts_from_source()


### PR DESCRIPTION
Fixes [COST-2346](https://issues.redhat.com/browse/COST-2346)

Changes proposed in this PR:
* Safe ORM attribute access from FK fields. This will return `None` if foreign keys cannot be resolved. Prior behavior was to throw `AttributeError` exceptions.


Testing Instructions:
1. `make docker-reinitdb-with-sources` (if there are no providers in your DB)
2. Execute a django shell
2. Execute
    ```python
    from masu.external.accounts.db.cur_accounts_db import CURAccountsDB
    from koku.database import get_model
    Provider = get_model("Provider")
    p = Provider.objects.first()
    p.authentication = None
    p.customer = None
    p.billing_source = None
    CURAccountsDB.get_account_information(p)
    ```
3. You should see `None` for the following keys `credentials`, `customer_name`, `data_source`, `schema_name`
