### PR TITLE
COST-3075: Fix excluded org units being visable when filtering by root

### DIFF
--- a/koku/api/report/aws/query_handler.py
+++ b/koku/api/report/aws/query_handler.py
@@ -668,6 +668,11 @@ select coalesce(raa.account_alias, t.usage_account_id)::text as "account",
                 .distinct("org_unit_id")
             )
 
+            # This is to remove the excluded values from the sub_org_units
+            if "org_unit_id" in list(self.query_table_exclude_keys):
+                for org_id in self.parameters.get_exclude("org_unit_id"):
+                    org_unit_list.append(org_id)
+
             sub_org_unit_list = None
             if org_unit_objects:
                 sub_org_units = []


### PR DESCRIPTION
## Jira Ticket

[COST-3075](https://issues.redhat.com/browse/COST-3075)

## Description

This change will fix exclude org unit when filtering by root org. 

Example url:
```
http://localhost:8000/api/cost-management/v1/reports/aws/costs/?group_by[org_unit_id]=R_001&filter[org_unit_id]=R_001&exclude[org_unit_id]=OU_002
```

## Testing

1. Load test customer data
2. On main look at the example url and see that `OU_002` is in the results.
3. Switch to this branch, run `make clear-cache` and refresh the page to notice that `OU_002` is no longer in the results. 

## Notes

...
