### PR TITLE
drop specific sentry transactions

### DIFF
--- a/koku/koku/sentry.py
+++ b/koku/koku/sentry.py
@@ -16,8 +16,9 @@ BLOCK_LIST = [
 
 
 def traces_sampler(sampling_context):
-    if sampling_context["transaction_context"]["op"] == "http.server" and any(
-        blocked in sampling_context["transaction_context"]["name"] for blocked in BLOCK_LIST
+    if (
+        sampling_context["transaction_context"]["op"] == "http.server"
+        and sampling_context["transaction_context"]["name"] in BLOCK_LIST
     ):
         # Drop this transaction, by setting its sample rate to 0%
         return 0

--- a/koku/koku/sentry.py
+++ b/koku/koku/sentry.py
@@ -9,13 +9,30 @@ from .env import ENVIRONMENT
 
 LOG = logging.getLogger(__name__)
 
+BLOCK_LIST = [
+    "/api/cost-management/v1/status/",
+    "/api/cost-management/v1/source-status/",
+]
+
+
+def traces_sampler(sampling_context):
+    if sampling_context["transaction_context"]["op"] == "http.server" and any(
+        blocked in sampling_context["transaction_context"]["name"] for blocked in BLOCK_LIST
+    ):
+        # Drop this transaction, by setting its sample rate to 0%
+        return 0
+
+    # Default sample rate for all others (replaces traces_sample_rate)
+    return 0.25
+
+
 if ENVIRONMENT.bool("KOKU_API_ENABLE_SENTRY", default=False):
     LOG.info("Enabling sentry for koku api.")
     sentry_sdk.init(
         dsn=ENVIRONMENT("KOKU_SENTRY_DSN"),
         environment=ENVIRONMENT("KOKU_SENTRY_ENVIRONMENT"),
         integrations=[DjangoIntegration()],
-        traces_sample_rate=0.25,
+        traces_sampler=traces_sampler,
     )
     LOG.info("Sentry setup.")
 elif ENVIRONMENT.bool("KOKU_CELERY_ENABLE_SENTRY", default=False):
@@ -24,7 +41,7 @@ elif ENVIRONMENT.bool("KOKU_CELERY_ENABLE_SENTRY", default=False):
         dsn=ENVIRONMENT("KOKU_CELERY_SENTRY_DSN"),
         environment=ENVIRONMENT("KOKU_SENTRY_ENVIRONMENT"),
         integrations=[CeleryIntegration()],
-        traces_sample_rate=0.25,
+        traces_sampler=traces_sampler,
     )
     LOG.info("Sentry setup.")
 else:

--- a/koku/koku/sentry.py
+++ b/koku/koku/sentry.py
@@ -16,10 +16,8 @@ BLOCK_LIST = [
 
 
 def traces_sampler(sampling_context):
-    if (
-        sampling_context["transaction_context"]["op"] == "http.server"
-        and sampling_context["transaction_context"]["name"] in BLOCK_LIST
-    ):
+    transaction_ctx = sampling_context["transaction_context"]
+    if transaction_ctx["op"] == "http.server" and transaction_ctx["name"] in BLOCK_LIST:
         # Drop this transaction, by setting its sample rate to 0%
         return 0
 


### PR DESCRIPTION
## Description

This change will add a block-list to prevent sending metrics on readiness/liveness checks and sources-status POSTs.

## Notes

This change is necessary to limit the impact cost-mgmt has against the enterprise sentry transaction quota.
...
