### PR TITLE
COST-2648 - Increase the max limit for the resource types APIs

### DIFF
--- a/koku/api/common/pagination.py
+++ b/koku/api/common/pagination.py
@@ -266,6 +266,12 @@ class OrgUnitPagination(ReportPagination):
         return dataset
 
 
+class ResourceTypePaginator(ListPaginator):
+    """A paginator that applies a larger max limit based query support for user access."""
+
+    max_limit = 20000
+
+
 class EmptyResultsSetPagination(StandardResultsSetPagination):
     """A paginator for an empty response."""
 

--- a/koku/api/resource_types/view.py
+++ b/koku/api/resource_types/view.py
@@ -9,7 +9,7 @@ from rest_framework.views import APIView
 from tenant_schemas.utils import tenant_context
 
 from api.common import CACHE_RH_IDENTITY_HEADER
-from api.common.pagination import ListPaginator
+from api.common.pagination import ResourceTypePaginator
 from api.common.permissions.resource_type_access import ResourceTypeAccessPermission
 from api.query_params import get_tenant
 from cost_models.models import CostModel
@@ -107,6 +107,6 @@ class ResourceTypeView(APIView):
                 gcp_project_dict,
                 cost_model_dict,
             ]
-            paginator = ListPaginator(data, request)
+            paginator = ResourceTypePaginator(data, request)
 
             return paginator.get_paginated_response(data)


### PR DESCRIPTION
Fixes [COST-2648](https://issues.redhat.com/browse/COST-2648)

Changes proposed in this PR:
* The user access dual list component doesn't support pagination and has to get all data at once
* Increasing the max limit for these APIs to make it possible to support customers with larger resource counts

Testing Instructions:
1. Create dataset with more than 1000 items (old max limit; e.g. aws accounts)
2. Ingest dataset
3. Call resource type API for the resource with a limit of over 1000

---
Additional Context:
https://issues.redhat.com/browse/RHCLOUD-18338
