### PR TITLE
[COST-3294] ocp on cloud delete fix

### DIFF
--- a/koku/masu/database/presto_sql/gcp/openshift/reporting_ocpgcpcostlineitem_daily_summary.sql
+++ b/koku/masu/database/presto_sql/gcp/openshift/reporting_ocpgcpcostlineitem_daily_summary.sql
@@ -46,8 +46,9 @@ CREATE TABLE IF NOT EXISTS hive.{{schema | sqlsafe}}.reporting_ocpgcpcostlineite
     tags varchar,
     project_rank integer,
     data_source_rank integer,
-    cost_category_id int
-) WITH(format = 'PARQUET')
+    cost_category_id int,
+    ocp_source varchar
+) WITH(format = 'PARQUET', partitioned_by=ARRAY['ocp_source'])
 ;
 
 -- Now create our proper table if it does not exist
@@ -106,6 +107,7 @@ CREATE TABLE IF NOT EXISTS hive.{{schema | sqlsafe}}.reporting_ocpgcpcostlineite
 ;
 
 DELETE FROM hive.{{schema | sqlsafe}}.reporting_ocpgcpcostlineitem_project_daily_summary_temp
+WHERE ocp_source = '{{ocp_source_uuid | sqlsafe}}'
 ;
 
 -- OCP ON GCP kubernetes-io-cluster-{cluster_id} label is applied on the VM and is exclusively a pod cost
@@ -153,7 +155,8 @@ INSERT INTO hive.{{schema | sqlsafe}}.reporting_ocpgcpcostlineitem_project_daily
     cluster_capacity_memory_gigabyte_hours,
     volume_labels,
     tags,
-    cost_category_id
+    cost_category_id,
+    ocp_source
 )
 SELECT gcp.uuid as gcp_uuid,
     max(ocp.cluster_id) as cluster_id,
@@ -198,7 +201,8 @@ SELECT gcp.uuid as gcp_uuid,
     max(ocp.cluster_capacity_memory_gigabyte_hours) as cluster_capacity_memory_gigabyte_hours,
     NULL as volume_labels,
     max(json_format(json_parse(gcp.labels))) as tags,
-    max(ocp.cost_category_id) as cost_category_id
+    max(ocp.cost_category_id) as cost_category_id,
+    '{{ocp_source_uuid | sqlsafe}}' as ocp_source
 FROM hive.{{schema | sqlsafe}}.gcp_openshift_daily as gcp
 JOIN hive.{{ schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary as ocp
     ON date(gcp.usage_start_time) = ocp.usage_start
@@ -263,7 +267,8 @@ INSERT INTO hive.{{schema | sqlsafe}}.reporting_ocpgcpcostlineitem_project_daily
     cluster_capacity_memory_gigabyte_hours,
     volume_labels,
     tags,
-    cost_category_id
+    cost_category_id,
+    ocp_source
 )
 SELECT gcp.uuid as gcp_uuid,
     max(ocp.cluster_id) as cluster_id,
@@ -308,7 +313,8 @@ SELECT gcp.uuid as gcp_uuid,
     max(ocp.cluster_capacity_memory_gigabyte_hours) as cluster_capacity_memory_gigabyte_hours,
     max(ocp.volume_labels) as volume_labels,
     max(json_format(json_parse(gcp.labels))) as tags,
-    max(ocp.cost_category_id) as cost_category_id
+    max(ocp.cost_category_id) as cost_category_id,
+    '{{ocp_source_uuid | sqlsafe}}' as ocp_source
 FROM hive.{{schema | sqlsafe}}.gcp_openshift_daily as gcp
 JOIN hive.{{ schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary as ocp
     ON date(gcp.usage_start_time) = ocp.usage_start
@@ -332,6 +338,7 @@ WHERE gcp.source = '{{gcp_source_uuid | sqlsafe}}'
     AND lpad(ocp.month, 2, '0') = {{month}} -- Zero pad the month when fewer than 2 characters
     AND ocp.day IN ({{days}})
     AND pds.gcp_uuid IS NULL
+    AND pds.ocp_source = '{{ocp_source_uuid | sqlsafe}}'
 GROUP BY gcp.uuid, ocp.namespace, ocp.data_source, gcp.invoice_month
 ;
 
@@ -551,4 +558,5 @@ WHERE gcp_source = '{{gcp_source_uuid | sqlsafe}}'
 ;
 
 DELETE FROM hive.{{schema | sqlsafe}}.reporting_ocpgcpcostlineitem_project_daily_summary_temp
+WHERE ocp_source = '{{ocp_source_uuid | sqlsafe}}'
 ;

--- a/koku/masu/database/presto_sql/gcp/openshift/reporting_ocpgcpcostlineitem_daily_summary.sql
+++ b/koku/masu/database/presto_sql/gcp/openshift/reporting_ocpgcpcostlineitem_daily_summary.sql
@@ -338,7 +338,6 @@ WHERE gcp.source = '{{gcp_source_uuid | sqlsafe}}'
     AND lpad(ocp.month, 2, '0') = {{month}} -- Zero pad the month when fewer than 2 characters
     AND ocp.day IN ({{days}})
     AND pds.gcp_uuid IS NULL
-    AND pds.ocp_source = '{{ocp_source_uuid | sqlsafe}}'
 GROUP BY gcp.uuid, ocp.namespace, ocp.data_source, gcp.invoice_month
 ;
 

--- a/koku/masu/database/presto_sql/gcp/openshift/reporting_ocpgcpcostlineitem_daily_summary_resource_id.sql
+++ b/koku/masu/database/presto_sql/gcp/openshift/reporting_ocpgcpcostlineitem_daily_summary_resource_id.sql
@@ -49,8 +49,9 @@ CREATE TABLE IF NOT EXISTS hive.{{schema | sqlsafe}}.reporting_ocpgcpcostlineite
     cost_category_id int,
     project_rank integer,
     data_source_rank integer,
-    ocp_matched boolean
-) WITH(format = 'PARQUET')
+    ocp_matched boolean,
+    ocp_source varchar
+) WITH(format = 'PARQUET', partitioned_by=ARRAY['ocp_source'])
 ;
 
 -- Now create our proper table if it does not exist
@@ -111,6 +112,7 @@ CREATE TABLE IF NOT EXISTS hive.{{schema | sqlsafe}}.reporting_ocpgcpcostlineite
 ;
 
 DELETE FROM hive.{{schema | sqlsafe}}.reporting_ocpgcpcostlineitem_project_daily_summary_temp
+WHERE ocp_source = '{{ocp_source_uuid | sqlsafe}}'
 ;
 
 -- Direct resource_id matching
@@ -161,7 +163,8 @@ INSERT INTO hive.{{schema | sqlsafe}}.reporting_ocpgcpcostlineitem_project_daily
     volume_labels,
     tags,
     cost_category_id,
-    ocp_matched
+    ocp_matched,
+    ocp_source
 )
 SELECT gcp.uuid as gcp_uuid,
     max(ocp.cluster_id) as cluster_id,
@@ -209,7 +212,8 @@ SELECT gcp.uuid as gcp_uuid,
     NULL as volume_labels,
     max(json_format(json_parse(gcp.labels))) as tags,
     max(ocp.cost_category_id) as cost_category_id,
-    max(gcp.ocp_matched) as ocp_matched
+    max(gcp.ocp_matched) as ocp_matched,
+    '{{ocp_source_uuid | sqlsafe}}' as ocp_source
 FROM hive.{{schema | sqlsafe}}.gcp_openshift_daily as gcp
 JOIN hive.{{ schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary as ocp
     ON gcp.usage_start_time = ocp.usage_start
@@ -277,7 +281,8 @@ INSERT INTO hive.{{schema | sqlsafe}}.reporting_ocpgcpcostlineitem_project_daily
     volume_labels,
     tags,
     cost_category_id,
-    ocp_matched
+    ocp_matched,
+    ocp_source
 )
 SELECT gcp.uuid as gcp_uuid,
     max(ocp.cluster_id) as cluster_id,
@@ -325,7 +330,8 @@ SELECT gcp.uuid as gcp_uuid,
     max(ocp.volume_labels) as volume_labels,
     max(json_format(json_parse(gcp.labels))) as tags,
     max(ocp.cost_category_id) as cost_category_id,
-    max(gcp.ocp_matched) as ocp_matched
+    max(gcp.ocp_matched) as ocp_matched,
+    '{{ocp_source_uuid | sqlsafe}}' as ocp_source
 FROM hive.{{schema | sqlsafe}}.gcp_openshift_daily as gcp
 JOIN hive.{{ schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary as ocp
     ON date(gcp.usage_start_time) = ocp.usage_start
@@ -349,6 +355,7 @@ WHERE gcp.source = '{{gcp_source_uuid | sqlsafe}}'
     AND lpad(ocp.month, 2, '0') = {{month}} -- Zero pad the month when fewer than 2 characters
     AND ocp.day IN ({{days}})
     AND pds.gcp_uuid IS NULL
+    AND pds.ocp_source = '{{ocp_source_uuid | sqlsafe}}'
 GROUP BY gcp.uuid, ocp.namespace, ocp.data_source, gcp.invoice_month
 ;
 
@@ -569,4 +576,5 @@ WHERE gcp_source = '{{gcp_source_uuid | sqlsafe}}'
 ;
 
 DELETE FROM hive.{{schema | sqlsafe}}.reporting_ocpgcpcostlineitem_project_daily_summary_temp
+WHERE ocp_source = '{{ocp_source_uuid | sqlsafe}}'
 ;

--- a/koku/masu/database/presto_sql/gcp/openshift/reporting_ocpgcpcostlineitem_daily_summary_resource_id.sql
+++ b/koku/masu/database/presto_sql/gcp/openshift/reporting_ocpgcpcostlineitem_daily_summary_resource_id.sql
@@ -355,7 +355,6 @@ WHERE gcp.source = '{{gcp_source_uuid | sqlsafe}}'
     AND lpad(ocp.month, 2, '0') = {{month}} -- Zero pad the month when fewer than 2 characters
     AND ocp.day IN ({{days}})
     AND pds.gcp_uuid IS NULL
-    AND pds.ocp_source = '{{ocp_source_uuid | sqlsafe}}'
 GROUP BY gcp.uuid, ocp.namespace, ocp.data_source, gcp.invoice_month
 ;
 

--- a/koku/masu/database/presto_sql/reporting_ocpawscostlineitem_daily_summary.sql
+++ b/koku/masu/database/presto_sql/reporting_ocpawscostlineitem_daily_summary.sql
@@ -318,7 +318,6 @@ SELECT aws.uuid as aws_uuid,
         AND lpad(ocp.month, 2, '0') = {{month}} -- Zero pad the month when fewer than 2 characters
         AND ocp.day IN ({{days}})
         AND pds.aws_uuid IS NULL
-        AND pds.ocp_source = '{{ocp_source_uuid | sqlsafe}}'
     GROUP BY aws.uuid, ocp.namespace, ocp.data_source
 ;
 

--- a/koku/masu/database/presto_sql/reporting_ocpazurecostlineitem_daily_summary.sql
+++ b/koku/masu/database/presto_sql/reporting_ocpazurecostlineitem_daily_summary.sql
@@ -315,7 +315,6 @@ SELECT azure.uuid as azure_uuid,
         AND ocp.usage_start >= TIMESTAMP '{{start_date | sqlsafe}}'
         AND ocp.usage_start < date_add('day', 1, TIMESTAMP '{{end_date | sqlsafe}}')
         AND pds.azure_uuid is NULL
-        AND pds.ocp_source = '{{ocp_source_uuid | sqlsafe}}'
     GROUP BY azure.uuid, ocp.namespace, ocp.data_source
 ;
 

--- a/koku/masu/database/presto_sql/reporting_ocpazurecostlineitem_daily_summary.sql
+++ b/koku/masu/database/presto_sql/reporting_ocpazurecostlineitem_daily_summary.sql
@@ -41,8 +41,9 @@ CREATE TABLE IF NOT EXISTS hive.{{schema | sqlsafe}}.reporting_ocpazurecostlinei
     project_rank integer,
     data_source_rank integer,
     resource_id_matched boolean,
-    cost_category_id int
-) WITH(format = 'PARQUET')
+    cost_category_id int,
+    ocp_source varchar
+) WITH(format = 'PARQUET', partitioned_by=ARRAY['ocp_source'])
 ;
 
 -- Now create our proper table if it does not exist
@@ -85,6 +86,7 @@ CREATE TABLE IF NOT EXISTS hive.{{schema | sqlsafe}}.reporting_ocpazurecostlinei
 ;
 
 DELETE FROM hive.{{schema | sqlsafe}}.reporting_ocpazurecostlineitem_project_daily_summary_temp
+WHERE ocp_source = '{{ocp_source_uuid | sqlsafe}}'
 ;
 
 -- Directly resource_id matching
@@ -127,7 +129,8 @@ INSERT INTO hive.{{schema | sqlsafe}}.reporting_ocpazurecostlineitem_project_dai
     volume_labels,
     tags,
     resource_id_matched,
-    cost_category_id
+    cost_category_id,
+    ocp_source
 )
 SELECT azure.uuid as azure_uuid,
     max(ocp.cluster_id) as cluster_id,
@@ -175,7 +178,8 @@ SELECT azure.uuid as azure_uuid,
     max(ocp.volume_labels) as volume_labels,
     max(azure.tags) as tags,
     max(azure.resource_id_matched) as resource_id_matched,
-    max(ocp.cost_category_id) as cost_category_id
+    max(ocp.cost_category_id) as cost_category_id,
+    '{{ocp_source_uuid | sqlsafe}}' as ocp_source
     FROM hive.{{schema | sqlsafe}}.azure_openshift_daily as azure
     JOIN hive.{{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary as ocp
         on coalesce(azure.date, azure.usagedatetime) = ocp.usage_start
@@ -237,7 +241,8 @@ INSERT INTO hive.{{schema | sqlsafe}}.reporting_ocpazurecostlineitem_project_dai
     volume_labels,
     tags,
     resource_id_matched,
-    cost_category_id
+    cost_category_id,
+    ocp_source
 )
 SELECT azure.uuid as azure_uuid,
     max(ocp.cluster_id) as cluster_id,
@@ -285,7 +290,8 @@ SELECT azure.uuid as azure_uuid,
     max(ocp.volume_labels) as volume_labels,
     max(azure.tags) as tags,
     max(azure.resource_id_matched) as resource_id_matched,
-    max(ocp.cost_category_id) as cost_category_id
+    max(ocp.cost_category_id) as cost_category_id,
+    '{{ocp_source_uuid | sqlsafe}}' as ocp_source
     FROM hive.{{schema | sqlsafe}}.azure_openshift_daily as azure
     JOIN hive.{{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary as ocp
         ON coalesce(azure.date, azure.usagedatetime) = ocp.usage_start
@@ -309,6 +315,7 @@ SELECT azure.uuid as azure_uuid,
         AND ocp.usage_start >= TIMESTAMP '{{start_date | sqlsafe}}'
         AND ocp.usage_start < date_add('day', 1, TIMESTAMP '{{end_date | sqlsafe}}')
         AND pds.azure_uuid is NULL
+        AND pds.ocp_source = '{{ocp_source_uuid | sqlsafe}}'
     GROUP BY azure.uuid, ocp.namespace, ocp.data_source
 ;
 
@@ -475,4 +482,5 @@ WHERE azure_source = '{{azure_source_uuid | sqlsafe}}'
 ;
 
 DELETE FROM hive.{{schema | sqlsafe}}.reporting_ocpazurecostlineitem_project_daily_summary_temp
+WHERE ocp_source = '{{ocp_source_uuid | sqlsafe}}'
 ;

--- a/scripts/cji_scripts/migrate_trino.py
+++ b/scripts/cji_scripts/migrate_trino.py
@@ -114,23 +114,23 @@ def main():
     logging.info("Running the hive migration for bucketing costs")
 
     logging.info("fetching schemas")
-    # schemas = get_schemas()
-    schemas = ["acct6089719"]
+    schemas = get_schemas()
     logging.info("Running against the following schemas")
     logging.info(schemas)
 
-    # tables_to_drop = ["aws_openshift_daily"]
+    tables_to_drop = [
+        "reporting_ocpazurecostlineitem_project_daily_summary_temp",
+        "reporting_ocpawscostlineitem_project_daily_summary_temp",
+        "reporting_ocpgcpcostlineitem_project_daily_summary_temp",
+    ]
     # columns_to_drop = ["ocp_matched"]
     # columns_to_add = {"cost_category_id": "int"}
 
     for schema in schemas:
         CONNECT_PARAMS["schema"] = schema
         # logging.info(f"*** Adding column to tables for schema {schema} ***")
-        logging.info(f"*** Dropping tables for schema {schema} ***")
-        drop_table_by_partition("reporting_ocpusagelineitem_daily_summary", "source", CONNECT_PARAMS)
-        drop_table_by_partition("reporting_ocpawscostlineitem_project_daily_summary", "ocp_source", CONNECT_PARAMS)
-        drop_table_by_partition("reporting_ocpazurecostlineitem_project_daily_summary", "ocp_source", CONNECT_PARAMS)
-        drop_table_by_partition("reporting_ocpgcpcostlineitem_project_daily_summary", "ocp_source", CONNECT_PARAMS)
+        logging.info(f"*** Dropping tables {tables_to_drop} for schema {schema} ***")
+        drop_tables(tables_to_drop, CONNECT_PARAMS)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Jira Ticket

[COST-3294](https://issues.redhat.com/browse/COST-3294)

## Description

This change will fix an issue where it was possible to delete data for other clusters running simultaneously for OCP on Cloud summary SQL.

## Testing

1. `git checkout main; make create-test-customer; make create-test-customer-data`
2. WAIT
3. `git checkout cost-3294-ocp-on-cloud-delete-fix`
4. `python scripts/cji_scripts/migrate_trino.py`
5. `make delete-test-sources; make clear-testing; make clear-trino-data`
6. `make create-test-customer; make create-test-customer-data`
7. Watch is run successfully! 

## Notes

...
