### PR TITLE
unit-testing: create more robust test User

### DIFF
--- a/koku/api/iam/test/iam_test_case.py
+++ b/koku/api/iam/test/iam_test_case.py
@@ -107,7 +107,8 @@ class IamTestCase(TestCase):
             "openshift.project": {"read": ["*"]},
             "openshift.node": {"read": ["*"]},
         }
-        return {"username": cls.fake.user_name(), "email": cls.fake.email(), "access": access}
+        profile = cls.fake.simple_profile()
+        return {"username": profile["username"], "email": profile["mail"], "access": access}
 
     @classmethod
     def _create_customer(cls, account, org_id, create_tenant=False):
@@ -166,7 +167,9 @@ class IamTestCase(TestCase):
         request = Mock(path=path)
         request.META = {RH_IDENTITY_HEADER: mock_header}
         if create_user:
-            tempUser = User(username=user_data["username"], email=user_data["email"], customer=cls.customer)
+            tempUser = User.objects.get_or_create(
+                username=user_data["username"], email=user_data["email"], customer=cls.customer
+            )[0]
             tempUser.save()
             request.user = tempUser
         else:


### PR DESCRIPTION
## Description

Sometimes we see unit-tests fail due to something like:
```
psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "api_user_username_key"
DETAIL:  Key (username)=(vrodriguez) already exists.
```

This PR updates the user creation to use a `profile` faker, so the username and email are linked, decreasing the likelihood of this `username already exists` error.
