### PR TITLE
bugfix: oci provider map - update units in storage filter

### DIFF
--- a/koku/api/report/oci/provider_map.py
+++ b/koku/api/report/oci/provider_map.py
@@ -221,14 +221,14 @@ class OCIProviderMap(ProviderMap):
                             ),
                             "cost_units": Coalesce(Max("currency"), Value("USD")),
                             "usage": Sum("usage_amount"),
-                            "usage_units": Coalesce(Max("unit"), Value("GB-Mo")),
+                            "usage_units": Coalesce(Max("unit"), Value("GB_MS")),
                             "source_uuid": ArrayAgg(
                                 F("source_uuid"), filter=Q(source_uuid__isnull=False), distinct=True
                             ),
                         },
                         "delta_key": {"usage": Sum("usage_amount")},
                         "filter": [
-                            {"field": "unit", "operation": "exact", "parameter": "GB-Mo"},
+                            {"field": "unit", "operation": "in", "parameter": ["GB_MS", "BYTES_MS", "BYTES"]},
                         ],
                         "cost_units_key": "currency",
                         "cost_units_fallback": "USD",


### PR DESCRIPTION
## Jira Ticket


## Description

This change will update the units used in OCI provider map and query_filter for storage endpoint

## Testing

1. Checkout Branch
2. Restart Koku
3. run `make create-test-customer`
4. load oci data with `load-test-customer-data test_source=oci`
5. Hit endpoint when everything has finished loading
    1. `http://127.0.0.1:8000/api/cost-management/v1/reports/oci/storage/?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=daily`
    
    2. You should see positive values in total cost similar to ones below
```
    "cost": {
                "raw": {
                    "value": 446445.81886014,
                    "units": "USD"
                },
                "markup": {
                    "value": 0.0,
                    "units": "USD"
                },
                "usage": {
                    "value": 0.0,
                    "units": "USD"
                },
                "total": {
                    "value": 446445.81886014,
                    "units": "USD"
                }
            }
```


## Notes

...
