### PR TITLE
[COST-2813] Expand currency fields for azure 

### DIFF
--- a/koku/masu/database/presto_sql/reporting_azurecostentrylineitem_daily_summary.sql
+++ b/koku/masu/database/presto_sql/reporting_azurecostentrylineitem_daily_summary.sql
@@ -26,7 +26,7 @@ WITH cte_line_items AS (
         json_extract_scalar(json_parse(additionalinfo), '$.ServiceType') as instance_type,
         cast(coalesce(quantity, usagequantity) as DECIMAL(24,9)) as usage_quantity,
         cast(coalesce(costinbillingcurrency, pretaxcost) as DECIMAL(24,9)) as pretax_cost,
-        coalesce(billingcurrencycode, currency) as currency,
+        coalesce(billingcurrencycode, currency, billingcurrency) as currency,
         json_parse(tags) as tags,
         coalesce(resourceid, instanceid) as instance_id,
         cast(source as UUID) as source_uuid,

--- a/koku/reporting/provider/azure/models.py
+++ b/koku/reporting/provider/azure/models.py
@@ -26,6 +26,7 @@ PRESTO_COLUMNS = [
     "billingaccountid",
     "billingaccountname",
     "billingcurrencycode",
+    "billingcurrency",
     "billingprofileid",
     "billingprofilename",
     "chargetype",

--- a/scripts/cji_scripts/migrate_trino.py
+++ b/scripts/cji_scripts/migrate_trino.py
@@ -86,7 +86,7 @@ def main():
     logging.info("Running against the following schemas")
     logging.info(schemas)
 
-    tables_to_drop = ["aws_line_items_daily"]
+    tables_to_drop = ["azure_line_items_daily", "azure_line_items"]
     # columns_to_add = []
     # columns_to_drop = []
 


### PR DESCRIPTION
## Jira Ticket

[COST-2813](https://issues.redhat.com/browse/COST-2813)

## Description

This change will drop the azure line item tables from trino so that we can coalesce on billingcurrency as well as the other currency fields 

## Testing

1. Checkout Main
2. Add Azure source (ask me if you need the creds) and load data for it
3. Look in postgres at the daily table and lineitem table and verify that currency doesn't have a value 
```
PGPASSWORD=postgres psql postgres -U postgres -h localhost -p 15432
postgres=# set search_path=acct10001;
SET
postgres=# select distinct currency from reporting_azurecostentrylineitem_daily_summary;
-[ RECORD 1 ]
currency | 
postgres=# select distinct currency from reporting_azure_cost_summary_p;
-[ RECORD 1 ]
currency | 
```
4. Check out this branch 
5. Run the migrate_trino.py script: 
```
./scripts/cji_scripts/migrate_trino.py
07/19/2022 04:21:52 PM: Running the hive migration for cost model effective cost
07/19/2022 04:21:52 PM: fetching schemas
07/19/2022 04:21:52 PM: Running against the following schemas
07/19/2022 04:21:52 PM: ['acct10001']
07/19/2022 04:21:52 PM: *** dropping tables for schema acct10001 ***
07/19/2022 04:21:52 PM: dropping table azure_line_items_daily
07/19/2022 04:21:52 PM: Drop table result: 
07/19/2022 04:21:52 PM: [[True]]
07/19/2022 04:21:52 PM: dropping table azure_line_items
07/19/2022 04:21:53 PM: Drop table result: 
07/19/2022 04:21:53 PM: [[True]]
```
6. Verify the tables are gone 
```
docker exec -it trino bash
trino --server localhost:8080 --catalog hive --schema acct10001 --user admin --debug
show tables;
SELECT * FROM azure_line_items LIMIT 1
```
7. Delete (`make delete-test-customer-data`) and recreate the source & hit the download endpoint http://127.0.0.1:5042/api/cost-management/v1/download/. 
8. Look at the tables again and verify that currency has a value
```
currency           | USD
```
## Notes

...
