### PR TITLE
update worker cache to accurately reflect running tasks

### DIFF
--- a/koku/masu/processor/worker_cache.py
+++ b/koku/masu/processor/worker_cache.py
@@ -153,7 +153,7 @@ class WorkerCache:
         """Add a cache entry for a single task to lock a specific task."""
         cache_str = create_single_task_cache_key(task_name, task_args)
         # Expire the cache so we don't infinite loop waiting
-        self.cache.add(cache_str, self._hostname, timeout)
+        self.cache.set(cache_str, self._hostname, timeout)
 
     def release_single_task(self, task_name, task_args=None):
         """Delete the cache entry for a single task."""

--- a/koku/masu/processor/worker_cache.py
+++ b/koku/masu/processor/worker_cache.py
@@ -146,13 +146,14 @@ class WorkerCache:
     def single_task_is_running(self, task_name, task_args=None):
         """Check for a single task key in the cache."""
         cache_str = create_single_task_cache_key(task_name, task_args)
-        return bool(self.cache.get(cache_str))
+        host = self.cache.get(cache_str)
+        return host and host in self.worker_cache_keys
 
     def lock_single_task(self, task_name, task_args=None, timeout=TASK_CACHE_EXPIRE):
         """Add a cache entry for a single task to lock a specific task."""
         cache_str = create_single_task_cache_key(task_name, task_args)
         # Expire the cache so we don't infinite loop waiting
-        self.cache.add(cache_str, "true", timeout, version=self._hostname)
+        self.cache.add(cache_str, self._hostname, timeout)
 
     def release_single_task(self, task_name, task_args=None):
         """Delete the cache entry for a single task."""

--- a/koku/masu/processor/worker_cache.py
+++ b/koku/masu/processor/worker_cache.py
@@ -141,21 +141,18 @@ class WorkerCache:
     def task_is_running(self, task_key):
         """Check if a task is in the cache."""
         task_list = self.get_all_running_tasks()
-        return True if task_key in task_list else False
+        return task_key in task_list
 
     def single_task_is_running(self, task_name, task_args=None):
         """Check for a single task key in the cache."""
         cache_str = create_single_task_cache_key(task_name, task_args)
-        return True if self.cache.get(cache_str) else False
+        return bool(self.cache.get(cache_str))
 
-    def lock_single_task(self, task_name, task_args=None, timeout=None):
+    def lock_single_task(self, task_name, task_args=None, timeout=TASK_CACHE_EXPIRE):
         """Add a cache entry for a single task to lock a specific task."""
         cache_str = create_single_task_cache_key(task_name, task_args)
         # Expire the cache so we don't infinite loop waiting
-        if timeout:
-            self.cache.add(cache_str, "true", timeout)
-        else:
-            self.cache.add(cache_str, "true", TASK_CACHE_EXPIRE)
+        self.cache.add(cache_str, "true", timeout, version=self._hostname)
 
     def release_single_task(self, task_name, task_args=None):
         """Delete the cache entry for a single task."""

--- a/koku/masu/test/processor/test_tasks.py
+++ b/koku/masu/test/processor/test_tasks.py
@@ -22,6 +22,7 @@ import faker
 from dateutil import relativedelta
 from django.core.cache import caches
 from django.db.utils import IntegrityError
+from django.test.utils import override_settings
 from tenant_schemas.utils import schema_context
 
 from api.iam.models import Tenant
@@ -845,6 +846,7 @@ class TestUpdateSummaryTablesTask(MasuTestCase):
             CostUsageReportStatus.objects.filter(report_name=report_file).exists()
 
 
+@override_settings(HOSTNAME="kokuworker")
 class TestWorkerCacheThrottling(MasuTestCase):
     """Tests for tasks that use the worker cache."""
 
@@ -852,13 +854,13 @@ class TestWorkerCacheThrottling(MasuTestCase):
         """Check for a single task key in the cache."""
         cache = caches["worker"]
         cache_str = create_single_task_cache_key(task_name, task_args)
-        return True if cache.get(cache_str) else False
+        return bool(cache.get(cache_str))
 
     def lock_single_task(self, task_name, task_args=None, timeout=None):
         """Add a cache entry for a single task to lock a specific task."""
         cache = caches["worker"]
         cache_str = create_single_task_cache_key(task_name, task_args)
-        cache.add(cache_str, "true", 3)
+        cache.add(cache_str, "kokuworker", 3)
 
     @patch("masu.processor.tasks.update_summary_tables.s")
     @patch("masu.processor.tasks.ReportSummaryUpdater.update_summary_tables")
@@ -882,6 +884,7 @@ class TestWorkerCacheThrottling(MasuTestCase):
         mock_delay,
     ):
         """Test that the worker cache is used."""
+        mock_inspect.reserved.return_value = {"celery@kokuworker": []}
         task_name = "masu.processor.tasks.update_summary_tables"
         cache_args = [self.schema, Provider.PROVIDER_AWS]
         mock_lock.side_effect = self.lock_single_task
@@ -921,6 +924,7 @@ class TestWorkerCacheThrottling(MasuTestCase):
         mock_delay,
     ):
         """Test that the worker cache is used."""
+        mock_inspect.reserved.return_value = {"celery@kokuworker": []}
         task_name = "masu.processor.tasks.update_summary_tables"
         cache_args = [self.schema]
 
@@ -955,6 +959,7 @@ class TestWorkerCacheThrottling(MasuTestCase):
         mock_delay,
     ):
         """Test that the update_summary_table cloud exception is caught."""
+        mock_inspect.reserved.return_value = {"celery@kokuworker": []}
         start_date = DateHelper().this_month_start
         end_date = DateHelper().this_month_end
         mock_daily.return_value = start_date, end_date
@@ -990,6 +995,7 @@ class TestWorkerCacheThrottling(MasuTestCase):
         mock_delay,
     ):
         """Test that the update_summary_table provider not found exception is caught."""
+        mock_inspect.reserved.return_value = {"celery@kokuworker": []}
         start_date = DateHelper().this_month_start
         end_date = DateHelper().this_month_end
         mock_daily.return_value = start_date, end_date
@@ -1011,6 +1017,7 @@ class TestWorkerCacheThrottling(MasuTestCase):
     @patch("masu.processor.worker_cache.CELERY_INSPECT")
     def test_update_cost_model_costs_throttled(self, mock_inspect, mock_lock, mock_release, mock_delay):
         """Test that refresh materialized views runs with cache lock."""
+        mock_inspect.reserved.return_value = {"celery@kokuworker": []}
         mock_lock.side_effect = self.lock_single_task
 
         start_date = DateHelper().last_month_start - relativedelta.relativedelta(months=1)
@@ -1046,6 +1053,7 @@ class TestWorkerCacheThrottling(MasuTestCase):
     @patch("masu.processor.worker_cache.CELERY_INSPECT")
     def test_update_cost_model_costs_error(self, mock_inspect, mock_lock, mock_release, mock_updater):
         """Test that refresh materialized views runs with cache lock."""
+        mock_inspect.reserved.return_value = {"celery@kokuworker": []}
         start_date = DateHelper().last_month_start - relativedelta.relativedelta(months=1)
         end_date = DateHelper().today
         expected_start_date = start_date.strftime("%Y-%m-%d")
@@ -1064,6 +1072,7 @@ class TestWorkerCacheThrottling(MasuTestCase):
     @patch("masu.processor.worker_cache.CELERY_INSPECT")
     def test_refresh_materialized_views_throttled(self, mock_inspect, mock_lock, mock_release, mock_delay):
         """Test that refresh materialized views runs with cache lock."""
+        mock_inspect.reserved.return_value = {"celery@kokuworker": []}
         mock_lock.side_effect = self.lock_single_task
 
         task_name = "masu.processor.tasks.refresh_materialized_views"

--- a/koku/masu/test/processor/test_worker_cache.py
+++ b/koku/masu/test/processor/test_worker_cache.py
@@ -185,9 +185,11 @@ class WorkerCacheTest(MasuTestCase):
         _cache.remove_offline_worker_keys()
         self.assertEqual(sorted(_cache.get_all_running_tasks()), sorted(first_host_list))
 
+    @override_settings(HOSTNAME="kokuworker")
     @patch("masu.processor.worker_cache.CELERY_INSPECT")
     def test_single_task_caching(self, mock_inspect):
         """Test that single task cache creates and deletes a cache entry."""
+        mock_inspect.reserved.return_value = {"celery@kokuworker": []}
         cache = WorkerCache()
 
         task_name = "test_task"


### PR DESCRIPTION
The property `worker_cache_keys` is a list of all of the running celery workers saved in the cache key called `keys`. When we instantiate the `WorkerCache`, we update this key (`keys`) in the db so it is always current with the running workers.

What this PR changes for the single task flow is to:
1. make the cache key's value the hostname.
2. when we check to see if `single_task_is_running`, we fetch the value (which is now the hostname) and check to see if it is in the `keys` list
- if the hostname is in the list, then the task is current and running
- if the hostname is not in the list, then the task is _not_ currently running.
