### PR TITLE
protect key word from project/tag groupby/filtering

### DIFF
--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -201,7 +201,7 @@ class ReportQueryHandler(QueryHandler):
         tag_filters = []
         filters = self.parameters.get(parameter_key, {})
         for filt in filters:
-            if filt in self._tag_keys:
+            if "tag" in filt and filt in self._tag_keys:
                 tag_filters.append(filt)
         return tag_filters
 
@@ -210,7 +210,7 @@ class ReportQueryHandler(QueryHandler):
         tag_groups = []
         filters = self.parameters.get("group_by", {})
         for filt in filters:
-            if filt in self._tag_keys:
+            if "tag" in filt and filt in self._tag_keys:
                 tag_groups.append(filt)
         return tag_groups
 


### PR DESCRIPTION
## Jira Ticket

[COST-3197](https://issues.redhat.com/browse/COST-3197)

## Description

This change will protect key words such as project when building the tag group_bys and filters 

## Testing

1. Checkout Pre this branch
2. Restart Koku
3. Create OCP source/data with a project tag key that shares a tag value with another key (label_appgroup:optimise|label_project:optimise)
    1. Check /api/cost-management/v1/reports/openshift/infrastructures/all/instance-types/?filter[time_scope_units]=day&filter[time_scope_value]=-10&group_by[project]=*&filter[tag:appgroup]=*
    2. See nested projects returned in response and the tag name returned as the project name
4. Checkout this branch
    1. Repeat Check step
    2. See that we no long have nested projects and the project name is correct

## Notes
Please reach out TO Andrew or Luke for this Yaml we have it in a Gdoc