### PR TITLE
[COST-3018] - API 500 from OCP-on-GCP storage endpoint

### DIFF
--- a/koku/api/report/all/openshift/provider_map.py
+++ b/koku/api/report/all/openshift/provider_map.py
@@ -129,6 +129,13 @@ class OCPAllProviderMap(ProviderMap):
                         "filter": [{}],
                         "cost_units_key": "currency_code",
                         "cost_units_fallback": "USD",
+                        "ranking_cost_total_exchanged": Sum(
+                            (
+                                Coalesce(F("unblended_cost"), Value(0, output_field=DecimalField()))
+                                + Coalesce(F("markup_cost"), Value(0, output_field=DecimalField()))
+                            )
+                            * Coalesce("exchange_rate", Value(1, output_field=DecimalField()))
+                        ),
                         "sum_columns": [
                             "cost_total",
                             "sup_total",
@@ -208,6 +215,13 @@ class OCPAllProviderMap(ProviderMap):
                         "filter": [{}],
                         "cost_units_key": "currency_code",
                         "cost_units_fallback": "USD",
+                        "ranking_cost_total_exchanged": Sum(
+                            (
+                                Coalesce(F("pod_cost"), Value(0, output_field=DecimalField()))
+                                + Coalesce(F("project_markup_cost"), Value(0, output_field=DecimalField()))
+                            )
+                            * Coalesce("exchange_rate", Value(1, output_field=DecimalField()))
+                        ),
                         "sum_columns": [
                             "infra_raw",
                             "infra_markup",
@@ -278,6 +292,13 @@ class OCPAllProviderMap(ProviderMap):
                         ],
                         "cost_units_key": "currency_code",
                         "cost_units_fallback": "USD",
+                        "ranking_cost_total_exchanged": Sum(
+                            (
+                                Coalesce(F("unblended_cost"), Value(0, output_field=DecimalField()))
+                                + Coalesce(F("markup_cost"), Value(0, output_field=DecimalField()))
+                            )
+                            * Coalesce("exchange_rate", Value(1, output_field=DecimalField()))
+                        ),
                         "usage_units_key": "unit",
                         "usage_units_fallback": "GB-Mo",
                         "sum_columns": [
@@ -364,6 +385,13 @@ class OCPAllProviderMap(ProviderMap):
                         ],
                         "cost_units_key": "currency_code",
                         "cost_units_fallback": "USD",
+                        "ranking_cost_total_exchanged": Sum(
+                            (
+                                Coalesce(F("pod_cost"), Value(0, output_field=DecimalField()))
+                                + Coalesce(F("project_markup_cost"), Value(0, output_field=DecimalField()))
+                            )
+                            * Coalesce("exchange_rate", Value(1, output_field=DecimalField()))
+                        ),
                         "usage_units_key": "unit",
                         "usage_units_fallback": "GB-Mo",
                         "sum_columns": [
@@ -438,6 +466,13 @@ class OCPAllProviderMap(ProviderMap):
                         "group_by": ["instance_type"],
                         "cost_units_key": "currency_code",
                         "cost_units_fallback": "USD",
+                        "ranking_cost_total_exchanged": Sum(
+                            (
+                                Coalesce(F("unblended_cost"), Value(0, output_field=DecimalField()))
+                                + Coalesce(F("markup_cost"), Value(0, output_field=DecimalField()))
+                            )
+                            * Coalesce("exchange_rate", Value(1, output_field=DecimalField()))
+                        ),
                         "usage_units_key": "unit",
                         "usage_units_fallback": "Hrs",
                         "count_units_fallback": "instances",
@@ -527,6 +562,13 @@ class OCPAllProviderMap(ProviderMap):
                         "group_by": ["instance_type"],
                         "cost_units_key": "currency_code",
                         "cost_units_fallback": "USD",
+                        "ranking_cost_total_exchanged": Sum(
+                            (
+                                Coalesce(F("pod_cost"), Value(0, output_field=DecimalField()))
+                                + Coalesce(F("project_markup_cost"), Value(0, output_field=DecimalField()))
+                            )
+                            * Coalesce("exchange_rate", Value(1, output_field=DecimalField()))
+                        ),
                         "usage_units_key": "unit",
                         "usage_units_fallback": "Hrs",
                         "count_units_fallback": "instances",

--- a/koku/api/report/aws/openshift/provider_map.py
+++ b/koku/api/report/aws/openshift/provider_map.py
@@ -277,6 +277,13 @@ class OCPAWSProviderMap(ProviderMap):
                         ],
                         "cost_units_key": "currency_code",
                         "cost_units_fallback": "USD",
+                        "ranking_cost_total_exchanged": Sum(
+                            (
+                                Coalesce(F("unblended_cost"), Value(0, output_field=DecimalField()))
+                                + Coalesce(F("markup_cost"), Value(0, output_field=DecimalField()))
+                            )
+                            * Coalesce("exchange_rate", Value(1, output_field=DecimalField()))
+                        ),
                         "usage_units_key": "unit",
                         "usage_units_fallback": "GB-Mo",
                         "sum_columns": ["usage", "cost_total", "sup_total", "infra_total"],
@@ -351,6 +358,13 @@ class OCPAWSProviderMap(ProviderMap):
                         "filter": [{"field": "product_family", "operation": "icontains", "parameter": "Storage"}],
                         "cost_units_key": "currency_code",
                         "cost_units_fallback": "USD",
+                        "ranking_cost_total_exchanged": Sum(
+                            (
+                                Coalesce(F("pod_cost"), Value(0, output_field=DecimalField()))
+                                + Coalesce(F("project_markup_cost"), Value(0, output_field=DecimalField()))
+                            )
+                            * Coalesce("exchange_rate", Value(1, output_field=DecimalField()))
+                        ),
                         "usage_units_key": "unit",
                         "usage_units_fallback": "GB-Mo",
                         "sum_columns": ["usage", "cost_total", "sup_total", "infra_total"],
@@ -417,6 +431,13 @@ class OCPAWSProviderMap(ProviderMap):
                         "group_by": ["instance_type"],
                         "cost_units_key": "currency_code",
                         "cost_units_fallback": "USD",
+                        "ranking_cost_total_exchanged": Sum(
+                            (
+                                Coalesce(F("unblended_cost"), Value(0, output_field=DecimalField()))
+                                + Coalesce(F("markup_cost"), Value(0, output_field=DecimalField()))
+                            )
+                            * Coalesce("exchange_rate", Value(1, output_field=DecimalField()))
+                        ),
                         "usage_units_key": "unit",
                         "usage_units_fallback": "Hrs",
                         "count_units_fallback": "instances",
@@ -497,6 +518,13 @@ class OCPAWSProviderMap(ProviderMap):
                         "group_by": ["instance_type"],
                         "cost_units_key": "currency_code",
                         "cost_units_fallback": "USD",
+                        "ranking_cost_total_exchanged": Sum(
+                            (
+                                Coalesce(F("pod_cost"), Value(0, output_field=DecimalField()))
+                                + Coalesce(F("project_markup_cost"), Value(0, output_field=DecimalField()))
+                            )
+                            * Coalesce("exchange_rate", Value(1, output_field=DecimalField()))
+                        ),
                         "usage_units_key": "unit",
                         "usage_units_fallback": "Hrs",
                         "count_units_fallback": "instances",

--- a/koku/api/report/aws/provider_map.py
+++ b/koku/api/report/aws/provider_map.py
@@ -203,6 +203,13 @@ class AWSProviderMap(ProviderMap):
                         "group_by": ["instance_type"],
                         "cost_units_key": "currency_code",
                         "cost_units_fallback": "USD",
+                        "ranking_cost_total_exchanged": Sum(
+                            (
+                                Coalesce(F(cost_type), Value(0, output_field=DecimalField()))
+                                + Coalesce(F(self.markup_cost), Value(0, output_field=DecimalField()))
+                            )
+                            * Coalesce("exchange_rate", Value(1, output_field=DecimalField()))
+                        ),
                         "usage_units_key": "unit",
                         "usage_units_fallback": "Hrs",
                         "count_units_fallback": "instances",
@@ -329,6 +336,13 @@ class AWSProviderMap(ProviderMap):
                         ],
                         "cost_units_key": "currency_code",
                         "cost_units_fallback": "USD",
+                        "ranking_cost_total_exchanged": Sum(
+                            (
+                                Coalesce(F(cost_type), Value(0, output_field=DecimalField()))
+                                + Coalesce(F(self.markup_cost), Value(0, output_field=DecimalField()))
+                            )
+                            * Coalesce("exchange_rate", Value(1, output_field=DecimalField()))
+                        ),
                         "usage_units_key": "unit",
                         "usage_units_fallback": "GB-Mo",
                         "sum_columns": ["usage", "cost_total", "sup_total", "infra_total"],

--- a/koku/api/report/azure/openshift/provider_map.py
+++ b/koku/api/report/azure/openshift/provider_map.py
@@ -296,6 +296,13 @@ class OCPAzureProviderMap(ProviderMap):
                         ],
                         "cost_units_key": "currency",
                         "cost_units_fallback": "USD",
+                        "ranking_cost_total_exchanged": Sum(
+                            (
+                                Coalesce(F("pretax_cost"), Value(0, output_field=DecimalField()))
+                                + Coalesce(F("markup_cost"), Value(0, output_field=DecimalField()))
+                            )
+                            * Coalesce("exchange_rate", Value(1, output_field=DecimalField()))
+                        ),
                         "usage_units_key": "unit_of_measure",
                         "usage_units_fallback": "GB-Mo",
                         "sum_columns": ["usage", "cost_total", "sup_total", "infra_total"],
@@ -385,6 +392,13 @@ class OCPAzureProviderMap(ProviderMap):
                         ],
                         "cost_units_key": "currency",
                         "cost_units_fallback": "USD",
+                        "ranking_cost_total_exchanged": Sum(
+                            (
+                                Coalesce(F("pod_cost"), Value(0, output_field=DecimalField()))
+                                + Coalesce(F("project_markup_cost"), Value(0, output_field=DecimalField()))
+                            )
+                            * Coalesce("exchange_rate", Value(1, output_field=DecimalField()))
+                        ),
                         "usage_units_key": "unit_of_measure",
                         "usage_units_fallback": "GB-Mo",
                         "sum_columns": ["usage", "cost_total", "sup_total", "infra_total"],
@@ -466,6 +480,13 @@ class OCPAzureProviderMap(ProviderMap):
                         "group_by": ["instance_type"],
                         "cost_units_key": "currency",
                         "cost_units_fallback": "USD",
+                        "ranking_cost_total_exchanged": Sum(
+                            (
+                                Coalesce(F("pretax_cost"), Value(0, output_field=DecimalField()))
+                                + Coalesce(F("markup_cost"), Value(0, output_field=DecimalField()))
+                            )
+                            * Coalesce("exchange_rate", Value(1, output_field=DecimalField()))
+                        ),
                         "usage_units_key": "unit_of_measure",
                         "usage_units_fallback": "Hrs",
                         "count_units_fallback": "instances",
@@ -561,6 +582,13 @@ class OCPAzureProviderMap(ProviderMap):
                         "group_by": ["instance_type"],
                         "cost_units_key": "currency",
                         "cost_units_fallback": "USD",
+                        "ranking_cost_total_exchanged": Sum(
+                            (
+                                Coalesce(F("pod_cost"), Value(0, output_field=DecimalField()))
+                                + Coalesce(F("project_markup_cost"), Value(0, output_field=DecimalField()))
+                            )
+                            * Coalesce("exchange_rate", Value(1, output_field=DecimalField()))
+                        ),
                         "usage_units_key": "unit_of_measure",
                         "usage_units_fallback": "Hrs",
                         "count_units_fallback": "instances",

--- a/koku/api/report/azure/provider_map.py
+++ b/koku/api/report/azure/provider_map.py
@@ -186,6 +186,13 @@ class AzureProviderMap(ProviderMap):
                         "group_by": ["instance_type"],
                         "cost_units_key": "currency",
                         "cost_units_fallback": "USD",
+                        "ranking_cost_total_exchanged": Sum(
+                            (
+                                Coalesce(F("pretax_cost"), Value(0, output_field=DecimalField()))
+                                + Coalesce(F("markup_cost"), Value(0, output_field=DecimalField()))
+                            )
+                            * Coalesce("exchange_rate", Value(1, output_field=DecimalField()))
+                        ),
                         "usage_units_key": "unit_of_measure",
                         "usage_units_fallback": "Hrs",
                         "count_units_fallback": "instances",
@@ -254,6 +261,13 @@ class AzureProviderMap(ProviderMap):
                         ],
                         "cost_units_key": "currency",
                         "cost_units_fallback": "USD",
+                        "ranking_cost_total_exchanged": Sum(
+                            (
+                                Coalesce(F("pretax_cost"), Value(0, output_field=DecimalField()))
+                                + Coalesce(F("markup_cost"), Value(0, output_field=DecimalField()))
+                            )
+                            * Coalesce("exchange_rate", Value(1, output_field=DecimalField()))
+                        ),
                         "usage_units_key": "unit_of_measure",
                         "usage_units_fallback": "GB-Mo",
                         "sum_columns": ["usage", "cost_total", "sup_total", "infra_total"],

--- a/koku/api/report/gcp/openshift/provider_map.py
+++ b/koku/api/report/gcp/openshift/provider_map.py
@@ -321,6 +321,14 @@ class OCPGCPProviderMap(ProviderMap):
                         "delta_key": {"usage": Sum("usage_amount")},
                         "cost_units_key": "currency",
                         "cost_units_fallback": "USD",
+                        "ranking_cost_total_exchanged": Sum(
+                            (
+                                Coalesce(F("unblended_cost"), Value(0, output_field=DecimalField()))
+                                + Coalesce(F("credit_amount"), Value(0, output_field=DecimalField()))
+                                + Coalesce(F("markup_cost"), Value(0, output_field=DecimalField()))
+                            )
+                            * Coalesce("exchange_rate", Value(1, output_field=DecimalField()))
+                        ),
                         "sum_columns": ["usage", "cost_total", "sup_total", "infra_total", "count"],
                         "default_ordering": {"usage": "desc"},
                         "filter": [{"field": "instance_type", "operation": "isnull", "parameter": False}],
@@ -414,6 +422,14 @@ class OCPGCPProviderMap(ProviderMap):
                         "group_by": ["instance_type"],
                         "cost_units_key": "currency",
                         "cost_units_fallback": "USD",
+                        "ranking_cost_total_exchanged": Sum(
+                            (
+                                Coalesce(F("pod_cost"), Value(0, output_field=DecimalField()))
+                                + Coalesce(F("project_markup_cost"), Value(0, output_field=DecimalField()))
+                                + Coalesce(F("credit_amount"), Value(0, output_field=DecimalField()))
+                            )
+                            * Coalesce("exchange_rate", Value(1, output_field=DecimalField()))
+                        ),
                         "usage_units_key": "unit",
                         "usage_units_fallback": "hour",
                         "count_units_fallback": "instances",
@@ -495,6 +511,14 @@ class OCPGCPProviderMap(ProviderMap):
                         "filter": [{"field": "unit", "operation": "exact", "parameter": "gibibyte month"}],
                         "cost_units_key": "currency",
                         "cost_units_fallback": "USD",
+                        "ranking_cost_total_exchanged": Sum(
+                            (
+                                Coalesce(F("unblended_cost"), Value(0, output_field=DecimalField()))
+                                + Coalesce(F("credit_amount"), Value(0, output_field=DecimalField()))
+                                + Coalesce(F("markup_cost"), Value(0, output_field=DecimalField()))
+                            )
+                            * Coalesce("exchange_rate", Value(1, output_field=DecimalField()))
+                        ),
                         "usage_units_key": "unit",
                         "usage_units_fallback": "gibibyte month",
                         "sum_columns": ["usage", "cost_total", "infra_total", "sup_total"],
@@ -581,6 +605,14 @@ class OCPGCPProviderMap(ProviderMap):
                         "filter": [{"field": "unit", "operation": "exact", "parameter": "gibibyte month"}],
                         "cost_units_key": "currency",
                         "cost_units_fallback": "USD",
+                        "ranking_cost_total_exchanged": Sum(
+                            (
+                                Coalesce(F("pod_cost"), Value(0, output_field=DecimalField()))
+                                + Coalesce(F("project_markup_cost"), Value(0, output_field=DecimalField()))
+                                + Coalesce(F("credit_amount"), Value(0, output_field=DecimalField()))
+                            )
+                            * Coalesce("exchange_rate", Value(1, output_field=DecimalField()))
+                        ),
                         "usage_units_key": "unit",
                         "usage_units_fallback": "gibibyte month",
                         "sum_columns": ["usage", "cost_total", "sup_total", "infra_total"],

--- a/koku/api/report/gcp/openshift/provider_map.py
+++ b/koku/api/report/gcp/openshift/provider_map.py
@@ -498,7 +498,7 @@ class OCPGCPProviderMap(ProviderMap):
                         "usage_units_key": "unit",
                         "usage_units_fallback": "gibibyte month",
                         "sum_columns": ["usage", "cost_total", "infra_total", "sup_total"],
-                        "default_ordering": {"cost_total": "desc"},
+                        "default_ordering": {"usage": "desc"},
                     },
                     "storage_by_project": {
                         "tables": {

--- a/koku/api/report/gcp/provider_map.py
+++ b/koku/api/report/gcp/provider_map.py
@@ -215,6 +215,14 @@ class GCPProviderMap(ProviderMap):
                         "group_by": ["instance_type"],
                         "cost_units_key": "currency",
                         "cost_units_fallback": "USD",
+                        "ranking_cost_total_exchanged": Sum(
+                            (
+                                Coalesce(F("unblended_cost"), Value(0, output_field=DecimalField()))
+                                + Coalesce(F("credit_amount"), Value(0, output_field=DecimalField()))
+                                + Coalesce(F("markup_cost"), Value(0, output_field=DecimalField()))
+                            )
+                            * Coalesce("exchange_rate", Value(1, output_field=DecimalField()))
+                        ),
                         "usage_units_key": "unit",
                         "usage_units_fallback": "hour",
                         "sum_columns": ["usage", "cost_total", "sup_total", "infra_total"],
@@ -284,6 +292,14 @@ class GCPProviderMap(ProviderMap):
                         "filter": [{"field": "unit", "operation": "exact", "parameter": "gibibyte month"}],
                         "cost_units_key": "currency",
                         "cost_units_fallback": "USD",
+                        "ranking_cost_total_exchanged": Sum(
+                            (
+                                Coalesce(F("unblended_cost"), Value(0, output_field=DecimalField()))
+                                + Coalesce(F("credit_amount"), Value(0, output_field=DecimalField()))
+                                + Coalesce(F("markup_cost"), Value(0, output_field=DecimalField()))
+                            )
+                            * Coalesce("exchange_rate", Value(1, output_field=DecimalField()))
+                        ),
                         "usage_units_key": "unit",
                         "usage_units_fallback": "gibibyte month",
                         "sum_columns": ["usage", "cost_total", "sup_total", "infra_total"],

--- a/koku/api/report/oci/provider_map.py
+++ b/koku/api/report/oci/provider_map.py
@@ -177,6 +177,13 @@ class OCIProviderMap(ProviderMap):
                         "group_by": ["instance_type"],
                         "cost_units_key": "currency",
                         "cost_units_fallback": "USD",
+                        "ranking_cost_total_exchanged": Sum(
+                            (
+                                Coalesce(F("cost"), Value(0, output_field=DecimalField()))
+                                + Coalesce(F("markup_cost"), Value(0, output_field=DecimalField()))
+                            )
+                            * Coalesce("exchange_rate", Value(1, output_field=DecimalField()))
+                        ),
                         "usage_units_key": "unit",
                         "usage_units_fallback": "Hrs",
                         "count_units_fallback": "instances",
@@ -240,6 +247,13 @@ class OCIProviderMap(ProviderMap):
                         ],
                         "cost_units_key": "currency",
                         "cost_units_fallback": "USD",
+                        "ranking_cost_total_exchanged": Sum(
+                            (
+                                Coalesce(F("cost"), Value(0, output_field=DecimalField()))
+                                + Coalesce(F("markup_cost"), Value(0, output_field=DecimalField()))
+                            )
+                            * Coalesce("exchange_rate", Value(1, output_field=DecimalField()))
+                        ),
                         "usage_units_key": "unit",
                         "usage_units_fallback": "GB-Mo",
                         "sum_columns": ["usage", "cost_total", "sup_total", "infra_total"],


### PR DESCRIPTION
## Jira Ticket

[COST-3018](https://issues.redhat.com/browse/COST-3018)

## Description

1. fix the OCP-on-GCP provider map default ordering for the storage report.
The above fix led to the realization that all the report types will need the `ranking_cost_total_exchanged` field.
3. add `ranking_cost_total_exchanged` to all report types
