### PR TITLE
only change the queue when the provider uuid is not None

### DIFF
--- a/koku/masu/processor/orchestrator.py
+++ b/koku/masu/processor/orchestrator.py
@@ -47,10 +47,12 @@ class Orchestrator:
             billing_source (String): Individual account to retrieve.
 
         """
-        self._accounts, self._polling_accounts = self.get_accounts(billing_source, provider_uuid)
         self.worker_cache = WorkerCache()
+        self.billing_source = billing_source
         self.bill_date = bill_date
+        self.provider_uuid = provider_uuid
         self.queue_name = queue_name
+        self._accounts, self._polling_accounts = self.get_accounts(self.billing_source, self.provider_uuid)
 
     @staticmethod
     def get_accounts(billing_source=None, provider_uuid=None):
@@ -134,7 +136,7 @@ class Orchestrator:
             (Boolean) - Whether we are processing this manifest
         """
         # Switching initial ingest to use priority queue for QE tests based on QE_SCHEMA flag
-        if self.queue_name is not None:
+        if self.queue_name is not None and self.provider_uuid is not None:
             SUMMARY_QUEUE = self.queue_name
             REPORT_QUEUE = self.queue_name
         else:

--- a/koku/masu/test/processor/test_orchestrator.py
+++ b/koku/masu/test/processor/test_orchestrator.py
@@ -6,6 +6,7 @@
 import logging
 import random
 from unittest.mock import patch
+from uuid import uuid4
 
 import faker
 
@@ -321,8 +322,9 @@ class OrchestratorTest(MasuTestCase):
     def test_start_manifest_processing_priority_queue(self, mock_download_manifest, mock_task, mock_inspect):
         """Test start_manifest_processing using priority queue."""
         test_queues = [
-            {"name": "qe-account", "queue-name": "priority", "expected": "priority"},
-            {"name": "qe-account", "queue-name": None, "expected": "summary"},
+            {"name": "qe-account", "provider_uuid": str(uuid4()), "queue-name": "priority", "expected": "priority"},
+            {"name": "qe-account", "provider_uuid": None, "queue-name": "priority", "expected": "summary"},
+            {"name": "qe-account", "provider_uuid": str(uuid4()), "queue-name": None, "expected": "summary"},
         ]
         mock_manifest = {
             "mock_downloader_manifest": {"manifest_id": 1, "files": [{"local_file": "file1.csv", "key": "filekey"}]}
@@ -330,7 +332,7 @@ class OrchestratorTest(MasuTestCase):
         for test in test_queues:
             with self.subTest(test=test.get("name")):
                 mock_download_manifest.return_value = mock_manifest.get("mock_downloader_manifest")
-                orchestrator = Orchestrator(queue_name=test.get("queue-name"))
+                orchestrator = Orchestrator(provider_uuid=test.get("provider_uuid"), queue_name=test.get("queue-name"))
                 account = self.mock_accounts[0]
                 orchestrator.start_manifest_processing(
                     account.get("customer_name"),


### PR DESCRIPTION
Changes proposed in this PR:
* Only send the ingest tasks to the priority queue when the queue_name and provider_uuid sent to the Orchestrator are both not None.
