### PR TITLE
Modify purge endpoint to not delete manifests.

### DIFF
--- a/koku/masu/openapi.json
+++ b/koku/masu/openapi.json
@@ -1771,6 +1771,37 @@
               "format": "date",
               "example": "2019-01-01"
             }
+          },
+          {
+            "name": "ignore_manifest",
+            "in": "query",
+            "description": "will not delete manifests if param is present",
+            "required": false,
+            "schema": {
+              "type": "string",
+            }
+          },
+          {
+            "name": "start_date",
+            "in": "query",
+            "description": "start of when you want the files purged",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "example": "2019-01-01"
+            }
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "description": "end of when you want the files purged",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "example": "2019-01-01"
+            }
           }
         ],
         "responses": {

--- a/koku/masu/test/api/test_purge_trino_files.py
+++ b/koku/masu/test/api/test_purge_trino_files.py
@@ -216,7 +216,7 @@ class PurgeTrinoFilesTest(MasuTestCase):
         "masu.api.purge_trino_files.purge_s3_files.delay",
         return_value=AsyncResult("dc350f15-ffc7-4fcb-92d7-2a9f1275568e"),
     )
-    def test_unleash_delete_request_with_date_range(self, mock_purge, _):
+    def test_unleash_delete_request_with_ignore_manifest(self, mock_purge, _):
         """Test the purge_trino_files endpoint with no parameters."""
         params = {
             "provider_uuid": self.gcp_provider_uuid,

--- a/koku/masu/test/api/test_purge_trino_files.py
+++ b/koku/masu/test/api/test_purge_trino_files.py
@@ -210,3 +210,30 @@ class PurgeTrinoFilesTest(MasuTestCase):
             )
             for key in body.keys():
                 self.assertEqual(key, "dc350f15-ffc7-4fcb-92d7-2a9f1275568e")
+
+    @patch("koku.middleware.MASU", return_value=True)
+    @patch(
+        "masu.api.purge_trino_files.purge_s3_files.delay",
+        return_value=AsyncResult("dc350f15-ffc7-4fcb-92d7-2a9f1275568e"),
+    )
+    def test_unleash_delete_request_with_date_range(self, mock_purge, _):
+        """Test the purge_trino_files endpoint with no parameters."""
+        params = {
+            "provider_uuid": self.gcp_provider_uuid,
+            "schema": self.schema,
+            "bill_date": self.bill_date,
+            "start_date": self.bill_date,
+            "ignore_manifest": "True",
+        }
+        query_string = urlencode(params)
+        url = reverse("purge_trino_files") + "?" + query_string
+        with patch("masu.api.purge_trino_files.ReportManifestDBAccessor") as mock_accessor:
+            mock_accessor.return_value.__enter__.return_value = FakeManifest()
+            response = self.client.delete(url)
+            body = response.json()
+            self.assertEqual(response.status_code, 200)
+            mock_purge.assert_called_with(
+                provider_uuid=self.gcp_provider_uuid, provider_type="GCP-local", schema_name=self.schema, prefix=ANY
+            )
+            for key in body.keys():
+                self.assertEqual(key, "dc350f15-ffc7-4fcb-92d7-2a9f1275568e")


### PR DESCRIPTION
## Jira Ticket

None

## Description

We have run into the problem where the parquet compactor has run for a customer's account. However, we do not want to download the entire month for GCP. Right now the GCP downloader is heavily tied into if manifests exist for that partition date or not.

1. So we are planning to run it for the entire month without deleting the manifest first.
^^^ This will allow us to remove all parquet & csv files for the month

2. Then we will run it to delete a specific range of time for the manifests & download just those days.  

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Notes

...
