### PR TITLE
Update apiPath in ClowdApp

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -207,6 +207,7 @@ objects:
           enabled: false
         public:
           enabled: true
+          apiPath: cost-management
     - minReplicas: ${{LISTENER_MIN_REPLICAS}}
       name: clowder-listener
       podSpec:


### PR DESCRIPTION
## Description

This change will update the Openshift route created by Clowder from `/api/koku-clowder-api` to `/api/cost-management`. Clower defaults to the service name unless overridden.
## Testing
It was tested in the ephemeral env while debugging the newly onboarded cost-management frontend. 

## Notes

Just a minor fix that will allow us to test koku's frontend correctly.