### PR TITLE
[COST-3040] Allow other months to be considered

### DIFF
--- a/koku/api/provider/provider_manager.py
+++ b/koku/api/provider/provider_manager.py
@@ -111,7 +111,6 @@ class ProviderManager:
         days_to_check = [today - timedelta(days=1), today, today + timedelta(days=1)]
         return CostUsageReportManifest.objects.filter(
             provider=self._uuid,
-            billing_period_start_datetime=self.date_helper.this_month_start,
             manifest_creation_datetime__date__in=days_to_check,
             manifest_completed_datetime__isnull=True,
         ).exists()


### PR DESCRIPTION
## Jira Ticket

[COST-3040](https://issues.redhat.com/browse/COST-3040)

## Description

This removes a filter on the the is processing check to allow us to look for other months that are processing. The manifest creation timestamp will still be the current date, but particularly for smoke tests we generate manifests for multiple months while processing. 

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Notes

...
