### PR TITLE
COST-2892: adding invoice month to GCP summary tasks

### DIFF
--- a/koku/api/resource_types/test/gcp_accounts/test_views.py
+++ b/koku/api/resource_types/test/gcp_accounts/test_views.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 """Test the Resource Types views."""
-import datetime
 from unittest.mock import patch
 from uuid import uuid4
 
@@ -62,7 +61,9 @@ class ResourceTypesViewTestGcpAccounts(MasuTestCase):
             ),
         ]
         mock_get_topo.return_value = mock_topo_record
-        self.accessor.populate_gcp_topology_information_tables(self.gcp_provider, self.start_date, self.end_date, self.invoice_month)
+        self.accessor.populate_gcp_topology_information_tables(
+            self.gcp_provider, self.start_date, self.end_date, self.invoice_month
+        )
         with schema_context(self.schema_name):
             expected = (
                 GCPTopology.objects.annotate(**{"value": F("project_id")})
@@ -107,7 +108,9 @@ class ResourceTypesViewTestGcpAccounts(MasuTestCase):
             ),
         ]
         mock_get_topo.return_value = mock_topo_record
-        self.accessor.populate_gcp_topology_information_tables(self.gcp_provider, self.start_date, self.end_date, self.invoice_month)
+        self.accessor.populate_gcp_topology_information_tables(
+            self.gcp_provider, self.start_date, self.end_date, self.invoice_month
+        )
         with schema_context(self.schema_name):
             expected = (
                 GCPTopology.objects.annotate(**{"value": F("account_id")})

--- a/koku/api/resource_types/test/gcp_accounts/test_views.py
+++ b/koku/api/resource_types/test/gcp_accounts/test_views.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 """Test the Resource Types views."""
+import datetime
 from unittest.mock import patch
 from uuid import uuid4
 
@@ -30,6 +31,10 @@ class ResourceTypesViewTestGcpAccounts(MasuTestCase):
     def setUp(self):
         """Set up a test with database objects."""
         super().setUp()
+        self.dh = DateHelper()
+        self.start_date = self.dh.this_month_start
+        self.end_date = self.dh.this_month_end
+        self.invoice_month = self.dh.gcp_find_invoice_months_in_date_range(self.start_date, self.end_date)
 
     @RbacPermissions({"gcp.project": {"read": ["example-project-id"]}, "gcp.account": {"read": ["*"]}})
     @patch("masu.database.gcp_report_db_accessor.GCPReportDBAccessor.get_gcp_topology_trino")
@@ -57,10 +62,7 @@ class ResourceTypesViewTestGcpAccounts(MasuTestCase):
             ),
         ]
         mock_get_topo.return_value = mock_topo_record
-        dh = DateHelper()
-        start_date = dh.this_month_start
-        end_date = dh.this_month_end
-        self.accessor.populate_gcp_topology_information_tables(self.gcp_provider, start_date, end_date)
+        self.accessor.populate_gcp_topology_information_tables(self.gcp_provider, self.start_date, self.end_date, self.invoice_month)
         with schema_context(self.schema_name):
             expected = (
                 GCPTopology.objects.annotate(**{"value": F("project_id")})
@@ -105,10 +107,7 @@ class ResourceTypesViewTestGcpAccounts(MasuTestCase):
             ),
         ]
         mock_get_topo.return_value = mock_topo_record
-        dh = DateHelper()
-        start_date = dh.this_month_start
-        end_date = dh.this_month_end
-        self.accessor.populate_gcp_topology_information_tables(self.gcp_provider, start_date, end_date)
+        self.accessor.populate_gcp_topology_information_tables(self.gcp_provider, self.start_date, self.end_date, self.invoice_month)
         with schema_context(self.schema_name):
             expected = (
                 GCPTopology.objects.annotate(**{"value": F("account_id")})

--- a/koku/api/resource_types/test/gcp_projects/test_views.py
+++ b/koku/api/resource_types/test/gcp_projects/test_views.py
@@ -64,7 +64,9 @@ class ResourceTypesViewTestGcpProjects(MasuTestCase):
             ),
         ]
         mock_get_topo.return_value = mock_topo_record
-        self.accessor.populate_gcp_topology_information_tables(self.gcp_provider, self.start_date, self.end_date, self.invoice_month)
+        self.accessor.populate_gcp_topology_information_tables(
+            self.gcp_provider, self.start_date, self.end_date, self.invoice_month
+        )
         with schema_context(self.schema_name):
             expected = (
                 GCPTopology.objects.annotate(**{"value": F("account_id")})
@@ -109,7 +111,9 @@ class ResourceTypesViewTestGcpProjects(MasuTestCase):
             ),
         ]
         mock_get_topo.return_value = mock_topo_record
-        self.accessor.populate_gcp_topology_information_tables(self.gcp_provider, self.start_date, self.end_date, self.invoice_month)
+        self.accessor.populate_gcp_topology_information_tables(
+            self.gcp_provider, self.start_date, self.end_date, self.invoice_month
+        )
         with schema_context(self.schema_name):
             expected = (
                 GCPTopology.objects.annotate(**{"value": F("project_id")})

--- a/koku/api/resource_types/test/gcp_projects/test_views.py
+++ b/koku/api/resource_types/test/gcp_projects/test_views.py
@@ -33,6 +33,10 @@ class ResourceTypesViewTestGcpProjects(MasuTestCase):
     def setUp(self):
         """Set up a test with database objects."""
         super().setUp()
+        self.dh = DateHelper()
+        self.start_date = self.dh.this_month_start
+        self.end_date = self.dh.this_month_end
+        self.invoice_month = self.dh.gcp_find_invoice_months_in_date_range(self.start_date, self.end_date)
 
     @RbacPermissions({"gcp.project": {"read": ["*"]}, "gcp.account": {"read": ["example_account_id"]}})
     @patch("masu.database.gcp_report_db_accessor.GCPReportDBAccessor.get_gcp_topology_trino")
@@ -60,10 +64,7 @@ class ResourceTypesViewTestGcpProjects(MasuTestCase):
             ),
         ]
         mock_get_topo.return_value = mock_topo_record
-        dh = DateHelper()
-        start_date = dh.this_month_start
-        end_date = dh.this_month_end
-        self.accessor.populate_gcp_topology_information_tables(self.gcp_provider, start_date, end_date)
+        self.accessor.populate_gcp_topology_information_tables(self.gcp_provider, self.start_date, self.end_date, self.invoice_month)
         with schema_context(self.schema_name):
             expected = (
                 GCPTopology.objects.annotate(**{"value": F("account_id")})
@@ -108,10 +109,7 @@ class ResourceTypesViewTestGcpProjects(MasuTestCase):
             ),
         ]
         mock_get_topo.return_value = mock_topo_record
-        dh = DateHelper()
-        start_date = dh.this_month_start
-        end_date = dh.this_month_end
-        self.accessor.populate_gcp_topology_information_tables(self.gcp_provider, start_date, end_date)
+        self.accessor.populate_gcp_topology_information_tables(self.gcp_provider, self.start_date, self.end_date, self.invoice_month)
         with schema_context(self.schema_name):
             expected = (
                 GCPTopology.objects.annotate(**{"value": F("project_id")})

--- a/koku/api/resource_types/test/gcp_regions/test_views.py
+++ b/koku/api/resource_types/test/gcp_regions/test_views.py
@@ -61,7 +61,9 @@ class ResourceTypesViewTestGcpRegions(MasuTestCase):
             ),
         ]
         mock_get_topo.return_value = mock_topo_record
-        self.accessor.populate_gcp_topology_information_tables(self.gcp_provider, self.start_date, self.end_date, self.invoice_month)
+        self.accessor.populate_gcp_topology_information_tables(
+            self.gcp_provider, self.start_date, self.end_date, self.invoice_month
+        )
         with schema_context(self.schema_name):
             expected = (
                 GCPTopology.objects.annotate(**{"value": F("region")})
@@ -106,7 +108,9 @@ class ResourceTypesViewTestGcpRegions(MasuTestCase):
             ),
         ]
         mock_get_topo.return_value = mock_topo_record
-        self.accessor.populate_gcp_topology_information_tables(self.gcp_provider, self.start_date, self.end_date, self.invoice_month)
+        self.accessor.populate_gcp_topology_information_tables(
+            self.gcp_provider, self.start_date, self.end_date, self.invoice_month
+        )
         with schema_context(self.schema_name):
             expected = (
                 GCPTopology.objects.annotate(**{"value": F("region")})

--- a/koku/api/resource_types/test/gcp_regions/test_views.py
+++ b/koku/api/resource_types/test/gcp_regions/test_views.py
@@ -30,6 +30,10 @@ class ResourceTypesViewTestGcpRegions(MasuTestCase):
     def setUp(self):
         """Set up a test with database objects."""
         super().setUp()
+        self.dh = DateHelper()
+        self.start_date = self.dh.this_month_start
+        self.end_date = self.dh.this_month_end
+        self.invoice_month = self.dh.gcp_find_invoice_months_in_date_range(self.start_date, self.end_date)
 
     @RbacPermissions({"gcp.project": {"read": ["*"]}, "gcp.account": {"read": ["example_account_id"]}})
     @patch("masu.database.gcp_report_db_accessor.GCPReportDBAccessor.get_gcp_topology_trino")
@@ -57,10 +61,7 @@ class ResourceTypesViewTestGcpRegions(MasuTestCase):
             ),
         ]
         mock_get_topo.return_value = mock_topo_record
-        dh = DateHelper()
-        start_date = dh.this_month_start
-        end_date = dh.this_month_end
-        self.accessor.populate_gcp_topology_information_tables(self.gcp_provider, start_date, end_date)
+        self.accessor.populate_gcp_topology_information_tables(self.gcp_provider, self.start_date, self.end_date, self.invoice_month)
         with schema_context(self.schema_name):
             expected = (
                 GCPTopology.objects.annotate(**{"value": F("region")})
@@ -105,10 +106,7 @@ class ResourceTypesViewTestGcpRegions(MasuTestCase):
             ),
         ]
         mock_get_topo.return_value = mock_topo_record
-        dh = DateHelper()
-        start_date = dh.this_month_start
-        end_date = dh.this_month_end
-        self.accessor.populate_gcp_topology_information_tables(self.gcp_provider, start_date, end_date)
+        self.accessor.populate_gcp_topology_information_tables(self.gcp_provider, self.start_date, self.end_date, self.invoice_month)
         with schema_context(self.schema_name):
             expected = (
                 GCPTopology.objects.annotate(**{"value": F("region")})

--- a/koku/api/resource_types/test/gcp_services/test_views.py
+++ b/koku/api/resource_types/test/gcp_services/test_views.py
@@ -61,7 +61,9 @@ class ResourceTypesViewTestGcpServices(MasuTestCase):
             ),
         ]
         mock_get_topo.return_value = mock_topo_record
-        self.accessor.populate_gcp_topology_information_tables(self.gcp_provider, self.start_date, self.end_date, self.invoice_month)
+        self.accessor.populate_gcp_topology_information_tables(
+            self.gcp_provider, self.start_date, self.end_date, self.invoice_month
+        )
         with schema_context(self.schema_name):
             expected = (
                 GCPTopology.objects.annotate(**{"value": F("service_alias")})
@@ -106,7 +108,9 @@ class ResourceTypesViewTestGcpServices(MasuTestCase):
             ),
         ]
         mock_get_topo.return_value = mock_topo_record
-        self.accessor.populate_gcp_topology_information_tables(self.gcp_provider, self.start_date, self.end_date, self.invoice_month)
+        self.accessor.populate_gcp_topology_information_tables(
+            self.gcp_provider, self.start_date, self.end_date, self.invoice_month
+        )
         with schema_context(self.schema_name):
             expected = (
                 GCPTopology.objects.annotate(**{"value": F("service_alias")})

--- a/koku/api/resource_types/test/gcp_services/test_views.py
+++ b/koku/api/resource_types/test/gcp_services/test_views.py
@@ -30,6 +30,10 @@ class ResourceTypesViewTestGcpServices(MasuTestCase):
     def setUp(self):
         """Set up a test with database objects."""
         super().setUp()
+        self.dh = DateHelper()
+        self.start_date = self.dh.this_month_start
+        self.end_date = self.dh.this_month_end
+        self.invoice_month = self.dh.gcp_find_invoice_months_in_date_range(self.start_date, self.end_date)
 
     @RbacPermissions({"gcp.project": {"read": ["*"]}, "gcp.account": {"read": ["example_account_id"]}})
     @patch("masu.database.gcp_report_db_accessor.GCPReportDBAccessor.get_gcp_topology_trino")
@@ -57,10 +61,7 @@ class ResourceTypesViewTestGcpServices(MasuTestCase):
             ),
         ]
         mock_get_topo.return_value = mock_topo_record
-        dh = DateHelper()
-        start_date = dh.this_month_start
-        end_date = dh.this_month_end
-        self.accessor.populate_gcp_topology_information_tables(self.gcp_provider, start_date, end_date)
+        self.accessor.populate_gcp_topology_information_tables(self.gcp_provider, self.start_date, self.end_date, self.invoice_month)
         with schema_context(self.schema_name):
             expected = (
                 GCPTopology.objects.annotate(**{"value": F("service_alias")})
@@ -105,10 +106,7 @@ class ResourceTypesViewTestGcpServices(MasuTestCase):
             ),
         ]
         mock_get_topo.return_value = mock_topo_record
-        dh = DateHelper()
-        start_date = dh.this_month_start
-        end_date = dh.this_month_end
-        self.accessor.populate_gcp_topology_information_tables(self.gcp_provider, start_date, end_date)
+        self.accessor.populate_gcp_topology_information_tables(self.gcp_provider, self.start_date, self.end_date, self.invoice_month)
         with schema_context(self.schema_name):
             expected = (
                 GCPTopology.objects.annotate(**{"value": F("service_alias")})

--- a/koku/api/utils.py
+++ b/koku/api/utils.py
@@ -407,6 +407,8 @@ def get_months_in_date_range(report=None, start=None, end=None, invoice_month=No
             start_date = start_date.strftime("%Y-%m-%d")
             end_date = DateAccessor().today().strftime("%Y-%m-%d")
     elif invoice_month:
+        if not end:
+            end = dh.today.date().strftime("%Y-%m-%d")
         return [(start, end, invoice_month)]  # For report_data masu api
     else:
         start_date = start

--- a/koku/api/utils.py
+++ b/koku/api/utils.py
@@ -17,6 +17,7 @@ from django.utils import timezone
 from pint.errors import UndefinedUnitError
 from tenant_schemas.utils import schema_context
 
+from api.provider.models import Provider
 from api.user_settings.settings import USER_SETTINGS
 from koku.settings import KOKU_DEFAULT_COST_TYPE
 from koku.settings import KOKU_DEFAULT_CURRENCY
@@ -389,7 +390,7 @@ def materialized_view_month_start(dh=DateHelper()):
     return dh.this_month_start - relativedelta(months=settings.RETAIN_NUM_MONTHS - 1)
 
 
-def get_months_in_date_range(report=None, start=None, end=None):
+def get_months_in_date_range(report=None, start=None, end=None, invoice_month=None):
     """returns the month periods in a given date range from report"""
     dh = DateHelper()
     if report:
@@ -397,11 +398,16 @@ def get_months_in_date_range(report=None, start=None, end=None):
             LOG.info(f"using start: {report.get('start')} and end: {report.get('end')} dates from manifest")
             start_date = report.get("start")
             end_date = report.get("end")
+            if report.get("invoice_month"):
+                LOG.info(f"using invoice_month: {report.get('invoice_month')}")
+                invoice_month = report.get("invoice_month")
         else:
             LOG.info("generating start and end dates for manifest")
             start_date = DateAccessor().today() - datetime.timedelta(days=2)
             start_date = start_date.strftime("%Y-%m-%d")
             end_date = DateAccessor().today().strftime("%Y-%m-%d")
+    elif invoice_month:
+        return [(start, end, invoice_month)]  # For report_data masu api
     else:
         start_date = start
         end_date = end
@@ -410,6 +416,9 @@ def get_months_in_date_range(report=None, start=None, end=None):
     summary_month = dh.today + relativedelta(months=-Config.INITIAL_INGEST_NUM_MONTHS)
     if start_date < summary_month.strftime("%Y-%m-01"):
         start_date = summary_month.strftime("%Y-%m-01")
+
+    if report.get("provider_type") in [Provider.PROVIDER_GCP, Provider.PROVIDER_GCP_LOCAL]:
+        return [(start_date, end_date, invoice_month)]
 
     start_date = ciso8601.parse_datetime(start_date).replace(tzinfo=pytz.UTC)
     end_date = ciso8601.parse_datetime(end_date).replace(tzinfo=pytz.UTC) if end_date else dh.today
@@ -427,7 +436,7 @@ def get_months_in_date_range(report=None, start=None, end=None):
         start, end = month
         start_date = start.date().strftime("%Y-%m-%d")
         end_date = end.date().strftime("%Y-%m-%d")
-        months[i] = (start_date, end_date)
+        months[i] = (start_date, end_date, invoice_month)  # Invoice month is really only for GCP
 
     return months
 

--- a/koku/api/utils.py
+++ b/koku/api/utils.py
@@ -417,7 +417,7 @@ def get_months_in_date_range(report=None, start=None, end=None, invoice_month=No
     if start_date < summary_month.strftime("%Y-%m-01"):
         start_date = summary_month.strftime("%Y-%m-01")
 
-    if report.get("provider_type") in [Provider.PROVIDER_GCP, Provider.PROVIDER_GCP_LOCAL]:
+    if report and report.get("provider_type") in [Provider.PROVIDER_GCP, Provider.PROVIDER_GCP_LOCAL]:
         return [(start_date, end_date, invoice_month)]
 
     start_date = ciso8601.parse_datetime(start_date).replace(tzinfo=pytz.UTC)

--- a/koku/masu/api/report_data.py
+++ b/koku/masu/api/report_data.py
@@ -23,6 +23,7 @@ from masu.processor.tasks import QUEUE_LIST
 from masu.processor.tasks import remove_expired_data
 from masu.processor.tasks import update_all_summary_tables
 from masu.processor.tasks import update_summary_tables
+from api.models import Provider
 
 LOG = logging.getLogger(__name__)
 REPORT_DATA_KEY = "Report Data Task IDs"
@@ -69,10 +70,11 @@ def report_data(request):
 
         invoice_month = None
         # For GCP invoice month summary periods
-        if end_date:
-            invoice_month = end_date[0:4] + end_date[5:7]
-        else:
-            invoice_month = start_date[0:4] + start_date[5:7]
+        if provider_type in [Provider.PROVIDER_GCP, Provider.PROVIDER_GCP_LOCAL]:
+            if end_date:
+                invoice_month = end_date[0:4] + end_date[5:7]
+            else:
+                invoice_month = start_date[0:4] + start_date[5:7]
 
         months = get_months_in_date_range(start=start_date, end=end_date, invoice_month=invoice_month)
 

--- a/koku/masu/api/report_data.py
+++ b/koku/masu/api/report_data.py
@@ -16,6 +16,7 @@ from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.settings import api_settings
 
+from api.models import Provider
 from api.utils import get_months_in_date_range
 from masu.database.provider_db_accessor import ProviderDBAccessor
 from masu.processor.tasks import PRIORITY_QUEUE
@@ -23,7 +24,6 @@ from masu.processor.tasks import QUEUE_LIST
 from masu.processor.tasks import remove_expired_data
 from masu.processor.tasks import update_all_summary_tables
 from masu.processor.tasks import update_summary_tables
-from api.models import Provider
 
 LOG = logging.getLogger(__name__)
 REPORT_DATA_KEY = "Report Data Task IDs"

--- a/koku/masu/api/report_data.py
+++ b/koku/masu/api/report_data.py
@@ -45,6 +45,7 @@ def report_data(request):
         schema_name = params.get("schema")
         start_date = params.get("start_date")
         end_date = params.get("end_date")
+        provider = None
 
         ocp_on_cloud = params.get("ocp_on_cloud", "true").lower()
         ocp_on_cloud = True if ocp_on_cloud == "true" else False
@@ -70,7 +71,10 @@ def report_data(request):
 
         invoice_month = None
         # For GCP invoice month summary periods
-        if provider_type in [Provider.PROVIDER_GCP, Provider.PROVIDER_GCP_LOCAL]:
+        if provider in [Provider.PROVIDER_GCP, Provider.PROVIDER_GCP_LOCAL] or provider_type in [
+            Provider.PROVIDER_GCP,
+            Provider.PROVIDER_GCP_LOCAL,
+        ]:
             if end_date:
                 invoice_month = end_date[0:4] + end_date[5:7]
             else:

--- a/koku/masu/database/gcp_report_db_accessor.py
+++ b/koku/masu/database/gcp_report_db_accessor.py
@@ -599,8 +599,9 @@ class GCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
 
         return [json.loads(result[0]) for result in results]
 
-    # TODO This may also need to take in the invoice_month_date to summarise tag matching correctly.
-    def get_openshift_on_cloud_matched_tags_trino(self, gcp_source_uuid, ocp_source_uuid, start_date, end_date):
+    def get_openshift_on_cloud_matched_tags_trino(
+        self, gcp_source_uuid, ocp_source_uuid, start_date, end_date, invoice_month_date
+    ):
         """Return a list of matched tags."""
         sql = pkgutil.get_data("masu.database", "presto_sql/gcp/openshift/reporting_ocpgcp_matched_tags.sql")
         sql = sql.decode("utf-8")
@@ -614,8 +615,8 @@ class GCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
             "schema": self.schema,
             "gcp_source_uuid": gcp_source_uuid,
             "ocp_source_uuid": ocp_source_uuid,
-            "year": start_date.strftime("%Y"),
-            "month": start_date.strftime("%m"),
+            "year": invoice_month_date.strftime("%Y"),
+            "month": invoice_month_date.strftime("%m"),
             "days": days_str,
         }
         sql, sql_params = self.jinja_sql.prepare_query(sql, sql_params)

--- a/koku/masu/database/gcp_report_db_accessor.py
+++ b/koku/masu/database/gcp_report_db_accessor.py
@@ -599,9 +599,8 @@ class GCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
 
         return [json.loads(result[0]) for result in results]
 
-    def get_openshift_on_cloud_matched_tags_trino(
-        self, gcp_source_uuid, ocp_source_uuid, start_date, end_date, invoice_month_date
-    ):
+    # TODO This may also need to take in the invoice_month_date to summarise tag matching correctly.
+    def get_openshift_on_cloud_matched_tags_trino(self, gcp_source_uuid, ocp_source_uuid, start_date, end_date):
         """Return a list of matched tags."""
         sql = pkgutil.get_data("masu.database", "presto_sql/gcp/openshift/reporting_ocpgcp_matched_tags.sql")
         sql = sql.decode("utf-8")
@@ -615,8 +614,8 @@ class GCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
             "schema": self.schema,
             "gcp_source_uuid": gcp_source_uuid,
             "ocp_source_uuid": ocp_source_uuid,
-            "year": invoice_month_date.strftime("%Y"),
-            "month": invoice_month_date.strftime("%m"),
+            "year": start_date.strftime("%Y"),
+            "month": start_date.strftime("%m"),
             "days": days_str,
         }
         sql, sql_params = self.jinja_sql.prepare_query(sql, sql_params)

--- a/koku/masu/database/gcp_report_db_accessor.py
+++ b/koku/masu/database/gcp_report_db_accessor.py
@@ -235,7 +235,9 @@ class GCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
             table_name, summary_sql, start_date, end_date, bind_params=list(summary_sql_params)
         )
 
-    def populate_line_item_daily_summary_table_presto(self, start_date, end_date, source_uuid, bill_id, markup_value):
+    def populate_line_item_daily_summary_table_presto(
+        self, start_date, end_date, source_uuid, bill_id, markup_value, invoice_month_date
+    ):
         """Populate the daily aggregated summary of line items table.
 
         Args:
@@ -266,8 +268,8 @@ class GCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
             "schema": self.schema,
             "table": PRESTO_LINE_ITEM_TABLE,
             "source_uuid": source_uuid,
-            "year": start_date.strftime("%Y"),
-            "month": start_date.strftime("%m"),
+            "year": invoice_month_date.strftime("%Y"),
+            "month": invoice_month_date.strftime("%m"),
             "markup": markup_value if markup_value else 0,
             "bill_id": bill_id,
         }
@@ -391,11 +393,11 @@ class GCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
             table_name, summary_sql, start_date, end_date, bind_params=list(summary_sql_params)
         )
 
-    def populate_gcp_topology_information_tables(self, provider, start_date, end_date):
+    def populate_gcp_topology_information_tables(self, provider, start_date, end_date, invoice_month_date):
         """Populate the GCP topology table."""
         msg = f"Populating GCP topology for {provider.uuid} from {start_date} to {end_date}"
         LOG.info(msg)
-        topology = self.get_gcp_topology_trino(provider.uuid, start_date, end_date)
+        topology = self.get_gcp_topology_trino(provider.uuid, start_date, end_date, invoice_month_date)
 
         with schema_context(self.schema):
             for record in topology:
@@ -410,7 +412,7 @@ class GCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
                 )
         LOG.info("Finished populating GCP topology")
 
-    def get_gcp_topology_trino(self, source_uuid, start_date, end_date):
+    def get_gcp_topology_trino(self, source_uuid, start_date, end_date, invoice_month_date):
         """Get the account topology for a GCP source."""
         sql = f"""
             SELECT source,
@@ -422,8 +424,8 @@ class GCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
                 location_region
             FROM hive.{self.schema}.gcp_line_items as gcp
             WHERE gcp.source = '{source_uuid}'
-                AND gcp.year = '{start_date.strftime("%Y")}'
-                AND gcp.month = '{start_date.strftime("%m")}'
+                AND gcp.year = '{invoice_month_date.strftime("%Y")}'
+                AND gcp.month = '{invoice_month_date.strftime("%m")}'
                 AND gcp.usage_start_time >= TIMESTAMP '{start_date}'
                 AND gcp.usage_start_time < date_add('day', 1, TIMESTAMP '{end_date}')
             GROUP BY source,
@@ -597,7 +599,9 @@ class GCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
 
         return [json.loads(result[0]) for result in results]
 
-    def get_openshift_on_cloud_matched_tags_trino(self, gcp_source_uuid, ocp_source_uuid, start_date, end_date):
+    def get_openshift_on_cloud_matched_tags_trino(
+        self, gcp_source_uuid, ocp_source_uuid, start_date, end_date, invoice_month_date
+    ):
         """Return a list of matched tags."""
         sql = pkgutil.get_data("masu.database", "presto_sql/gcp/openshift/reporting_ocpgcp_matched_tags.sql")
         sql = sql.decode("utf-8")
@@ -611,8 +615,8 @@ class GCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
             "schema": self.schema,
             "gcp_source_uuid": gcp_source_uuid,
             "ocp_source_uuid": ocp_source_uuid,
-            "year": start_date.strftime("%Y"),
-            "month": start_date.strftime("%m"),
+            "year": invoice_month_date.strftime("%Y"),
+            "month": invoice_month_date.strftime("%m"),
             "days": days_str,
         }
         sql, sql_params = self.jinja_sql.prepare_query(sql, sql_params)

--- a/koku/masu/external/downloader/gcp/gcp_report_downloader.py
+++ b/koku/masu/external/downloader/gcp/gcp_report_downloader.py
@@ -67,9 +67,9 @@ def create_daily_archives(tracing_id, account, provider_uuid, filename, filepath
         for invoice_month in data_frame["invoice.month"].unique():
             invoice_filter = data_frame["invoice.month"] == invoice_month
             invoice_month_data = data_frame[invoice_filter]
-            unique_usage_days = pd.to_datetime(data_frame["usage_start_time"]).dt.date.unique()
+            unique_usage_days = pd.to_datetime(invoice_month_data["usage_start_time"]).dt.date.unique()
             days = list({day.strftime("%Y-%m-%d") for day in unique_usage_days})
-            date_range = {"start": min(days), "end": max(days)}
+            date_range = {"start": min(days), "end": max(days), "invoice": str(invoice_month)}
             partition_dates = invoice_month_data.partition_date.unique()
             for partition_date in partition_dates:
                 partition_date_filter = invoice_month_data["partition_date"] == partition_date

--- a/koku/masu/external/downloader/gcp/gcp_report_downloader.py
+++ b/koku/masu/external/downloader/gcp/gcp_report_downloader.py
@@ -69,7 +69,7 @@ def create_daily_archives(tracing_id, account, provider_uuid, filename, filepath
             invoice_month_data = data_frame[invoice_filter]
             unique_usage_days = pd.to_datetime(invoice_month_data["usage_start_time"]).dt.date.unique()
             days = list({day.strftime("%Y-%m-%d") for day in unique_usage_days})
-            date_range = {"start": min(days), "end": max(days), "invoice": str(invoice_month)}
+            date_range = {"start": min(days), "end": max(days), "invoice_month": str(invoice_month)}
             partition_dates = invoice_month_data.partition_date.unique()
             for partition_date in partition_dates:
                 partition_date_filter = invoice_month_data["partition_date"] == partition_date

--- a/koku/masu/external/report_downloader.py
+++ b/koku/masu/external/report_downloader.py
@@ -206,4 +206,5 @@ class ReportDownloader:
             "create_table": report_context.get("create_table", False),
             "start": date_range.get("start"),
             "end": date_range.get("end"),
+            "invoice": date_range.get("invoice"),
         }

--- a/koku/masu/external/report_downloader.py
+++ b/koku/masu/external/report_downloader.py
@@ -206,5 +206,5 @@ class ReportDownloader:
             "create_table": report_context.get("create_table", False),
             "start": date_range.get("start"),
             "end": date_range.get("end"),
-            "invoice": date_range.get("invoice"),
+            "invoice_month": date_range.get("invoice_month"),
         }

--- a/koku/masu/processor/gcp/gcp_report_parquet_summary_updater.py
+++ b/koku/masu/processor/gcp/gcp_report_parquet_summary_updater.py
@@ -86,7 +86,7 @@ class GCPReportParquetSummaryUpdater(PartitionHandlerMixin):
                     bill_ids = [str(bill.id) for bill in bills]
                     current_bill_id = bills.first().id if bills else None
                 else:
-                    msg = f"No bill was found for invoice month {invoice_month}. Skipping summarization"
+                    msg = "No invoice month was provided during summarization. Skipping summarization"
                     LOG.info(msg)
                     return start_date, end_date
 

--- a/koku/masu/processor/gcp/gcp_report_parquet_summary_updater.py
+++ b/koku/masu/processor/gcp/gcp_report_parquet_summary_updater.py
@@ -81,7 +81,7 @@ class GCPReportParquetSummaryUpdater(PartitionHandlerMixin):
             # Need these bills on the session to update dates after processing
             with schema_context(self._schema):
                 if invoice_month:
-                    invoice_month_date = DateHelper().invoice_month_start(invoice_month)
+                    invoice_month_date = DateHelper().invoice_month_start(invoice_month).date()
                     bills = accessor.bills_for_provider_uuid(self._provider.uuid, invoice_month_date)
                     bill_ids = [str(bill.id) for bill in bills]
                     current_bill_id = bills.first().id if bills else None

--- a/koku/masu/processor/gcp/gcp_report_parquet_summary_updater.py
+++ b/koku/masu/processor/gcp/gcp_report_parquet_summary_updater.py
@@ -9,6 +9,7 @@ import ciso8601
 from django.conf import settings
 from tenant_schemas.utils import schema_context
 
+from api.utils import DateHelper
 from koku.pg_partition import PartitionHandlerMixin
 from masu.database.cost_model_db_accessor import CostModelDBAccessor
 from masu.database.gcp_report_db_accessor import GCPReportDBAccessor
@@ -80,9 +81,7 @@ class GCPReportParquetSummaryUpdater(PartitionHandlerMixin):
             # Need these bills on the session to update dates after processing
             with schema_context(self._schema):
                 if invoice_month:
-                    invoice_month_date, _ = self._get_sql_inputs(
-                        f"{invoice_month[0:4]}-{invoice_month[4:6]}-01", end_date
-                    )
+                    invoice_month_date = DateHelper().invoice_month_start(invoice_month)
                     bills = accessor.bills_for_provider_uuid(self._provider.uuid, invoice_month_date)
                     bill_ids = [str(bill.id) for bill in bills]
                     current_bill_id = bills.first().id if bills else None

--- a/koku/masu/processor/gcp/gcp_report_summary_updater.py
+++ b/koku/masu/processor/gcp/gcp_report_summary_updater.py
@@ -44,7 +44,7 @@ class GCPReportSummaryUpdater(PartitionHandlerMixin):
 
         return start_date, end_date
 
-    def update_daily_tables(self, start_date, end_date, invoice_month):
+    def update_daily_tables(self, start_date, end_date):
         """Populate the daily tables for reporting.
 
         Args:

--- a/koku/masu/processor/gcp/gcp_report_summary_updater.py
+++ b/koku/masu/processor/gcp/gcp_report_summary_updater.py
@@ -44,7 +44,7 @@ class GCPReportSummaryUpdater(PartitionHandlerMixin):
 
         return start_date, end_date
 
-    def update_daily_tables(self, start_date, end_date):
+    def update_daily_tables(self, start_date, end_date, invoice_month):
         """Populate the daily tables for reporting.
 
         Args:

--- a/koku/masu/processor/gcp/gcp_report_summary_updater.py
+++ b/koku/masu/processor/gcp/gcp_report_summary_updater.py
@@ -44,7 +44,7 @@ class GCPReportSummaryUpdater(PartitionHandlerMixin):
 
         return start_date, end_date
 
-    def update_daily_tables(self, start_date, end_date, invoice_month):
+    def update_daily_tables(self, start_date, end_date, invoice_month=None):
         """Populate the daily tables for reporting.
 
         Args:
@@ -81,7 +81,7 @@ class GCPReportSummaryUpdater(PartitionHandlerMixin):
 
         return start_date, end_date
 
-    def update_summary_tables(self, start_date, end_date):
+    def update_summary_tables(self, start_date, end_date, invoice_month=None):
         """Populate the summary tables for reporting.
 
         Args:

--- a/koku/masu/processor/parquet/ocp_cloud_parquet_report_processor.py
+++ b/koku/masu/processor/parquet/ocp_cloud_parquet_report_processor.py
@@ -154,9 +154,18 @@ class OCPCloudParquetReportProcessor(ParquetReportProcessor):
                 matched_tags = self.db_accessor.get_openshift_on_cloud_matched_tags(self.bill_id, report_period_id)
                 if not matched_tags:
                     LOG.info("Matched tags not yet available via Postgres. Getting matching tags from Trino.")
-                    matched_tags = self.db_accessor.get_openshift_on_cloud_matched_tags_trino(
-                        self.provider_uuid, ocp_provider_uuid, self.start_date, self.end_date
-                    )
+                    if self._provider_type in [Provider.PROVIDER_GCP, Provider.PROVIDER_GCP_LOCAL]:
+                        matched_tags = self.db_accessor.get_openshift_on_cloud_matched_tags_trino(
+                            self.provider_uuid,
+                            ocp_provider_uuid,
+                            self.start_date,
+                            self.end_date,
+                            self.invoice_month_date,
+                        )
+                    else:
+                        matched_tags = self.db_accessor.get_openshift_on_cloud_matched_tags_trino(
+                            self.provider_uuid, ocp_provider_uuid, self.start_date, self.end_date
+                        )
             for i, daily_data_frame in enumerate(daily_data_frames):
                 openshift_filtered_data_frame = self.ocp_on_cloud_data_processor(
                     daily_data_frame, cluster_topology, matched_tags

--- a/koku/masu/processor/parquet/parquet_report_processor.py
+++ b/koku/masu/processor/parquet/parquet_report_processor.py
@@ -85,6 +85,9 @@ class ParquetReportProcessor:
         self._manifest_id = manifest_id
         self._context = context
         self.start_date = self._context.get("start_date")
+        self.invoice_month = self._context.get("invoice_month")
+        if self.invoice_month:
+            self.invoice_month_date = DateHelper().invoice_month_start(self.invoice_month).date()
         self.presto_table_exists = {}
         self.files_to_remove = []
 

--- a/koku/masu/processor/report_summary_updater.py
+++ b/koku/masu/processor/report_summary_updater.py
@@ -154,7 +154,10 @@ class ReportSummaryUpdater:
         LOG.info(log_json(self._tracing_id, msg))
         start_date, end_date = self._format_dates(start_date, end_date)
 
-        start_date, end_date = self._updater.update_daily_tables(start_date, end_date, invoice_month)
+        if invoice_month:
+            start_date, end_date = self._updater.update_daily_tables(start_date, end_date, invoice_month)
+        else:
+            start_date, end_date = self._updater.update_daily_tables(start_date, end_date)
 
         invalidate_view_cache_for_tenant_and_source_type(self._schema, self._provider.type)
         msg = f"Daily summary completed for source {self._provider_uuid}"
@@ -181,7 +184,10 @@ class ReportSummaryUpdater:
         LOG.info(log_json(tracing_id, f"Using end date: {end_date}"))
         LOG.info(log_json(tracing_id, f"Using invoice month: {invoice_month}"))
 
-        start_date, end_date = self._updater.update_summary_tables(start_date, end_date, invoice_month)
+        if invoice_month:
+            start_date, end_date = self._updater.update_summary_tables(start_date, end_date, invoice_month)
+        else:
+            start_date, end_date = self._updater.update_summary_tables(start_date, end_date)
 
         msg = f"Summary processing completed for source {self._provider_uuid} start: {start_date} - end: {end_date}"
         LOG.info(log_json(self._tracing_id, msg))

--- a/koku/masu/processor/report_summary_updater.py
+++ b/koku/masu/processor/report_summary_updater.py
@@ -138,7 +138,7 @@ class ReportSummaryUpdater:
             end_date = end_date.strftime("%Y-%m-%d")
         return start_date, end_date
 
-    def update_daily_tables(self, start_date, end_date):
+    def update_daily_tables(self, start_date, end_date, invoice_month=None):
         """
         Update report daily rollup tables.
 
@@ -154,14 +154,14 @@ class ReportSummaryUpdater:
         LOG.info(log_json(self._tracing_id, msg))
         start_date, end_date = self._format_dates(start_date, end_date)
 
-        start_date, end_date = self._updater.update_daily_tables(start_date, end_date)
+        start_date, end_date = self._updater.update_daily_tables(start_date, end_date, invoice_month)
 
         invalidate_view_cache_for_tenant_and_source_type(self._schema, self._provider.type)
         msg = f"Daily summary completed for source {self._provider_uuid}"
         LOG.info(log_json(self._tracing_id, msg))
         return start_date, end_date
 
-    def update_summary_tables(self, start_date, end_date, tracing_id):
+    def update_summary_tables(self, start_date, end_date, tracing_id, invoice_month=None):
         """
         Update report summary tables.
 
@@ -179,8 +179,9 @@ class ReportSummaryUpdater:
         start_date, end_date = self._format_dates(start_date, end_date)
         LOG.info(log_json(tracing_id, f"Using start date: {start_date}"))
         LOG.info(log_json(tracing_id, f"Using end date: {end_date}"))
+        LOG.info(log_json(tracing_id, f"Using invoice month: {invoice_month}"))
 
-        start_date, end_date = self._updater.update_summary_tables(start_date, end_date)
+        start_date, end_date = self._updater.update_summary_tables(start_date, end_date, invoice_month)
 
         msg = f"Summary processing completed for source {self._provider_uuid} start: {start_date} - end: {end_date}"
         LOG.info(log_json(self._tracing_id, msg))

--- a/koku/masu/processor/tasks.py
+++ b/koku/masu/processor/tasks.py
@@ -208,7 +208,7 @@ def get_report_files(  # noqa: C901
             "tracing_id": tracing_id,
             "start": report_dict.get("start"),
             "end": report_dict.get("end"),
-            "invoice": report_dict.get("invoice"),
+            "invoice_month": report_dict.get("invoice_month"),
         }
 
         try:

--- a/koku/masu/processor/tasks.py
+++ b/koku/masu/processor/tasks.py
@@ -294,7 +294,7 @@ def summarize_reports(reports_to_summarize, queue_name=None, manifest_list=None)
     for source, report_list in reports_by_source.items():
         starts = []
         ends = []
-        if report.get("provider_type") in [Provider.PROVIDER_GCP, Provider.PROVIDER_GCP_LOCAL]:
+        if report and report.get("provider_type") in [Provider.PROVIDER_GCP, Provider.PROVIDER_GCP_LOCAL]:
             reports_deduplicated += deduplicate_reports_for_gcp(report_list)
         else:
             for report in report_list:

--- a/koku/masu/test/api/test_report_data.py
+++ b/koku/masu/test/api/test_report_data.py
@@ -528,3 +528,35 @@ class ReportDataTests(TestCase):
             ocp_on_cloud=False,
             invoice_month=self.invoice,
         )
+
+    @patch("koku.middleware.MASU", return_value=True)
+    @patch("masu.api.report_data.ProviderDBAccessor")
+    @patch("masu.api.report_data.update_summary_tables")
+    def test_get_report_data_gcp_end_date(self, mock_update, mock_accessor, _):
+        """Test the GET report_data endpoint."""
+        provider_type = Provider.PROVIDER_GCP
+        mock_accessor.return_value.__enter__.return_value.get_type.return_value = provider_type
+        params = {
+            "schema": "org1234567",
+            "start_date": self.start_date,
+            "end_date": self.start_date,
+            "provider_uuid": "6e212746-484a-40cd-bba0-09a19d132d64",
+            "ocp_on_cloud": "false",
+        }
+        expected_key = "Report Data Task IDs"
+
+        response = self.client.get(reverse("report_data"), params)
+        body = response.json()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(expected_key, body)
+        mock_update.s.assert_called_with(
+            params["schema"],
+            provider_type,
+            params["provider_uuid"],
+            params["end_date"],
+            DateHelper().today.date().strftime("%Y-%m-%d"),
+            queue_name=PRIORITY_QUEUE,
+            ocp_on_cloud=False,
+            invoice_month=self.invoice,
+        )

--- a/koku/masu/test/api/test_report_data.py
+++ b/koku/masu/test/api/test_report_data.py
@@ -51,7 +51,7 @@ class ReportDataTests(TestCase):
             DateHelper().today.date().strftime("%Y-%m-%d"),
             queue_name=PRIORITY_QUEUE,
             ocp_on_cloud=True,
-            invoice_month=None
+            invoice_month=None,
         )
 
     @patch("koku.middleware.MASU", return_value=True)
@@ -83,7 +83,7 @@ class ReportDataTests(TestCase):
             DateHelper().today.date().strftime("%Y-%m-%d"),
             queue_name=OCP_QUEUE,
             ocp_on_cloud=True,
-            invoice_month=None
+            invoice_month=None,
         )
 
     @patch("koku.middleware.MASU", return_value=True)
@@ -227,7 +227,7 @@ class ReportDataTests(TestCase):
                 params["end_date"],
                 queue_name=PRIORITY_QUEUE,
                 ocp_on_cloud=True,
-                invoice_month=None
+                invoice_month=None,
             )
         ]
 
@@ -241,7 +241,7 @@ class ReportDataTests(TestCase):
                     params["start_date"],
                     queue_name=PRIORITY_QUEUE,
                     ocp_on_cloud=True,
-                    invoice_month=None
+                    invoice_month=None,
                 ),
                 call(
                     params["schema"],
@@ -251,7 +251,7 @@ class ReportDataTests(TestCase):
                     params["end_date"],
                     queue_name=PRIORITY_QUEUE,
                     ocp_on_cloud=True,
-                    invoice_month=None
+                    invoice_month=None,
                 ),
             ]
 
@@ -285,7 +285,7 @@ class ReportDataTests(TestCase):
                 params["end_date"],
                 queue_name=PRIORITY_QUEUE,
                 ocp_on_cloud=True,
-                invoice_month=None
+                invoice_month=None,
             )
         ]
 
@@ -299,7 +299,7 @@ class ReportDataTests(TestCase):
                     params["start_date"],
                     queue_name=PRIORITY_QUEUE,
                     ocp_on_cloud=True,
-                    invoice_month=None
+                    invoice_month=None,
                 ),
                 call(
                     params["schema"],
@@ -309,7 +309,7 @@ class ReportDataTests(TestCase):
                     params["end_date"],
                     queue_name=PRIORITY_QUEUE,
                     ocp_on_cloud=True,
-                    invoice_month=None
+                    invoice_month=None,
                 ),
             ]
 
@@ -334,7 +334,9 @@ class ReportDataTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIn(expected_key, body)
-        mock_update.delay.assert_called_with(params["start_date"], DateHelper().today.date().strftime("%Y-%m-%d"), invoice_month=None)
+        mock_update.delay.assert_called_with(
+            params["start_date"], DateHelper().today.date().strftime("%Y-%m-%d"), invoice_month=None
+        )
 
     @override_settings(DEVELOPMENT=False)
     @patch("koku.middleware.MASU", return_value=True)

--- a/koku/masu/test/api/test_report_data.py
+++ b/koku/masu/test/api/test_report_data.py
@@ -51,6 +51,7 @@ class ReportDataTests(TestCase):
             DateHelper().today.date().strftime("%Y-%m-%d"),
             queue_name=PRIORITY_QUEUE,
             ocp_on_cloud=True,
+            invoice_month=None
         )
 
     @patch("koku.middleware.MASU", return_value=True)
@@ -82,6 +83,7 @@ class ReportDataTests(TestCase):
             DateHelper().today.date().strftime("%Y-%m-%d"),
             queue_name=OCP_QUEUE,
             ocp_on_cloud=True,
+            invoice_month=None
         )
 
     @patch("koku.middleware.MASU", return_value=True)
@@ -225,6 +227,7 @@ class ReportDataTests(TestCase):
                 params["end_date"],
                 queue_name=PRIORITY_QUEUE,
                 ocp_on_cloud=True,
+                invoice_month=None
             )
         ]
 
@@ -238,6 +241,7 @@ class ReportDataTests(TestCase):
                     params["start_date"],
                     queue_name=PRIORITY_QUEUE,
                     ocp_on_cloud=True,
+                    invoice_month=None
                 ),
                 call(
                     params["schema"],
@@ -247,6 +251,7 @@ class ReportDataTests(TestCase):
                     params["end_date"],
                     queue_name=PRIORITY_QUEUE,
                     ocp_on_cloud=True,
+                    invoice_month=None
                 ),
             ]
 
@@ -280,6 +285,7 @@ class ReportDataTests(TestCase):
                 params["end_date"],
                 queue_name=PRIORITY_QUEUE,
                 ocp_on_cloud=True,
+                invoice_month=None
             )
         ]
 
@@ -293,6 +299,7 @@ class ReportDataTests(TestCase):
                     params["start_date"],
                     queue_name=PRIORITY_QUEUE,
                     ocp_on_cloud=True,
+                    invoice_month=None
                 ),
                 call(
                     params["schema"],
@@ -302,6 +309,7 @@ class ReportDataTests(TestCase):
                     params["end_date"],
                     queue_name=PRIORITY_QUEUE,
                     ocp_on_cloud=True,
+                    invoice_month=None
                 ),
             ]
 
@@ -326,7 +334,7 @@ class ReportDataTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIn(expected_key, body)
-        mock_update.delay.assert_called_with(params["start_date"], DateHelper().today.date().strftime("%Y-%m-%d"))
+        mock_update.delay.assert_called_with(params["start_date"], DateHelper().today.date().strftime("%Y-%m-%d"), invoice_month=None)
 
     @override_settings(DEVELOPMENT=False)
     @patch("koku.middleware.MASU", return_value=True)
@@ -488,4 +496,5 @@ class ReportDataTests(TestCase):
             DateHelper().today.date().strftime("%Y-%m-%d"),
             queue_name=PRIORITY_QUEUE,
             ocp_on_cloud=False,
+            invoice_month=None,
         )

--- a/koku/masu/test/api/test_report_data.py
+++ b/koku/masu/test/api/test_report_data.py
@@ -23,6 +23,14 @@ from masu.processor.tasks import QUEUE_LIST
 class ReportDataTests(TestCase):
     """Test Cases for the report_data endpoint."""
 
+    def setUp(self):
+        """Create test case setup."""
+        super().setUp()
+        dh = DateHelper()
+        self.start_date_time = dh.today.date()
+        self.start_date = dh.today.date().strftime("%Y-%m-%d")
+        self.invoice = dh.gcp_find_invoice_months_in_date_range(dh.today, dh.tomorrow)[0]
+
     @patch("koku.middleware.MASU", return_value=True)
     @patch("masu.api.report_data.ProviderDBAccessor")
     @patch("masu.api.report_data.update_summary_tables")
@@ -30,10 +38,9 @@ class ReportDataTests(TestCase):
         """Test the GET report_data endpoint."""
         provider_type = Provider.PROVIDER_AWS
         mock_accessor.return_value.__enter__.return_value.get_type.return_value = provider_type
-        start_date = DateHelper().today.date().strftime("%Y-%m-%d")
         params = {
             "schema": "org1234567",
-            "start_date": start_date,
+            "start_date": self.start_date,
             "provider_uuid": "6e212746-484a-40cd-bba0-09a19d132d64",
         }
         expected_key = "Report Data Task IDs"
@@ -61,10 +68,9 @@ class ReportDataTests(TestCase):
         """Test the GET report_data endpoint."""
         provider_type = Provider.PROVIDER_OCP
         mock_accessor.return_value.__enter__.return_value.get_type.return_value = provider_type
-        start_date = DateHelper().today.date().strftime("%Y-%m-%d")
         params = {
             "schema": "org1234567",
-            "start_date": start_date,
+            "start_date": self.start_date,
             "provider_uuid": "6e212746-484a-40cd-bba0-09a19d132d64",
             "queue": "ocp",
         }
@@ -90,8 +96,7 @@ class ReportDataTests(TestCase):
     @patch("masu.api.report_data.update_summary_tables")
     def test_get_report_data_schema_missing(self, mock_update, _):
         """Test GET report_data endpoint returns a 400 for missing schema."""
-        start_date = DateHelper().today.date().strftime("%Y-%m-%d")
-        params = {"start_date": start_date, "provider_uuid": "6e212746-484a-40cd-bba0-09a19d132d64"}
+        params = {"start_date": self.start_date, "provider_uuid": "6e212746-484a-40cd-bba0-09a19d132d64"}
         expected_key = "Error"
         expected_message = "schema is a required parameter."
 
@@ -106,8 +111,7 @@ class ReportDataTests(TestCase):
     @patch("masu.api.report_data.update_summary_tables")
     def test_get_report_data_provider_uuid_missing(self, mock_update, _):
         """Test GET report_data endpoint returns a 400 for missing provider_uuid."""
-        start_date = DateHelper().today.date().strftime("%Y-%m-%d")
-        params = {"start_date": start_date, "schema": "org1234567"}
+        params = {"start_date": self.start_date, "schema": "org1234567"}
 
         expected_key = "Error"
         expected_message = "provider_uuid or provider_type must be supplied as a parameter."
@@ -123,9 +127,8 @@ class ReportDataTests(TestCase):
     @patch("masu.api.report_data.update_summary_tables")
     def test_get_report_data_provider_invalid_uuid_(self, mock_update, _):
         """Test GET report_data endpoint returns a 400 for invalid provider_uuid."""
-        start_date = DateHelper().today.date().strftime("%Y-%m-%d")
         params = {
-            "start_date": start_date,
+            "start_date": self.start_date,
             "schema": "org1234567",
             "provider_uuid": "6e212746-484a-40cd-bba0-09a19d132ddd",
         }
@@ -143,9 +146,8 @@ class ReportDataTests(TestCase):
     @patch("masu.api.report_data.update_summary_tables")
     def test_get_report_data_invalid_queue(self, mock_update, _):
         """Test GET report_data endpoint returns a 400 for invalid queue."""
-        start_date = DateHelper().today.date().strftime("%Y-%m-%d")
         params = {
-            "start_date": start_date,
+            "start_date": self.start_date,
             "schema": "org1234567",
             "provider_uuid": "6e212746-484a-40cd-bba0-09a19d132ddd",
             "queue": "not-a-real-queue",
@@ -180,14 +182,13 @@ class ReportDataTests(TestCase):
     @patch("masu.api.report_data.update_summary_tables")
     def test_get_report_data_mismatch_types_uuid(self, mock_update, mock_accessor, _):
         """Test GET report_data endpoint returns a 400 for mismatched type and uuid."""
-        start_date = DateHelper().today.date().strftime("%Y-%m-%d")
         provider_type = Provider.PROVIDER_AWS
         mock_accessor.return_value.__enter__.return_value.get_type.return_value = provider_type
         params = {
             "schema": "org1234567",
             "provider_uuid": "6e212746-484a-40cd-bba0-09a19d132d64",
             "provider_type": Provider.PROVIDER_OCP,
-            "start_date": start_date,
+            "start_date": self.start_date,
         }
         expected_key = "Error"
         expected_message = "provider_uuid and provider_type have mismatched provider types."
@@ -265,15 +266,14 @@ class ReportDataTests(TestCase):
     @patch("masu.api.report_data.update_summary_tables")
     def test_get_report_data_with_only_provider_type(self, mock_update, _):
         """Test GET report_data endpoint with only provider_type."""
-        start_date = DateHelper().today
-        end_date = start_date + datetime.timedelta(days=1)
-        multiple_calls = start_date.month != end_date.month
+        end_date = self.start_date_time + datetime.timedelta(days=1)
+        multiple_calls = self.start_date_time.month != end_date.month
 
         params = {
             "schema": "org1234567",
             "provider_type": Provider.PROVIDER_AWS,
-            "start_date": start_date.date().strftime("%Y-%m-%d"),
-            "end_date": end_date.date().strftime("%Y-%m-%d"),
+            "start_date": self.start_date,
+            "end_date": end_date.strftime("%Y-%m-%d"),
         }
         expected_key = "Report Data Task IDs"
         expected_calls = [
@@ -325,8 +325,7 @@ class ReportDataTests(TestCase):
     @patch("masu.api.report_data.update_all_summary_tables")
     def test_get_report_data_for_all_providers_dev_true(self, mock_update, _):
         """Test GET report_data endpoint with provider_uuid=*."""
-        start_date = DateHelper().today.date().strftime("%Y-%m-%d")
-        params = {"provider_uuid": "*", "start_date": start_date}
+        params = {"provider_uuid": "*", "start_date": self.start_date}
         expected_key = "Report Data Task IDs"
 
         response = self.client.get(reverse("report_data"), params)
@@ -343,8 +342,7 @@ class ReportDataTests(TestCase):
     @patch("masu.api.report_data.update_all_summary_tables")
     def test_get_report_data_for_all_providers_dev_false(self, mock_update, _):
         """Test GET report_data endpoint with provider_uuid=*."""
-        start_date = DateHelper().today.date().strftime("%Y-%m-%d")
-        params = {"provider_uuid": "*", "start_date": start_date}
+        params = {"provider_uuid": "*", "start_date": self.start_date}
         response = self.client.get(reverse("report_data"), params)
         self.assertEqual(response.status_code, 400)
 
@@ -476,10 +474,9 @@ class ReportDataTests(TestCase):
         """Test the GET report_data endpoint."""
         provider_type = Provider.PROVIDER_AWS
         mock_accessor.return_value.__enter__.return_value.get_type.return_value = provider_type
-        start_date = DateHelper().today.date().strftime("%Y-%m-%d")
         params = {
             "schema": "org1234567",
-            "start_date": start_date,
+            "start_date": self.start_date,
             "provider_uuid": "6e212746-484a-40cd-bba0-09a19d132d64",
             "ocp_on_cloud": "false",
         }
@@ -499,4 +496,35 @@ class ReportDataTests(TestCase):
             queue_name=PRIORITY_QUEUE,
             ocp_on_cloud=False,
             invoice_month=None,
+        )
+
+    @patch("koku.middleware.MASU", return_value=True)
+    @patch("masu.api.report_data.ProviderDBAccessor")
+    @patch("masu.api.report_data.update_summary_tables")
+    def test_get_report_data_gcp(self, mock_update, mock_accessor, _):
+        """Test the GET report_data endpoint."""
+        provider_type = Provider.PROVIDER_GCP
+        mock_accessor.return_value.__enter__.return_value.get_type.return_value = provider_type
+        params = {
+            "schema": "org1234567",
+            "start_date": self.start_date,
+            "provider_uuid": "6e212746-484a-40cd-bba0-09a19d132d64",
+            "ocp_on_cloud": "false",
+        }
+        expected_key = "Report Data Task IDs"
+
+        response = self.client.get(reverse("report_data"), params)
+        body = response.json()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(expected_key, body)
+        mock_update.s.assert_called_with(
+            params["schema"],
+            provider_type,
+            params["provider_uuid"],
+            params["start_date"],
+            DateHelper().today.date().strftime("%Y-%m-%d"),
+            queue_name=PRIORITY_QUEUE,
+            ocp_on_cloud=False,
+            invoice_month=self.invoice,
         )

--- a/koku/masu/test/database/test_gcp_report_db_accessor.py
+++ b/koku/masu/test/database/test_gcp_report_db_accessor.py
@@ -294,11 +294,9 @@ class GCPReportDBAccessorTest(MasuTestCase):
         dh = DateHelper()
         start_date = dh.this_month_start.date()
         end_date = dh.this_month_end.date()
-        invoice_month = dh.gcp_find_invoice_months_in_date_range(start_date, end_date)[0]
-        invoice_month_date = dh.invoice_month_start(invoice_month)
 
         self.accessor.get_openshift_on_cloud_matched_tags_trino(
-            self.gcp_provider_uuid, self.ocp_provider_uuid, start_date, end_date, invoice_month_date
+            self.gcp_provider_uuid, self.ocp_provider_uuid, start_date, end_date
         )
         mock_presto.assert_called()
 

--- a/koku/masu/test/database/test_gcp_report_db_accessor.py
+++ b/koku/masu/test/database/test_gcp_report_db_accessor.py
@@ -294,9 +294,11 @@ class GCPReportDBAccessorTest(MasuTestCase):
         dh = DateHelper()
         start_date = dh.this_month_start.date()
         end_date = dh.this_month_end.date()
+        invoice_month = dh.gcp_find_invoice_months_in_date_range(start_date, end_date)[0]
+        invoice_month_date = dh.invoice_month_start(invoice_month)
 
         self.accessor.get_openshift_on_cloud_matched_tags_trino(
-            self.gcp_provider_uuid, self.ocp_provider_uuid, start_date, end_date
+            self.gcp_provider_uuid, self.ocp_provider_uuid, start_date, end_date, invoice_month_date
         )
         mock_presto.assert_called()
 

--- a/koku/masu/test/database/test_gcp_report_db_accessor.py
+++ b/koku/masu/test/database/test_gcp_report_db_accessor.py
@@ -170,6 +170,8 @@ class GCPReportDBAccessorTest(MasuTestCase):
         dh = DateHelper()
         start_date = dh.this_month_start.date()
         end_date = dh.this_month_end.date()
+        invoice_month = dh.gcp_find_invoice_months_in_date_range(start_date, end_date)[0]
+        invoice_month_date = dh.invoice_month_start(invoice_month)
 
         bills = self.accessor.get_cost_entry_bills_query_by_provider(self.gcp_provider.uuid)
         with schema_context(self.schema):
@@ -180,7 +182,7 @@ class GCPReportDBAccessorTest(MasuTestCase):
             markup_value = float(markup.get("value", 0)) / 100
 
         self.accessor.populate_line_item_daily_summary_table_presto(
-            start_date, end_date, self.gcp_provider_uuid, current_bill_id, markup_value
+            start_date, end_date, self.gcp_provider_uuid, current_bill_id, markup_value, invoice_month_date
         )
         mock_presto.assert_called()
 
@@ -292,9 +294,11 @@ class GCPReportDBAccessorTest(MasuTestCase):
         dh = DateHelper()
         start_date = dh.this_month_start.date()
         end_date = dh.this_month_end.date()
+        invoice_month = dh.gcp_find_invoice_months_in_date_range(start_date, end_date)[0]
+        invoice_month_date = dh.invoice_month_start(invoice_month)
 
         self.accessor.get_openshift_on_cloud_matched_tags_trino(
-            self.gcp_provider_uuid, self.ocp_provider_uuid, start_date, end_date
+            self.gcp_provider_uuid, self.ocp_provider_uuid, start_date, end_date, invoice_month_date
         )
         mock_presto.assert_called()
 
@@ -329,7 +333,9 @@ class GCPReportDBAccessorTest(MasuTestCase):
         dh = DateHelper()
         start_date = dh.this_month_start
         end_date = dh.this_month_end
-        self.accessor.populate_gcp_topology_information_tables(self.gcp_provider, start_date, end_date)
+        invoice_month = dh.gcp_find_invoice_months_in_date_range(start_date, end_date)[0]
+        invoice_month_date = dh.invoice_month_start(invoice_month)
+        self.accessor.populate_gcp_topology_information_tables(self.gcp_provider, start_date, end_date, invoice_month_date)
 
         with schema_context(self.schema):
             records = GCPTopology.objects.all()
@@ -343,7 +349,9 @@ class GCPReportDBAccessorTest(MasuTestCase):
         dh = DateHelper()
         start_date = dh.this_month_start
         end_date = dh.this_month_end
-        self.accessor.get_gcp_topology_trino(self.gcp_provider_uuid, start_date, end_date)
+        invoice_month = dh.gcp_find_invoice_months_in_date_range(start_date, end_date)[0]
+        invoice_month_date = dh.invoice_month_start(invoice_month)
+        self.accessor.get_gcp_topology_trino(self.gcp_provider_uuid, start_date, end_date, invoice_month_date)
 
         mock_trino.assert_called()
 

--- a/koku/masu/test/database/test_gcp_report_db_accessor.py
+++ b/koku/masu/test/database/test_gcp_report_db_accessor.py
@@ -335,7 +335,9 @@ class GCPReportDBAccessorTest(MasuTestCase):
         end_date = dh.this_month_end
         invoice_month = dh.gcp_find_invoice_months_in_date_range(start_date, end_date)[0]
         invoice_month_date = dh.invoice_month_start(invoice_month)
-        self.accessor.populate_gcp_topology_information_tables(self.gcp_provider, start_date, end_date, invoice_month_date)
+        self.accessor.populate_gcp_topology_information_tables(
+            self.gcp_provider, start_date, end_date, invoice_month_date
+        )
 
         with schema_context(self.schema):
             records = GCPTopology.objects.all()

--- a/koku/masu/test/external/downloader/gcp/test_gcp_report_downloader.py
+++ b/koku/masu/test/external/downloader/gcp/test_gcp_report_downloader.py
@@ -222,7 +222,7 @@ class GCPReportDownloaderTest(MasuTestCase):
         daily_file_names, date_range = create_daily_archives(
             "request_id", "account", self.gcp_provider_uuid, file_name, temp_path, None, start_date, None
         )
-        expected_date_range = {"start": "2020-11-08", "end": "2020-11-11"}
+        expected_date_range = {"start": "2020-11-08", "end": "2020-11-11", "invoice": "202011"}
         self.assertEqual(date_range, expected_date_range)
         self.assertIsInstance(daily_file_names, list)
 

--- a/koku/masu/test/external/downloader/gcp/test_gcp_report_downloader.py
+++ b/koku/masu/test/external/downloader/gcp/test_gcp_report_downloader.py
@@ -222,7 +222,7 @@ class GCPReportDownloaderTest(MasuTestCase):
         daily_file_names, date_range = create_daily_archives(
             "request_id", "account", self.gcp_provider_uuid, file_name, temp_path, None, start_date, None
         )
-        expected_date_range = {"start": "2020-11-08", "end": "2020-11-11", "invoice": "202011"}
+        expected_date_range = {"start": "2020-11-08", "end": "2020-11-11", "invoice_month": "202011"}
         self.assertEqual(date_range, expected_date_range)
         self.assertIsInstance(daily_file_names, list)
 

--- a/koku/masu/test/processor/gcp/test_gcp_report_parquet_summary_updater.py
+++ b/koku/masu/test/processor/gcp/test_gcp_report_parquet_summary_updater.py
@@ -126,6 +126,35 @@ class GCPReportParquetSummaryUpdaterTest(MasuTestCase):
         self.assertEqual(start_return, start)
         self.assertEqual(end_return, end)
 
+    @patch(
+        "masu.processor.gcp.gcp_report_parquet_summary_updater.GCPReportDBAccessor.populate_gcp_topology_information_tables"  # noqa: E501
+    )
+    @patch(
+        "masu.processor.gcp.gcp_report_parquet_summary_updater.GCPReportDBAccessor.delete_line_item_daily_summary_entries_for_date_range_raw"  # noqa: E501
+    )
+    @patch(
+        "masu.processor.gcp.gcp_report_parquet_summary_updater.GCPReportDBAccessor.update_line_item_daily_summary_with_enabled_tags"  # noqa: E501
+    )
+    @patch("masu.processor.gcp.gcp_report_parquet_summary_updater.GCPReportDBAccessor.populate_tags_summary_table")
+    @patch(
+        "masu.processor.gcp.gcp_report_parquet_summary_updater.GCPReportDBAccessor.populate_line_item_daily_summary_table_presto"  # noqa: E501
+    )
+    def test_update_daily_summary_tables_no_invoice_month(
+        self, mock_presto, mock_tag_update, mock_summary_update, mock_delete, mock_topo
+    ):
+        """Test that we run Presto summary."""
+        start_str = self.dh.this_month_start.isoformat()
+        end_str = self.dh.this_month_end.isoformat()
+        start, end = self.updater._get_sql_inputs(start_str, end_str)
+        start_return, end_return = self.updater.update_summary_tables(start, end, invoice_month=None)
+        mock_delete.assert_not_called()
+        mock_presto.assert_not_called()
+        mock_tag_update.assert_not_called()
+        mock_summary_update.assert_not_called()
+
+        self.assertEqual(start_return, start)
+        self.assertEqual(end_return, end)
+
     def test_determine_if_full_summary_update_needed_false(self):
         """
         Test that false is return if the manifest is already present in the db.

--- a/koku/masu/test/processor/gcp/test_gcp_report_parquet_summary_updater.py
+++ b/koku/masu/test/processor/gcp/test_gcp_report_parquet_summary_updater.py
@@ -65,6 +65,7 @@ class GCPReportParquetSummaryUpdaterTest(MasuTestCase):
         start_str = self.dh.this_month_start.isoformat()
         end_str = self.dh.this_month_end.isoformat()
         expected_start, expected_end = self.updater._get_sql_inputs(start_str, end_str)
+        invoice_month = self.dh.gcp_find_invoice_months_in_date_range(expected_start, expected_end)
 
         expected_log = (
             "INFO:masu.processor.gcp.gcp_report_parquet_summary_updater:"
@@ -72,7 +73,7 @@ class GCPReportParquetSummaryUpdaterTest(MasuTestCase):
         )
 
         with self.assertLogs("masu.processor.gcp.gcp_report_parquet_summary_updater", level="INFO") as logger:
-            start, end = self.updater.update_daily_tables(start_str, end_str)
+            start, end = self.updater.update_daily_tables(start_str, end_str, invoice_month)
             self.assertIn(expected_log, logger.output)
         self.assertEqual(start, expected_start)
         self.assertEqual(end, expected_end)
@@ -97,6 +98,7 @@ class GCPReportParquetSummaryUpdaterTest(MasuTestCase):
         start_str = self.dh.this_month_start.isoformat()
         end_str = self.dh.this_month_end.isoformat()
         start, end = self.updater._get_sql_inputs(start_str, end_str)
+        invoice_month = self.dh.gcp_find_invoice_months_in_date_range(start, end)
 
         for s, e in date_range_pair(start, end, step=settings.TRINO_DATE_STEP):
             expected_start, expected_end = s, e
@@ -111,12 +113,12 @@ class GCPReportParquetSummaryUpdaterTest(MasuTestCase):
             markup = cost_model_accessor.markup
             markup_value = float(markup.get("value", 0)) / 100
 
-        start_return, end_return = self.updater.update_summary_tables(start, end)
+        start_return, end_return = self.updater.update_summary_tables(start, end, invoice_month[0])
         mock_delete.assert_called_with(
             self.gcp_provider.uuid, expected_start, expected_end, {"cost_entry_bill_id": current_bill_id}
         )
         mock_presto.assert_called_with(
-            expected_start, expected_end, self.gcp_provider.uuid, current_bill_id, markup_value
+            expected_start, expected_end, self.gcp_provider.uuid, current_bill_id, markup_value, start
         )
         mock_tag_update.assert_called_with(bill_ids, start, end)
         mock_summary_update.assert_called_with(start, end, bill_ids)

--- a/koku/masu/test/processor/gcp/test_gcp_report_summary_updater.py
+++ b/koku/masu/test/processor/gcp/test_gcp_report_summary_updater.py
@@ -6,6 +6,7 @@
 import datetime
 from unittest.mock import patch
 
+from api.utils import DateHelper
 from masu.database import GCP_REPORT_TABLE_MAP
 from masu.database.gcp_report_db_accessor import GCPReportDBAccessor
 from masu.database.report_manifest_db_accessor import ReportManifestDBAccessor
@@ -55,6 +56,8 @@ class GCPReportSummaryUpdaterTest(MasuTestCase):
         start_date = self.date_accessor.today_with_timezone("UTC")
         end_date = start_date + datetime.timedelta(days=1)
         bill_date = start_date.replace(day=1).date()
+        dh = DateHelper()
+        invoice_month = dh.gcp_find_invoice_months_in_date_range(start_date, end_date)
 
         with GCPReportDBAccessor(self.schema) as accessor:
             bill = accessor.get_cost_entry_bills_by_date(bill_date)[0]
@@ -67,7 +70,7 @@ class GCPReportSummaryUpdaterTest(MasuTestCase):
         expected_start_date = start_date.date()
         expected_end_date = end_date.date()
 
-        self.updater.update_daily_tables(start_date_str, end_date_str)
+        self.updater.update_daily_tables(start_date_str, end_date_str, invoice_month)
         mock_daily.assert_called_with(expected_start_date, expected_end_date, [str(bill.id)])
         mock_summary.assert_not_called()
 

--- a/koku/masu/test/processor/gcp/test_gcp_report_summary_updater.py
+++ b/koku/masu/test/processor/gcp/test_gcp_report_summary_updater.py
@@ -10,7 +10,6 @@ from masu.database import GCP_REPORT_TABLE_MAP
 from masu.database.gcp_report_db_accessor import GCPReportDBAccessor
 from masu.database.report_manifest_db_accessor import ReportManifestDBAccessor
 from masu.external.date_accessor import DateAccessor
-from api.utils import DateHelper
 from masu.processor.gcp.gcp_report_summary_updater import GCPReportSummaryUpdater
 from masu.test import MasuTestCase
 from masu.test.database.helpers import ReportObjectCreator

--- a/koku/masu/test/processor/gcp/test_gcp_report_summary_updater.py
+++ b/koku/masu/test/processor/gcp/test_gcp_report_summary_updater.py
@@ -10,6 +10,7 @@ from masu.database import GCP_REPORT_TABLE_MAP
 from masu.database.gcp_report_db_accessor import GCPReportDBAccessor
 from masu.database.report_manifest_db_accessor import ReportManifestDBAccessor
 from masu.external.date_accessor import DateAccessor
+from api.utils import DateHelper
 from masu.processor.gcp.gcp_report_summary_updater import GCPReportSummaryUpdater
 from masu.test import MasuTestCase
 from masu.test.database.helpers import ReportObjectCreator

--- a/koku/masu/test/processor/test_tasks.py
+++ b/koku/masu/test/processor/test_tasks.py
@@ -364,7 +364,7 @@ class ProcessReportFileTests(MasuTestCase):
                 report_meta["start"] = str(DateHelper().yesterday)
                 report_meta["end"] = str(DateHelper().today)
                 if provider_dict.get("type") == Provider.PROVIDER_GCP:
-                    report_meta["invoice"] = invoice_month
+                    report_meta["invoice_month"] = invoice_month
 
                 # add a report with start/end dates specified
                 report2_meta = {}
@@ -376,7 +376,7 @@ class ProcessReportFileTests(MasuTestCase):
                 report2_meta["start"] = str(DateHelper().yesterday)
                 report2_meta["end"] = str(DateHelper().today)
                 if provider_dict.get("type") == Provider.PROVIDER_GCP:
-                    report_meta["invoice"] = invoice_month
+                    report_meta["invoice_month"] = invoice_month
 
                 reports_to_summarize = [report_meta, report2_meta]
 

--- a/koku/masu/test/processor/test_tasks.py
+++ b/koku/masu/test/processor/test_tasks.py
@@ -345,31 +345,43 @@ class ProcessReportFileTests(MasuTestCase):
     @patch("masu.processor.tasks.update_summary_tables")
     def test_summarize_reports_processing_list(self, mock_update_summary):
         """Test that the summarize_reports task is called when a processing list is provided."""
-        mock_update_summary.s = Mock()
+        providers = [
+            {"type": Provider.PROVIDER_OCP, "uuid": self.ocp_test_provider_uuid},
+            {"type": Provider.PROVIDER_GCP, "uuid": self.gcp_test_provider_uuid},
+        ]
+        for provider_dict in providers:
+            invoice_month = DateHelper().gcp_find_invoice_months_in_date_range(
+                DateHelper().yesterday, DateHelper().today
+            )[0]
+            with self.subTest(provider_dict=provider_dict):
+                mock_update_summary.s = Mock()
+                report_meta = {}
+                report_meta["start_date"] = str(DateHelper().today)
+                report_meta["schema_name"] = self.schema
+                report_meta["provider_type"] = Provider.PROVIDER_OCP
+                report_meta["provider_uuid"] = self.ocp_test_provider_uuid
+                report_meta["manifest_id"] = 1
+                report_meta["start"] = str(DateHelper().yesterday)
+                report_meta["end"] = str(DateHelper().today)
+                if provider_dict.get("type") == Provider.PROVIDER_GCP:
+                    report_meta["invoice"] = invoice_month
 
-        report_meta = {}
-        report_meta["start_date"] = str(DateHelper().today)
-        report_meta["schema_name"] = self.schema
-        report_meta["provider_type"] = Provider.PROVIDER_OCP
-        report_meta["provider_uuid"] = self.ocp_test_provider_uuid
-        report_meta["manifest_id"] = 1
-        report_meta["start"] = str(DateHelper().yesterday)
-        report_meta["end"] = str(DateHelper().today)
+                # add a report with start/end dates specified
+                report2_meta = {}
+                report2_meta["start_date"] = str(DateHelper().today)
+                report2_meta["schema_name"] = self.schema
+                report2_meta["provider_type"] = Provider.PROVIDER_OCP
+                report2_meta["provider_uuid"] = self.ocp_test_provider_uuid
+                report2_meta["manifest_id"] = 2
+                report2_meta["start"] = str(DateHelper().yesterday)
+                report2_meta["end"] = str(DateHelper().today)
+                if provider_dict.get("type") == Provider.PROVIDER_GCP:
+                    report_meta["invoice"] = invoice_month
 
-        # add a report with start/end dates specified
-        report2_meta = {}
-        report2_meta["start_date"] = str(DateHelper().today)
-        report2_meta["schema_name"] = self.schema
-        report2_meta["provider_type"] = Provider.PROVIDER_OCP
-        report2_meta["provider_uuid"] = self.ocp_test_provider_uuid
-        report2_meta["manifest_id"] = 2
-        report2_meta["start"] = str(DateHelper().yesterday)
-        report2_meta["end"] = str(DateHelper().today)
+                reports_to_summarize = [report_meta, report2_meta]
 
-        reports_to_summarize = [report_meta, report2_meta]
-
-        summarize_reports(reports_to_summarize)
-        mock_update_summary.s.assert_called()
+                summarize_reports(reports_to_summarize)
+                mock_update_summary.s.assert_called()
 
     @patch("masu.processor.tasks.update_summary_tables")
     def test_summarize_reports_processing_list_with_none(self, mock_update_summary):
@@ -639,6 +651,43 @@ class TestUpdateSummaryTablesTask(MasuTestCase):
                 self.schema,
                 provider,
                 provider_uuid=provider_aws_uuid,
+                manifest_list=[manifest_id],
+                tracing_id=tracing_id,
+            ).set(queue=MARK_MANIFEST_COMPLETE_QUEUE)
+        )
+
+    @patch("masu.processor.tasks.enable_trino_processing", return_value=True)
+    @patch("masu.processor.tasks.chain")
+    @patch("masu.processor.tasks.CostModelDBAccessor")
+    def test_update_summary_tables_remove_expired_data_gcp(self, mock_accessor, mock_chain, _):
+        # COST-444: We use start & end date based off manifest
+        provider = Provider.PROVIDER_GCP
+        start_date = DateHelper().last_month_start - relativedelta.relativedelta(months=1)
+        end_date = DateHelper().today
+        manifest_id = 1
+        tracing_id = "1234"
+
+        invoice_month = DateHelper().gcp_find_invoice_months_in_date_range(start_date, end_date)[0]
+        update_summary_tables(
+            self.schema,
+            provider,
+            self.gcp_provider_uuid,
+            start_date,
+            end_date,
+            manifest_id,
+            tracing_id=tracing_id,
+            synchronous=True,
+            invoice_month=invoice_month,
+        )
+        mock_chain.assert_called
+        mock_chain.assert_called_once_with(
+            update_cost_model_costs.s(self.schema, self.gcp_provider_uuid, ANY, ANY, tracing_id=tracing_id).set(
+                queue=UPDATE_COST_MODEL_COSTS_QUEUE
+            )
+            | mark_manifest_complete.si(
+                self.schema,
+                provider,
+                provider_uuid=self.gcp_provider_uuid,
                 manifest_list=[manifest_id],
                 tracing_id=tracing_id,
             ).set(queue=MARK_MANIFEST_COMPLETE_QUEUE)

--- a/koku/masu/test/util/gcp/test_common.py
+++ b/koku/masu/test/util/gcp/test_common.py
@@ -306,3 +306,70 @@ class TestGCPUtils(MasuTestCase):
         # if we have an empty data frame, we should get one back
         empty_df = pd.DataFrame()
         self.assertTrue(utils.gcp_generate_daily_data(empty_df).empty)
+
+    def test_deduplicate_reports_for_gcp(self):
+        """Test the deduplication of reports for gcp."""
+        expected_results_dict = {
+            "202207": {"start": "2022-07-01", "end": "2022-07-21"},
+            "202208": {"start": "2022-07-31", "end": "2022-08-30"},
+        }
+        mocked_reports = [
+            {
+                "schema_name": "org1234567",
+                "provider_type": "GCP",
+                "provider_uuid": "1we",
+                "manifest_id": 1,
+                "tracing_id": "2022-07-20|2022-07-21 02:40:55.848000+00:00",
+                "start": "2022-07-01",
+                "end": "2022-07-04",
+                "invoice": "202207",
+            },
+            {
+                "schema_name": "org1234567",
+                "provider_type": "GCP",
+                "provider_uuid": "1we",
+                "manifest_id": 1,
+                "tracing_id": "2022-07-20|2022-07-21 02:40:55.848000+00:00",
+                "start": "2022-07-19",
+                "end": "2022-07-20",
+                "invoice": "202207",
+            },
+            {
+                "schema_name": "org1234567",
+                "provider_type": "GCP",
+                "provider_uuid": "1we",
+                "manifest_id": 1,
+                "tracing_id": "2022-07-20|2022-07-21 02:40:55.848000+00:00",
+                "start": "2022-07-19",
+                "end": "2022-07-21",
+                "invoice": "202207",
+            },
+            {
+                "schema_name": "org1234567",
+                "provider_type": "GCP",
+                "provider_uuid": "1we",
+                "manifest_id": 2,
+                "tracing_id": "2022-08-01|2022-08-02 01:11:12.066000+00:00",
+                "start": "2022-07-31",
+                "end": "2022-08-01",
+                "invoice": "202208",
+            },
+            {
+                "schema_name": "org1234567",
+                "provider_type": "GCP",
+                "provider_uuid": "1we",
+                "manifest_id": 3,
+                "tracing_id": "2022-08-03|2022-08-04 01:43:05.921000+00:00",
+                "start": "2022-08-23",
+                "end": "2022-08-30",
+                "invoice": "202208",
+            },
+        ]
+        results = utils.deduplicate_reports_for_gcp(mocked_reports)
+        self.assertEqual(len(results), 2)
+        for result in results:
+            result_invoice = result.get("invoice_month")
+            expected_dates = expected_results_dict.get(result_invoice)
+            self.assertIsNotNone(expected_dates)
+            self.assertEqual(expected_dates.get("start"), result.get("start"))
+            self.assertEqual(expected_dates.get("end"), result.get("end"))

--- a/koku/masu/test/util/gcp/test_common.py
+++ b/koku/masu/test/util/gcp/test_common.py
@@ -322,7 +322,7 @@ class TestGCPUtils(MasuTestCase):
                 "tracing_id": "2022-07-20|2022-07-21 02:40:55.848000+00:00",
                 "start": "2022-07-01",
                 "end": "2022-07-04",
-                "invoice": "202207",
+                "invoice_month": "202207",
             },
             {
                 "schema_name": "org1234567",
@@ -332,7 +332,7 @@ class TestGCPUtils(MasuTestCase):
                 "tracing_id": "2022-07-20|2022-07-21 02:40:55.848000+00:00",
                 "start": "2022-07-19",
                 "end": "2022-07-20",
-                "invoice": "202207",
+                "invoice_month": "202207",
             },
             {
                 "schema_name": "org1234567",
@@ -342,7 +342,7 @@ class TestGCPUtils(MasuTestCase):
                 "tracing_id": "2022-07-20|2022-07-21 02:40:55.848000+00:00",
                 "start": "2022-07-19",
                 "end": "2022-07-21",
-                "invoice": "202207",
+                "invoice_month": "202207",
             },
             {
                 "schema_name": "org1234567",
@@ -352,7 +352,7 @@ class TestGCPUtils(MasuTestCase):
                 "tracing_id": "2022-08-01|2022-08-02 01:11:12.066000+00:00",
                 "start": "2022-07-31",
                 "end": "2022-08-01",
-                "invoice": "202208",
+                "invoice_month": "202208",
             },
             {
                 "schema_name": "org1234567",
@@ -362,7 +362,7 @@ class TestGCPUtils(MasuTestCase):
                 "tracing_id": "2022-08-03|2022-08-04 01:43:05.921000+00:00",
                 "start": "2022-08-23",
                 "end": "2022-08-30",
-                "invoice": "202208",
+                "invoice_month": "202208",
             },
         ]
         results = utils.deduplicate_reports_for_gcp(mocked_reports)

--- a/koku/masu/util/gcp/common.py
+++ b/koku/masu/util/gcp/common.py
@@ -252,7 +252,7 @@ def deduplicate_reports_for_gcp(report_list):
     """Deduplicate the reports using the invoice."""
     invoice_dict = {}
     for report in report_list:
-        invoice = report.get("invoice")
+        invoice = report.get("invoice_month")
         start_key = invoice + "_start"
         end_key = invoice + "_end"
         if not invoice_dict.get(start_key) or not invoice_dict.get(end_key):

--- a/koku/masu/util/gcp/common.py
+++ b/koku/masu/util/gcp/common.py
@@ -246,3 +246,46 @@ def match_openshift_resources_and_labels(data_frame, cluster_topology, matched_t
     )
 
     return openshift_matched_data_frame
+
+
+def deduplicate_reports_for_gcp(report_list):
+    """Deduplicate the reports using the invoice."""
+    invoice_dict = {}
+    for report in report_list:
+        invoice = report.get("invoice")
+        start_key = invoice + "_start"
+        end_key = invoice + "_end"
+        if not invoice_dict.get(start_key) or not invoice_dict.get(end_key):
+            invoice_dict[start_key] = [report.get("start")]
+            invoice_dict[end_key] = [report.get("end")]
+        else:
+            invoice_dict[start_key].append(report.get("start"))
+            invoice_dict[end_key].append(report.get("end"))
+
+    restructure_dict = {}
+    reports_deduplicated = []
+    for invoice_key, date_list in invoice_dict.items():
+        invoice_month, date_term = invoice_key.split("_")
+        if date_term == "start":
+            date_agg = min(date_list)
+        else:
+            date_agg = max(date_list)
+        if restructure_dict.get(invoice_month):
+            restructure_dict[invoice_month][date_term] = date_agg
+        else:
+            restructure_dict[invoice_month] = {date_term: date_agg}
+
+    for invoice_month, date_dict in restructure_dict.items():
+        reports_deduplicated.append(
+            {
+                "manifest_id": report.get("manifest_id"),
+                "tracing_id": report.get("tracing_id"),
+                "schema_name": report.get("schema_name"),
+                "provider_type": report.get("provider_type"),
+                "provider_uuid": report.get("provider_uuid"),
+                "start": date_dict.get("start"),
+                "end": date_dict.get("end"),
+                "invoice_month": invoice_month,
+            }
+        )
+    return reports_deduplicated


### PR DESCRIPTION
## Jira Ticket

[COST-2892](https://issues.redhat.com/browse/COST-2892)

## Description 

Add GCP invoice month to summary tasks. This is because we miss month bound crossover data when running summary via standard dates. With this change we can pass in start/ends past a month boundary with the inclusion of invoice month so the full billed month is summarised rather than just a date range. 

## Testing

1. Checkout Branch
2. Restart Koku
3. Add real GCP data
4. Verify all the numbers add up correctly per month

## Notes

...
