### PR TITLE
[COST-2353] Handle a null tag value coming from GCP

### DIFF
--- a/koku/masu/database/sql/gcp/openshift/reporting_ocpgcptags_summary.sql
+++ b/koku/masu/database/sql/gcp/openshift/reporting_ocpgcptags_summary.sql
@@ -13,6 +13,7 @@ WITH cte_tag_value AS (
         unnest(li.namespace) projects(project)
     WHERE li.usage_start >= {{start_date}}
         AND li.usage_start <= {{end_date}}
+        AND value IS NOT NULL
     {% if bill_ids %}
         AND li.cost_entry_bill_id IN (
         {%- for bill_id in bill_ids -%}

--- a/koku/masu/database/sql/reporting_gcptags_summary.sql
+++ b/koku/masu/database/sql/reporting_gcptags_summary.sql
@@ -9,6 +9,7 @@ WITH cte_tag_value AS (
         jsonb_each_text(li.tags) labels
     WHERE li.usage_start >= {{start_date}}
         AND li.usage_start <= {{end_date}}
+        AND value IS NOT NULL
     {% if bill_ids %}
         AND li.cost_entry_bill_id IN (
         {%- for bill_id in bill_ids -%}

--- a/koku/masu/test/util/ocp/test_common.py
+++ b/koku/masu/test/util/ocp/test_common.py
@@ -238,6 +238,26 @@ class OCPUtilTests(MasuTestCase):
             result = utils.match_openshift_labels(td, matched_tags)
             self.assertEqual(result, expected)
 
+    def test_match_openshift_labels_null_value(self):
+        """Test that a label match doesn't return null tag values."""
+        matched_tags = [{"key": "value"}, {"other_key": "other_value"}]
+
+        tag_dicts = [
+            {"tag": json.dumps({"key": "value"}), "expected": '"key": "value"'},
+            {"tag": json.dumps({"key": "other_value"}), "expected": ""},
+            {
+                "tag": json.dumps({"key": "value", "other_key": "other_value"}),
+                "expected": '"key": "value","other_key": "other_value"',
+            },
+            {"tag": json.dumps({"key": "value", "other_key": None}), "expected": '"key": "value"'},
+        ]
+
+        for tag_dict in tag_dicts:
+            td = tag_dict.get("tag")
+            expected = tag_dict.get("expected")
+            result = utils.match_openshift_labels(td, matched_tags)
+            self.assertEqual(result, expected)
+
     def test_get_report_details(self):
         """Test that we handle manifest files properly."""
         with tempfile.TemporaryDirectory() as manifest_path:

--- a/koku/masu/util/ocp/common.py
+++ b/koku/masu/util/ocp/common.py
@@ -466,6 +466,8 @@ def match_openshift_labels(tag_dict, matched_tags):
     tag_dict = json.loads(tag_dict)
     tag_matches = []
     for key, value in tag_dict.items():
+        if not value:
+            continue
         lower_tag = {key.lower(): value.lower()}
         if lower_tag in matched_tags:
             tag = json.dumps(lower_tag).replace("{", "").replace("}", "")


### PR DESCRIPTION
Fixes [COST-2353](https://issues.redhat.com/browse/COST-2353)

Changes proposed in this PR:
* Filter out null values in gcp and ocp on gcp tags summaries
* In match openshift labels, if the value is null continue through the loop

Testing Instructions:
1. Bring everything up with trino, for example: `make docker-up-min-trino`
2. Create a gcp bigquery source with a Null value for a label (if you need help with this, ask Corey) 
3. Example yml to use for the bigquery source (remove the .txt github doesnt let you upload a yml)
[gcp_static_data.yml.txt](https://github.com/project-koku/koku/files/8125657/gcp_static_data.yml.txt)

4. Send the source to cost management and watch the logs as it creates. If you are on main, you will see an error similar to:
```
koku-worker_1     | [2022-02-23 14:12:37,654] ERROR 78282aab-b499-4900-8806-c575041031d9 Task failed: null value in column "value" of relation "reporting_gcptags_values" violates not-null constraint
```
If you are on this branch, you will not see the error

---
Additional Context:

- Chatted with Eva about the smoke failures and she ran them locally and said it should be good