### PR TITLE
[COST-1380] - set api version

### DIFF
--- a/koku/kafka_utils/utils.py
+++ b/koku/kafka_utils/utils.py
@@ -49,6 +49,7 @@ def _get_consumer_config(address, **conf_settings):
         "queued.max.messages.kbytes": 1024,
         "enable.auto.commit": False,
         "max.poll.interval.ms": 1080000,  # 18 minutes
+        "broker.version.fallback": "0.10.2",
     }
     conf = _get_managed_kafka_config(conf)
     conf.update(conf_settings)

--- a/koku/sources/kafka_listener.py
+++ b/koku/sources/kafka_listener.py
@@ -256,6 +256,7 @@ def _get_consumer_config():
         "group.id": "hccm-sources",
         "queued.max.messages.kbytes": 1024,
         "enable.auto.commit": False,
+        "broker.version.fallback": "0.10.2",
     }
 
     if all(


### PR DESCRIPTION
## Jira Ticket

[COST-1380](https://issues.redhat.com/browse/COST-1380)

## Description

This change will set the api-version-fallback for kafka.

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Notes

...
