### PR TITLE
_zerofill_rank tune-up

### DIFF
--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -825,22 +825,24 @@ class ReportQueryHandler(QueryHandler):
         """Ensure the data set has at least one entry from every ranked category."""
         rank_field = self._get_group_by()[0]
         missing = set(ranks) - {item[rank_field] for item in data}
-        fd = data[0]  # first data record
-        fd_date = data[0].get("date")  # first data record date field
 
-        data.extend(
-            {
-                k: m
-                if k == rank_field
-                else fd_date
-                if k == "date"
-                else account_alias_map.get(m, m)
-                if k == "account_alias" and rank_field == "account"
-                else type(v)()
-                for k, v in fd.items()
-            }
-            for m in missing
-        )  # noqa
+        if missing:
+            fd = data[0]  # first data record
+            fd_date = data[0].get("date")  # first data record date field
+
+            data.extend(
+                {
+                    k: m
+                    if k == rank_field
+                    else fd_date
+                    if k == "date"
+                    else account_alias_map.get(m, m)
+                    if k == "account_alias" and rank_field == "account"
+                    else type(v)()
+                    for k, v in fd.items()
+                }
+                for m in missing
+            )  # noqa
 
         return data
 

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -825,16 +825,16 @@ class ReportQueryHandler(QueryHandler):
         """Ensure the data set has at least one entry from every ranked category."""
         rank_field = self._get_group_by()[0]
         missing = set(ranks) - {item[rank_field] for item in data}
+        fd = data[0]  # first data record
+        fd_date = data[0].get("date")  # first data record date field
 
-        fd = data[0]  # first data
-        aam = account_alias_map
         data.extend(
             {
                 k: m
                 if k == rank_field
-                else fd.get(k)
+                else fd_date
                 if k == "date"
-                else aam.get(m, m)
+                else account_alias_map.get(m, m)
                 if k == "account_alias" and rank_field == "account"
                 else type(v)()
                 for k, v in fd.items()

--- a/koku/api/report/view.py
+++ b/koku/api/report/view.py
@@ -148,10 +148,10 @@ class ReportView(APIView):
 
         """
         # Logging extra info regarding view processing time only when view is AWSCostView
-        _viewstart = datetime.utcnow()
         _klassname = self.__class__.__name__
         _log_view_time = _klassname == "AWSCostView"
         if _log_view_time:
+            _viewstart = datetime.utcnow()
             LOG.info(f"###### {_klassname}.get() BEGIN {_viewstart} ######")
 
         LOG.debug(f"API: {request.path} USER: {request.user.username}")
@@ -181,9 +181,9 @@ class ReportView(APIView):
         LOG.debug(f"DATA: {output}")
         response = paginator.get_paginated_response(paginated_result)
 
-        _viewend = datetime.utcnow()
-        _duration = _viewend - _viewstart
         if _log_view_time:
+            _viewend = datetime.utcnow()
+            _duration = _viewend - _viewstart
             LOG.info(f"###### {_klassname}.get()   END {_viewend} ###### (Duration: {_duration.total_seconds()}sec)")
 
         return response


### PR DESCRIPTION
Fixes [COST-2604](https://issues.redhat.com/browse/COST-2604)

Changes proposed in this PR:
* Tune-up `ReportQueryHandler._zerofill_ranks` method by collapsing the logic down to essentially a list(dict) comprehension

Testing Instructions:
1. checkout branch
2. Generate a large amount of AWS data (like, **really** big)
3. Hit the aws cost explorer endpoint with something like:
    `http://127.0.0.1:8000/api/cost-management/v1/reports/aws/costs/?filter[limit]=5&group_by[account]=*&start_date=2022-03-01&end_date=2022-05-02`
4. Examine the `koku-server` logs. You should see a log entry with the text `_zerofill_ranks() method total time` The decimal number you see should be sub-second completion

