### PR TITLE
add post_test_results.sh to pr-check

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -177,6 +177,7 @@ if [[ $exit_code == 0 ]]; then
     else
         echo "running PR smoke tests"
         run_smoke_tests
+        source $CICD_ROOT/post_test_results.sh  # send test results to Ibutsu
     fi
 fi
 


### PR DESCRIPTION
Changes proposed in this PR:
* using the bonfire/post_test_results.sh script will send smoke test results to Ibutsu