### PR TITLE
Adding the ability to disable a specific schema from processing

### DIFF
--- a/.unleash/flags.json
+++ b/.unleash/flags.json
@@ -56,6 +56,25 @@
             "createdAt": "2022-08-12T21:22:00.756Z"
         },
         {
+            "name": "disable_cloud_source_processing",
+            "description": "Toggle to disable source processing for account.",
+            "type": "permission",
+            "project": "default",
+            "enabled": true,
+            "stale": false,
+            "strategies": [
+                {
+                    "name": "schema-strategy",
+                    "parameters": {
+                        "schema-name": ""
+                    },
+                    "constraints": []
+                }
+            ],
+            "variants": [],
+            "createdAt": "2022-08-20T19:50:00.756Z"
+        },
+        {
             "name": "hcs-data-processor",
             "description": "any account listed in this strategy will be allowed to generate HCS report data",
             "type": "permission",

--- a/koku/masu/processor/__init__.py
+++ b/koku/masu/processor/__init__.py
@@ -40,3 +40,15 @@ def enable_purge_trino_files(account):
     context = {"schema": account}
     LOG.info(f"enable_purge_trino_files context: {context}")
     return bool(UNLEASH_CLIENT.is_enabled("enable-purge-turnpike", context))
+
+
+def disable_cloud_source_processing(account):
+    if account and not account.startswith("acct") and not account.startswith("org"):
+        account = f"acct{account}"
+
+    context = {"schema": account}
+    LOG.info(f"Processing UNLEASH check: {context}")
+    res = bool(UNLEASH_CLIENT.is_enabled("disable_cloud_source_processing", context))
+    LOG.info(f"    Processing {'disabled' if res else 'enabled'}")
+
+    return res

--- a/koku/masu/processor/orchestrator.py
+++ b/koku/masu/processor/orchestrator.py
@@ -91,7 +91,8 @@ class Orchestrator:
 
         for account in all_accounts:
             if disable_cloud_source_processing(account.get("schema_name")):
-                LOG.info("Cloud source processing disabled for {account}")
+                LOG.info(f"Cloud source processing disabled for {account.get('schema_name')}")
+                continue
             else:
                 if AccountsAccessor().is_polling_account(account):
                     polling_accounts.append(account)

--- a/koku/masu/processor/orchestrator.py
+++ b/koku/masu/processor/orchestrator.py
@@ -21,6 +21,7 @@ from masu.external.accounts_accessor import AccountsAccessorError
 from masu.external.date_accessor import DateAccessor
 from masu.external.report_downloader import ReportDownloader
 from masu.external.report_downloader import ReportDownloaderError
+from masu.processor import disable_cloud_source_processing
 from masu.processor.tasks import get_report_files
 from masu.processor.tasks import GET_REPORT_FILES_QUEUE
 from masu.processor.tasks import record_all_manifest_files
@@ -89,8 +90,11 @@ class Orchestrator:
                     all_accounts = [account]
 
         for account in all_accounts:
-            if AccountsAccessor().is_polling_account(account):
-                polling_accounts.append(account)
+            if disable_cloud_source_processing(account.get("schema_name")):
+                LOG.info("Cloud source processing disabled for {account}")
+            else:
+                if AccountsAccessor().is_polling_account(account):
+                    polling_accounts.append(account)
 
         return all_accounts, polling_accounts
 

--- a/koku/masu/processor/orchestrator.py
+++ b/koku/masu/processor/orchestrator.py
@@ -90,7 +90,7 @@ class Orchestrator:
                     all_accounts = [account]
 
         for account in all_accounts:
-            if disable_cloud_source_processing(account.get("schema_name")):
+            if disable_cloud_source_processing(account.get("schema_name")) and not provider_uuid:
                 LOG.info(f"Cloud source processing disabled for {account.get('schema_name')}")
                 continue
             else:

--- a/koku/masu/test/processor/test_orchestrator.py
+++ b/koku/masu/test/processor/test_orchestrator.py
@@ -147,6 +147,19 @@ class OrchestratorTest(MasuTestCase):
         mock_account_labler.assert_not_called()
 
     @patch("masu.processor.worker_cache.CELERY_INSPECT")
+    @patch(
+        "masu.processor.orchestrator.disable_cloud_source_processing",
+        return_value=True,
+    )
+    def test_unleash_disable_cloud_source_processing(self, mock_processing, mock_inspect):
+        """Test the disable_cloud_source_processing."""
+        expected_result = "Cloud source processing disabled for "
+        orchestrator = Orchestrator()
+        with self.assertLogs("masu.processor.orchestrator", level="INFO") as captured_logs:
+            orchestrator.get_accounts()
+            self.assertIn(expected_result, captured_logs.output[0])
+
+    @patch("masu.processor.worker_cache.CELERY_INSPECT")
     @patch.object(AccountsAccessor, "get_accounts")
     def test_init_all_accounts(self, mock_accessor, mock_inspect):
         """Test initializing orchestrator with forced billing source."""


### PR DESCRIPTION
## Jira Ticket

[COST-2903](https://issues.redhat.com/browse/COST-2903)

## Description

This change will give the ability to disable a specific schema's cloud sources from scheduling download tasks during polling. Done via unleash.

## Testing

1. Checkout Branch
2. Restart Koku
3. Add schema to disable_cloud_source_processing flag in unleash
4. Add a source under specific schema and see no data is ingested + logs say schema processing is disabled.

## Notes

...
