### PR TITLE
fix gcp provider map to fetch instance_type tables

### DIFF
--- a/koku/api/report/gcp/provider_map.py
+++ b/koku/api/report/gcp/provider_map.py
@@ -297,7 +297,7 @@ class GCPProviderMap(ProviderMap):
                 ("gcp_project",): GCPCostSummaryByProjectP,
                 ("account", "gcp_project"): GCPCostSummaryByProjectP,
             },
-            "instance-type": {"default": GCPComputeSummaryP, ("account",): GCPComputeSummaryByAccountP},
+            "instance_type": {"default": GCPComputeSummaryP, ("account",): GCPComputeSummaryByAccountP},
             "storage": {
                 "default": GCPStorageSummaryP,
                 ("account",): GCPStorageSummaryByAccountP,


### PR DESCRIPTION
Fixes [COST-####](https://issues.redhat.com/browse/COST-####)

Changes proposed in this PR:
* The provider map had the wrong key for instance-type reports. This PR replaces `instance-type` with `instance_type` so that it aligns with [this](https://github.com/project-koku/koku/blob/44b92e6e3313fc2d24cdc99b9ef0db89f3d763ce/koku/api/report/gcp/view.py#L33)
*

Testing Instructions:
1. Run `this command` ...
2. Ingest this data `with this other command` ...
3. Expect to see this result:
   ```
   GET http://localhost:8000/api/endpoint

   {json: response}
   ```
4.
5.

---
Additional Context:
