### PR TITLE
Prevent duplicate providers across accounts

### DIFF
--- a/koku/api/provider/serializers.py
+++ b/koku/api/provider/serializers.py
@@ -400,9 +400,7 @@ class ProviderSerializer(serializers.ModelSerializer):
             bill, __ = ProviderBillingSource.objects.get_or_create(**billing_source)
             auth, __ = ProviderAuthentication.objects.get_or_create(**authentication)
             if instance.billing_source != bill or instance.authentication != auth:
-                dup_queryset = (
-                    Provider.objects.filter(authentication=auth).filter(billing_source=bill).filter(customer=customer)
-                )
+                dup_queryset = Provider.objects.filter(authentication=auth).filter(billing_source=bill)
                 if dup_queryset.count() != 0:
                     conflict_provder = dup_queryset.first()
                     message = (

--- a/koku/api/provider/serializers.py
+++ b/koku/api/provider/serializers.py
@@ -347,9 +347,7 @@ class ProviderSerializer(serializers.ModelSerializer):
         auth, __ = ProviderAuthentication.objects.get_or_create(**authentication)
 
         # We can re-use a billing source or a auth, but not the same combination.
-        dup_queryset = (
-            Provider.objects.filter(authentication=auth).filter(billing_source=bill).filter(customer=customer)
-        )
+        dup_queryset = Provider.objects.filter(authentication=auth).filter(billing_source=bill)
         if dup_queryset.count() != 0:
             conflict_provider = dup_queryset.first()
             message = (

--- a/koku/api/provider/test/test_serializers.py
+++ b/koku/api/provider/test/test_serializers.py
@@ -546,7 +546,7 @@ class ProviderSerializerTest(IamTestCase):
                     serializer.save()
 
     def test_create_same_provider_different_customers(self):
-        """Test that the same provider can be created for 2 different customers."""
+        """Test that the same provider can not be created for 2 different customers."""
         user_data = self._create_user_data()
         alt_request_context = self._create_request_context(
             self.create_mock_customer_data(), user_data, create_tenant=True
@@ -556,18 +556,17 @@ class ProviderSerializerTest(IamTestCase):
                 data=self.generic_providers[Provider.PROVIDER_AZURE], context=self.request_context
             )
             if serializer.is_valid(raise_exception=True):
-                instance1 = serializer.save()
+                serializer.save()
 
-        with patch.object(ProviderAccessor, "cost_usage_source_ready", returns=True):
-            serializer = ProviderSerializer(
-                data=self.generic_providers[Provider.PROVIDER_AZURE], context=alt_request_context
-            )
-            if serializer.is_valid(raise_exception=True):
-                instance2 = serializer.save()
-
-        self.assertNotEqual(instance1.uuid, instance2.uuid)
-        self.assertEqual(instance1.billing_source_id, instance2.billing_source_id)
-        self.assertEqual(instance1.authentication_id, instance2.authentication_id)
+        with self.assertRaises(ValidationError) as excCtx:
+            with patch.object(ProviderAccessor, "cost_usage_source_ready", returns=True):
+                serializer = ProviderSerializer(
+                    data=self.generic_providers[Provider.PROVIDER_AZURE], context=alt_request_context
+                )
+                if serializer.is_valid(raise_exception=True):
+                    serializer.save()
+        validationErr = excCtx.exception.detail[ProviderErrors.DUPLICATE_AUTH][0]
+        self.assertTrue("Cost management does not allow duplicate accounts" in str(validationErr))
 
     def test_create_provider_for_demo_account(self):
         """Test creating a provider for a demo account."""


### PR DESCRIPTION
## Jira Ticket

[COST-2728](https://issues.redhat.com/browse/COST-2728)

## Description

This change will prevent you adding the same source/provider in different account/schema

## Testing

1. Checkout Branch
2. Start koku
3. Add OCP source
4. Attempt to add the exact same OCP source to a new schema
5. RESULT: Cost management does not allow duplicate accounts. test_cost_ocp already exists. Edit source settings to configure a new source.

## Notes

...
