### PR TITLE
Removing date override step

### DIFF
--- a/koku/masu/processor/oci/oci_report_parquet_summary_updater.py
+++ b/koku/masu/processor/oci/oci_report_parquet_summary_updater.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 """Summary Updater for OCI Parquet files."""
-import calendar
 import logging
 
 import ciso8601
@@ -15,7 +14,6 @@ from masu.database.cost_model_db_accessor import CostModelDBAccessor
 from masu.database.oci_report_db_accessor import OCIReportDBAccessor
 from masu.external.date_accessor import DateAccessor
 from masu.util.common import date_range_pair
-from masu.util.common import determine_if_full_summary_update_needed
 from reporting.provider.oci.models import UI_SUMMARY_TABLES
 
 LOG = logging.getLogger(__name__)
@@ -33,23 +31,6 @@ class OCIReportParquetSummaryUpdater(PartitionHandlerMixin):
 
     def _get_sql_inputs(self, start_date, end_date):
         """Get the required inputs for running summary SQL."""
-        with OCIReportDBAccessor(self._schema) as accessor:
-            # This is the normal processing route
-            if self._manifest:
-                # Override the bill date to correspond with the manifest
-                bill_date = self._manifest.billing_period_start_datetime.date()
-                bills = accessor.get_cost_entry_bills_query_by_provider(self._provider.uuid)
-                bills = bills.filter(billing_period_start=bill_date).all()
-                first_bill = bills.filter(billing_period_start=bill_date).first()
-                do_month_update = False
-                with schema_context(self._schema):
-                    if first_bill:
-                        do_month_update = determine_if_full_summary_update_needed(first_bill)
-                if do_month_update:
-                    last_day_of_month = calendar.monthrange(bill_date.year, bill_date.month)[1]
-                    start_date = bill_date
-                    end_date = bill_date.replace(day=last_day_of_month)
-                    LOG.info("Overriding start and end date to process full period.")
 
         if isinstance(start_date, str):
             start_date = ciso8601.parse_datetime(start_date).date()

--- a/koku/masu/test/processor/oci/test_oci_report_parquet_summary_updater.py
+++ b/koku/masu/test/processor/oci/test_oci_report_parquet_summary_updater.py
@@ -33,30 +33,29 @@ class OCIReportParquetSummaryUpdaterTest(MasuTestCase):
     def test_get_sql_inputs(self):
         """Test that dates are returned."""
         # Previous month
-        start_str = (self.dh.last_month_end - timedelta(days=3)).isoformat()
-        end_str = self.dh.last_month_end.isoformat()
-        start, end = self.updater._get_sql_inputs(start_str, end_str)
-        self.assertEqual(start, self.dh.last_month_start.date())
-        self.assertEqual(end, self.dh.last_month_end.date())
+        org_start = self.dh.last_month_end - timedelta(days=3)
+        org_end = self.dh.last_month_end
+        start, end = self.updater._get_sql_inputs(org_start.isoformat(), org_end.isoformat())
+        self.assertEqual(start, org_start.date())
+        self.assertEqual(end, org_end.date())
 
         # Current month
         with ReportManifestDBAccessor() as manifest_accessor:
             manifest = manifest_accessor.get_manifest_by_id(2)
         updater = OCIReportParquetSummaryUpdater(self.schema_name, self.oci_provider, manifest)
-        start_str = self.dh.this_month_start.isoformat()
-        end_str = self.dh.this_month_end.isoformat()
-        start, end = updater._get_sql_inputs(start_str, end_str)
-        self.assertEqual(start, self.dh.this_month_start.date())
-        self.assertEqual(end, self.dh.this_month_end.date())
+        org_start = self.dh.this_month_start
+        org_end = self.dh.this_month_end
+        start, end = updater._get_sql_inputs(org_start.isoformat(), org_end.isoformat())
+        self.assertEqual(start, org_start.date())
+        self.assertEqual(end, org_end.date())
 
         # No manifest
         updater = OCIReportParquetSummaryUpdater(self.schema_name, self.oci_provider, None)
-        start_date = self.dh.last_month_end - timedelta(days=3)
-        start_str = start_date.isoformat()
-        end_str = self.dh.last_month_end.isoformat()
-        start, end = updater._get_sql_inputs(start_str, end_str)
-        self.assertEqual(start, start_date.date())
-        self.assertEqual(end, self.dh.last_month_end.date())
+        org_start = self.dh.last_month_end - timedelta(days=3)
+        org_end = self.dh.last_month_end
+        start, end = updater._get_sql_inputs(org_start.isoformat(), org_end.isoformat())
+        self.assertEqual(start, org_start.date())
+        self.assertEqual(end, org_end.date())
 
     def test_update_daily_tables(self):
         """Test that this is a placeholder method."""


### PR DESCRIPTION
## Jira Ticket

[COST-2706](https://issues.redhat.com/browse/COST-2706)

## Description

This change will remove the initial ingest date override check for summary tasks since this logic is not needed for OCI's flow. Without this change last months initial ingest summary task would have its dates overridden to the current month. Thus making us run summary twice for the current month (Or multiplied by the number of initial ingest months that is)

## Testing

1. Checkout Branch
2. Restart Koku
3. Add OCI source
4. Ensure we have data ingested for all months expected

## Notes

...
