### PR TITLE
Fix semantic error on organizations endpoint in API docs 

### DIFF
--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -924,9 +924,6 @@
                     "basic_auth": []
                 }],
                 "parameters": [{
-                        "$ref": "#/components/parameters/QueryDelta"
-                    },
-                    {
                         "$ref": "#/components/parameters/QueryFilter"
                     },
                     {
@@ -936,7 +933,7 @@
                         "$ref": "#/components/parameters/ReportQueryLimit"
                     },
                     {
-                        "$ref": "#/components/schemas/OrganizationFilter"
+                        "$ref": "#/components/parameters/OrganizationFilter"
                     }
                 ],
                 "responses": {
@@ -5233,6 +5230,15 @@
                     "blended_cost",
                     "savingsplan_effective_cost"
                   ]
+                }
+            },
+            "OrganizationFilter": {
+                "name": "org_unit_id",
+                "required": false,
+                "in": "query",
+                "description": "String to indicate org unit id",
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationFilter"
                 }
             },
             "QueryComputeCount": {


### PR DESCRIPTION
## Jira Ticket

I noticed we had a semantic error on our api docs for the organizations endpoint. 

## Description
Create a OrganizationFilter parameter reference so that the parameters section doesn't point to a schema 

This change will ...

## Testing

1. Copy/paste the openapi.json into https://editor.swagger.io/ and notice that there is no longer a semantic error

## Notes

...
