### PR TITLE
Updating OCP/GCP sql for node/pod costs

### DIFF
--- a/koku/masu/database/gcp_report_db_accessor.py
+++ b/koku/masu/database/gcp_report_db_accessor.py
@@ -592,9 +592,11 @@ class GCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
         # Default to cpu distribution
         pod_column = "pod_effective_usage_cpu_core_hours"
         cluster_column = "cluster_capacity_cpu_core_hours"
+        node_column = "node_capacity_cpu_core_hours"
         if distribution == "memory":
             pod_column = "pod_effective_usage_memory_gigabyte_hours"
             cluster_column = "cluster_capacity_memory_gigabyte_hours"
+            node_column = "node_capacity_memory_gigabyte_hours"
 
         if resource_level:
             sql_level = "reporting_ocpgcpcostlineitem_daily_summary_resource_id"
@@ -619,6 +621,7 @@ class GCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
             "markup": markup_value,
             "pod_column": pod_column,
             "cluster_column": cluster_column,
+            "node_column": node_column,
             "cluster_id": cluster_id,
             "cluster_alias": cluster_alias,
             "matching_type": matching_type,

--- a/koku/masu/database/presto_sql/gcp/openshift/reporting_ocpgcpcostlineitem_daily_summary_by_node.sql
+++ b/koku/masu/database/presto_sql/gcp/openshift/reporting_ocpgcpcostlineitem_daily_summary_by_node.sql
@@ -145,7 +145,7 @@ INSERT INTO hive.{{schema | sqlsafe}}.reporting_ocpgcpcostlineitem_project_daily
     pod_request_memory_gigabyte_hours,
     pod_effective_usage_memory_gigabyte_hours,
     cluster_capacity_cpu_core_hours,
-    cluster_capacity_memory_gigabyte_hours,
+    cluster_capacity_memory_gigabyte_hours,zzz
     volume_labels,
     tags
 )

--- a/koku/masu/database/presto_sql/gcp/openshift/reporting_ocpgcpcostlineitem_daily_summary_by_node.sql
+++ b/koku/masu/database/presto_sql/gcp/openshift/reporting_ocpgcpcostlineitem_daily_summary_by_node.sql
@@ -145,7 +145,7 @@ INSERT INTO hive.{{schema | sqlsafe}}.reporting_ocpgcpcostlineitem_project_daily
     pod_request_memory_gigabyte_hours,
     pod_effective_usage_memory_gigabyte_hours,
     cluster_capacity_cpu_core_hours,
-    cluster_capacity_memory_gigabyte_hours,zzz
+    cluster_capacity_memory_gigabyte_hours,
     volume_labels,
     tags
 )

--- a/koku/masu/database/presto_sql/gcp/openshift/reporting_ocpgcpcostlineitem_daily_summary_resource_id.sql
+++ b/koku/masu/database/presto_sql/gcp/openshift/reporting_ocpgcpcostlineitem_daily_summary_resource_id.sql
@@ -42,6 +42,8 @@ CREATE TABLE IF NOT EXISTS hive.{{schema | sqlsafe}}.reporting_ocpgcpcostlineite
     pod_effective_usage_memory_gigabyte_hours double,
     cluster_capacity_cpu_core_hours double,
     cluster_capacity_memory_gigabyte_hours double,
+    node_capacity_cpu_core_hours double,
+    node_capacity_memory_gigabyte_hours double,
     volume_labels varchar,
     tags varchar,
     project_rank integer,
@@ -92,6 +94,8 @@ CREATE TABLE IF NOT EXISTS hive.{{schema | sqlsafe}}.reporting_ocpgcpcostlineite
     pod_request_memory_gigabyte_hours double,
     cluster_capacity_cpu_core_hours double,
     cluster_capacity_memory_gigabyte_hours double,
+    node_capacity_cpu_core_hours double,
+    node_capacity_memory_gigabyte_hours double,
     volume_labels varchar,
     tags varchar,
     project_rank integer,
@@ -150,6 +154,8 @@ INSERT INTO hive.{{schema | sqlsafe}}.reporting_ocpgcpcostlineitem_project_daily
     pod_effective_usage_memory_gigabyte_hours,
     cluster_capacity_cpu_core_hours,
     cluster_capacity_memory_gigabyte_hours,
+    node_capacity_cpu_core_hours,
+    node_capacity_memory_gigabyte_hours,
     volume_labels,
     tags,
     ocp_matched
@@ -195,6 +201,8 @@ SELECT gcp.uuid as gcp_uuid,
     sum(ocp.pod_effective_usage_memory_gigabyte_hours) as pod_effective_usage_memory_gigabyte_hours,
     max(ocp.cluster_capacity_cpu_core_hours) as cluster_capacity_cpu_core_hours,
     max(ocp.cluster_capacity_memory_gigabyte_hours) as cluster_capacity_memory_gigabyte_hours,
+    max(ocp.node_capacity_cpu_core_hours) as node_capacity_cpu_core_hours,
+    max(ocp.node_capacity_memory_gigabyte_hours) as node_capacity_memory_gigabyte_hours,
     NULL as volume_labels,
     max(json_format(json_parse(gcp.labels))) as tags,
     max(gcp.ocp_matched) as ocp_matched
@@ -260,6 +268,8 @@ INSERT INTO hive.{{schema | sqlsafe}}.reporting_ocpgcpcostlineitem_project_daily
     pod_effective_usage_memory_gigabyte_hours,
     cluster_capacity_cpu_core_hours,
     cluster_capacity_memory_gigabyte_hours,
+    node_capacity_cpu_core_hours,
+    node_capacity_memory_gigabyte_hours,
     volume_labels,
     tags,
     ocp_matched
@@ -305,6 +315,8 @@ SELECT gcp.uuid as gcp_uuid,
     sum(ocp.pod_effective_usage_memory_gigabyte_hours) as pod_effective_usage_memory_gigabyte_hours,
     max(ocp.cluster_capacity_cpu_core_hours) as cluster_capacity_cpu_core_hours,
     max(ocp.cluster_capacity_memory_gigabyte_hours) as cluster_capacity_memory_gigabyte_hours,
+    max(ocp.node_capacity_cpu_core_hours) as node_capacity_cpu_core_hours,
+    max(ocp.node_capacity_memory_gigabyte_hours) as node_capacity_memory_gigabyte_hours,
     max(ocp.volume_labels) as volume_labels,
     max(json_format(json_parse(gcp.labels))) as tags,
     max(gcp.ocp_matched) as ocp_matched
@@ -375,6 +387,8 @@ INSERT INTO hive.{{schema | sqlsafe}}.reporting_ocpgcpcostlineitem_project_daily
     pod_request_memory_gigabyte_hours,
     cluster_capacity_cpu_core_hours,
     cluster_capacity_memory_gigabyte_hours,
+    node_capacity_cpu_core_hours,
+    node_capacity_memory_gigabyte_hours,
     volume_labels,
     tags,
     gcp_source,
@@ -430,15 +444,15 @@ SELECT pds.gcp_uuid,
     unblended_cost / r.gcp_uuid_count as unblended_cost,
     markup_cost / r.gcp_uuid_count as markup_cost,
     CASE WHEN ocp_matched = TRUE AND data_source = 'Pod'
-        THEN ({{pod_column | sqlsafe}} / {{cluster_column | sqlsafe}}) * unblended_cost * cast({{markup}} as decimal(24,9))
+        THEN ({{pod_column | sqlsafe}} / {{node_column | sqlsafe}}) * unblended_cost * cast({{markup}} as decimal(24,9))
         ELSE unblended_cost / r.gcp_uuid_count * cast({{markup}} as decimal(24,9))
     END as project_markup_cost,
     CASE WHEN ocp_matched = TRUE AND data_source = 'Pod'
-        THEN ({{pod_column | sqlsafe}} / {{cluster_column | sqlsafe}}) * unblended_cost
+        THEN ({{pod_column | sqlsafe}} / {{node_column | sqlsafe}}) * unblended_cost
         ELSE unblended_cost / r.gcp_uuid_count
     END as pod_cost,
     CASE WHEN ocp_matched = TRUE AND data_source = 'Pod'
-        THEN ({{pod_column | sqlsafe}} / {{cluster_column | sqlsafe}}) * credit_amount
+        THEN ({{pod_column | sqlsafe}} / {{node_column | sqlsafe}}) * credit_amount
         ELSE credit_amount / r.gcp_uuid_count
     END as pod_credit,
     pod_usage_cpu_core_hours,
@@ -448,6 +462,8 @@ SELECT pds.gcp_uuid,
     pod_request_memory_gigabyte_hours,
     cluster_capacity_cpu_core_hours,
     cluster_capacity_memory_gigabyte_hours,
+    node_capacity_cpu_core_hours,
+    node_capacity_memory_gigabyte_hours,
     volume_labels,
     tags,
     '{{gcp_source_uuid | sqlsafe }}' as gcp_source,

--- a/koku/masu/test/database/test_gcp_report_db_accessor.py
+++ b/koku/masu/test/database/test_gcp_report_db_accessor.py
@@ -303,28 +303,29 @@ class GCPReportDBAccessorTest(MasuTestCase):
         with CostModelDBAccessor(self.schema, self.gcp_provider.uuid) as cost_model_accessor:
             markup = cost_model_accessor.markup
             markup_value = float(markup.get("value", 0)) / 100
-            distribution = cost_model_accessor.distribution
 
-        expected_log = "INFO:masu.util.gcp.common:OCP GCP matching set to resource level"
-        with patch(
-            "masu.util.gcp.common.ProviderDBAccessor.get_data_source",
-            Mock(return_value={"table_id": "resource"}),
-        ):
-            with self.assertLogs("masu.util.gcp.common", level="INFO") as logger:
-                self.accessor.populate_ocp_on_gcp_cost_daily_summary_presto(
-                    start_date,
-                    end_date,
-                    self.ocp_provider_uuid,
-                    self.ocp_cluster_id,
-                    self.gcp_provider_uuid,
-                    self.ocp_cluster_id,
-                    current_bill_id,
-                    markup_value,
-                    distribution,
-                )
-                mock_presto.assert_called()
-                mock_delete.assert_called()
-                self.assertIn(expected_log, logger.output)
+        for distribution in ["cpu", "memory"]:
+            with self.subTest(distribution=distribution):
+                expected_log = "INFO:masu.util.gcp.common:OCP GCP matching set to resource level"
+                with patch(
+                    "masu.util.gcp.common.ProviderDBAccessor.get_data_source",
+                    Mock(return_value={"table_id": "resource"}),
+                ):
+                    with self.assertLogs("masu.util.gcp.common", level="INFO") as logger:
+                        self.accessor.populate_ocp_on_gcp_cost_daily_summary_presto(
+                            start_date,
+                            end_date,
+                            self.ocp_provider_uuid,
+                            self.ocp_cluster_id,
+                            self.gcp_provider_uuid,
+                            self.ocp_cluster_id,
+                            current_bill_id,
+                            markup_value,
+                            distribution,
+                        )
+                        mock_presto.assert_called()
+                        mock_delete.assert_called()
+                        self.assertIn(expected_log, logger.output)
 
     @patch("masu.database.gcp_report_db_accessor.GCPReportDBAccessor.delete_ocp_on_gcp_hive_partition_by_day")
     @patch("masu.database.gcp_report_db_accessor.GCPReportDBAccessor._execute_presto_multipart_sql_query")


### PR DESCRIPTION
## Jira Ticket

[COST-3193](https://issues.redhat.com/browse/COST-3193)

## Description

This change will update the OCP/GCP resource matching sql to calculate pod costs using node capacity over cluster capacity.

## Testing

1. Checkout Branch
2. Restart Koku
3. Load test customer data 
4. Check costs are correctly distributed

## Notes
Or run the following QE test test_api_ocp_on_gcp_source_raw_calc
...
