### PR TITLE
Fix first of month distribution test errors.

### DIFF
--- a/koku/masu/test/database/test_ocp_report_db_accessor.py
+++ b/koku/masu/test/database/test_ocp_report_db_accessor.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 """Test the OCPReportDBAccessor utility object."""
-import logging
 import random
 import string
 import uuid
@@ -48,8 +47,6 @@ from reporting.provider.ocp.models import OCPNode
 from reporting.provider.ocp.models import OCPProject
 from reporting.provider.ocp.models import OCPPVC
 from reporting_common import REPORT_COLUMN_MAP
-
-LOG = logging.getLogger(__name__)
 
 
 class OCPReportDBAccessorTest(MasuTestCase):


### PR DESCRIPTION
Fixes first of the month errors:

So, I did some debugging and the issue was that for the `06-01-2022` to `07-01-2022` period we only had one node being populated:

```
select node, sum(node_capacity_cpu_core_hours), sum(cluster_capacity_cpu_core_hours) from reporting_ocpusagelineitem_daily_summary WHERE usage_start >= '2022-06-01' AND usage_start < '2022-07-01' AND cluster_id = 'OCP-on-Prem' and node IS NOT NULL GROUP BY node;
  node  |              sum              |              sum
--------+-------------------------------+--------------------------------
 node_0 | 9449194386544.660607250000000 | 13303467628156.476598570000000
 ``` 
 
 Our cluster to node distribution method works like this:
 `(node_cap / cluster_cap) * cluster_rate`
 
Since we have one node only a portion of the 1000 was being assigned:
```
INFO None Distributing Cluster Cost to Nodes:
 cluster (OCP-on-Prem) cost: 1000
 node (node_0) distributed cost: 710.28055621721232648000
 distribution type: cpu
```

**Assumption:**
In the real world I think the node-capacity would equal the cluster-capacity if there was only one node. However, I don't think it does cause of dummy data being populated by model bakery. 
 
The fix was to have it use the previous month instead of the current so more than one node will be returned. 


---
Additional Context:
