### PR TITLE
Add time range to the purge turnpike endpoint

### DIFF
--- a/koku/api/test_utils.py
+++ b/koku/api/test_utils.py
@@ -213,6 +213,21 @@ class DateHelperTest(TestCase):
         expected = datetime.time(0, 0, 0, 0)
         self.assertEqual(self.date_helper.midnight, expected)
 
+    def test_list_days_params_as_strings(self):
+        """Test the list_days method."""
+        first = datetime.datetime.now().replace(microsecond=0, second=0, minute=0, hour=0, day=1)
+        second = first.replace(day=2)
+        third = first.replace(day=3)
+        expected = [first, second, third]
+        result = self.date_helper.list_days(str(first), str(third))
+        self.assertEqual(result, expected)
+
+    def test_invoice_month_from_bill_date(self):
+        """Test that we can get the gcp invoice month from bill date."""
+        bill_date_str = "2022-08-01"
+        result_invoice_month = self.date_helper.invoice_month_from_bill_date(bill_date_str)
+        self.assertEqual(str(result_invoice_month), "202208")
+
 
 class APIUtilsUnitConverterTest(TestCase):
     """Tests against the API utils."""

--- a/koku/api/utils.py
+++ b/koku/api/utils.py
@@ -379,6 +379,23 @@ class DateHelper:
         month_start = self.month_start(date_obj)
         return month_start
 
+    def invoice_month_from_bill_date(self, bill_date):
+        """Find the beginning of the month for invoice month.
+
+        Invoice month format is {year}{month}.
+        Ex. 202011
+
+        Args:
+            bill_date: Start of the month for the bill.
+
+        Returns:
+            (datetime.datetime)
+        """
+        if isinstance(bill_date, str):
+            bill_date = ciso8601.parse_datetime(bill_date).replace(tzinfo=pytz.UTC)
+        date_obj = bill_date.strftime("%Y%m")
+        return date_obj
+
     def gcp_find_invoice_months_in_date_range(self, start, end):
         """Finds all the invoice months in a given date range.
 

--- a/koku/api/utils.py
+++ b/koku/api/utils.py
@@ -258,6 +258,10 @@ class DateHelper:
         """
         end_midnight = end_date
         start_midnight = start_date
+        if isinstance(start_date, str):
+            start_midnight = ciso8601.parse_datetime(start_date).replace(tzinfo=pytz.UTC)
+        if isinstance(end_date, str):
+            end_midnight = ciso8601.parse_datetime(end_date).replace(tzinfo=pytz.UTC)
         if isinstance(end_date, datetime.datetime):
             end_midnight = end_date.replace(hour=0, minute=0, second=0, microsecond=0)
         if isinstance(start_date, datetime.datetime):

--- a/koku/api/utils.py
+++ b/koku/api/utils.py
@@ -259,9 +259,9 @@ class DateHelper:
         end_midnight = end_date
         start_midnight = start_date
         if isinstance(start_date, str):
-            start_midnight = ciso8601.parse_datetime(start_date).replace(tzinfo=pytz.UTC)
+            start_midnight = ciso8601.parse_datetime(start_date).replace(hour=0, minute=0, second=0, microsecond=0)
         if isinstance(end_date, str):
-            end_midnight = ciso8601.parse_datetime(end_date).replace(tzinfo=pytz.UTC)
+            end_midnight = ciso8601.parse_datetime(end_date).replace(hour=0, minute=0, second=0, microsecond=0)
         if isinstance(end_date, datetime.datetime):
             end_midnight = end_date.replace(hour=0, minute=0, second=0, microsecond=0)
         if isinstance(start_date, datetime.datetime):

--- a/koku/masu/api/purge_trino_files.py
+++ b/koku/masu/api/purge_trino_files.py
@@ -78,8 +78,8 @@ def purge_trino_files(request):  # noqa: C901
         manifest_id=None,
         context={"start_date": bill_date},
     )
-    invoice_month = str(DateHelper().invoice_month_from_bill_date(bill_date))
     if start_date and end_date:
+        invoice_month = str(DateHelper().invoice_month_from_bill_date(bill_date))
         dates = DateHelper().list_days(start_date, end_date)
         s3_csv_path = []
         s3_parquet_path = []

--- a/koku/masu/api/purge_trino_files.py
+++ b/koku/masu/api/purge_trino_files.py
@@ -67,7 +67,7 @@ def purge_trino_files(request):  # noqa: C901
         return Response({"Error": errmsg}, status=status.HTTP_400_BAD_REQUEST)
 
     start_date = params.get("start_date")
-    end_date = params.get("end_date")
+    end_date = params.get("end_date") if params.get("end_date") else start_date
 
     # Use ParquetReportProcessor to build s3 paths
     pq_processor_object = ParquetReportProcessor(

--- a/koku/masu/api/purge_trino_files.py
+++ b/koku/masu/api/purge_trino_files.py
@@ -78,7 +78,7 @@ def purge_trino_files(request):  # noqa: C901
         manifest_id=None,
         context={"start_date": bill_date},
     )
-    invoice_month = "202208"
+    invoice_month = str(DateHelper().invoice_month_from_bill_date(bill_date))
     if start_date and end_date:
         dates = DateHelper().list_days(start_date, end_date)
         s3_csv_path = []

--- a/koku/masu/celery/tasks.py
+++ b/koku/masu/celery/tasks.py
@@ -108,17 +108,19 @@ def purge_s3_files(prefix, schema_name, provider_type, provider_uuid):
     return remaining_objects
 
 
-def deleted_archived_with_prefix(s3_bucket_name, prefix):
+def deleted_archived_with_prefix(s3_bucket_name, prefix, date_list=None):
     """
     Delete data from archive with given prefix.
 
     Args:
         s3_bucket_name (str): The s3 bucket name
         prefix (str): The prefix for deletion
+        include (list):
     """
     s3_resource = get_s3_resource()
     s3_bucket = s3_resource.Bucket(s3_bucket_name)
     object_keys = [{"Key": s3_object.key} for s3_object in s3_bucket.objects.filter(Prefix=prefix)]
+    LOG.info(f"Starting objects: {object_keys}")
     batch_size = 1000  # AWS S3 delete API limits to 1000 objects per request.
     for batch_number in range(math.ceil(len(object_keys) / batch_size)):
         batch_start = batch_size * batch_number

--- a/koku/masu/celery/tasks.py
+++ b/koku/masu/celery/tasks.py
@@ -108,19 +108,18 @@ def purge_s3_files(prefix, schema_name, provider_type, provider_uuid):
     return remaining_objects
 
 
-def deleted_archived_with_prefix(s3_bucket_name, prefix, date_list=None):
+def deleted_archived_with_prefix(s3_bucket_name, prefix):
     """
     Delete data from archive with given prefix.
 
     Args:
         s3_bucket_name (str): The s3 bucket name
         prefix (str): The prefix for deletion
-        include (list):
     """
     s3_resource = get_s3_resource()
     s3_bucket = s3_resource.Bucket(s3_bucket_name)
     object_keys = [{"Key": s3_object.key} for s3_object in s3_bucket.objects.filter(Prefix=prefix)]
-    LOG.info(f"Starting objects: {object_keys}")
+    LOG.info(f"Starting objects: {len(object_keys)}")
     batch_size = 1000  # AWS S3 delete API limits to 1000 objects per request.
     for batch_number in range(math.ceil(len(object_keys) / batch_size)):
         batch_start = batch_size * batch_number

--- a/koku/masu/test/api/test_purge_trino_files.py
+++ b/koku/masu/test/api/test_purge_trino_files.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 """Test the purge_trino_files endpoint view."""
+from unittest.mock import ANY
 from unittest.mock import patch
 from urllib.parse import urlencode
 
@@ -26,6 +27,17 @@ class FakeManifest:
         manifest = manifest_accessor.add(**manifest_dict)
         return [manifest]
 
+    def get_manifest_list_for_provider_and_date_range(self, provider_uuid, start_date, end_date):
+        manifest_dict = {
+            "assembly_id": "1234",
+            "billing_period_start_datetime": "2020-02-01",
+            "num_total_files": 2,
+            "provider_uuid": provider_uuid,
+        }
+        manifest_accessor = ReportManifestDBAccessor()
+        manifest = manifest_accessor.add(**manifest_dict)
+        return [manifest]
+
     def bulk_delete_manifests(self, provider_uuid, manifest_id_list):
         return True
 
@@ -33,6 +45,12 @@ class FakeManifest:
 @override_settings(ROOT_URLCONF="masu.urls")
 class PurgeTrinoFilesTest(MasuTestCase):
     """Test Cases for the purge_trino_files endpoint."""
+
+    def setUp(self):
+        """Create test case setup."""
+        super().setUp()
+        self.schema = "org1234"
+        self.bill_date = "2022-08-01"
 
     @patch("koku.middleware.MASU", return_value=True)
     def test_require_parameters(self, _):
@@ -114,8 +132,8 @@ class PurgeTrinoFilesTest(MasuTestCase):
         """Test the purge_trino_files endpoint with no parameters."""
         params = {
             "provider_uuid": self.aws_provider_uuid,
-            "schema": "org1234567",
-            "bill_date": "08-01-2022",
+            "schema": self.schema,
+            "bill_date": self.bill_date,
         }
         query_string = urlencode(params)
         url = reverse("purge_trino_files") + "?" + query_string
@@ -131,8 +149,8 @@ class PurgeTrinoFilesTest(MasuTestCase):
         """Test the purge_trino_files endpoint with no parameters."""
         params = {
             "provider_uuid": self.aws_provider_uuid,
-            "schema": "org1234",
-            "bill_date": "08-01-2022",
+            "schema": self.schema,
+            "bill_date": self.bill_date,
         }
         query_string = urlencode(params)
         url = reverse("purge_trino_files") + "?" + query_string
@@ -150,8 +168,8 @@ class PurgeTrinoFilesTest(MasuTestCase):
         """Test the purge_trino_files endpoint with no parameters."""
         params = {
             "provider_uuid": self.aws_provider_uuid,
-            "schema": "org1234",
-            "bill_date": "08-01-2022",
+            "schema": self.schema,
+            "bill_date": self.bill_date,
         }
         query_string = urlencode(params)
         url = reverse("purge_trino_files") + "?" + query_string
@@ -160,6 +178,35 @@ class PurgeTrinoFilesTest(MasuTestCase):
             response = self.client.delete(url)
             body = response.json()
             self.assertEqual(response.status_code, 200)
-            mock_purge.assert_called()
+            mock_purge.assert_called_with(
+                provider_uuid=self.aws_provider_uuid, provider_type="AWS-local", schema_name=self.schema, prefix=ANY
+            )
+            for key in body.keys():
+                self.assertEqual(key, "dc350f15-ffc7-4fcb-92d7-2a9f1275568e")
+
+    @patch("koku.middleware.MASU", return_value=True)
+    @patch(
+        "masu.api.purge_trino_files.purge_s3_files.delay",
+        return_value=AsyncResult("dc350f15-ffc7-4fcb-92d7-2a9f1275568e"),
+    )
+    def test_unleash_delete_request_with_date_range(self, mock_purge, _):
+        """Test the purge_trino_files endpoint with no parameters."""
+        params = {
+            "provider_uuid": self.gcp_provider_uuid,
+            "schema": self.schema,
+            "bill_date": self.bill_date,
+            "start_date": self.bill_date,
+            "end_date": "2022-08-03",
+        }
+        query_string = urlencode(params)
+        url = reverse("purge_trino_files") + "?" + query_string
+        with patch("masu.api.purge_trino_files.ReportManifestDBAccessor") as mock_accessor:
+            mock_accessor.return_value.__enter__.return_value = FakeManifest()
+            response = self.client.delete(url)
+            body = response.json()
+            self.assertEqual(response.status_code, 200)
+            mock_purge.assert_called_with(
+                provider_uuid=self.gcp_provider_uuid, provider_type="GCP-local", schema_name=self.schema, prefix=ANY
+            )
             for key in body.keys():
                 self.assertEqual(key, "dc350f15-ffc7-4fcb-92d7-2a9f1275568e")


### PR DESCRIPTION
## Jira Ticket

None

## Description

Update the purge endpoint to accept a time range. 

## Testing

1. Upload test data from the gcp dev account
2. Hit the endpoint with something like:
- http://127.0.0.1:5042/api/cost-management/v1/purge_trino_files/?provider_uuid=17c2fd30-0059-455a-9e5f-c0d22e29fa89&schema=org1234567&bill_date=2022-07-01&start_date=2022-07-03&end_date=2022-07-06
3. Check to make sure the files disappear in Minio.
4. Check to make sure the manifests for that bill date & partition_dates are removed.
5. Redownload
6. Check the cost in trino & with the `bigquery_cost`

## Notes

...
