### PR TITLE
Removing manifest id check from self healing delete.

### DIFF
--- a/koku/masu/util/aws/common.py
+++ b/koku/masu/util/aws/common.py
@@ -440,12 +440,16 @@ def gcp_self_healing_remove_files_for_manifest_from_s3_bucket(request_id, s3_pat
                 existing_objects = s3_resource.Bucket(settings.S3_BUCKET_NAME).objects.filter(Prefix=s3_path)
                 for obj_summary in existing_objects:
                     existing_object = obj_summary.Object()
-                    metadata = existing_object.metadata
-                    manifest = metadata.get("manifestid")
-                    if manifest in manifest_list:
-                        key = existing_object.key
-                        bulk_delete_objects.append({"Key": key})
-                        removed.append(key)
+                    # metadata = existing_object.metadata
+                    # manifest = metadata.get("manifestid")
+                    # We believe the reason the parquet files are not being deleted is associated
+                    # with this metadata check. We believe the parquet compactor is destroying the
+                    # metadata id associated with the parquet files.
+                    # to the this metadata check
+                    # if manifest in manifest_list:
+                    key = existing_object.key
+                    bulk_delete_objects.append({"Key": key})
+                    removed.append(key)
             bucket = s3_resource.Bucket(settings.S3_BUCKET_NAME)
             # split the bulk delete objects into x number of objects to delete at a time
             num_files_delete = 250


### PR DESCRIPTION
## Jira Ticket

We believed that the parquet compactor was destroying the manifest data causing the parquet files from not deleting. We removed that check. 

We check to make sure that we won't ever delete for the new manifests here:
https://github.com/project-koku/koku/blob/a201f254580bc63d9940df9cad24caf150b5767a/koku/masu/external/downloader/gcp/gcp_report_downloader.py#L187-L189



## Description

This change will ...

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Notes

...
