### PR TITLE
export DOCKER_BUILDKIT in build-deploy

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -3,6 +3,8 @@
 
 set -exv
 
+export DOCKER_BUILDKIT=1
+
 DOCKERFILE=${DOCKERFILE:="Dockerfile"}
 IMAGE="quay.io/cloudservices/koku"
 IMAGE_TAG=$(git rev-parse --short=7 HEAD)


### PR DESCRIPTION
## Description

This change will export the `DOCKER_BUILDKIT` to build the main image.

## Testing

1. Disable buildkit in Docker settings:
```
  "features": {
    "buildkit": false
  }
```

2. Build the image and see it fail:
```
docker build .

invalid reference format
```

3. run the script and see it succeed:
```
$ ./build_deploy.sh                                                                                                                                                                                                                                                 
```
and see it succeed.