### PR TITLE
OCP cost model currency conversion

### DIFF
--- a/.github/workflows/required-smokes-labeler.yaml
+++ b/.github/workflows/required-smokes-labeler.yaml
@@ -2,7 +2,6 @@ name: Smoke Tests Required Labeler
 
 on:
   pull_request:
-  push:
     branches:
       - main
 

--- a/koku/api/report/ocp/query_handler.py
+++ b/koku/api/report/ocp/query_handler.py
@@ -188,7 +188,12 @@ class OCPReportQueryHandler(ReportQueryHandler):
             )
         df["infra_raw"] = df.apply(
             lambda row: row["infra_raw"]
-            * self.exchange_rates.get(row[self._mapper.cost_units_key], {}).get(self.currency, Decimal(1.0)),
+            * self.exchange_rates.get(row[self._mapper.cost_units_key], {}).get(self.currency, Decimal(1.0))
+            if row[self._mapper.cost_units_key]
+            else row["infra_raw"]
+            * self.exchange_rates.get(source_mapping.get(row[source_column], "USD"), {}).get(
+                self.currency, Decimal(1.0)
+            ),
             axis=1,
         )
         df["infra_total"] = df.apply(

--- a/koku/api/report/ocp/query_handler.py
+++ b/koku/api/report/ocp/query_handler.py
@@ -188,12 +188,12 @@ class OCPReportQueryHandler(ReportQueryHandler):
             )
         df["infra_raw"] = df.apply(
             lambda row: row["infra_raw"]
-            * self.exchange_rates.get(row[self._mapper.cost_units_key], {}).get(self.currency, Decimal(1.0))
-            if row[self._mapper.cost_units_key]
-            else row["infra_raw"]
-            * self.exchange_rates.get(source_mapping.get(row[source_column], "USD"), {}).get(
-                self.currency, Decimal(1.0)
-            ),
+            * self.exchange_rates.get(
+                # fallback to source_mapping in case row[self._mapper.cost_units_key] is None
+                row[self._mapper.cost_units_key]
+                or source_mapping.get(row[source_column], "USD")
+                or {}
+            ).get(self.currency, Decimal(1.0)),
             axis=1,
         )
         df["infra_total"] = df.apply(

--- a/koku/api/report/ocp/query_handler.py
+++ b/koku/api/report/ocp/query_handler.py
@@ -180,17 +180,21 @@ class OCPReportQueryHandler(ReportQueryHandler):
             df = pd.DataFrame(query_data)
             columns = self._mapper.PACK_DEFINITIONS["cost_groups"]["keys"].keys()
             for column in columns:
+                if column == "infra_raw":
+                    continue
                 df[column] = df.apply(
                     lambda row: row[column]
-                    * self.exchange_rates.get(row[self._mapper.cost_units_key], {}).get(self.currency, Decimal(1.0))
-                    if row[self._mapper.cost_units_key]
-                    else row[column]
                     * self.exchange_rates.get(source_mapping.get(row[source_column], "USD"), {}).get(
                         self.currency, Decimal(1.0)
                     ),
                     axis=1,
                 )
-                df["cost_units"] = self.currency
+            df["infra_raw"] = df.apply(
+                lambda row: row["infra_raw"]
+                * self.exchange_rates.get(row[self._mapper.cost_units_key], {}).get(self.currency, Decimal(1.0)),
+                axis=1,
+            )
+            df["cost_units"] = self.currency
             skip_columns = []
             annotations = list(self.report_annotations.keys())
             if self.query_table == OCPUsageLineItemDailySummary:


### PR DESCRIPTION
## Description

This change will convert `infra_raw` costs based on cloud provider currency and convert all other costs based on the cost-model currency.

## Testing

1. IQE branch: `esebesto/currency_testing`
2. Run this test: `test_api_ocp_on_aws_source_raw_calc`
```
ENV_FOR_DYNACONF=local iqe tests plugin cost_management -k test_api_ocp_on_aws_source_raw_calc
```

