### PR TITLE
Enable Parquet processing for gcp smoke pr checks

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -74,7 +74,7 @@ function run_smoke_tests() {
 }
 
 function run_trino_smoke_tests() {
-    if check_for_labels "trino-smoke-tests|gcp_smoke_tests"
+    if check_for_labels "trino-smoke-tests|gcp-smoke-tests"
     then
         echo "Running smoke tests with ENABLE_PARQUET_PROCESSING set to TRUE"
         ENABLE_PARQUET_PROCESSING="true"

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -74,7 +74,7 @@ function run_smoke_tests() {
 }
 
 function run_trino_smoke_tests() {
-    if check_for_labels "trino-smoke-tests"
+    if check_for_labels "trino-smoke-tests|gcp_smoke_tests"
     then
         echo "Running smoke tests with ENABLE_PARQUET_PROCESSING set to TRUE"
         ENABLE_PARQUET_PROCESSING="true"


### PR DESCRIPTION
Fixes [COST-####](https://issues.redhat.com/browse/COST-####)

Changes proposed in this PR:
* Enable parquet processing on gcp smokes label so the ocp source for ocp on gcp is run through the trino flow
*

Testing Instructions:
1. put the gcp-smoke-tests label on and retest smokes and make sure `ENABLE_PARQUET_PROCESSING` gets set to true during the PR check run

---
Additional Context:
https://ci.ext.devshift.net/job/project-koku-koku-pr-check/4294/ this pr check ran smokes and the ocp on gcp tests ran swimmingly