### PR TITLE
[COST-3323] update group by project classifications

### DIFF
--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -33,6 +33,7 @@ from django.db.models import Window
 from django.db.models.expressions import OrderBy
 from django.db.models.expressions import RawSQL
 from django.db.models.functions import Coalesce
+from django.db.models.functions import Concat
 from django.db.models.functions import RowNumber
 from pandas.api.types import CategoricalDtype
 
@@ -623,21 +624,24 @@ class ReportQueryHandler(QueryHandler):
 
     def _project_classification_annotation(self, query_data):
         """Get the correct annotation for a project or category"""
+        whens = []
         if self._category:
-            return query_data.annotate(
-                classification=Case(
-                    When(project__in=self._category, then=Value("category")),
-                    default=Value("project"),
-                    output_field=CharField(),
-                )
-            )
-        else:
-            project_default_whens = [
-                When(project__startswith=project, then=Value("True")) for project in ["openshift-", "kube-"]
+            whens.append(When(project__in=self._category, then=Concat(Value("category_"), F("cost_category__name"))))
+        whens.extend(
+            [
+                When(project__startswith="openshift-", then=Value("default")),
+                When(project__startswith="kube-", then=Value("default")),
+                When(project__in=["Platform unallocated", "Worker unallocated"], then=Value("unallocated")),
             ]
-            return query_data.annotate(
-                default_project=Case(*project_default_whens, default=Value("False"), output_field=CharField())
+        )
+
+        return query_data.annotate(
+            classification=Case(
+                *whens,
+                default=Value("project"),
+                output_field=CharField(),
             )
+        )
 
     @property
     def annotations(self):


### PR DESCRIPTION
## Jira Ticket

[COST-3323](https://issues.redhat.com/browse/COST-3323)

## Description

This change will update the group by project pages to always show `classification`, not only when you also include category. It also removes the `default_project=T or F` from group by project with no category in favor of a classification. The classifications are as follows:
- `default` for the projects that are kube- or openshift-
- `category_<category_name>` for the categories, so category_Platform for the Platform category
- `unallocated` for the `Platform unallocated` and `Worker unallocated` projects
- `project` for anything that does not fit any of the above criteria

## Testing

1. Checkout Branch
2. Restart Koku
3. load some data: `make create-test-customer` followed by `make load-test-customer-data`
4. Hit a few group by project endpoints and see the classifications:
5. http://localhost:8000/api/cost-management/v1/reports/openshift/costs/?group_by[project]=*
6. http://localhost:8000/api/cost-management/v1/reports/openshift/costs/?group_by[project]=*&category=*
7. http://localhost:8000/api/cost-management/v1/reports/openshift/infrastructures/aws/costs/?group_by[project]=*
8. http://localhost:8000/api/cost-management/v1/reports/openshift/infrastructures/aws/costs/?group_by[project]=*&category=Platform


## Notes

...
