### PR TITLE
fix UnboundLocalError

### DIFF
--- a/scripts/cji_scripts/truncate_old_tables.py
+++ b/scripts/cji_scripts/truncate_old_tables.py
@@ -126,6 +126,7 @@ select p."uuid" as source_uuid,
 
 def get_trino_enabled_accounts(conn):
     enabled_accounts = []
+    unleash_res = None
     unleash_request = 0
     unleash_limit = 100
 


### PR DESCRIPTION
Fixes:
```
File "/opt/koku/scripts/cji_scripts/truncate_old_tables.py", line 146, in get_trino_enabled_accounts
if unleash_res:
UnboundLocalError: local variable 'unleash_res' referenced before assignment
```