### PR TITLE
[COST-3331] rename unallocated projects and no-<something> to No-<something>

### DIFF
--- a/koku/api/report/ocp/provider_map.py
+++ b/koku/api/report/ocp/provider_map.py
@@ -1621,12 +1621,12 @@ class OCPProviderMap(ProviderMap):
                                     {
                                         "field": "namespace",
                                         "operation": "exact",
-                                        "parameter": "Workers Unallocated Capacity",
+                                        "parameter": "Worker unallocated",
                                     },
                                     {
                                         "field": "namespace",
                                         "operation": "exact",
-                                        "parameter": "Platform Unallocated Capacity",
+                                        "parameter": "Platform unallocated",
                                     },
                                 ],
                             },
@@ -1949,12 +1949,12 @@ class OCPProviderMap(ProviderMap):
                                     {
                                         "field": "namespace",
                                         "operation": "exact",
-                                        "parameter": "Workers Unallocated Capacity",
+                                        "parameter": "Worker unallocated",
                                     },
                                     {
                                         "field": "namespace",
                                         "operation": "exact",
-                                        "parameter": "Platform Unallocated Capacity",
+                                        "parameter": "Platform unallocated",
                                     },
                                 ],
                             },

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -708,7 +708,7 @@ class ReportQueryHandler(QueryHandler):
                 value = group
                 if group.startswith(tag_prefix):
                     value = group[len(tag_prefix) :]  # noqa
-                group_label = f"no-{value}"
+                group_label = f"No-{value}"
                 data[group] = group_label
 
         return data
@@ -775,7 +775,7 @@ class ReportQueryHandler(QueryHandler):
                         new_key = group_info.get("key")
                         if data.get(group_key):
                             if isinstance(data[group_key], str):
-                                # This if is to overwrite the "cost": "no-cost"
+                                # This if is to overwrite the "cost": "No-cost"
                                 # that is provided by the order_by function.
                                 data[group_key] = {}
                             data[group_key][new_key] = {"value": value, "units": units}
@@ -837,7 +837,7 @@ class ReportQueryHandler(QueryHandler):
                 group_title = group_type[len(tag_prefix) :]  # noqa
             group_label = group
             if group is None:
-                group_label = f"no-{group_title}"
+                group_label = f"No-{group_title}"
             cur = {group_title: group_label, label: self._transform_data(groups, next_group_index, group_value)}
             out_data.append(cur)
 
@@ -864,7 +864,7 @@ class ReportQueryHandler(QueryHandler):
             return self._order_by(query_data, query_order_by)
         df = pd.DataFrame(query_data)
         sort_terms = self._get_group_by()
-        none_sort_terms = [f"no-{sort_term}" for sort_term in sort_terms]
+        none_sort_terms = [f"No-{sort_term}" for sort_term in sort_terms]
         for sort_term, none_sort_term in zip(sort_terms, none_sort_terms):
             # use a dictionary to uniquify the list and maintain the correct order
             ordered_list = dict.fromkeys([entry.get(sort_term) or none_sort_term for entry in ordered_data]).keys()
@@ -920,7 +920,7 @@ class ReportQueryHandler(QueryHandler):
             else:
                 for line_data in sorted_data:
                     if not line_data.get(field):
-                        line_data[field] = f"no-{field}"
+                        line_data[field] = f"No-{field}"
                 sorted_data = sorted(
                     sorted_data,
                     key=lambda entry: (bool(re.match(r"other*", entry[field].lower())), entry[field].lower()),

--- a/koku/api/report/test/all/openshift/test_query_handler.py
+++ b/koku/api/report/test/all/openshift/test_query_handler.py
@@ -277,7 +277,7 @@ class OCPAllQueryHandlerTest(IamTestCase):
         query_params = self.mocked_query_params(url, OCPAllCostView)
         handler = OCPAllReportQueryHandler(query_params)
         data = handler.execute_query().get("data")
-        if f"no-{group_tag}" in str(data):
+        if f"No-{group_tag}" in str(data):
             check_no_option = True
         previous_total = handler.query_sum.get("cost", {}).get("total", {}).get("value")
         for exclude_value in exclude_vals:
@@ -286,7 +286,7 @@ class OCPAllQueryHandlerTest(IamTestCase):
             handler = OCPAllReportQueryHandler(query_params)
             data = handler.execute_query()
             if check_no_option:
-                self.assertIn(f"no-{group_tag}", str(data))
+                self.assertIn(f"No-{group_tag}", str(data))
             current_total = handler.query_sum.get("cost", {}).get("total", {}).get("value")
             self.assertLess(current_total, previous_total)
             previous_total = current_total
@@ -307,7 +307,7 @@ class OCPAllQueryHandlerTest(IamTestCase):
                 exclude_one = None
                 exclude_two = None
                 for exclude_option in opt_list:
-                    if "no-" not in exclude_option.get(ex_opt):
+                    if "No-" not in exclude_option.get(ex_opt):
                         if not exclude_one:
                             exclude_one = exclude_option.get(ex_opt)
                         elif not exclude_two:

--- a/koku/api/report/test/aws/openshift/test_ocp_aws_query_handler.py
+++ b/koku/api/report/test/aws/openshift/test_ocp_aws_query_handler.py
@@ -591,7 +591,7 @@ class OCPAWSQueryHandlerTest(IamTestCase):
         handler = OCPAWSReportQueryHandler(query_params)
         # spot check for no-option
         data = handler.execute_query().get("data")
-        if f"no-{group_tag}" in str(data):
+        if f"No-{group_tag}" in str(data):
             check_no_option = True
         previous_total = handler.query_sum.get("cost", {}).get("total", {}).get("value")
         for exclude_value in exclude_vals:
@@ -600,7 +600,7 @@ class OCPAWSQueryHandlerTest(IamTestCase):
             handler = OCPAWSReportQueryHandler(query_params)
             data = handler.execute_query()
             if check_no_option:
-                self.assertIn(f"no-{group_tag}", str(data))
+                self.assertIn(f"No-{group_tag}", str(data))
             current_total = handler.query_sum.get("cost", {}).get("total", {}).get("value")
             self.assertLess(current_total, previous_total)
             previous_total = current_total
@@ -622,7 +622,7 @@ class OCPAWSQueryHandlerTest(IamTestCase):
                 exclude_one = None
                 exclude_two = None
                 for exclude_option in opt_list:
-                    if "no-" not in exclude_option.get(ex_opt):
+                    if "No-" not in exclude_option.get(ex_opt):
                         if not exclude_one:
                             exclude_one = exclude_option.get(ex_opt)
                         elif not exclude_two:

--- a/koku/api/report/test/aws/test_queries.py
+++ b/koku/api/report/test/aws/test_queries.py
@@ -162,7 +162,7 @@ class AWSReportQueryTest(IamTestCase):
         handler = AWSReportQueryHandler(query_params)
         groups = ["region"]
         data = {"region": None, "units": "USD"}
-        expected = {"region": "no-region", "units": "USD"}
+        expected = {"region": "No-region", "units": "USD"}
         out_data = handler._apply_group_null_label(data, groups)
         self.assertEqual(expected, out_data)
 
@@ -182,8 +182,8 @@ class AWSReportQueryTest(IamTestCase):
         handler = AWSReportQueryHandler(query_params)
         groups = ["region"]
         group_index = 0
-        data = {None: [{"region": "no-region", "units": "USD"}]}
-        expected = [{"region": "no-region", "values": [{"region": "no-region", "units": "USD"}]}]
+        data = {None: [{"region": "No-region", "units": "USD"}]}
+        expected = [{"region": "No-region", "values": [{"region": "No-region", "units": "USD"}]}]
         out_data = handler._transform_data(groups, group_index, data)
         self.assertEqual(expected, out_data)
 
@@ -192,8 +192,8 @@ class AWSReportQueryTest(IamTestCase):
         out_data = handler._transform_data(groups, group_index, data)
         self.assertEqual(expected, out_data)
 
-        data = {None: {"region": "no-region", "units": "USD"}}
-        expected = [{"region": "no-region", "values": {"region": "no-region", "units": "USD"}}]
+        data = {None: {"region": "No-region", "units": "USD"}}
+        expected = [{"region": "No-region", "values": {"region": "No-region", "units": "USD"}}]
         out_data = handler._transform_data(groups, group_index, data)
         self.assertEqual(expected, out_data)
 
@@ -204,8 +204,8 @@ class AWSReportQueryTest(IamTestCase):
         handler = AWSReportQueryHandler(query_params)
         groups = ["region"]
         group_index = 0
-        data = {None: [{"region": "no-region", "units": "USD"}]}
-        expected = [{"region": "no-region", "values": [{"region": "no-region", "units": "USD"}]}]
+        data = {None: [{"region": "No-region", "units": "USD"}]}
+        expected = [{"region": "No-region", "values": [{"region": "No-region", "units": "USD"}]}]
         out_data = handler._transform_data(groups, group_index, data)
         self.assertEqual(expected, out_data)
 
@@ -214,8 +214,8 @@ class AWSReportQueryTest(IamTestCase):
         out_data = handler._transform_data(groups, group_index, data)
         self.assertEqual(expected, out_data)
 
-        data = {None: {"region": "no-region", "units": "USD"}}
-        expected = [{"region": "no-region", "values": {"region": "no-region", "units": "USD"}}]
+        data = {None: {"region": "No-region", "units": "USD"}}
+        expected = [{"region": "No-region", "values": {"region": "No-region", "units": "USD"}}]
         out_data = handler._transform_data(groups, group_index, data)
         self.assertEqual(expected, out_data)
 
@@ -2829,7 +2829,7 @@ class AWSReportQueryTest(IamTestCase):
                 correctlst = [field.get(gb) for field in expected]
                 if correctlst and None in correctlst:
                     ind = correctlst.index(None)
-                    correctlst[ind] = "no-" + group_by
+                    correctlst[ind] = "No-" + group_by
                 tested = False
                 for element in data:
                     lst = [field.get(group_by) for field in element.get(group_by + "s", [])]
@@ -3299,7 +3299,7 @@ class AWSQueryHandlerTest(IamTestCase):
         query_params = self.mocked_query_params(url, AWSCostView)
         handler = AWSReportQueryHandler(query_params)
         data = handler.execute_query().get("data")
-        if f"no-{group_tag}" in str(data):
+        if f"No-{group_tag}" in str(data):
             check_no_option = True
         previous_total = handler.query_sum.get("cost", {}).get("total", {}).get("value")
         for exclude_value in exclude_vals:
@@ -3308,7 +3308,7 @@ class AWSQueryHandlerTest(IamTestCase):
             handler = AWSReportQueryHandler(query_params)
             data = handler.execute_query()
             if check_no_option:
-                self.assertIn(f"no-{group_tag}", str(data))
+                self.assertIn(f"No-{group_tag}", str(data))
             current_total = handler.query_sum.get("cost", {}).get("total", {}).get("value")
             self.assertLess(current_total, previous_total)
             previous_total = current_total
@@ -3329,7 +3329,7 @@ class AWSQueryHandlerTest(IamTestCase):
                 exclude_one = None
                 exclude_two = None
                 for exclude_option in opt_list:
-                    if "no-" not in exclude_option.get(ex_opt):
+                    if "No-" not in exclude_option.get(ex_opt):
                         if not exclude_one:
                             exclude_one = exclude_option.get(ex_opt)
                         elif not exclude_two:

--- a/koku/api/report/test/azure/openshift/test_ocp_azure_query_handler.py
+++ b/koku/api/report/test/azure/openshift/test_ocp_azure_query_handler.py
@@ -1265,7 +1265,7 @@ class OCPAzureQueryHandlerTest(IamTestCase):
         expected = [
             {"node": "alpha", "cluster": "cluster-2"},
             {"node": "bravo", "cluster": "cluster-3"},
-            {"node": "no-node", "cluster": "cluster-1"},
+            {"node": "No-node", "cluster": "cluster-1"},
             {"node": "oscar", "cluster": "cluster-4"},
         ]
         ordered_data = handler.order_by(unordered_data, order_fields)
@@ -1451,8 +1451,8 @@ class OCPAzureQueryHandlerTest(IamTestCase):
                     opt_dict = overall_output.get("data", [{}])[0]
                     opt_dict = opt_dict.get(f"{exclude_opt}s")[0]
                     opt_value = opt_dict.get(exclude_opt)
-                    if "no-" in opt_value:
-                        # Hanlde cases where "no-instance-type" is returned
+                    if "No-" in opt_value:
+                        # Hanlde cases where "No-instance-type" is returned
                         continue
                     # Grab filtered value
                     filtered_url = f"?group_by[{exclude_opt}]=*&filter[{exclude_opt}]={opt_value}"
@@ -1496,7 +1496,7 @@ class OCPAzureQueryHandlerTest(IamTestCase):
         query_params = self.mocked_query_params(url, OCPAzureCostView)
         handler = OCPAzureReportQueryHandler(query_params)
         data = handler.execute_query().get("data")
-        if f"no-{group_tag}" in str(data):
+        if f"No-{group_tag}" in str(data):
             check_no_option = True
         previous_total = handler.query_sum.get("cost", {}).get("total", {}).get("value")
         for exclude_value in exclude_vals:
@@ -1505,7 +1505,7 @@ class OCPAzureQueryHandlerTest(IamTestCase):
             handler = OCPAzureReportQueryHandler(query_params)
             data = handler.execute_query()
             if check_no_option:
-                self.assertIn(f"no-{group_tag}", str(data))
+                self.assertIn(f"No-{group_tag}", str(data))
             current_total = handler.query_sum.get("cost", {}).get("total", {}).get("value")
             self.assertLess(current_total, previous_total)
             previous_total = current_total
@@ -1525,7 +1525,7 @@ class OCPAzureQueryHandlerTest(IamTestCase):
                 exclude_one = None
                 exclude_two = None
                 for exclude_option in opt_list:
-                    if "no-" not in exclude_option.get(ex_opt):
+                    if "No-" not in exclude_option.get(ex_opt):
                         if not exclude_one:
                             exclude_one = exclude_option.get(ex_opt)
                         elif not exclude_two:

--- a/koku/api/report/test/azure/test_azure_query_handler.py
+++ b/koku/api/report/test/azure/test_azure_query_handler.py
@@ -1388,7 +1388,7 @@ class AzureReportQueryHandlerTest(IamTestCase):
         expected = [
             {"node": "alpha", "cluster": "cluster-2"},
             {"node": "bravo", "cluster": "cluster-3"},
-            {"node": "no-node", "cluster": "cluster-1"},
+            {"node": "No-node", "cluster": "cluster-1"},
             {"node": "oscar", "cluster": "cluster-4"},
         ]
         ordered_data = handler.order_by(unordered_data, order_fields)
@@ -1660,8 +1660,8 @@ class AzureReportQueryHandlerTest(IamTestCase):
                     opt_dict = overall_output.get("data", [{}])[0]
                     opt_dict = opt_dict.get(f"{exclude_opt}s")[0]
                     opt_value = opt_dict.get(exclude_opt)
-                    if "no-" in opt_value:
-                        # Hanlde cases where "no-instance-type" is returned
+                    if "No-" in opt_value:
+                        # Hanlde cases where "No-instance-type" is returned
                         continue
                     # Grab filtered value
                     filtered_url = f"?group_by[{exclude_opt}]=*&filter[{exclude_opt}]={opt_value}"
@@ -1704,7 +1704,7 @@ class AzureReportQueryHandlerTest(IamTestCase):
         query_params = self.mocked_query_params(url, AzureCostView)
         handler = AzureReportQueryHandler(query_params)
         data = handler.execute_query().get("data")
-        if f"no-{group_tag}" in str(data):
+        if f"No-{group_tag}" in str(data):
             check_no_option = True
         previous_total = handler.query_sum.get("cost", {}).get("total", {}).get("value")
         for exclude_value in exclude_vals:
@@ -1713,7 +1713,7 @@ class AzureReportQueryHandlerTest(IamTestCase):
             handler = AzureReportQueryHandler(query_params)
             data = handler.execute_query()
             if check_no_option:
-                self.assertIn(f"no-{group_tag}", str(data))
+                self.assertIn(f"No-{group_tag}", str(data))
             current_total = handler.query_sum.get("cost", {}).get("total", {}).get("value")
             self.assertLess(current_total, previous_total)
             previous_total = current_total
@@ -1733,7 +1733,7 @@ class AzureReportQueryHandlerTest(IamTestCase):
                 exclude_one = None
                 exclude_two = None
                 for exclude_option in opt_list:
-                    if "no-" not in exclude_option.get(ex_opt):
+                    if "No-" not in exclude_option.get(ex_opt):
                         if not exclude_one:
                             exclude_one = exclude_option.get(ex_opt)
                         elif not exclude_two:

--- a/koku/api/report/test/gcp/openshift/test_ocp_gcp_query_handler.py
+++ b/koku/api/report/test/gcp/openshift/test_ocp_gcp_query_handler.py
@@ -728,7 +728,7 @@ class OCPGCPQueryHandlerTest(IamTestCase):
         expected = [
             {"node": "alpha", "cluster": "cluster-2"},
             {"node": "bravo", "cluster": "cluster-3"},
-            {"node": "no-node", "cluster": "cluster-1"},
+            {"node": "No-node", "cluster": "cluster-1"},
             {"node": "oscar", "cluster": "cluster-4"},
         ]
         ordered_data = handler.order_by(unordered_data, order_fields)
@@ -1458,7 +1458,7 @@ class OCPGCPQueryHandlerTest(IamTestCase):
         query_params = self.mocked_query_params(url, OCPGCPCostView)
         handler = OCPGCPReportQueryHandler(query_params)
         data = handler.execute_query().get("data")
-        if f"no-{group_tag}" in str(data):
+        if f"No-{group_tag}" in str(data):
             check_no_option = True
         previous_total = handler.query_sum.get("cost", {}).get("total", {}).get("value")
         for exclude_value in exclude_vals:
@@ -1467,7 +1467,7 @@ class OCPGCPQueryHandlerTest(IamTestCase):
             handler = OCPGCPReportQueryHandler(query_params)
             data = handler.execute_query()
             if check_no_option:
-                self.assertIn(f"no-{group_tag}", str(data))
+                self.assertIn(f"No-{group_tag}", str(data))
             current_total = handler.query_sum.get("cost", {}).get("total", {}).get("value")
             self.assertLess(current_total, previous_total)
             previous_total = current_total
@@ -1487,7 +1487,7 @@ class OCPGCPQueryHandlerTest(IamTestCase):
                 exclude_one = None
                 exclude_two = None
                 for exclude_option in opt_list:
-                    if "no-" not in exclude_option.get(ex_opt):
+                    if "No-" not in exclude_option.get(ex_opt):
                         if not exclude_one:
                             exclude_one = exclude_option.get(ex_opt)
                         elif not exclude_two:

--- a/koku/api/report/test/gcp/test_gcp_query_handler.py
+++ b/koku/api/report/test/gcp/test_gcp_query_handler.py
@@ -1586,7 +1586,7 @@ class GCPReportQueryHandlerTest(IamTestCase):
         query_params = self.mocked_query_params(url, GCPCostView)
         handler = GCPReportQueryHandler(query_params)
         data = handler.execute_query().get("data")
-        if f"no-{group_tag}" in str(data):
+        if f"No-{group_tag}" in str(data):
             check_no_option = True
         previous_total = handler.query_sum.get("cost", {}).get("total", {}).get("value")
         for exclude_value in exclude_vals:
@@ -1595,7 +1595,7 @@ class GCPReportQueryHandlerTest(IamTestCase):
             handler = GCPReportQueryHandler(query_params)
             data = handler.execute_query()
             if check_no_option:
-                self.assertIn(f"no-{group_tag}", str(data))
+                self.assertIn(f"No-{group_tag}", str(data))
             current_total = handler.query_sum.get("cost", {}).get("total", {}).get("value")
             self.assertLess(current_total, previous_total)
             previous_total = current_total
@@ -1615,7 +1615,7 @@ class GCPReportQueryHandlerTest(IamTestCase):
                 exclude_one = None
                 exclude_two = None
                 for exclude_option in opt_list:
-                    if "no-" not in exclude_option.get(ex_opt):
+                    if "No-" not in exclude_option.get(ex_opt):
                         if not exclude_one:
                             exclude_one = exclude_option.get(ex_opt)
                         elif not exclude_two:

--- a/koku/api/report/test/oci/test_oci_query_handler.py
+++ b/koku/api/report/test/oci/test_oci_query_handler.py
@@ -1239,7 +1239,7 @@ class OCIReportQueryHandlerTest(IamTestCase):
         expected = [
             {"node": "alpha", "cluster": "cluster-2"},
             {"node": "bravo", "cluster": "cluster-3"},
-            {"node": "no-node", "cluster": "cluster-1"},
+            {"node": "No-node", "cluster": "cluster-1"},
             {"node": "oscar", "cluster": "cluster-4"},
         ]
         ordered_data = handler.order_by(unordered_data, order_fields)
@@ -1519,8 +1519,8 @@ class OCIReportQueryHandlerTest(IamTestCase):
                         continue
                     opt_dict = opt_dict.get(f"{exclude_opt}s")[0]
                     opt_value = opt_dict.get(exclude_opt, "")
-                    if opt_value.startswith("no-"):
-                        # Hanlde cases where "no-instance-type" is returned
+                    if opt_value.startswith("No-"):
+                        # Hanlde cases where "No-instance-type" is returned
                         continue
                     # Grab filtered value
                     filtered_url = f"?group_by[{exclude_opt}]=*&filter[{exclude_opt}]={opt_value}"
@@ -1563,7 +1563,7 @@ class OCIReportQueryHandlerTest(IamTestCase):
         query_params = self.mocked_query_params(url, OCICostView)
         handler = OCIReportQueryHandler(query_params)
         data = handler.execute_query().get("data")
-        if f"no-{group_tag}" in str(data):
+        if f"No-{group_tag}" in str(data):
             check_no_option = True
         previous_total = handler.query_sum.get("cost", {}).get("total", {}).get("value")
         for exclude_value in exclude_vals:
@@ -1572,7 +1572,7 @@ class OCIReportQueryHandlerTest(IamTestCase):
             handler = OCIReportQueryHandler(query_params)
             url = handler.execute_query()
             if check_no_option:
-                self.assertIn(f"no-{group_tag}", str(data))
+                self.assertIn(f"No-{group_tag}", str(data))
             current_total = handler.query_sum.get("cost", {}).get("total", {}).get("value")
             self.assertLess(current_total, previous_total)
             previous_total = current_total
@@ -1593,7 +1593,7 @@ class OCIReportQueryHandlerTest(IamTestCase):
                 exclude_two = None
                 for exclude_option in opt_list:
                     _exclude_option = exclude_option.get(ex_opt, "")
-                    if not _exclude_option.startswith("no-"):
+                    if not _exclude_option.startswith("No-"):
                         if not exclude_one:
                             exclude_one = _exclude_option
                         elif not exclude_two:

--- a/koku/api/report/test/ocp/test_ocp_query_handler.py
+++ b/koku/api/report/test/ocp/test_ocp_query_handler.py
@@ -546,7 +546,7 @@ class OCPReportQueryHandlerTest(IamTestCase):
         expected = [
             {"node": "alpha", "cluster": "cluster-2"},
             {"node": "bravo", "cluster": "cluster-3"},
-            {"node": "no-node", "cluster": "cluster-1"},
+            {"node": "No-node", "cluster": "cluster-1"},
             {"node": "oscar", "cluster": "cluster-4"},
         ]
         ordered_data = handler.order_by(unordered_data, order_fields)
@@ -826,7 +826,7 @@ class OCPReportQueryHandlerTest(IamTestCase):
                     opt_value = None
                     for date_dict in overall_output.get("data", [{}]):
                         for element in date_dict.get(f"{exclude_opt}s"):
-                            if f"no-{exclude_opt}" != element.get(exclude_opt):
+                            if f"No-{exclude_opt}" != element.get(exclude_opt):
                                 opt_value = element.get(exclude_opt)
                                 break
                         if opt_value:
@@ -851,7 +851,7 @@ class OCPReportQueryHandlerTest(IamTestCase):
                         grouping_list = date_dict.get(f"{exclude_opt}s", [])
                         self.assertIsNotNone(grouping_list)
                         for group_dict in grouping_list:
-                            if f"no-{exclude_opt}" != opt_value:
+                            if f"No-{exclude_opt}" != opt_value:
                                 self.assertNotEqual(opt_value, group_dict.get(exclude_opt))
                     self.assertAlmostEqual(expected_total, excluded_total, 6)
                     self.assertNotEqual(overall_total, excluded_total)
@@ -910,7 +910,7 @@ class OCPReportQueryHandlerTest(IamTestCase):
         query_params = self.mocked_query_params(url, OCPCostView)
         handler = OCPReportQueryHandler(query_params)
         data = handler.execute_query().get("data")
-        if f"no-{group_tag}" in str(data):
+        if f"No-{group_tag}" in str(data):
             check_no_option = True
         returned_values = []
         for date in data:
@@ -927,7 +927,7 @@ class OCPReportQueryHandlerTest(IamTestCase):
             handler = OCPReportQueryHandler(query_params)
             data = handler.execute_query()
             if check_no_option:
-                self.assertIn(f"no-{group_tag}", str(data))
+                self.assertIn(f"No-{group_tag}", str(data))
             current_total = handler.query_sum.get("cost", {}).get("total", {}).get("value")
             self.assertLess(current_total, previous_total)
             previous_total = current_total
@@ -949,7 +949,7 @@ class OCPReportQueryHandlerTest(IamTestCase):
                 exclude_one = None
                 exclude_two = None
                 for exclude_option in opt_list:
-                    if "no-" not in exclude_option.get(ex_opt):
+                    if "No-" not in exclude_option.get(ex_opt):
                         if not exclude_one:
                             exclude_one = exclude_option.get(ex_opt)
                         elif not exclude_two:

--- a/koku/api/report/test/ocp/test_views.py
+++ b/koku/api/report/test/ocp/test_views.py
@@ -450,7 +450,7 @@ class OCPReportViewTest(IamTestCase):
 
         # assert the others count is correct
         meta = data.get("meta")
-        if "'no-node'" in str(data):
+        if "'No-node'" in str(data):
             num_nodes += 1
         self.assertEqual(meta.get("others"), num_nodes - 1)
 
@@ -1408,18 +1408,18 @@ class OCPReportViewTest(IamTestCase):
                 if option in order_mapping:
                     data_key = option
                     for node in nodes:
-                        if node.get("node") in ("Others", "no-node"):
+                        if node.get("node") in ("Others", "No-node"):
                             continue
                         previous_value = node.get("values", [])[0].get(data_key, {}).get("total", {}).get("value")
                         break
                 else:
                     for node in nodes:
-                        if node.get("node") in ("Others", "no-node"):
+                        if node.get("node") in ("Others", "No-node"):
                             continue
                         previous_value = node.get("values", [])[0].get(option, {}).get("value")
                         break
                 for entry in nodes:
-                    if entry.get("node", "") in ("Others", "no-node"):
+                    if entry.get("node", "") in ("Others", "No-node"):
                         continue
                     if data_key:
                         current_value = entry.get("values", [])[0].get(data_key, {}).get("total", {}).get("value")

--- a/koku/masu/database/presto_sql/gcp/openshift/reporting_ocpgcpcostlineitem_daily_summary.sql
+++ b/koku/masu/database/presto_sql/gcp/openshift/reporting_ocpgcpcostlineitem_daily_summary.sql
@@ -325,8 +325,8 @@ JOIN hive.{{ schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary as ocp
                 -- OR (gcp.matched_tag != '' AND any_match(split(gcp.matched_tag, ','), x->strpos(ocp.pod_labels, replace(x, ' ')) != 0))
                 -- OR (gcp.matched_tag != '' AND any_match(split(gcp.matched_tag, ','), x->strpos(ocp.volume_labels, replace(x, ' ')) != 0))
             )
-        AND ocp.namespace != 'Workers Unallocated Capacity'
-        AND ocp.namespace != 'Platform Unallocated Capacity'
+        AND ocp.namespace != 'Worker unallocated'
+        AND ocp.namespace != 'Platform unallocated'
 LEFT JOIN hive.{{schema | sqlsafe}}.reporting_ocpgcpcostlineitem_project_daily_summary_temp AS pds
     ON gcp.uuid = pds.gcp_uuid
 WHERE gcp.source = '{{gcp_source_uuid | sqlsafe}}'

--- a/koku/masu/database/presto_sql/gcp/openshift/reporting_ocpgcpcostlineitem_daily_summary_by_node.sql
+++ b/koku/masu/database/presto_sql/gcp/openshift/reporting_ocpgcpcostlineitem_daily_summary_by_node.sql
@@ -200,8 +200,8 @@ JOIN hive.{{ schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary as ocp
     ON date(gcp.usage_start_time) = ocp.usage_start
         AND (strpos(gcp.labels, 'kubernetes-io-cluster-{{cluster_id | sqlsafe}}') != 0 -- THIS IS THE SPECIFIC TO OCP ON GCP TAG MATCH
             OR strpos(gcp.labels, 'kubernetes-io-cluster-{{cluster_alias | sqlsafe}}') != 0)
-        AND namespace != 'Workers Unallocated Capacity'
-        AND namespace != 'Platform Unallocated Capacity'
+        AND namespace != 'Worker unallocated'
+        AND namespace != 'Platform unallocated'
 WHERE gcp.source = '{{gcp_source_uuid | sqlsafe}}'
     AND gcp.year = '{{year | sqlsafe}}'
     AND gcp.month = '{{month | sqlsafe}}'
@@ -317,8 +317,8 @@ JOIN hive.{{ schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary as ocp
                 -- OR (gcp.matched_tag != '' AND any_match(split(gcp.matched_tag, ','), x->strpos(ocp.pod_labels, replace(x, ' ')) != 0))
                 -- OR (gcp.matched_tag != '' AND any_match(split(gcp.matched_tag, ','), x->strpos(ocp.volume_labels, replace(x, ' ')) != 0))
             )
-            AND namespace != 'Workers Unallocated Capacity'
-            AND namespace != 'Platform Unallocated Capacity'
+            AND namespace != 'Worker unallocated'
+            AND namespace != 'Platform unallocated'
 LEFT JOIN hive.{{schema | sqlsafe}}.reporting_ocpgcpcostlineitem_project_daily_summary_temp AS pds
     ON gcp.uuid = pds.gcp_uuid
 WHERE gcp.source = '{{gcp_source_uuid | sqlsafe}}'

--- a/koku/masu/database/presto_sql/gcp/openshift/reporting_ocpgcpcostlineitem_daily_summary_resource_id.sql
+++ b/koku/masu/database/presto_sql/gcp/openshift/reporting_ocpgcpcostlineitem_daily_summary_resource_id.sql
@@ -342,8 +342,8 @@ JOIN hive.{{ schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary as ocp
                 -- OR (gcp.matched_tag != '' AND any_match(split(gcp.matched_tag, ','), x->strpos(ocp.pod_labels, replace(x, ' ')) != 0))
                 -- OR (gcp.matched_tag != '' AND any_match(split(gcp.matched_tag, ','), x->strpos(ocp.volume_labels, replace(x, ' ')) != 0))
             )
-    AND ocp.namespace != 'Workers Unallocated Capacity'
-    AND ocp.namespace != 'Platform Unallocated Capacity'
+    AND ocp.namespace != 'Worker unallocated'
+    AND ocp.namespace != 'Platform unallocated'
 LEFT JOIN hive.{{schema | sqlsafe}}.reporting_ocpgcpcostlineitem_project_daily_summary_temp AS pds
     ON gcp.uuid = pds.gcp_uuid
 WHERE gcp.source = '{{gcp_source_uuid | sqlsafe}}'

--- a/koku/masu/database/presto_sql/reporting_ocpawscostlineitem_daily_summary.sql
+++ b/koku/masu/database/presto_sql/reporting_ocpawscostlineitem_daily_summary.sql
@@ -330,8 +330,8 @@ SELECT aws.uuid as aws_uuid,
                     OR (aws.matched_tag != '' AND any_match(split(aws.matched_tag, ','), x->strpos(ocp.pod_labels, replace(x, ' ')) != 0))
                     OR (aws.matched_tag != '' AND any_match(split(aws.matched_tag, ','), x->strpos(ocp.volume_labels, replace(x, ' ')) != 0))
             )
-        AND namespace != 'Workers Unallocated Capacity'
-        AND namespace != 'Platform Unallocated Capacity'
+        AND namespace != 'Worker unallocated'
+        AND namespace != 'Platform unallocated'
     LEFT JOIN hive.{{schema | sqlsafe}}.reporting_ocpawscostlineitem_project_daily_summary_temp AS pds
         ON aws.uuid = pds.aws_uuid
     WHERE aws.source = '{{aws_source_uuid | sqlsafe}}'

--- a/koku/masu/database/presto_sql/reporting_ocpazurecostlineitem_daily_summary.sql
+++ b/koku/masu/database/presto_sql/reporting_ocpazurecostlineitem_daily_summary.sql
@@ -302,8 +302,8 @@ SELECT azure.uuid as azure_uuid,
                     OR (azure.matched_tag != '' AND any_match(split(azure.matched_tag, ','), x->strpos(ocp.pod_labels, replace(x, ' ')) != 0))
                     OR (azure.matched_tag != '' AND any_match(split(azure.matched_tag, ','), x->strpos(ocp.volume_labels, replace(x, ' ')) != 0))
             )
-        AND namespace != 'Workers Unallocated Capacity'
-        AND namespace != 'Platform Unallocated Capacity'
+        AND namespace != 'Worker unallocated'
+        AND namespace != 'Platform unallocated'
     LEFT JOIN hive.{{schema | sqlsafe}}.reporting_ocpazurecostlineitem_project_daily_summary_temp AS pds
         ON azure.uuid = pds.azure_uuid
     WHERE azure.source = '{{azure_source_uuid | sqlsafe}}'

--- a/koku/masu/database/presto_sql/reporting_ocpusagelineitem_daily_summary.sql
+++ b/koku/masu/database/presto_sql/reporting_ocpusagelineitem_daily_summary.sql
@@ -416,8 +416,8 @@ FROM (
  * ====================================
 Developer Note: Add these to make it easier to verify
 What was selected from unallocated capacity.
-AND lids.namespace != 'Platform Unallocated Capacity'
-AND lids.namespace != 'Workers Unallocated Capacity'
+AND lids.namespace != 'Platform unallocated'
+AND lids.namespace != 'Worker unallocated'
  */
 INSERT INTO hive.{{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary (
     uuid,
@@ -458,9 +458,9 @@ WITH cte_unallocated_capacity AS (
         max(lids.usage_start) as usage_start,
         max(lids.usage_end) as usage_end,
         CASE max(nodes.node_role)
-            WHEN 'master' THEN 'Platform Unallocated Capacity'
-            WHEN 'infra' THEN 'Platform Unallocated Capacity'
-            WHEN 'worker' THEN 'Workers Unallocated Capacity'
+            WHEN 'master' THEN 'Platform unallocated'
+            WHEN 'infra' THEN 'Platform unallocated'
+            WHEN 'worker' THEN 'Worker unallocated'
         END as namespace,
         lids.node,
         max(lids.resource_id) as resource_id,

--- a/koku/masu/database/sql/openshift/reporting_ocp_pod_summary_by_project_p.sql
+++ b/koku/masu/database/sql/openshift/reporting_ocp_pod_summary_by_project_p.sql
@@ -83,7 +83,7 @@ INSERT INTO {{schema | sqlsafe}}.reporting_ocp_pod_summary_by_project_p (
         AND usage_start <= {{end_date}}::date
         AND source_uuid = {{source_uuid}}
         AND data_source = 'Pod'
-        AND namespace IS DISTINCT FROM 'Workers Unallocated Capacity'
-        AND namespace IS DISTINCT FROM 'Platform Unallocated Capacity'
+        AND namespace IS DISTINCT FROM 'Worker unallocated'
+        AND namespace IS DISTINCT FROM 'Platform unallocated'
     GROUP BY usage_start, cluster_id, cluster_alias, namespace
 ;

--- a/koku/masu/database/sql/openshift/reporting_ocp_pod_summary_p.sql
+++ b/koku/masu/database/sql/openshift/reporting_ocp_pod_summary_p.sql
@@ -81,7 +81,7 @@ INSERT INTO {{schema | sqlsafe}}.reporting_ocp_pod_summary_p (
         AND usage_start <= {{end_date}}::date
         AND source_uuid = {{source_uuid}}
         AND data_source = 'Pod'
-        AND namespace IS DISTINCT FROM 'Workers Unallocated Capacity'
-        AND namespace IS DISTINCT FROM 'Platform Unallocated Capacity'
+        AND namespace IS DISTINCT FROM 'Worker unallocated'
+        AND namespace IS DISTINCT FROM 'Platform unallocated'
     GROUP BY usage_start, cluster_id, cluster_alias
 ;


### PR DESCRIPTION
## Jira Ticket

[COST-3331](https://issues.redhat.com/browse/COST-3331)

## Description

This change will rename the unallocated capacity projects and the `no-<something>` projects to `No-<something>` based on a conversation with UX.

## Testing

1. Checkout Branch
2. Restart Koku
3. load in test data `make create-test-customer` followed by `make load-test-customer-data`
4. hit the ocp costs endpoint grouped by project and look for the `Platform unallocated` and `Worker unallocated` projects: http://localhost:8000/api/cost-management/v1/reports/openshift/costs/?group_by[project]=*
5. hit the ocp costs endpoint with a tag group by and you should see `No-app` (depending on what tag you group by) in the output: http://localhost:8000/api/cost-management/v1/reports/openshift/costs/?group_by[tag:app]=*

## Notes

...
