### PR TITLE
COST-2645: Test cases need sorted list for matching

### DIFF
--- a/koku/sources/test/api/test_view.py
+++ b/koku/sources/test/api/test_view.py
@@ -280,7 +280,7 @@ class SourcesViewTests(IamTestCase):
         expected = []
         for resource_type in RESOURCE_TYPE_MAP.keys():
             expected.extend(RESOURCE_TYPE_MAP.get(resource_type))
-        self.assertEqual(list(set(excluded)), list(set(expected)))
+        self.assertEqual(sorted(list(set(excluded))), sorted(list(set(expected))))
 
         permissions = {AwsAccessPermission.resource_type: {"read": []}}
         mock_user = Mock(admin=False, access=permissions)
@@ -289,7 +289,7 @@ class SourcesViewTests(IamTestCase):
         expected = []
         for resource_type in RESOURCE_TYPE_MAP.keys():
             expected.extend(RESOURCE_TYPE_MAP.get(resource_type))
-        self.assertEqual(list(set(excluded)), list(set(expected)))
+        self.assertEqual(sorted(list(set(excluded))), sorted(list(set(expected))))
 
         permissions = {AwsAccessPermission.resource_type: {"read": ["*"]}}
         mock_user = Mock(admin=False, access=permissions)
@@ -302,4 +302,4 @@ class SourcesViewTests(IamTestCase):
             Provider.PROVIDER_GCP,
             Provider.PROVIDER_GCP_LOCAL,
         ]
-        self.assertEqual(list(set(excluded)), list(set(expected)))
+        self.assertEqual(sorted(list(set(excluded))), sorted(list(set(expected))))


### PR DESCRIPTION
Fixes [COST-2645](https://issues.redhat.com/browse/COST-2645)

Changes proposed in this PR:
* Test case some times fails due to list ordering

Related to: https://github.com/project-koku/koku/pull/3655