### PR TITLE
[COST-2621] Job to populate ORG-ID

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -2712,6 +2712,35 @@ objects:
           requests:
             cpu: ${KOKU_CPU_REQUEST}
             memory: ${KOKU_MEMORY_REQUEST}
+    - name: org-id-populator
+      podSpec:
+        command:
+        - ./org-id-column-populator
+        - -C
+        - -a
+        - account_id
+        - -o
+        - org_id
+        - -t
+        - ${ORG_ID_TRANSLATE_TARGET}
+        - --ean-translator-addr
+        - test
+        # - http://${TENANT_TRANSLATOR_HOST}:${TENANT_TRANSLATOR_PORT}
+        - --prometheus-push-addr
+        - ${PROMETHEUS_PUSHGATEWAY}
+        env:
+        - name: LOG_FORMAT
+          value: ${POPULATOR_LOG_FORMAT}
+        - name: LOG_BATCH_FREQUENCY
+          value: 1s
+        image: ${POPULATOR_IMAGE}:${POPULATOR_IMAGE_TAG}
+        resources:
+          limits:
+            cpu: 300m
+            memory: 1Gi
+          requests:
+            cpu: 50m
+            memory: 512Mi
     kafkaTopics:
     - topicName: platform.sources.event-stream
     - topicName: platform.upload.hccm
@@ -2730,6 +2759,14 @@ objects:
     appName: koku
     jobs:
     - db-migrate-cji-${DBM_IMAGE_TAG}-${DBM_INVOCATION}
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdJobInvocation
+  metadata:
+    name: populate-org-id-column-${POPULATOR_RUN_NUMBER}
+  spec:
+    appName: koku
+    jobs:
+    - org-id-populator
 - apiVersion: v1
   data:
     django-secret-key: ${SECRET_KEY}
@@ -3052,6 +3089,20 @@ parameters:
 - displayName: RBAC_CACHE_TIMEOUT
   name: RBAC_CACHE_TIMEOUT
   value: "300"
+- name: ORG_ID_TRANSLATE_TARGET
+  value: api_customer
+- name: TENANT_TRANSLATOR_HOST
+  required: true
+- name: TENANT_TRANSLATOR_PORT
+  value: "8892"
+- name: POPULATOR_LOG_FORMAT
+  value: text
+- name: POPULATOR_IMAGE
+  value: quay.io/cloudservices/tenant-utils
+- name: POPULATOR_IMAGE_TAG
+  value: latest
+- name: POPULATOR_RUN_NUMBER
+  value: "1"
 - displayName: Minimum replicas
   name: KOKU_MIN_REPLICAS
   required: true

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -2724,8 +2724,7 @@ objects:
         - -t
         - ${ORG_ID_TRANSLATE_TARGET}
         - --ean-translator-addr
-        - test
-        # - http://${TENANT_TRANSLATOR_HOST}:${TENANT_TRANSLATOR_PORT}
+        - http://${TENANT_TRANSLATOR_HOST}:${TENANT_TRANSLATOR_PORT}
         - --prometheus-push-addr
         - ${PROMETHEUS_PUSHGATEWAY}
         env:

--- a/deploy/kustomize/base/base.yaml
+++ b/deploy/kustomize/base/base.yaml
@@ -81,6 +81,34 @@ objects:
           value: ${DBM_INVOCATION}
         - name: _MIGRATION_DIRECTIVE
           value: ${_MIGRATION_DIRECTIVE}
+    - name: org-id-populator
+      podSpec:
+        image: ${POPULATOR_IMAGE}:${POPULATOR_IMAGE_TAG}
+        command:
+          - ./org-id-column-populator
+          - -C
+          - -a
+          - account_id
+          - -o
+          - org_id
+          - -t
+          - ${ORG_ID_TRANSLATE_TARGET}
+          - --ean-translator-addr
+          - http://${TENANT_TRANSLATOR_HOST}:${TENANT_TRANSLATOR_PORT}
+          - --prometheus-push-addr
+          - ${PROMETHEUS_PUSHGATEWAY}
+        env:
+          - name: LOG_FORMAT
+            value: ${POPULATOR_LOG_FORMAT}
+          - name: LOG_BATCH_FREQUENCY
+            value: '1s'
+        resources:
+          limits:
+            cpu: 300m
+            memory: 1Gi
+          requests:
+            cpu: 50m
+            memory: 512Mi
 
     # The bulk of your App. This is where your running apps will live
     deployments:
@@ -97,6 +125,14 @@ objects:
     appName: koku
     jobs:
       - db-migrate-cji-${DBM_IMAGE_TAG}-${DBM_INVOCATION}
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdJobInvocation
+  metadata:
+    name: populate-org-id-column-${POPULATOR_RUN_NUMBER}
+  spec:
+    appName: koku
+    jobs:
+      - org-id-populator
 
 - apiVersion: v1
   kind: Secret # For ephemeral/local environment only
@@ -436,3 +472,18 @@ parameters:
 - name: RBAC_CACHE_TIMEOUT
   displayName: RBAC_CACHE_TIMEOUT
   value: "300"
+
+- name: ORG_ID_TRANSLATE_TARGET
+  value: api_customer
+- name: TENANT_TRANSLATOR_HOST
+  required: true
+- name: TENANT_TRANSLATOR_PORT
+  value: '8892'
+- name: POPULATOR_LOG_FORMAT
+  value: text
+- name: POPULATOR_IMAGE
+  value: quay.io/cloudservices/tenant-utils
+- name: POPULATOR_IMAGE_TAG
+  value: latest
+- name: POPULATOR_RUN_NUMBER # in case the populator needs to be run more than once increment this parameter to get a new job
+  value: "1"


### PR DESCRIPTION
## Jira Ticket

[COST-2621](https://issues.redhat.com/browse/COST-2621)

## Description

This change will add a CJI to the ClowdApp to populate org ids using the RedHatInsights Tenant Utils re-usable job.

## Testing

1. Checkout a namespace in ephemeral
2. Deploy koku to your namespace
3. Add a few sources with different identity headers to create a couple different customers
4. Look in the `api_customer` table in the db and verify there are no org units on the table `SELECT * FROM api_customer;`
5. Deploy `ee1702c14772fda20f6c45c8b3af10274984b972` (that commit has replaced the tenant-translator piece with the word test to use the test translator that just makes org-id `<account-id>-test` on the specified table) to your namespace filling in some of the environment variables in your config: 
```
        ORG_ID_TRANSLATE_TARGET: api_customer
        TENANT_TRANSLATOR_HOST: test
        TENANT_TRANSLATOR_PORT: test
        POPULATOR_LOG_FORMAT: text
        POPULATOR_IMAGE_TAG: 7336069
        POPULATOR_RUN_NUMBER: 1
```
6. Look in the `api_customer` table in the db and verify there are now org units on the table, woohoo! `SELECT * FROM api_customer;`
7. Look in the `api_sources` table in the db and verify there are no org units on the table `SELECT * FROM api_sources;`
8. Update your config to run on the api_sources table:
```
        ORG_ID_TRANSLATE_TARGET: api_sources
        TENANT_TRANSLATOR_HOST: test
        TENANT_TRANSLATOR_PORT: test
        POPULATOR_LOG_FORMAT: text
        POPULATOR_IMAGE_TAG: 7336069
        POPULATOR_RUN_NUMBER: 2
```
9. 7. Look in the `api_sources` table in the db and verify there are now org units on the table, woohoo! `SELECT * FROM api_sources;`


## Notes

...
