### PR TITLE
Bug: Fix make create-test-customer

### DIFF
--- a/koku/api/query_params.py
+++ b/koku/api/query_params.py
@@ -508,10 +508,6 @@ class QueryParameters:
         """Get a filter parameter."""
         return self.get("filter", OrderedDict()).get(filt, default)
 
-    def get_exclusions(self, filt, default=None):
-        """Get a filter parameter."""
-        return self.get("exclude", OrderedDict())
-
     def get_start_date(self):
         """Get a start_date parameter."""
         return self.get("start_date")

--- a/koku/api/query_params.py
+++ b/koku/api/query_params.py
@@ -35,7 +35,11 @@ OR_TAG_PREFIX = "or:tag:"
 
 def enable_negative_filtering(org_id):
     """Helper to determine if account is enabled for negative filtering."""
-    if org_id and not org_id.startswith("org"):
+    if not org_id:
+        return False
+    if isinstance(org_id, str) and not org_id.startswith("org"):
+        org_id = f"acct{org_id}"
+    elif not isinstance(org_id, str):
         org_id = f"acct{org_id}"
 
     context = {"schema": org_id}
@@ -503,6 +507,10 @@ class QueryParameters:
     def get_filter(self, filt, default=None):
         """Get a filter parameter."""
         return self.get("filter", OrderedDict()).get(filt, default)
+
+    def get_exclusions(self, filt, default=None):
+        """Get a filter parameter."""
+        return self.get("exclude", OrderedDict())
 
     def get_start_date(self):
         """Get a start_date parameter."""

--- a/koku/api/test_query_params.py
+++ b/koku/api/test_query_params.py
@@ -20,6 +20,7 @@ from rest_framework.serializers import ValidationError
 from api.models import Provider
 from api.models import Tenant
 from api.models import User
+from api.query_params import enable_negative_filtering
 from api.query_params import get_tenant
 from api.query_params import QueryParameters
 from api.report.serializers import ParamSerializer
@@ -122,6 +123,11 @@ class QueryParametersTests(TestCase):
         )
         with self.assertRaises(ValidationError):
             QueryParameters(fake_request, fake_view)
+
+    def test_enable_negitive_filtering(self):
+        """Test if none is passed in that it returns false."""
+        result = enable_negative_filtering(None)
+        self.assertFalse(result)
 
     def test_constructor_invalid_data(self):
         """Test that ValidationError is raised when serializer data is invalid."""


### PR DESCRIPTION
## Problem
After clearing everything out and attempting to run:
```
make create-test-customer
```
I see the following error:
```
koku_server       |   File "/opt/koku/.venv/lib/python3.9/site-packages/django/utils/decorators.py", line 43, in _wrapper
koku_server       |     return bound_method(*args, **kwargs)
koku_server       |   File "/opt/koku/.venv/lib/python3.9/site-packages/django/views/decorators/vary.py", line 20, in inner_func
koku_server       |     response = func(*args, **kwargs)
koku_server       |   File "/koku/koku/api/report/view.py", line 160, in get
koku_server       |     params = QueryParameters(request=request, caller=self, **kwargs)
koku_server       |   File "/koku/koku/api/query_params.py", line 108, in __init__
koku_server       |     if enable_negative_filtering(org_id):
koku_server       |   File "/koku/koku/api/query_params.py", line 38, in enable_negative_filtering
koku_server       |     if org_id and not org_id.startswith("org"):
koku_server       | AttributeError: 'int' object has no attribute 'startswith'
```

## Description



## Testing

1. Bring everything up fresh on main, and run `make create-test-customer` and see the error above. 
2. Check out this branch and run the same test and see no error. 

## Notes

...
