### PR TITLE
update aws tag query unit tests

### DIFF
--- a/koku/api/tags/test/aws/openshift/test_queries.py
+++ b/koku/api/tags/test/aws/openshift/test_queries.py
@@ -7,7 +7,6 @@ from tenant_schemas.utils import tenant_context
 
 from api.functions import JSONBObjectKeys
 from api.iam.test.iam_test_case import IamTestCase
-from api.report.test.util.constants import OCP_POD_LABELS
 from api.tags.aws.openshift.queries import OCPAWSTagQueryHandler
 from api.tags.aws.openshift.view import OCPAWSTagView
 from api.utils import DateHelper
@@ -132,7 +131,7 @@ class OCPAWSTagQueryHandlerTest(IamTestCase):
 
     def test_execute_query_for_key_filter(self):
         """Test that the execute query runs properly with key query."""
-        key = list(OCP_POD_LABELS[0].keys())[0]
+        key = "app"
         url = f"?filter[key]={key}"
         query_params = self.mocked_query_params(url, OCPAWSTagView)
         handler = OCPAWSTagQueryHandler(query_params)
@@ -146,14 +145,16 @@ class OCPAWSTagQueryHandlerTest(IamTestCase):
 
     def test_execute_query_for_value_filter(self):
         """Test that the execute query runs properly with value query."""
-        key = "version"
-        value = "prod"
+        key = "app"
+        with tenant_context(self.tenant):
+            tag = OCPAWSTagsValues.objects.filter(key__exact=key).values("value").first()
+        value = tag.get("value")
         url = f"?filter[value]={value}"
         query_params = self.mocked_query_params(url, OCPAWSTagView)
         handler = OCPAWSTagQueryHandler(query_params)
         handler.key = key
         with tenant_context(self.tenant):
-            tags = OCPAWSTagsValues.objects.filter(key__exact="version", value="prod").values("value").distinct().all()
+            tags = OCPAWSTagsValues.objects.filter(key__exact=key, value=value).values("value").distinct().all()
             tag_values = [tag.get("value") for tag in tags]
         expected = {"key": key, "values": tag_values}
         result = handler.get_tag_values()
@@ -162,9 +163,11 @@ class OCPAWSTagQueryHandlerTest(IamTestCase):
 
     def test_execute_query_for_value_filter_partial_match(self):
         """Test that the execute query runs properly with value query."""
-        key = "version"
-        value = "a"
-        url = f"/version/?filter[value]={value}"
+        key = "app"
+        with tenant_context(self.tenant):
+            tag = OCPAWSTagsValues.objects.filter(key__exact=key).values("value").first()
+        value = tag.get("value")[0]  # get first letter of value
+        url = f"/{key}/?filter[value]={value}"
         query_params = self.mocked_query_params(url, OCPAWSTagView)
         # the mocked query parameters dont include the key from the url so it needs to be added
         query_params.kwargs = {"key": key}


### PR DESCRIPTION
Changes proposed in this PR:
* Update the AWS tags unit tests to use the `app` key and retrieve values from the database (Changes from previous COST-444 PRs made `app` the only enabled tag key)