### PR TITLE
sources set-status: accept any 2xx status as success

### DIFF
--- a/koku/sources/sources_http_client.py
+++ b/koku/sources/sources_http_client.py
@@ -324,10 +324,10 @@ class SourcesHTTPClient:
                     f"[set_source_status] error: Status code: "
                     f"{application_response.status_code}. Response: {application_response.text}."
                 )
-                if application_response.status_code != 204:
-                    if application_response.status_code != 404:
-                        raise SourcesHTTPClientError(error_message)
-                    else:
-                        LOG.info(error_message)
-                return True
+                if 200 <= application_response.status_code < 300:
+                    return True
+                if application_response.status_code != 404:
+                    raise SourcesHTTPClientError(error_message)
+                else:
+                    LOG.info(error_message)
         return False


### PR DESCRIPTION
Fixes (https://sentry.io/organizations/project-koku/issues/3201075680/?project=5183020).

Changes proposed in this PR:
* Accept any 2xx level status as success when setting the source status
