### PR TITLE
fix storage units in reporting_oci_storage_summary_by_account_p

### DIFF
--- a/koku/masu/database/sql/oci/reporting_oci_storage_summary_by_account_p.sql
+++ b/koku/masu/database/sql/oci/reporting_oci_storage_summary_by_account_p.sql
@@ -31,7 +31,7 @@ SELECT uuid_generate_v4() as id,
 FROM {{schema | sqlsafe}}.reporting_ocicostentrylineitem_daily_summary
 -- Get data for this month or last month
 WHERE product_service LIKE '%%STORAGE%%'
-    AND unit in ('GB_MS', 'BYTES_MS', 'BYTES')
+    AND unit = 'GB-Mo'
     AND usage_start >= {{start_date}}::date
     AND usage_end <= {{end_date}}::date
     AND source_uuid = {{source_uuid}}::uuid


### PR DESCRIPTION
## Jira Ticket

[COST-3264](https://issues.redhat.com/browse/COST-3264)

## Description

This change will update storage units in reporting_oci_storage_summary_by_account_p

## Testing

1. Checkout Branch
2. Restart Koku and load test customer data
3. Hit this endpoint  http://localhost:8000/api/cost-management/v1/reports/oci/storage/?group_by[payer_tenant_id]=*
    1. You should see data in the response with non-zero costs
4. there should be rows in reporting_oci_storage_summary_by_account_p
```
postgres=# select count(*) from reporting_oci_storage_summary_by_account_p;
 count 
-------
    45
(1 row)
```

## Notes

...
