### PR TITLE
default projects startwith

### DIFF
--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -541,7 +541,7 @@ class ReportQueryHandler(QueryHandler):
             )
         else:
             project_default_whens = [
-                When(project__icontains=project, then=Value("True")) for project in ["openshift-", "kube-"]
+                When(project__startswith=project, then=Value("True")) for project in ["openshift-", "kube-"]
             ]
             return query_data.annotate(
                 default_project=Case(*project_default_whens, default=Value("False"), output_field=CharField())


### PR DESCRIPTION
## Jira Ticket

[COST-2872](https://issues.redhat.com/browse/COST-2872)

## Description

This change will switch from using icontains to startswith for default project queries. This will prevent classing any projects as default if  theycontain openshift- or kube-, but instead match when they startwith instead.

## Testing

1. Checkout Branch
2. Restart Koku
3. ingest some data with project names starting with and containing openshift- and/o kube-
4. Verify that projects starting with openshift- or kube- get marked as default
5. verify any projects just containing the above do not get marked as default

## Notes

...
