### PR TITLE
[COST-2829] - update kafka message handler

### DIFF
--- a/docs/koku_setup_on_m1.rst
+++ b/docs/koku_setup_on_m1.rst
@@ -20,9 +20,10 @@ From the current list of packages used by Koku, only ``confluent-kafka`` has no 
 
     brew install librdkafka
 
-2. Add the following line into ``~/.zshrc`` and run ``source ~/.zshrc``. *Note:* Replace ``<version>`` with the version of librdkafka you installed above: ::
+2. Add the following lines into ``~/.zshrc`` and run ``source ~/.zshrc`` ::
 
-    C_INCLUDE_PATH=/opt/homebrew/Cellar/librdkafka/<version>/include LIBRARY_PATH=/opt/homebrew/Cellar/librdkafka/<version>/lib pip3 install confluent_kafka
+    export C_INCLUDE_PATH=$(brew --prefix)/include
+    export LIBRARY_PATH=$(brew --prefix)/lib
 
 After compoleting these steps, you should be able to follow the development on `Koku's README`_. Make sure to install the versions of Docker and Homebrew that are made for M1 Macs.
 

--- a/koku/masu/test/external/test_kafka_msg_handler.py
+++ b/koku/masu/test/external/test_kafka_msg_handler.py
@@ -73,7 +73,7 @@ class MockMessage:
 
     def __init__(
         self,
-        topic="mocked-topic",
+        topic=Config.UPLOAD_TOPIC,
         url="http://unreal",
         value_dict={},
         offset=50,
@@ -168,12 +168,14 @@ class KafkaMsgHandlerTest(MasuTestCase):
         """Test that the message loop only calls listen for messages on valid messages."""
         msg_list = [
             None,
-            MockMessage(offset=1),
             MockMessage(offset=2, error=MockError(KafkaError._PARTITION_EOF)),
             MockMessage(offset=3, error=MockError(KafkaError._MSG_TIMED_OUT)),
+            MockMessage(offset=4, topic="wrong-topic"),
+            MockMessage(offset=5, service="wrong-service"),
+            MockMessage(offset=1),  # this is the only message that will cause the `mock_listen` to assert called once
         ]
         mock_consumer.return_value = MockKafkaConsumer(msg_list)
-        with patch("itertools.count", side_effect=[[0, 1, 2, 3]]):  # mocking the infinite loop
+        with patch("itertools.count", side_effect=[range(len(msg_list))]):  # mocking the infinite loop
             with self.assertLogs(logger="masu.external.kafka_msg_handler", level=logging.WARNING):
                 msg_handler.listen_for_messages_loop()
         mock_listen.assert_called_once()
@@ -376,12 +378,6 @@ class KafkaMsgHandlerTest(MasuTestCase):
     def test_handle_messages(self, _):
         """Test to ensure that kafka messages are handled."""
         hccm_msg = MockMessage(Config.UPLOAD_TOPIC, "http://insights-upload.com/quarnantine/file_to_validate")
-        advisor_msg = MockMessage(
-            Config.UPLOAD_TOPIC, "http://insights-upload.com/quarnantine/file_to_validate", service="advisor"
-        )
-        other_advisor_msg = MockMessage(
-            "platform.upload.advisor", "http://insights-upload.com/quarnantine/file_to_validate", service="advisor"
-        )
 
         # Verify that when extract_payload is successful with 'hccm' message that SUCCESS_CONFIRM_STATUS is returned
         with patch("masu.external.kafka_msg_handler.extract_payload", return_value=(None, None)):
@@ -390,10 +386,6 @@ class KafkaMsgHandlerTest(MasuTestCase):
         # Verify that when extract_payload is not successful with 'hccm' message that FAILURE_CONFIRM_STATUS is returned
         with patch("masu.external.kafka_msg_handler.extract_payload", side_effect=msg_handler.KafkaMsgHandlerError):
             self.assertEqual(msg_handler.handle_message(hccm_msg), (msg_handler.FAILURE_CONFIRM_STATUS, None, None))
-
-        # Verify that when None status is returned for non-hccm messages (we don't confirm these)
-        self.assertEqual(msg_handler.handle_message(advisor_msg), (None, None, None))
-        self.assertEqual(msg_handler.handle_message(other_advisor_msg), (None, None, None))
 
         # Verify that when extract_payload has a OperationalError that KafkaMessageError is raised
         with patch("masu.external.kafka_msg_handler.extract_payload", side_effect=OperationalError):


### PR DESCRIPTION
## Jira Ticket

[COST-2829](https://issues.redhat.com/browse/COST-2829)

## Description

Since we switched ingress kafka topics, our lag alert has been very noisy. After some discussions, we decided to filter the messages before we check its topic or decode the payload. The hope here is that the message will be skipped before it is counted as belonging to the hccm-group consumer.

## Testing

1. smoke tests

## Notes

...
