### PR TITLE
[COST-3270] delete managed trino partitions on provider delete

### DIFF
--- a/koku/masu/celery/tasks.py
+++ b/koku/masu/celery/tasks.py
@@ -252,8 +252,8 @@ def delete_archived_data(schema_name, provider_type, provider_uuid):  # noqa: C9
 
     if provider_type == Provider.PROVIDER_OCP:
         accessor = OCPReportDBAccessor(schema_name)
-        for table in TRINO_MANAGED_TABLES:
-            accessor.delete_hive_partitions_by_source(table, provider_uuid)
+        for table, partition_column in TRINO_MANAGED_TABLES.items():
+            accessor.delete_hive_partitions_by_source(table, partition_column, provider_uuid)
 
 
 @celery_app.task(

--- a/koku/masu/celery/tasks.py
+++ b/koku/masu/celery/tasks.py
@@ -30,6 +30,7 @@ from koku import celery_app
 from koku.notifications import NotificationService
 from masu.config import Config
 from masu.database.cost_model_db_accessor import CostModelDBAccessor
+from masu.database.ocp_report_db_accessor import OCPReportDBAccessor
 from masu.database.report_manifest_db_accessor import ReportManifestDBAccessor
 from masu.external.accounts.hierarchy.aws.aws_org_unit_crawler import AWSOrgUnitCrawler
 from masu.external.accounts_accessor import AccountsAccessor
@@ -44,6 +45,7 @@ from masu.processor.tasks import REMOVE_EXPIRED_DATA_QUEUE
 from masu.prometheus_stats import QUEUES
 from masu.util.aws.common import get_s3_resource
 from masu.util.ocp.common import REPORT_TYPES
+from reporting.models import TRINO_MANAGED_TABLES
 from sources.tasks import delete_source
 
 LOG = logging.getLogger(__name__)
@@ -247,6 +249,11 @@ def delete_archived_data(schema_name, provider_type, provider_uuid):  # noqa: C9
     for prefix in prefixes:
         LOG.info("Attempting to delete our archived data in S3 under %s", prefix)
         deleted_archived_with_prefix(settings.S3_BUCKET_NAME, prefix)
+
+    if provider_type == Provider.PROVIDER_OCP:
+        accessor = OCPReportDBAccessor(schema_name)
+        for table in TRINO_MANAGED_TABLES:
+            accessor.delete_hive_partitions_by_source(table, provider_uuid)
 
 
 @celery_app.task(

--- a/koku/masu/database/ocp_report_db_accessor.py
+++ b/koku/masu/database/ocp_report_db_accessor.py
@@ -709,26 +709,26 @@ class OCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
                         else:
                             raise err
 
-    def delete_hive_partitions_by_source(self, table, source):
+    def delete_hive_partitions_by_source(self, table, partition_column, provider_uuid):
         """Deletes partitions individually for each day in days list."""
         retries = settings.HIVE_PARTITION_DELETE_RETRIES
         if self.table_exists_trino(table):
             LOG.info(
                 "Deleting Hive partitions for the following: \n\tSchema: %s " "\n\tOCP Source: %s \n\tTable: %s",
                 self.schema,
-                source,
+                provider_uuid,
                 table,
             )
             for i in range(retries):
                 try:
                     sql = f"""
                     DELETE FROM hive.{self.schema}.{table}
-                    WHERE source = '{source}'
+                    WHERE {partition_column} = '{provider_uuid}'
                     """
                     self._execute_presto_raw_sql_query(
                         self.schema,
                         sql,
-                        log_ref=f"delete_hive_partitions_by_source for {source}",
+                        log_ref=f"delete_hive_partitions_by_source for {provider_uuid}",
                         attempts_left=(retries - 1) - i,
                     )
                     break
@@ -741,9 +741,11 @@ class OCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
                 "Successfully deleted Hive partitions for the following: \n\tSchema: %s "
                 "\n\tOCP Source: %s \n\tTable: %s",
                 self.schema,
-                source,
+                provider_uuid,
                 table,
             )
+            return True
+        return False
 
     def populate_line_item_daily_summary_table_presto(
         self, start_date, end_date, report_period_id, cluster_id, cluster_alias, source

--- a/koku/masu/test/celery/test_tasks.py
+++ b/koku/masu/test/celery/test_tasks.py
@@ -25,6 +25,7 @@ from masu.database.report_manifest_db_accessor import ReportManifestDBAccessor
 from masu.processor.orchestrator import Orchestrator
 from masu.test import MasuTestCase
 from masu.test.database.helpers import ManifestCreationHelper
+from reporting.models import TRINO_MANAGED_TABLES
 
 fake = faker.Faker()
 DummyS3Object = namedtuple("DummyS3Object", "key")
@@ -261,6 +262,22 @@ class TestCeleryTasks(MasuTestCase):
         with self.assertLogs("masu.celery.tasks", "INFO") as captured_logs:
             tasks.delete_archived_data(schema_name, provider_type, provider_uuid)
             self.assertIn("Skipping delete_archived_data. MinIO in use.", captured_logs.output[0])
+
+    @override_settings(ENABLE_S3_ARCHIVING=True)
+    @patch("masu.celery.tasks.OCPReportDBAccessor.delete_hive_partitions_by_source")
+    @patch("masu.celery.tasks.deleted_archived_with_prefix")
+    def test_delete_archived_data_ocp_delete_trino_partitions(self, mock_delete, mock_delete_partitions):
+        """Test that delete_archived_data correctly interacts with AWS S3."""
+        schema_name = "org1234567"
+        provider_type = Provider.PROVIDER_OCP
+        provider_uuid = "00000000-0000-0000-0000-000000000001"
+
+        tasks.delete_archived_data(schema_name, provider_type, provider_uuid)
+        mock_delete.assert_called()
+        calls = []
+        for table, partition_column in TRINO_MANAGED_TABLES.items():
+            calls.append(call(table, partition_column, provider_uuid))
+        mock_delete_partitions.assert_has_calls(calls)
 
     @patch("masu.celery.tasks.Config")
     @patch("masu.external.date_accessor.DateAccessor.get_billing_months")

--- a/koku/reporting/models.py
+++ b/koku/reporting/models.py
@@ -177,3 +177,10 @@ OCP_ON_AZURE_PERSPECTIVES = (
     OCPAzureNetworkSummaryP,
     OCPAzureDatabaseSummaryP,
 )
+
+TRINO_MANAGED_TABLES = (
+    "reporting_ocpusagelineitem_daily_summary",
+    "reporting_ocpawscostlineitem_project_daily_summary",
+    "reporting_ocpazurecostlineitem_project_daily_summary",
+    "reporting_ocpgcpcostlineitem_project_daily_summary",
+)

--- a/koku/reporting/models.py
+++ b/koku/reporting/models.py
@@ -178,9 +178,9 @@ OCP_ON_AZURE_PERSPECTIVES = (
     OCPAzureDatabaseSummaryP,
 )
 
-TRINO_MANAGED_TABLES = (
-    "reporting_ocpusagelineitem_daily_summary",
-    "reporting_ocpawscostlineitem_project_daily_summary",
-    "reporting_ocpazurecostlineitem_project_daily_summary",
-    "reporting_ocpgcpcostlineitem_project_daily_summary",
-)
+TRINO_MANAGED_TABLES = {
+    "reporting_ocpusagelineitem_daily_summary": "source",
+    "reporting_ocpawscostlineitem_project_daily_summary": "ocp_source",
+    "reporting_ocpazurecostlineitem_project_daily_summary": "ocp_source",
+    "reporting_ocpgcpcostlineitem_project_daily_summary": "ocp_source",
+}


### PR DESCRIPTION
## Jira Ticket

[COST-3270](https://issues.redhat.com/browse/COST-3270)

## Description

This change will now also delete partitions in Trino managed tables when we delete a source.

## Testing

1. Checkout Branch
2. On clean DB `make create-test-customer` and `make load-test-customer-data`
3. WAIT SO LONG
4. `make docker-logs` in it's own terminal/tab
5. When you've got alllll that data loaded, let's delete it with `make delete-test-sources`
6. Watch the logs on the deletes and we should see log messages about deleting trino partitions for the source if it is an OCP source.
7. `trino --server localhost:8080 --catalog hive --schema org1234567 --user admin --debug`
8. confirm data is gone with `select * from reporting_ocpusagelineitem_daily_summary;`
9. Do the same for reporting_ocpawscostlineitem_project_daily_summary, reporting_ocpazurecostlineitem_project_daily_summary, and reporting_ocpgcpcostlineitem_project_daily_summary

## Notes

...
