### PR TITLE
[COST-1880] Only update cost models if provider active

### DIFF
--- a/koku/cost_models/cost_model_manager.py
+++ b/koku/cost_models/cost_model_manager.py
@@ -87,29 +87,30 @@ class CostModelManager:
             except Provider.DoesNotExist:
                 LOG.info(f"Provider {provider_uuid} does not exist. Skipping cost-model update.")
             else:
-                schema_name = provider.customer.schema_name
-                # Because this is triggered from the UI, we use the priority queue
-                LOG.info(
-                    f"provider {provider_uuid} update for cost model {self._cost_model_uuid} "
-                    + f"with tracing_id {tracing_id}"
-                )
-                chain(
-                    update_cost_model_costs.s(
-                        schema_name,
-                        provider.uuid,
-                        start_date,
-                        end_date,
-                        tracing_id=tracing_id,
-                        queue_name=PRIORITY_QUEUE,
-                    ).set(queue=PRIORITY_QUEUE),
-                    refresh_materialized_views.si(
-                        schema_name,
-                        provider.type,
-                        provider_uuid=provider.uuid,
-                        tracing_id=tracing_id,
-                        queue_name=PRIORITY_QUEUE,
-                    ).set(queue=PRIORITY_QUEUE),
-                ).apply_async()
+                if provider.active:
+                    schema_name = provider.customer.schema_name
+                    # Because this is triggered from the UI, we use the priority queue
+                    LOG.info(
+                        f"provider {provider_uuid} update for cost model {self._cost_model_uuid} "
+                        + f"with tracing_id {tracing_id}"
+                    )
+                    chain(
+                        update_cost_model_costs.s(
+                            schema_name,
+                            provider.uuid,
+                            start_date,
+                            end_date,
+                            tracing_id=tracing_id,
+                            queue_name=PRIORITY_QUEUE,
+                        ).set(queue=PRIORITY_QUEUE),
+                        refresh_materialized_views.si(
+                            schema_name,
+                            provider.type,
+                            provider_uuid=provider.uuid,
+                            tracing_id=tracing_id,
+                            queue_name=PRIORITY_QUEUE,
+                        ).set(queue=PRIORITY_QUEUE),
+                    ).apply_async()
 
     def update(self, **data):
         """Update the cost model object."""

--- a/koku/cost_models/test/test_cost_model_manager.py
+++ b/koku/cost_models/test/test_cost_model_manager.py
@@ -290,7 +290,7 @@ class CostModelManagerTest(IamTestCase):
     @patch("cost_models.cost_model_manager.update_cost_model_costs")
     @patch("cost_models.cost_model_manager.chain")
     def test_deleting_cost_model_not_triggers_tasks(self, mock_chain, mock_update, mock_refresh):
-        """Test deleting a cost model refreshes the materialized views."""
+        """Test deleting a cost model with an inactive provider does not trigger tasks."""
         provider_name = "sample_provider"
         with patch("masu.celery.tasks.check_report_updates"):
             provider = Provider.objects.create(name=provider_name, created_by=self.user, customer=self.customer)


### PR DESCRIPTION
Fixes [COST-1880](https://issues.redhat.com/browse/COST-1880)

Changes proposed in this PR:
* Conditionally recalculate cost model costs only if the source is marked active.

Testing Instructions:
1. Run `this command` ...
2. Ingest this data `with this other command` ...
3. Expect to see this result:
   ```
   GET http://localhost:8000/api/endpoint

   {json: response}
   ```
4.
5.

---
Additional Context:
This puts a condition on relaunching cost model updates when we remove a provider from a cost model. When we delete a source, we first mark it inactive, then do cleanup and then finally remove it. Our smoke tests also delete the cost model during this time, which triggers a cost model recalculation on the dying provider. It’s gone before we finish and we get the IntegrityError in the alert channel