### PR TITLE
Utilize managed kafka user, paswd, sasl_mech, sec_proto

### DIFF
--- a/koku/koku/configurator.py
+++ b/koku/koku/configurator.py
@@ -216,6 +216,26 @@ class EnvConfigurator(Configurator):
         return requestedName
 
     @staticmethod
+    def get_kafka_username():
+        """Obtain kafka username"""
+        return None
+
+    @staticmethod
+    def get_kafka_password():
+        """Obtain kafka password"""
+        return None
+
+    @staticmethod
+    def get_kafka_sasl_mechanism():
+        """Obtain kafka sasl mechanism"""
+        return None
+
+    @staticmethod
+    def get_kafka_security_protocol():
+        """Obtain kafka security protocol"""
+        return None
+
+    @staticmethod
     def get_cloudwatch_access_id():
         """Obtain cloudwatch access id."""
         return ENVIRONMENT.get_value("CW_AWS_ACCESS_KEY_ID", default=None)
@@ -379,6 +399,26 @@ class ClowderConfigurator(Configurator):
     def get_kafka_topic(requestedName: str):
         """Obtain kafka topic."""
         return KafkaTopics.get(requestedName).name
+
+    @staticmethod
+    def get_kafka_username():
+        """Obtain kafka username"""
+        return LoadedConfig.kafka.brokers[0].sasl.username
+
+    @staticmethod
+    def get_kafka_password():
+        """Obtain kafka password"""
+        return LoadedConfig.kafka.brokers[0].sasl.password
+
+    @staticmethod
+    def get_kafka_sasl_mechanism():
+        """Obtain kafka sasl mechanism"""
+        return LoadedConfig.kafka.brokers[0].sasl.saslMechanism
+
+    @staticmethod
+    def get_kafka_security_protocol():
+        """Obtain kafka security protocol"""
+        return LoadedConfig.kafka.brokers[0].sasl.securityProdocol
 
     @staticmethod
     def get_cloudwatch_access_id():

--- a/koku/masu/config.py
+++ b/koku/masu/config.py
@@ -84,6 +84,10 @@ class Config:
     INSIGHTS_KAFKA_HOST = CONFIGURATOR.get_kafka_broker_host()
     INSIGHTS_KAFKA_PORT = CONFIGURATOR.get_kafka_broker_port()
     INSIGHTS_KAFKA_ADDRESS = f"{INSIGHTS_KAFKA_HOST}:{INSIGHTS_KAFKA_PORT}"
+    INSIGHTS_KAFKA_USER = CONFIGURATOR.get_kafka_username()
+    INSIGHTS_KAFKA_PASSWORD = CONFIGURATOR.get_kafka_password()
+    INSIGHTS_KAFKA_SASL_MECHANISM = CONFIGURATOR.get_kafka_sasl_mechanism()
+    INSIGHTS_KAFKA_SECURITY_PROTOCOL = CONFIGURATOR.get_kafka_security_protocol()
     HCCM_TOPIC = CONFIGURATOR.get_kafka_topic("platform.upload.hccm")
     VALIDATION_TOPIC = CONFIGURATOR.get_kafka_topic("platform.upload.validation")
     NOTIFICATION_TOPIC = CONFIGURATOR.get_kafka_topic("platform.notifications.ingress")

--- a/koku/masu/external/kafka_msg_handler.py
+++ b/koku/masu/external/kafka_msg_handler.py
@@ -671,6 +671,10 @@ def get_consumer():  # pragma: no cover
             "queued.max.messages.kbytes": 1024,
             "enable.auto.commit": False,
             "max.poll.interval.ms": 1080000,  # 18 minutes
+            "security_protocol": Config.INSIGHTS_KAFKA_SECURITY_PROTOCOL,
+            "sasl_mechanism": Config.INSIGHTS_KAFKA_SASL_MECHANISM,
+            "sasl_plain_username": Config.INSIGHTS_KAFKA_USER,
+            "sasl_plain_password": Config.INSIGHTS_KAFKA_PASSWORD,
         },
         logger=LOG,
     )
@@ -680,7 +684,16 @@ def get_consumer():  # pragma: no cover
 
 def get_producer():  # pragma: no cover
     """Create a Kafka producer."""
-    producer = Producer({"bootstrap.servers": Config.INSIGHTS_KAFKA_ADDRESS, "message.timeout.ms": 1000})
+    producer = Producer(
+        {
+            "bootstrap.servers": Config.INSIGHTS_KAFKA_ADDRESS,
+            "message.timeout.ms": 1000,
+            "security_protocol": Config.INSIGHTS_KAFKA_SECURITY_PROTOCOL,
+            "sasl_mechanism": Config.INSIGHTS_KAFKA_SASL_MECHANISM,
+            "sasl_plain_username": Config.INSIGHTS_KAFKA_USER,
+            "sasl_plain_password": Config.INSIGHTS_KAFKA_PASSWORD,
+        }
+    )
     return producer
 
 

--- a/koku/sources/config.py
+++ b/koku/sources/config.py
@@ -16,6 +16,10 @@ class Config:
     SOURCES_KAFKA_HOST = CONFIGURATOR.get_kafka_broker_host()
     SOURCES_KAFKA_PORT = CONFIGURATOR.get_kafka_broker_port()
     SOURCES_KAFKA_ADDRESS = f"{SOURCES_KAFKA_HOST}:{SOURCES_KAFKA_PORT}"
+    SOURCES_KAFKA_USER = CONFIGURATOR.get_kafka_username()
+    SOURCES_KAFKA_PASSWORD = CONFIGURATOR.get_kafka_password()
+    SOURCES_KAFKA_SASL_MECHANISM = CONFIGURATOR.get_kafka_sasl_mechanism()
+    SOURCES_KAFKA_SECURITY_PROTOCOL = CONFIGURATOR.get_kafka_security_protocol()
 
     SOURCES_API_HOST = CONFIGURATOR.get_endpoint_host("sources-api", "svc", "localhost")
     SOURCES_API_PORT = CONFIGURATOR.get_endpoint_port("sources-api", "svc", "3000")

--- a/koku/sources/kafka_listener.py
+++ b/koku/sources/kafka_listener.py
@@ -258,6 +258,10 @@ def get_consumer():
             "group.id": "hccm-sources",
             "queued.max.messages.kbytes": 1024,
             "enable.auto.commit": False,
+            "security_protocol": Config.SOURCES_KAFKA_SECURITY_PROTOCOL,
+            "sasl_mechanism": Config.SOURCES_KAFKA_SASL_MECHANISM,
+            "sasl_plain_username": Config.SOURCES_KAFKA_USER,
+            "sasl_plain_password": Config.SOURCES_KAFKA_PASSWORD,
         },
         logger=LOG,
     )


### PR DESCRIPTION
## Jira Ticket

[COST-1380](https://issues.redhat.com/browse/COST-1380)

## Description

This change utilizes the **managed** Kafka username, password, sasl_mechanism, and security_protocol in the `Configurator` and when creating Kafka `Producer` and `Consumer`

## Testing

1. Checkout Branch
2. Restart Koku
3. Run tox
4. Deploy to ephemeral (should not be any errors in kafka listener, producer code

## Notes

Once approved, this should get deployed to staging for another system test.

