### PR TITLE
unleash: create fallback function based on development environment

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -2775,7 +2775,7 @@ parameters:
 - description: Koku Sentry Env
   displayName: Koku Sentry Env
   name: KOKU_SENTRY_ENV
-  value: dev
+  value: development
 - description: Enable API Sentry
   displayName: Enable API Sentry
   name: ENABLE_API_SENTRY

--- a/deploy/kustomize/base/base.yaml
+++ b/deploy/kustomize/base/base.yaml
@@ -219,7 +219,7 @@ parameters:
 - description: Koku Sentry Env
   displayName: Koku Sentry Env
   name: KOKU_SENTRY_ENV
-  value: "dev"
+  value: "development"
 - description: Enable API Sentry
   displayName: Enable API Sentry
   name: ENABLE_API_SENTRY

--- a/koku/api/settings/settings.py
+++ b/koku/api/settings/settings.py
@@ -6,7 +6,6 @@
 import logging
 import re
 
-from django.conf import settings
 from django.test import RequestFactory
 from rest_framework.serializers import ValidationError
 from tenant_schemas.utils import schema_context
@@ -39,6 +38,7 @@ from api.tags.ocp.queries import OCPTagQueryHandler
 from api.tags.ocp.view import OCPTagView
 from koku.cache import invalidate_view_cache_for_tenant_and_all_source_types
 from koku.cache import invalidate_view_cache_for_tenant_and_source_type
+from koku.feature_flags import fallback_development_true
 from koku.feature_flags import UNLEASH_CLIENT
 from masu.util.common import update_enabled_keys
 from reporting.models import AWSEnabledTagKeys
@@ -154,7 +154,7 @@ class Settings:
         tag_key_text_name = f"{SETTINGS_PREFIX}.tag_management.form-text"
 
         sub_form_fields = []
-        if UNLEASH_CLIENT.is_enabled("cost-management.ui.currency", self.unleash_context):
+        if UNLEASH_CLIENT.is_enabled("cost-management.ui.currency", self.unleash_context, fallback_development_true):
             currency_select_name = "api.settings.currency"
             currency_text_context = "Select the preferred currency view for your organization."
             currency_title = create_plain_text(currency_select_name, "Currency", "h2")

--- a/koku/koku/feature_flags.py
+++ b/koku/koku/feature_flags.py
@@ -24,6 +24,10 @@ def fallback_true(feature_name: str, context: dict) -> bool:
     return True
 
 
+def fallback_development_true(feature_name: str, context: dict) -> bool:
+    return context.get("environment") == "development"
+
+
 class KokuUnleashClient(UnleashClient):
     """Koku Unleash Client."""
 

--- a/koku/koku/feature_flags.py
+++ b/koku/koku/feature_flags.py
@@ -25,7 +25,7 @@ def fallback_true(feature_name: str, context: dict) -> bool:
 
 
 def fallback_development_true(feature_name: str, context: dict) -> bool:
-    return context.get("environment") == "development"
+    return context.get("environment", "").lower() == "development"
 
 
 class KokuUnleashClient(UnleashClient):


### PR DESCRIPTION
## Description

The Unleash client creates default `context` which includes the client's `environment`. In stage and prod, this value is set to `stage` and `prod`, respectively (in app-interface through the `KOKU_SENTRY_ENV` variable). Locally and in ephemeral, we fallback to the default value which is `development`.

This PR creates a fallback function which enables a flag if the environment is `development` (so, locally or in ephemeral). Sometimes we want a flag always enabled for development, but still have finer control in stage or prod.

This PR also utilizes this new fallback function for the currency settings on the settings endpoint.

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit `http://localhost:8000/api/cost-management/v1/settings/`
    1. You should see the first fields entry:
    ````
        "fields": [
            {
                "component": "plain-text",
                "label": "Currency",
                "name": "api.settings.currency",
                "variant": "h2"
            },
    ````

To test that the flag still functions through unleash:
1. start koku with gunicorn: `RUN_GUNICORN=True docker compose up koku-server`
1. Go to http://localhost:4242/
2. add a new toggle `cost-management.ui.currency`
3. add the `userWithId` strategy and delete the `default` strategy
4. Wait about a minute so the cache refreshes
5. Hit `http://localhost:8000/api/cost-management/v1/settings/`
    1. You should see the first fields entry:
    ````
        "fields": [
            {
                "component": "plain-text",
                "label": "Enable tags and labels",
                "name": "api.settings.tag_management.form-text",
                "variant": "h2"
            },
    ````
6. in the unleash ui, add `1234567` to the userWithId strategy.
7. wait about a minute for the cache to refresh
8. Hit `http://localhost:8000/api/cost-management/v1/settings/`
    1. You should see the first fields entry:
    ````
        "fields": [
            {
                "component": "plain-text",
                "label": "Currency",
                "name": "api.settings.currency",
                "variant": "h2"
            },
    ````