### PR TITLE
Rerun migration for specific schemas

### DIFF
--- a/scripts/cji_scripts/migrate_trino.py
+++ b/scripts/cji_scripts/migrate_trino.py
@@ -93,7 +93,7 @@ def main():
     logging.info("Running the hive migration for bucketing costs")
 
     logging.info("fetching schemas")
-    schemas = get_schemas()
+    schemas = ["acct7117525", "acct531488", "acct608080", "acct6089719"]
     logging.info("Running against the following schemas")
     logging.info(schemas)
 


### PR DESCRIPTION
## Jira Ticket

[COST-2872](https://issues.redhat.com/browse/COST-2872)

## Description

This change will migrate a few schemas in prod that timed out on the first run. This will prevent us attempting to run the migration on all accounts again to save time.

## Notes

...
