### PR TITLE
COST-2884: Configure unleash for negative filtering feature

### DIFF
--- a/.unleash/flags.json
+++ b/.unleash/flags.json
@@ -113,6 +113,25 @@
             "createdAt": "2022-09-06T11:50:00.756Z"
         },
         {
+            "name": "cost-enable-negative-filtering",
+            "description": "Toggle to enable negative filtering in query",
+            "type": "permission",
+            "project": "default",
+            "enabled": true,
+            "stale": false,
+            "strategies": [
+                {
+                    "name": "schema-strategy",
+                    "parameters": {
+                        "schema-name": ""
+                    },
+                    "constraints": []
+                }
+            ],
+            "variants": [],
+            "createdAt": "2022-09-08T11:50:00.756Z"
+        },
+        {
             "name": "hcs-data-processor",
             "description": "any account listed in this strategy will be allowed to generate HCS report data",
             "type": "permission",


### PR DESCRIPTION
* Update unleash flags.json
* Add unleash client setup to query_params
* Add check for flag enablement to query_params
* Update param processing based on flag enablement for an org_id
* Add test cases based on the check

## Jira Ticket

[COST-2884](https://issues.redhat.com/browse/COST-2884)

## Description

This change will add a check in unleash for if negative filtering is enable for a schema
