### PR TITLE
[COST-2593] in refresh_materialized_views convert default arg to empty string

### DIFF
--- a/koku/masu/processor/tasks.py
+++ b/koku/masu/processor/tasks.py
@@ -661,7 +661,7 @@ def refresh_materialized_views(  # noqa: C901
     schema_name,
     provider_type,
     manifest_id=None,
-    provider_uuid=None,
+    provider_uuid="",
     synchronous=False,
     queue_name=None,
     tracing_id=None,


### PR DESCRIPTION


Fixes [COST-2593](https://issues.redhat.com/browse/COST-2593)

Changes proposed in this PR:
* convert the default `provider_uuid=None` to `provider_uuid=""`

We do not pass a provider uuid into refresh materialized views from the data expiration flow. This results in a TypeError when creating the cache key from the cache_args. By setting the default to an empty string instead of a NoneType, we should not raise a TypeError when creating the cache key.