### PR TITLE
allow duplicates across customers for non-OCP providers

### DIFF
--- a/koku/api/provider/serializers.py
+++ b/koku/api/provider/serializers.py
@@ -347,7 +347,9 @@ class ProviderSerializer(serializers.ModelSerializer):
         auth, __ = ProviderAuthentication.objects.get_or_create(**authentication)
 
         # We can re-use a billing source or a auth, but not the same combination.
-        dup_queryset = Provider.objects.filter(authentication=auth).filter(billing_source=bill)
+        dup_queryset = Provider.objects.filter(authentication=auth, billing_source=bill)
+        if provider_type != Provider.PROVIDER_OCP:
+            dup_queryset = dup_queryset.filter(customer=customer)
         if dup_queryset.count() != 0:
             message = (
                 "Cost management does not allow duplicate accounts. "
@@ -399,7 +401,9 @@ class ProviderSerializer(serializers.ModelSerializer):
             bill, __ = ProviderBillingSource.objects.get_or_create(**billing_source)
             auth, __ = ProviderAuthentication.objects.get_or_create(**authentication)
             if instance.billing_source != bill or instance.authentication != auth:
-                dup_queryset = Provider.objects.filter(authentication=auth).filter(billing_source=bill)
+                dup_queryset = Provider.objects.filter(authentication=auth, billing_source=bill)
+                if provider_type != Provider.PROVIDER_OCP:
+                    dup_queryset = dup_queryset.filter(customer=customer)
                 if dup_queryset.count() != 0:
                     message = (
                         "Cost management does not allow duplicate accounts. "


### PR DESCRIPTION
## Description

This change partially reverts https://github.com/project-koku/koku/pull/3741. This PR will allow duplicates for different customers for non-OCP providers.
