### PR TITLE
Start of the month fix for OCI unit tests

### DIFF
--- a/koku/api/report/test/util/model_bakery_loader.py
+++ b/koku/api/report/test/util/model_bakery_loader.py
@@ -494,7 +494,7 @@ class ModelBakeryDataLoader(DataLoader):
             bill = self.create_bill(provider_type, provider, bill_date)
             bills.append(bill)
             with schema_context(self.schema):
-                days = (end_date - start_date).days
+                days = (end_date - start_date).days + 1
                 for i in range(days):
                     baker.make_recipe(
                         "api.report.test.util.oci_daily_summary",


### PR DESCRIPTION
Fixes
Changes proposed in this PR:
* Adding `+1` to bakery data generator for OCI unit tests

