### PR TITLE
Cost 2500 explain query no spellcheck

### DIFF
--- a/koku/masu/api/db_performance/dbp_views.py
+++ b/koku/masu/api/db_performance/dbp_views.py
@@ -8,6 +8,7 @@ import os
 from decimal import Decimal
 
 from django.http import HttpResponse
+from django.shortcuts import redirect
 from django.urls import reverse
 from django.views.decorators.cache import never_cache
 from jinja2 import Template as JinjaTemplate
@@ -78,6 +79,13 @@ def set_null_display(rec, null_display_val=""):
 def get_identity_username(request):
     # This is a placeholder for now. This should resolve a username once actions are enabled.
     return "koku-user"
+
+
+@never_cache
+@api_view(http_method_names=["GET"])
+@permission_classes((AllowAny,))
+def db_performance_redirect(request):
+    return redirect("db_version")
 
 
 @never_cache

--- a/koku/masu/api/db_performance/dbp_views.py
+++ b/koku/masu/api/db_performance/dbp_views.py
@@ -47,9 +47,11 @@ def get_menu(curr_url_name):
     menu_elements = ['<ul id="menu-list" class="menu unselectable">']
     for url_name, content_name in menu_values:
         if url_name == curr_url_name:
-            element = f"<li><a>{content_name}</a></li>"
+            element = f'<li class="current unselectable"><a class="unselectable">{content_name}</a></li>'
         else:
-            element = f'<li><a href="{reverse(url_name)}">{content_name}</a></li>'
+            element = (
+                f'<li class="unselectable"><a class=unselectable href="{reverse(url_name)}">{content_name}</a></li>'
+            )
         menu_elements.append(element)
     menu_elements.append("</ul>")
 
@@ -317,7 +319,7 @@ def explain_query(request):
         page_header = f"""Explain Query Using Database: "{CONFIGURATOR.get_database_name()}" """
         return HttpResponse(
             render_template(
-                "explain_wuery", page_header, (), (), template="explain.html", action_urls=[reverse("explain_query")]
+                "explain_query", page_header, (), (), template="explain.html", action_urls=[reverse("explain_query")]
             )
         )
     else:

--- a/koku/masu/api/db_performance/templates/explain.html
+++ b/koku/masu/api/db_performance/templates/explain.html
@@ -94,8 +94,7 @@ function explain_it() {
         <h1 class="unselectable">Database Performance</h1>
         <hr class="unselectable" />
         <h2 id="data_header" class="unselectable">{{page_header}}</h2>
-        <!-- <textarea id="t-sql-statement" class="sqlinput" placeholder="Enter or paste a SQL query."></textarea> -->
-        <div id="div-sql-statement" contenteditable="true" class="pre monospace sans inset black-fg sqlinput xy-scroll box-margin"></div>
+        <div id="div-sql-statement" contenteditable="true" spellcheck="false" class="pre monospace sans inset black-fg sqlinput xy-scroll box-margin"></div>
         <div id="div-btn"  class="unselectable">
             <button id="explain-btn" onclick="explain_it()" class="unselectable">Explain</button>
         </div>

--- a/koku/masu/api/db_performance/templates/explain.html
+++ b/koku/masu/api/db_performance/templates/explain.html
@@ -19,6 +19,9 @@ SPDX-License-Identifier: Apache-2.0
                 margin-inline-end: 0px;
                 margin-right: 1em;
                 font-weight: bold;
+                margin-right: 0.5em;
+                padding-right: 1em;
+                border-right: 2px solid black;
             }
             ul.menu {
                 list-style-type: none;
@@ -42,6 +45,9 @@ SPDX-License-Identifier: Apache-2.0
             ul.menu > li a:hover {
                 background-color: black;
                 color: white;
+            }
+            .current {
+                border-bottom: 2px solid black;
             }
             .pre {white-space: pre;}
             .monospace {font-family: 'Courier New', Courier, monospace;}

--- a/koku/masu/api/db_performance/templates/explain.html
+++ b/koku/masu/api/db_performance/templates/explain.html
@@ -6,6 +6,43 @@ SPDX-License-Identifier: Apache-2.0
     <head>
         <title>Cost Management DB Performance Statistics</title>
         <style>
+            .container > * {
+                display: inline-block;
+                vertical-align: middle;
+            }
+            .header1 {
+                display: block;
+                font-size: 2em;
+                margin-block-start: 0.67em;
+                margin-block-end: 0.67em;
+                margin-inline-start: 0px;
+                margin-inline-end: 0px;
+                margin-right: 1em;
+                font-weight: bold;
+            }
+            ul.menu {
+                list-style-type: none;
+                margin: 0;
+                padding: 0;
+                overflow: hidden;
+                background-color: white;
+            }
+            ul.menu > li {
+                float: left;
+                font-family: Arial, Helvetica, sans-serif;
+            }
+            ul.menu > li > a {
+                display: block;
+                color: black;
+                text-align: center;
+                padding: 16px;
+                text-decoration: none;
+                font-weight: bold;
+            }
+            ul.menu > li a:hover {
+                background-color: black;
+                color: white;
+            }
             .pre {white-space: pre;}
             .monospace {font-family: 'Courier New', Courier, monospace;}
             .sans {font-family:'Courier New', Courier, monospace}
@@ -91,7 +128,12 @@ function explain_it() {
         </script>
     </head>
     <body>
-        <h1 class="unselectable">Database Performance</h1>
+        <div id="header-container" class="container unselectable">
+            <div id="header-div" class="header1 unselectable" style="display: inline-block !important;">Database Performance</div>
+            <div id="menu-div unselectable">
+                {{db_performance_menu}}
+            </div>
+        </div>
         <hr class="unselectable" />
         <h2 id="data_header" class="unselectable">{{page_header}}</h2>
         <div id="div-sql-statement" contenteditable="true" spellcheck="false" class="pre monospace sans inset black-fg sqlinput xy-scroll box-margin"></div>

--- a/koku/masu/api/db_performance/templates/gen_table.html
+++ b/koku/masu/api/db_performance/templates/gen_table.html
@@ -6,6 +6,43 @@ SPDX-License-Identifier: Apache-2.0
     <head>
         <title>Cost Management DB Performance Statistics</title>
         <style>
+            .container > * {
+                display: inline-block;
+                vertical-align: middle;
+            }
+            .header1 {
+                display: block;
+                font-size: 2em;
+                margin-block-start: 0.67em;
+                margin-block-end: 0.67em;
+                margin-inline-start: 0px;
+                margin-inline-end: 0px;
+                margin-right: 1em;
+                font-weight: bold;
+            }
+            ul.menu {
+                list-style-type: none;
+                margin: 0;
+                padding: 0;
+                overflow: hidden;
+                background-color: white;
+            }
+            ul.menu > li {
+                float: left;
+                font-family: Arial, Helvetica, sans-serif;
+            }
+            ul.menu > li > a {
+                display: block;
+                color: black;
+                text-align: center;
+                padding: 16px;
+                text-decoration: none;
+                font-weight: bold;
+            }
+            ul.menu > li a:hover {
+                background-color: black;
+                color: white;
+            }
             .pre {white-space: pre;}
             .monospace {font-family: 'Courier New', Courier, monospace;}
             .sans {font-family: 'Franklin Gothic Medium', 'Arial Narrow', Arial, sans-serif;}
@@ -19,7 +56,12 @@ SPDX-License-Identifier: Apache-2.0
         </style>
     </head>
     <body>
-        <h1>Database Performance</h1>
+        <div id="header-container" class="container unselectable">
+            <div id="header-div" class="header1 unselectable" style="display: inline-block !important;">Database Performance</div>
+            <div id="menu-div unselectable">
+                {{db_performance_menu}}
+            </div>
+        </div>
         <hr />
         <h2 id="data_header">{{page_header}}</h2>
         <table id="generic_table" cellspacing="0">

--- a/koku/masu/api/db_performance/templates/gen_table.html
+++ b/koku/masu/api/db_performance/templates/gen_table.html
@@ -19,6 +19,9 @@ SPDX-License-Identifier: Apache-2.0
                 margin-inline-end: 0px;
                 margin-right: 1em;
                 font-weight: bold;
+                margin-right: 0.5em;
+                padding-right: 1em;
+                border-right: 2px solid black;
             }
             ul.menu {
                 list-style-type: none;
@@ -43,6 +46,9 @@ SPDX-License-Identifier: Apache-2.0
                 background-color: black;
                 color: white;
             }
+            .current {
+                border-bottom: 2px solid black;
+            }
             .pre {white-space: pre;}
             .monospace {font-family: 'Courier New', Courier, monospace;}
             .sans {font-family: 'Franklin Gothic Medium', 'Arial Narrow', Arial, sans-serif;}
@@ -53,6 +59,18 @@ SPDX-License-Identifier: Apache-2.0
             th {border-bottom: 1px solid black; background-color: #cecece;}
             th:not(:first-child) {border-left: 1px solid black;}
             td:not(:first-child) {border-left: 1px solid black;}
+            .unselectable {
+                -moz-user-select: -moz-none;
+                -khtml-user-select: none;
+                -webkit-user-select: none;
+
+                /*
+                    Introduced in IE 10.
+                    See http://ie.microsoft.com/testdrive/HTML5/msUserSelect/
+                */
+                -ms-user-select: none;
+                user-select: none;
+            }
         </style>
     </head>
     <body>

--- a/koku/masu/api/db_performance/templates/stats_table.html
+++ b/koku/masu/api/db_performance/templates/stats_table.html
@@ -19,6 +19,9 @@ SPDX-License-Identifier: Apache-2.0
                 margin-inline-end: 0px;
                 margin-right: 1em;
                 font-weight: bold;
+                margin-right: 0.5em;
+                padding-right: 1em;
+                border-right: 2px solid black;
             }
             ul.menu {
                 list-style-type: none;
@@ -43,6 +46,9 @@ SPDX-License-Identifier: Apache-2.0
                 background-color: black;
                 color: white;
             }
+            .current {
+                border-bottom: 2px solid black;
+            }
             .hidden {display: none;}
             .show {display: block;}
             .pre {white-space: pre;}
@@ -56,6 +62,18 @@ SPDX-License-Identifier: Apache-2.0
             th {border-bottom: 1px solid black; background-color: #cecece;}
             th:not(:first-child) {border-left: 1px solid black;}
             td:not(:first-child) {border-left: 1px solid black;}
+            .unselectable {
+                -moz-user-select: -moz-none;
+                -khtml-user-select: none;
+                -webkit-user-select: none;
+
+                /*
+                    Introduced in IE 10.
+                    See http://ie.microsoft.com/testdrive/HTML5/msUserSelect/
+                */
+                -ms-user-select: none;
+                user-select: none;
+            }
         </style>
         <!-- <script>
 function clear_stmt_stats() {

--- a/koku/masu/api/db_performance/templates/stats_table.html
+++ b/koku/masu/api/db_performance/templates/stats_table.html
@@ -6,6 +6,43 @@ SPDX-License-Identifier: Apache-2.0
     <head>
         <title>Cost Management DB Performance Statistics</title>
         <style>
+            .container > * {
+                display: inline-block;
+                vertical-align: middle;
+            }
+            .header1 {
+                display: block;
+                font-size: 2em;
+                margin-block-start: 0.67em;
+                margin-block-end: 0.67em;
+                margin-inline-start: 0px;
+                margin-inline-end: 0px;
+                margin-right: 1em;
+                font-weight: bold;
+            }
+            ul.menu {
+                list-style-type: none;
+                margin: 0;
+                padding: 0;
+                overflow: hidden;
+                background-color: white;
+            }
+            ul.menu > li {
+                float: left;
+                font-family: Arial, Helvetica, sans-serif;
+            }
+            ul.menu > li > a {
+                display: block;
+                color: black;
+                text-align: center;
+                padding: 16px;
+                text-decoration: none;
+                font-weight: bold;
+            }
+            ul.menu > li a:hover {
+                background-color: black;
+                color: white;
+            }
             .hidden {display: none;}
             .show {display: block;}
             .pre {white-space: pre;}
@@ -36,7 +73,12 @@ function clear_stmt_stats() {
         </script>
     </head> -->
     <body>
-        <h1>Database Performance</h1>
+        <div id="header-container" class="container unselectable">
+            <div id="header-div" class="header1 unselectable" style="display: inline-block !important;">Database Performance</div>
+            <div id="menu-div unselectable">
+                {{db_performance_menu}}
+            </div>
+        </div>
         <hr />
         <h2 id="data_header">{{page_header}}</h2>
         <!-- <button class="clear-stats" id="clear-stats-btn" onclick="clear_stmt_stats();" disabled="true">Clear Statement Statistics</button> -->

--- a/koku/masu/api/db_performance/templates/t_action_table.html
+++ b/koku/masu/api/db_performance/templates/t_action_table.html
@@ -6,6 +6,43 @@ SPDX-License-Identifier: Apache-2.0
     <head>
         <title>Cost Management DB Performance Statistics</title>
         <style>
+            .container > * {
+                display: inline-block;
+                vertical-align: middle;
+            }
+            .header1 {
+                display: block;
+                font-size: 2em;
+                margin-block-start: 0.67em;
+                margin-block-end: 0.67em;
+                margin-inline-start: 0px;
+                margin-inline-end: 0px;
+                margin-right: 1em;
+                font-weight: bold;
+            }
+            ul.menu {
+                list-style-type: none;
+                margin: 0;
+                padding: 0;
+                overflow: hidden;
+                background-color: white;
+            }
+            ul.menu > li {
+                float: left;
+                font-family: Arial, Helvetica, sans-serif;
+            }
+            ul.menu > li > a {
+                display: block;
+                color: black;
+                text-align: center;
+                padding: 16px;
+                text-decoration: none;
+                font-weight: bold;
+            }
+            ul.menu > li a:hover {
+                background-color: black;
+                color: white;
+            }
             .pre {white-space: pre;}
             .monospace {font-family: 'Courier New', Courier, monospace;}
             .sans {font-family: 'Franklin Gothic Medium', 'Arial Narrow', Arial, sans-serif;}
@@ -83,9 +120,13 @@ SPDX-License-Identifier: Apache-2.0
         </script>
     </head>
     <body>
-        <h1>Database Performance</h1>
+        <div id="header-container" class="container unselectable">
+            <div id="header-div" class="header1 unselectable" style="display: inline-block !important;">Database Performance</div>
+            <div id="menu-div unselectable">
+                {{db_performance_menu}}
+            </div>
+        </div>
         <hr />
-        <h2 id="data_header">{{page_header}}</h2>
         <table id="term_action_table" cellspacing="0">
 {% for rec in data %}
     {% set rec_loop = loop %}

--- a/koku/masu/api/db_performance/templates/t_action_table.html
+++ b/koku/masu/api/db_performance/templates/t_action_table.html
@@ -17,8 +17,10 @@ SPDX-License-Identifier: Apache-2.0
                 margin-block-end: 0.67em;
                 margin-inline-start: 0px;
                 margin-inline-end: 0px;
-                margin-right: 1em;
                 font-weight: bold;
+                margin-right: 0.5em;
+                padding-right: 1em;
+                border-right: 2px solid black;
             }
             ul.menu {
                 list-style-type: none;
@@ -43,6 +45,9 @@ SPDX-License-Identifier: Apache-2.0
                 background-color: black;
                 color: white;
             }
+            .current {
+                border-bottom: 2px solid black;
+            }
             .pre {white-space: pre;}
             .monospace {font-family: 'Courier New', Courier, monospace;}
             .sans {font-family: 'Franklin Gothic Medium', 'Arial Narrow', Arial, sans-serif;}
@@ -54,6 +59,18 @@ SPDX-License-Identifier: Apache-2.0
             th {border-bottom: 1px solid black; background-color: #cecece;}
             th:not(:first-child) {border-left: 1px solid black;}
             td:not(:first-child) {border-left: 1px solid black;}
+            .unselectable {
+                -moz-user-select: -moz-none;
+                -khtml-user-select: none;
+                -webkit-user-select: none;
+
+                /*
+                    Introduced in IE 10.
+                    See http://ie.microsoft.com/testdrive/HTML5/msUserSelect/
+                */
+                -ms-user-select: none;
+                user-select: none;
+            }
         </style>
         <script>
             function do_terminate(target_pid) {
@@ -127,6 +144,7 @@ SPDX-License-Identifier: Apache-2.0
             </div>
         </div>
         <hr />
+        <h2 id="data_header">{{page_header}}</h2>
         <table id="term_action_table" cellspacing="0">
 {% for rec in data %}
     {% set rec_loop = loop %}

--- a/koku/masu/api/urls.py
+++ b/koku/masu/api/urls.py
@@ -11,6 +11,7 @@ from masu.api.sources.views import SourcesViewSet
 from masu.api.views import celery_queue_lengths
 from masu.api.views import cleanup
 from masu.api.views import crawl_account_hierarchy
+from masu.api.views import db_performance_redirect
 from masu.api.views import dbsettings
 from masu.api.views import download_report
 from masu.api.views import enabled_tags
@@ -66,6 +67,8 @@ urlpatterns = [
         name="get_one_manifest_file",
     ),
     path("gcp_invoice_monthly_cost/", gcp_invoice_monthly_cost, name="gcp_invoice_monthly_cost"),
+    path("db-performance", db_performance_redirect, name="db_perf_no_slash_redirect"),
+    path("db-performance/", db_performance_redirect, name="db_perf_slash_redirect"),
     path("db-performance/db-settings/", dbsettings, name="db_settings"),
     path("db-performance/lock-info/", lockinfo, name="lock_info"),
     path("db-performance/stat-activity/", stat_activity, name="conn_activity"),

--- a/koku/masu/api/views.py
+++ b/koku/masu/api/views.py
@@ -5,6 +5,7 @@
 """API views for import organization"""
 # flake8: noqa
 from masu.api.crawl_account_hierarchy import crawl_account_hierarchy
+from masu.api.db_performance.dbp_views import db_performance_redirect
 from masu.api.db_performance.dbp_views import dbsettings
 from masu.api.db_performance.dbp_views import explain_query
 from masu.api.db_performance.dbp_views import lockinfo


### PR DESCRIPTION
## Jira Ticket

[COST-2500](https://issues.redhat.com/browse/COST-2500)

## Description

* Remove spellcheck from explain query text input control
* Add menu
* Add redirects

## Testing

First download this branch and restart koku, then:

### Redirects

1. Navigate to [http://localhost:5042/api/cost-management/v1/db-performance/](http://localhost:5042/api/cost-management/v1/db-performance/)
2. You will be redirected to: [http://localhost:5042/api/cost-management/v1/db-performance/db-version/](http://localhost:5042/api/cost-management/v1/db-performance/db-version/)
3. Navigate to [http://localhost:5042/api/cost-management/v1/db-performance](http://localhost:5042/api/cost-management/v1/db-performance) __Note no trailing backslash__
4. You will be redirected to: [http://localhost:5042/api/cost-management/v1/db-performance/db-version/](http://localhost:5042/api/cost-management/v1/db-performance/db-version/)

### Menu

1. While on any page, note the menu at the top to the right of the page header. Options will be:
    * DB Engine Version
    * DB Engine Settings
    * Connection Activity
    * Statement Statistics
    * Lock Information
    * Explain Query
2. Whichever page you are on will have that menu option underlined.
3. You can navigate to any of the other pages by clicking on the menu option.
4. When hovering over the menu option, the colors will reverse (black text on white becomes white text on black)
5. By design, you cannot click on the current menu option to reload the page.

### Spellcheck

1. Navigate to [http://localhost:5042/api/cost-management/v1/db-performance/explain-query/](http://localhost:5042/api/cost-management/v1/db-performance/explain-query/) or click on the **Explain Query** menu option.
2. The Explain Query page will load.
3. Click on the query input control and then type some incomprehensible gibberish. You should see no red underlining of any words in the input control.
