### PR TITLE
Fix arg error affecting Fedora users when default date range is calcu…

### DIFF
--- a/dev/scripts/load_test_customer_data.sh
+++ b/dev/scripts/load_test_customer_data.sh
@@ -75,7 +75,7 @@ log-info "Calculating dates..."
 if [[ $OS = "Darwin" ]]; then
     START_DATE=${2:-$(date -v '-1m' +'%Y-%m-01')}
 else
-    START_DATE=${2:-$(date --date='last month' + '%Y-%m-01')}
+    START_DATE=${2:-$(date --date='last month' '+%Y-%m-01')}
 fi
 
 END_DATE=${3:-$(date +'%Y-%m-%d')}    # defaults to today


### PR DESCRIPTION
Fixes [COST-2579](https://issues.redhat.com/browse/COST-2579)

Changes proposed in this PR:
* Fixes argument error for Fedora users

Testing Instructions FEDORA OS ONLY:
1. Checkout branch
2. Run `DEBUG=true ./dev/scripts/load_test_customer_data.sh AWS`
3. When you see 2 distinct sets of log lines in blue, hit `ctrl+c`
4. Expect to see no errors and a valid start date and end date in `YYYY-MM-DD` format
