### PR TITLE
[COST-2829] - switch ingress kafka topic

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -2742,7 +2742,7 @@ objects:
             memory: 512Mi
     kafkaTopics:
     - topicName: platform.sources.event-stream
-    - topicName: platform.upload.available
+    - topicName: platform.upload.announce
     - topicName: platform.upload.hccm
     - topicName: platform.upload.validation
     - topicName: platform.notifications.ingress

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -2742,6 +2742,7 @@ objects:
             memory: 512Mi
     kafkaTopics:
     - topicName: platform.sources.event-stream
+    - topicName: platform.upload.available
     - topicName: platform.upload.hccm
     - topicName: platform.upload.validation
     - topicName: platform.notifications.ingress

--- a/deploy/kustomize/base/base.yaml
+++ b/deploy/kustomize/base/base.yaml
@@ -30,7 +30,7 @@ objects:
     # Request kafka topics for your application here
     kafkaTopics:
     - topicName: platform.sources.event-stream
-    - topicName: platform.upload.available
+    - topicName: platform.upload.announce
     - topicName: platform.upload.hccm
     - topicName: platform.upload.validation
     - topicName: platform.notifications.ingress

--- a/deploy/kustomize/base/base.yaml
+++ b/deploy/kustomize/base/base.yaml
@@ -30,6 +30,7 @@ objects:
     # Request kafka topics for your application here
     kafkaTopics:
     - topicName: platform.sources.event-stream
+    - topicName: platform.upload.available
     - topicName: platform.upload.hccm
     - topicName: platform.upload.validation
     - topicName: platform.notifications.ingress

--- a/koku/kafka_utils/utils.py
+++ b/koku/kafka_utils/utils.py
@@ -120,3 +120,18 @@ def is_kafka_connected(host, port):
             backoff(count)
             count += 1
     return result
+
+
+def extract_from_header(headers, header_type):
+    """Retrieve information from Kafka Headers."""
+    LOG.debug(f"[extract_from_header] extracting `{header_type}` from headers: {headers}")
+    if headers is None:
+        return
+    for header in headers:
+        if header_type in header:
+            for item in header:
+                if item == header_type:
+                    continue
+                else:
+                    return item.decode("ascii")
+    return

--- a/koku/masu/config.py
+++ b/koku/masu/config.py
@@ -91,6 +91,7 @@ class Config:
     INSIGHTS_KAFKA_CACERT = CONFIGURATOR.get_kafka_cacert()
     INSIGHTS_KAFKA_AUTHTYPE = CONFIGURATOR.get_kafka_authtype()
     HCCM_TOPIC = CONFIGURATOR.get_kafka_topic("platform.upload.hccm")
+    UPLOAD_TOPIC = CONFIGURATOR.get_kafka_topic("platform.upload.available")
     VALIDATION_TOPIC = CONFIGURATOR.get_kafka_topic("platform.upload.validation")
     NOTIFICATION_TOPIC = CONFIGURATOR.get_kafka_topic("platform.notifications.ingress")
 

--- a/koku/masu/config.py
+++ b/koku/masu/config.py
@@ -91,7 +91,7 @@ class Config:
     INSIGHTS_KAFKA_CACERT = CONFIGURATOR.get_kafka_cacert()
     INSIGHTS_KAFKA_AUTHTYPE = CONFIGURATOR.get_kafka_authtype()
     HCCM_TOPIC = CONFIGURATOR.get_kafka_topic("platform.upload.hccm")
-    UPLOAD_TOPIC = CONFIGURATOR.get_kafka_topic("platform.upload.available")
+    UPLOAD_TOPIC = CONFIGURATOR.get_kafka_topic("platform.upload.announce")
     VALIDATION_TOPIC = CONFIGURATOR.get_kafka_topic("platform.upload.validation")
     NOTIFICATION_TOPIC = CONFIGURATOR.get_kafka_topic("platform.notifications.ingress")
 

--- a/koku/masu/external/kafka_msg_handler.py
+++ b/koku/masu/external/kafka_msg_handler.py
@@ -423,7 +423,7 @@ def handle_message(msg):
     """
     if msg.topic() == Config.UPLOAD_TOPIC:
         service = extract_from_header(msg.headers(), "service")
-        LOG.info(f"service: {service} | {msg.headers()}")
+        LOG.debug(f"service: {service} | {msg.headers()}")
         if service != "hccm":
             LOG.debug("message not for cost-management")
             return None, None, None

--- a/koku/masu/external/kafka_msg_handler.py
+++ b/koku/masu/external/kafka_msg_handler.py
@@ -423,6 +423,7 @@ def handle_message(msg):
     """
     if msg.topic() == Config.UPLOAD_TOPIC:
         service = extract_from_header(msg.headers(), "service")
+        LOG.info(f"service: {service} | {msg.headers()}")
         if service != "hccm":
             LOG.debug("message not for cost-management")
             return None, None, None

--- a/koku/sources/kafka_message_processor.py
+++ b/koku/sources/kafka_message_processor.py
@@ -8,6 +8,7 @@ import logging
 from rest_framework.exceptions import ValidationError
 
 from api.provider.models import Provider
+from kafka_utils.utils import extract_from_header
 from sources import storage
 from sources.config import Config
 from sources.sources_http_client import AUTH_TYPES
@@ -333,21 +334,6 @@ class SourceMsgProcessor(KafkaMessageProcessor):
             storage.enqueue_source_create_or_update(self.source_id)
         else:
             LOG.info(f"[SourceMsgProcessor] source_id {self.source_id} not updated. No changes detected.")
-
-
-def extract_from_header(headers, header_type):
-    """Retrieve information from Kafka Headers."""
-    LOG.debug(f"[extract_from_header] extracting `{header_type}` from headers: {headers}")
-    if headers is None:
-        return
-    for header in headers:
-        if header_type in header:
-            for item in header:
-                if item == header_type:
-                    continue
-                else:
-                    return item.decode("ascii")
-    return
 
 
 def create_msg_processor(msg, cost_mgmt_id):


### PR DESCRIPTION
## Jira Ticket

[COST-2829](https://issues.redhat.com/browse/COST-2829)

## Description

This change switches us to using the `platform.upload.announce` topic and adds filtering for `hccm` messages.

## Testing

1. The easiest way to test is to use ingress in the ephemeral cluster. Smokes should be sufficient for testing.

## Notes

...
