### PR TITLE
skip HCS finalization month tests for now

### DIFF
--- a/koku/hcs/test/test_tasks.py
+++ b/koku/hcs/test/test_tasks.py
@@ -6,6 +6,7 @@
 import logging
 import uuid
 from datetime import timedelta
+from unittest import skip
 from unittest.mock import Mock
 from unittest.mock import patch
 from unittest.mock import PropertyMock
@@ -234,6 +235,7 @@ class TestHCSTasks(HCSTestCase):
 
             self.assertIn("tracing_id", _logs.output[0])
 
+    @skip("HCS finalization month assumes the current year and we can only finalize the past.")
     @patch("hcs.tasks.collect_hcs_report_data")
     def test_hcs_report_finalization_month(self, rd, mock_ehp, mock_report):
         """Test finalization providing month"""

--- a/koku/masu/test/api/test_hcs_report_finalization.py
+++ b/koku/masu/test/api/test_hcs_report_finalization.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 """Test the hcs_report_data endpoint view."""
+from unittest import skip
 from unittest.mock import patch
 
 from django.test import TestCase
@@ -32,6 +33,7 @@ class HCSFinalizationTests(TestCase):
         self.assertIn(expected_key, body)
         mock_celery.s.assert_called()
 
+    @skip("HCS finalization month assumes the current year and we can only finalize the past.")
     def test_get_report_finalization_month(self, mock_celery, _):
         """Test the GET hcs_report_finalization endpoint with specified month"""
 


### PR DESCRIPTION
## Description

This change will skip the finalization tests that are only based on a month as we can only finalize months in the past and it will not work for 2023 yet until the test is re-done or we are in feb. Skipping until it can be adjusted.


...
