### PR TITLE
HCS, GCP data collection

### DIFF
--- a/koku/hcs/database/report_db_accessor.py
+++ b/koku/hcs/database/report_db_accessor.py
@@ -17,12 +17,14 @@ from masu.database.report_db_accessor_base import ReportDBAccessorBase
 from masu.external.date_accessor import DateAccessor
 from reporting.provider.aws.models import PRESTO_LINE_ITEM_DAILY_TABLE as AWS_PRESTO_LINE_ITEM_DAILY_TABLE
 from reporting.provider.azure.models import PRESTO_LINE_ITEM_DAILY_TABLE as AZURE_PRESTO_LINE_ITEM_DAILY_TABLE
+from reporting.provider.gcp.models import PRESTO_LINE_ITEM_DAILY_TABLE as GCP_PRESTO_LINE_ITEM_DAILY_TABLE
 
 LOG = logging.getLogger(__name__)
 
 HCS_TABLE_MAP = {
     Provider.PROVIDER_AWS: AWS_PRESTO_LINE_ITEM_DAILY_TABLE,
     Provider.PROVIDER_AZURE: AZURE_PRESTO_LINE_ITEM_DAILY_TABLE,
+    Provider.PROVIDER_GCP: GCP_PRESTO_LINE_ITEM_DAILY_TABLE,
 }
 
 

--- a/koku/hcs/database/sql/reporting_gcp-local_hcs_daily_summary.sql
+++ b/koku/hcs/database/sql/reporting_gcp-local_hcs_daily_summary.sql
@@ -1,0 +1,3 @@
+SELECT *, '{{ebs_acct_num | sqlsafe}}' as ebs_account_id, '{{org_id | sqlsafe}}' as org_id
+FROM hive.{{schema | sqlsafe}}.{{table | sqlsafe}}
+WHERE sku_description LIKE 'Licensing Fee for RedHat%'

--- a/koku/hcs/database/sql/reporting_gcp_hcs_daily_summary.sql
+++ b/koku/hcs/database/sql/reporting_gcp_hcs_daily_summary.sql
@@ -1,0 +1,3 @@
+SELECT *, '{{ebs_acct_num | sqlsafe}}' as ebs_account_id, '{{org_id | sqlsafe}}' as org_id
+FROM hive.{{schema | sqlsafe}}.{{table | sqlsafe}}
+WHERE sku_description LIKE 'Licensing Fee for RedHat%'

--- a/koku/hcs/tasks.py
+++ b/koku/hcs/tasks.py
@@ -27,6 +27,8 @@ HCS_EXCEPTED_PROVIDERS = (
     Provider.PROVIDER_AWS_LOCAL,
     Provider.PROVIDER_AZURE,
     Provider.PROVIDER_AZURE_LOCAL,
+    Provider.PROVIDER_GCP,
+    Provider.PROVIDER_GCP_LOCAL,
 )
 
 # any additional queues should be added to this list


### PR DESCRIPTION
## Jira Ticket

[COST-2469](https://issues.redhat.com/browse/COST-2469)

## Description

Adds HCS marketplace data collect for GCP provider

## Testing

1. Checkout Branch
    - Make sure you have the latest nise (nise 2.9.8 or above)
2. Start Koku (make docker-up-min-trino)
3. Add `org1234567` to local unleash server
4. make create-test-customer
5. make load-test-customer-data test_source=GCP
6. You should see GCP objects(files) using local minio

example:
koku-bucket/hcs/csv/org1234567/GCP-local/source=9d80e199-c76a-4e73-a9db-515bddd0aedc/year=2022/month=06/hcs_2022-06-01.csv

## Notes
 As Always more than happy to demo if it is faster
