### PR TITLE
Fix get_exchange_rates

### DIFF
--- a/koku/api/currency/view.py
+++ b/koku/api/currency/view.py
@@ -45,6 +45,4 @@ def get_exchange_rates(request):
 
         get_daily_currency_rates()
         exchange_rates = ExchangeRateDictionary.objects.all().first()
-        if exchange_rates:
-            return Response(exchange_rates.currency_exchange_dictionary)
-    return Response({})
+    return Response(exchange_rates.currency_exchange_dictionary)


### PR DESCRIPTION
## Description

This change reverts the recent changes to the get_exchange_rates function. In its current form, the function returns a dict of exchange rates only if the exchange rates have not yet been downloaded, otherwise an empty dict is returned (which is not what we want).

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Notes

...
