### PR TITLE
Added ability to check for invalid request params

### DIFF
--- a/koku/masu/api/hcs_report_finalization.py
+++ b/koku/masu/api/hcs_report_finalization.py
@@ -31,11 +31,11 @@ def hcs_report_finalization(request):
 
     if request.method == "GET":
         params = request.query_params
-        expected_params = ("month", "year", "provider_type", "provider_uuid", "schema_name")
+        excepted_params = ("month", "year", "provider_type", "provider_uuid", "schema_name")
 
         for param in params:
-            if param not in expected_params:
-                errmsg = f"{param}: is not a valid Request parameter. Valid params: {expected_params}"
+            if param not in excepted_params:
+                errmsg = f"{param}: is not a valid Request parameter. Valid params: {excepted_params}"
                 return Response({"Error": errmsg}, status=status.HTTP_400_BAD_REQUEST)
 
         month = params.get("month")

--- a/koku/masu/api/hcs_report_finalization.py
+++ b/koku/masu/api/hcs_report_finalization.py
@@ -35,7 +35,7 @@ def hcs_report_finalization(request):
 
         for param in params:
             if param not in expected_params:
-                errmsg = f"'{param}' is not a valid Request parameter"
+                errmsg = f"{param}: is not a valid Request parameter." f"Valid params: {expected_params}"
                 return Response({"Error": errmsg}, status=status.HTTP_400_BAD_REQUEST)
 
         month = params.get("month")

--- a/koku/masu/api/hcs_report_finalization.py
+++ b/koku/masu/api/hcs_report_finalization.py
@@ -31,6 +31,13 @@ def hcs_report_finalization(request):
 
     if request.method == "GET":
         params = request.query_params
+        expected_params = ("month", "year", "provider_type", "provider_uuid", "schema_name")
+
+        for param in params:
+            if param not in expected_params:
+                errmsg = f"'{param}' is not a valid Request parameter"
+                return Response({"Error": errmsg}, status=status.HTTP_400_BAD_REQUEST)
+
         month = params.get("month")
         year = params.get("year")
         provider_type = params.get("provider_type")

--- a/koku/masu/api/hcs_report_finalization.py
+++ b/koku/masu/api/hcs_report_finalization.py
@@ -35,7 +35,7 @@ def hcs_report_finalization(request):
 
         for param in params:
             if param not in expected_params:
-                errmsg = f"{param}: is not a valid Request parameter." f"Valid params: {expected_params}"
+                errmsg = f"{param}: is not a valid Request parameter. Valid params: {expected_params}"
                 return Response({"Error": errmsg}, status=status.HTTP_400_BAD_REQUEST)
 
         month = params.get("month")

--- a/koku/masu/test/api/test_hcs_report_finalization.py
+++ b/koku/masu/test/api/test_hcs_report_finalization.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 """Test the hcs_report_data endpoint view."""
-import uuid
 from unittest.mock import patch
 
 from django.test import TestCase
@@ -22,13 +21,9 @@ class HCSFinalizationTests(TestCase):
     def test_get_report_finalization_data(self, mock_celery, _):
         """Test the hcs_report_finalization endpoint."""
 
-        params = {
-            "tracing_id": str(uuid.uuid4()),
-        }
-
         expected_key = "HCS Report Finalization"
 
-        response = self.client.get(reverse(self.ENDPOINT), params)
+        response = self.client.get(reverse(self.ENDPOINT))
         body = response.json()
         self.assertEqual(response.status_code, 200)
         self.assertIn(expected_key, body)
@@ -68,6 +63,15 @@ class HCSFinalizationTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(expected_key, result)
         mock_celery.s.assert_called()
+
+    def test_get_report_finalization_neg_param(self, mock_celery, _):
+        """Test GET hcs_report_finalization endpoint by providing bad parameter"""
+        params = {
+            "bogus": "bad_param",
+        }
+        response = self.client.get(reverse(self.ENDPOINT), params)
+
+        self.assertEqual(response.status_code, 400)
 
     def test_get_report_finalization_year_negative(self, mock_celery, _):
         """Test the GET hcs_report_finalization endpoint for you must provide 'month' when providing 'year'"""


### PR DESCRIPTION
## Jira Ticket

[COST-2812](https://issues.redhat.com/browse/COST-2812)

## Description
Added the ability to check for bad request parameters

## Testing
Start up koku normally. no need to run create customer or load customer targets

run the following masu endpoint and you will see that any none excepted params will cause and error.

`/api/cost-management/v1/hcs_report_finalization/?bogus=nothing'`

Should see something like the following in the logs
```
[2022-07-19 12:30:08,276] INFO None {'method': 'GET', 'path': '/api/cost-management/v1/hcs_report_finalization/?bogus=nothing', 'status': 400, 'request_id': None, 'account': None, 'username': None, 'is_admin': False, 'response_time': '125.58 ms'}
```

Client response would be
```
{
    "Error": "bogus: is not a valid Request parameter.Valid params: ('month', 'year', 'provider_type', 'provider_uuid', 'schema_name')"
}
```
...
