### PR TITLE
[COST-2989] update account_id if one was not present initially

### DIFF
--- a/koku/koku/middleware.py
+++ b/koku/koku/middleware.py
@@ -318,7 +318,7 @@ class IdentityHeaderMiddleware(MiddlewareMixin):
                         customer.account_id = account
                         customer.date_updated = DateHelper().now_utc
                         customer.save()
-                        LOG.info(f"New account_id found for Customer, updating with account_id of: {account}")
+                        LOG.info(f"adding account_id {account} to Customer (org_id {org_id})")
                     IdentityHeaderMiddleware.customer_cache[org_id] = customer
                     LOG.debug(f"Customer added to cache: {org_id}")
                 else:

--- a/koku/koku/middleware.py
+++ b/koku/koku/middleware.py
@@ -41,6 +41,7 @@ from api.iam.serializers import create_schema_name
 from api.iam.serializers import extract_header
 from api.iam.serializers import UserSerializer
 from api.settings.utils import generate_doc_link
+from api.utils import DateHelper
 from koku.metrics import DB_CONNECTION_ERRORS_COUNTER
 from koku.rbac import RbacConnectionError
 from koku.rbac import RbacService
@@ -313,6 +314,11 @@ class IdentityHeaderMiddleware(MiddlewareMixin):
             try:
                 if org_id not in IdentityHeaderMiddleware.customer_cache:
                     customer = Customer.objects.filter(org_id=org_id).get()
+                    if not customer.account_id and account:
+                        customer.account_id = account
+                        customer.date_updated = DateHelper().now_utc
+                        customer.save()
+                        LOG.info(f"New account_id found for Customer, updating with account_id of: {account}")
                     IdentityHeaderMiddleware.customer_cache[org_id] = customer
                     LOG.debug(f"Customer added to cache: {org_id}")
                 else:

--- a/koku/koku/test_middleware.py
+++ b/koku/koku/test_middleware.py
@@ -219,6 +219,34 @@ class IdentityHeaderMiddlewareTest(IamTestCase):
         with self.assertRaises(User.DoesNotExist):
             User.objects.get(username=user_data["username"])
 
+    def test_process_customer_new_account_id(self):
+        """Test that a customer that later recieves an account_id is updated appropriately."""
+        org_id = "88888"
+        account_id = "88888888"
+        # create customer initially without an account_id
+        customer = self._create_customer_data(account=None, org_id=org_id)
+        user_data = self._create_user_data()
+        request_context = self._create_request_context(customer, user_data, create_customer=True, create_user=False)
+        mock_request = request_context["request"]
+        mock_request.META["QUERY_STRING"] = ""
+        mock_request.path = "/api/v1/tags/aws/"
+        middleware = IdentityHeaderMiddleware()
+        middleware.process_request(mock_request)
+        self.assertTrue(hasattr(mock_request, "user"))
+        customer = Customer.objects.get(org_id=org_id)
+        self.assertIsNone(customer.account_id)
+
+        # send another request with the new account_id and ensure it is updated
+        customer = self._create_customer_data(account=account_id, org_id=org_id)
+        request_context = self._create_request_context(customer, user_data, create_customer=False, create_user=False)
+        mock_request = request_context["request"]
+        mock_request.META["QUERY_STRING"] = ""
+        mock_request.path = "/api/v1/tags/aws/"
+        middleware = IdentityHeaderMiddleware()
+        middleware.process_request(mock_request)
+        customer = Customer.objects.get(org_id=org_id)
+        self.assertEqual(customer.account_id, account_id)
+
     def test_race_condition_customer(self):
         """Test case where another request may create the customer in a race condition."""
         customer = self._create_customer_data()


### PR DESCRIPTION
## Jira Ticket

[COST-2989](https://issues.redhat.com/browse/COST-2989)

## Description

This change will update a customer's account_id in the `api_customer` table if one was not initially present but has since been added to the requests that come through.

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit any endpoint such as `http://localhost:8000/api/cost-management/v1/reports/aws/costs/` with a header for `x-rh-identity` that does not include an account_id. Such as:
```
eyJpZGVudGl0eSI6IHsib3JnX2lkIjogIjg2NzUzMDkiLCAidHlwZSI6ICJVc2VyIiwgInVzZXIiOiB7InVzZXJuYW1lIjogInVzZXJfdGVzdCIsICJlbWFpbCI6ICJ1c2VyX3Rlc3RAZm9vLmNvbSIsICJpc19vcmdfYWRtaW4iOiAiVHJ1ZSIsICJhY2Nlc3MiOiB7fX19LCJlbnRpdGxlbWVudHMiOiB7ImNvc3RfbWFuYWdlbWVudCI6IHsiaXNfZW50aXRsZWQiOiAiVHJ1ZSJ9fX0=
```
4. Check your `api_customer` table in the db to verify there is no account_id for the customer:
`SELECT * FROM api_customer;`
5. Hit that endpoint again with a header that has the same info, but a new account_id, such as: 
```
eyJpZGVudGl0eSI6IHsib3JnX2lkIjogIjg2NzUzMDkiLCAiYWNjb3VudF9udW1iZXIiOiAiOTAzNTc2OCIsICJ0eXBlIjogIlVzZXIiLCAidXNlciI6IHsidXNlcm5hbWUiOiAidXNlcl90ZXN0IiwgImVtYWlsIjogInVzZXJfdGVzdEBmb28uY29tIiwgImlzX29yZ19hZG1pbiI6ICJUcnVlIiwgImFjY2VzcyI6IHt9fX0sImVudGl0bGVtZW50cyI6IHsiY29zdF9tYW5hZ2VtZW50IjogeyJpc19lbnRpdGxlZCI6ICJUcnVlIn19fQ==
```
6. Check your `api_customer` table in the db to verify there is now an account_id for the customer:
`SELECT * FROM api_customer;`

## Notes

...
