### PR TITLE
prevent InterfaceError double alerting

### DIFF
--- a/koku/masu/external/kafka_msg_handler.py
+++ b/koku/masu/external/kafka_msg_handler.py
@@ -434,7 +434,7 @@ def handle_message(kmsg):
     except (OperationalError, InterfaceError) as error:
         close_and_set_db_connection()
         msg = f"Unable to extract payload, db closed. {type(error).__name__}: {error}"
-        LOG.error(log_json(request_id, msg, context))
+        LOG.warning(log_json(request_id, msg, context))
         raise KafkaMsgHandlerError(msg) from error
     except Exception as error:  # noqa
         traceback.print_exc()


### PR DESCRIPTION
## Description

The raised `KafkaMsgHandlerError` following the log message which was updated in this PR causes a logged error [here](https://github.com/project-koku/koku/blob/main/koku/masu/external/kafka_msg_handler.py#L743). This PR converts one of the logged errors to a warning to prevent double alerting.

