### PR TITLE
updating notifications for org_id support

### DIFF
--- a/koku/koku/notifications.py
+++ b/koku/koku/notifications.py
@@ -43,9 +43,11 @@ class NotificationService:
         provider_uuid = account.get("provider_uuid")
         with ProviderDBAccessor(provider_uuid) as provider_accessor:
             name = provider_accessor.get_provider_name()
+            account_id = provider_accessor.get_account_id()
+            org_id = provider_accessor.get_org_id()
 
-        account_id = (account.get("account_id").strip("acct"), "")
-        org_id = (account.get("org_id").strip("org"), "")
+        account_id = account_id if account_id else ""
+        org_id = org_id if org_id else ""
 
         if event_type in ["cost-model-create", "cost-model-update", "cost-model-remove"]:
             context = {

--- a/koku/koku/notifications.py
+++ b/koku/koku/notifications.py
@@ -51,8 +51,8 @@ class NotificationService:
 
         if event_type in ["cost-model-create", "cost-model-update", "cost-model-remove"]:
             context = {
-                "cost_model_id": str(cost_model.cost_model_uuid),
-                "cost_model_name": cost_model.cost_model_name,
+                "cost_model_id": str(cost_model.get("cost_model_uuid")),
+                "cost_model_name": cost_model.get("cost_model_name"),
                 "host_url": "https://console.redhat.com/openshift/cost-management/cost-models/",
             }
         else:

--- a/koku/koku/test_notifications.py
+++ b/koku/koku/test_notifications.py
@@ -27,8 +27,11 @@ class NotificationsTest(TestCase):
         """Test triggering a cost model crud notification."""
         polling_accounts = AccountsAccessor().get_accounts()
         notification = NotificationService()
-        notification.cost_model_crud_notification(polling_accounts[0])
-        mock_send_notification.assert_called()
+        cost_model = {"cost_model_uuid": "1234", "cost_model_name": "My cost model"}
+        cost_model_types = ["create", "update", "remove"]
+        for cmt in cost_model_types:
+            notification.cost_model_crud_notification(polling_accounts[0], cost_model, cmt)
+            mock_send_notification.assert_called()
 
     @patch("koku.notifications.NotificationService.send_notification", return_result=True)
     def test_ocp_stale_cluster_notification(self, mock_send_notification):
@@ -47,8 +50,8 @@ class NotificationsTest(TestCase):
         mock_send_notification.assert_called()
 
     @patch("koku.notifications.NotificationService.send_notification", return_result=True)
-    def test_ocp_data_recieved_notification(self, mock_send_notification):
-        """Test triggering data recieved cluster notification."""
+    def test_ocp_data_received_notification(self, mock_send_notification):
+        """Test triggering data received cluster notification."""
         polling_accounts = AccountsAccessor().get_accounts()
         notification = NotificationService()
         notification.ocp_data_received_notification(polling_accounts[0])

--- a/koku/masu/celery/tasks.py
+++ b/koku/masu/celery/tasks.py
@@ -396,7 +396,7 @@ def check_for_stale_ocp_source(provider_uuid=None):
         for data in manifest_data:
             last_upload_time = data.get("most_recent_manifest")
             if not last_upload_time or last_upload_time < check_date:
-                accounts = AccountsAccessor().get_accounts(data.provider_id)
+                accounts = AccountsAccessor().get_accounts(data.get("provider_id"))
                 NotificationService().ocp_stale_source_notification(accounts[0])
                 processed += 1
             else:

--- a/koku/masu/database/cost_model_db_accessor.py
+++ b/koku/masu/database/cost_model_db_accessor.py
@@ -18,7 +18,7 @@ LOG = logging.getLogger(__name__)
 class CostModelDBAccessor(KokuDBAccess):
     """Class to interact with customer reporting tables."""
 
-    def __init__(self, schema, provider_uuid=None):
+    def __init__(self, schema, provider_uuid):
         """Establish the database connection.
 
         Args:
@@ -29,14 +29,6 @@ class CostModelDBAccessor(KokuDBAccess):
         super().__init__(schema)
         self.provider_uuid = provider_uuid
         self._cost_model = None
-
-    @property
-    def list_cost_models(self):
-        """Return the cost model database object."""
-        if self._cost_model is None:
-            with schema_context(self.schema):
-                self._cost_model = CostModel.objects.filter()
-        return self._cost_model
 
     @property
     def cost_model(self):

--- a/koku/masu/database/cost_model_db_accessor.py
+++ b/koku/masu/database/cost_model_db_accessor.py
@@ -18,7 +18,7 @@ LOG = logging.getLogger(__name__)
 class CostModelDBAccessor(KokuDBAccess):
     """Class to interact with customer reporting tables."""
 
-    def __init__(self, schema, provider_uuid):
+    def __init__(self, schema, provider_uuid=None):
         """Establish the database connection.
 
         Args:
@@ -29,6 +29,14 @@ class CostModelDBAccessor(KokuDBAccess):
         super().__init__(schema)
         self.provider_uuid = provider_uuid
         self._cost_model = None
+
+    @property
+    def list_cost_models(self):
+        """Return the cost model database object."""
+        if self._cost_model is None:
+            with schema_context(self.schema):
+                self._cost_model = CostModel.objects.filter()
+        return self._cost_model
 
     @property
     def cost_model(self):

--- a/koku/masu/database/provider_db_accessor.py
+++ b/koku/masu/database/provider_db_accessor.py
@@ -221,6 +221,30 @@ class ProviderDBAccessor(KokuDBAccess):
         """
         return self.provider.customer.schema_name
 
+    def get_account_id(self):
+        """
+        Return the account id for the customer.
+
+        Args:
+            None
+        Returns:
+            (String): "account id",
+
+        """
+        return self.provider.customer.account_id
+
+    def get_org_id(self):
+        """
+        Return the org id for the customer.
+
+        Args:
+            None
+        Returns:
+            (String): "org id",
+
+        """
+        return self.provider.customer.org_id
+
     def get_infrastructure_type(self):
         """Retrun the infrastructure type for an OpenShift provider."""
         if self.infrastructure:


### PR DESCRIPTION
## Jira Ticket

[COST-2723](https://issues.redhat.com/browse/COST-2723)

## Description

This change will add org_id support for notifications kafka messages

## Testing

1. Checkout Branch
2. Restart Koku
3. Add ocp source
4. Hit masu notifcations endpoint
5. Check log message includes both account_id and org_id

## Notes

...
