### PR TITLE
force header override in `RbacPermissions`

### DIFF
--- a/koku/api/iam/test/iam_test_case.py
+++ b/koku/api/iam/test/iam_test_case.py
@@ -210,7 +210,6 @@ class RbacPermissions:
 
         @functools.wraps(function)
         def wrapper(*args, **kwargs):
-            original_id = args[0].headers[RH_IDENTITY_HEADER]
             user = self.user
             user["access"] = self.access
 
@@ -226,19 +225,12 @@ class RbacPermissions:
 
             with override_settings(DEVELOPMENT=True):
                 with override_settings(DEVELOPMENT_IDENTITY=identity):
-                    with override_settings(MIDDLEWARE=middleware):
-                        request_context = IamTestCase._create_request_context(self.customer, user)
-                        # clear the intial IamTestCase class header so it does not go through DevMiddleware
-                        args[0].headers[RH_IDENTITY_HEADER] = None
-                        middleware = DevelopmentIdentityHeaderMiddleware()
-                        middleware.process_request(request_context["request"])
-                        try:
+                    with override_settings(FORCE_HEADER_OVERRIDE=True):
+                        with override_settings(MIDDLEWARE=middleware):
+                            request_context = IamTestCase._create_request_context(self.customer, user)
+                            middleware = DevelopmentIdentityHeaderMiddleware()
+                            middleware.process_request(request_context["request"])
                             result = function(*args, **kwargs)
-                        except Exception as e:
-                            raise e
-                        finally:
-                            # after we have our result, we need to reset the IamTestCase class header
-                            args[0].headers[RH_IDENTITY_HEADER] = original_id
             return result
 
         return wrapper

--- a/koku/koku/dev_middleware.py
+++ b/koku/koku/dev_middleware.py
@@ -56,6 +56,9 @@ class DevelopmentIdentityHeaderMiddleware(MiddlewareMixin):
                 request_id_header = json.loads(b64decode(request.META.get(self.header)).decode("utf-8"))
             identity_header = request_id_header or settings.DEVELOPMENT_IDENTITY
 
+            if hasattr(settings, "FORCE_HEADER_OVERRIDE") and settings.FORCE_HEADER_OVERRIDE:
+                identity_header = settings.DEVELOPMENT_IDENTITY
+
             user_dict = identity_header.get("identity", {}).get("user")
             user = Mock(
                 spec=User,

--- a/koku/koku/settings.py
+++ b/koku/koku/settings.py
@@ -137,6 +137,7 @@ if DEVELOPMENT:
         "entitlements": {"cost_management": {"is_entitled": "True"}},
     }
     DEVELOPMENT_IDENTITY = ENVIRONMENT.json("DEVELOPMENT_IDENTITY", default=DEFAULT_IDENTITY)
+    FORCE_HEADER_OVERRIDE = ENVIRONMENT.bool("FORCE_HEADER_OVERRIDE", default=False)
     MIDDLEWARE.insert(5, "koku.dev_middleware.DevelopmentIdentityHeaderMiddleware")
     MIDDLEWARE.insert(len(MIDDLEWARE) - 1, "django_cprofile_middleware.middleware.ProfilerMiddleware")
     DJANGO_CPROFILE_MIDDLEWARE_REQUIRE_STAFF = False


### PR DESCRIPTION
`DevelopmentIdentityHeaderMiddleware` used to force all requests to use either the env defined `DEVELOPMENT_IDENTITY` or the built in header. This mechanism would overwrite headers that were sent with the request. The middleware was modified so that headers sent with the request would not be overwritten. This update required a change to the `RbacPermissions` wrapper so that the header used by tests was correct.

Today, we have random test failures that seem related to test headers. This PR updates the wrapper to add an additional setting called `FORCE_HEADER_OVERRIDE`. When true, this variable forces the middleware to explicitly overwrite the request header. I think the previous logic for overwriting the header was fragile leading to our random failures.