### PR TITLE
convert errors to warnings to prevent double alerting

### DIFF
--- a/koku/koku/koku_test_runner.py
+++ b/koku/koku/koku_test_runner.py
@@ -7,7 +7,6 @@
 import logging
 import os
 import sys
-from unittest.mock import patch
 
 from dev.scripts.insert_org_tree import UploadAwsTree
 from django.conf import settings
@@ -44,15 +43,6 @@ class KokuTestRunner(DiscoverRunner):
         """Set up database tenant schema."""
         self.keepdb = settings.KEEPDB
         return setup_databases(self.verbosity, self.interactive, self.keepdb, self.debug_sql, self.parallel, **kwargs)
-
-    # @patch("koku.presto_database._execute")
-    # @patch("masu.database.report_db_accessor_base.ReportDBAccessorBase._execute_presto_multipart_sql_query")
-    # @patch("masu.database.report_db_accessor_base.ReportDBAccessorBase._execute_presto_raw_sql_query")
-    # @patch("masu.processor.report_parquet_processor_base.ReportParquetProcessorBase._execute_sql")
-    # def run_tests(self, test_labels, mock_execute, mock_raw, mock_multipart, mock_presto, extra_tests=None, **kwargs):
-    # def run_tests(self, test_labels, extra_tests=None, **kwargs):
-    #     """Mock Trino DB connections and run tests."""
-    #     return super().run_tests(test_labels, extra_tests=extra_tests, kwargs=kwargs)
 
 
 def setup_databases(verbosity, interactive, keepdb=False, debug_sql=False, parallel=0, aliases=None, **kwargs):

--- a/koku/koku/presto_database.py
+++ b/koku/koku/presto_database.py
@@ -211,7 +211,7 @@ def executescript(presto_conn, sqlscript, params=None, preprocessor=None):
                     stmt, s_params = preprocessor(p_stmt, params)
                 # If a different preprocessor is used, we can't know what the exception type is.
                 except Exception as e:
-                    LOG.error(
+                    LOG.warning(
                         f"Preprocessor Error ({e.__class__.__name__}) : {str(e)}"
                         + os.linesep
                         + f"Statement template : {p_stmt}"
@@ -233,7 +233,7 @@ def executescript(presto_conn, sqlscript, params=None, preprocessor=None):
                     + os.linesep
                     + f"Parameters: {s_params}"
                 )
-                LOG.error(exc_msg)
+                LOG.warning(exc_msg)
                 raise TrinoStatementExecError(exc_msg)
 
             all_results.extend(results)

--- a/koku/masu/database/ocp_report_db_accessor.py
+++ b/koku/masu/database/ocp_report_db_accessor.py
@@ -757,7 +757,7 @@ class OCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
                 presto_conn, tmpl_summary_sql, params=summary_sql_params, preprocessor=self.jinja_sql.prepare_query
             )
         except Exception as e:
-            LOG.error(
+            LOG.warning(
                 f"TRINO OCP ERROR : {e}"
                 + os.linesep
                 + "File : masu/database/presto_sql/reporting_ocpusagelineitem_daily_summary.sql"


### PR DESCRIPTION
Changes proposed in this PR:
* Convert excessive `log.error` to `log.warning`
* Failed celery tasks are logged with a full traceback all the way from the source of the exception. But we currently have some places where we catch an exception, log an error, and re-raise. This `catch -> log -> raise` clutters Sentry with duplicate errors and these logged errors do not contain the full traceback.

Here are examples:
* [This](https://sentry.io/organizations/project-koku/issues/3002713571/events/9ad32b6f5cf24600a1991ce514f4616c/?project=1822753) alert is raised by Celery. The full traceback can be seen.
* [This](https://sentry.io/organizations/project-koku/issues/3223748873/events/c9acbbc6d02742b39a6f1476db22d9df/?project=1822753) is one log that was generated by the above error. This error does not contain the same level of information that the previous alert contains.

This PR aims to not alert on this second error.

