### PR TITLE
add masu endpoint to trigger notification tasks

### DIFF
--- a/koku/masu/api/notifications.py
+++ b/koku/masu/api/notifications.py
@@ -1,0 +1,26 @@
+#
+# Copyright 2022 Red Hat Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+"""View for temporary force download endpoint."""
+from django.views.decorators.cache import never_cache
+from rest_framework.decorators import api_view
+from rest_framework.decorators import permission_classes
+from rest_framework.decorators import renderer_classes
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from rest_framework.settings import api_settings
+
+from masu.celery.tasks import check_cost_model_status
+
+
+@never_cache
+@api_view(http_method_names=["GET"])
+@permission_classes((AllowAny,))
+@renderer_classes(tuple(api_settings.DEFAULT_RENDERER_CLASSES))
+def notification(request):
+    """Return download file async task ID."""
+    params = request.query_params
+    provider_uuid = params.get("provider_uuid")
+    async_notification_result = check_cost_model_status.delay(provider_uuid=provider_uuid)
+    return Response({"Notification Request Task ID": str(async_notification_result)})

--- a/koku/masu/api/urls.py
+++ b/koku/masu/api/urls.py
@@ -22,6 +22,7 @@ from masu.api.views import get_status
 from masu.api.views import hcs_report_data
 from masu.api.views import hcs_report_finalization
 from masu.api.views import lockinfo
+from masu.api.views import notification
 from masu.api.views import pg_engine_version
 from masu.api.views import report_data
 from masu.api.views import running_celery_tasks
@@ -43,6 +44,7 @@ urlpatterns = [
     path("hcs_report_finalization/", hcs_report_finalization, name="hcs_report_finalization"),
     path("report_data/", report_data, name="report_data"),
     path("source_cleanup/", cleanup, name="cleanup"),
+    path("notification/", notification, name="notification"),
     path("update_cost_model_costs/", update_cost_model_costs, name="update_cost_model_costs"),
     path("crawl_account_hierarchy/", crawl_account_hierarchy, name="crawl_account_hierarchy"),
     path("running_celery_tasks/", running_celery_tasks, name="running_celery_tasks"),

--- a/koku/masu/api/views.py
+++ b/koku/masu/api/views.py
@@ -19,6 +19,7 @@ from masu.api.gcp_invoice_monthly_cost import gcp_invoice_monthly_cost
 from masu.api.hcs_report_data import hcs_report_data
 from masu.api.hcs_report_finalization import hcs_report_finalization
 from masu.api.manifest.views import ManifestView
+from masu.api.notifications import notification
 from masu.api.report_data import report_data
 from masu.api.running_celery_tasks import celery_queue_lengths
 from masu.api.running_celery_tasks import running_celery_tasks

--- a/koku/masu/openapi.json
+++ b/koku/masu/openapi.json
@@ -47,6 +47,10 @@
       "description": "Information on all cost management sources"
     },
     {
+      "name": "Notification",
+      "description": "Start task to check and send cost management notifications"
+    },
+    {
       "name": "Crawl Account Hierarchy",
       "description": "Start the crawler for account hierarchy."
     },
@@ -782,6 +786,43 @@
       },
       "parameters": []
     },
+    "paths": {
+      "/notification/": {
+        "get": {
+          "summary": "check and send notifications",
+          "operationId": "getNotifications",
+          "description": "Return notification file async task ID.",
+          "parameters": [],
+          "responses": {
+            "200": {
+              "description": "The celery task ID of the notification task",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/NotificationGetResponse"
+                  }
+                }
+              }
+            }
+          },
+          "tags": [
+            "Notification"
+          ]
+        },
+        "parameters": [
+          {
+            "name": "provider_uuid",
+            "in": "query",
+            "description": "The provider UUID",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "83ee048e-3c1d-43ef-b945-108225ae52f4"
+            }
+          }
+        ]
+      },
     "/crawl_account_hierarchy/": {
       "get": {
         "summary": "Start the crawler for account hierarchy.",

--- a/koku/masu/test/api/test_notification.py
+++ b/koku/masu/test/api/test_notification.py
@@ -1,0 +1,44 @@
+#
+# Copyright 2022 Red Hat Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Test the Notification endpoint view."""
+from unittest.mock import patch
+
+from celery.result import AsyncResult
+from django.test import TestCase
+from django.test.utils import override_settings
+from django.urls import reverse
+
+from api.iam.models import Tenant
+
+
+@override_settings(ROOT_URLCONF="masu.urls")
+class NotificationAPIViewTest(TestCase):
+    """Test Cases for the Notification API."""
+
+    def setUp(self):
+        """Create test case setup."""
+        super().setUp()
+        Tenant.objects.get_or_create(schema_name="public")
+
+    @patch("koku.middleware.MASU", return_value=True)
+    @patch(
+        "masu.celery.tasks.check_cost_model_status.delay",
+        return_value=AsyncResult("dc350f15-ffc7-4fcb-92d7-2a9f1275568e"),
+    )
+    def test_notification(self, file_list, _):
+        """Test the Notification endpoint."""
+        url = reverse("notification")
+        response = self.client.get(url)
+        body = response.json()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Notification Request Task ID", body)
+
+        url_w_params = url + "?provider_uuid=1&bill_date=2021-04-01"
+        response = self.client.get(url_w_params)
+        body = response.json()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Notification Request Task ID", body)


### PR DESCRIPTION
## Jira Ticket

[COST-2830](https://issues.redhat.com/browse/COST-2830)

## Description

This change will add a masu endpoint so we can trigger notifications manually

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint http://localhost:5042/api/cost-management/v1/notification/ optionally with ?provider_uuid=
    1. You should see task ID
4. Logs should check and run notifications for sources missing cost models.

## Notes

...
