### PR TITLE
Cost 2527 default lock info limit

### DIFF
--- a/koku/masu/api/db_performance/db_performance.py
+++ b/koku/masu/api/db_performance/db_performance.py
@@ -294,8 +294,7 @@ SELECT blocking_locks.pid::int     AS blocking_pid,
 """
         LOG.info(self._prep_log_message("requsting blocked process information"))
         res = self._execute(sql, params).fetchall()
-        if not res:
-            res = [{"Result": "No blocking locks"}]
+
         return res
 
     def get_activity(self, pid=[], state=[], include_self=False, limit=500, offset=None, records_per_db=100):

--- a/koku/masu/api/db_performance/db_performance.py
+++ b/koku/masu/api/db_performance/db_performance.py
@@ -258,7 +258,7 @@ where "rec_by_db" <= %(records_per_db)s
         else:
             return [{"Result": "pg_stat_statements extension not installled"}]
 
-    def get_lock_info(self, limit=None, offset=None):
+    def get_lock_info(self, limit=500, offset=None):
         params = {}
         limit_clause = self._handle_limit(limit, params)
         offset_clause = self._handle_offset(offset, params)

--- a/koku/masu/openapi.json
+++ b/koku/masu/openapi.json
@@ -855,6 +855,30 @@
           "summary": "Returns a table showing query statement statistics if the pg_stat_statements extension has been installed.",
           "operationId": "dbPerformanceStatStatements",
           "description": "Returns a HTML document showing query statement statistics if the pg_stat_statements extension has been installed.",
+          "parameters": [
+            {
+              "name": "limit",
+              "in": "query",
+              "description": "Limit of the returned result set",
+              "required": false,
+              "schema": {
+                "type": "integer",
+                "format": "int32",
+                "minimum": 1
+              }
+            },
+            {
+              "name": "offset",
+              "in": "query",
+              "description": "Offset into the query result set before returning records",
+              "required": false,
+              "schema": {
+                "type": "integer",
+                "format": "int32",
+                "minimum": 1
+              }
+            }
+          ],
           "responses": {
             "200": {
               "description": "Returns a HTML document showing query statement statistics if the pg_stat_statements extension has been installed.",
@@ -874,6 +898,78 @@
           "summary": "Returns a table showing current connection activity.",
           "operationId": "dbPerformanceStatActivity",
           "description": "Returns a HTML document showing current connection activity.",
+          "parameters": [
+            {
+              "name": "limit",
+              "in": "query",
+              "description": "Limit of the returned result set. The default is 500.",
+              "required": false,
+              "schema": {
+                "type": "integer",
+                "format": "int32",
+                "minimum": 1
+              }
+            },
+            {
+              "name": "offset",
+              "in": "query",
+              "description": "Offset into the query result set before returning records. The default is no offset.",
+              "required": false,
+              "schema": {
+                "type": "integer",
+                "format": "int32",
+                "minimum": 1
+              }
+            },
+            {
+              "name": "pid",
+              "in": "query",
+              "description": "Narrow results to supplied pid values",
+              "required": false,
+              "schema": {
+                "type": "array",
+                "items": {
+                    "type": "integer",
+                    "format": "int32",
+                    "minimum": 1
+                }
+              }
+            },
+            {
+              "name": "state",
+              "in": "query",
+              "description": "Narrow results to supplied state values. These include: active, idle, idle in transaction",
+              "required": false,
+              "schema": {
+                "type": "array",
+                "items": {
+                    "type": "string",
+                    "minlength": 4,
+                    "maxlength": 100
+                }
+              }
+            },
+            {
+              "name": "include_self",
+              "in": "query",
+              "description": "If true, include the pid of the connection running the DB Performance queries",
+              "required": false,
+              "schema": {
+                "type": "boolean"
+              }
+            },
+            {
+              "name": "records_per_db",
+              "in": "query",
+              "description": "If there are multiple databases hosted by the engine, then how many records per db to include up to the limit. The default is 100.",
+              "required": false,
+              "schema": {
+                "type": "integer",
+                "format": "int32",
+                "minimum": 1
+              }
+            }
+          ],
           "responses": {
             "200": {
               "description": "Returns a HTML document showing current connection activity.",
@@ -893,6 +989,30 @@
           "summary": "Returns a table showing any detected blocking locks.",
           "operationId": "dbPerformanceLockInfo",
           "description": "Returns a HTML document showing any blocking locks and processes that are blocked by them.",
+          "parameters": [
+            {
+              "name": "limit",
+              "in": "query",
+              "description": "Limit of the returned result set",
+              "required": false,
+              "schema": {
+                "type": "integer",
+                "format": "int32",
+                "minimum": 1
+              }
+            },
+            {
+              "name": "offset",
+              "in": "query",
+              "description": "Offset into the query result set before returning records",
+              "required": false,
+              "schema": {
+                "type": "integer",
+                "format": "int32",
+                "minimum": 1
+              }
+            }
+          ],
           "responses": {
             "200": {
               "description": "Returns a HTML document showing any blocking locks and processes that are blocked by them.",

--- a/koku/masu/test/api/test_db_performance.py
+++ b/koku/masu/test/api/test_db_performance.py
@@ -141,12 +141,14 @@ class TestDBPerformanceClass(IamTestCase):
     def test_get_stmt_stats(self):
         """Test that statement statistics are returned."""
         with DBPerformanceStats("KOKU", CONFIGURATOR) as dbp:
-            has_pss = dbp._validate_pg_stat_statements()
+            has_pss, pss_ver = dbp._validate_pg_stat_statements()
             if has_pss:
+                self.assertIsNotNone(pss_ver)
                 stats = dbp.get_statement_stats()
                 self.assertTrue(0 < len(stats) <= 500)
                 self.assertIn("calls", stats[0])
             else:
+                self.assertIsNone(pss_ver)
                 stats = dbp.get_statement_stats()
                 self.assertEqual(len(stats), 1)
                 self.assertIn("Result", stats[0])

--- a/koku/masu/test/api/test_db_performance.py
+++ b/koku/masu/test/api/test_db_performance.py
@@ -88,6 +88,10 @@ class TestDBPerformanceClass(IamTestCase):
             self.assertEqual(res, "")
             self.assertEqual(params, {})
 
+            res = dbp._handle_limit(-1, params)
+            self.assertEqual(res, "")
+            self.assertEqual(params, {})
+
             res = dbp._handle_limit(10, params)
             self.assertEqual(res.strip(), "limit %(limit)s")
             self.assertEqual(params, {"limit": 10})
@@ -100,6 +104,10 @@ class TestDBPerformanceClass(IamTestCase):
             self.assertEqual(res, "")
             self.assertEqual(params, {})
 
+            res = dbp._handle_offset(-1, params)
+            self.assertEqual(res, "")
+            self.assertEqual(params, {})
+
             res = dbp._handle_offset(10, params)
             self.assertEqual(res.strip(), "offset %(offset)s")
             self.assertEqual(params, {"offset": 10})
@@ -107,8 +115,12 @@ class TestDBPerformanceClass(IamTestCase):
     def test_handle_lockinfo(self):
         with DBPerformanceStats("KOKU", CONFIGURATOR) as dbp:
             lockinfo = dbp.get_lock_info()
-            self.assertNotEqual(lockinfo, [])  # This should always return a list of at least one element
-            self.assertTrue(len(lockinfo) < 500)
+            if lockinfo:
+                self.assertTrue(len(lockinfo) < 500)
+
+            lockinfo = dbp.get_lock_info(limit=1)
+            if lockinfo:
+                self.assertTrue(len(lockinfo) < 1)
 
     def test_get_conn_activity(self):
         """Test that the correct connection activty is returned."""

--- a/koku/masu/test/api/test_db_performance.py
+++ b/koku/masu/test/api/test_db_performance.py
@@ -108,6 +108,7 @@ class TestDBPerformanceClass(IamTestCase):
         with DBPerformanceStats("KOKU", CONFIGURATOR) as dbp:
             lockinfo = dbp.get_lock_info()
             self.assertNotEqual(lockinfo, [])  # This should always return a list of at least one element
+            self.assertTrue(len(lockinfo) < 500)
 
     def test_get_conn_activity(self):
         """Test that the correct connection activty is returned."""

--- a/koku/masu/test/api/test_db_performance_views.py
+++ b/koku/masu/test/api/test_db_performance_views.py
@@ -18,6 +18,8 @@ from api.common import RH_IDENTITY_HEADER
 from api.iam.test.iam_test_case import IamTestCase
 from masu.api.db_performance.dbp_views import get_limit_offset
 from masu.api.db_performance.dbp_views import get_menu
+from masu.api.db_performance.dbp_views import get_parameter_bool
+from masu.api.db_performance.dbp_views import get_parameter_list
 
 
 LOG = logging.getLogger(__name__)
@@ -194,3 +196,57 @@ class TestDBPerformance(IamTestCase):
         limit, offset = get_limit_offset(request)
         self.assertEqual(limit, 250)
         self.assertEqual(offset, 150)
+
+    @patch("koku.middleware.MASU", return_value=True)
+    def test_get_parameter_list(self, mok_middl):
+        class QP:
+            def __init__(self, initvalues=[]):
+                self._qp = initvalues
+                self._qp_keys = {p[0] for p in self._qp}
+
+            def getlist(self, param, default=None):
+                return [p[1] for p in self._qp if p[0] == param] or default
+
+            def __contains__(self, param):
+                return param in self._qp_keys
+
+        request = Mock()
+
+        request.query_params = QP()
+        x = get_parameter_list(request, "a_param", "a_silly_default")
+        self.assertEqual(x, "a_silly_default")
+
+        request.query_params = QP([["a_param", "a_value"]])
+        x = get_parameter_list(request, "a_param")
+        self.assertEqual(x, ["a_value"])
+
+        request.query_params = QP([["a_param", "a_value,b_value"]])
+        x = get_parameter_list(request, "a_param")
+        self.assertEqual(x, ["a_value", "b_value"])
+
+        request.query_params = QP([["a_param", "a_value|b_value"]])
+        x = get_parameter_list(request, "a_param", sep="|")
+        self.assertEqual(x, ["a_value", "b_value"])
+
+        request.query_params = QP([["a_param", "d_value"], ["a_param", "e_value"]])
+        x = get_parameter_list(request, "a_param")
+        self.assertEqual(x, ["d_value", "e_value"])
+
+    @patch("koku.middleware.MASU", return_value=True)
+    def test_get_parameter_bool(self, mok_middl):
+        request = Mock()
+
+        request.query_params = {}
+        self.assertTrue(get_parameter_bool(request, "a_param", "a_silly_default"))
+
+        self.assertFalse(get_parameter_bool(request, "a_param", 0))
+
+        self.assertIsNone(get_parameter_bool(request, "a_param"))
+
+        request.query_params = {"a_param": "nope"}
+        self.assertFalse(get_parameter_bool(request, "a_param"))
+
+        truthy = ("1", "y", "yes", "t", "true", "on")
+        for p_val in truthy:
+            request.query_params["a_param"] = p_val
+            self.assertTrue(get_parameter_bool(request, "a_param"))


### PR DESCRIPTION
## Jira Ticket

[COST-2527](https://issues.redhat.com/browse/COST-2527)

## Description

* Sets a default limit of 500 records returned from the `get_lock_info` method
* Processes `limit` and `offset` from the request if supplied
* Exposes parameters in masu `openapi.json`

## Testing

First, checkout this code and restart koku

### Limit & Offset

This is best done with the Connection Activity page, but this will also work on the Statement Statistics and Lock Info pages.

1. Navigate to the Connection Activity page
2. In the url bar, append `?limit=4`. You should see only 4 records
3. Change `?limit=4` to `?limit=-2`. You should see all records as the limit value was invalid.
    1. If you change the integer to a string, the limit will also not be applied

You can also repeat the same test for `offset` by changing `limit` to `offset`
You can also combine them: `?limit=5&offset=5`

### Connection Activity Parameters

#### include_self

This parameter will include the connection that is running these check queries.

1. Navigate to the Connection Activity page
2. Add `?include_self=true` to the end of the url. You should now see a process with the application name `database_performance_stats`

#### pid & state

1. Navigate to the Connection Activity page
2. Find a single backend_pid value.
3. Append to the url: `?pid=<the pid you picked>` and reload
4. Only that pid will display in the output.
5. Remove the parameter and reload.
6. Pick multiple pids.
7. Append to the url: `?pid=<pid1>&pid=<pid2>...` and reload
    1. Altenately, you can specify: `?pid=<pid1>,<pid2>...`
8. Output will be constrained to only those pids.

These testing steps can be repeated with the `state` parameter and use of one or more of the state values.

Enter a bizarre value for `pid` (like 999999) You will get a message that no records match your criteria.
The same is true for a garbage value for state.

#### records_per_db

This is another way to limit records per db instead of the total records returned.

1. Navigate to the Connection Activity page
2. Append `?records_per_db=2` and reload
3. You should see a maximum of 2 records for each database reporting.

