### PR TITLE
Update Sources API Client to use only one filtering operation type

### DIFF
--- a/koku/sources/sources_http_client.py
+++ b/koku/sources/sources_http_client.py
@@ -162,7 +162,7 @@ class SourcesHTTPClient:
             msg = f"[get_data_source] Unexpected source type: {source_type}"
             LOG.error(msg)
             raise SourcesHTTPClientError(msg)
-        application_url = f"{self._base_url}/{ENDPOINT_APPLICATIONS}?filter[source_id]={self._source_id}&filter[application_type_id]={app_type_id}" # noqa: E501
+        application_url = f"{self._base_url}/{ENDPOINT_APPLICATIONS}?filter[source_id]={self._source_id}&filter[application_type_id]={app_type_id}"  # noqa: E501
         applications_response = self._get_network_response(application_url, "Unable to get application settings")
         applications_data = (applications_response.get("data") or [None])[0]
         if not applications_data:
@@ -194,7 +194,7 @@ class SourcesHTTPClient:
     def _get_aws_credentials(self, _):
         """Get the roleARN from Sources Authentication service."""
         auth_type = AUTH_TYPES.get(Provider.PROVIDER_AWS)
-        authentications_url = f"{self._base_url}/{ENDPOINT_AUTHENTICATIONS}?filter[source_id]={self._source_id}&filter[authtype]={auth_type}" # noqa: E501
+        authentications_url = f"{self._base_url}/{ENDPOINT_AUTHENTICATIONS}?filter[source_id]={self._source_id}&filter[authtype]={auth_type}"  # noqa: E501
         auth_response = self._get_network_response(authentications_url, "Unable to get AWS RoleARN")
         auth_data = (auth_response.get("data") or [None])[0]
         if not auth_data:
@@ -220,7 +220,7 @@ class SourcesHTTPClient:
     def _get_gcp_credentials(self, _):
         """Get the GCP credentials from Sources Authentication service."""
         auth_type = AUTH_TYPES.get(Provider.PROVIDER_GCP)
-        authentications_url = f"{self._base_url}/{ENDPOINT_AUTHENTICATIONS}?filter[source_id]={self._source_id}&filter[authtype]={auth_type}" # noqa: E501
+        authentications_url = f"{self._base_url}/{ENDPOINT_AUTHENTICATIONS}?filter[source_id]={self._source_id}&filter[authtype]={auth_type}"  # noqa: E501
         auth_response = self._get_network_response(authentications_url, "Unable to get GCP credentials")
         auth_data = (auth_response.get("data") or [None])[0]
         if not auth_data:
@@ -234,7 +234,7 @@ class SourcesHTTPClient:
     def _get_azure_credentials(self, app_type_id):
         """Get the Azure Credentials from Sources Authentication service."""
         # get subscription_id from applications extra
-        url = f"{self._base_url}/{ENDPOINT_APPLICATIONS}?filter[source_id]={self._source_id}&filter[application_type_id]={app_type_id}" # noqa: E501
+        url = f"{self._base_url}/{ENDPOINT_APPLICATIONS}?filter[source_id]={self._source_id}&filter[application_type_id]={app_type_id}"  # noqa: E501
         app_response = self._get_network_response(url, "Unable to get Azure credentials")
         app_data = (app_response.get("data") or [None])[0]
         if not app_data:
@@ -243,7 +243,7 @@ class SourcesHTTPClient:
 
         # get client and tenant ids
         auth_type = AUTH_TYPES.get(Provider.PROVIDER_AZURE)
-        authentications_url = f"{self._base_url}/{ENDPOINT_AUTHENTICATIONS}?filter[source_id]={self._source_id}&filter[authtype]={auth_type}" # noqa: E501
+        authentications_url = f"{self._base_url}/{ENDPOINT_AUTHENTICATIONS}?filter[source_id]={self._source_id}&filter[authtype]={auth_type}"  # noqa: E501
         auth_response = self._get_network_response(authentications_url, "Unable to get Azure credentials")
         auth_data = (auth_response.get("data") or [None])[0]
         if not auth_data:

--- a/koku/sources/sources_http_client.py
+++ b/koku/sources/sources_http_client.py
@@ -163,7 +163,7 @@ class SourcesHTTPClient:
             LOG.error(msg)
             raise SourcesHTTPClientError(msg)
         application_url = (
-            f"{self._base_url}/{ENDPOINT_APPLICATIONS}?source_id={self._source_id}&application_type_id={app_type_id}"
+            f"{self._base_url}/{ENDPOINT_APPLICATIONS}?filter[source_id]={self._source_id}&filter[application_type_id]={app_type_id}" # noqa: E501
         )
         applications_response = self._get_network_response(application_url, "Unable to get application settings")
         applications_data = (applications_response.get("data") or [None])[0]
@@ -197,7 +197,7 @@ class SourcesHTTPClient:
         """Get the roleARN from Sources Authentication service."""
         auth_type = AUTH_TYPES.get(Provider.PROVIDER_AWS)
         authentications_url = (
-            f"{self._base_url}/{ENDPOINT_AUTHENTICATIONS}?source_id={self._source_id}&authtype={auth_type}"
+            f"{self._base_url}/{ENDPOINT_AUTHENTICATIONS}?filter[source_id]={self._source_id}&filter[authtype]={auth_type}" # noqa: E501
         )
         auth_response = self._get_network_response(authentications_url, "Unable to get AWS RoleARN")
         auth_data = (auth_response.get("data") or [None])[0]
@@ -225,7 +225,7 @@ class SourcesHTTPClient:
         """Get the GCP credentials from Sources Authentication service."""
         auth_type = AUTH_TYPES.get(Provider.PROVIDER_GCP)
         authentications_url = (
-            f"{self._base_url}/{ENDPOINT_AUTHENTICATIONS}?source_id={self._source_id}&authtype={auth_type}"
+            f"{self._base_url}/{ENDPOINT_AUTHENTICATIONS}?filter[source_id]={self._source_id}&filter[authtype]={auth_type}" # noqa: E501
         )
         auth_response = self._get_network_response(authentications_url, "Unable to get GCP credentials")
         auth_data = (auth_response.get("data") or [None])[0]
@@ -240,7 +240,7 @@ class SourcesHTTPClient:
     def _get_azure_credentials(self, app_type_id):
         """Get the Azure Credentials from Sources Authentication service."""
         # get subscription_id from applications extra
-        url = f"{self._base_url}/{ENDPOINT_APPLICATIONS}?source_id={self._source_id}&application_type_id={app_type_id}"
+        url = f"{self._base_url}/{ENDPOINT_APPLICATIONS}?filter[source_id]={self._source_id}&filter[application_type_id]={app_type_id}" # noqa: E501
         app_response = self._get_network_response(url, "Unable to get Azure credentials")
         app_data = (app_response.get("data") or [None])[0]
         if not app_data:
@@ -250,7 +250,7 @@ class SourcesHTTPClient:
         # get client and tenant ids
         auth_type = AUTH_TYPES.get(Provider.PROVIDER_AZURE)
         authentications_url = (
-            f"{self._base_url}/{ENDPOINT_AUTHENTICATIONS}?source_id={self._source_id}&authtype={auth_type}"
+            f"{self._base_url}/{ENDPOINT_AUTHENTICATIONS}?filter[source_id]={self._source_id}&filter[authtype]={auth_type}" # noqa: E501
         )
         auth_response = self._get_network_response(authentications_url, "Unable to get Azure credentials")
         auth_data = (auth_response.get("data") or [None])[0]

--- a/koku/sources/sources_http_client.py
+++ b/koku/sources/sources_http_client.py
@@ -162,9 +162,7 @@ class SourcesHTTPClient:
             msg = f"[get_data_source] Unexpected source type: {source_type}"
             LOG.error(msg)
             raise SourcesHTTPClientError(msg)
-        application_url = (
-            f"{self._base_url}/{ENDPOINT_APPLICATIONS}?filter[source_id]={self._source_id}&filter[application_type_id]={app_type_id}" # noqa: E501
-        )
+        application_url = f"{self._base_url}/{ENDPOINT_APPLICATIONS}?filter[source_id]={self._source_id}&filter[application_type_id]={app_type_id}" # noqa: E501
         applications_response = self._get_network_response(application_url, "Unable to get application settings")
         applications_data = (applications_response.get("data") or [None])[0]
         if not applications_data:
@@ -196,9 +194,7 @@ class SourcesHTTPClient:
     def _get_aws_credentials(self, _):
         """Get the roleARN from Sources Authentication service."""
         auth_type = AUTH_TYPES.get(Provider.PROVIDER_AWS)
-        authentications_url = (
-            f"{self._base_url}/{ENDPOINT_AUTHENTICATIONS}?filter[source_id]={self._source_id}&filter[authtype]={auth_type}" # noqa: E501
-        )
+        authentications_url = f"{self._base_url}/{ENDPOINT_AUTHENTICATIONS}?filter[source_id]={self._source_id}&filter[authtype]={auth_type}" # noqa: E501
         auth_response = self._get_network_response(authentications_url, "Unable to get AWS RoleARN")
         auth_data = (auth_response.get("data") or [None])[0]
         if not auth_data:
@@ -224,9 +220,7 @@ class SourcesHTTPClient:
     def _get_gcp_credentials(self, _):
         """Get the GCP credentials from Sources Authentication service."""
         auth_type = AUTH_TYPES.get(Provider.PROVIDER_GCP)
-        authentications_url = (
-            f"{self._base_url}/{ENDPOINT_AUTHENTICATIONS}?filter[source_id]={self._source_id}&filter[authtype]={auth_type}" # noqa: E501
-        )
+        authentications_url = f"{self._base_url}/{ENDPOINT_AUTHENTICATIONS}?filter[source_id]={self._source_id}&filter[authtype]={auth_type}" # noqa: E501
         auth_response = self._get_network_response(authentications_url, "Unable to get GCP credentials")
         auth_data = (auth_response.get("data") or [None])[0]
         if not auth_data:
@@ -249,9 +243,7 @@ class SourcesHTTPClient:
 
         # get client and tenant ids
         auth_type = AUTH_TYPES.get(Provider.PROVIDER_AZURE)
-        authentications_url = (
-            f"{self._base_url}/{ENDPOINT_AUTHENTICATIONS}?filter[source_id]={self._source_id}&filter[authtype]={auth_type}" # noqa: E501
-        )
+        authentications_url = f"{self._base_url}/{ENDPOINT_AUTHENTICATIONS}?filter[source_id]={self._source_id}&filter[authtype]={auth_type}" # noqa: E501
         auth_response = self._get_network_response(authentications_url, "Unable to get Azure credentials")
         auth_data = (auth_response.get("data") or [None])[0]
         if not auth_data:

--- a/koku/sources/test/test_kafka_listener.py
+++ b/koku/sources/test/test_kafka_listener.py
@@ -209,12 +209,12 @@ class SourcesKafkaMsgHandlerTest(IamTestCase):
                     "json": {"data": [{"name": SOURCE_TYPE_IDS[SOURCE_TYPE_IDS_MAP[Provider.PROVIDER_AWS]]}]},
                 },
                 {
-                    "url": f"{MOCK_URL}/api/v1.0/{ENDPOINT_APPLICATIONS}?source_id={self.source_ids.get(Provider.PROVIDER_AWS)}",  # noqa: E501
+                    "url": f"{MOCK_URL}/api/v1.0/{ENDPOINT_APPLICATIONS}?filter[source_id]={self.source_ids.get(Provider.PROVIDER_AWS)}",  # noqa: E501
                     "status": 200,
                     "json": {"data": [{"extra": {"bucket": "test_bucket"}}]},
                 },
                 {
-                    "url": f"{MOCK_URL}/api/v1.0/{ENDPOINT_AUTHENTICATIONS}?source_id={self.source_ids.get(Provider.PROVIDER_AWS)}",  # noqa: E501
+                    "url": f"{MOCK_URL}/api/v1.0/{ENDPOINT_AUTHENTICATIONS}?filter[source_id]={self.source_ids.get(Provider.PROVIDER_AWS)}",  # noqa: E501
                     "status": 200,
                     "json": {"data": [{"id": self.source_ids.get(Provider.PROVIDER_AWS), "username": FAKE_AWS_ARN}]},
                 },
@@ -264,12 +264,12 @@ class SourcesKafkaMsgHandlerTest(IamTestCase):
                     "json": {"data": [{"name": SOURCE_TYPE_IDS[SOURCE_TYPE_IDS_MAP[Provider.PROVIDER_AWS]]}]},
                 },
                 {
-                    "url": f"{MOCK_URL}/api/v1.0/{ENDPOINT_APPLICATIONS}?source_id={self.source_ids.get(Provider.PROVIDER_AWS)}",  # noqa: E501
+                    "url": f"{MOCK_URL}/api/v1.0/{ENDPOINT_APPLICATIONS}?filter[source_id]={self.source_ids.get(Provider.PROVIDER_AWS)}",  # noqa: E501
                     "status": 200,
                     "json": {"data": [{"extra": {"bucket": "test_bucket_2"}}]},
                 },
                 {
-                    "url": f"{MOCK_URL}/api/v1.0/{ENDPOINT_AUTHENTICATIONS}?source_id={self.source_ids.get(Provider.PROVIDER_AWS)}",  # noqa: E501
+                    "url": f"{MOCK_URL}/api/v1.0/{ENDPOINT_AUTHENTICATIONS}?filter[source_id]={self.source_ids.get(Provider.PROVIDER_AWS)}",  # noqa: E501
                     "status": 200,
                     "json": {"data": [{"id": self.source_ids.get(Provider.PROVIDER_AWS), "username": FAKE_AWS_ARN2}]},
                 },

--- a/koku/sources/test/test_sources_http_client.py
+++ b/koku/sources/test/test_sources_http_client.py
@@ -399,7 +399,7 @@ class SourcesHTTPClientTest(TestCase):
         with requests_mock.mock() as m:
             resource_id = 2
             m.get(
-                f"{MOCK_URL}/api/v1.0/{ENDPOINT_AUTHENTICATIONS}?source_id={self.source_id}&authtype={auth_type}",
+                f"{MOCK_URL}/api/v1.0/{ENDPOINT_AUTHENTICATIONS}?filter[source_id]={self.source_id}&filter[authtype]={auth_type}",  # noqa: E501
                 status_code=200,
                 json={"data": [{"id": resource_id, "username": self.authentication}]},
             )
@@ -455,7 +455,7 @@ class SourcesHTTPClientTest(TestCase):
                 json={"data": [applications_reponse]},
             )
             m.get(
-                f"{MOCK_URL}/api/v1.0/{ENDPOINT_AUTHENTICATIONS}?source_id={self.source_id}&authtype={auth_type}",
+                f"{MOCK_URL}/api/v1.0/{ENDPOINT_AUTHENTICATIONS}?filter[source_id]={self.source_id}&filter[authtype]={auth_type}",  # noqa: E501
                 status_code=200,
                 json={"data": [authentications_response]},
             )

--- a/koku/sources/test/test_sources_http_client.py
+++ b/koku/sources/test/test_sources_http_client.py
@@ -248,7 +248,7 @@ class SourcesHTTPClientTest(TestCase):
                 with requests_mock.mock() as m:
                     m.get(
                         f"{MOCK_URL}/api/v1.0/{ENDPOINT_APPLICATIONS}?"
-                        f"source_id={self.source_id}&application_type_id={COST_MGMT_APP_TYPE_ID}",
+                        f"filter[source_id]={self.source_id}&filter[application_type_id]={COST_MGMT_APP_TYPE_ID}",
                         status_code=200,
                         json={"data": [test.get("json")]},
                     )
@@ -265,7 +265,7 @@ class SourcesHTTPClientTest(TestCase):
                 with requests_mock.mock() as m:
                     m.get(
                         f"{MOCK_URL}/api/v1.0/{ENDPOINT_APPLICATIONS}?"
-                        f"source_id={self.source_id}&application_type_id={COST_MGMT_APP_TYPE_ID}",
+                        f"filter[source_id]={self.source_id}&filter[application_type_id]={COST_MGMT_APP_TYPE_ID}",
                         status_code=200,
                         json={"data": json},
                     )
@@ -282,7 +282,7 @@ class SourcesHTTPClientTest(TestCase):
                 with requests_mock.mock() as m:
                     m.get(
                         f"{MOCK_URL}/api/v1.0/{ENDPOINT_APPLICATIONS}?"
-                        f"source_id={self.source_id}&application_type_id={COST_MGMT_APP_TYPE_ID}",
+                        f"filter[source_id]={self.source_id}&filter[application_type_id]={COST_MGMT_APP_TYPE_ID}",
                         status_code=200,
                         json={"data": json},
                     )
@@ -322,7 +322,7 @@ class SourcesHTTPClientTest(TestCase):
         with requests_mock.mock() as m:
             resource_id = 2
             m.get(
-                f"{MOCK_URL}/api/v1.0/{ENDPOINT_AUTHENTICATIONS}?source_id={self.source_id}&authtype={auth_type}",
+                f"{MOCK_URL}/api/v1.0/{ENDPOINT_AUTHENTICATIONS}?filter[source_id]={self.source_id}&filter[authtype]={auth_type}",  # noqa: E501
                 status_code=200,
                 json={"data": [{"id": resource_id, "username": self.authentication}]},
             )
@@ -338,7 +338,7 @@ class SourcesHTTPClientTest(TestCase):
             {
                 "url": (
                     f"{MOCK_URL}/api/v1.0/{ENDPOINT_AUTHENTICATIONS}?"
-                    f"source_id={self.source_id}&authtype={auth_type}"
+                    f"filter[source_id]={self.source_id}&filter[authtype]={auth_type}"
                 ),
                 "status": 200,
                 "json": {"data": [{"id": resource_id}]},
@@ -368,7 +368,7 @@ class SourcesHTTPClientTest(TestCase):
                 with self.subTest(test=test):
                     m.get(
                         f"{MOCK_URL}/api/v1.0/{ENDPOINT_AUTHENTICATIONS}?"
-                        f"source_id={self.source_id}&authtype={auth_type}",
+                        f"filter[source_id]={self.source_id}&filter[authtype]={auth_type}",
                         status_code=200,
                         json={"data": test},
                     )
@@ -416,7 +416,7 @@ class SourcesHTTPClientTest(TestCase):
                 with self.subTest(test=test):
                     m.get(
                         f"{MOCK_URL}/api/v1.0/{ENDPOINT_AUTHENTICATIONS}?"
-                        f"source_id={self.source_id}&authtype={auth_type}",
+                        f"filter[source_id]={self.source_id}&filter[authtype]={auth_type}",
                         status_code=200,
                         json={"data": test},
                     )
@@ -450,7 +450,7 @@ class SourcesHTTPClientTest(TestCase):
         with requests_mock.mock() as m:
             m.get(
                 f"{MOCK_URL}/api/v1.0/{ENDPOINT_APPLICATIONS}?"
-                f"source_id={self.source_id}&application_type_id={COST_MGMT_APP_TYPE_ID}",
+                f"filter[source_id]={self.source_id}&filter[application_type_id]={COST_MGMT_APP_TYPE_ID}",
                 status_code=200,
                 json={"data": [applications_reponse]},
             )
@@ -557,13 +557,13 @@ class SourcesHTTPClientTest(TestCase):
                 with requests_mock.mock() as m:
                     m.get(
                         f"{MOCK_URL}/api/v1.0/{ENDPOINT_APPLICATIONS}?"
-                        f"source_id={self.source_id}&application_type_id={COST_MGMT_APP_TYPE_ID}",
+                        f"filter[source_id]={self.source_id}&filter[application_type_id]={COST_MGMT_APP_TYPE_ID}",
                         status_code=200,
                         json={"data": [app.get("json")]},
                     )
                     m.get(
                         f"{MOCK_URL}/api/v1.0/{ENDPOINT_AUTHENTICATIONS}?"
-                        f"source_id={self.source_id}&authtype={auth_type}",
+                        f"filter[source_id]={self.source_id}&filter[authtype]={auth_type}",
                         status_code=200,
                         json={"data": [auth.get("json")]},
                     )


### PR DESCRIPTION
Fixes [COST-####](https://issues.redhat.com/browse/COST-####)

Changes proposed in this PR:
* Updating the sources-api client code to use the "new" (it already existed, but we chose to only support this type of filtering going forward with the rewrite) filtering operations. 

Testing Instructions:
1. Smoke tests should catch any errors. It should work with the current rails implementation as well as the new go rewrite. 

---
Additional Context:
This was found during integration of the applications with the new rewrite. Thank you all for the help!