### PR TITLE
[COST-2371] Azure Query for HCS

### DIFF
--- a/koku/api/iam/test/iam_test_case.py
+++ b/koku/api/iam/test/iam_test_case.py
@@ -40,6 +40,9 @@ class FakePrestoCur(trino.dbapi.Cursor):
     def fetchall(self):
         return [["eek"]]
 
+    def description(self):
+        pass
+
 
 class FakePrestoConn(trino.dbapi.Connection):
     def __init__(self, *args, **kwargs):

--- a/koku/hcs/csv_file_handler.py
+++ b/koku/hcs/csv_file_handler.py
@@ -18,11 +18,12 @@ class CSVFileHandler:
         self._provider = provider
         self._provider_uuid = provider_uuid
 
-    def write_csv_to_s3(self, date, data, tracing_id=None):
+    def write_csv_to_s3(self, date, data, cols, tracing_id=None):
         """
         Generates an HCS CSV from the specified schema and provider.
         :param date
         :param data
+        :param cols
         :param tracing_id
 
         :return none
@@ -36,6 +37,6 @@ class CSVFileHandler:
         )
 
         LOG.info(log_json(tracing_id, "preparing to write file to object storage"))
-        my_df.to_csv(filename, index=False)
+        my_df.to_csv(filename, header=cols, index=False)
         copy_local_report_file_to_s3_bucket(tracing_id, s3_csv_path, filename, filename, "", date)
         os.remove(filename)

--- a/koku/hcs/database/report_db_accessor.py
+++ b/koku/hcs/database/report_db_accessor.py
@@ -9,12 +9,19 @@ import pkgutil
 from jinjasql import JinjaSql
 
 from api.common import log_json
+from api.provider.models import Provider
 from hcs.csv_file_handler import CSVFileHandler
 from masu.database.report_db_accessor_base import ReportDBAccessorBase
 from masu.external.date_accessor import DateAccessor
-from reporting.provider.aws.models import PRESTO_LINE_ITEM_DAILY_TABLE
+from reporting.provider.aws.models import PRESTO_LINE_ITEM_DAILY_TABLE as AWS_PRESTO_LINE_ITEM_DAILY_TABLE
+from reporting.provider.azure.models import PRESTO_LINE_ITEM_DAILY_TABLE as AZURE_PRESTO_LINE_ITEM_DAILY_TABLE
 
 LOG = logging.getLogger(__name__)
+
+HCS_TABLE_MAP = {
+    Provider.PROVIDER_AWS: AWS_PRESTO_LINE_ITEM_DAILY_TABLE,
+    Provider.PROVIDER_AZURE: AZURE_PRESTO_LINE_ITEM_DAILY_TABLE,
+}
 
 
 class HCSReportDBAccessor(ReportDBAccessorBase):
@@ -46,14 +53,20 @@ class HCSReportDBAccessor(ReportDBAccessorBase):
             sql = pkgutil.get_data("hcs.database", sql_summary_file)
             sql = sql.decode("utf-8")
 
-            sql_params = {"date": date, "schema": self.schema, "table": PRESTO_LINE_ITEM_DAILY_TABLE}
+            sql_params = {"date": date, "schema": self.schema, "table": HCS_TABLE_MAP.get(provider)}
             sql, sql_params = self.jinja_sql.prepare_query(sql, sql_params)
-            data = self._execute_presto_raw_sql_query(self.schema, sql, bind_params=sql_params)
+            data, description = self._execute_presto_raw_sql_query_with_description(
+                self.schema, sql, bind_params=sql_params
+            )
+            # The format for the description is:
+            # [(name, type_code, display_size, internal_size, precision, scale, null_ok)]
+            # col[0] grabs the column names from the query results
+            cols = [col[0] for col in description]
 
             if len(data) > 0:
                 LOG.info(log_json(tracing_id, f"data found for date: {date}"))
                 csv_handler = CSVFileHandler(self.schema, provider, provider_uuid)
-                csv_handler.write_csv_to_s3(date, data, tracing_id)
+                csv_handler.write_csv_to_s3(date, data, cols, tracing_id)
             else:
                 LOG.info(log_json(tracing_id, f"no data found for date: {date}"))
 

--- a/koku/hcs/database/sql/reporting_azure_hcs_daily_summary.sql
+++ b/koku/hcs/database/sql/reporting_azure_hcs_daily_summary.sql
@@ -1,8 +1,6 @@
--- SELECT *, '10001' as ebs_account_id
--- FROM hive.{{schema | sqlsafe}}.{{table | sqlsafe}}
--- WHERE bill_billingentity = 'AWS Marketplace'
---     AND product_productname like '%Red Hat%'
 SELECT *, '{{schema | sqlsafe}}' as ebs_account_id
 FROM hive.{{schema | sqlsafe}}.{{table | sqlsafe}}
 WHERE publishertype = 'Marketplace'
     AND publishername like '%Red Hat%'
+    AND coalesce(date, usagedatetime) >= TIMESTAMP '{{date | sqlsafe}}'
+    AND coalesce(date, usagedatetime) < date_add('day', 1, TIMESTAMP '{{date | sqlsafe}}')

--- a/koku/hcs/test/database/test_report_db_accessor.py
+++ b/koku/hcs/test/database/test_report_db_accessor.py
@@ -4,6 +4,7 @@
 #
 """Test HCSReportDBAccessor."""
 from datetime import timedelta
+from unittest.mock import MagicMock
 from unittest.mock import patch
 
 from api.models import Provider
@@ -50,9 +51,10 @@ class TestHCSReportDBAccessor(HCSTestCase):
             self.assertRaises(FileNotFoundError)
 
     @patch("masu.database.report_db_accessor_base.ReportDBAccessorBase")
-    @patch("masu.database.report_db_accessor_base.ReportDBAccessorBase._execute_presto_raw_sql_query")
-    def test_no_data_hcs_customer(self, mock_dba, mock_dba_query):
+    @patch("masu.database.report_db_accessor_base.ReportDBAccessorBase._execute_presto_raw_sql_query_with_description")
+    def test_no_data_hcs_customer(self, mock_dba_query, mock_dba):
         """Test no data found for specified date"""
+        mock_dba_query.return_value = (MagicMock(), MagicMock())
 
         with self.assertLogs("hcs.database", "INFO") as _logs:
             hcs_accessor = HCSReportDBAccessor(self.schema)
@@ -69,10 +71,10 @@ class TestHCSReportDBAccessor(HCSTestCase):
 
     @patch("hcs.csv_file_handler.CSVFileHandler")
     @patch("hcs.csv_file_handler.CSVFileHandler.write_csv_to_s3")
-    @patch("masu.database.report_db_accessor_base.ReportDBAccessorBase._execute_presto_raw_sql_query", mock_sql_query)
-    def test_data_hcs_customer(self, mock_fh, mock_fh_writer):
+    @patch("masu.database.report_db_accessor_base.ReportDBAccessorBase._execute_presto_raw_sql_query_with_description")
+    def test_data_hcs_customer(self, mock_dba_query, mock_fh_writer, mock_fh):
         """Test data found for specified date"""
-        from hcs.database.report_db_accessor import HCSReportDBAccessor
+        mock_dba_query.return_value = (MagicMock(), MagicMock())
 
         with self.assertLogs("hcs.database", "INFO") as _logs:
             hcs_accessor = HCSReportDBAccessor(self.schema)

--- a/koku/masu/database/report_db_accessor_base.py
+++ b/koku/masu/database/report_db_accessor_base.py
@@ -363,23 +363,19 @@ class ReportDBAccessorBase(KokuDBAccess):
         LOG.info("Finished %s on %s in %f seconds.", operation, table, t2 - t1)
 
     def _execute_presto_raw_sql_query(self, schema, sql, bind_params=None, log_ref=None):
-        """Execute a single presto query"""
-        results, _ = self._run_trino_sql_query(schema, sql, bind_params, log_ref)
+        """Execute a single presto query returning only the fetchall results"""
+        results, _ = self._execute_presto_raw_sql_query_with_description(schema, sql, bind_params, log_ref)
         return results
 
     def _execute_presto_raw_sql_query_with_description(self, schema, sql, bind_params=None, log_ref=None):
-        """Execute a single presto query and return cur.fetchall and the cur.description"""
-        return self._run_trino_sql_query(schema, sql, bind_params, log_ref)
-
-    def _run_trino_sql_query(self, schema, sql, bind_params=None, log_ref=None):
-        """Execute a single trino query and return cur.fetchall and cur.description"""
+        """Execute a single presto query and return cur.fetchall and cur.description"""
         try:
             t1 = time.time()
-            trino_conn = kpdb.connect(schema=schema)
-            trino_cur = trino_conn.cursor()
-            trino_cur.execute(sql, bind_params)
-            results = trino_cur.fetchall()
-            description = trino_cur.description
+            presto_conn = kpdb.connect(schema=schema)
+            presto_cur = presto_conn.cursor()
+            presto_cur.execute(sql, bind_params)
+            results = presto_cur.fetchall()
+            description = presto_cur.description
             t2 = time.time()
             if log_ref:
                 msg = f"{log_ref} for {schema} \n\twith params {bind_params} \n\tcompleted in {t2 - t1} seconds."

--- a/koku/masu/database/report_db_accessor_base.py
+++ b/koku/masu/database/report_db_accessor_base.py
@@ -362,7 +362,7 @@ class ReportDBAccessorBase(KokuDBAccess):
 
         LOG.info("Finished %s on %s in %f seconds.", operation, table, t2 - t1)
 
-    def _execute_presto_raw_sql_query(self, schema, sql, bind_params=None, log_ref=None, needs_desc=False):
+    def _execute_presto_raw_sql_query(self, schema, sql, bind_params=None, log_ref=None):
         """Execute a single presto query"""
         results, _ = self._run_trino_sql_query(schema, sql, bind_params, log_ref)
         return results


### PR DESCRIPTION
Fixes [COST-2371](https://issues.redhat.com/browse/COST-2371)

Changes proposed in this PR:
* Allow HCS processing to work for AWS or Azure and include date filtering for Azure SQL
* Adjust the trino SQL query process to allow for the description to be returned to build the csv header column list from the query

Testing Instructions:
1. Spin up koku locally with Trino, such as: `make docker-up-min-trino`
2. After everything spins up, ingest some AWS data:
      - `make create-test-customer`
      - `make test_source=aws load-test-customer-data`
3. Ingest some Azure data:
      - `make test_source=azure load-test-customer-data`
4. Check minio to see that you have no HCS data in the koku-bucket (there would be a folder called HCS next to the data one) http://localhost:9090/login
5.  Add your account to unleash under the `hcs-data-processor` http://localhost:4242/#/features/strategies/hcs-data-processor
6. Hit the masu endpoint for hcs and put in your AWS source info:  http://localhost:5042/api/cost-management/v1/hcs_report_data/?start_date=2022-04-01&schema=acct10001&provider_type=AWS&provider_uuid=02d80185-78ea-45c5-b75b-925786d26b7d

7. Check minio again and this time there is a path down HCS that leads to some daily AWS csvs based on the date you used int he masu endpoint
8. Repeat 6 and 7 but for the Azure V2 source


---
Additional Context:
[Smokes](https://ci.ext.devshift.net/job/project-koku-koku-pr-check/4760/), these are being investigated with our stage issues so not related to this PR: 
```
Test Result (2 failures / -1615)tests.rest_api.v1.test_source.test_api_ocp_on_aws_source_crudtests.rest_api.v1.test_source.test_api_ocp_on_azure_source_crud
--
[Test Result](https://ci.ext.devshift.net/job/project-koku-koku-pr-check/4760/testReport/) (2 failures / -1615)
[tests.rest_api.v1.test_source.test_api_ocp_on_aws_source_crud](https://ci.ext.devshift.net/job/project-koku-koku-pr-check/4760/testReport/junit/tests.rest_api.v1/test_source/test_api_ocp_on_aws_source_crud/)
[tests.rest_api.v1.test_source.test_api_ocp_on_azure_source_crud](https://ci.ext.devshift.net/job/project-koku-koku-pr-check/4760/testReport/junit/tests.rest_api.v1/test_source/test_api_ocp_on_azure_source_crud/)
```