### PR TITLE
[COST-2353] Handle null tags in ocp tag updates

### DIFF
--- a/koku/masu/database/sql/reporting_ocpstoragevolumelabel_summary.sql
+++ b/koku/masu/database/sql/reporting_ocpstoragevolumelabel_summary.sql
@@ -16,6 +16,7 @@ WITH cte_tag_value(key, value, report_period_id, namespace) AS (
     {% endif %}
         AND li.usage_start >= {{start_date}}
         AND li.usage_start <= {{end_date}}
+        AND value IS NOT NULL
     GROUP BY key, value, li.report_period_id, li.namespace, li.node
 ),
 cte_values_agg AS (

--- a/koku/masu/database/sql/reporting_ocpusagepodlabel_summary.sql
+++ b/koku/masu/database/sql/reporting_ocpusagepodlabel_summary.sql
@@ -16,6 +16,7 @@ WITH cte_tag_value(key, value, report_period_id, namespace) AS (
     {% endif %}
         AND li.usage_start >= {{start_date}}
         AND li.usage_start <= {{end_date}}
+        AND value IS NOT NULL
     GROUP BY key, value, li.report_period_id, li.namespace, li.node
 ),
 cte_values_agg AS (


### PR DESCRIPTION
Fixes [COST-2353](https://issues.redhat.com/browse/COST-2353)

Changes proposed in this PR:
* Filter out null values in ocp tags summaries that are coming from the null in gcp tags and ocp/gcp

Testing Instructions:
1. Bring everything up with trino, for example: make docker-up-min-trino

2. Create an ocp on gcp source with a Null value for a gcp label (if you need help with this, ask Corey)

3. Send the ocp source to cost management and then the gcp source to cost management and watch the logs as it creates. After both sources are complete, resummarize the openshift source. If you are on main, you will see an error similar to:

`koku-worker_1     | [2022-02-23 14:12:37,654] ERROR 78282aab-b499-4900-8806-c575041031d9 Task failed: null value in column "value" of relation "reporting_gcptags_values" violates not-null constraint`
If you are on this branch, you will not see the error

---
Additional Context:
Follow up of this PR: https://github.com/project-koku/koku/pull/3485