### PR TITLE
Add an unleash flag to disable summary.

### DIFF
--- a/.unleash/flags.json
+++ b/.unleash/flags.json
@@ -75,6 +75,25 @@
             "createdAt": "2022-08-20T19:50:00.756Z"
         },
         {
+            "name": "disable-summary-processing",
+            "description": "Toggle to disable summary for a particular source.",
+            "type": "permission",
+            "project": "default",
+            "enabled": true,
+            "stale": false,
+            "strategies": [
+                {
+                    "name": "schema-strategy",
+                    "parameters": {
+                        "schema-name": ""
+                    },
+                    "constraints": []
+                }
+            ],
+            "variants": [],
+            "createdAt": "2022-08-29T11:50:00.756Z"
+        },
+        {
             "name": "hcs-data-processor",
             "description": "any account listed in this strategy will be allowed to generate HCS report data",
             "type": "permission",

--- a/koku/masu/processor/__init__.py
+++ b/koku/masu/processor/__init__.py
@@ -52,3 +52,14 @@ def disable_cloud_source_processing(account):
     LOG.info(f"    Processing {'disabled' if res else 'enabled'} {account}")
 
     return res
+
+def disable_summary_processing(account):
+    if account and not account.startswith("acct") and not account.startswith("org"):
+        account = f"acct{account}"
+
+    context = {"schema": account}
+    LOG.info(f"Summary UNLEASH check: {context}")
+    res = bool(UNLEASH_CLIENT.is_enabled("disable-summary-processing", context))
+    LOG.info(f"    Summary {'disabled' if res else 'enabled'} {account}")
+
+    return res

--- a/koku/masu/processor/__init__.py
+++ b/koku/masu/processor/__init__.py
@@ -53,6 +53,7 @@ def disable_cloud_source_processing(account):
 
     return res
 
+
 def disable_summary_processing(account):
     if account and not account.startswith("acct") and not account.startswith("org"):
         account = f"acct{account}"

--- a/koku/masu/processor/tasks.py
+++ b/koku/masu/processor/tasks.py
@@ -24,6 +24,7 @@ from api.iam.models import Tenant
 from api.provider.models import Provider
 from api.utils import get_months_in_date_range
 from koku import celery_app
+from masu.processor import disable_summary_processing
 from koku.middleware import KokuTenantMiddleware
 from masu.database.cost_model_db_accessor import CostModelDBAccessor
 from masu.database.provider_db_accessor import ProviderDBAccessor
@@ -373,6 +374,10 @@ def update_summary_tables(  # noqa: C901
         None
 
     """
+    if disable_summary_processing(schema_name):
+        msg = f"Summary diabled for {schema_name}."
+        LOG.info(msg)
+        return
     worker_stats.REPORT_SUMMARY_ATTEMPTS_COUNTER.labels(provider_type=provider).inc()
     task_name = "masu.processor.tasks.update_summary_tables"
     if isinstance(start_date, str):

--- a/koku/masu/processor/tasks.py
+++ b/koku/masu/processor/tasks.py
@@ -24,7 +24,6 @@ from api.iam.models import Tenant
 from api.provider.models import Provider
 from api.utils import get_months_in_date_range
 from koku import celery_app
-from masu.processor import disable_summary_processing
 from koku.middleware import KokuTenantMiddleware
 from masu.database.cost_model_db_accessor import CostModelDBAccessor
 from masu.database.provider_db_accessor import ProviderDBAccessor
@@ -36,6 +35,7 @@ from masu.external.accounts_accessor import AccountsAccessor
 from masu.external.accounts_accessor import AccountsAccessorError
 from masu.external.downloader.report_downloader_base import ReportDownloaderWarning
 from masu.external.report_downloader import ReportDownloaderError
+from masu.processor import disable_summary_processing
 from masu.processor import enable_trino_processing
 from masu.processor._tasks.download import _get_report_files
 from masu.processor._tasks.process import _process_report_file

--- a/koku/masu/processor/tasks.py
+++ b/koku/masu/processor/tasks.py
@@ -375,7 +375,7 @@ def update_summary_tables(  # noqa: C901
 
     """
     if disable_summary_processing(schema_name):
-        msg = f"Summary diabled for {schema_name}."
+        msg = f"Summary disabled for {schema_name}."
         LOG.info(msg)
         return
     worker_stats.REPORT_SUMMARY_ATTEMPTS_COUNTER.labels(provider_type=provider).inc()

--- a/koku/masu/test/processor/test_tasks.py
+++ b/koku/masu/test/processor/test_tasks.py
@@ -626,7 +626,7 @@ class TestUpdateSummaryTablesTask(MasuTestCase):
     @patch("masu.processor.tasks.chain")
     @patch("masu.processor.tasks.update_cost_model_costs")
     @patch("masu.processor.ocp.ocp_cost_model_cost_updater.CostModelDBAccessor")
-    def test_update_summary_tables_ocp(
+    def test_update_summary_tables_ocp_unleash_check(
         self, mock_cost_model, mock_charge_info, mock_chain, mock_task_cost_model, mock_cache, mock_unleash
     ):
         """Test that the summary table task runs."""

--- a/koku/masu/test/processor/test_tasks.py
+++ b/koku/masu/test/processor/test_tasks.py
@@ -617,6 +617,28 @@ class TestUpdateSummaryTablesTask(MasuTestCase):
 
         mock_chain.return_value.apply_async.assert_called()
 
+    @patch(
+        "masu.processor.tasks.disable_summary_processing",
+        return_value=True,
+    )
+    @patch("masu.processor.worker_cache.CELERY_INSPECT")
+    @patch("masu.processor.tasks.CostModelDBAccessor")
+    @patch("masu.processor.tasks.chain")
+    @patch("masu.processor.tasks.update_cost_model_costs")
+    @patch("masu.processor.ocp.ocp_cost_model_cost_updater.CostModelDBAccessor")
+    def test_update_summary_tables_ocp(
+        self, mock_cost_model, mock_charge_info, mock_chain, mock_task_cost_model, mock_cache, mock_unleash
+    ):
+        """Test that the summary table task runs."""
+
+        provider = Provider.PROVIDER_OCP
+        provider_ocp_uuid = self.ocp_test_provider_uuid
+
+        start_date = DateHelper().last_month_start
+        end_date = DateHelper().last_month_end
+        update_summary_tables(self.schema, provider, provider_ocp_uuid, start_date, end_date, synchronous=True)
+        mock_chain.return_value.apply_async.assert_not_called()
+
     @patch("masu.processor.tasks.chain")
     @patch("masu.processor.tasks.CostModelDBAccessor")
     def test_update_summary_tables_remove_expired_data(self, mock_accessor, mock_chain):


### PR DESCRIPTION
## Jira Ticket

[COST-####](https://issues.redhat.com/browse/COST-####)

## Description

This change will ...

## Testing

1. Add the schema to the disabled summary unleash client. 
2. Add a source, watch the download happen but then see this logs in these logs:
```
koku-worker_1     | [2022-08-29 21:16:08,985] INFO a689d33b-d348-488c-8307-de80cd7dc9a8 Processing UNLEASH check: {'schema': 'org1234567'}
koku-worker_1     | [2022-08-29 21:16:08,985] INFO a689d33b-d348-488c-8307-de80cd7dc9a8     Processing disabled org1234567
koku-worker_1     | [2022-08-29 21:16:08,986] INFO a689d33b-d348-488c-8307-de80cd7dc9a8 Summary diabled for org1234567.
```
Note: I have fixed "Processing" in this log example to Summary. 

## Notes

...
