### PR TITLE
remove end date from gcp daily group by

### DIFF
--- a/koku/masu/util/gcp/common.py
+++ b/koku/masu/util/gcp/common.py
@@ -155,7 +155,6 @@ def gcp_generate_daily_data(data_frame):
             "billing_account_id",
             "project_id",
             pd.Grouper(key="usage_start_time", freq="D"),
-            pd.Grouper(key="usage_end_time", freq="D"),
             "service_id",
             "sku_id",
             "system_labels",


### PR DESCRIPTION
## Jira Ticket

[COST-####](https://issues.redhat.com/browse/COST-####)

## Description

This change will remove the end date grouping for GCP daily data frames since we only ever deal with start dates

## Testing

1. Checkout Branch
2. Start koku fresh
3. Create and load gcp data:
      - `make create-test-customer`
      - `make load-test-customer-data`
4. Data should process like normal and if you check the data in `gcp_line_items_daily` in trino, you should see one unique record per start date rather than two, one with a start date and end date of the same day and one with a start and end a day apart.


OLD (something like this, there are field not showing):
```
invoice_month	billing_account_id	project_id	usage_start_time	usage_end_time
202207	todays_raw_calc_id	todays-raw-calc-id	2022-07-31 00:00:00.000	2022-07-31 00:00:00.000
202207	todays_raw_calc_id	todays-raw-calc-id	2022-07-31 00:00:00.000	2022-08-01 00:00:00.000
```

NEW (some fields excluded and the duplicates here for the same SKU have different labels):
```
 invoice_month | billing_account_id |         project_id         |    usage_start_time     |   service_id   |     sku_id     |                              
 202207        | example_account_id | example-project-id         | 2022-07-31 00:00:00.000 | 6F81-5844-456A | 123C-0EFC-B7C8
 202207        | example_account_id | example-project-id         | 2022-07-31 00:00:00.000 | 6F81-5844-456A | 123C-0EFC-B7C8
 202207        | example_account_id | example-project-id         | 2022-07-31 00:00:00.000 | 6F81-5844-456A | 227B-5B2B-A75A
 202207        | example_account_id | example-project-id         | 2022-07-31 00:00:00.000 | 6F81-5844-456A | 227B-5B2B-A75A
```

## Notes

...
