### PR TITLE
Fixed script so we are loading the correct info

### DIFF
--- a/dev/scripts/load_test_customer_data.sh
+++ b/dev/scripts/load_test_customer_data.sh
@@ -253,7 +253,7 @@ build_azure_data() {
                               "$YAML_PATH/ocp_on_azure/rendered_ocp_static_data.yml"
                               "$YAML_PATH/rendered_azure_v2.yml")
 
-  local _download_types=("Test OCP on GCP" "Test GCP Source" "Test OCPGCP Source")
+  local _download_types=("Test OCP on Azure" "Test Azure Source" "Test Azure v2 Source")
 
   log-info "Rendering ${_source_name} YAML files..."
   render_yaml_files "${_yaml_files[@]}"
@@ -284,7 +284,7 @@ build_gcp_data() {
                               "$YAML_PATH/ocp_on_gcp/rendered_ocp_static_data.yml"
                               "$YAML_PATH/ocp_on_gcp/rendered_gcp_static_data.yml")
 
-  local _download_types=("Test OCP on Azure" "Test Azure Source" "Test Azure v2 Source")
+  local _download_types=("Test OCP on GCP" "Test GCP Source" "Test OCPGCP Source")
 
   log-info "Rendering ${_source_name} YAML files..."
   render_yaml_files "${_yaml_files[@]}"

--- a/dev/scripts/load_test_customer_data.sh
+++ b/dev/scripts/load_test_customer_data.sh
@@ -148,9 +148,9 @@ trigger_download() {
   #
   local _download_types=("$@")
   for download_type in "${_download_types[@]}"; do
-    UUID=$(psql $DATABASE_NAME --no-password --tuples-only -c "SELECT uuid from public.api_provider WHERE name = '$1'" | head -1 | sed -e 's/^[ \t]*//')
+    UUID=$(psql $DATABASE_NAME --no-password --tuples-only -c "SELECT uuid from public.api_provider WHERE name = '$download_type'" | head -1 | sed -e 's/^[ \t]*//')
     if [[ ! -z $UUID ]]; then
-        log-info "Triggering download for, source_name: $1, uuid: $UUID"
+        log-info "Triggering download for, source_name: $download_type, uuid: $UUID"
         RESPONSE=$(curl -s -w "%{http_code}\n" ${MASU_URL_PREFIX}/v1/download/?provider_uuid=$UUID)
         STATUS_CODE=${RESPONSE: -3}
         DATA=${RESPONSE:: -3}


### PR DESCRIPTION
FIX for - Refactor on load-test-customer-data script

notice the difference `source_name & uuid` in the below outputs (duplicates in bad run)

Here is the bad run
```
(koku) bash-3.2$ make test_source=gcp load-test-customer-data
/Users/dougdonahue/github/koku/dev/scripts/load_test_customer_data.sh gcp  
2022-03-09 19:37:09 [INFO	]  Checking environment variables...
2022-03-09 19:37:09 [INFO	]  Calculating dates...
2022-03-09 19:37:09 [INFO	]  Koku is up and running
2022-03-09 19:37:09 [INFO	]  Masu is up and running
2022-03-09 19:37:09 [INFO	]  Rendering GCP YAML files...
2022-03-09 19:37:09 [INFO	]  Building OpenShift on GCP report data...
2022-03-09 19:37:09 [INFO	]  Cleanup GCP rendered YAML files...
2022-03-09 19:37:09 [INFO	]  Adding GCP cost models...
2022-03-09 19:37:09 [INFO	]  creating cost model, source_name: Test GCP Source, uuid: 8f2f6dd3-bbad-4f87-b2c6-802ebf1db4d9
2022-03-09 19:37:09 [WARNING	]  {"errors":[{"detail":"Source 8f2f6dd3-bbad-4f87-b2c6-802ebf1db4d9 is already associated with cost model: b9da92f3-56ca-4234-813a-47c06feaed3c.","source":"cost-models","status":400}]}
2022-03-09 19:37:09 [INFO	]  Trigger downloads...
2022-03-09 19:37:09 [INFO	]  Triggering download for, source_name: Test OCP on GCP, uuid: 9f0ce3c4-0998-48e3-8131-6d906617d41c
2022-03-09 19:37:09 [INFO	]  Triggering download for, source_name: Test OCP on GCP, uuid: 9f0ce3c4-0998-48e3-8131-6d906617d41c
2022-03-09 19:37:09 [INFO	]  Triggering download for, source_name: Test OCP on GCP, uuid: 9f0ce3c4-0998-48e3-8131-6d906617d41c
2022-03-09 19:37:09 [INFO	]  Enabling OCP tags...
make load-aws-org-unit-tre
```
Good Run
```
(koku) bash-3.2$ make test_source=gcp load-test-customer-data
/Users/dougdonahue/github/koku/dev/scripts/load_test_customer_data.sh gcp  
2022-03-09 19:48:01 [INFO	]  Checking environment variables...
2022-03-09 19:48:01 [INFO	]  Calculating dates...
2022-03-09 19:48:01 [INFO	]  Koku is up and running
2022-03-09 19:48:01 [INFO	]  Masu is up and running
2022-03-09 19:48:01 [INFO	]  Rendering GCP YAML files...
2022-03-09 19:48:01 [INFO	]  Building OpenShift on GCP report data...
2022-03-09 19:48:01 [INFO	]  Cleanup GCP rendered YAML files...
2022-03-09 19:48:01 [INFO	]  Adding GCP cost models...
2022-03-09 19:48:01 [INFO	]  creating cost model, source_name: Test GCP Source, uuid: 8f2f6dd3-bbad-4f87-b2c6-802ebf1db4d9
2022-03-09 19:48:01 [WARNING	]  {"errors":[{"detail":"Source 8f2f6dd3-bbad-4f87-b2c6-802ebf1db4d9 is already associated with cost model: b9da92f3-56ca-4234-813a-47c06feaed3c.","source":"cost-models","status":400}]}
2022-03-09 19:48:01 [INFO	]  Trigger downloads...
2022-03-09 19:48:01 [INFO	]  Triggering download for, source_name: Test OCP on GCP, uuid: 9f0ce3c4-0998-48e3-8131-6d906617d41c
2022-03-09 19:48:01 [INFO	]  Triggering download for, source_name: Test GCP Source, uuid: 8753db2f-5e7f-4e14-b340-73be2c76d245
2022-03-09 19:48:01 [INFO	]  Triggering download for, source_name: Test OCPGCP Source, uuid: db677853-3238-4d94-87f7-c8a4990c68a8
2022-03-09 19:48:01 [INFO	]  Enabling OCP tags...
make load-aws-org-unit-tree
```
Changes proposed in this PR:

better logging output (debug flag is right)
options to allow loading individual source types
Testing Instructions:

Setup as normal
run create customer data
make create-test-customer
Test loading just Azure data
make test_source=azure load-test-customer-data
Test loading AWS with debug flag set to true
export DEBUG=true
make test_source=aws load-test-customer-data
Test default which will load all data
make load-test-customer-data
