### PR TITLE
[COST-2460] temporarily disable GCP HCS Processing

### DIFF
--- a/koku/hcs/tasks.py
+++ b/koku/hcs/tasks.py
@@ -29,8 +29,9 @@ HCS_EXCEPTED_PROVIDERS = (
     Provider.PROVIDER_AWS_LOCAL,
     Provider.PROVIDER_AZURE,
     Provider.PROVIDER_AZURE_LOCAL,
-    Provider.PROVIDER_GCP,
-    Provider.PROVIDER_GCP_LOCAL,
+    # COST-2460, disabling GCP HCS while we determine what data we are looking for
+    # Provider.PROVIDER_GCP,
+    # Provider.PROVIDER_GCP_LOCAL,
 )
 
 # any additional queues should be added to this list


### PR DESCRIPTION
## Jira Ticket
Related to:
[COST-2460](https://issues.redhat.com/browse/COST-2460)

## Description

This change will temporarily disable GCP HCS processing while we determine what our query for HCS offer data should look like. It should be re-enabled when we have determined that query and are ready to process HCS GCP data again.

## Testing

1. Checkout Branch
2. Make sure you have `ENABLE_HCS_DEBUG=True` set in your environment
3. Restart Koku
4. Load some GCP data, such as with: `make create-test-customer` and `make load-test-customer-data`
5. Verify in minio that no GCP data was put into the HCS path
6. You should see log messages that resemble the following:
```
[2022-08-31 15:43:30,830: INFO/ForkPoolWorker-17] {'message': '[SKIPPED] HCS report generation: Schema_name: org1234567, provider_type: GCP-local, provider_uuid: 916dce31-0039-456c-b0da-9d5b6077766b, dates 2022-07-01 - 2022-07-31', 'tracing_id': '2022-07-01|2022-08-01|916dce31-0039-456c-b0da-9d5b6077766b'}
```

## Notes

...
