### PR TITLE
Cost 2133

### DIFF
--- a/.unleash/flags.json
+++ b/.unleash/flags.json
@@ -35,9 +35,39 @@
             ],
             "variants": [],
             "createdAt": "2021-09-14T21:22:00.756Z"
+        },
+        {
+            "name": "hcs-data-processor",
+            "description": "any account listed in this strategy will be allowed to generate HCS report data",
+            "type": "permission",
+            "project": "default",
+            "enabled": true,
+            "stale": false,
+            "strategies": [
+                {
+                    "name": "HCSCustomers",
+                    "parameters": {
+                        "schema-name": ""
+                    }
+                }
+            ],
+            "variants": [],
+            "createdAt": "2022-02-22T15:48:54.492Z"
         }
     ],
     "strategies": [
+        {
+            "name": "HCSCustomers",
+            "description": "accounts for HCS data generation",
+            "parameters": [
+                {
+                    "name": "schema-name",
+                    "type": "list",
+                    "description": "values must start with `acct`",
+                    "required": false
+                }
+            ]
+        },
         {
             "name": "schema-strategy",
             "description": "Enablement based on account/schema number",

--- a/.unleash/flags.json
+++ b/.unleash/flags.json
@@ -45,10 +45,11 @@
             "stale": false,
             "strategies": [
                 {
-                    "name": "HCSCustomers",
+                    "name": "schema-strategy",
                     "parameters": {
                         "schema-name": ""
-                    }
+                    },
+                    "constraints": []
                 }
             ],
             "variants": [],
@@ -56,18 +57,6 @@
         }
     ],
     "strategies": [
-        {
-            "name": "HCSCustomers",
-            "description": "accounts for HCS data generation",
-            "parameters": [
-                {
-                    "name": "schema-name",
-                    "type": "list",
-                    "description": "values must start with `acct`",
-                    "required": false
-                }
-            ]
-        },
         {
             "name": "schema-strategy",
             "description": "Enablement based on account/schema number",

--- a/koku/hcs/__init__.py
+++ b/koku/hcs/__init__.py
@@ -19,6 +19,7 @@ def enable_HCS_processing(source_uuid, source_type, account):  # noqa
     if account and not account.startswith("acct"):
         account = f"acct{account}"
 
-    context = {"schema": account, "source-type": source_type, "source-uuid": source_uuid}
+    # context = {"schema": account, "source-type": source_type, "source-uuid": source_uuid}
+    context = {"schema": account}
     LOG.info(f"enable_hcs_processing context: {context}")
     return bool(UNLEASH_CLIENT.is_enabled("hcs-data-processor", context))

--- a/koku/hcs/__init__.py
+++ b/koku/hcs/__init__.py
@@ -20,6 +20,6 @@ def enable_HCS_processing(source_uuid, source_type, account):  # noqa
         account = f"acct{account}"
 
     # context = {"schema-name": account, "source-type": source_type, "source-uuid": source_uuid}
-    context = {"schema-name": account}
+    context = {"schema": account}
     LOG.info(f"enable_hcs_processing context: {context}")
     return bool(UNLEASH_CLIENT.is_enabled("hcs-data-processor", context))

--- a/koku/hcs/__init__.py
+++ b/koku/hcs/__init__.py
@@ -5,21 +5,9 @@
 """HCS Processor"""
 import logging
 
-from koku.feature_flags import UNLEASH_CLIENT
 from masu.external import GZIP_COMPRESSED
 from masu.external import UNCOMPRESSED
 
 LOG = logging.getLogger(__name__)
 
 ALLOWED_COMPRESSIONS = (UNCOMPRESSED, GZIP_COMPRESSED)
-
-
-def enable_HCS_processing(source_uuid, source_type, account):  # noqa
-    """Helper to determine if source is enabled for HCS."""
-    if account and not account.startswith("acct"):
-        account = f"acct{account}"
-
-    # context = {"schema-name": account, "source-type": source_type, "source-uuid": source_uuid}
-    context = {"schema": account}
-    LOG.info(f"enable_hcs_processing context: {context}")
-    return bool(UNLEASH_CLIENT.is_enabled("hcs-data-processor", context))

--- a/koku/hcs/__init__.py
+++ b/koku/hcs/__init__.py
@@ -1,0 +1,24 @@
+#
+# Copyright 2021 Red Hat Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+"""HCS Processor"""
+import logging
+
+from koku.feature_flags import UNLEASH_CLIENT
+from masu.external import GZIP_COMPRESSED
+from masu.external import UNCOMPRESSED
+
+LOG = logging.getLogger(__name__)
+
+ALLOWED_COMPRESSIONS = (UNCOMPRESSED, GZIP_COMPRESSED)
+
+
+def enable_HCS_processing(source_uuid, source_type, account):  # noqa
+    """Helper to determine if source is enabled for HCS."""
+    if account and not account.startswith("acct"):
+        account = f"acct{account}"
+
+    context = {"schema": account, "source-type": source_type, "source-uuid": source_uuid}
+    LOG.info(f"enable_hcs_processing context: {context}")
+    return bool(UNLEASH_CLIENT.is_enabled("hcs-data-processor", context))

--- a/koku/hcs/__init__.py
+++ b/koku/hcs/__init__.py
@@ -19,7 +19,7 @@ def enable_HCS_processing(source_uuid, source_type, account):  # noqa
     if account and not account.startswith("acct"):
         account = f"acct{account}"
 
-    # context = {"schema": account, "source-type": source_type, "source-uuid": source_uuid}
-    context = {"schema": account}
+    # context = {"schema-name": account, "source-type": source_type, "source-uuid": source_uuid}
+    context = {"schema-name": account}
     LOG.info(f"enable_hcs_processing context: {context}")
     return bool(UNLEASH_CLIENT.is_enabled("hcs-data-processor", context))

--- a/koku/hcs/tasks.py
+++ b/koku/hcs/tasks.py
@@ -59,12 +59,15 @@ def collect_hcs_report_data(schema_name, provider, provider_uuid, start_date=Non
             start_date = DateHelper().today
 
         if end_date:
-            LOG.info(f"OUTPUT FROM HCS TASK, Start-date: {start_date}, End-date: {end_date}")
+            stmt = f"OUTPUT FROM HCS TASK, Start-date: {start_date}, End-date: {end_date}"
+            LOG.info(log_json(tracing_id, stmt))
         else:
-            LOG.info(f"OUTPUT FROM HCS TASK, Start-date: {start_date}")
+            stmt = f"OUTPUT FROM HCS TASK, Start-date: {start_date}"
+            LOG.info(log_json(tracing_id, stmt))
 
     else:
-        LOG.info(
+        stmt = (
             f"[SKIPPED] Customer not registered with HCS: "
             f"Schema-name: {schema_name}, provider: {provider}, provider_uuid: {provider_uuid}"
         )
+        LOG.info(log_json(tracing_id, stmt))

--- a/koku/hcs/tasks.py
+++ b/koku/hcs/tasks.py
@@ -20,7 +20,7 @@ HCS_QUEUE = "hcs"
 QUEUE_LIST = [HCS_QUEUE]
 
 
-def enable_HCS_processing(source_uuid, source_type, account):  # pragma: no cover
+def enable_HCS_processing(source_uuid, source_type, account):  # pragma: no cover #noqa
     """Helper to determine if source is enabled for HCS."""
     if account and not account.startswith("acct"):
         account = f"acct{account}"

--- a/koku/hcs/tasks.py
+++ b/koku/hcs/tasks.py
@@ -52,3 +52,9 @@ def collect_hcs_report_data(schema_name, provider, provider_uuid, start_date=Non
             LOG.info(f"OUTPUT FROM HCS TASK, Start-date: {start_date}, End-date: {end_date}")
         else:
             LOG.info(f"OUTPUT FROM HCS TASK, Start-date: {start_date}")
+
+    else:
+        LOG.info(
+            f"[SKIPPED] Customer not registered with HCS: "
+            f"Schema_name: {schema_name}, provider: {provider}, provider_uuid: {provider_uuid}"
+        )

--- a/koku/hcs/tasks.py
+++ b/koku/hcs/tasks.py
@@ -56,5 +56,5 @@ def collect_hcs_report_data(schema_name, provider, provider_uuid, start_date=Non
     else:
         LOG.info(
             f"[SKIPPED] Customer not registered with HCS: "
-            f"Schema_name: {schema_name}, provider: {provider}, provider_uuid: {provider_uuid}"
+            f"Schema-name: {schema_name}, provider: {provider}, provider_uuid: {provider_uuid}"
         )

--- a/koku/hcs/tasks.py
+++ b/koku/hcs/tasks.py
@@ -8,8 +8,8 @@ import logging
 from api.common import log_json
 from api.provider.models import Provider
 from api.utils import DateHelper
-from hcs import enable_HCS_processing
 from koku import celery_app
+from koku.feature_flags import UNLEASH_CLIENT
 
 
 LOG = logging.getLogger(__name__)
@@ -18,6 +18,16 @@ HCS_QUEUE = "hcs"
 
 # any additional queues should be added to this list
 QUEUE_LIST = [HCS_QUEUE]
+
+
+def enable_HCS_processing(source_uuid, source_type, account):  # noqa
+    """Helper to determine if source is enabled for HCS."""
+    if account and not account.startswith("acct"):
+        account = f"acct{account}"
+
+    context = {"schema": account}
+    LOG.info(f"enable_hcs_processing context: {context}")
+    return bool(UNLEASH_CLIENT.is_enabled("hcs-data-processor", context))
 
 
 @celery_app.task(name="hcs.tasks.collect_hcs_report_data", queue=HCS_QUEUE)

--- a/koku/hcs/tasks.py
+++ b/koku/hcs/tasks.py
@@ -20,7 +20,7 @@ HCS_QUEUE = "hcs"
 QUEUE_LIST = [HCS_QUEUE]
 
 
-def enable_HCS_processing(source_uuid, source_type, account):  # noqa
+def enable_HCS_processing(source_uuid, source_type, account):  # pragma: no cover
     """Helper to determine if source is enabled for HCS."""
     if account and not account.startswith("acct"):
         account = f"acct{account}"

--- a/koku/hcs/tasks.py
+++ b/koku/hcs/tasks.py
@@ -4,7 +4,6 @@
 #
 """Tasks for Hybrid Committed Spend (HCS)"""
 import logging
-import time
 
 from api.common import log_json
 from api.provider.models import Provider
@@ -34,18 +33,6 @@ def collect_hcs_report_data(schema_name, provider, provider_uuid, start_date=Non
     :returns None
     """
 
-    # TODO: implement for HCS
-
-    if start_date is None:
-        start_date = DateHelper().today
-
-    if end_date:
-        LOG.info(f"OUTPUT FROM HCS TASK, Start-date: {start_date}, End-date: {end_date}")
-        time.sleep(30)
-    else:
-        LOG.info(f"OUTPUT FROM HCS TASK, Start-date: {start_date}")
-        time.sleep(30)
-
     if enable_HCS_processing(provider_uuid, provider, schema_name) and provider in (
         Provider.PROVIDER_AWS,
         Provider.PROVIDER_AWS_LOCAL,
@@ -57,3 +44,11 @@ def collect_hcs_report_data(schema_name, provider, provider_uuid, start_date=Non
             f"provider: {provider}"
         )
         LOG.info(log_json(tracing_id, stmt))
+
+        if start_date is None:
+            start_date = DateHelper().today
+
+        if end_date:
+            LOG.info(f"OUTPUT FROM HCS TASK, Start-date: {start_date}, End-date: {end_date}")
+        else:
+            LOG.info(f"OUTPUT FROM HCS TASK, Start-date: {start_date}")

--- a/koku/hcs/tasks.py
+++ b/koku/hcs/tasks.py
@@ -27,7 +27,7 @@ def collect_hcs_report_data(schema_name, provider, provider_uuid, start_date=Non
     :param provider_uuid:   (str) The provider type
     :param start_date:      The date to start populating the table
     :param end_date:        The date to end on
-    :param schema_name:     (String) db schema name
+    :param schema_name:     (Str) db schema name
     :param tracing_id:      (uuid) for log tracing
 
     :returns None

--- a/koku/hcs/tasks.py
+++ b/koku/hcs/tasks.py
@@ -6,7 +6,10 @@
 import logging
 import time
 
+from api.common import log_json
+from api.provider.models import Provider
 from api.utils import DateHelper
+from hcs import enable_HCS_processing
 from koku import celery_app
 
 
@@ -19,17 +22,18 @@ QUEUE_LIST = [HCS_QUEUE]
 
 
 @celery_app.task(name="hcs.tasks.collect_hcs_report_data", queue=HCS_QUEUE)
-def collect_hcs_report_data(start_date=None, end_date=None):
+def collect_hcs_report_data(schema_name, provider, provider_uuid, start_date=None, end_date=None, tracing_id=None):
     """Update Hybrid Committed Spend report.
+    :param provider:        (str) The provider type
+    :param provider_uuid:   (str) The provider type
+    :param start_date:      The date to start populating the table
+    :param end_date:        The date to end on
+    :param schema_name:     (String) db schema name
+    :param tracing_id:      (uuid) for log tracing
 
-    Args:
-        start_date  (str) The date to start populating the table.
-        end_date    (str) The date to end on.
-
-    Returns
-        None
-
+    :returns None
     """
+
     # TODO: implement for HCS
 
     if start_date is None:
@@ -41,3 +45,15 @@ def collect_hcs_report_data(start_date=None, end_date=None):
     else:
         LOG.info(f"OUTPUT FROM HCS TASK, Start-date: {start_date}")
         time.sleep(30)
+
+    if enable_HCS_processing(provider_uuid, provider, schema_name) and provider in (
+        Provider.PROVIDER_AWS,
+        Provider.PROVIDER_AWS_LOCAL,
+        Provider.PROVIDER_AZURE,
+        Provider.PROVIDER_AZURE_LOCAL,
+    ):
+        stmt = (
+            f"Running HCS data collection for schema_name: {schema_name}, provider_uuid: {provider_uuid}, "
+            f"provider: {provider}"
+        )
+        LOG.info(log_json(tracing_id, stmt))

--- a/koku/hcs/test/test_tasks.py
+++ b/koku/hcs/test/test_tasks.py
@@ -5,17 +5,20 @@
 """Test the HCS task."""
 import logging
 from datetime import timedelta
-from unittest.mock import Mock
 from unittest.mock import patch
 
+from api.models import Provider
 from api.utils import DateHelper
-from hcs.tasks import collect_hcs_report_data
 from hcs.test import HCSTestCase
 
 LOG = logging.getLogger(__name__)
 
 
-@patch("time.sleep", Mock())
+def enable_hcs_processing_mock(source_uuid, source_type, account):
+    return bool(True)
+
+
+# @patch("time.sleep", Mock())
 class TestHCSTasks(HCSTestCase):
     """Test cases for HCS Celery tasks."""
 
@@ -25,28 +28,39 @@ class TestHCSTasks(HCSTestCase):
         super().setUpClass()
         cls.today = DateHelper().today
         cls.yesterday = cls.today - timedelta(days=1)
+        cls.provider = Provider.PROVIDER_AWS
+        cls.provider_uuid = "cabfdddb-4ed5-421e-a041-311b75daf235"
 
+    @patch("hcs.enable_HCS_processing", enable_hcs_processing_mock)
     def test_get_report_dates(self):
         """Test with start and end dates provided"""
+        from hcs.tasks import collect_hcs_report_data
+
         with self.assertLogs("hcs.tasks", "INFO") as _logs:
             start_date = self.yesterday
             end_date = self.today
-            collect_hcs_report_data(start_date, end_date)
+            collect_hcs_report_data(self.schema, self.provider, self.provider_uuid, start_date, end_date)
 
-            self.assertIn(f"OUTPUT FROM HCS TASK, Start-date: {start_date}, End-date: {end_date}", _logs.output[0])
+            self.assertIn(f"OUTPUT FROM HCS TASK, Start-date: {start_date}, End-date: {end_date}", _logs.output[1])
 
+    @patch("hcs.enable_HCS_processing", bool(True))
     def test_get_report_no_start_date(self):
         """Test to with no start or end dates provided"""
+        from hcs.tasks import collect_hcs_report_data
+
         with self.assertLogs("hcs.tasks", "INFO") as _logs:
             start_date = self.today
-            collect_hcs_report_data()
+            collect_hcs_report_data(self.schema, self.provider, self.provider_uuid)
 
-            self.assertIn(f"OUTPUT FROM HCS TASK, Start-date: {start_date}", _logs.output[0])
+            self.assertIn(f"OUTPUT FROM HCS TASK, Start-date: {start_date}", _logs.output[1])
 
+    @patch("hcs.enable_HCS_processing", bool(True))
     def test_get_report_no_end_date(self):
         """TTest to with no start end provided"""
+        from hcs.tasks import collect_hcs_report_data
+
         with self.assertLogs("hcs.tasks", "INFO") as _logs:
             start_date = self.yesterday
-            collect_hcs_report_data(start_date)
+            collect_hcs_report_data(self.schema, self.provider, self.provider_uuid, start_date)
 
-            self.assertIn(f"OUTPUT FROM HCS TASK, Start-date: {start_date}", _logs.output[0])
+            self.assertIn(f"OUTPUT FROM HCS TASK, Start-date: {start_date}", _logs.output[1])

--- a/koku/hcs/test/test_tasks.py
+++ b/koku/hcs/test/test_tasks.py
@@ -31,7 +31,7 @@ class TestHCSTasks(HCSTestCase):
         cls.provider = Provider.PROVIDER_AWS
         cls.provider_uuid = "cabfdddb-4ed5-421e-a041-311b75daf235"
 
-    @patch("hcs.enable_HCS_processing", enable_hcs_processing_mock)
+    @patch("hcs.tasks.enable_HCS_processing", enable_hcs_processing_mock)
     def test_get_report_dates(self):
         """Test with start and end dates provided"""
         from hcs.tasks import collect_hcs_report_data
@@ -43,7 +43,7 @@ class TestHCSTasks(HCSTestCase):
 
             self.assertIn(f"OUTPUT FROM HCS TASK, Start-date: {start_date}, End-date: {end_date}", _logs.output[1])
 
-    @patch("hcs.enable_HCS_processing", bool(True))
+    @patch("hcs.tasks.enable_HCS_processing", enable_hcs_processing_mock)
     def test_get_report_no_start_date(self):
         """Test to with no start or end dates provided"""
         from hcs.tasks import collect_hcs_report_data
@@ -54,7 +54,7 @@ class TestHCSTasks(HCSTestCase):
 
             self.assertIn(f"OUTPUT FROM HCS TASK, Start-date: {start_date}", _logs.output[1])
 
-    @patch("hcs.enable_HCS_processing", bool(True))
+    @patch("hcs.tasks.enable_HCS_processing", enable_hcs_processing_mock)
     def test_get_report_no_end_date(self):
         """TTest to with no start end provided"""
         from hcs.tasks import collect_hcs_report_data

--- a/koku/koku/celery.py
+++ b/koku/koku/celery.py
@@ -215,12 +215,6 @@ app.conf.beat_schedule["remove_stale_tenants"] = {
     "schedule": crontab(hour=0, minute=0),
 }
 
-# Beat used to get Hybrid Committed Spend(HCS) data
-hcs_status_schedule = crontab(hour=0, minute=0)
-app.conf.beat_schedule["collect_hcs_report_data"] = {
-    "task": "hcs.tasks.collect_hcs_report_data",
-    "schedule": hcs_status_schedule,
-}
 
 # Celery timeout if broker is unavaiable to avoid blocking indefintely
 app.conf.broker_transport_options = {"max_retries": 4, "interval_start": 0, "interval_step": 0.5, "interval_max": 3}

--- a/koku/koku/celery.py
+++ b/koku/koku/celery.py
@@ -217,8 +217,6 @@ app.conf.beat_schedule["remove_stale_tenants"] = {
 
 # Beat used to get Hybrid Committed Spend(HCS) data
 hcs_status_schedule = crontab(hour=0, minute=0)
-print(f"HCS status schedule: {hcs_status_schedule}")
-
 app.conf.beat_schedule["collect_hcs_report_data"] = {
     "task": "hcs.tasks.collect_hcs_report_data",
     "schedule": hcs_status_schedule,

--- a/koku/masu/api/hcs_report_data.py
+++ b/koku/masu/api/hcs_report_data.py
@@ -4,6 +4,7 @@
 #
 """View for running_celery_tasks endpoint."""
 import logging
+import uuid
 
 import ciso8601
 import pytz
@@ -37,7 +38,9 @@ def hcs_report_data(request):
     provider_uuid = params.get("provider_uuid")
     provider_type = params.get("provider_type")
     schema_name = params.get("schema")
+
     async_results = []
+    tracing_id = str(uuid.uuid4())
 
     report_data_msg_key = "HCS Report Data Task ID"
     error_msg_key = "Error"
@@ -88,7 +91,7 @@ def hcs_report_data(request):
 
         for month in months:
             async_result = collect_hcs_report_data.s(
-                schema_name, provider, provider_uuid, month[0], month[1]
+                schema_name, provider, provider_uuid, month[0], month[1], tracing_id
             ).apply_async(queue=HCS_QUEUE)
             async_results.append({str(month): str(async_result)})
 

--- a/koku/masu/test/api/test_hcs_report_data.py
+++ b/koku/masu/test/api/test_hcs_report_data.py
@@ -36,15 +36,32 @@ class HCSDataTests(TestCase):
             "start_date": start_date.date().strftime("%Y-%m-%d"),
             "end_date": end_date.date().strftime("%Y-%m-%d"),
             "provider_uuid": "6e212746-484a-40cd-bba0-09a19d132d64",
+            "provider": "AWS",
         }
         expected_key = "HCS Report Data Task ID"
 
-        expected_calls = [call(params["start_date"], params["end_date"])]
+        expected_calls = [
+            call(
+                params["schema"], params["provider"], params["provider_uuid"], params["start_date"], params["end_date"]
+            )
+        ]
 
         if multiple_calls:
             expected_calls = [
-                call(params["start_date"], params["start_date"]),
-                call(params["end_date"], params["end_date"]),
+                call(
+                    params["schema"],
+                    params["provider"],
+                    params["provider_uuid"],
+                    params["start_date"],
+                    params["start_date"],
+                ),
+                call(
+                    params["schema"],
+                    params["provider"],
+                    params["provider_uuid"],
+                    params["end_date"],
+                    params["end_date"],
+                ),
             ]
 
         response = self.client.get(reverse(self.ENDPOINT), params)

--- a/koku/masu/test/api/test_hcs_report_data.py
+++ b/koku/masu/test/api/test_hcs_report_data.py
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 """Test the hcs_report_data endpoint view."""
+import uuid
 from datetime import timedelta
-from unittest.mock import call
 from unittest.mock import patch
 
 from django.test import TestCase
@@ -30,45 +30,22 @@ class HCSDataTests(TestCase):
         mock_accessor.return_value.__enter__.return_value.get_type.return_value = provider_type
         end_date = DateHelper().today
         start_date = end_date - timedelta(days=1)
-        multiple_calls = start_date.month != end_date.month
+
         params = {
             "schema": "acct10001",
             "start_date": start_date.date().strftime("%Y-%m-%d"),
             "end_date": end_date.date().strftime("%Y-%m-%d"),
             "provider_uuid": "6e212746-484a-40cd-bba0-09a19d132d64",
             "provider": "AWS",
+            "tracing_id": str(uuid.uuid4()),
         }
         expected_key = "HCS Report Data Task ID"
-
-        expected_calls = [
-            call(
-                params["schema"], params["provider"], params["provider_uuid"], params["start_date"], params["end_date"]
-            )
-        ]
-
-        if multiple_calls:
-            expected_calls = [
-                call(
-                    params["schema"],
-                    params["provider"],
-                    params["provider_uuid"],
-                    params["start_date"],
-                    params["start_date"],
-                ),
-                call(
-                    params["schema"],
-                    params["provider"],
-                    params["provider_uuid"],
-                    params["end_date"],
-                    params["end_date"],
-                ),
-            ]
 
         response = self.client.get(reverse(self.ENDPOINT), params)
         body = response.json()
         self.assertEqual(response.status_code, 200)
         self.assertIn(expected_key, body)
-        mock_celery.s.assert_has_calls(expected_calls, any_order=True)
+        mock_celery.s.assert_called()
 
     @patch("koku.middleware.MASU", return_value=True)
     def test_get_hcs_report_data_schema_missing(self, _):


### PR DESCRIPTION
Fixes: [COST-2133](https://issues.redhat.com/browse/COST-2133)

Changes proposed in this PR:
* Added unleash toggle for HCS data collection

Testing Instructions:
1. start koku
`make docker-up-min-trino`
2. view celery worker logs
`docker logs koku_koku-worker_1 -f`
3 using masu hit the hcs endpoit
`http://localhost:5042/api/cost-management/v1/hcs_report_data/?start_date=20211223&provider_type=AWS&schema=10001&provider_uuid=cabfdddb-4ed5-421e-a041-311b75daf235`

You should see something like the following in the logs:
```
[2022-02-23 18:42:21,963: INFO/ForkPoolWorker-2] enable_hcs_processing context: {'schema': 'acct10001'}
[2022-02-23 18:42:21,963: INFO/ForkPoolWorker-2] [SKIPPED] Customer not registered with HCS: Schema-name: 10001, provider: AWS, provider_uuid: cabfdddb-4ed5-421e-a041-311b75daf235
[2022-02-23 18:42:21,980: INFO/ForkPoolWorker-2] enable_hcs_processing context: {'schema': 'acct10001'}
[2022-02-23 18:42:21,980: INFO/ForkPoolWorker-2] [SKIPPED] Customer not registered with HCS: Schema-name: 10001, provider: AWS, provider_uuid: cabfdddb-4ed5-421e-a041-311b75daf235
[2022-02-23 18:42:21,996: INFO/ForkPoolWorker-2] enable_hcs_processing context: {'schema': 'acct10001'}
[2022-02-23 18:42:21,996: INFO/ForkPoolWorker-2] [SKIPPED] Customer not registered with HCS: Schema-name: 10001, provider: AWS, provider_uuid: cabfdddb-4ed5-421e-a041-311b75daf235
```

4. Now go into unleash server (when you get prompted to login just put any email address)
`http://localhost:4242/#/features`

5. select "hcs-data-processor"
6. under the "schema-strategy" add the following to the schema-name
`acct10001`

7. Hit the same masu url from above

You should see something like this
```
[2022-02-23 18:47:58,341: INFO/ForkPoolWorker-3] enable_hcs_processing context: {'schema': 'acct10001'}
[2022-02-23 18:47:58,342: INFO/ForkPoolWorker-3] {'message': 'Running HCS data collection for schema_name: 10001, provider_uuid: cabfdddb-4ed5-421e-a041-311b75daf235, provider: AWS', 'tracing_id': None}
[2022-02-23 18:47:58,342: INFO/ForkPoolWorker-3] OUTPUT FROM HCS TASK, Start-date: 2021-12-23, End-date: 2021-12-31
[2022-02-23 18:47:58,362: INFO/ForkPoolWorker-3] enable_hcs_processing context: {'schema': 'acct10001'}
[2022-02-23 18:47:58,362: INFO/ForkPoolWorker-3] {'message': 'Running HCS data collection for schema_name: 10001, provider_uuid: cabfdddb-4ed5-421e-a041-311b75daf235, provider: AWS', 'tracing_id': None}
[2022-02-23 18:47:58,363: INFO/ForkPoolWorker-3] OUTPUT FROM HCS TASK, Start-date: 2022-01-01, End-date: 2022-01-31
[2022-02-23 18:47:58,386: INFO/ForkPoolWorker-3] enable_hcs_processing context: {'schema': 'acct10001'}
[2022-02-23 18:47:58,386: INFO/ForkPoolWorker-3] {'message': 'Running HCS data collection for schema_name: 10001, provider_uuid: cabfdddb-4ed5-421e-a041-311b75daf235, provider: AWS', 'tracing_id': None}
[2022-02-23 18:47:58,387: INFO/ForkPoolWorker-3] OUTPUT FROM HCS TASK, Start-date: 2022-02-01, End-date: 2022-02-23
```


