### PR TITLE
Fixing notification to not fire on cloud sources

### DIFF
--- a/koku/masu/test/celery/test_tasks.py
+++ b/koku/masu/test/celery/test_tasks.py
@@ -327,6 +327,15 @@ class TestCeleryTasks(MasuTestCase):
             self.assertIn(expected_log_msg, captured_logs.output[0])
 
     @patch("masu.celery.tasks.CostModelDBAccessor")
+    def test_cost_model_status_check_with_incompatible_provider_uuid(self, mock_cost_check):
+        """Test that only accounts associated with the provider_uuid are polled."""
+        mock_cost_check.cost_model_notification.return_value = True
+        with self.assertLogs("masu.celery.tasks", "INFO") as captured_logs:
+            tasks.check_cost_model_status(self.gcp_test_provider_uuid)
+            expected_log_msg = f"Source {self.gcp_test_provider_uuid} is not an openshift source."
+            self.assertIn(expected_log_msg, captured_logs.output[0])
+
+    @patch("masu.celery.tasks.CostModelDBAccessor")
     def test_cost_model_status_check_without_provider_uuid(self, mock_cost_check):
         """Test that all polling accounts are used when no provider_uuid is provided."""
         polling_accounts = AccountsAccessor().get_accounts()

--- a/koku/masu/test/celery/test_tasks.py
+++ b/koku/masu/test/celery/test_tasks.py
@@ -22,7 +22,7 @@ from api.models import Provider
 from api.utils import DateHelper
 from masu.celery import tasks
 from masu.database.report_manifest_db_accessor import ReportManifestDBAccessor
-from masu.external.accounts_accessor import AccountsAccessor
+from masu.processor.orchestrator import Orchestrator
 from masu.test import MasuTestCase
 from masu.test.database.helpers import ManifestCreationHelper
 
@@ -309,11 +309,11 @@ class TestCeleryTasks(MasuTestCase):
     @patch("masu.celery.tasks.AWSOrgUnitCrawler")
     def test_crawl_account_hierarchy_without_provider_uuid(self, mock_crawler):
         """Test that all polling accounts for user are used when no provider_uuid is provided."""
-        providers = Provider.objects.filter(infrastructure_id__isnull=True, type=Provider.PROVIDER_OCP).all()
+        _, polling_accounts = Orchestrator.get_accounts()
         mock_crawler.crawl_account_hierarchy.return_value = True
         with self.assertLogs("masu.celery.tasks", "INFO") as captured_logs:
             tasks.crawl_account_hierarchy()
-            expected_log_msg = "Account hierarchy crawler found %s accounts to scan" % (len(providers))
+            expected_log_msg = "Account hierarchy crawler found %s accounts to scan" % (len(polling_accounts))
             self.assertIn(expected_log_msg, captured_logs.output[0])
 
     @patch("masu.celery.tasks.CostModelDBAccessor")
@@ -337,11 +337,11 @@ class TestCeleryTasks(MasuTestCase):
     @patch("masu.celery.tasks.CostModelDBAccessor")
     def test_cost_model_status_check_without_provider_uuid(self, mock_cost_check):
         """Test that all polling accounts are used when no provider_uuid is provided."""
-        polling_accounts = AccountsAccessor().get_accounts()
+        providers = Provider.objects.filter(infrastructure_id__isnull=True, type=Provider.PROVIDER_OCP).all()
         mock_cost_check.cost_model_notification.return_value = True
         with self.assertLogs("masu.celery.tasks", "INFO") as captured_logs:
             tasks.check_cost_model_status()
-            expected_log_msg = "Cost model status check found %s accounts to scan" % (len(polling_accounts))
+            expected_log_msg = "Cost model status check found %s providers to scan" % (len(providers))
             self.assertIn(expected_log_msg, captured_logs.output[0])
 
     def test_stale_ocp_source_check_with_provider_uuid(self):


### PR DESCRIPTION
## Jira Ticket

[COST-2722](https://issues.redhat.com/browse/COST-2722)

## Description

This change will change cost model notifications to skip ocp sources associated with cloud sources

## Testing

1. Checkout Branch
2. Restart Koku
3. add OCP source + OCP on Cloud sources
4. Hit notifcations masu endpoint
5. see we trigger notification for NON OCP on Cloud sources

## Notes

...
