### PR TITLE
Tech Debt: Use constants for providers types in report_downloader

### DIFF
--- a/koku/masu/external/report_downloader.py
+++ b/koku/masu/external/report_downloader.py
@@ -8,6 +8,7 @@ import logging
 from dateutil.relativedelta import relativedelta
 
 from api.common import log_json
+from api.provider.models import Provider
 from masu.database.report_stats_db_accessor import ReportStatsDBAccessor
 from masu.external.date_accessor import DateAccessor
 from masu.external.downloader.aws.aws_report_downloader import AWSReportDownloader
@@ -87,16 +88,16 @@ class ReportDownloader:
 
         """
         downloader_map = {
-            "AWS": AWSReportDownloader,
-            "AWS-local": AWSLocalReportDownloader,
-            "Azure": AzureReportDownloader,
-            "Azure-local": AzureLocalReportDownloader,
-            "GCP": GCPReportDownloader,
-            "GCP-local": GCPLocalReportDownloader,
-            "OCI": OCIReportDownloader,
-            "OCI-local": OCILocalReportDownloader,
-            "IBM": IBMReportDownloader,
-            "OCP": OCPReportDownloader,
+            Provider.PROVIDER_AWS: AWSReportDownloader,
+            Provider.PROVIDER_AWS_LOCAL: AWSLocalReportDownloader,
+            Provider.PROVIDER_AZURE: AzureReportDownloader,
+            Provider.PROVIDER_AZURE_LOCAL: AzureLocalReportDownloader,
+            Provider.PROVIDER_GCP: GCPReportDownloader,
+            Provider.PROVIDER_GCP_LOCAL: GCPLocalReportDownloader,
+            Provider.PROVIDER_OCI: OCIReportDownloader,
+            Provider.PROVIDER_OCI_LOCAL: OCILocalReportDownloader,
+            Provider.PROVIDER_IBM: IBMReportDownloader,
+            Provider.PROVIDER_OCP: OCPReportDownloader,
         }
         if self.provider_type in downloader_map:
             return downloader_map[self.provider_type](


### PR DESCRIPTION
I totally missed this during the code review, but wee should use constants instead of hardcoded values for provider types. If we ever need to change these it would be nice if we could just update the constants and it would automagically be updated everywhere. 
Logs:
```
koku-worker_1     | [2022-05-18 15:53:51,065] INFO 3ca68fc6-6230-43d1-b7bc-28ad638578ee {'AWS': <class 'masu.external.downloader.aws.aws_report_downloader.AWSReportDownloader'>,
koku-worker_1     |  'AWS-local': <class 'masu.external.downloader.aws_local.aws_local_report_downloader.AWSLocalReportDownloader'>,
koku-worker_1     |  'Azure': <class 'masu.external.downloader.azure.azure_report_downloader.AzureReportDownloader'>,
koku-worker_1     |  'Azure-local': <class 'masu.external.downloader.azure_local.azure_local_report_downloader.AzureLocalReportDownloader'>,
koku-worker_1     |  'GCP': <class 'masu.external.downloader.gcp.gcp_report_downloader.GCPReportDownloader'>,
koku-worker_1     |  'GCP-local': <class 'masu.external.downloader.gcp_local.gcp_local_report_downloader.GCPLocalReportDownloader'>,
koku-worker_1     |  'IBM': <class 'masu.external.downloader.ibm.ibm_report_downloader.IBMReportDownloader'>,
koku-worker_1     |  'OCI': <class 'masu.external.downloader.oci.oci_report_downloader.OCIReportDownloader'>,
koku-worker_1     |  'OCI-local': <class 'masu.external.downloader.oci_local.oci_local_report_downloader.OCILocalReportDownloader'>,
koku-worker_1     |  'OCP': <class 'masu.external.downloader.ocp.ocp_report_downloader.OCPReportDownloader'>}
```
# Testing
load test customer data and make sure data is still available. 
