### PR TITLE
COST-2972: Add unleash flag to disable ocp on cloud summary.

### DIFF
--- a/.unleash/flags.json
+++ b/.unleash/flags.json
@@ -94,6 +94,25 @@
             "createdAt": "2022-08-29T11:50:00.756Z"
         },
         {
+            "name": "disable-cloud-source-summary",
+            "description": "Toggle to disable cloud source summary for account.",
+            "type": "permission",
+            "project": "default",
+            "enabled": true,
+            "stale": false,
+            "strategies": [
+                {
+                    "name": "schema-strategy",
+                    "parameters": {
+                        "schema-name": ""
+                    },
+                    "constraints": []
+                }
+            ],
+            "variants": [],
+            "createdAt": "2022-09-06T11:50:00.756Z"
+        },
+        {
             "name": "hcs-data-processor",
             "description": "any account listed in this strategy will be allowed to generate HCS report data",
             "type": "permission",

--- a/.unleash/flags.json
+++ b/.unleash/flags.json
@@ -94,8 +94,8 @@
             "createdAt": "2022-08-29T11:50:00.756Z"
         },
         {
-            "name": "disable-cloud-source-summary",
-            "description": "Toggle to disable cloud source summary for account.",
+            "name": "disable-ocp-on-cloud-summary",
+            "description": "Toggle to disable ocp on cloud summary for account.",
             "type": "permission",
             "project": "default",
             "enabled": true,

--- a/koku/masu/processor/__init__.py
+++ b/koku/masu/processor/__init__.py
@@ -64,3 +64,15 @@ def disable_summary_processing(account):
     LOG.info(f"    Summary {'disabled' if res else 'enabled'} {account}")
 
     return res
+
+
+def disable_cloud_source_summary(account):
+    if account and not account.startswith("acct") and not account.startswith("org"):
+        account = f"acct{account}"
+
+    context = {"schema": account}
+    LOG.info(f"Summary UNLEASH check: {context}")
+    res = bool(UNLEASH_CLIENT.is_enabled("disable-cloud-source-summary", context))
+    LOG.info(f"    Summary {'disabled' if res else 'enabled'} {account}")
+
+    return res

--- a/koku/masu/processor/__init__.py
+++ b/koku/masu/processor/__init__.py
@@ -66,13 +66,13 @@ def disable_summary_processing(account):
     return res
 
 
-def disable_cloud_source_summary(account):
+def disable_ocp_on_cloud_summary(account):
     if account and not account.startswith("acct") and not account.startswith("org"):
         account = f"acct{account}"
 
     context = {"schema": account}
     LOG.info(f"Summary UNLEASH check: {context}")
-    res = bool(UNLEASH_CLIENT.is_enabled("disable-cloud-source-summary", context))
+    res = bool(UNLEASH_CLIENT.is_enabled("disable-ocp-on-cloud-summary", context))
     LOG.info(f"    Summary {'disabled' if res else 'enabled'} {account}")
 
     return res

--- a/koku/masu/processor/tasks.py
+++ b/koku/masu/processor/tasks.py
@@ -35,7 +35,7 @@ from masu.external.accounts_accessor import AccountsAccessor
 from masu.external.accounts_accessor import AccountsAccessorError
 from masu.external.downloader.report_downloader_base import ReportDownloaderWarning
 from masu.external.report_downloader import ReportDownloaderError
-from masu.processor import disable_cloud_source_summary
+from masu.processor import disable_ocp_on_cloud_summary
 from masu.processor import disable_summary_processing
 from masu.processor import enable_trino_processing
 from masu.processor._tasks.download import _get_report_files
@@ -379,8 +379,8 @@ def update_summary_tables(  # noqa: C901
         msg = f"Summary disabled for {schema_name}."
         LOG.info(msg)
         return
-    if disable_cloud_source_summary(schema_name):
-        msg = f"Cloud summary disabled for {schema_name}."
+    if disable_ocp_on_cloud_summary(schema_name):
+        msg = f"OCP on Cloud summary disabled for {schema_name}."
         LOG.info(msg)
         ocp_on_cloud = False
     worker_stats.REPORT_SUMMARY_ATTEMPTS_COUNTER.labels(provider_type=provider).inc()

--- a/koku/masu/processor/tasks.py
+++ b/koku/masu/processor/tasks.py
@@ -35,6 +35,7 @@ from masu.external.accounts_accessor import AccountsAccessor
 from masu.external.accounts_accessor import AccountsAccessorError
 from masu.external.downloader.report_downloader_base import ReportDownloaderWarning
 from masu.external.report_downloader import ReportDownloaderError
+from masu.processor import disable_cloud_source_summary
 from masu.processor import disable_summary_processing
 from masu.processor import enable_trino_processing
 from masu.processor._tasks.download import _get_report_files
@@ -378,6 +379,10 @@ def update_summary_tables(  # noqa: C901
         msg = f"Summary disabled for {schema_name}."
         LOG.info(msg)
         return
+    if disable_cloud_source_summary(schema_name):
+        msg = f"Cloud summary disabled for {schema_name}."
+        LOG.info(msg)
+        ocp_on_cloud = False
     worker_stats.REPORT_SUMMARY_ATTEMPTS_COUNTER.labels(provider_type=provider).inc()
     task_name = "masu.processor.tasks.update_summary_tables"
     if isinstance(start_date, str):

--- a/koku/masu/test/processor/test_tasks.py
+++ b/koku/masu/test/processor/test_tasks.py
@@ -648,11 +648,11 @@ class TestUpdateSummaryTablesTask(MasuTestCase):
     @patch("masu.processor.tasks.chain")
     @patch("masu.processor.tasks.update_cost_model_costs")
     @patch("masu.processor.ocp.ocp_cost_model_cost_updater.CostModelDBAccessor")
-    @patch
-    def test_update_summary_tables_ocp_disable_cloud_source_summary(
+    def test_update_summary_tables_ocp_disabled_check(
         self, mock_cost_model, mock_charge_info, mock_chain, mock_task_cost_model, mock_cache, mock_unleash
     ):
         """Test that the summary table task runs."""
+
         provider = Provider.PROVIDER_OCP
         provider_ocp_uuid = self.ocp_test_provider_uuid
 

--- a/koku/masu/test/processor/test_tasks.py
+++ b/koku/masu/test/processor/test_tasks.py
@@ -639,6 +639,28 @@ class TestUpdateSummaryTablesTask(MasuTestCase):
         update_summary_tables(self.schema, provider, provider_ocp_uuid, start_date, end_date, synchronous=True)
         mock_chain.return_value.apply_async.assert_not_called()
 
+    @patch(
+        "masu.processor.tasks.disable_cloud_source_summary",
+        return_value=True,
+    )
+    @patch("masu.processor.worker_cache.CELERY_INSPECT")
+    @patch("masu.processor.tasks.CostModelDBAccessor")
+    @patch("masu.processor.tasks.chain")
+    @patch("masu.processor.tasks.update_cost_model_costs")
+    @patch("masu.processor.ocp.ocp_cost_model_cost_updater.CostModelDBAccessor")
+    @patch
+    def test_update_summary_tables_ocp_disable_cloud_source_summary(
+        self, mock_cost_model, mock_charge_info, mock_chain, mock_task_cost_model, mock_cache, mock_unleash
+    ):
+        """Test that the summary table task runs."""
+        provider = Provider.PROVIDER_OCP
+        provider_ocp_uuid = self.ocp_test_provider_uuid
+
+        start_date = DateHelper().last_month_start
+        end_date = DateHelper().last_month_end
+        update_summary_tables(self.schema, provider, provider_ocp_uuid, start_date, end_date, synchronous=True)
+        mock_chain.return_value.apply_async.assert_called()
+
     @patch("masu.processor.tasks.chain")
     @patch("masu.processor.tasks.CostModelDBAccessor")
     def test_update_summary_tables_remove_expired_data(self, mock_accessor, mock_chain):

--- a/koku/masu/test/processor/test_tasks.py
+++ b/koku/masu/test/processor/test_tasks.py
@@ -640,7 +640,7 @@ class TestUpdateSummaryTablesTask(MasuTestCase):
         mock_chain.return_value.apply_async.assert_not_called()
 
     @patch(
-        "masu.processor.tasks.disable_cloud_source_summary",
+        "masu.processor.tasks.disable_ocp_on_cloud_summary",
         return_value=True,
     )
     @patch("masu.processor.worker_cache.CELERY_INSPECT")


### PR DESCRIPTION
## Jira Ticket

[COST-2972](https://issues.redhat.com/browse/COST-2972)

## Description

This change will ...

## Testing

1. Checkout Branch
2. Add schema to `disable-cloud-source-summary` in http://localhost:4242/#/features/strategies/disable-cloud-source-summary

3. Upload ocp on cloud source and check for logs:
```
koku-worker_1     | [2022-09-06 19:11:09,758] INFO 59fc70f7-c82c-403a-886b-4b0ae5b953bf Summary UNLEASH check: {'schema': 'org1234567'}
koku-worker_1     | [2022-09-06 19:11:09,758] INFO 59fc70f7-c82c-403a-886b-4b0ae5b953bf     Summary disabled org1234567
koku-worker_1     | [2022-09-06 19:11:09,759] INFO 59fc70f7-c82c-403a-886b-4b0ae5b953bf Cloud summary disabled for org1234567.
```

## Notes

...
