### PR TITLE
COST-3199 (pt3): Tag Exclusions for OCP tables should be an AND.

### DIFF
--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -392,7 +392,7 @@ class ReportQueryHandler(QueryHandler):
                 tag_filter_list.append({"field": tag_db_name, "operation": "noticontainslist", "parameter": list_})
                 null_collections.add(QueryFilter(**{"field": tag_db_name, "operation": "isnull", "parameter": True}))
         null_composed = null_collections.compose()
-        if self.provider in OCP_LIST:
+        if self.provider and self.provider in OCP_LIST:
             # For OCP tables we need to use the AND operator because the two tag keys are found
             # in the same json structure per row.
             tag_exclusion_composed = None

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -402,9 +402,10 @@ class ReportQueryHandler(QueryHandler):
                     tag_exclusion_composed = tag_filt_composed
                 else:
                     tag_exclusion_composed = tag_exclusion_composed & tag_filt_composed
-            tag_exclusion_composed = (
-                tag_exclusion_composed | QueryFilterCollection([QueryFilter(**empty_json_filter)]).compose()
-            )
+            if tag_exclusion_composed:
+                tag_exclusion_composed = (
+                    tag_exclusion_composed | QueryFilterCollection([QueryFilter(**empty_json_filter)]).compose()
+                )
         else:
             if tag_filter_list:
                 tag_filter_list.append(empty_json_filter)

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -381,18 +381,36 @@ class ReportQueryHandler(QueryHandler):
         noticontainslist is a custom django lookup we wrote to handle
         tag exclusions.
         """
+        OCP_LIST = [Provider.OCP_AWS, Provider.OCP_AZURE, Provider.OCP_ALL, Provider.OCP_GCP, Provider.PROVIDER_OCP]
         null_collections = QueryFilterCollection()
         tag_filter_list = []
+        empty_json_filter = {"field": self._mapper.tag_column, "operation": "exact", "parameter": "{}"}
         for tag in self.get_tag_filter_keys(parameter_key="exclude"):
             tag_db_name = self._mapper.tag_column + "__" + strip_tag_prefix(tag)
             list_ = self.parameters.get_exclude(tag, list())
             if list_ and not ReportQueryHandler.has_wildcard(list_):
                 tag_filter_list.append({"field": tag_db_name, "operation": "noticontainslist", "parameter": list_})
                 null_collections.add(QueryFilter(**{"field": tag_db_name, "operation": "isnull", "parameter": True}))
-        if tag_filter_list:
-            tag_filter_list.append({"field": self._mapper.tag_column, "operation": "exact", "parameter": "{}"})
         null_composed = null_collections.compose()
-        tag_exclusion_composed = self._set_or_filters(tag_filter_list)
+        if self.provider in OCP_LIST:
+            # For OCP tables we need to use the AND operator because the two tag keys are found
+            # in the same json structure per row.
+            tag_exclusion_composed = None
+            for tag_filt in tag_filter_list:
+                tag_filt_composed = QueryFilterCollection([QueryFilter(**tag_filt)]).compose()
+                if not tag_exclusion_composed:
+                    tag_exclusion_composed = tag_filt_composed
+                else:
+                    tag_exclusion_composed = tag_exclusion_composed & tag_filt_composed
+            tag_exclusion_composed = (
+                tag_exclusion_composed | QueryFilterCollection([QueryFilter(**empty_json_filter)]).compose()
+            )
+        else:
+            if tag_filter_list:
+                tag_filter_list.append(empty_json_filter)
+            # We use OR here for our non ocp tables because the tag keys will not live in the
+            # same json structure.
+            tag_exclusion_composed = self._set_or_filters(tag_filter_list)
         if tag_exclusion_composed and null_composed:
             tag_exclusion_composed = tag_exclusion_composed | null_composed
         return tag_exclusion_composed


### PR DESCRIPTION
## Jira Ticket

[COST-3199](https://issues.redhat.com/browse/COST-3199)

*TLDR:*

For our cloud we need to tell it to build this section with an OR when combining our `noticontainslist` filters cause only one key is found in the json structure per row. However, for our tables using OCP we need to combine our `noticontainslist` filters with an `AND`.


## Description

In my haste to try to wrap up this issue quickly, I made a mistake regarding a change I made on [this line](https://github.com/project-koku/koku/commit/c9b93caf4a4b608c91f3b1f01a82bc5c2b9e1c55#diff-7856c4ba653f802f9901aa185f9dfcd3754d01fe20a6fa824b6443d31b88d48aR395).

That line told django to build the sql with an `OR` creating sql like this:
```
SELECT
    (reporting_awscostentrylineitem_daily_summary.tags -> 'app'),
    (reporting_awscostentrylineitem_daily_summary.tags -> 'storageclass'),
    DATE_TRUNC('day', reporting_awscostentrylineitem_daily_summary.usage_start) AS date,
    SUM(((COALESCE(reporting_awscostentrylineitem_daily_summary.unblended_cost, 0) + COALESCE(reporting_awscostentrylineitem_daily_summary.markup_cost, 0)) * COALESCE(1, 1))) AS cost_total,
    COALESCE('USD', 'USD') AS cost_units, ARRAY_AGG(DISTINCT reporting_awscostentrylineitem_daily_summary.source_uuid )
    FILTER (WHERE reporting_awscostentrylineitem_daily_summary.source_uuid IS NOT NULL) AS source_uuid
FROM reporting_awscostentrylineitem_daily_summary
WHERE (
    reporting_awscostentrylineitem_daily_summary.usage_start >= '2022-11-19'::date
    AND reporting_awscostentrylineitem_daily_summary.usage_start <= '2022-11-20'::date
    AND (
        (UPPER((reporting_awscostentrylineitem_daily_summary.tags -> 'storageclass')::text) NOT LIKE UPPER('%bravo%'))
        OR (UPPER((reporting_awscostentrylineitem_daily_summary.tags -> 'app')::text) NOT LIKE UPPER('%analytics%'))
        OR reporting_awscostentrylineitem_daily_summary.tags = '{}'
        OR (
            (reporting_awscostentrylineitem_daily_summary.tags -> 'storageclass') IS NULL
            AND (reporting_awscostentrylineitem_daily_summary.tags -> 'app') IS NULL))
    ) GROUP BY (reporting_awscostentrylineitem_daily_summary.tags -> 'app'), (reporting_awscostentrylineitem_daily_summary.tags -> 'storageclass'), DATE_TRUNC('day', reporting_awscostentrylineitem_daily_summary.usage_start), COALESCE('USD', 'USD');
```
Which if you run it gives you:
```
app_tag_key  |  storage_tag_key  |          date          |  cost_total   | cost_units |                                 source_uuid
-----------+-----------+------------------------+---------------+------------+-----------------------------------------------------------------------------
 "catalog" |           | 2022-11-19 00:00:00+00 |   2.591668595 | USD        | {f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
 "catalog" |           | 2022-11-20 00:00:00+00 |   2.635447728 | USD        | {f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
 "cost"    |           | 2022-11-19 00:00:00+00 |   1.722015833 | USD        | {f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
 "cost"    |           | 2022-11-20 00:00:00+00 |   1.642780875 | USD        | {f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
           | "charlie" | 2022-11-19 00:00:00+00 |  13.200000000 | USD        | {f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
           | "charlie" | 2022-11-20 00:00:00+00 |  13.200000000 | USD        | {f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
           | "delta"   | 2022-11-19 00:00:00+00 |   2.640000000 | USD        | {f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
           | "delta"   | 2022-11-20 00:00:00+00 |   2.640000000 | USD        | {f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
           | "epsilon" | 2022-11-19 00:00:00+00 |   2.640000000 | USD        | {f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
           | "epsilon" | 2022-11-20 00:00:00+00 |   2.640000000 | USD        | {f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
           | "gamma"   | 2022-11-19 00:00:00+00 |   2.640000000 | USD        | {f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
           | "gamma"   | 2022-11-20 00:00:00+00 |   2.640000000 | USD        | {f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
           |           | 2022-11-19 00:00:00+00 | 317.669437552 | USD        | {d7847e25-c725-45ea-a192-182395d44750,f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
           |           | 2022-11-20 00:00:00+00 | 317.669437552 | USD        | {d7847e25-c725-45ea-a192-182395d44750,f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
(14 rows
```
The OR used in this section:
```
(UPPER((reporting_awscostentrylineitem_daily_summary.tags -> 'storageclass')::text) NOT LIKE UPPER('%bravo%'))
        OR (UPPER((reporting_awscostentrylineitem_daily_summary.tags -> 'app')::text) NOT LIKE UPPER('%analytics%'))
```
works perfectly for tables where the two different tag keys can not be found in the same json structure per row. Which is the case for our cloud providers. 

However, this is not the case for our tables using OCP:
```
    app_tag_key    | storage_tag_key  |          date          |     cost_total     |      clusters       |              source_uuid
----------------+-----------+------------------------+--------------------+---------------------+----------------------------------------
 "analytics"    | "charlie" | 2022-11-20 00:00:00+00 | 14.234959216562985 | {"Test OCP on AWS"} | {f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
 "analytics"    | "charlie" | 2022-11-21 00:00:00+00 | 14.251605677271333 | {"Test OCP on AWS"} | {f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
 "analytics"    | "charlie" | 2022-11-22 00:00:00+00 | 14.224436037738567 | {"Test OCP on AWS"} | {f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
 "analytics"    | "charlie" | 2022-11-23 00:00:00+00 | 14.248104856796609 | {"Test OCP on AWS"} | {f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
 "analytics"    | "charlie" | 2022-11-24 00:00:00+00 | 14.248485191125143 | {"Test OCP on AWS"} | {f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
 "analytics"    | "charlie" | 2022-11-25 00:00:00+00 | 14.237610679350353 | {"Test OCP on AWS"} | {f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
 "analytics"    | "charlie" | 2022-11-26 00:00:00+00 | 14.238226918803750 | {"Test OCP on AWS"} | {f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
 "analytics"    | "charlie" | 2022-11-27 00:00:00+00 | 14.257991801485819 | {"Test OCP on AWS"} | {f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
 "catalog"      | "bravo"   | 2022-11-20 00:00:00+00 |  3.385292572048491 | {"Test OCP on AWS"} | {f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
 "catalog"      | "bravo"   | 2022-11-21 00:00:00+00 |  3.386681436213223 | {"Test OCP on AWS"} | {f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
 "catalog"      | "bravo"   | 2022-11-22 00:00:00+00 |  3.003397784562395 | {"Test OCP on AWS"} | {f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
 "catalog"      | "bravo"   | 2022-11-23 00:00:00+00 |  3.378705897883846 | {"Test OCP on AWS"} | {f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
 "catalog"      | "bravo"   | 2022-11-24 00:00:00+00 |  2.988133996986223 | {"Test OCP on AWS"} | {f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
 ```
 Which is allowing the excluded values to sneak back into the return. Therefore, I needed to change the `OR` to an `AND` for OCP providers:
 Example:
 ```
 SELECT
    (reporting_ocpawscostlineitem_daily_summary_p.tags -> 'app'),
    (reporting_ocpawscostlineitem_daily_summary_p.tags -> 'storageclass'),
    DATE_TRUNC('day', reporting_ocpawscostlineitem_daily_summary_p.usage_start) AS date,
    SUM(((COALESCE(reporting_ocpawscostlineitem_daily_summary_p.unblended_cost, 0) + COALESCE(reporting_ocpawscostlineitem_daily_summary_p.markup_cost, 0)) * COALESCE(1, 1))) AS cost_total,
    ARRAY_AGG(DISTINCT COALESCE(reporting_ocpawscostlineitem_daily_summary_p.cluster_alias, reporting_ocpawscostlineitem_daily_summary_p.cluster_id) ) AS clusters,
    ARRAY_AGG(DISTINCT reporting_ocpawscostlineitem_daily_summary_p.source_uuid ) FILTER (WHERE reporting_ocpawscostlineitem_daily_summary_p.source_uuid IS NOT NULL) AS source_uuid
FROM reporting_ocpawscostlineitem_daily_summary_p
WHERE 
    (reporting_ocpawscostlineitem_daily_summary_p.usage_start >= '2022-11-20'::date 
    AND reporting_ocpawscostlineitem_daily_summary_p.usage_start <= '2022-11-29'::date 
    AND (
        (UPPER((reporting_ocpawscostlineitem_daily_summary_p.tags -> 'storageclass')::text) NOT LIKE UPPER('%bravo%')) 
        AND (UPPER((reporting_ocpawscostlineitem_daily_summary_p.tags -> 'app')::text) NOT LIKE UPPER('%analytics%')) 
        OR reporting_ocpawscostlineitem_daily_summary_p.tags = '{}' 
        OR (
            (reporting_ocpawscostlineitem_daily_summary_p.tags -> 'storageclass') IS NULL 
            AND (reporting_ocpawscostlineitem_daily_summary_p.tags -> 'app') IS NULL))
    ) GROUP BY (reporting_ocpawscostlineitem_daily_summary_p.tags -> 'app'), (reporting_ocpawscostlineitem_daily_summary_p.tags -> 'storageclass'), DATE_TRUNC('day', reporting_ocpawscostlineitem_daily_summary_p.usage_start), COALESCE('USD', 'USD');
```
Which will give us:
```
?column?  | ?column?  |          date          |    cost_total     |      clusters       |              source_uuid
-----------+-----------+------------------------+-------------------+---------------------+----------------------------------------
 "catalog" | "delta"   | 2022-11-20 00:00:00+00 | 3.385292572048491 | {"Test OCP on AWS"} | {f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
 "catalog" | "delta"   | 2022-11-21 00:00:00+00 | 3.386681436213223 | {"Test OCP on AWS"} | {f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
 "catalog" | "delta"   | 2022-11-22 00:00:00+00 | 3.003397784562395 | {"Test OCP on AWS"} | {f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
 "catalog" | "delta"   | 2022-11-23 00:00:00+00 | 3.378705897883846 | {"Test OCP on AWS"} | {f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
 "catalog" | "delta"   | 2022-11-24 00:00:00+00 | 2.988133996986223 | {"Test OCP on AWS"} | {f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
 "catalog" | "delta"   | 2022-11-25 00:00:00+00 | 3.375549981593844 | {"Test OCP on AWS"} | {f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
 "catalog" | "delta"   | 2022-11-26 00:00:00+00 | 3.029477948495410 | {"Test OCP on AWS"} | {f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
 "catalog" | "delta"   | 2022-11-27 00:00:00+00 | 3.366768422071599 | {"Test OCP on AWS"} | {f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
 "cost"    | "epsilon" | 2022-11-20 00:00:00+00 | 3.376881447922975 | {"Test OCP on AWS"} | {f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
 "cost"    | "epsilon" | 2022-11-21 00:00:00+00 | 3.393729588421742 | {"Test OCP on AWS"} | {f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
 "cost"    | "epsilon" | 2022-11-22 00:00:00+00 | 3.395050198058738 | {"Test OCP on AWS"} | {f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
 "cost"    | "epsilon" | 2022-11-23 00:00:00+00 | 3.390175862207789 | {"Test OCP on AWS"} | {f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
 "cost"    | "epsilon" | 2022-11-24 00:00:00+00 | 3.405849370660090 | {"Test OCP on AWS"} | {f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
 "cost"    | "epsilon" | 2022-11-25 00:00:00+00 | 3.398204950376923 | {"Test OCP on AWS"} | {f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
 "cost"    | "epsilon" | 2022-11-26 00:00:00+00 | 3.377844506495200 | {"Test OCP on AWS"} | {f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
 "cost"    | "epsilon" | 2022-11-27 00:00:00+00 | 3.376206846783604 | {"Test OCP on AWS"} | {f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
           |           | 2022-11-20 00:00:00+00 | 0.844800000000000 | {"Test OCP on AWS"} | {f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
           |           | 2022-11-21 00:00:00+00 | 0.844800000000000 | {"Test OCP on AWS"} | {f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
           |           | 2022-11-22 00:00:00+00 | 0.844800000000000 | {"Test OCP on AWS"} | {f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
           |           | 2022-11-23 00:00:00+00 | 0.844800000000000 | {"Test OCP on AWS"} | {f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
           |           | 2022-11-24 00:00:00+00 | 0.844800000000000 | {"Test OCP on AWS"} | {f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
           |           | 2022-11-25 00:00:00+00 | 0.844800000000000 | {"Test OCP on AWS"} | {f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
           |           | 2022-11-26 00:00:00+00 | 0.844800000000000 | {"Test OCP on AWS"} | {f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
           |           | 2022-11-27 00:00:00+00 | 0.844800000000000 | {"Test OCP on AWS"} | {f5100eaf-5d01-4677-9c66-8e2ad8550eaf}
```

## Testing

How to test:
1. make load test-customer-data
2. Compare main & this branch with the following urls, and make sure the excluded values are not in the return for this branch. You will additionally want to check that `no-` appears in these endpoint returns except for OCP on GCP. We don't populate any rows without tag keys for that provider locally.

URLS:

### OCP on CLOUD different tag keys
* OCP on AWS: `http://127.0.0.1:8000/api/cost-management/v1/reports/openshift/infrastructures/aws/costs/?group_by[tag:app]=*&group_by[tag:storageclass]=*&exclude[tag:storageclass]=bravo&exclude[tag:app]=analytics`
* OCP on GCP: `http://127.0.0.1:8000/api/cost-management/v1/reports/openshift/infrastructures/gcp/costs/?group_by[tag:app]=*&group_by[tag:environment]=*&exclude[tag:environment]=murphy&exclude[tag:app]=analytics`
* OCP on Azure: `http://127.0.0.1:8000/api/cost-management/v1/reports/openshift/infrastructures/azure/costs/?group_by[tag:storageclass]=*&group_by[tag:environment]=*&exclude[tag:storageclass]=loki&exclude[tag:environment]=Mars`
* OCP on ALL: `http://localhost:8000/api/cost-management/v1/reports/openshift/infrastructures/all/costs/?exclude[tag:app]=Sombrero&group_by[tag:app]=*&group_by[tag:environment]=*&exclude[tag:environment]=qe&exclude[tag:environment]=murphy`

### Cloud Providers different keys
* AWS: `http://localhost:8000/api/cost-management/v1/reports/aws/costs/?group_by[tag:app]=*&group_by[tag:storageclass]=*&exclude[tag:app]=analytics&exclude[tag:storageclass]=bravo&start_date=2022-11-19&end_date=2022-11-20`
* Azure: `http://localhost:8000/api/cost-management/v1/reports/azure/costs/?group_by[tag:app]=*&exclude[tag:app]=Bromine&exclude[tag:app]=Sodium&group_by[tag:environment]=*&exclude[tag:environment]=Carbon`
* GCP: `http://localhost:8000/api/cost-management/v1/reports/gcp/costs/?group_by[tag:environment]=*&group_by[tag:app]=*&exclude[tag:environment]=murphy&exclude[tag:app]=fall&exclude[tag:app]=winter`
* OCP: `http://localhost:8000/api/cost-management/v1/reports/openshift/costs/?group_by[tag:app]=*&group_by[tag:environment]=*&exclude[tag:app]=Atomic&exclude[tag:environment]=Development&exclude[tag:environment]=Test`

## Notes
1) I did try seeing if I could just use an `AND` on the cloud providers but it messed up the return. So, I do think we need a special case here to handle the two different query paths. 
2) When performing the `AND` needed for OCP I did just try to do a normal `.compose()`, but the way django built the query caused only no- to be returned. So, I had to treat each tag filter as a `QueryFilterCollection` in order to get the correct `AND` structure.

...
