### PR TITLE
[COST-2482] speed up postgres deletes

### DIFF
--- a/koku/masu/database/aws_report_db_accessor.py
+++ b/koku/masu/database/aws_report_db_accessor.py
@@ -276,7 +276,12 @@ class AWSReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
             }
             summary_sql, summary_sql_params = self.jinja_sql.prepare_query(summary_sql, summary_sql_params)
             self._execute_raw_sql_query(
-                table_name, summary_sql, start_date, end_date, bind_params=list(summary_sql_params)
+                table_name,
+                summary_sql,
+                start_date,
+                end_date,
+                bind_params=list(summary_sql_params),
+                operation="DELETE/INSERT",
             )
 
     def populate_line_item_daily_summary_table_presto(self, start_date, end_date, source_uuid, bill_id, markup_value):

--- a/koku/masu/database/azure_report_db_accessor.py
+++ b/koku/masu/database/azure_report_db_accessor.py
@@ -312,7 +312,12 @@ class AzureReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
             }
             summary_sql, summary_sql_params = self.jinja_sql.prepare_query(summary_sql, summary_sql_params)
             self._execute_raw_sql_query(
-                table_name, summary_sql, start_date, end_date, bind_params=list(summary_sql_params)
+                table_name,
+                summary_sql,
+                start_date,
+                end_date,
+                bind_params=list(summary_sql_params),
+                operation="DELETE/INSERT",
             )
 
     def populate_ocp_on_azure_ui_summary_tables(self, sql_params, tables=OCPAZURE_UI_SUMMARY_TABLES):

--- a/koku/masu/database/ocp_report_db_accessor.py
+++ b/koku/masu/database/ocp_report_db_accessor.py
@@ -369,7 +369,12 @@ class OCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
             }
             summary_sql, summary_sql_params = self.jinja_sql.prepare_query(summary_sql, summary_sql_params)
             self._execute_raw_sql_query(
-                table_name, summary_sql, start_date, end_date, bind_params=list(summary_sql_params)
+                table_name,
+                summary_sql,
+                start_date,
+                end_date,
+                bind_params=list(summary_sql_params),
+                operation="DELETE/INSERT",
             )
 
     def update_line_item_daily_summary_with_enabled_tags(self, start_date, end_date, report_period_ids):

--- a/koku/masu/database/report_db_accessor_base.py
+++ b/koku/masu/database/report_db_accessor_base.py
@@ -5,6 +5,7 @@
 """Database accessor for report data."""
 import logging
 import os
+import time
 import uuid
 from decimal import Decimal
 from decimal import InvalidOperation
@@ -341,23 +342,25 @@ class ReportDBAccessorBase(KokuDBAccess):
                 value = None
         return value
 
-    def _execute_raw_sql_query(self, table, sql, start=None, end=None, bind_params=None):
+    def _execute_raw_sql_query(self, table, sql, start=None, end=None, bind_params=None, operation="UPDATE"):
         """Run a SQL statement via a cursor."""
         if start and end:
-            LOG.info("Updating %s from %s to %s.", table, start, end)
+            LOG.info("Triggering %s on %s from %s to %s.", operation, table, start, end)
         else:
-            LOG.info("Updating %s", table)
+            LOG.info("Triggering %s %s", operation, table)
 
         with connection.cursor() as cursor:
             cursor.db.set_schema(self.schema)
             try:
+                t1 = time.time()
                 cursor.execute(sql, params=bind_params)
+                t2 = time.time()
             except OperationalError as exc:
                 db_exc = get_extended_exception_by_type(exc)
                 LOG.error(log_json(os.getpid(), str(db_exc), context=db_exc.as_dict()))
                 raise db_exc
 
-        LOG.info("Finished updating %s.", table)
+        LOG.info("Finished %s on %s in %f seconds.", operation, table, t2 - t1)
 
     def _execute_presto_raw_sql_query(self, schema, sql, bind_params=None):
         """Execute a single presto query"""
@@ -449,17 +452,20 @@ class ReportDBAccessorBase(KokuDBAccess):
         LOG.info(msg)
 
     def delete_line_item_daily_summary_entries_for_date_range_raw(
-        self, source_uuid, start_date, end_date, table=None, filters=None
+        self, source_uuid, start_date, end_date, filters, table=None
     ):
+        if filters is None:
+            msg = "The filters param must be a valid dictionary of filters."
+            raise ReportDBAccessorException(msg)
+
         if table is None:
             table = self.line_item_daily_summary_table
-        msg = f"Deleting records from {table._meta.db_table} from {start_date} to {end_date}"
+        msg = f"Deleting records from {table._meta.db_table} for source {source_uuid} from {start_date} to {end_date}"
         LOG.info(msg)
 
         sql = f"""
             DELETE FROM {self.schema}.{table._meta.db_table}
-            WHERE source_uuid = %(source_uuid)s::uuid
-                AND usage_start >= %(start_date)s::date
+            WHERE usage_start >= %(start_date)s::date
                 AND usage_start <= %(end_date)s::date
         """
         if filters:
@@ -467,11 +473,10 @@ class ReportDBAccessorBase(KokuDBAccess):
             sql += "\n".join(filter_list)
         else:
             filters = {}
-        filters["source_uuid"] = source_uuid
         filters["start_date"] = start_date
         filters["end_date"] = end_date
 
-        self._execute_raw_sql_query(table, sql, start_date, end_date, bind_params=filters)
+        self._execute_raw_sql_query(table, sql, start_date, end_date, bind_params=filters, operation="DELETE")
 
     def table_exists_trino(self, table_name):
         """Check if table exists."""

--- a/koku/masu/processor/aws/aws_report_parquet_summary_updater.py
+++ b/koku/masu/processor/aws/aws_report_parquet_summary_updater.py
@@ -110,7 +110,12 @@ class AWSReportParquetSummaryUpdater(PartitionHandlerMixin):
                     start,
                     end,
                 )
-                accessor.delete_line_item_daily_summary_entries_for_date_range_raw(self._provider.uuid, start, end)
+                filters = {
+                    "cost_entry_bill_id": current_bill_id
+                }  # Use cost_entry_bill_id to leverage DB index on DELETE
+                accessor.delete_line_item_daily_summary_entries_for_date_range_raw(
+                    self._provider.uuid, start, end, filters
+                )
                 accessor.populate_line_item_daily_summary_table_presto(
                     start, end, self._provider.uuid, current_bill_id, markup_value
                 )

--- a/koku/masu/processor/azure/azure_report_parquet_summary_updater.py
+++ b/koku/masu/processor/azure/azure_report_parquet_summary_updater.py
@@ -105,7 +105,12 @@ class AzureReportParquetSummaryUpdater(PartitionHandlerMixin):
                     start,
                     end,
                 )
-                accessor.delete_line_item_daily_summary_entries_for_date_range_raw(self._provider.uuid, start, end)
+                filters = {
+                    "cost_entry_bill_id": current_bill_id
+                }  # Use cost_entry_bill_id to leverage DB index on DELETE
+                accessor.delete_line_item_daily_summary_entries_for_date_range_raw(
+                    self._provider.uuid, start, end, filters
+                )
                 accessor.populate_line_item_daily_summary_table_presto(
                     start, end, self._provider.uuid, current_bill_id, markup_value
                 )

--- a/koku/masu/processor/gcp/gcp_report_parquet_summary_updater.py
+++ b/koku/masu/processor/gcp/gcp_report_parquet_summary_updater.py
@@ -115,7 +115,12 @@ class GCPReportParquetSummaryUpdater(PartitionHandlerMixin):
                     start,
                     end,
                 )
-                accessor.delete_line_item_daily_summary_entries_for_date_range_raw(self._provider.uuid, start, end)
+                filters = {
+                    "cost_entry_bill_id": current_bill_id
+                }  # Use cost_entry_bill_id to leverage DB index on DELETE
+                accessor.delete_line_item_daily_summary_entries_for_date_range_raw(
+                    self._provider.uuid, start, end, filters
+                )
                 accessor.populate_line_item_daily_summary_table_presto(
                     start, end, self._provider.uuid, current_bill_id, markup_value
                 )

--- a/koku/masu/processor/ocp/ocp_cloud_parquet_summary_updater.py
+++ b/koku/masu/processor/ocp/ocp_cloud_parquet_summary_updater.py
@@ -112,12 +112,11 @@ class OCPCloudParquetReportSummaryUpdater(OCPCloudReportSummaryUpdater):
                     cluster_id,
                     current_aws_bill_id,
                 )
+                filters = {
+                    "report_period_id": current_ocp_report_period_id
+                }  # Use report_period_id to leverage DB index on DELETE
                 accessor.delete_line_item_daily_summary_entries_for_date_range_raw(
-                    self._provider.uuid,
-                    start,
-                    end,
-                    table=OCPAWSCostLineItemProjectDailySummaryP,
-                    filters={"cluster_id": cluster_id},
+                    self._provider.uuid, start, end, filters, table=OCPAWSCostLineItemProjectDailySummaryP
                 )
                 accessor.populate_ocp_on_aws_cost_daily_summary_presto(
                     start,
@@ -222,12 +221,11 @@ class OCPCloudParquetReportSummaryUpdater(OCPCloudReportSummaryUpdater):
                     cluster_id,
                     current_azure_bill_id,
                 )
+                filters = {
+                    "report_period_id": current_ocp_report_period_id
+                }  # Use report_period_id to leverage DB index on DELETE
                 accessor.delete_line_item_daily_summary_entries_for_date_range_raw(
-                    self._provider.uuid,
-                    start,
-                    end,
-                    table=OCPAzureCostLineItemProjectDailySummaryP,
-                    filters={"cluster_id": cluster_id},
+                    self._provider.uuid, start, end, filters, table=OCPAzureCostLineItemProjectDailySummaryP
                 )
                 accessor.populate_ocp_on_azure_cost_daily_summary_presto(
                     start,
@@ -321,12 +319,11 @@ class OCPCloudParquetReportSummaryUpdater(OCPCloudReportSummaryUpdater):
                     cluster_id,
                     current_gcp_bill_id,
                 )
+                filters = {
+                    "report_period_id": current_ocp_report_period_id
+                }  # Use report_period_id to leverage DB index on DELETE
                 accessor.delete_line_item_daily_summary_entries_for_date_range_raw(
-                    self._provider.uuid,
-                    start,
-                    end,
-                    table=OCPGCPCostLineItemProjectDailySummaryP,
-                    filters={"cluster_id": cluster_id},
+                    self._provider.uuid, start, end, filters, table=OCPGCPCostLineItemProjectDailySummaryP
                 )
                 accessor.populate_ocp_on_gcp_cost_daily_summary_presto(
                     start,

--- a/koku/masu/processor/ocp/ocp_report_parquet_summary_updater.py
+++ b/koku/masu/processor/ocp/ocp_report_parquet_summary_updater.py
@@ -126,7 +126,10 @@ class OCPReportParquetSummaryUpdater(PartitionHandlerMixin):
                     end,
                 )
                 # This will process POD and STORAGE together
-                accessor.delete_line_item_daily_summary_entries_for_date_range_raw(self._provider.uuid, start, end)
+                filters = {"report_period_id": report_period_id}  # Use report_period_id to leverage DB index on DELETE
+                accessor.delete_line_item_daily_summary_entries_for_date_range_raw(
+                    self._provider.uuid, start, end, filters
+                )
                 accessor.populate_line_item_daily_summary_table_presto(
                     start, end, report_period_id, self._cluster_id, self._cluster_alias, self._provider.uuid
                 )


### PR DESCRIPTION
Fixes [COST-2482](https://issues.redhat.com/browse/COST-2482)

Changes proposed in this PR:
* This changes our raw deletes to use an indexed column for the DELETE statement to speed things up
* Adds logging for how long SQL query took to execute

Testing Instructions:
1. Run `this command` ...
2. Ingest this data `with this other command` ...
3. Expect to see this result:
   ```
   GET http://localhost:8000/api/endpoint

   {json: response}
   ```
4.
5.

---
Additional Context:

I used EXPLAIN to show that what we were doing should be much slower than leveraging an indexed column.

First is an example using the source_uuid as we have been. It requires sequence scans which means it must go through the full table to figure out which records to delete.

```
koku=# explain delete from reporting_ocpusagelineitem_daily_summary where source_uuid = '916b0fe4-4c23-4445-9f7c-17167a843dfd';
                                                                    QUERY PLAN
---------------------------------------------------------------------------------------------------------------------------------------------------
 Delete on reporting_ocpusagelineitem_daily_summary  (cost=0.00..567.83 rows=5 width=6)
   Delete on reporting_ocpusagelineitem_daily_summary_2022_01 reporting_ocpusagelineitem_daily_summary_1
   Delete on reporting_ocpusagelineitem_daily_summary_2022_02 reporting_ocpusagelineitem_daily_summary_2
   Delete on reporting_ocpusagelineitem_daily_summary_2022_03 reporting_ocpusagelineitem_daily_summary_3
   Delete on reporting_ocpusagelineitem_daily_summary_2022_04 reporting_ocpusagelineitem_daily_summary_4
   Delete on reporting_ocpusagelineitem_daily_summary_default reporting_ocpusagelineitem_daily_summary_5
   ->  Seq Scan on reporting_ocpusagelineitem_daily_summary_2022_01 reporting_ocpusagelineitem_daily_summary_1  (cost=0.00..10.12 rows=1 width=6)
         Filter: (source_uuid = '916b0fe4-4c23-4445-9f7c-17167a843dfd'::uuid)
   ->  Seq Scan on reporting_ocpusagelineitem_daily_summary_2022_02 reporting_ocpusagelineitem_daily_summary_2  (cost=0.00..308.43 rows=1 width=6)
         Filter: (source_uuid = '916b0fe4-4c23-4445-9f7c-17167a843dfd'::uuid)
   ->  Seq Scan on reporting_ocpusagelineitem_daily_summary_2022_03 reporting_ocpusagelineitem_daily_summary_3  (cost=0.00..229.03 rows=1 width=6)
         Filter: (source_uuid = '916b0fe4-4c23-4445-9f7c-17167a843dfd'::uuid)
   ->  Seq Scan on reporting_ocpusagelineitem_daily_summary_2022_04 reporting_ocpusagelineitem_daily_summary_4  (cost=0.00..10.12 rows=1 width=6)
         Filter: (source_uuid = '916b0fe4-4c23-4445-9f7c-17167a843dfd'::uuid)
   ->  Seq Scan on reporting_ocpusagelineitem_daily_summary_default reporting_ocpusagelineitem_daily_summary_5  (cost=0.00..10.12 rows=1 width=6)
         Filter: (source_uuid = '916b0fe4-4c23-4445-9f7c-17167a843dfd'::uuid)
```

Using the report_period_id, which is a foreign key and is automatically indexed as such uses an index scan and should go faster on large tables
```
koku=# explain delete from reporting_ocpusagelineitem_daily_summary where report_period_id = 1;
                                                                                                       QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Delete on reporting_ocpusagelineitem_daily_summary  (cost=0.14..41.05 rows=5 width=6)
   Delete on reporting_ocpusagelineitem_daily_summary_2022_01 reporting_ocpusagelineitem_daily_summary_1
   Delete on reporting_ocpusagelineitem_daily_summary_2022_02 reporting_ocpusagelineitem_daily_summary_2
   Delete on reporting_ocpusagelineitem_daily_summary_2022_03 reporting_ocpusagelineitem_daily_summary_3
   Delete on reporting_ocpusagelineitem_daily_summary_2022_04 reporting_ocpusagelineitem_daily_summary_4
   Delete on reporting_ocpusagelineitem_daily_summary_default reporting_ocpusagelineitem_daily_summary_5
   ->  Index Scan using reporting_ocpusagelineitem_daily_summary__report_period_id_idx3 on reporting_ocpusagelineitem_daily_summary_2022_01 reporting_ocpusagelineitem_daily_summary_1  (cost=0.14..8.15 rows=1 width=6)
         Index Cond: (report_period_id = 1)
   ->  Index Scan using reporting_ocpusagelineitem_daily_summary_2_report_period_id_idx on reporting_ocpusagelineitem_daily_summary_2022_02 reporting_ocpusagelineitem_daily_summary_2  (cost=0.28..8.30 rows=1 width=6)
         Index Cond: (report_period_id = 1)
   ->  Index Scan using reporting_ocpusagelineitem_daily_summary__report_period_id_idx1 on reporting_ocpusagelineitem_daily_summary_2022_03 reporting_ocpusagelineitem_daily_summary_3  (cost=0.28..8.30 rows=1 width=6)
         Index Cond: (report_period_id = 1)
   ->  Index Scan using reporting_ocpusagelineitem_daily_summary__report_period_id_idx2 on reporting_ocpusagelineitem_daily_summary_2022_04 reporting_ocpusagelineitem_daily_summary_4  (cost=0.14..8.15 rows=1 width=6)
         Index Cond: (report_period_id = 1)
   ->  Index Scan using reporting_ocpusagelineitem_daily_summary_d_report_period_id_idx on reporting_ocpusagelineitem_daily_summary_default reporting_ocpusagelineitem_daily_summary_5  (cost=0.14..8.15 rows=1 width=6)
         Index Cond: (report_period_id = 1)
(16 rows)
```
