### PR TITLE
[COST-2750] - use path instead of full_path

### DIFF
--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -163,12 +163,12 @@ class ReportQueryHandler(QueryHandler):
     @property
     def is_openshift(self):
         """Determine if we are working with an OpenShift API."""
-        return "openshift" in self.parameters.request.get_full_path()
+        return "openshift" in self.parameters.request.path
 
     @property
     def is_aws(self):
         """Determine if we are working with an OpenShift API."""
-        return "aws" in self.parameters.request.get_full_path()
+        return "aws" in self.parameters.request.path
 
     def initialize_totals(self):
         """Initialize the total response column values."""


### PR DESCRIPTION
Fixes [COST-2750](https://issues.redhat.com/browse/COST-2750)

Changes proposed in this PR:
* do not check for `openshift` or `aws` in the full path as this could incorrectly return true if those words are in the query parameters
*

Testing Instructions:
1. On main, go here: [`http://localhost:8000/api/cost-management/v1/reports/gcp/costs/?delta=cost&filter[limit]=10&filter[offset]=0&filter[resolution]=monthly&filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[gcp_project]=platform-openshift&group_by[gcp_project]=*&order_by[cost]=desc`](http://localhost:8000/api/cost-management/v1/reports/gcp/costs/?delta=cost&filter[limit]=10&filter[offset]=0&filter[resolution]=monthly&filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[gcp_project]=platform-openshift&group_by[gcp_project]=*&order_by[cost]=desc)
2. See 500 error
3. Checkout `cost-2750-path` and reload koku
4. revisit endpoint
5. See 200 response

---
Additional Context:
