### PR TITLE
minio has added a feature that is not backwards compatible.

### DIFF
--- a/Dockerfile.minio
+++ b/Dockerfile.minio
@@ -1,4 +1,4 @@
-FROM minio/minio:latest
+FROM minio/minio:RELEASE.2022-05-26T05-48-41Z.hotfix.15f13935a
 
 ARG USER_ID=1000
 


### PR DESCRIPTION
Fixes [COST-2711](https://issues.redhat.com/browse/COST-2711)

Changes proposed in this PR:
* pin version of minIO for dev env

Testing Instructions: (make it fail first, using master branch rung the following)
1. make docker-trino-down-all
2. docker system prune --all
3. make clear-testing clear-trino
4. make docker-up-min-trino
5. docker ps (you should not see the kokiminio container

Now run the same commands on this branch. 
You should see the kokuminio container

`
9b6c6464f27a   local-minio:latest                                   "/usr/bin/docker-ent…"   11 seconds ago   Up 5 seconds   0.0.0.0:9000->9000/tcp, 0.0.0.0:9090->9090/tcp     kokuminio
`

