### PR TITLE
use exact matching rather than contains matching

### DIFF
--- a/koku/api/tags/test/aws/openshift/test_queries.py
+++ b/koku/api/tags/test/aws/openshift/test_queries.py
@@ -136,7 +136,7 @@ class OCPAWSTagQueryHandlerTest(IamTestCase):
         query_params = self.mocked_query_params(url, OCPAWSTagView)
         handler = OCPAWSTagQueryHandler(query_params)
         with tenant_context(self.tenant):
-            tags = OCPAWSTagsSummary.objects.filter(key__contains=key).values("values").distinct().all()
+            tags = OCPAWSTagsSummary.objects.filter(key__exact=key).values("values").distinct().all()
             tag_values = [value for tag in tags for value in tag.get("values")]
         expected = {"key": key, "values": tag_values}
         result = handler.get_tags()

--- a/koku/api/tags/test/aws/test_aws_tag_query_handler.py
+++ b/koku/api/tags/test/aws/test_aws_tag_query_handler.py
@@ -112,7 +112,7 @@ class AWSTagQueryHandlerTest(IamTestCase):
         query_params = self.mocked_query_params(url, AWSTagView)
         handler = AWSTagQueryHandler(query_params)
         with tenant_context(self.tenant):
-            tags = AWSTagsSummary.objects.filter(key__contains=key).values("values").distinct().all()
+            tags = AWSTagsSummary.objects.filter(key__exact=key).values("values").distinct().all()
             tag_values = tags[0].get("values")
         expected = {"key": key, "values": tag_values}
         result = handler.get_tags()


### PR DESCRIPTION
Changes proposed in this PR:
* The query to retrieve the expected result should use `exact` matching, rather than `contains`
