### PR TITLE
Fixing timing issue with load dummy data make command

### DIFF
--- a/dev/scripts/load_test_customer_data.sh
+++ b/dev/scripts/load_test_customer_data.sh
@@ -289,8 +289,8 @@ build_gcp_data() {
   render_yaml_files "${_yaml_files[@]}"
 
   log-info "Building OpenShift on ${_source_name} report data..."
-  nise_report gcp --static-report-file "$YAML_PATH/gcp/rendered_gcp_static_data.yml" --gcp-bucket-name "$NISE_DATA_PATH/local_providers/gcp_local"
   nise_report ocp --static-report-file "$YAML_PATH/ocp_on_gcp/rendered_ocp_static_data.yml" --ocp-cluster-id test-ocp-gcp-cluster --insights-upload "$NISE_DATA_PATH/pvc_dir/insights_local"
+  nise_report gcp --static-report-file "$YAML_PATH/gcp/rendered_gcp_static_data.yml" --gcp-bucket-name "$NISE_DATA_PATH/local_providers/gcp_local"
   nise_report gcp --static-report-file "$YAML_PATH/ocp_on_gcp/rendered_gcp_static_data.yml" --gcp-bucket-name "$NISE_DATA_PATH/local_providers/gcp_local_0"
 
   log-info "Cleanup ${_source_name} rendered YAML files..."


### PR DESCRIPTION
## Jira Ticket
None

## Description
Quick PR to fix a timing issue between when the files are created from nise and we trigger our first download for the provider. I think this issue has been addressed on the other providers already since they add OCP first. 


## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Notes

...
