### PR TITLE
[COST-2841] masu report data skip ocp on cloud

### DIFF
--- a/koku/masu/api/report_data.py
+++ b/koku/masu/api/report_data.py
@@ -45,7 +45,7 @@ def report_data(request):
         schema_name = params.get("schema")
         start_date = params.get("start_date")
         end_date = params.get("end_date")
-        ocp_on_cloud = bool(strtobool(params.get("ocp_on_cloud", "false")))
+        ocp_on_cloud = bool(strtobool(params.get("ocp_on_cloud", "true")))
         queue_name = params.get("queue") or PRIORITY_QUEUE
         if provider_uuid is None and provider_type is None:
             errmsg = "provider_uuid or provider_type must be supplied as a parameter."

--- a/koku/masu/api/report_data.py
+++ b/koku/masu/api/report_data.py
@@ -5,7 +5,6 @@
 """View for report_data endpoint."""
 # flake8: noqa
 import logging
-from distutils.util import strtobool
 
 from django.conf import settings
 from django.views.decorators.cache import never_cache
@@ -45,7 +44,9 @@ def report_data(request):
         schema_name = params.get("schema")
         start_date = params.get("start_date")
         end_date = params.get("end_date")
-        ocp_on_cloud = bool(strtobool(params.get("ocp_on_cloud", "true")))
+
+        ocp_on_cloud = params.get("ocp_on_cloud", "true").lower()
+        ocp_on_cloud = True if ocp_on_cloud == "true" else False
         queue_name = params.get("queue") or PRIORITY_QUEUE
         if provider_uuid is None and provider_type is None:
             errmsg = "provider_uuid or provider_type must be supplied as a parameter."

--- a/koku/masu/api/report_data.py
+++ b/koku/masu/api/report_data.py
@@ -5,6 +5,7 @@
 """View for report_data endpoint."""
 # flake8: noqa
 import logging
+from distutils.util import strtobool
 
 from django.conf import settings
 from django.views.decorators.cache import never_cache
@@ -44,6 +45,7 @@ def report_data(request):
         schema_name = params.get("schema")
         start_date = params.get("start_date")
         end_date = params.get("end_date")
+        ocp_on_cloud = bool(strtobool(params.get("ocp_on_cloud", "false")))
         queue_name = params.get("queue") or PRIORITY_QUEUE
         if provider_uuid is None and provider_type is None:
             errmsg = "provider_uuid or provider_type must be supplied as a parameter."
@@ -81,7 +83,13 @@ def report_data(request):
 
             for month in months:
                 async_result = update_summary_tables.s(
-                    schema_name, provider, provider_uuid, month[0], month[1], queue_name=queue_name
+                    schema_name,
+                    provider,
+                    provider_uuid,
+                    month[0],
+                    month[1],
+                    queue_name=queue_name,
+                    ocp_on_cloud=ocp_on_cloud,
                 ).apply_async(queue=queue_name or PRIORITY_QUEUE)
                 async_results.append({str(month): str(async_result)})
         else:

--- a/koku/masu/openapi.json
+++ b/koku/masu/openapi.json
@@ -445,6 +445,15 @@
               "format": "date",
               "example": "2019-12-31"
             }
+          },
+          {
+            "name": "ocp_on_cloud",
+            "in": "query",
+            "description": "Whether to summarize OCP on Cloud as well.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {

--- a/koku/masu/processor/tasks.py
+++ b/koku/masu/processor/tasks.py
@@ -348,6 +348,7 @@ def update_summary_tables(  # noqa: C901
     queue_name=None,
     synchronous=False,
     tracing_id=None,
+    ocp_on_cloud=True,
 ):
     """Populate the summary tables for reporting.
 
@@ -405,7 +406,8 @@ def update_summary_tables(  # noqa: C901
         updater = ReportSummaryUpdater(schema_name, provider_uuid, manifest_id, tracing_id)
         start_date, end_date = updater.update_daily_tables(start_date, end_date)
         updater.update_summary_tables(start_date, end_date, tracing_id)
-        ocp_on_cloud_infra_map = updater.get_openshift_on_cloud_infra_map(start_date, end_date, tracing_id)
+        if ocp_on_cloud:
+            ocp_on_cloud_infra_map = updater.get_openshift_on_cloud_infra_map(start_date, end_date, tracing_id)
     except ReportSummaryUpdaterCloudError as ex:
         LOG.info(
             log_json(tracing_id, f"Failed to correlate OpenShift metrics for provider: {provider_uuid}. Error: {ex}")


### PR DESCRIPTION
## Jira Ticket

[COST-2841](https://issues.redhat.com/browse/COST-2841)

## Description

This adds a param option to not run ocp on cloud with the report_data masu API.

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Notes

...
