### PR TITLE
Unittests: reduce the number of users created

### DIFF
--- a/koku/api/forecast/test/test_serializers.py
+++ b/koku/api/forecast/test/test_serializers.py
@@ -32,8 +32,8 @@ class AWSCostForecastParamSerializerTest(IamTestCase):
     def test_valid_cost_type_no_exception(self):
         """Test that a valid cost type doesn't raise an exception."""
         query_params = {"cost_type": "blended_cost"}
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/forecasts/aws/costs/")
-        serializer = AWSCostForecastParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/forecasts/aws/costs/"
+        serializer = AWSCostForecastParamSerializer(data=query_params, context=self.ctx_w_path)
         serializer.is_valid(raise_exception=True)
 
 

--- a/koku/api/forecast/test/test_serializers.py
+++ b/koku/api/forecast/test/test_serializers.py
@@ -32,7 +32,7 @@ class AWSCostForecastParamSerializerTest(IamTestCase):
     def test_valid_cost_type_no_exception(self):
         """Test that a valid cost type doesn't raise an exception."""
         query_params = {"cost_type": "blended_cost"}
-        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/forecasts/aws/costs/")
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/forecasts/aws/costs/")
         serializer = AWSCostForecastParamSerializer(data=query_params, context=ctx)
         serializer.is_valid(raise_exception=True)
 

--- a/koku/api/forecast/test/test_serializers.py
+++ b/koku/api/forecast/test/test_serializers.py
@@ -32,10 +32,7 @@ class AWSCostForecastParamSerializerTest(IamTestCase):
     def test_valid_cost_type_no_exception(self):
         """Test that a valid cost type doesn't raise an exception."""
         query_params = {"cost_type": "blended_cost"}
-        path = "/api/cost-management/v1/forecasts/aws/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/forecasts/aws/costs/")
         serializer = AWSCostForecastParamSerializer(data=query_params, context=ctx)
         serializer.is_valid(raise_exception=True)
 

--- a/koku/api/iam/test/iam_test_case.py
+++ b/koku/api/iam/test/iam_test_case.py
@@ -83,6 +83,7 @@ class IamTestCase(TestCase):
         cls.headers = cls.request_context["request"].META
         cls.provider_uuid = UUID("00000000-0000-0000-0000-000000000001")
         cls.factory = RequestFactory()
+        cls.request_path = "/api/cost-management/v1/"
 
     @classmethod
     def tearDownClass(cls):
@@ -177,6 +178,20 @@ class IamTestCase(TestCase):
             request.user = user_data["username"]
         return {"request": request}
 
+    @property
+    def ctx_w_path(self):
+        mock_request = deepcopy(self.request_context["request"])
+        mock_request.path = self.request_path
+        return {"request": mock_request}
+
+    @property
+    def request_path(self):
+        return self._request_path
+
+    @request_path.setter
+    def request_path(self, value):
+        self._request_path = value
+
     def create_mock_customer_data(self):
         """Create randomized data for a customer test."""
         account = self.fake.ean8()
@@ -196,12 +211,6 @@ class IamTestCase(TestCase):
         if path:
             m_request.path = path
         return QueryParameters(m_request, view)
-
-    def get_request_ctx_w_path(self, path):
-        """Update the request context path value."""
-        mock_request = deepcopy(self.request_context["request"])
-        mock_request.path = path
-        return {"request": mock_request}
 
 
 class RbacPermissions:

--- a/koku/api/iam/test/iam_test_case.py
+++ b/koku/api/iam/test/iam_test_case.py
@@ -5,6 +5,7 @@
 """Test Case extension to collect common test data."""
 import functools
 from base64 import b64encode
+from copy import deepcopy
 from json import dumps as json_dumps
 from unittest.mock import Mock
 from uuid import UUID
@@ -195,6 +196,12 @@ class IamTestCase(TestCase):
         if path:
             m_request.path = path
         return QueryParameters(m_request, view)
+
+    def get_request_ctx_w_path(self, path):
+        """Update the request context path value."""
+        mock_request = deepcopy(self.request_context["request"])
+        mock_request.path = path
+        return {"request": mock_request}
 
 
 class RbacPermissions:

--- a/koku/api/organizations/test/test_serializers.py
+++ b/koku/api/organizations/test/test_serializers.py
@@ -82,10 +82,7 @@ class AWSOrgQueryParamSerializerTest(IamTestCase):
             "limit": "5",
             "offset": "3",
         }
-        path = "/api/cost-management/v1/organizations/aws/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/organizations/aws/")
         serializer = AWSOrgQueryParamSerializer(data=query_params, context=ctx)
         self.assertTrue(serializer.is_valid())
 
@@ -101,10 +98,8 @@ class AWSOrgQueryParamSerializerTest(IamTestCase):
             "limit": "5",
             "offset": "3",
         }
-        path = "/api/cost-management/v1/organizations/aws/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/organizations/aws/")
         serializer = AWSOrgQueryParamSerializer(data=query_params, context=ctx)
         self.assertTrue(serializer.is_valid(raise_exception=True))
 
@@ -116,20 +111,14 @@ class AWSOrgQueryParamSerializerTest(IamTestCase):
             "limit": "5",
             "offset": "3",
         }
-        path = "/api/cost-management/v1/organizations/aws/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/organizations/aws/")
         serializer = AWSOrgQueryParamSerializer(data=query_params, context=ctx)
         self.assertTrue(serializer.is_valid(raise_exception=True))
 
     def test_query_params_invalid_fields(self):
         """Test parse of query params for invalid fields."""
         query_params = {"invalid": "invalid"}
-        path = "/api/cost-management/v1/organizations/aws/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/organizations/aws/")
         serializer = AWSOrgQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
@@ -137,10 +126,7 @@ class AWSOrgQueryParamSerializerTest(IamTestCase):
     def test_parse_filter_dates_valid(self):
         """Test parse of a filter date-based param should succeed."""
         dh = DateHelper()
-        path = "/api/cost-management/v1/organizations/aws/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/organizations/aws/")
         scenarios = [
             {"start_date": dh.yesterday.date(), "end_date": dh.today.date()},
             {"start_date": dh.this_month_start.date(), "end_date": dh.today.date()},
@@ -165,10 +151,7 @@ class AWSOrgQueryParamSerializerTest(IamTestCase):
     def test_parse_filter_dates_invalid(self):
         """Test parse of invalid data for filter date-based param should not succeed."""
         dh = DateHelper()
-        path = "/api/cost-management/v1/organizations/aws/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/organizations/aws/")
         scenarios = [
             {"start_date": dh.today.date()},
             {"end_date": dh.today.date()},

--- a/koku/api/organizations/test/test_serializers.py
+++ b/koku/api/organizations/test/test_serializers.py
@@ -82,8 +82,8 @@ class AWSOrgQueryParamSerializerTest(IamTestCase):
             "limit": "5",
             "offset": "3",
         }
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/organizations/aws/")
-        serializer = AWSOrgQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/organizations/aws/"
+        serializer = AWSOrgQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         self.assertTrue(serializer.is_valid())
 
     def test_parse_query_params_filter_with_org_unit_id_success(self):
@@ -99,8 +99,8 @@ class AWSOrgQueryParamSerializerTest(IamTestCase):
             "offset": "3",
         }
 
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/organizations/aws/")
-        serializer = AWSOrgQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/organizations/aws/"
+        serializer = AWSOrgQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         self.assertTrue(serializer.is_valid(raise_exception=True))
 
     def test_parse_query_params_exclude_with_org_unit_id_success(self):
@@ -111,22 +111,22 @@ class AWSOrgQueryParamSerializerTest(IamTestCase):
             "limit": "5",
             "offset": "3",
         }
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/organizations/aws/")
-        serializer = AWSOrgQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/organizations/aws/"
+        serializer = AWSOrgQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         self.assertTrue(serializer.is_valid(raise_exception=True))
 
     def test_query_params_invalid_fields(self):
         """Test parse of query params for invalid fields."""
         query_params = {"invalid": "invalid"}
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/organizations/aws/")
-        serializer = AWSOrgQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/organizations/aws/"
+        serializer = AWSOrgQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
     def test_parse_filter_dates_valid(self):
         """Test parse of a filter date-based param should succeed."""
         dh = DateHelper()
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/organizations/aws/")
+        self.request_path = "/api/cost-management/v1/organizations/aws/"
         scenarios = [
             {"start_date": dh.yesterday.date(), "end_date": dh.today.date()},
             {"start_date": dh.this_month_start.date(), "end_date": dh.today.date()},
@@ -145,13 +145,13 @@ class AWSOrgQueryParamSerializerTest(IamTestCase):
 
         for params in scenarios:
             with self.subTest(params=params):
-                serializer = AWSOrgQueryParamSerializer(data=params, context=ctx)
+                serializer = AWSOrgQueryParamSerializer(data=params, context=self.ctx_w_path)
                 self.assertTrue(serializer.is_valid(raise_exception=True))
 
     def test_parse_filter_dates_invalid(self):
         """Test parse of invalid data for filter date-based param should not succeed."""
         dh = DateHelper()
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/organizations/aws/")
+        self.request_path = "/api/cost-management/v1/organizations/aws/"
         scenarios = [
             {"start_date": dh.today.date()},
             {"end_date": dh.today.date()},
@@ -183,5 +183,5 @@ class AWSOrgQueryParamSerializerTest(IamTestCase):
 
         for params in scenarios:
             with self.subTest(params=params):
-                serializer = AWSOrgQueryParamSerializer(data=params, context=ctx)
+                serializer = AWSOrgQueryParamSerializer(data=params, context=self.ctx_w_path)
                 self.assertFalse(serializer.is_valid())

--- a/koku/api/report/test/aws/openshift/test_serializers.py
+++ b/koku/api/report/test/aws/openshift/test_serializers.py
@@ -257,10 +257,7 @@ class OCPAWSQueryParamSerializerTest(IamTestCase):
             {"filter": {"limit": "1"}},
             {"filter": {"offset": "1"}},
         ]
-        path = "/api/cost-management/v1/reports/openshift/infrastructures/aws/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/infrastructures/aws/costs/")
         for param in param_failures_list:
             with self.subTest(param=param):
                 with self.assertRaises(serializers.ValidationError):

--- a/koku/api/report/test/aws/openshift/test_serializers.py
+++ b/koku/api/report/test/aws/openshift/test_serializers.py
@@ -257,10 +257,10 @@ class OCPAWSQueryParamSerializerTest(IamTestCase):
             {"filter": {"limit": "1"}},
             {"filter": {"offset": "1"}},
         ]
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/infrastructures/aws/costs/")
+        self.request_path = "/api/cost-management/v1/reports/openshift/infrastructures/aws/costs/"
         for param in param_failures_list:
             with self.subTest(param=param):
                 with self.assertRaises(serializers.ValidationError):
-                    serializer = OCPAWSQueryParamSerializer(data=param, context=ctx)
+                    serializer = OCPAWSQueryParamSerializer(data=param, context=self.ctx_w_path)
                     self.assertFalse(serializer.is_valid())
                     serializer.is_valid(raise_exception=True)

--- a/koku/api/report/test/azure/openshift/test_serializers.py
+++ b/koku/api/report/test/azure/openshift/test_serializers.py
@@ -321,9 +321,8 @@ class OCPAzureQueryParamSerializerTest(IamTestCase):
             },
         }
 
-        path = "/api/cost-management/v1/reports/openshift/infrastructures/azure/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
+        ctx = self.get_request_ctx_w_path(
+            path="/api/cost-management/v1/reports/openshift/infrastructures/azure/costs/"
         )
         serializer = OCPAzureQueryParamSerializer(data=query_params, context=ctx)
         self.assertTrue(serializer.is_valid())
@@ -340,9 +339,8 @@ class OCPAzureQueryParamSerializerTest(IamTestCase):
                 "resource_scope": [],
             },
         }
-        path = "/api/cost-management/v1/reports/openshift/infrastructures/azure/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
+        ctx = self.get_request_ctx_w_path(
+            path="/api/cost-management/v1/reports/openshift/infrastructures/azure/costs/"
         )
         serializer = OCPAzureQueryParamSerializer(data=query_params, context=ctx)
         self.assertTrue(serializer.is_valid())
@@ -359,9 +357,8 @@ class OCPAzureQueryParamSerializerTest(IamTestCase):
             },
             "invalid": "param",
         }
-        path = "/api/cost-management/v1/reports/openshift/infrastructures/azure/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
+        ctx = self.get_request_ctx_w_path(
+            path="/api/cost-management/v1/reports/openshift/infrastructures/azure/costs/"
         )
         serializer = OCPAzureQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
@@ -378,9 +375,8 @@ class OCPAzureQueryParamSerializerTest(IamTestCase):
                 "subscription_guid": [FAKE.uuid4()],
             },
         }
-        path = "/api/cost-management/v1/reports/openshift/infrastructures/azure/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
+        ctx = self.get_request_ctx_w_path(
+            path="/api/cost-management/v1/reports/openshift/infrastructures/azure/costs/"
         )
         serializer = OCPAzureQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
@@ -390,9 +386,8 @@ class OCPAzureQueryParamSerializerTest(IamTestCase):
         """Test that tag keys are validated as fields."""
         tag_keys = ["valid_tag"]
         query_params = {"filter": {"valid_tag": "value"}}
-        path = "/api/cost-management/v1/reports/openshift/infrastructures/azure/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
+        ctx = self.get_request_ctx_w_path(
+            path="/api/cost-management/v1/reports/openshift/infrastructures/azure/costs/"
         )
         serializer = OCPAzureQueryParamSerializer(data=query_params, tag_keys=tag_keys, context=ctx)
         self.assertTrue(serializer.is_valid())
@@ -401,9 +396,8 @@ class OCPAzureQueryParamSerializerTest(IamTestCase):
         """Test that invalid tag keys are not valid fields."""
         tag_keys = ["valid_tag"]
         query_params = {"filter": {"bad_tag": "value"}}
-        path = "/api/cost-management/v1/reports/openshift/infrastructures/azure/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
+        ctx = self.get_request_ctx_w_path(
+            path="/api/cost-management/v1/reports/openshift/infrastructures/azure/costs/"
         )
         serializer = OCPAzureQueryParamSerializer(data=query_params, tag_keys=tag_keys, context=ctx)
         with self.assertRaises(serializers.ValidationError):
@@ -412,30 +406,21 @@ class OCPAzureQueryParamSerializerTest(IamTestCase):
     def test_valid_delta_costs(self):
         """Test successful handling of valid delta for cost requests."""
         query_params = {"delta": "cost"}
-        path = "/api/cost-management/v1/reports/azure/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/azure/costs/")
         serializer = OCPAzureQueryParamSerializer(data=query_params, context=ctx)
         self.assertTrue(serializer.is_valid())
 
     def test_valid_delta_usage(self):
         """Test successful handling of valid delta for usage requests."""
         query_params = {"delta": "usage"}
-        path = "/api/cost-management/v1/reports/azure/storage/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/azure/storage/")
         serializer = OCPAzureQueryParamSerializer(data=query_params, context=ctx)
         self.assertTrue(serializer.is_valid())
 
     def test_invalid_delta_costs(self):
         """Test failure while handling invalid delta for cost requests."""
         query_params = {"delta": "cost_bad"}
-        path = "/api/cost-management/v1/reports/azure/storage/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/azure/storage/")
         serializer = OCPAzureQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
@@ -443,10 +428,7 @@ class OCPAzureQueryParamSerializerTest(IamTestCase):
     def test_invalid_delta_usage(self):
         """Test failure while handling invalid delta for usage requests."""
         query_params = {"delta": "usage"}
-        path = "/api/cost-management/v1/reports/azure/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/azure/costs/")
         serializer = OCPAzureQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
@@ -455,9 +437,8 @@ class OCPAzureQueryParamSerializerTest(IamTestCase):
         """Test that order_by[service_name] works with a matching group-by."""
         query_params = {"group_by": {"service_name": "asc"}, "order_by": {"service_name": "asc"}}
 
-        path = "/api/cost-management/v1/reports/openshift/infrastructures/azure/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
+        ctx = self.get_request_ctx_w_path(
+            path="/api/cost-management/v1/reports/openshift/infrastructures/azure/costs/"
         )
         serializer = OCPAzureQueryParamSerializer(data=query_params, context=ctx)
         self.assertTrue(serializer.is_valid())
@@ -466,9 +447,8 @@ class OCPAzureQueryParamSerializerTest(IamTestCase):
         """Test that order_by[service_name] fails without a matching group-by."""
         query_params = {"order_by": {"service_name": "asc"}}
 
-        path = "/api/cost-management/v1/reports/openshift/infrastructures/azure/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
+        ctx = self.get_request_ctx_w_path(
+            path="/api/cost-management/v1/reports/openshift/infrastructures/azure/costs/"
         )
         serializer = OCPAzureQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
@@ -484,9 +464,8 @@ class OCPAzureQueryParamSerializerTest(IamTestCase):
             "invalid": "param",
         }
 
-        path = "/api/cost-management/v1/reports/openshift/infrastructures/azure/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
+        ctx = self.get_request_ctx_w_path(
+            path="/api/cost-management/v1/reports/openshift/infrastructures/azure/costs/"
         )
         serializer = OCPAzureQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
@@ -502,9 +481,8 @@ class OCPAzureQueryParamSerializerTest(IamTestCase):
             "invalid": "param",
         }
 
-        path = "/api/cost-management/v1/reports/openshift/infrastructures/azure/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
+        ctx = self.get_request_ctx_w_path(
+            path="/api/cost-management/v1/reports/openshift/infrastructures/azure/costs/"
         )
         serializer = OCPAzureQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
@@ -517,9 +495,8 @@ class OCPAzureQueryParamSerializerTest(IamTestCase):
             {"filter": {"limit": "1"}},
             {"filter": {"offset": "1"}},
         ]
-        path = "/api/cost-management/v1/reports/openshift/infrastructures/azure/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
+        ctx = self.get_request_ctx_w_path(
+            path="/api/cost-management/v1/reports/openshift/infrastructures/azure/costs/"
         )
         for param in param_failures_list:
             with self.subTest(param=param):

--- a/koku/api/report/test/azure/openshift/test_serializers.py
+++ b/koku/api/report/test/azure/openshift/test_serializers.py
@@ -321,10 +321,8 @@ class OCPAzureQueryParamSerializerTest(IamTestCase):
             },
         }
 
-        ctx = self.get_request_ctx_w_path(
-            path="/api/cost-management/v1/reports/openshift/infrastructures/azure/costs/"
-        )
-        serializer = OCPAzureQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/openshift/infrastructures/azure/costs/"
+        serializer = OCPAzureQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         self.assertTrue(serializer.is_valid())
 
     def test_parse_query_ocp_params_success(self):
@@ -339,10 +337,8 @@ class OCPAzureQueryParamSerializerTest(IamTestCase):
                 "resource_scope": [],
             },
         }
-        ctx = self.get_request_ctx_w_path(
-            path="/api/cost-management/v1/reports/openshift/infrastructures/azure/costs/"
-        )
-        serializer = OCPAzureQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/openshift/infrastructures/azure/costs/"
+        serializer = OCPAzureQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         self.assertTrue(serializer.is_valid())
 
     def test_query_params_invalid_fields(self):
@@ -357,10 +353,8 @@ class OCPAzureQueryParamSerializerTest(IamTestCase):
             },
             "invalid": "param",
         }
-        ctx = self.get_request_ctx_w_path(
-            path="/api/cost-management/v1/reports/openshift/infrastructures/azure/costs/"
-        )
-        serializer = OCPAzureQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/openshift/infrastructures/azure/costs/"
+        serializer = OCPAzureQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
@@ -375,10 +369,8 @@ class OCPAzureQueryParamSerializerTest(IamTestCase):
                 "subscription_guid": [FAKE.uuid4()],
             },
         }
-        ctx = self.get_request_ctx_w_path(
-            path="/api/cost-management/v1/reports/openshift/infrastructures/azure/costs/"
-        )
-        serializer = OCPAzureQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/openshift/infrastructures/azure/costs/"
+        serializer = OCPAzureQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
@@ -386,50 +378,47 @@ class OCPAzureQueryParamSerializerTest(IamTestCase):
         """Test that tag keys are validated as fields."""
         tag_keys = ["valid_tag"]
         query_params = {"filter": {"valid_tag": "value"}}
-        ctx = self.get_request_ctx_w_path(
-            path="/api/cost-management/v1/reports/openshift/infrastructures/azure/costs/"
-        )
-        serializer = OCPAzureQueryParamSerializer(data=query_params, tag_keys=tag_keys, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/openshift/infrastructures/azure/costs/"
+        serializer = OCPAzureQueryParamSerializer(data=query_params, tag_keys=tag_keys, context=self.ctx_w_path)
         self.assertTrue(serializer.is_valid())
 
     def test_tag_keys_dynamic_field_validation_failure(self):
         """Test that invalid tag keys are not valid fields."""
         tag_keys = ["valid_tag"]
         query_params = {"filter": {"bad_tag": "value"}}
-        ctx = self.get_request_ctx_w_path(
-            path="/api/cost-management/v1/reports/openshift/infrastructures/azure/costs/"
-        )
-        serializer = OCPAzureQueryParamSerializer(data=query_params, tag_keys=tag_keys, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/openshift/infrastructures/azure/costs/"
+
+        serializer = OCPAzureQueryParamSerializer(data=query_params, tag_keys=tag_keys, context=self.ctx_w_path)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
     def test_valid_delta_costs(self):
         """Test successful handling of valid delta for cost requests."""
         query_params = {"delta": "cost"}
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/azure/costs/")
-        serializer = OCPAzureQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/azure/costs/"
+        serializer = OCPAzureQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         self.assertTrue(serializer.is_valid())
 
     def test_valid_delta_usage(self):
         """Test successful handling of valid delta for usage requests."""
         query_params = {"delta": "usage"}
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/azure/storage/")
-        serializer = OCPAzureQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/azure/storage/"
+        serializer = OCPAzureQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         self.assertTrue(serializer.is_valid())
 
     def test_invalid_delta_costs(self):
         """Test failure while handling invalid delta for cost requests."""
         query_params = {"delta": "cost_bad"}
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/azure/storage/")
-        serializer = OCPAzureQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/azure/storage/"
+        serializer = OCPAzureQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
     def test_invalid_delta_usage(self):
         """Test failure while handling invalid delta for usage requests."""
         query_params = {"delta": "usage"}
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/azure/costs/")
-        serializer = OCPAzureQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/azure/costs/"
+        serializer = OCPAzureQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
@@ -437,20 +426,16 @@ class OCPAzureQueryParamSerializerTest(IamTestCase):
         """Test that order_by[service_name] works with a matching group-by."""
         query_params = {"group_by": {"service_name": "asc"}, "order_by": {"service_name": "asc"}}
 
-        ctx = self.get_request_ctx_w_path(
-            path="/api/cost-management/v1/reports/openshift/infrastructures/azure/costs/"
-        )
-        serializer = OCPAzureQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/openshift/infrastructures/azure/costs/"
+        serializer = OCPAzureQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         self.assertTrue(serializer.is_valid())
 
     def test_order_by_service_without_groupby(self):
         """Test that order_by[service_name] fails without a matching group-by."""
         query_params = {"order_by": {"service_name": "asc"}}
 
-        ctx = self.get_request_ctx_w_path(
-            path="/api/cost-management/v1/reports/openshift/infrastructures/azure/costs/"
-        )
-        serializer = OCPAzureQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/openshift/infrastructures/azure/costs/"
+        serializer = OCPAzureQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
@@ -464,10 +449,8 @@ class OCPAzureQueryParamSerializerTest(IamTestCase):
             "invalid": "param",
         }
 
-        ctx = self.get_request_ctx_w_path(
-            path="/api/cost-management/v1/reports/openshift/infrastructures/azure/costs/"
-        )
-        serializer = OCPAzureQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/openshift/infrastructures/azure/costs/"
+        serializer = OCPAzureQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
@@ -481,10 +464,8 @@ class OCPAzureQueryParamSerializerTest(IamTestCase):
             "invalid": "param",
         }
 
-        ctx = self.get_request_ctx_w_path(
-            path="/api/cost-management/v1/reports/openshift/infrastructures/azure/costs/"
-        )
-        serializer = OCPAzureQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/openshift/infrastructures/azure/costs/"
+        serializer = OCPAzureQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
@@ -495,12 +476,10 @@ class OCPAzureQueryParamSerializerTest(IamTestCase):
             {"filter": {"limit": "1"}},
             {"filter": {"offset": "1"}},
         ]
-        ctx = self.get_request_ctx_w_path(
-            path="/api/cost-management/v1/reports/openshift/infrastructures/azure/costs/"
-        )
+        self.request_path = "/api/cost-management/v1/reports/openshift/infrastructures/azure/costs/"
         for param in param_failures_list:
             with self.subTest(param=param):
                 with self.assertRaises(serializers.ValidationError):
-                    serializer = OCPAzureQueryParamSerializer(data=param, context=ctx)
+                    serializer = OCPAzureQueryParamSerializer(data=param, context=self.ctx_w_path)
                     self.assertFalse(serializer.is_valid())
                     serializer.is_valid(raise_exception=True)

--- a/koku/api/report/test/azure/test_serializers.py
+++ b/koku/api/report/test/azure/test_serializers.py
@@ -249,8 +249,8 @@ class AzureQueryParamSerializerTest(IamTestCase):
             },
         }
 
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/azure/costs/")
-        serializer = AzureQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/azure/costs/"
+        serializer = AzureQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         self.assertTrue(serializer.is_valid())
 
     def test_query_params_invalid_fields(self):
@@ -266,8 +266,8 @@ class AzureQueryParamSerializerTest(IamTestCase):
             "invalid": "param",
         }
 
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/azure/costs/")
-        serializer = AzureQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/azure/costs/"
+        serializer = AzureQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
@@ -283,8 +283,8 @@ class AzureQueryParamSerializerTest(IamTestCase):
             },
         }
 
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/azure/costs/")
-        serializer = AzureQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/azure/costs/"
+        serializer = AzureQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
@@ -293,8 +293,8 @@ class AzureQueryParamSerializerTest(IamTestCase):
         tag_keys = ["valid_tag"]
         query_params = {"filter": {"valid_tag": "value"}}
 
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/azure/costs/")
-        serializer = AzureQueryParamSerializer(data=query_params, tag_keys=tag_keys, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/azure/costs/"
+        serializer = AzureQueryParamSerializer(data=query_params, tag_keys=tag_keys, context=self.ctx_w_path)
         self.assertTrue(serializer.is_valid())
 
     def test_tag_keys_dynamic_field_validation_failure(self):
@@ -302,53 +302,53 @@ class AzureQueryParamSerializerTest(IamTestCase):
         tag_keys = ["valid_tag"]
         query_params = {"filter": {"bad_tag": "value"}}
 
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/azure/costs/")
-        serializer = AzureQueryParamSerializer(data=query_params, tag_keys=tag_keys, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/azure/costs/"
+        serializer = AzureQueryParamSerializer(data=query_params, tag_keys=tag_keys, context=self.ctx_w_path)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
     def test_valid_delta_costs(self):
         """Test successful handling of valid delta for cost requests."""
         query_params = {"delta": "cost"}
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/azure/costs/")
-        serializer = AzureQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/azure/costs/"
+        serializer = AzureQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         self.assertTrue(serializer.is_valid())
 
     def test_valid_delta_usage(self):
         """Test successful handling of valid delta for usage requests."""
         query_params = {"delta": "usage"}
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/azure/storage/")
-        serializer = AzureQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/azure/storage/"
+        serializer = AzureQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         self.assertTrue(serializer.is_valid())
 
     def test_invalid_delta_costs(self):
         """Test failure while handling invalid delta for cost requests."""
         query_params = {"delta": "cost_bad"}
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/azure/storage/")
-        serializer = AzureQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/azure/storage/"
+        serializer = AzureQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
     def test_invalid_delta_usage(self):
         """Test failure while handling invalid delta for usage requests."""
         query_params = {"delta": "usage"}
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/azure/costs/")
-        serializer = AzureQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/azure/costs/"
+        serializer = AzureQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
     def test_order_by_service_with_groupby(self):
         """Test that order_by[service_name] works with a matching group-by."""
         query_params = {"group_by": {"service_name": "asc"}, "order_by": {"service_name": "asc"}}
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/azure/costs/")
-        serializer = AzureQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/azure/costs/"
+        serializer = AzureQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         self.assertTrue(serializer.is_valid())
 
     def test_order_by_service_without_groupby(self):
         """Test that order_by[service_name] fails without a matching group-by."""
         query_params = {"order_by": {"service_name": "asc"}}
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/azure/costs/")
-        serializer = AzureQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/azure/costs/"
+        serializer = AzureQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
@@ -361,8 +361,8 @@ class AzureQueryParamSerializerTest(IamTestCase):
             "filter": {"resolution": "daily", "time_scope_value": "-10", "time_scope_units": "day"},
             "invalid": "param",
         }
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/azure/costs/")
-        serializer = AzureQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/azure/costs/"
+        serializer = AzureQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
@@ -375,8 +375,8 @@ class AzureQueryParamSerializerTest(IamTestCase):
             "filter": {"resolution": "daily", "time_scope_value": "-10", "time_scope_units": "day"},
             "invalid": "param",
         }
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/azure/costs/")
-        serializer = AzureQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/azure/costs/"
+        serializer = AzureQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
@@ -387,11 +387,11 @@ class AzureQueryParamSerializerTest(IamTestCase):
             {"filter": {"limit": "1"}},
             {"filter": {"offset": "1"}},
         ]
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/azure/costs/")
+        self.request_path = "/api/cost-management/v1/reports/azure/costs/"
         for param in param_failures_list:
             with self.subTest(param=param):
                 with self.assertRaises(serializers.ValidationError):
-                    serializer = AzureQueryParamSerializer(data=param, context=ctx)
+                    serializer = AzureQueryParamSerializer(data=param, context=self.ctx_w_path)
                     self.assertFalse(serializer.is_valid())
                     serializer.is_valid(raise_exception=True)
 
@@ -402,8 +402,8 @@ class AzureQueryParamSerializerTest(IamTestCase):
             {"filter": {"limit": "1"}},
             {"filter": {"offset": "1"}},
         ]
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/azure/instance-types/")
+        self.request_path = "/api/cost-management/v1/reports/azure/instance-types/"
         for param in param_list:
             with self.subTest(param=param):
-                serializer = AzureQueryParamSerializer(data=param, context=ctx)
+                serializer = AzureQueryParamSerializer(data=param, context=self.ctx_w_path)
                 self.assertTrue(serializer.is_valid())

--- a/koku/api/report/test/azure/test_serializers.py
+++ b/koku/api/report/test/azure/test_serializers.py
@@ -249,10 +249,7 @@ class AzureQueryParamSerializerTest(IamTestCase):
             },
         }
 
-        path = "/api/cost-management/v1/reports/azure/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/azure/costs/")
         serializer = AzureQueryParamSerializer(data=query_params, context=ctx)
         self.assertTrue(serializer.is_valid())
 
@@ -269,10 +266,7 @@ class AzureQueryParamSerializerTest(IamTestCase):
             "invalid": "param",
         }
 
-        path = "/api/cost-management/v1/reports/azure/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/azure/costs/")
         serializer = AzureQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
@@ -289,10 +283,7 @@ class AzureQueryParamSerializerTest(IamTestCase):
             },
         }
 
-        path = "/api/cost-management/v1/reports/azure/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/azure/costs/")
         serializer = AzureQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
@@ -302,10 +293,7 @@ class AzureQueryParamSerializerTest(IamTestCase):
         tag_keys = ["valid_tag"]
         query_params = {"filter": {"valid_tag": "value"}}
 
-        path = "/api/cost-management/v1/reports/azure/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/azure/costs/")
         serializer = AzureQueryParamSerializer(data=query_params, tag_keys=tag_keys, context=ctx)
         self.assertTrue(serializer.is_valid())
 
@@ -314,10 +302,7 @@ class AzureQueryParamSerializerTest(IamTestCase):
         tag_keys = ["valid_tag"]
         query_params = {"filter": {"bad_tag": "value"}}
 
-        path = "/api/cost-management/v1/reports/azure/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/azure/costs/")
         serializer = AzureQueryParamSerializer(data=query_params, tag_keys=tag_keys, context=ctx)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
@@ -325,30 +310,21 @@ class AzureQueryParamSerializerTest(IamTestCase):
     def test_valid_delta_costs(self):
         """Test successful handling of valid delta for cost requests."""
         query_params = {"delta": "cost"}
-        path = "/api/cost-management/v1/reports/azure/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/azure/costs/")
         serializer = AzureQueryParamSerializer(data=query_params, context=ctx)
         self.assertTrue(serializer.is_valid())
 
     def test_valid_delta_usage(self):
         """Test successful handling of valid delta for usage requests."""
         query_params = {"delta": "usage"}
-        path = "/api/cost-management/v1/reports/azure/storage/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/azure/storage/")
         serializer = AzureQueryParamSerializer(data=query_params, context=ctx)
         self.assertTrue(serializer.is_valid())
 
     def test_invalid_delta_costs(self):
         """Test failure while handling invalid delta for cost requests."""
         query_params = {"delta": "cost_bad"}
-        path = "/api/cost-management/v1/reports/azure/storage/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/azure/storage/")
         serializer = AzureQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
@@ -356,10 +332,7 @@ class AzureQueryParamSerializerTest(IamTestCase):
     def test_invalid_delta_usage(self):
         """Test failure while handling invalid delta for usage requests."""
         query_params = {"delta": "usage"}
-        path = "/api/cost-management/v1/reports/azure/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/azure/costs/")
         serializer = AzureQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
@@ -367,22 +340,14 @@ class AzureQueryParamSerializerTest(IamTestCase):
     def test_order_by_service_with_groupby(self):
         """Test that order_by[service_name] works with a matching group-by."""
         query_params = {"group_by": {"service_name": "asc"}, "order_by": {"service_name": "asc"}}
-
-        path = "/api/cost-management/v1/reports/azure/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/azure/costs/")
         serializer = AzureQueryParamSerializer(data=query_params, context=ctx)
         self.assertTrue(serializer.is_valid())
 
     def test_order_by_service_without_groupby(self):
         """Test that order_by[service_name] fails without a matching group-by."""
         query_params = {"order_by": {"service_name": "asc"}}
-
-        path = "/api/cost-management/v1/reports/azure/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/azure/costs/")
         serializer = AzureQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
@@ -396,11 +361,7 @@ class AzureQueryParamSerializerTest(IamTestCase):
             "filter": {"resolution": "daily", "time_scope_value": "-10", "time_scope_units": "day"},
             "invalid": "param",
         }
-
-        path = "/api/cost-management/v1/reports/azure/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/azure/costs/")
         serializer = AzureQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
@@ -414,11 +375,7 @@ class AzureQueryParamSerializerTest(IamTestCase):
             "filter": {"resolution": "daily", "time_scope_value": "-10", "time_scope_units": "day"},
             "invalid": "param",
         }
-
-        path = "/api/cost-management/v1/reports/azure/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/azure/costs/")
         serializer = AzureQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
@@ -430,10 +387,7 @@ class AzureQueryParamSerializerTest(IamTestCase):
             {"filter": {"limit": "1"}},
             {"filter": {"offset": "1"}},
         ]
-        path = "/api/cost-management/v1/reports/azure/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/azure/costs/")
         for param in param_failures_list:
             with self.subTest(param=param):
                 with self.assertRaises(serializers.ValidationError):
@@ -448,10 +402,7 @@ class AzureQueryParamSerializerTest(IamTestCase):
             {"filter": {"limit": "1"}},
             {"filter": {"offset": "1"}},
         ]
-        path = "/api/cost-management/v1/reports/azure/instance-types/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/azure/instance-types/")
         for param in param_list:
             with self.subTest(param=param):
                 serializer = AzureQueryParamSerializer(data=param, context=ctx)

--- a/koku/api/report/test/gcp/openshift/test_serializers.py
+++ b/koku/api/report/test/gcp/openshift/test_serializers.py
@@ -313,8 +313,8 @@ class OCPGCPQueryParamSerializerTest(IamTestCase):
             },
         }
 
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/infrastructures/gcp/costs/")
-        serializer = OCPGCPQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/openshift/infrastructures/gcp/costs/"
+        serializer = OCPGCPQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         self.assertTrue(serializer.is_valid())
 
     def test_parse_query_ocp_params_success(self):
@@ -330,8 +330,8 @@ class OCPGCPQueryParamSerializerTest(IamTestCase):
             },
         }
 
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/infrastructures/gcp/costs/")
-        serializer = OCPGCPQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/openshift/infrastructures/gcp/costs/"
+        serializer = OCPGCPQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         self.assertTrue(serializer.is_valid())
 
     def test_query_params_invalid_fields(self):
@@ -347,8 +347,8 @@ class OCPGCPQueryParamSerializerTest(IamTestCase):
             "invalid": "param",
         }
 
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/infrastructures/gcp/costs/")
-        serializer = OCPGCPQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/openshift/infrastructures/gcp/costs/"
+        serializer = OCPGCPQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
@@ -364,8 +364,8 @@ class OCPGCPQueryParamSerializerTest(IamTestCase):
             },
         }
 
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/infrastructures/gcp/costs/")
-        serializer = OCPGCPQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/openshift/infrastructures/gcp/costs/"
+        serializer = OCPGCPQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
@@ -374,8 +374,8 @@ class OCPGCPQueryParamSerializerTest(IamTestCase):
         tag_keys = ["valid_tag"]
         query_params = {"filter": {"valid_tag": "value"}}
 
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/infrastructures/gcp/costs/")
-        serializer = OCPGCPQueryParamSerializer(data=query_params, tag_keys=tag_keys, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/openshift/infrastructures/gcp/costs/"
+        serializer = OCPGCPQueryParamSerializer(data=query_params, tag_keys=tag_keys, context=self.ctx_w_path)
         self.assertTrue(serializer.is_valid())
 
     def test_tag_keys_dynamic_field_validation_failure(self):
@@ -383,38 +383,38 @@ class OCPGCPQueryParamSerializerTest(IamTestCase):
         tag_keys = ["valid_tag"]
         query_params = {"filter": {"bad_tag": "value"}}
 
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/infrastructures/gcp/costs/")
-        serializer = OCPGCPQueryParamSerializer(data=query_params, tag_keys=tag_keys, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/openshift/infrastructures/gcp/costs/"
+        serializer = OCPGCPQueryParamSerializer(data=query_params, tag_keys=tag_keys, context=self.ctx_w_path)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
     def test_valid_delta_costs(self):
         """Test successful handling of valid delta for cost requests."""
         query_params = {"delta": "cost"}
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/gcp/costs/")
-        serializer = OCPGCPQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/gcp/costs/"
+        serializer = OCPGCPQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         self.assertTrue(serializer.is_valid())
 
     def test_valid_delta_usage(self):
         """Test successful handling of valid delta for usage requests."""
         query_params = {"delta": "usage"}
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/gcp/storage/")
-        serializer = OCPGCPQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/gcp/storage/"
+        serializer = OCPGCPQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         self.assertTrue(serializer.is_valid())
 
     def test_invalid_delta_costs(self):
         """Test failure while handling invalid delta for cost requests."""
         query_params = {"delta": "cost_bad"}
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/gcp/storage/")
-        serializer = OCPGCPQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/gcp/storage/"
+        serializer = OCPGCPQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
     def test_invalid_delta_usage(self):
         """Test failure while handling invalid delta for usage requests."""
         query_params = {"delta": "usage"}
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/gcp/costs/")
-        serializer = OCPGCPQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/gcp/costs/"
+        serializer = OCPGCPQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
@@ -422,16 +422,16 @@ class OCPGCPQueryParamSerializerTest(IamTestCase):
         """Test that order_by[service] works with a matching group-by."""
         query_params = {"group_by": {"service": "asc"}, "order_by": {"service": "asc"}}
 
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/infrastructures/gcp/costs/")
-        serializer = OCPGCPQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/openshift/infrastructures/gcp/costs/"
+        serializer = OCPGCPQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         self.assertTrue(serializer.is_valid())
 
     def test_order_by_service_without_groupby(self):
         """Test that order_by[service] fails without a matching group-by."""
         query_params = {"order_by": {"service": "asc"}}
 
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/infrastructures/gcp/costs/")
-        serializer = OCPGCPQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/openshift/infrastructures/gcp/costs/"
+        serializer = OCPGCPQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
@@ -444,8 +444,8 @@ class OCPGCPQueryParamSerializerTest(IamTestCase):
             "filter": {"resolution": "daily", "time_scope_value": "-10", "time_scope_units": "day"},
             "invalid": "param",
         }
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/infrastructures/gcp/costs/")
-        serializer = OCPGCPQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/openshift/infrastructures/gcp/costs/"
+        serializer = OCPGCPQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
@@ -459,8 +459,8 @@ class OCPGCPQueryParamSerializerTest(IamTestCase):
             "invalid": "param",
         }
 
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/infrastructures/gcp/costs/")
-        serializer = OCPGCPQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/openshift/infrastructures/gcp/costs/"
+        serializer = OCPGCPQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
@@ -471,10 +471,10 @@ class OCPGCPQueryParamSerializerTest(IamTestCase):
             {"filter": {"limit": "1"}},
             {"filter": {"offset": "1"}},
         ]
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/infrastructures/gcp/costs/")
+        self.request_path = "/api/cost-management/v1/reports/openshift/infrastructures/gcp/costs/"
         for param in param_failures_list:
             with self.subTest(param=param):
                 with self.assertRaises(serializers.ValidationError):
-                    serializer = OCPGCPQueryParamSerializer(data=param, context=ctx)
+                    serializer = OCPGCPQueryParamSerializer(data=param, context=self.ctx_w_path)
                     self.assertFalse(serializer.is_valid())
                     serializer.is_valid(raise_exception=True)

--- a/koku/api/report/test/gcp/openshift/test_serializers.py
+++ b/koku/api/report/test/gcp/openshift/test_serializers.py
@@ -313,10 +313,7 @@ class OCPGCPQueryParamSerializerTest(IamTestCase):
             },
         }
 
-        path = "/api/cost-management/v1/reports/openshift/infrastructures/gcp/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/infrastructures/gcp/costs/")
         serializer = OCPGCPQueryParamSerializer(data=query_params, context=ctx)
         self.assertTrue(serializer.is_valid())
 
@@ -333,10 +330,7 @@ class OCPGCPQueryParamSerializerTest(IamTestCase):
             },
         }
 
-        path = "/api/cost-management/v1/reports/openshift/infrastructures/gcp/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/infrastructures/gcp/costs/")
         serializer = OCPGCPQueryParamSerializer(data=query_params, context=ctx)
         self.assertTrue(serializer.is_valid())
 
@@ -353,10 +347,7 @@ class OCPGCPQueryParamSerializerTest(IamTestCase):
             "invalid": "param",
         }
 
-        path = "/api/cost-management/v1/reports/openshift/infrastructures/gcp/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/infrastructures/gcp/costs/")
         serializer = OCPGCPQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
@@ -373,10 +364,7 @@ class OCPGCPQueryParamSerializerTest(IamTestCase):
             },
         }
 
-        path = "/api/cost-management/v1/reports/openshift/infrastructures/gcp/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/infrastructures/gcp/costs/")
         serializer = OCPGCPQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
@@ -386,10 +374,7 @@ class OCPGCPQueryParamSerializerTest(IamTestCase):
         tag_keys = ["valid_tag"]
         query_params = {"filter": {"valid_tag": "value"}}
 
-        path = "/api/cost-management/v1/reports/openshift/infrastructures/gcp/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/infrastructures/gcp/costs/")
         serializer = OCPGCPQueryParamSerializer(data=query_params, tag_keys=tag_keys, context=ctx)
         self.assertTrue(serializer.is_valid())
 
@@ -398,10 +383,7 @@ class OCPGCPQueryParamSerializerTest(IamTestCase):
         tag_keys = ["valid_tag"]
         query_params = {"filter": {"bad_tag": "value"}}
 
-        path = "/api/cost-management/v1/reports/openshift/infrastructures/gcp/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/infrastructures/gcp/costs/")
         serializer = OCPGCPQueryParamSerializer(data=query_params, tag_keys=tag_keys, context=ctx)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
@@ -409,30 +391,21 @@ class OCPGCPQueryParamSerializerTest(IamTestCase):
     def test_valid_delta_costs(self):
         """Test successful handling of valid delta for cost requests."""
         query_params = {"delta": "cost"}
-        path = "/api/cost-management/v1/reports/gcp/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/gcp/costs/")
         serializer = OCPGCPQueryParamSerializer(data=query_params, context=ctx)
         self.assertTrue(serializer.is_valid())
 
     def test_valid_delta_usage(self):
         """Test successful handling of valid delta for usage requests."""
         query_params = {"delta": "usage"}
-        path = "/api/cost-management/v1/reports/gcp/storage/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/gcp/storage/")
         serializer = OCPGCPQueryParamSerializer(data=query_params, context=ctx)
         self.assertTrue(serializer.is_valid())
 
     def test_invalid_delta_costs(self):
         """Test failure while handling invalid delta for cost requests."""
         query_params = {"delta": "cost_bad"}
-        path = "/api/cost-management/v1/reports/gcp/storage/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/gcp/storage/")
         serializer = OCPGCPQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
@@ -440,10 +413,7 @@ class OCPGCPQueryParamSerializerTest(IamTestCase):
     def test_invalid_delta_usage(self):
         """Test failure while handling invalid delta for usage requests."""
         query_params = {"delta": "usage"}
-        path = "/api/cost-management/v1/reports/gcp/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/gcp/costs/")
         serializer = OCPGCPQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
@@ -452,10 +422,7 @@ class OCPGCPQueryParamSerializerTest(IamTestCase):
         """Test that order_by[service] works with a matching group-by."""
         query_params = {"group_by": {"service": "asc"}, "order_by": {"service": "asc"}}
 
-        path = "/api/cost-management/v1/reports/openshift/infrastructures/gcp/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/infrastructures/gcp/costs/")
         serializer = OCPGCPQueryParamSerializer(data=query_params, context=ctx)
         self.assertTrue(serializer.is_valid())
 
@@ -463,10 +430,7 @@ class OCPGCPQueryParamSerializerTest(IamTestCase):
         """Test that order_by[service] fails without a matching group-by."""
         query_params = {"order_by": {"service": "asc"}}
 
-        path = "/api/cost-management/v1/reports/openshift/infrastructures/gcp/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/infrastructures/gcp/costs/")
         serializer = OCPGCPQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
@@ -480,10 +444,7 @@ class OCPGCPQueryParamSerializerTest(IamTestCase):
             "filter": {"resolution": "daily", "time_scope_value": "-10", "time_scope_units": "day"},
             "invalid": "param",
         }
-        path = "/api/cost-management/v1/reports/openshift/infrastructures/gcp/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/infrastructures/gcp/costs/")
         serializer = OCPGCPQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
@@ -498,10 +459,7 @@ class OCPGCPQueryParamSerializerTest(IamTestCase):
             "invalid": "param",
         }
 
-        path = "/api/cost-management/v1/reports/openshift/infrastructures/gcp/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/infrastructures/gcp/costs/")
         serializer = OCPGCPQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
@@ -513,10 +471,7 @@ class OCPGCPQueryParamSerializerTest(IamTestCase):
             {"filter": {"limit": "1"}},
             {"filter": {"offset": "1"}},
         ]
-        path = "/api/cost-management/v1/reports/openshift/infrastructures/gcp/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/infrastructures/gcp/costs/")
         for param in param_failures_list:
             with self.subTest(param=param):
                 with self.assertRaises(serializers.ValidationError):

--- a/koku/api/report/test/gcp/test_serializers.py
+++ b/koku/api/report/test/gcp/test_serializers.py
@@ -242,10 +242,7 @@ class GCPQueryParamSerializerTest(IamTestCase):
                 "account": [FAKE.uuid4()],
             },
         }
-        path = "/api/cost-management/v1/reports/gcp/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/gcp/costs/")
         serializer = GCPQueryParamSerializer(data=query_params, context=ctx)
         self.assertTrue(serializer.is_valid())
 
@@ -261,10 +258,7 @@ class GCPQueryParamSerializerTest(IamTestCase):
             },
             "invalid": "param",
         }
-        path = "/api/cost-management/v1/reports/gcp/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/gcp/costs/")
         serializer = GCPQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
@@ -280,10 +274,7 @@ class GCPQueryParamSerializerTest(IamTestCase):
                 "subscription_guid": [FAKE.uuid4()],
             },
         }
-        path = "/api/cost-management/v1/reports/gcp/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/gcp/costs/")
         serializer = GCPQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
@@ -292,10 +283,7 @@ class GCPQueryParamSerializerTest(IamTestCase):
         """Test that tag keys are validated as fields."""
         tag_keys = ["valid_tag"]
         query_params = {"filter": {"valid_tag": "value"}}
-        path = "/api/cost-management/v1/reports/gcp/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/gcp/costs/")
         serializer = GCPQueryParamSerializer(data=query_params, tag_keys=tag_keys, context=ctx)
         self.assertTrue(serializer.is_valid())
 
@@ -303,10 +291,7 @@ class GCPQueryParamSerializerTest(IamTestCase):
         """Test that invalid tag keys are not valid fields."""
         tag_keys = ["valid_tag"]
         query_params = {"filter": {"bad_tag": "value"}}
-        path = "/api/cost-management/v1/reports/gcp/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/gcp/costs/")
         serializer = GCPQueryParamSerializer(data=query_params, tag_keys=tag_keys, context=ctx)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
@@ -348,20 +333,14 @@ class GCPQueryParamSerializerTest(IamTestCase):
     def test_order_by_service_with_groupby(self):
         """Test that order_by[service] works with a matching group-by."""
         query_params = {"group_by": {"service": "asc"}, "order_by": {"service": "asc"}}
-        path = "/api/cost-management/v1/reports/gcp/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/gcp/costs/")
         serializer = GCPQueryParamSerializer(data=query_params, context=ctx)
         self.assertTrue(serializer.is_valid())
 
     def test_order_by_service_without_groupby(self):
         """Test that order_by[service_name] fails without a matching group-by."""
         query_params = {"order_by": {"service_name": "asc"}}
-        path = "/api/cost-management/v1/reports/gcp/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/gcp/costs/")
         serializer = GCPQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
@@ -375,10 +354,7 @@ class GCPQueryParamSerializerTest(IamTestCase):
             "filter": {"resolution": "daily", "time_scope_value": "-10", "time_scope_units": "day"},
             "invalid": "param",
         }
-        path = "/api/cost-management/v1/reports/gcp/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/gcp/costs/")
         serializer = GCPQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
@@ -392,10 +368,7 @@ class GCPQueryParamSerializerTest(IamTestCase):
             "filter": {"resolution": "daily", "time_scope_value": "-10", "time_scope_units": "day"},
             "invalid": "param",
         }
-        path = "/api/cost-management/v1/reports/gcp/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/gcp/costs/")
         serializer = GCPQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
@@ -407,10 +380,7 @@ class GCPQueryParamSerializerTest(IamTestCase):
             {"filter": {"limit": "1"}},
             {"filter": {"offset": "1"}},
         ]
-        path = "/api/cost-management/v1/reports/gcp/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/gcp/costs/")
         for param in param_failures_list:
             with self.subTest(param=param):
                 with self.assertRaises(serializers.ValidationError):
@@ -425,10 +395,7 @@ class GCPQueryParamSerializerTest(IamTestCase):
             {"filter": {"limit": "1"}},
             {"filter": {"offset": "1"}},
         ]
-        path = "/api/cost-management/v1/reports/gcp/instance-types/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/gcp/instance-types/")
         for param in param_list:
             with self.subTest(param=param):
                 serializer = GCPQueryParamSerializer(data=param, context=ctx)

--- a/koku/api/report/test/gcp/test_serializers.py
+++ b/koku/api/report/test/gcp/test_serializers.py
@@ -242,8 +242,8 @@ class GCPQueryParamSerializerTest(IamTestCase):
                 "account": [FAKE.uuid4()],
             },
         }
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/gcp/costs/")
-        serializer = GCPQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/gcp/costs/"
+        serializer = GCPQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         self.assertTrue(serializer.is_valid())
 
     def test_query_params_invalid_fields(self):
@@ -258,8 +258,8 @@ class GCPQueryParamSerializerTest(IamTestCase):
             },
             "invalid": "param",
         }
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/gcp/costs/")
-        serializer = GCPQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/gcp/costs/"
+        serializer = GCPQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
@@ -274,8 +274,8 @@ class GCPQueryParamSerializerTest(IamTestCase):
                 "subscription_guid": [FAKE.uuid4()],
             },
         }
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/gcp/costs/")
-        serializer = GCPQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/gcp/costs/"
+        serializer = GCPQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
@@ -283,16 +283,16 @@ class GCPQueryParamSerializerTest(IamTestCase):
         """Test that tag keys are validated as fields."""
         tag_keys = ["valid_tag"]
         query_params = {"filter": {"valid_tag": "value"}}
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/gcp/costs/")
-        serializer = GCPQueryParamSerializer(data=query_params, tag_keys=tag_keys, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/gcp/costs/"
+        serializer = GCPQueryParamSerializer(data=query_params, tag_keys=tag_keys, context=self.ctx_w_path)
         self.assertTrue(serializer.is_valid())
 
     def test_tag_keys_dynamic_field_validation_failure(self):
         """Test that invalid tag keys are not valid fields."""
         tag_keys = ["valid_tag"]
         query_params = {"filter": {"bad_tag": "value"}}
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/gcp/costs/")
-        serializer = GCPQueryParamSerializer(data=query_params, tag_keys=tag_keys, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/gcp/costs/"
+        serializer = GCPQueryParamSerializer(data=query_params, tag_keys=tag_keys, context=self.ctx_w_path)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
@@ -303,14 +303,12 @@ class GCPQueryParamSerializerTest(IamTestCase):
             "/api/cost-management/v1/reports/gcp/instance-types/": ["usage"],
             "/api/cost-management/v1/reports/gcp/storage/": ["usage"],
         }
-        for url, delta_list in valid_delta_map.items():
+        for path, delta_list in valid_delta_map.items():
             for valid_delta in delta_list:
-                with self.subTest(path_delta=(url, valid_delta)):
-                    ctx = self._create_request_context(
-                        self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=url
-                    )
+                with self.subTest(path_delta=(path, valid_delta)):
+                    self.request_path = path
                     query_params = {"delta": valid_delta}
-                    serializer = GCPQueryParamSerializer(data=query_params, context=ctx)
+                    serializer = GCPQueryParamSerializer(data=query_params, context=self.ctx_w_path)
                     self.assertTrue(serializer.is_valid())
 
     def test_invalid_deltas(self):
@@ -321,27 +319,25 @@ class GCPQueryParamSerializerTest(IamTestCase):
             "/api/cost-management/v1/reports/gcp/storage/": ["cost", "cost_total", "bad_delta"],
         }
         for path, delta_list in bad_delta_map.items():
-            ctx = self._create_request_context(
-                self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-            )
+            self.request_path = path
             for bad_delta in delta_list:
                 query_params = {"delta": bad_delta}
-                serializer = GCPQueryParamSerializer(data=query_params, context=ctx)
+                serializer = GCPQueryParamSerializer(data=query_params, context=self.ctx_w_path)
                 with self.assertRaises(serializers.ValidationError):
                     serializer.is_valid(raise_exception=True)
 
     def test_order_by_service_with_groupby(self):
         """Test that order_by[service] works with a matching group-by."""
         query_params = {"group_by": {"service": "asc"}, "order_by": {"service": "asc"}}
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/gcp/costs/")
-        serializer = GCPQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/gcp/costs/"
+        serializer = GCPQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         self.assertTrue(serializer.is_valid())
 
     def test_order_by_service_without_groupby(self):
         """Test that order_by[service_name] fails without a matching group-by."""
         query_params = {"order_by": {"service_name": "asc"}}
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/gcp/costs/")
-        serializer = GCPQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/gcp/costs/"
+        serializer = GCPQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
@@ -354,8 +350,8 @@ class GCPQueryParamSerializerTest(IamTestCase):
             "filter": {"resolution": "daily", "time_scope_value": "-10", "time_scope_units": "day"},
             "invalid": "param",
         }
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/gcp/costs/")
-        serializer = GCPQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/gcp/costs/"
+        serializer = GCPQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
@@ -368,8 +364,8 @@ class GCPQueryParamSerializerTest(IamTestCase):
             "filter": {"resolution": "daily", "time_scope_value": "-10", "time_scope_units": "day"},
             "invalid": "param",
         }
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/gcp/costs/")
-        serializer = GCPQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/gcp/costs/"
+        serializer = GCPQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
@@ -380,11 +376,11 @@ class GCPQueryParamSerializerTest(IamTestCase):
             {"filter": {"limit": "1"}},
             {"filter": {"offset": "1"}},
         ]
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/gcp/costs/")
+        self.request_path = "/api/cost-management/v1/reports/gcp/costs/"
         for param in param_failures_list:
             with self.subTest(param=param):
                 with self.assertRaises(serializers.ValidationError):
-                    serializer = GCPQueryParamSerializer(data=param, context=ctx)
+                    serializer = GCPQueryParamSerializer(data=param, context=self.ctx_w_path)
                     self.assertFalse(serializer.is_valid())
                     serializer.is_valid(raise_exception=True)
 
@@ -395,8 +391,8 @@ class GCPQueryParamSerializerTest(IamTestCase):
             {"filter": {"limit": "1"}},
             {"filter": {"offset": "1"}},
         ]
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/gcp/instance-types/")
+        self.request_path = "/api/cost-management/v1/reports/gcp/instance-types/"
         for param in param_list:
             with self.subTest(param=param):
-                serializer = GCPQueryParamSerializer(data=param, context=ctx)
+                serializer = GCPQueryParamSerializer(data=param, context=self.ctx_w_path)
                 self.assertTrue(serializer.is_valid())

--- a/koku/api/report/test/oci/test_serializers.py
+++ b/koku/api/report/test/oci/test_serializers.py
@@ -258,10 +258,7 @@ class OCIQueryParamSerializerTest(IamTestCase):
     def test_invalid_delta_costs(self):
         """Test failure while handling invalid delta for cost requests."""
         query_params = {"delta": "cost_bad"}
-        path = "/api/cost-management/v1/reports/oci/storage/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/oci/storage/")
         serializer = OCIQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
@@ -269,10 +266,7 @@ class OCIQueryParamSerializerTest(IamTestCase):
     def test_invalid_delta_usage(self):
         """Test failure while handling invalid delta for usage requests."""
         query_params = {"delta": "usage"}
-        path = "/api/cost-management/v1/reports/oci/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/oci/costs/")
         serializer = OCIQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)

--- a/koku/api/report/test/oci/test_serializers.py
+++ b/koku/api/report/test/oci/test_serializers.py
@@ -258,16 +258,16 @@ class OCIQueryParamSerializerTest(IamTestCase):
     def test_invalid_delta_costs(self):
         """Test failure while handling invalid delta for cost requests."""
         query_params = {"delta": "cost_bad"}
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/oci/storage/")
-        serializer = OCIQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/oci/storage/"
+        serializer = OCIQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
     def test_invalid_delta_usage(self):
         """Test failure while handling invalid delta for usage requests."""
         query_params = {"delta": "usage"}
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/oci/costs/")
-        serializer = OCIQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/oci/costs/"
+        serializer = OCIQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 

--- a/koku/api/report/test/ocp/test_serializers.py
+++ b/koku/api/report/test/ocp/test_serializers.py
@@ -262,7 +262,7 @@ class OCPQueryParamSerializerTest(IamTestCase):
                 "resource_scope": [],
             },
         }
-        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/reports/openshift/costs/")
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/costs/")
         serializer = OCPQueryParamSerializer(data=query_params, context=ctx)
         self.assertTrue(serializer.is_valid())
 
@@ -279,7 +279,7 @@ class OCPQueryParamSerializerTest(IamTestCase):
             "invalid": "param",
         }
 
-        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/reports/openshift/costs/")
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/costs/")
         serializer = OCPQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
@@ -295,7 +295,7 @@ class OCPQueryParamSerializerTest(IamTestCase):
                 "resource_scope": [],
             },
         }
-        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/reports/openshift/costs/")
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/costs/")
         serializer = OCPQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
@@ -305,7 +305,7 @@ class OCPQueryParamSerializerTest(IamTestCase):
         tag_keys = ["valid_tag"]
         query_params = {"filter": {"valid_tag": "value"}}
 
-        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/reports/openshift/costs/")
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/costs/")
         serializer = OCPQueryParamSerializer(data=query_params, tag_keys=tag_keys, context=ctx)
         self.assertTrue(serializer.is_valid())
 
@@ -314,7 +314,7 @@ class OCPQueryParamSerializerTest(IamTestCase):
         tag_keys = ["valid_tag"]
         query_params = {"filter": {"bad_tag": "value"}}
 
-        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/reports/openshift/costs/")
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/costs/")
         serializer = OCPQueryParamSerializer(data=query_params, tag_keys=tag_keys, context=ctx)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
@@ -335,7 +335,7 @@ class OCPInventoryQueryParamSerializerTest(IamTestCase):
                 "resource_scope": [],
             },
         }
-        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/reports/openshift/costs/")
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/costs/")
         serializer = OCPInventoryQueryParamSerializer(data=query_params, context=ctx)
         self.assertTrue(serializer.is_valid())
 
@@ -354,24 +354,24 @@ class OCPInventoryQueryParamSerializerTest(IamTestCase):
             },
             "invalid": "param",
         }
-        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/reports/openshift/costs/")
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/costs/")
         serializer = OCPInventoryQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
     def test_delta_success(self):
         """Test that a proper delta value is serialized."""
-        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/reports/openshift/costs/?delta=cost")
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/costs/?delta=cost")
         query_params = {"delta": "cost"}
         serializer = OCPInventoryQueryParamSerializer(data=query_params, context=ctx)
         self.assertTrue(serializer.is_valid())
 
-        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/reports/openshift/costs/?delta=usage")
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/costs/?delta=usage")
         query_params = {"delta": "usage"}
         serializer = OCPInventoryQueryParamSerializer(data=query_params, context=ctx)
         self.assertTrue(serializer.is_valid())
 
-        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/reports/openshift/costs/?delta=request")
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/costs/?delta=request")
         query_params = {"delta": "request"}
         serializer = OCPInventoryQueryParamSerializer(data=query_params, context=ctx)
         self.assertTrue(serializer.is_valid())
@@ -379,31 +379,35 @@ class OCPInventoryQueryParamSerializerTest(IamTestCase):
     def test_delta_failure(self):
         """Test that a bad delta value is not serialized."""
         query_params = {"delta": "bad_delta"}
-        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/reports/openshift/costs/?delta=bad_delta")
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/costs/?delta=bad_delta")
         serializer = OCPInventoryQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
     def test_current_month_delta_success(self):
         """Test that a proper current month delta value is serialized."""
-        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/reports/openshift/costs/?delta=usage__request")
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/costs/?delta=usage__request")
         query_params = {"delta": "usage__request"}
         serializer = OCPInventoryQueryParamSerializer(data=query_params, context=ctx)
         self.assertTrue(serializer.is_valid())
 
-        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/reports/openshift/costs/?delta=usage__capacity")
+        ctx = self.get_request_ctx_w_path(
+            path="/api/cost-management/v1/reports/openshift/costs/?delta=usage__capacity"
+        )
         query_params = {"delta": "usage__capacity"}
         serializer = OCPInventoryQueryParamSerializer(data=query_params, context=ctx)
         self.assertTrue(serializer.is_valid())
 
-        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/reports/openshift/costs/?delta=request__capacity")
+        ctx = self.get_request_ctx_w_path(
+            path="/api/cost-management/v1/reports/openshift/costs/?delta=request__capacity"
+        )
         query_params = {"delta": "request__capacity"}
         serializer = OCPInventoryQueryParamSerializer(data=query_params, context=ctx)
         self.assertTrue(serializer.is_valid())
 
     def test_current_month_delta_failure(self):
         """Test that a bad current month delta value is not serialized."""
-        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/reports/openshift/costs/")
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/costs/")
         query_params = {"delta": "bad__delta"}
         serializer = OCPInventoryQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
@@ -416,14 +420,14 @@ class OCPInventoryQueryParamSerializerTest(IamTestCase):
 
     def test_order_by_delta_with_delta(self):
         """Test that order_by[delta] works with a delta param."""
-        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/reports/openshift/costs/")
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/costs/")
         query_params = {"delta": "usage__request", "order_by": {"delta": "asc"}}
         serializer = OCPInventoryQueryParamSerializer(data=query_params, context=ctx)
         self.assertTrue(serializer.is_valid())
 
     def test_order_by_delta_without_delta(self):
         """Test that order_by[delta] does not work without a delta param."""
-        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/reports/openshift/costs/")
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/costs/")
         query_params = {"order_by": {"delta": "asc"}}
         serializer = OCPInventoryQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
@@ -431,14 +435,14 @@ class OCPInventoryQueryParamSerializerTest(IamTestCase):
 
     def test_order_by_node_with_groupby(self):
         """Test that order_by[node] works with a matching group-by."""
-        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/reports/openshift/costs/")
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/costs/")
         query_params = {"group_by": {"node": "asc"}, "order_by": {"node": "asc"}}
         serializer = OCPInventoryQueryParamSerializer(data=query_params, context=ctx)
         self.assertTrue(serializer.is_valid())
 
     def test_order_by_node_without_groupby(self):
         """Test that order_by[node] fails without a matching group-by."""
-        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/reports/openshift/costs/")
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/costs/")
         query_params = {"order_by": {"node": "asc"}}
         serializer = OCPInventoryQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
@@ -460,7 +464,7 @@ class OCPCostQueryParamSerializerTest(IamTestCase):
                 "resource_scope": [],
             },
         }
-        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/reports/openshift/costs/")
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/costs/")
         serializer = OCPCostQueryParamSerializer(data=query_params, context=ctx)
         self.assertTrue(serializer.is_valid())
 
@@ -479,7 +483,7 @@ class OCPCostQueryParamSerializerTest(IamTestCase):
             "invalid": "param",
         }
 
-        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/reports/openshift/costs/")
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/costs/")
         serializer = OCPCostQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
@@ -499,7 +503,7 @@ class OCPCostQueryParamSerializerTest(IamTestCase):
             "invalid": "param",
         }
 
-        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/reports/openshift/costs/")
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/costs/")
         serializer = OCPCostQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
@@ -519,7 +523,7 @@ class OCPCostQueryParamSerializerTest(IamTestCase):
             "delta": "cost",
         }
 
-        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/reports/openshift/costs/")
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/costs/")
         serializer = OCPCostQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
@@ -531,7 +535,7 @@ class OCPCostQueryParamSerializerTest(IamTestCase):
             {"filter": {"limit": "1"}},
             {"filter": {"offset": "1"}},
         ]
-        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/reports/openshift/costs/")
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/costs/")
         for param in param_failures_list:
             with self.subTest(param=param):
                 with self.assertRaises(serializers.ValidationError):

--- a/koku/api/report/test/ocp/test_serializers.py
+++ b/koku/api/report/test/ocp/test_serializers.py
@@ -262,10 +262,7 @@ class OCPQueryParamSerializerTest(IamTestCase):
                 "resource_scope": [],
             },
         }
-        path = "/api/cost-management/v1/reports/openshift/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/reports/openshift/costs/")
         serializer = OCPQueryParamSerializer(data=query_params, context=ctx)
         self.assertTrue(serializer.is_valid())
 
@@ -282,10 +279,7 @@ class OCPQueryParamSerializerTest(IamTestCase):
             "invalid": "param",
         }
 
-        path = "/api/cost-management/v1/reports/openshift/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/reports/openshift/costs/")
         serializer = OCPQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
@@ -301,10 +295,7 @@ class OCPQueryParamSerializerTest(IamTestCase):
                 "resource_scope": [],
             },
         }
-        path = "/api/cost-management/v1/reports/openshift/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/reports/openshift/costs/")
         serializer = OCPQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
@@ -314,10 +305,7 @@ class OCPQueryParamSerializerTest(IamTestCase):
         tag_keys = ["valid_tag"]
         query_params = {"filter": {"valid_tag": "value"}}
 
-        path = "/api/cost-management/v1/reports/openshift/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/reports/openshift/costs/")
         serializer = OCPQueryParamSerializer(data=query_params, tag_keys=tag_keys, context=ctx)
         self.assertTrue(serializer.is_valid())
 
@@ -326,10 +314,7 @@ class OCPQueryParamSerializerTest(IamTestCase):
         tag_keys = ["valid_tag"]
         query_params = {"filter": {"bad_tag": "value"}}
 
-        path = "/api/cost-management/v1/reports/openshift/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/reports/openshift/costs/")
         serializer = OCPQueryParamSerializer(data=query_params, tag_keys=tag_keys, context=ctx)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
@@ -350,10 +335,7 @@ class OCPInventoryQueryParamSerializerTest(IamTestCase):
                 "resource_scope": [],
             },
         }
-        path = "/api/cost-management/v1/reports/openshift/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/reports/openshift/costs/")
         serializer = OCPInventoryQueryParamSerializer(data=query_params, context=ctx)
         self.assertTrue(serializer.is_valid())
 
@@ -372,36 +354,24 @@ class OCPInventoryQueryParamSerializerTest(IamTestCase):
             },
             "invalid": "param",
         }
-        path = "/api/cost-management/v1/reports/openshift/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/reports/openshift/costs/")
         serializer = OCPInventoryQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
     def test_delta_success(self):
         """Test that a proper delta value is serialized."""
-        path = "/api/cost-management/v1/reports/openshift/costs/?delta=cost"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/reports/openshift/costs/?delta=cost")
         query_params = {"delta": "cost"}
         serializer = OCPInventoryQueryParamSerializer(data=query_params, context=ctx)
         self.assertTrue(serializer.is_valid())
 
-        path = "/api/cost-management/v1/reports/openshift/costs/?delta=usage"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/reports/openshift/costs/?delta=usage")
         query_params = {"delta": "usage"}
         serializer = OCPInventoryQueryParamSerializer(data=query_params, context=ctx)
         self.assertTrue(serializer.is_valid())
 
-        path = "/api/cost-management/v1/reports/openshift/costs/?delta=request"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/reports/openshift/costs/?delta=request")
         query_params = {"delta": "request"}
         serializer = OCPInventoryQueryParamSerializer(data=query_params, context=ctx)
         self.assertTrue(serializer.is_valid())
@@ -409,47 +379,31 @@ class OCPInventoryQueryParamSerializerTest(IamTestCase):
     def test_delta_failure(self):
         """Test that a bad delta value is not serialized."""
         query_params = {"delta": "bad_delta"}
-        path = "/api/cost-management/v1/reports/openshift/costs/?delta=bad_delta"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/reports/openshift/costs/?delta=bad_delta")
         serializer = OCPInventoryQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
     def test_current_month_delta_success(self):
         """Test that a proper current month delta value is serialized."""
-        path = "/api/cost-management/v1/reports/openshift/costs/?delta=usage__request"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/reports/openshift/costs/?delta=usage__request")
         query_params = {"delta": "usage__request"}
         serializer = OCPInventoryQueryParamSerializer(data=query_params, context=ctx)
         self.assertTrue(serializer.is_valid())
 
-        path = "/api/cost-management/v1/reports/openshift/costs/?delta=usage__capacity"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/reports/openshift/costs/?delta=usage__capacity")
         query_params = {"delta": "usage__capacity"}
         serializer = OCPInventoryQueryParamSerializer(data=query_params, context=ctx)
         self.assertTrue(serializer.is_valid())
 
-        path = "/api/cost-management/v1/reports/openshift/costs/?delta=request__capacity"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/reports/openshift/costs/?delta=request__capacity")
         query_params = {"delta": "request__capacity"}
         serializer = OCPInventoryQueryParamSerializer(data=query_params, context=ctx)
         self.assertTrue(serializer.is_valid())
 
     def test_current_month_delta_failure(self):
         """Test that a bad current month delta value is not serialized."""
-
-        path = "/api/cost-management/v1/reports/openshift/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/reports/openshift/costs/")
         query_params = {"delta": "bad__delta"}
         serializer = OCPInventoryQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
@@ -462,20 +416,14 @@ class OCPInventoryQueryParamSerializerTest(IamTestCase):
 
     def test_order_by_delta_with_delta(self):
         """Test that order_by[delta] works with a delta param."""
-        path = "/api/cost-management/v1/reports/openshift/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/reports/openshift/costs/")
         query_params = {"delta": "usage__request", "order_by": {"delta": "asc"}}
         serializer = OCPInventoryQueryParamSerializer(data=query_params, context=ctx)
         self.assertTrue(serializer.is_valid())
 
     def test_order_by_delta_without_delta(self):
         """Test that order_by[delta] does not work without a delta param."""
-        path = "/api/cost-management/v1/reports/openshift/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/reports/openshift/costs/")
         query_params = {"order_by": {"delta": "asc"}}
         serializer = OCPInventoryQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
@@ -483,20 +431,14 @@ class OCPInventoryQueryParamSerializerTest(IamTestCase):
 
     def test_order_by_node_with_groupby(self):
         """Test that order_by[node] works with a matching group-by."""
-        path = "/api/cost-management/v1/reports/openshift/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/reports/openshift/costs/")
         query_params = {"group_by": {"node": "asc"}, "order_by": {"node": "asc"}}
         serializer = OCPInventoryQueryParamSerializer(data=query_params, context=ctx)
         self.assertTrue(serializer.is_valid())
 
     def test_order_by_node_without_groupby(self):
         """Test that order_by[node] fails without a matching group-by."""
-        path = "/api/cost-management/v1/reports/openshift/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/reports/openshift/costs/")
         query_params = {"order_by": {"node": "asc"}}
         serializer = OCPInventoryQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
@@ -518,10 +460,7 @@ class OCPCostQueryParamSerializerTest(IamTestCase):
                 "resource_scope": [],
             },
         }
-        path = "/api/cost-management/v1/reports/openshift/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/reports/openshift/costs/")
         serializer = OCPCostQueryParamSerializer(data=query_params, context=ctx)
         self.assertTrue(serializer.is_valid())
 
@@ -540,10 +479,7 @@ class OCPCostQueryParamSerializerTest(IamTestCase):
             "invalid": "param",
         }
 
-        path = "/api/cost-management/v1/reports/openshift/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/reports/openshift/costs/")
         serializer = OCPCostQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
@@ -563,10 +499,7 @@ class OCPCostQueryParamSerializerTest(IamTestCase):
             "invalid": "param",
         }
 
-        path = "/api/cost-management/v1/reports/openshift/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/reports/openshift/costs/")
         serializer = OCPCostQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
@@ -586,10 +519,7 @@ class OCPCostQueryParamSerializerTest(IamTestCase):
             "delta": "cost",
         }
 
-        path = "/api/cost-management/v1/reports/openshift/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/reports/openshift/costs/")
         serializer = OCPCostQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
@@ -601,10 +531,7 @@ class OCPCostQueryParamSerializerTest(IamTestCase):
             {"filter": {"limit": "1"}},
             {"filter": {"offset": "1"}},
         ]
-        path = "/api/cost-management/v1/reports/openshift/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path("/api/cost-management/v1/reports/openshift/costs/")
         for param in param_failures_list:
             with self.subTest(param=param):
                 with self.assertRaises(serializers.ValidationError):

--- a/koku/api/report/test/ocp/test_serializers.py
+++ b/koku/api/report/test/ocp/test_serializers.py
@@ -262,8 +262,8 @@ class OCPQueryParamSerializerTest(IamTestCase):
                 "resource_scope": [],
             },
         }
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/costs/")
-        serializer = OCPQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/openshift/costs/"
+        serializer = OCPQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         self.assertTrue(serializer.is_valid())
 
     def test_query_params_invalid_fields(self):
@@ -279,8 +279,8 @@ class OCPQueryParamSerializerTest(IamTestCase):
             "invalid": "param",
         }
 
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/costs/")
-        serializer = OCPQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/openshift/costs/"
+        serializer = OCPQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
@@ -295,8 +295,8 @@ class OCPQueryParamSerializerTest(IamTestCase):
                 "resource_scope": [],
             },
         }
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/costs/")
-        serializer = OCPQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/openshift/costs/"
+        serializer = OCPQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
@@ -305,8 +305,8 @@ class OCPQueryParamSerializerTest(IamTestCase):
         tag_keys = ["valid_tag"]
         query_params = {"filter": {"valid_tag": "value"}}
 
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/costs/")
-        serializer = OCPQueryParamSerializer(data=query_params, tag_keys=tag_keys, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/openshift/costs/"
+        serializer = OCPQueryParamSerializer(data=query_params, tag_keys=tag_keys, context=self.ctx_w_path)
         self.assertTrue(serializer.is_valid())
 
     def test_tag_keys_dynamic_field_validation_failure(self):
@@ -314,8 +314,8 @@ class OCPQueryParamSerializerTest(IamTestCase):
         tag_keys = ["valid_tag"]
         query_params = {"filter": {"bad_tag": "value"}}
 
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/costs/")
-        serializer = OCPQueryParamSerializer(data=query_params, tag_keys=tag_keys, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/openshift/costs/"
+        serializer = OCPQueryParamSerializer(data=query_params, tag_keys=tag_keys, context=self.ctx_w_path)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
@@ -335,8 +335,8 @@ class OCPInventoryQueryParamSerializerTest(IamTestCase):
                 "resource_scope": [],
             },
         }
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/costs/")
-        serializer = OCPInventoryQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/openshift/costs/"
+        serializer = OCPInventoryQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         self.assertTrue(serializer.is_valid())
 
     def test_query_params_invalid_order_by(self):
@@ -354,97 +354,93 @@ class OCPInventoryQueryParamSerializerTest(IamTestCase):
             },
             "invalid": "param",
         }
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/costs/")
-        serializer = OCPInventoryQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/openshift/costs/"
+        serializer = OCPInventoryQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
     def test_delta_success(self):
         """Test that a proper delta value is serialized."""
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/costs/?delta=cost")
+        self.request_path = "/api/cost-management/v1/reports/openshift/costs/?delta=cost"
         query_params = {"delta": "cost"}
-        serializer = OCPInventoryQueryParamSerializer(data=query_params, context=ctx)
+        serializer = OCPInventoryQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         self.assertTrue(serializer.is_valid())
 
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/costs/?delta=usage")
+        self.request_path = "/api/cost-management/v1/reports/openshift/costs/?delta=usage"
         query_params = {"delta": "usage"}
-        serializer = OCPInventoryQueryParamSerializer(data=query_params, context=ctx)
+        serializer = OCPInventoryQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         self.assertTrue(serializer.is_valid())
 
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/costs/?delta=request")
+        self.request_path = "/api/cost-management/v1/reports/openshift/costs/?delta=request"
         query_params = {"delta": "request"}
-        serializer = OCPInventoryQueryParamSerializer(data=query_params, context=ctx)
+        serializer = OCPInventoryQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         self.assertTrue(serializer.is_valid())
 
     def test_delta_failure(self):
         """Test that a bad delta value is not serialized."""
         query_params = {"delta": "bad_delta"}
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/costs/?delta=bad_delta")
-        serializer = OCPInventoryQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/openshift/costs/?delta=bad_delta"
+        serializer = OCPInventoryQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
     def test_current_month_delta_success(self):
         """Test that a proper current month delta value is serialized."""
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/costs/?delta=usage__request")
+        self.request_path = "/api/cost-management/v1/reports/openshift/costs/?delta=usage__request"
         query_params = {"delta": "usage__request"}
-        serializer = OCPInventoryQueryParamSerializer(data=query_params, context=ctx)
+        serializer = OCPInventoryQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         self.assertTrue(serializer.is_valid())
 
-        ctx = self.get_request_ctx_w_path(
-            path="/api/cost-management/v1/reports/openshift/costs/?delta=usage__capacity"
-        )
+        self.request_path = "/api/cost-management/v1/reports/openshift/costs/?delta=usage__capacity"
         query_params = {"delta": "usage__capacity"}
-        serializer = OCPInventoryQueryParamSerializer(data=query_params, context=ctx)
+        serializer = OCPInventoryQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         self.assertTrue(serializer.is_valid())
 
-        ctx = self.get_request_ctx_w_path(
-            path="/api/cost-management/v1/reports/openshift/costs/?delta=request__capacity"
-        )
+        self.request_path = "/api/cost-management/v1/reports/openshift/costs/?delta=request__capacity"
         query_params = {"delta": "request__capacity"}
-        serializer = OCPInventoryQueryParamSerializer(data=query_params, context=ctx)
+        serializer = OCPInventoryQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         self.assertTrue(serializer.is_valid())
 
     def test_current_month_delta_failure(self):
         """Test that a bad current month delta value is not serialized."""
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/costs/")
+        self.request_path = "/api/cost-management/v1/reports/openshift/costs/"
         query_params = {"delta": "bad__delta"}
-        serializer = OCPInventoryQueryParamSerializer(data=query_params, context=ctx)
+        serializer = OCPInventoryQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
         query_params = {"delta": "usage__request__capacity"}
-        serializer = OCPInventoryQueryParamSerializer(data=query_params, context=ctx)
+        serializer = OCPInventoryQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
     def test_order_by_delta_with_delta(self):
         """Test that order_by[delta] works with a delta param."""
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/costs/")
+        self.request_path = "/api/cost-management/v1/reports/openshift/costs/"
         query_params = {"delta": "usage__request", "order_by": {"delta": "asc"}}
-        serializer = OCPInventoryQueryParamSerializer(data=query_params, context=ctx)
+        serializer = OCPInventoryQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         self.assertTrue(serializer.is_valid())
 
     def test_order_by_delta_without_delta(self):
         """Test that order_by[delta] does not work without a delta param."""
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/costs/")
+        self.request_path = "/api/cost-management/v1/reports/openshift/costs/"
         query_params = {"order_by": {"delta": "asc"}}
-        serializer = OCPInventoryQueryParamSerializer(data=query_params, context=ctx)
+        serializer = OCPInventoryQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
     def test_order_by_node_with_groupby(self):
         """Test that order_by[node] works with a matching group-by."""
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/costs/")
+        self.request_path = "/api/cost-management/v1/reports/openshift/costs/"
         query_params = {"group_by": {"node": "asc"}, "order_by": {"node": "asc"}}
-        serializer = OCPInventoryQueryParamSerializer(data=query_params, context=ctx)
+        serializer = OCPInventoryQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         self.assertTrue(serializer.is_valid())
 
     def test_order_by_node_without_groupby(self):
         """Test that order_by[node] fails without a matching group-by."""
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/costs/")
+        self.request_path = "/api/cost-management/v1/reports/openshift/costs/"
         query_params = {"order_by": {"node": "asc"}}
-        serializer = OCPInventoryQueryParamSerializer(data=query_params, context=ctx)
+        serializer = OCPInventoryQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
@@ -464,8 +460,8 @@ class OCPCostQueryParamSerializerTest(IamTestCase):
                 "resource_scope": [],
             },
         }
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/costs/")
-        serializer = OCPCostQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/openshift/costs/"
+        serializer = OCPCostQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         self.assertTrue(serializer.is_valid())
 
     def test_query_params_invalid_order_by_request(self):
@@ -482,9 +478,8 @@ class OCPCostQueryParamSerializerTest(IamTestCase):
             },
             "invalid": "param",
         }
-
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/costs/")
-        serializer = OCPCostQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/openshift/costs/"
+        serializer = OCPCostQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
@@ -502,9 +497,8 @@ class OCPCostQueryParamSerializerTest(IamTestCase):
             },
             "invalid": "param",
         }
-
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/costs/")
-        serializer = OCPCostQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/openshift/costs/"
+        serializer = OCPCostQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
@@ -522,9 +516,8 @@ class OCPCostQueryParamSerializerTest(IamTestCase):
             },
             "delta": "cost",
         }
-
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/costs/")
-        serializer = OCPCostQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/openshift/costs/"
+        serializer = OCPCostQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
@@ -535,10 +528,10 @@ class OCPCostQueryParamSerializerTest(IamTestCase):
             {"filter": {"limit": "1"}},
             {"filter": {"offset": "1"}},
         ]
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/openshift/costs/")
+        self.request_path = "/api/cost-management/v1/reports/openshift/costs/"
         for param in param_failures_list:
             with self.subTest(param=param):
                 with self.assertRaises(serializers.ValidationError):
-                    serializer = OCPInventoryQueryParamSerializer(data=param, context=ctx)
+                    serializer = OCPInventoryQueryParamSerializer(data=param, context=self.ctx_w_path)
                     self.assertFalse(serializer.is_valid())
                     serializer.is_valid(raise_exception=True)

--- a/koku/api/report/test/test_serializers.py
+++ b/koku/api/report/test/test_serializers.py
@@ -541,8 +541,8 @@ class QueryParamSerializerTest(IamTestCase):
     def test_valid_cost_type_no_exception(self):
         """Test that a valid cost type doesn't raise an exception."""
         query_params = {"cost_type": "blended_cost"}
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/aws/costs/")
-        serializer = AWSQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/reports/aws/costs/"
+        serializer = AWSQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         serializer.is_valid(raise_exception=True)
 
     def test_multiple_group_by(self):
@@ -766,11 +766,11 @@ class ParamSerializerTest(IamTestCase):
             {"filter": {"limit": "1"}},
             {"filter": {"offset": "1"}},
         ]
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/")
+        self.request_path = "/api/cost-management/v1/"
         for param in param_failures_list:
             with self.subTest(param=param):
                 with self.assertRaises(ValidationError):
-                    serializer = ParamSerializer(data=param, context=ctx)
+                    serializer = ParamSerializer(data=param, context=self.ctx_w_path)
                     self.assertFalse(serializer.is_valid())
                     serializer.is_valid(raise_exception=True)
 
@@ -778,8 +778,8 @@ class ParamSerializerTest(IamTestCase):
 class ReportQueryParamSerializerTest(IamTestCase):
     def test_validate_delta(self):
         """Test `delta` on base ReportQueryParamSerializer is invalid."""
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/")
-        serializer = ReportQueryParamSerializer(data={"delta": "cost"}, context=ctx)
+        self.request_path = "/api/cost-management/v1/"
+        serializer = ReportQueryParamSerializer(data={"delta": "cost"}, context=self.ctx_w_path)
         with self.assertRaises(ValidationError):
             self.assertFalse(serializer.is_valid())
             serializer.is_valid(raise_exception=True)

--- a/koku/api/report/test/test_serializers.py
+++ b/koku/api/report/test/test_serializers.py
@@ -541,10 +541,7 @@ class QueryParamSerializerTest(IamTestCase):
     def test_valid_cost_type_no_exception(self):
         """Test that a valid cost type doesn't raise an exception."""
         query_params = {"cost_type": "blended_cost"}
-        path = "/api/cost-management/v1/reports/aws/costs/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/reports/aws/costs/")
         serializer = AWSQueryParamSerializer(data=query_params, context=ctx)
         serializer.is_valid(raise_exception=True)
 
@@ -769,10 +766,7 @@ class ParamSerializerTest(IamTestCase):
             {"filter": {"limit": "1"}},
             {"filter": {"offset": "1"}},
         ]
-        path = "/api/cost-management/v1/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/")
         for param in param_failures_list:
             with self.subTest(param=param):
                 with self.assertRaises(ValidationError):
@@ -784,10 +778,7 @@ class ParamSerializerTest(IamTestCase):
 class ReportQueryParamSerializerTest(IamTestCase):
     def test_validate_delta(self):
         """Test `delta` on base ReportQueryParamSerializer is invalid."""
-        path = "/api/cost-management/v1/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/")
         serializer = ReportQueryParamSerializer(data={"delta": "cost"}, context=ctx)
         with self.assertRaises(ValidationError):
             self.assertFalse(serializer.is_valid())

--- a/koku/api/tags/test/test_serializers.py
+++ b/koku/api/tags/test/test_serializers.py
@@ -218,8 +218,8 @@ class TagsQueryParamSerializerTest(IamTestCase):
     def test_parse_query_params_success(self):
         """Test parse of a query params successfully."""
         query_params = {"filter": {"resolution": "daily", "time_scope_value": "-10", "time_scope_units": "day"}}
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/tags/aws/")
-        serializer = TagsQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/tags/aws/"
+        serializer = TagsQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         self.assertTrue(serializer.is_valid())
 
     def test_query_params_ocp_invalid_fields(self):
@@ -227,8 +227,8 @@ class TagsQueryParamSerializerTest(IamTestCase):
         query_params = {
             "filter": {"resolution": "daily", "time_scope_value": "-10", "time_scope_units": "day", "invalid": "param"}
         }
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/tags/aws/")
-        serializer = OCPTagsQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/tags/aws/"
+        serializer = OCPTagsQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
@@ -237,15 +237,15 @@ class TagsQueryParamSerializerTest(IamTestCase):
         query_params = {
             "filter": {"resolution": "daily", "time_scope_value": "-10", "time_scope_units": "day", "invalid": "param"}
         }
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/tags/aws/")
-        serializer = AWSTagsQueryParamSerializer(data=query_params, context=ctx)
+        self.request_path = "/api/cost-management/v1/tags/aws/"
+        serializer = AWSTagsQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
     def test_parse_filter_dates_valid(self):
         """Test parse of a filter date-based param should succeed."""
         dh = DateHelper()
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/tags/aws/")
+        self.request_path = "/api/cost-management/v1/tags/aws/"
         scenarios = [
             {"start_date": dh.yesterday.date(), "end_date": dh.today.date()},
             {"start_date": dh.this_month_start.date(), "end_date": dh.today.date()},
@@ -264,13 +264,13 @@ class TagsQueryParamSerializerTest(IamTestCase):
 
         for params in scenarios:
             with self.subTest(params=params):
-                serializer = TagsQueryParamSerializer(data=params, context=ctx)
+                serializer = TagsQueryParamSerializer(data=params, context=self.ctx_w_path)
                 self.assertTrue(serializer.is_valid(raise_exception=True))
 
     def test_parse_filter_dates_invalid(self):
         """Test parse of invalid data for filter date-based param should not succeed."""
         dh = DateHelper()
-        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/tags/aws/")
+        self.request_path = "/api/cost-management/v1/tags/aws/"
         scenarios = [
             {"start_date": dh.today.date()},
             {"end_date": dh.today.date()},
@@ -303,5 +303,5 @@ class TagsQueryParamSerializerTest(IamTestCase):
 
         for params in scenarios:
             with self.subTest(params=params):
-                serializer = TagsQueryParamSerializer(data=params, context=ctx)
+                serializer = TagsQueryParamSerializer(data=params, context=self.ctx_w_path)
                 self.assertFalse(serializer.is_valid())

--- a/koku/api/tags/test/test_serializers.py
+++ b/koku/api/tags/test/test_serializers.py
@@ -218,10 +218,7 @@ class TagsQueryParamSerializerTest(IamTestCase):
     def test_parse_query_params_success(self):
         """Test parse of a query params successfully."""
         query_params = {"filter": {"resolution": "daily", "time_scope_value": "-10", "time_scope_units": "day"}}
-        path = "/api/cost-management/v1/tags/aws/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/tags/aws/")
         serializer = TagsQueryParamSerializer(data=query_params, context=ctx)
         self.assertTrue(serializer.is_valid())
 
@@ -230,10 +227,7 @@ class TagsQueryParamSerializerTest(IamTestCase):
         query_params = {
             "filter": {"resolution": "daily", "time_scope_value": "-10", "time_scope_units": "day", "invalid": "param"}
         }
-        path = "/api/cost-management/v1/tags/aws/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/tags/aws/")
         serializer = OCPTagsQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
@@ -243,10 +237,7 @@ class TagsQueryParamSerializerTest(IamTestCase):
         query_params = {
             "filter": {"resolution": "daily", "time_scope_value": "-10", "time_scope_units": "day", "invalid": "param"}
         }
-        path = "/api/cost-management/v1/tags/aws/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/tags/aws/")
         serializer = AWSTagsQueryParamSerializer(data=query_params, context=ctx)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
@@ -254,10 +245,7 @@ class TagsQueryParamSerializerTest(IamTestCase):
     def test_parse_filter_dates_valid(self):
         """Test parse of a filter date-based param should succeed."""
         dh = DateHelper()
-        path = "/api/cost-management/v1/tags/aws/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/tags/aws/")
         scenarios = [
             {"start_date": dh.yesterday.date(), "end_date": dh.today.date()},
             {"start_date": dh.this_month_start.date(), "end_date": dh.today.date()},
@@ -282,10 +270,7 @@ class TagsQueryParamSerializerTest(IamTestCase):
     def test_parse_filter_dates_invalid(self):
         """Test parse of invalid data for filter date-based param should not succeed."""
         dh = DateHelper()
-        path = "/api/cost-management/v1/tags/aws/"
-        ctx = self._create_request_context(
-            self.customer_data, self._create_user_data(), create_customer=False, create_user=True, path=path
-        )
+        ctx = self.get_request_ctx_w_path(path="/api/cost-management/v1/tags/aws/")
         scenarios = [
             {"start_date": dh.today.date()},
             {"end_date": dh.today.date()},


### PR DESCRIPTION
## Description

This change will reduce the number of users created during unit tests by creating a `ctx_w_path` property on `IamTestCase` which simply updates the request `path` of the class' `request_context` instead of using `_create_request_context` everywhere which created new Users.
