### PR TITLE
[COST-3349] - add handler for OCI RequesException

### DIFF
--- a/koku/providers/test/oci/test_oci_provider.py
+++ b/koku/providers/test/oci/test_oci_provider.py
@@ -9,6 +9,7 @@ from django.test import TestCase
 from django.utils.translation import ugettext as _
 from faker import Faker
 from oci.exceptions import ClientError
+from oci.exceptions import RequestException
 from oci.exceptions import ServiceError
 from rest_framework.exceptions import ValidationError
 
@@ -18,7 +19,15 @@ from providers.oci.provider import OCIProvider
 FAKE = Faker()
 
 
-class mock_OCI_exception:
+class mock_OCI_request_exception:
+    def __init__(self, **kwargs):
+        pass
+
+    def list_objects(self, namespace=None, bucket=None, prefix=None):
+        raise RequestException()
+
+
+class mock_OCI_exception_service_error:
     def __init__(self, **kwargs):
         pass
 
@@ -62,9 +71,18 @@ class OCIProviderTestCase(TestCase):
         mock_storage_client.assert_called()
 
     @patch("providers.oci.provider.storage_client.ObjectStorageClient")
+    def test_check_cost_report_access_request_exception(self, mock_storage_client):
+        """Test_check_cost_report_access error."""
+        mock_storage_client.return_value = mock_OCI_request_exception
+        provider_interface = OCIProvider()
+        data_source = {"bucket": "bucket", "bucket_namespace": "namespace", "bucket_region": "region"}
+        with self.assertRaises(ValidationError):
+            provider_interface.cost_usage_source_is_reachable(FAKE.md5(), data_source)
+
+    @patch("providers.oci.provider.storage_client.ObjectStorageClient")
     def test_check_cost_report_access_service_error(self, mock_storage_client):
         """Test_check_cost_report_access error."""
-        mock_storage_client.return_value = mock_OCI_exception
+        mock_storage_client.return_value = mock_OCI_exception_service_error
         provider_interface = OCIProvider()
         data_source = {"bucket": "bucket", "bucket_namespace": "namespace", "bucket_region": "region"}
         with self.assertRaises(ValidationError):


### PR DESCRIPTION
## Jira Ticket

[COST-3349](https://issues.redhat.com/browse/COST-3349)

## Description

This change will add a handler for exceptions occurring when making requests to attempt authenticating OCI.

## Testing

1. Checkout Branch
2. Restart Koku
3. Make a `POST` request to this endpoint http://127.0.0.1:8000/api/cost-management/v1/sources/  with the following body
    ```
     {
    "name": "OCI Test source",
    "source_type": "OCI",
    "credentials": {},
    "billing_source": {
        "data_source": {
            "bucket": "test_bucket",
            "bucket_namespace": "test_namespace",
            "bucket_region": "test_region"
        }
       }
     }

     ```

    1. You should see the error message in the logs similar to this
    ```
    koku_server  | [2022-12-15 20:06:41,966] WARNING None (MaxRetryError("OCIConnectionPool(host='objectstorage.<test_region>.oraclecloud.com', port=443): Max retries exceeded with url: /n/<test_namespace>/b/<test_bucket>/o
     ```

## Notes

_test_bucket_, _test_namespace_ and _test_region_ can replaced with a random string
...
