### PR TITLE
[COST-3301] determine cost category id for Unallocated Capacity Costs

### DIFF
--- a/koku/masu/database/sql/reporting_ocpaws_ocp_infrastructure_back_populate.sql
+++ b/koku/masu/database/sql/reporting_ocpaws_ocp_infrastructure_back_populate.sql
@@ -36,7 +36,8 @@ INSERT INTO {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary (
     persistentvolumeclaim_capacity_gigabyte_months,
     volume_request_storage_gigabyte_months,
     persistentvolumeclaim_usage_gigabyte_months,
-    raw_currency
+    raw_currency,
+    cost_category_id
 )
     SELECT uuid_generate_v4() as uuid,
         ocp_aws.report_period_id,
@@ -80,7 +81,8 @@ INSERT INTO {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary (
         0 as persistentvolumeclaim_capacity_gigabyte_months,
         0 as volume_request_storage_gigabyte_months,
         0 as persistentvolumeclaim_usage_gigabyte_months,
-        max(ocp_aws.currency_code) as raw_currency
+        max(ocp_aws.currency_code) as raw_currency,
+        max(ocp_aws.cost_category_id) as cost_category_id
     FROM {{schema | sqlsafe}}.reporting_ocpawscostlineitem_project_daily_summary_p AS ocp_aws
     JOIN {{schema | sqlsafe}}.reporting_ocpusagereportperiod AS rp
         ON ocp_aws.cluster_id = rp.cluster_id

--- a/koku/masu/database/sql/reporting_ocpazurecostentrylineitem_daily_summary_back_populate.sql
+++ b/koku/masu/database/sql/reporting_ocpazurecostentrylineitem_daily_summary_back_populate.sql
@@ -29,7 +29,8 @@ INSERT INTO {{schema | sqlsafe}}.reporting_ocpazurecostlineitem_daily_summary_p 
     currency,
     unit_of_measure,
     shared_projects,
-    source_uuid
+    source_uuid,
+    cost_category_id
 )
     SELECT uuid_generate_v4(),
         report_period_id,
@@ -52,7 +53,8 @@ INSERT INTO {{schema | sqlsafe}}.reporting_ocpazurecostlineitem_daily_summary_p 
         max(currency) as currency,
         max(unit_of_measure) as unit_of_measure,
         count(DISTINCT namespace) as shared_projects,
-        source_uuid
+        source_uuid,
+        max(cost_category_id)
     FROM reporting_ocpazurecostlineitem_project_daily_summary_p
     WHERE report_period_id = {{report_period_id | sqlsafe}}
         AND usage_start >= date({{start_date}})
@@ -110,7 +112,8 @@ INSERT INTO {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary (
     persistentvolumeclaim_capacity_gigabyte_months,
     volume_request_storage_gigabyte_months,
     persistentvolumeclaim_usage_gigabyte_months,
-    raw_currency
+    raw_currency,
+    cost_category_id
 )
     SELECT uuid_generate_v4() as uuid,
         ocp_azure.report_period_id,
@@ -154,7 +157,8 @@ INSERT INTO {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary (
         0 as persistentvolumeclaim_capacity_gigabyte_months,
         0 as volume_request_storage_gigabyte_months,
         0 as persistentvolumeclaim_usage_gigabyte_months,
-        max(ocp_azure.currency) as raw_currency
+        max(ocp_azure.currency) as raw_currency,
+        max(ocp_azure.cost_category_id) as cost_category_id
     FROM {{schema | sqlsafe}}.reporting_ocpazurecostlineitem_project_daily_summary_p AS ocp_azure
     JOIN {{schema | sqlsafe}}.reporting_ocpusagereportperiod AS rp
         ON ocp_azure.cluster_id = rp.cluster_id


### PR DESCRIPTION
## Jira Ticket

[COST-3301](https://issues.redhat.com/browse/COST-3301)

## Description

This change will include the cost_category_id for the unallocated capacity namespaces if one is associated with a category, in this case Platform Unallocated Capacity goes with the platform category.

## Testing

1. Checkout Branch
2. Restart Koku
3. Load test customer data with `make create-test-customer` followed by `make load-test-customer-data`
4. go to an endpoint grouped by projects with a category and you should see the platform category is present, but the Platform Unallocated Capacity project is not.
http://localhost:8000/api/cost-management/v1/reports/openshift/costs/?group_by%5Bproject%5D=*&category=platform

## Notes

...
