### PR TITLE
COST-444 bakery updates

### DIFF
--- a/koku/api/report/test/util/baker_recipes.py
+++ b/koku/api/report/test/util/baker_recipes.py
@@ -17,6 +17,12 @@ from api.report.test.util.constants import OCP_CONSTANTS
 
 fake = Faker()
 
+
+def decimal_yielder():
+    while True:
+        yield fake.pydecimal(left_digits=13, right_digits=8, positive=True)
+
+
 billing_source = Recipe("ProviderBillingSource", data_source={})
 provider = Recipe("Provider", billing_source=foreign_key(billing_source))
 
@@ -31,7 +37,6 @@ aws_daily_summary = Recipe(
     region=cycle(AWS_GEOG["regions"]),
     availability_zone=cycle(AWS_GEOG["availability_zones"]),
     _fill_optional=True,
-    _bulk_create=True,
     _quantity=AWS_CONSTANTS.length,
 )
 
@@ -44,7 +49,6 @@ azure_daily_summary = Recipe(
     unit_of_measure=cycle(AZURE_CONSTANTS["units_of_measure"]),
     resource_location="US East",
     _fill_optional=True,
-    _bulk_create=True,
     _quantity=AZURE_CONSTANTS.length,
 )
 
@@ -55,12 +59,11 @@ gcp_daily_summary = Recipe(
     sku_id=cycle(GCP_CONSTANTS["service_ids"]),
     sku_alias=cycle(GCP_CONSTANTS["sku_aliases"]),
     unit=cycle(GCP_CONSTANTS["units"]),
-    usage_amount=fake.pydecimal(left_digits=13, right_digits=8, positive=True),
-    unblended_cost=fake.pydecimal(left_digits=13, right_digits=8, positive=True),
-    markup_cost=fake.pydecimal(left_digits=13, right_digits=8, positive=True),
-    credit_amount=fake.pydecimal(left_digits=13, right_digits=8, positive=True),
+    usage_amount=cycle(decimal_yielder()),
+    unblended_cost=cycle(decimal_yielder()),
+    markup_cost=cycle(decimal_yielder()),
+    credit_amount=cycle(decimal_yielder()),
     _fill_optional=True,
-    _bulk_create=True,
     _quantity=GCP_CONSTANTS.length,
 )
 
@@ -70,23 +73,22 @@ ocp_usage_pod = Recipe(  # Pod data_source
     node=cycle(f"node_{i}" for i in range(OCP_CONSTANTS.length - 1)),
     resource_id=cycle(f"i-000000{i}" for i in range(OCP_CONSTANTS.length - 1)),
     namespace=cycle(OCP_CONSTANTS["namespaces"]),
-    pod_limit_cpu_core_hours=fake.pydecimal(left_digits=13, right_digits=8, positive=True),
-    pod_usage_cpu_core_hours=fake.pydecimal(left_digits=13, right_digits=8, positive=True),
-    pod_request_cpu_core_hours=fake.pydecimal(left_digits=13, right_digits=8, positive=True),
-    pod_effective_usage_cpu_core_hours=fake.pydecimal(left_digits=13, right_digits=8, positive=True),
-    pod_limit_memory_gigabyte_hours=fake.pydecimal(left_digits=13, right_digits=8, positive=True),
-    pod_usage_memory_gigabyte_hours=fake.pydecimal(left_digits=13, right_digits=8, positive=True),
-    pod_request_memory_gigabyte_hours=fake.pydecimal(left_digits=13, right_digits=8, positive=True),
-    pod_effective_usage_memory_gigabyte_hours=fake.pydecimal(left_digits=13, right_digits=8, positive=True),
-    node_capacity_cpu_cores=fake.pydecimal(left_digits=13, right_digits=8, positive=True),
-    node_capacity_cpu_core_hours=fake.pydecimal(left_digits=13, right_digits=8, positive=True),
-    node_capacity_memory_gigabytes=fake.pydecimal(left_digits=13, right_digits=8, positive=True),
-    node_capacity_memory_gigabyte_hours=fake.pydecimal(left_digits=13, right_digits=8, positive=True),
-    cluster_capacity_cpu_core_hours=fake.pydecimal(left_digits=13, right_digits=8, positive=True),
-    cluster_capacity_memory_gigabyte_hours=fake.pydecimal(left_digits=13, right_digits=8, positive=True),
+    pod_limit_cpu_core_hours=cycle(decimal_yielder()),
+    pod_usage_cpu_core_hours=cycle(decimal_yielder()),
+    pod_request_cpu_core_hours=cycle(decimal_yielder()),
+    pod_effective_usage_cpu_core_hours=cycle(decimal_yielder()),
+    pod_limit_memory_gigabyte_hours=cycle(decimal_yielder()),
+    pod_usage_memory_gigabyte_hours=cycle(decimal_yielder()),
+    pod_request_memory_gigabyte_hours=cycle(decimal_yielder()),
+    pod_effective_usage_memory_gigabyte_hours=cycle(decimal_yielder()),
+    node_capacity_cpu_cores=cycle(decimal_yielder()),
+    node_capacity_cpu_core_hours=cycle(decimal_yielder()),
+    node_capacity_memory_gigabytes=cycle(decimal_yielder()),
+    node_capacity_memory_gigabyte_hours=cycle(decimal_yielder()),
+    cluster_capacity_cpu_core_hours=cycle(decimal_yielder()),
+    cluster_capacity_memory_gigabyte_hours=cycle(decimal_yielder()),
     pod_labels=cycle(OCP_CONSTANTS["pod_labels"]),
     _fill_optional=False,
-    _bulk_create=True,
     _quantity=OCP_CONSTANTS.length,
 )
 
@@ -99,19 +101,18 @@ ocp_usage_storage = Recipe(  # Storage data_source
     persistentvolumeclaim=cycle(f"pvc_{i}" for i in range(OCP_CONSTANTS.length - 1)),
     persistentvolume=cycle(f"pv_{i}" for i in range(OCP_CONSTANTS.length - 1)),
     storageclass=cycle(OCP_CONSTANTS["storage_classes"]),
-    persistentvolumeclaim_capacity_gigabyte=fake.pydecimal(left_digits=13, right_digits=8, positive=True),
-    persistentvolumeclaim_capacity_gigabyte_months=fake.pydecimal(left_digits=13, right_digits=8, positive=True),
-    volume_request_storage_gigabyte_months=fake.pydecimal(left_digits=13, right_digits=8, positive=True),
-    persistentvolumeclaim_usage_gigabyte_months=fake.pydecimal(left_digits=13, right_digits=8, positive=True),
-    node_capacity_cpu_cores=fake.pydecimal(left_digits=13, right_digits=8, positive=True),
-    node_capacity_cpu_core_hours=fake.pydecimal(left_digits=13, right_digits=8, positive=True),
-    node_capacity_memory_gigabytes=fake.pydecimal(left_digits=13, right_digits=8, positive=True),
-    node_capacity_memory_gigabyte_hours=fake.pydecimal(left_digits=13, right_digits=8, positive=True),
-    cluster_capacity_cpu_core_hours=fake.pydecimal(left_digits=13, right_digits=8, positive=True),
-    cluster_capacity_memory_gigabyte_hours=fake.pydecimal(left_digits=13, right_digits=8, positive=True),
+    persistentvolumeclaim_capacity_gigabyte=cycle(decimal_yielder()),
+    persistentvolumeclaim_capacity_gigabyte_months=cycle(decimal_yielder()),
+    volume_request_storage_gigabyte_months=cycle(decimal_yielder()),
+    persistentvolumeclaim_usage_gigabyte_months=cycle(decimal_yielder()),
+    node_capacity_cpu_cores=cycle(decimal_yielder()),
+    node_capacity_cpu_core_hours=cycle(decimal_yielder()),
+    node_capacity_memory_gigabytes=cycle(decimal_yielder()),
+    node_capacity_memory_gigabyte_hours=cycle(decimal_yielder()),
+    cluster_capacity_cpu_core_hours=cycle(decimal_yielder()),
+    cluster_capacity_memory_gigabyte_hours=cycle(decimal_yielder()),
     volume_labels=cycle(OCP_CONSTANTS["pvc_labels"]),
     _fill_optional=False,
-    _bulk_create=True,
     _quantity=OCP_CONSTANTS.length,
 )
 
@@ -125,7 +126,6 @@ ocp_on_aws_daily_summary = Recipe(
     product_family=cycle(AWS_CONSTANTS["product_families"]),
     unit=cycle(AWS_CONSTANTS["units"]),
     _fill_optional=True,
-    _bulk_create=True,
     _quantity=min(AWS_CONSTANTS.length, 9),
 )
 
@@ -144,7 +144,6 @@ ocp_on_aws_project_daily_summary_pod = Recipe(  # Pod data_source
     product_family=cycle(AWS_CONSTANTS["product_families"]),
     unit=cycle(AWS_CONSTANTS["units"]),
     _fill_optional=True,
-    _bulk_create=True,
     _quantity=min(AWS_CONSTANTS.length, 9),
 )
 
@@ -162,7 +161,6 @@ ocp_on_aws_project_daily_summary_storage = Recipe(  # Storage data_source
     product_family=cycle(AWS_CONSTANTS["product_families"]),
     unit=cycle(AWS_CONSTANTS["units"]),
     _fill_optional=True,
-    _bulk_create=True,
     _quantity=min(AWS_CONSTANTS.length, 9),
 )
 
@@ -176,7 +174,6 @@ ocp_on_azure_daily_summary = Recipe(
     unit_of_measure=cycle(AZURE_CONSTANTS["units_of_measure"]),
     resource_location="US East",
     _fill_optional=True,
-    _bulk_create=True,
     _quantity=min(AZURE_CONSTANTS.length, 9),
 )
 
@@ -194,7 +191,6 @@ ocp_on_azure_project_daily_summary_pod = Recipe(  # Pod data_source
     instance_type=cycle(AZURE_CONSTANTS["instance_types"]),
     unit_of_measure=cycle(AZURE_CONSTANTS["units_of_measure"]),
     _fill_optional=True,
-    _bulk_create=True,
     _quantity=min(AZURE_CONSTANTS.length, 9),
 )
 
@@ -211,36 +207,31 @@ ocp_on_azure_project_daily_summary_storage = Recipe(  # Storage data_source
     instance_type=cycle(AZURE_CONSTANTS["instance_types"]),
     unit_of_measure=cycle(AZURE_CONSTANTS["units_of_measure"]),
     _fill_optional=True,
-    _bulk_create=True,
     _quantity=min(AZURE_CONSTANTS.length, 9),
 )
 
 ocp_on_gcp_daily_summary = Recipe(
     "OCPGCPCostLineItemDailySummaryP",
+    namespace=cycle([ns] for ns in OCP_CONSTANTS["namespaces"]),
     node=cycle(f"gcp_node_{i}" for i in range(GCP_CONSTANTS.length - 1)),
     resource_id=cycle(f"i-{i}{i}{i}{i}{i}{i}{i}" for i in range(GCP_CONSTANTS.length - 1)),
     project_id=cycle(OCP_CONSTANTS["namespaces"]),
     project_name=cycle(OCP_CONSTANTS["storage_classes"]),  # maybe this can change, idk
-    namespace=cycle([ns] for ns in OCP_CONSTANTS["namespaces"]),
     service_id=cycle(GCP_CONSTANTS["service_ids"]),
     service_alias=cycle(GCP_CONSTANTS["service_aliases"]),
-    sku_id=cycle(GCP_CONSTANTS["service_ids"]),
-    sku_alias=cycle(GCP_CONSTANTS["sku_aliases"]),
     unit=cycle(GCP_CONSTANTS["units"]),
-    resource_location="US East",
     _fill_optional=True,
-    _bulk_create=True,
     _quantity=min(GCP_CONSTANTS.length, 9),
 )
 
 ocp_on_gcp_project_daily_summary_pod = Recipe(  # Pod data_source
     "OCPGCPCostLineItemProjectDailySummaryP",
     data_source="Pod",
+    namespace=cycle(OCP_CONSTANTS["namespaces"]),
     node=cycle(f"gcp_node_{i}" for i in range(GCP_CONSTANTS.length - 1)),
     resource_id=cycle(f"i-{i}{i}{i}{i}{i}{i}{i}" for i in range(GCP_CONSTANTS.length - 1)),
     project_id=cycle(OCP_CONSTANTS["namespaces"]),
     project_name=cycle(OCP_CONSTANTS["storage_classes"]),  # maybe this can change, idk
-    namespace=cycle(OCP_CONSTANTS["namespaces"]),
     pod_labels=cycle(OCP_CONSTANTS["pod_labels"]),
     persistentvolumeclaim=None,
     persistentvolume=None,
@@ -251,18 +242,17 @@ ocp_on_gcp_project_daily_summary_pod = Recipe(  # Pod data_source
     sku_alias=cycle(GCP_CONSTANTS["sku_aliases"]),
     unit=cycle(GCP_CONSTANTS["units"]),
     _fill_optional=True,
-    _bulk_create=True,
     _quantity=min(GCP_CONSTANTS.length, 9),
 )
 
 ocp_on_gcp_project_daily_summary_storage = Recipe(  # Storage data_source
     "OCPGCPCostLineItemProjectDailySummaryP",
     data_source="Storage",
+    namespace=cycle(OCP_CONSTANTS["namespaces"]),
     node=cycle(f"gcp_node_{i}" for i in range(GCP_CONSTANTS.length - 1)),
     resource_id=cycle(f"i-{i}{i}{i}{i}{i}{i}{i}" for i in range(GCP_CONSTANTS.length - 1)),
     project_id=cycle(OCP_CONSTANTS["namespaces"]),
     project_name=cycle(OCP_CONSTANTS["storage_classes"]),  # maybe this can change, idk
-    namespace=cycle(OCP_CONSTANTS["namespaces"]),
     persistentvolumeclaim=cycle(f"pvc_gcp_{i}" for i in range(GCP_CONSTANTS.length - 1)),
     persistentvolume=cycle(f"pv_gcp{i}" for i in range(GCP_CONSTANTS.length - 1)),
     storageclass=cycle(OCP_CONSTANTS["storage_classes"]),
@@ -272,6 +262,5 @@ ocp_on_gcp_project_daily_summary_storage = Recipe(  # Storage data_source
     sku_alias=cycle(GCP_CONSTANTS["sku_aliases"]),
     unit=cycle(GCP_CONSTANTS["units"]),
     _fill_optional=True,
-    _bulk_create=True,
     _quantity=min(GCP_CONSTANTS.length, 9),
 )

--- a/koku/api/report/test/util/constants.py
+++ b/koku/api/report/test/util/constants.py
@@ -148,6 +148,7 @@ OCP_ON_PREM_COST_MODEL = {
     "name": "Cost Management OpenShift Cost Model",
     "description": "A cost model of on-premises OpenShift clusters.",
     "distribution": "cpu",
+    "markup": {"value": 10, "unit": "percent"},
     "rates": [
         {
             "metric": {"name": "cpu_core_usage_per_hour"},
@@ -155,9 +156,29 @@ OCP_ON_PREM_COST_MODEL = {
             "cost_type": "Supplementary",
         },
         {
+            "metric": {"name": "cpu_core_usage_per_hour"},
+            "tiered_rates": [{"unit": "USD", "value": 0.0140000000, "usage_start": None, "usage_end": None}],
+            "cost_type": "Infrastructure",
+        },
+        {
             "metric": {"name": "cpu_core_request_per_hour"},
             "tiered_rates": [{"unit": "USD", "value": 0.2000000000, "usage_start": None, "usage_end": None}],
             "cost_type": "Supplementary",
+        },
+        {
+            "metric": {"name": "cpu_core_request_per_hour"},
+            "tiered_rates": [{"unit": "USD", "value": 0.4000000000, "usage_start": None, "usage_end": None}],
+            "cost_type": "Infrastructure",
+        },
+        {
+            "metric": {"name": "cpu_core_effective_usage_per_hour"},
+            "tiered_rates": [{"unit": "USD", "value": 0.7000000000, "usage_start": None, "usage_end": None}],
+            "cost_type": "Supplementary",
+        },
+        {
+            "metric": {"name": "cpu_core_effective_usage_per_hour"},
+            "tiered_rates": [{"unit": "USD", "value": 1.4000000000, "usage_start": None, "usage_end": None}],
+            "cost_type": "Infrastructure",
         },
         {
             "metric": {"name": "memory_gb_usage_per_hour"},
@@ -165,9 +186,29 @@ OCP_ON_PREM_COST_MODEL = {
             "cost_type": "Supplementary",
         },
         {
+            "metric": {"name": "memory_gb_usage_per_hour"},
+            "tiered_rates": [{"unit": "USD", "value": 0.0180000000, "usage_start": None, "usage_end": None}],
+            "cost_type": "Infrastructure",
+        },
+        {
             "metric": {"name": "memory_gb_request_per_hour"},
             "tiered_rates": [{"unit": "USD", "value": 0.0500000000, "usage_start": None, "usage_end": None}],
             "cost_type": "Supplementary",
+        },
+        {
+            "metric": {"name": "memory_gb_request_per_hour"},
+            "tiered_rates": [{"unit": "USD", "value": 0.1000000000, "usage_start": None, "usage_end": None}],
+            "cost_type": "Infrastructure",
+        },
+        {
+            "metric": {"name": "memory_gb_effective_usage_per_hour"},
+            "tiered_rates": [{"unit": "USD", "value": 0.500000000, "usage_start": None, "usage_end": None}],
+            "cost_type": "Supplementary",
+        },
+        {
+            "metric": {"name": "memory_gb_effective_usage_per_hour"},
+            "tiered_rates": [{"unit": "USD", "value": 1.0000000000, "usage_start": None, "usage_end": None}],
+            "cost_type": "Infrastructure",
         },
         {
             "metric": {"name": "storage_gb_usage_per_month"},
@@ -175,23 +216,23 @@ OCP_ON_PREM_COST_MODEL = {
             "cost_type": "Supplementary",
         },
         {
+            "metric": {"name": "storage_gb_usage_per_month"},
+            "tiered_rates": [{"unit": "USD", "value": 0.02, "usage_start": None, "usage_end": None}],
+            "cost_type": "Infrastructure",
+        },
+        {
             "metric": {"name": "storage_gb_request_per_month"},
             "tiered_rates": [{"unit": "USD", "value": 0.01, "usage_start": None, "usage_end": None}],
             "cost_type": "Supplementary",
         },
         {
+            "metric": {"name": "storage_gb_request_per_month"},
+            "tiered_rates": [{"unit": "USD", "value": 0.02, "usage_start": None, "usage_end": None}],
+            "cost_type": "Infrastructure",
+        },
+        {
             "metric": {"name": "node_cost_per_month"},
             "tiered_rates": [{"unit": "USD", "value": 1000.0, "usage_start": None, "usage_end": None}],
-            "cost_type": "Infrastructure",
-        },
-        {
-            "metric": {"name": "cluster_cost_per_month"},
-            "tiered_rates": [{"unit": "USD", "value": 10000.0, "usage_start": None, "usage_end": None}],
-            "cost_type": "Infrastructure",
-        },
-        {
-            "metric": {"name": "pvc_cost_per_month"},
-            "tiered_rates": [{"unit": "USD", "value": 10.0, "usage_start": None, "usage_end": None}],
             "cost_type": "Infrastructure",
         },
         {
@@ -201,8 +242,18 @@ OCP_ON_PREM_COST_MODEL = {
         },
         {
             "metric": {"name": "cluster_cost_per_month"},
+            "tiered_rates": [{"unit": "USD", "value": 10000.0, "usage_start": None, "usage_end": None}],
+            "cost_type": "Infrastructure",
+        },
+        {
+            "metric": {"name": "cluster_cost_per_month"},
             "tiered_rates": [{"unit": "USD", "value": 1000.0, "usage_start": None, "usage_end": None}],
             "cost_type": "Supplementary",
+        },
+        {
+            "metric": {"name": "pvc_cost_per_month"},
+            "tiered_rates": [{"unit": "USD", "value": 10.0, "usage_start": None, "usage_end": None}],
+            "cost_type": "Infrastructure",
         },
         {
             "metric": {"name": "pvc_cost_per_month"},

--- a/koku/api/report/test/util/model_bakery_loader.py
+++ b/koku/api/report/test/util/model_bakery_loader.py
@@ -5,6 +5,7 @@
 """Test utilities."""
 import logging
 import random
+from datetime import datetime
 from datetime import timedelta
 from itertools import cycle
 from itertools import product
@@ -115,6 +116,8 @@ class ModelBakeryDataLoader(DataLoader):
             if provider_type == Provider.PROVIDER_OCP:
                 data["report_period_start"] = bill_date
                 data["report_period_end"] = month_end + timedelta(days=1)
+                data["summary_data_creation_datetime"] = datetime.now()
+                data["summary_data_updated_datetime"] = datetime.now()
             else:
                 data["billing_period_start"] = bill_date
                 data["billing_period_end"] = month_end
@@ -135,6 +138,7 @@ class ModelBakeryDataLoader(DataLoader):
                 description=OCP_ON_PREM_COST_MODEL.get("description"),
                 rates=OCP_ON_PREM_COST_MODEL.get("rates"),
                 distribution=OCP_ON_PREM_COST_MODEL.get("distribution"),
+                markup=OCP_ON_PREM_COST_MODEL.get("markup"),
                 source_type=provider.type,
                 currency=self.currency,
                 _fill_optional=True,
@@ -347,7 +351,11 @@ class ModelBakeryDataLoader(DataLoader):
             daily_summary_recipe = "api.report.test.util.ocp_on_aws_daily_summary"
             project_summary_pod_recipe = "api.report.test.util.ocp_on_aws_project_daily_summary_pod"
             project_summary_storage_recipe = "api.report.test.util.ocp_on_aws_project_daily_summary_storage"
-            dbaccessor, tags_update_method = AWSReportDBAccessor, "populate_ocp_on_aws_tags_summary_table"
+            dbaccessor, tags_update_method, ui_update_method = (
+                AWSReportDBAccessor,
+                "populate_ocp_on_aws_tags_summary_table",
+                "populate_ocp_on_aws_ui_summary_tables",
+            )
             with schema_context(self.schema):
                 account_alias = random.choice(list(AWSAccountAlias.objects.all()))
             unique_fields = {"currency_code": self.currency, "account_alias": account_alias}
@@ -355,23 +363,32 @@ class ModelBakeryDataLoader(DataLoader):
             daily_summary_recipe = "api.report.test.util.ocp_on_azure_daily_summary"
             project_summary_pod_recipe = "api.report.test.util.ocp_on_azure_project_daily_summary_pod"
             project_summary_storage_recipe = "api.report.test.util.ocp_on_azure_project_daily_summary_storage"
-            dbaccessor, tags_update_method = AzureReportDBAccessor, "populate_ocp_on_azure_tags_summary_table"
+            dbaccessor, tags_update_method, ui_update_method = (
+                AzureReportDBAccessor,
+                "populate_ocp_on_azure_tags_summary_table",
+                "populate_ocp_on_azure_ui_summary_tables",
+            )
             unique_fields = {"currency": self.currency, "subscription_guid": self.faker.uuid4()}
         elif provider_type in (Provider.PROVIDER_GCP, Provider.PROVIDER_GCP_LOCAL):
             daily_summary_recipe = "api.report.test.util.ocp_on_gcp_daily_summary"
             project_summary_pod_recipe = "api.report.test.util.ocp_on_gcp_project_daily_summary_pod"
             project_summary_storage_recipe = "api.report.test.util.ocp_on_gcp_project_daily_summary_storage"
-            dbaccessor, tags_update_method = GCPReportDBAccessor, "populate_ocp_on_gcp_tags_summary_table"
+            dbaccessor, tags_update_method, ui_update_method = (
+                GCPReportDBAccessor,
+                "populate_ocp_on_gcp_tags_summary_table",
+                "populate_ocp_on_gcp_ui_summary_tables",
+            )
             unique_fields = {
                 "currency": self.currency,
-                "account_id": self.faker.pystr_format(string_format="####################"),
+                "account_id": self.faker.pystr_format(string_format="???????????????"),
             }
 
         provider = Provider.objects.filter(type=provider_type).first()
         for dates, bill, report_period in zip(self.dates, bills, report_periods):
-            start_date = dates[0]
-            end_date = dates[1]
-            LOG.info(f"load ocp-on-{provider.type} data for start: {start_date}, end: {end_date}")
+            start_date, end_date, bill_date = dates
+            if provider_type in (Provider.PROVIDER_GCP, Provider.PROVIDER_GCP_LOCAL):
+                unique_fields["invoice_month"] = bill_date.strftime("%Y%m")
+            LOG.info(f"load OCP-on-{provider.type} data for start: {start_date}, end: {end_date}")
             with schema_context(self.schema):
                 days = (end_date - start_date).days
                 for i in range(days):
@@ -415,7 +432,20 @@ class ModelBakeryDataLoader(DataLoader):
                         **unique_fields,
                     )
         with dbaccessor(self.schema) as accessor:
+            # update tags
             cls_method = getattr(accessor, tags_update_method)
             cls_method([bill.id for bill in bills], self.first_start_date, self.last_end_date)
+
+            # update ui tables
+            sql_params = {
+                "schema_name": self.schema,
+                "start_date": self.first_start_date,
+                "end_date": self.last_end_date,
+                "source_uuid": provider.uuid,
+                "cluster_id": cluster_id,
+                "cluster_alias": cluster_id,
+            }
+            cls_method = getattr(accessor, ui_update_method)
+            cls_method(sql_params)
 
         refresh_materialized_views(self.schema, provider_type, provider_uuid=provider.uuid, synchronous=True)


### PR DESCRIPTION
Related to [COST-444](https://issues.redhat.com/browse/COST-444)

Changes proposed in this PR:
* For some reason, the previous usage of `fake.pydecimal` was not adding any variability. Switched this to a generator function and stuck it into `cycle`
* Update the OCP-on-X UI summary tables when populating that data
* Add more data to the on-prem cost model

Testing Instructions:
1. Run unit tests