### PR TITLE
[COST-2642] - Allow longer headers in requetsts via gunicorn

### DIFF
--- a/koku/gunicorn_conf.py
+++ b/koku/gunicorn_conf.py
@@ -36,6 +36,10 @@ if gunicorn_threads:
     threads = cpu_resources * 2 + 1
 
 
+# Allow HTTP headers up to this size
+limit_request_field_size = 16380
+
+
 # Server Hooks
 def on_starting(server):
     """Called just before the main process is initialized."""


### PR DESCRIPTION
Fixes [COST-2642](https://issues.redhat.com/browse/COST-2642)

Changes proposed in this PR:
* Bump up gunicorn limit_request_field_size to allow larger headers

---
Additional Context:

Matching https://github.com/RedHatInsights/insights-rbac/blob/fb86e205b390d0ac7925fe58a17a2497a88d196f/rbac/gunicorn.py#L9