### PR TITLE
Drop GCP tables for resource columns

### DIFF
--- a/scripts/cji_scripts/migrate_trino.py
+++ b/scripts/cji_scripts/migrate_trino.py
@@ -86,7 +86,7 @@ def main():
     logging.info("Running against the following schemas")
     logging.info(schemas)
 
-    tables_to_drop = ["gcp_line_items", "gcp_line_items_daily"]
+    tables_to_drop = ["gcp_line_items_daily", "gcp_line_items"]
     # columns_to_add = []
     # columns_to_drop = []
 


### PR DESCRIPTION
## Jira Ticket

[COST-3014](https://issues.redhat.com/browse/COST-3014)

## Description

This change will drop the trino tables "gcp_line_items_daily" and "gcp_line_items" to make way for the next download and the resource columns to come in!

...
