### PR TITLE
Updated .dockerignore file to fix issues on static files permissions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,3 +13,7 @@
 **/*test*
 **/__pycache__
 **/*.log
+
+# remove any static files
+koku/static/**
+!koku/static/README


### PR DESCRIPTION
We currently see permission errors on static files access when building docker containers.

Changes proposed in this PR:
* Update .dockerignore to ignore files inside static folder
