### PR TITLE
GCP implement self healing for upcoming breaking changes in the downloader

### DIFF
--- a/koku/masu/database/report_manifest_db_accessor.py
+++ b/koku/masu/database/report_manifest_db_accessor.py
@@ -244,3 +244,13 @@ class ReportManifestDBAccessor(KokuDBAccess):
             .filter(partition_date__gte=start_date, partition_date__lte=end_date)
         )
         return manifests
+
+    def get_outdated_gcp_manifests(self, provider_uuid, bill_date):
+        """Returns all manifests for a provider that are outdated.
+
+        The new gcp manifest contain "|" that is used to get the
+        partition date."""
+        manifests = CostUsageReportManifest.objects.filter(
+            provider_id=provider_uuid,
+        ).exclude(assembly_id__icontains="|")
+        return manifests

--- a/koku/masu/external/downloader/gcp/gcp_report_downloader.py
+++ b/koku/masu/external/downloader/gcp/gcp_report_downloader.py
@@ -260,6 +260,7 @@ class GCPReportDownloader(ReportDownloaderBase, DownloaderInterface):
             # Ensure that we don't try to run the new downloader version
             # on manifests formatted with the old assembly_id version.
             self.activate_self_healing()
+            # TODO: Remove the two lines below.
             msg = "New downloader attempting to use old manifest version, stopping download."
             raise GCPNewDownloaderVersion(msg)
 

--- a/koku/masu/processor/orchestrator.py
+++ b/koku/masu/processor/orchestrator.py
@@ -19,7 +19,7 @@ from masu.external.account_label import AccountLabel
 from masu.external.accounts_accessor import AccountsAccessor
 from masu.external.accounts_accessor import AccountsAccessorError
 from masu.external.date_accessor import DateAccessor
-from masu.external.downloader.gcp.gcp_report_downloader import GCPNewDownloaderVersion
+from masu.external.downloader.gcp.gcp_report_downloader import GCPSelfHealingComplete
 from masu.external.report_downloader import ReportDownloader
 from masu.external.report_downloader import ReportDownloaderError
 from masu.processor.tasks import get_report_files
@@ -288,8 +288,10 @@ class Orchestrator:
             _, reports_tasks_queued = self.start_manifest_processing(**account)
         except ReportDownloaderError as err:
             LOG.warning(f"Unable to download manifest for provider: {provider_uuid}. Error: {str(err)}.")
-        except GCPNewDownloaderVersion as msg_info:
+        except GCPSelfHealingComplete as msg_info:
             LOG.info(msg_info)
+            # Retry now that we have removed the old manifests
+            self.start_manifest_processing(**account)
         except Exception as err:
             # Broad exception catching is important here because any errors thrown can
             # block all subsequent account processing.

--- a/koku/masu/util/aws/common.py
+++ b/koku/masu/util/aws/common.py
@@ -421,6 +421,39 @@ def remove_files_not_in_set_from_s3_bucket(request_id, s3_path, manifest_id, con
     return removed
 
 
+def remove_files_for_manifest_from_s3_bucket(request_id, s3_path, manifest_id, context={}):
+    """
+    Removes all files in a given prefix if they are not within the given set.
+    """
+    if not (
+        settings.ENABLE_S3_ARCHIVING
+        or enable_trino_processing(context.get("provider_uuid"), context.get("provider_type"), context.get("account"))
+    ):
+        return []
+
+    removed = []
+    if s3_path:
+        try:
+            s3_resource = get_s3_resource()
+            existing_objects = s3_resource.Bucket(settings.S3_BUCKET_NAME).objects.filter(Prefix=s3_path)
+            for obj_summary in existing_objects:
+                existing_object = obj_summary.Object()
+                metadata = existing_object.metadata
+                manifest = metadata.get("manifestid")
+                manifest_id_str = str(manifest_id)
+                key = existing_object.key
+                if manifest == manifest_id_str:
+                    # s3_resource.Object(settings.S3_BUCKET_NAME, key).delete()
+                    removed.append(key)
+            if removed:
+                msg = f"Removed files from s3 bucket {settings.S3_BUCKET_NAME}: {','.join(removed)}."
+                LOG.info(log_json(request_id, msg, context))
+        except (EndpointConnectionError, ClientError) as err:
+            msg = f"Unable to remove data in bucket {settings.S3_BUCKET_NAME}.  Reason: {str(err)}"
+            LOG.info(log_json(request_id, msg, context))
+    return removed
+
+
 def aws_post_processor(data_frame):
     """
     Consume the AWS data and add a column creating a dictionary for the aws tags

--- a/koku/masu/util/aws/common.py
+++ b/koku/masu/util/aws/common.py
@@ -443,6 +443,7 @@ def remove_files_for_manifest_from_s3_bucket(request_id, s3_path, manifest_id, c
                 manifest_id_str = str(manifest_id)
                 key = existing_object.key
                 if manifest == manifest_id_str:
+                    # TODO: Remove this when ready to test deletes.
                     # s3_resource.Object(settings.S3_BUCKET_NAME, key).delete()
                     removed.append(key)
             if removed:

--- a/koku/masu/util/aws/common.py
+++ b/koku/masu/util/aws/common.py
@@ -29,6 +29,7 @@ from masu.util.common import safe_float
 from masu.util.common import strip_characters_from_column_name
 from masu.util.ocp.common import match_openshift_labels
 from reporting.provider.aws.models import PRESTO_REQUIRED_COLUMNS
+from pprint import pformat
 
 LOG = logging.getLogger(__name__)
 
@@ -421,7 +422,7 @@ def remove_files_not_in_set_from_s3_bucket(request_id, s3_path, manifest_id, con
     return removed
 
 
-def remove_files_for_manifest_from_s3_bucket(request_id, s3_path, manifest_id, context={}):
+def gcp_self_healing_remove_files_for_manifest_from_s3_bucket(request_id, s3_path, manifest_id, context={}):
     """
     Removes all files in a given prefix if they are not within the given set.
     """
@@ -443,8 +444,7 @@ def remove_files_for_manifest_from_s3_bucket(request_id, s3_path, manifest_id, c
                 manifest_id_str = str(manifest_id)
                 key = existing_object.key
                 if manifest == manifest_id_str:
-                    # TODO: Remove this when ready to test deletes.
-                    # s3_resource.Object(settings.S3_BUCKET_NAME, key).delete()
+                    s3_resource.Object(settings.S3_BUCKET_NAME, key).delete()
                     removed.append(key)
             if removed:
                 msg = f"Removed files from s3 bucket {settings.S3_BUCKET_NAME}: {','.join(removed)}."


### PR DESCRIPTION
## Jira Ticket

I am waiting to create the jira issue for this until we verify that this implementation is a possibility. 

**TODO:**

- [ ] If we decide to move forward with the auto healing in this pull request instead of using an SRE we will need to create a jira issue for removing the auto healing code from the codebase once all of the manifest have been converted over to the new functionality. 

## Description
This pull request is to help handle the breaking changes that will be introduced in this pull request https://github.com/project-koku/koku/pull/3728

**Breaking Changes:**
1. New assembly_id
2. New naming convention for the csv & parquet files stored inside of Trino
3. New manifest creation system where one manifest == one gcp download

My solution to handle these breaking changes was to create some self healing logic that would do the following:
1. Find all the old manifest
2. Remove csv & parquet files that are within the aws bucket for the old manifest
3. Delete old manifest from the table and then redownload the gcp data using the new downloader method. 

## Testing

#### Run a download on main
We are testing the transition from the old gcp downloader to the new gcp downloader. Therefore we will need to run a download on main using the DATE_OVERRIDE variable:

*GCP Date Override*
```
export DATE_OVERRIDE='2022-06-27'
```
You can check to make sure this variable is inside of your python environment with this command:
```
printenv | grep DATE_OVERRIDE
```

Now check to make sure this variable is inside of the koku worker because it will be running the download task.
```
docker exec -it koku_koku-worker_1 bash -c "echo $DATE_OVERRIDE"
```

If the variable is not inside of your conatiner you can restart it and check again:
```
docker-compose up -d koku-worker
```

These changes are to the real GCP downloader so you will need to use our dev gcp account to test it. 
```
make gcp-source gcp_name=CodyTest
```
Wait for the gcp download to be completed. 

#### Run a download on this branch
```
git fetch origin issue/cost-2682-self-healing
git checkout issue/cost-2682-self-healing
```

1. http://127.0.0.1:5042/api/cost-management/v1/download/

**Important Logs to notice**
1. Remove csv & parquet files that are within the aws bucket for the old manifest
```
Removed files from s3 bucket koku-bucket....
```
2. Removed
```
koku-worker_1     | [2022-07-08 15:46:13,793] INFO 06585d27-ec25-4842-ad52-22b4ca989771 Removed (14, {'reporting_common.CostUsageReportStatus': 12, 'reporting_common.CostUsageReportManifest': 2}) outdated GCP manifests for provider_uuid ee56eb85-1b22-466f-a569-205ab2d53bb5
```
After the manifest & report files are removed you will see this log:
```
koku-worker_1     | [2022-07-08 15:46:13,794] INFO 06585d27-ec25-4842-ad52-22b4ca989771 Completed GCP self healing for provider ee56eb85-1b22-466f-a569-205ab2d53bb5
```
Then a new initial download will start.

## Notes

...
