### PR TITLE
COST-3330: Add migration to update cost category

### DIFF
--- a/koku/reporting/migrations/0267_update_cost_category.py
+++ b/koku/reporting/migrations/0267_update_cost_category.py
@@ -1,0 +1,26 @@
+import django.contrib.postgres.fields
+import django.db.models.deletion
+from django.db import migrations
+from django.db import models
+from django.db import transaction
+
+
+def update_platform_category(apps, schema_editor):
+    OpenshiftCostCategory = apps.get_model("reporting", "OpenshiftCostCategory")
+    model_qs = OpenshiftCostCategory.objects.filter(name="platform")
+    # name is a unique key constraint so there can only be one.
+    for model_obj in model_qs:
+        model_obj.name = "Platform"
+        model_obj.namespace = ["openshift-%", "kube-%", "Platform unallocated"]
+        model_obj.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("reporting", "0266_ocpgcp_precision"),
+    ]
+
+    operations = [
+        migrations.RunPython(update_platform_category),
+    ]


### PR DESCRIPTION
## Jira Ticket

[COST-3330](https://issues.redhat.com/browse/COST-3330)

## Description

This change will rename `platform` to `Platform` & update our namespace search to match the changes Corey made [here](https://github.com/project-koku/koku/pull/4052).

## Testing

1. If you already have a local version up all you will need to do is run this query both before the migration in this branch is run and after:
```
postgres=# select * from reporting_ocp_cost_category;
 id |   name   |                        description                        | source_type | system_default |                      namespace                       | label
----+----------+-----------------------------------------------------------+-------------+----------------+------------------------------------------------------+-------
  1 | platform | Default OpenShift projects bucketed into a Platform group | OCP         | t              | {openshift-%,kube-%,"Platform Unallocated Capacity"} | {}
(1 row)
```

2. `make run-migrations`

3. Check changes:
```
postgres=# select * from reporting_ocp_cost_category;
 id |   name   |                        description                        | source_type | system_default |                  namespace                  | label
----+----------+-----------------------------------------------------------+-------------+----------------+---------------------------------------------+-------
  1 | Platform | Default OpenShift projects bucketed into a Platform group | OCP         | t              | {openshift-%,kube-%,"Platform unallocated"} | {}
```