### PR TITLE
[COST-2659] - fix sources-cleanup pagination

### DIFF
--- a/koku/masu/api/source_cleanup.py
+++ b/koku/masu/api/source_cleanup.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 """View for Source cleanup."""
-import contextlib
 import logging
 from uuid import UUID
 
@@ -62,12 +61,20 @@ def cleanup(request):
         return handle_providers_without_sources_response(request, _providers_without_sources(source_uuid))
 
     if "out_of_order_deletes" in params.keys():
-        return handle_out_of_order_deletes_response(request, _sources_out_of_order_deletes())
+        return handle_out_of_order_deletes_response(
+            request, _sources_out_of_order_deletes(source_uuid, params["limit"], params["offset"])
+        )
 
     if "missing_sources" in params.keys():
         return handle_missing_sources_response(
             request, _missing_sources(source_uuid, params["limit"], params["offset"])
         )
+
+
+class SimplePaginate(ListPaginator):
+    @property
+    def paginated_data_set(self):
+        return self.data_set
 
 
 def handle_providers_without_sources_response(request, dataset):
@@ -76,7 +83,7 @@ def handle_providers_without_sources_response(request, dataset):
         return Response({"job_queued": "providers_without_sources"})
     else:
         providers_without_sources = [f"{provider.name} ({provider.uuid})" for provider in dataset]
-        return ListPaginator(providers_without_sources, request).paginated_response
+        return SimplePaginate(providers_without_sources, request).paginated_response
 
 
 def handle_out_of_order_deletes_response(request, dataset):
@@ -85,7 +92,7 @@ def handle_out_of_order_deletes_response(request, dataset):
         return Response({"job_queued": "out_of_order_deletes"})
     else:
         out_of_order_delete = [f"Source ID: {source.source_id}" for source in dataset]
-        return ListPaginator(out_of_order_delete, request).paginated_response
+        return SimplePaginate(out_of_order_delete, request).paginated_response
 
 
 def handle_missing_sources_response(request, dataset):
@@ -94,7 +101,7 @@ def handle_missing_sources_response(request, dataset):
         return Response({"job_queued": "missing_sources"})
     else:
         missing_sources = [f"Source ID: {source.source_id} Source UUID: {source.source_uuid}" for source in dataset]
-        return ListPaginator(missing_sources, request).paginated_response
+        return SimplePaginate(missing_sources, request).paginated_response
 
 
 def cleanup_provider_without_source(cleaning_list):
@@ -131,16 +138,24 @@ def _providers_without_sources(provider_uuid=None):
     return providers_without_sources
 
 
-def _sources_out_of_order_deletes():
-    with contextlib.suppress(Sources.DoesNotExist):
-        return list(Sources.objects.filter(out_of_order_delete=True, koku_uuid=None).all())
+def _sources_out_of_order_deletes(source_uuid=None, limit=10, offset=0):
+    if source_uuid:
+        sources = Sources.objects.filter(source_uuid=source_uuid, out_of_order_delete=True, koku_uuid=None)
+    else:
+        sources = (
+            Sources.objects.filter(out_of_order_delete=True, koku_uuid=None)
+            .all()
+            .order_by("source_id")[offset : offset + limit]  # noqa: E203
+        )
+
+    return list(sources)
 
 
 def _missing_sources(source_uuid=None, limit=10, offset=0):
     if source_uuid:
         sources = Sources.objects.filter(source_uuid=source_uuid)
     else:
-        sources = Sources.objects.all()
+        sources = Sources.objects.all().order_by("source_id")
 
     missing_sources = []
     # the request to sources-api is a "slow" process.


### PR DESCRIPTION
## Jira Ticket

[COST-2659](https://issues.redhat.com/browse/COST-2659)

## Description

The previous implementation of pagination for the sources-cleanup was "double" paginating the data. It was applying [offset:offset + limit] to the DB query and then the same [offset:offset + limit] to the Response dataset. This was resulting in accurate responses.

