### PR TITLE
reduce risk of DateAccessor unit test failure

### DIFF
--- a/koku/masu/test/external/test_date_accessor.py
+++ b/koku/masu/test/external/test_date_accessor.py
@@ -38,6 +38,7 @@ class DateAccessorTest(MasuTestCase):
     def setUp(self):
         """Set up the tests."""
         DateAccessor.mock_date_time = None
+        DateAccessor.date_time_last_accessed = datetime.now(tz=pytz.UTC)
         Config.DEBUG = False
         Config.MASU_DATE_OVERRIDE = None
 


### PR DESCRIPTION
Fixes [COST-####](https://issues.redhat.com/browse/COST-####)

`test_today_override` has a tendency to fail. Looking over the DateAccessor code, we do some interesting math when overriding the date. Part of that involves calculating the difference between the current time and the last time the DateAccessor was accessed. We then add this difference to the `mock_date_time`. If the `mock_date_time` is late enough in a day (i.e. 23:59), the difference may change the date to the next day. If we reset the `date_time_last_accessed` in the unit test SetUp method, the risk of date changes throughout unit testing should be minimized.

Changes proposed in this PR:
* Reset `date_time_last_accessed` in the unit test SetUp method.
