### PR TITLE
Update apiPath in ClowdApp and patches

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -206,6 +206,7 @@ objects:
         private:
           enabled: false
         public:
+          apiPath: cost-management
           enabled: true
     - minReplicas: ${{LISTENER_MIN_REPLICAS}}
       name: clowder-listener

--- a/deploy/kustomize/patches/koku.yaml
+++ b/deploy/kustomize/patches/koku.yaml
@@ -6,6 +6,7 @@
     webServices:
       public:
         enabled: true
+        apiPath: cost-management
       private:
         enabled: false
       metrics:


### PR DESCRIPTION
## Description

This change will update the Openshift route created by Clowder from `/api/koku-clowder-api` to `/api/cost-management`. Clower defaults to the service name unless overridden.
## Testing
It was tested in the ephemeral env while debugging the newly onboarded cost-management frontend. 

## Notes

Just a minor fix that will allow us to test koku's frontend correctly.