### PR TITLE
COST-3366/3367: Update category filter for tag endpoint.

### DIFF
--- a/koku/api/report/serializers.py
+++ b/koku/api/report/serializers.py
@@ -324,11 +324,13 @@ class ParamSerializer(BaseSerializer):
         """
         super().validate(data)
 
-        if data.get("category") and ("key_only" not in data.keys()):
-            # allow category to be passed in without group by for the tags endpoint
-            if data.get("category") and (not data.get("group_by") or not data.get("group_by").get("project")):
-                error = {"error": ("Category may not be used without a group_by project parameter")}
-                raise serializers.ValidationError(error)
+        if data.get("category") and ("key_only" in data.keys()):
+            error = {"error": ("Category may only be used as a filter for the tag endpoints.")}
+            raise serializers.ValidationError(error)
+
+        if data.get("category") and (not data.get("group_by") or not data.get("group_by").get("project")):
+            error = {"error": ("Category may not be used without a group_by project parameter")}
+            raise serializers.ValidationError(error)
 
         if not data.get("currency"):
             data["currency"] = get_currency(self.context.get("request"))
@@ -382,8 +384,6 @@ class ParamSerializer(BaseSerializer):
         Raises:
             (ValidationError): if field inputs are invalid
         """
-        # Categories should always be capitalized
-        value = [item.title() for item in value]
         categories = None
         db_categories = OpenshiftCostCategory.objects.values_list("name", flat=True).distinct()
         if ReportQueryHandler.has_wildcard(value):

--- a/koku/api/report/serializers.py
+++ b/koku/api/report/serializers.py
@@ -324,7 +324,7 @@ class ParamSerializer(BaseSerializer):
         """
         super().validate(data)
 
-        if data.get("category")
+        if data.get("category"):
             if "key_only" in data:
                 error = {"error": "Category may only be used as a filter for the tag endpoints."}
                 raise serializers.ValidationError(error)

--- a/koku/api/report/serializers.py
+++ b/koku/api/report/serializers.py
@@ -329,7 +329,7 @@ class ParamSerializer(BaseSerializer):
                 error = {"error": "Category may only be used as a filter for the tag endpoints."}
                 raise serializers.ValidationError(error)
 
-             if not data.get("group_by") or not data.get("group_by").get("project"):
+            if not data.get("group_by") or not data.get("group_by").get("project"):
                 error = {"error": "Category may not be used without a group_by project parameter"}
                 raise serializers.ValidationError(error)
 

--- a/koku/api/report/serializers.py
+++ b/koku/api/report/serializers.py
@@ -324,12 +324,12 @@ class ParamSerializer(BaseSerializer):
         """
         super().validate(data)
 
-        if data.get("category") and ("key_only" in data.keys()):
-            error = {"error": ("Category may only be used as a filter for the tag endpoints.")}
+        if data.get("category") and ("key_only" in data):
+            error = {"error": "Category may only be used as a filter for the tag endpoints."}
             raise serializers.ValidationError(error)
 
         if data.get("category") and (not data.get("group_by") or not data.get("group_by").get("project")):
-            error = {"error": ("Category may not be used without a group_by project parameter")}
+            error = {"error": "Category may not be used without a group_by project parameter"}
             raise serializers.ValidationError(error)
 
         if not data.get("currency"):

--- a/koku/api/report/serializers.py
+++ b/koku/api/report/serializers.py
@@ -324,13 +324,14 @@ class ParamSerializer(BaseSerializer):
         """
         super().validate(data)
 
-        if data.get("category") and ("key_only" in data):
-            error = {"error": "Category may only be used as a filter for the tag endpoints."}
-            raise serializers.ValidationError(error)
+        if data.get("category")
+            if "key_only" in data:
+                error = {"error": "Category may only be used as a filter for the tag endpoints."}
+                raise serializers.ValidationError(error)
 
-        if data.get("category") and (not data.get("group_by") or not data.get("group_by").get("project")):
-            error = {"error": "Category may not be used without a group_by project parameter"}
-            raise serializers.ValidationError(error)
+             if not data.get("group_by") or not data.get("group_by").get("project"):
+                error = {"error": "Category may not be used without a group_by project parameter"}
+                raise serializers.ValidationError(error)
 
         if not data.get("currency"):
             data["currency"] = get_currency(self.context.get("request"))

--- a/koku/api/report/test/ocp/test_ocp_query_handler.py
+++ b/koku/api/report/test/ocp/test_ocp_query_handler.py
@@ -701,7 +701,7 @@ class OCPReportQueryHandlerTest(IamTestCase):
         total = query_output.get("total")
         for line in query_output.get("data")[0].get("projects"):
             if "openshift-" in line.get("project") or "kube-" in line.get("project"):
-                self.assertEqual(line["values"][0]["classification"], "project")
+                self.assertIn(line["values"][0]["classification"], ["project", "default"])
             elif line.get("project") != "Platform":
                 self.assertEqual(line["values"][0]["classification"], "project")
         result_cost_total = total.get("cost", {}).get("total", {}).get("value")
@@ -739,7 +739,7 @@ class OCPReportQueryHandlerTest(IamTestCase):
                 elif line["project"] == "Worker unallocated":
                     self.assertEqual(line["values"][0]["classification"], "unallocated")
                 else:
-                    self.assertEqual(line["values"][0]["classification"], "project")
+                    self.assertIn(line["values"][0]["classification"], ["project", "default"])
             result_cost_total = total.get("cost", {}).get("total", {}).get("value")
             self.assertIsNotNone(result_cost_total)
             overall = result_cost_total - expected_cost_total

--- a/koku/api/report/test/test_serializers.py
+++ b/koku/api/report/test/test_serializers.py
@@ -17,6 +17,7 @@ from api.report.aws.serializers import AWSFilterSerializer
 from api.report.aws.serializers import AWSGroupBySerializer
 from api.report.aws.serializers import AWSOrderBySerializer
 from api.report.aws.serializers import AWSQueryParamSerializer
+from api.report.ocp.serializers import OCPQueryParamSerializer
 from api.report.serializers import ParamSerializer
 from api.report.serializers import ReportQueryParamSerializer
 from api.utils import DateHelper
@@ -531,6 +532,16 @@ class QueryParamSerializerTest(IamTestCase):
         serializer = AWSQueryParamSerializer(data=query_params, context={"request": req})
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
+
+    def test_invalid_category_usage(self):
+        """Test handling invalid category usage on tag endpoint."""
+        query_params = {"category": "Platform"}
+        req = Mock(path="/api/cost-management/v1/tags/openshift/")
+        with patch("reporting.provider.ocp.models.OpenshiftCostCategory.objects") as mock_object:
+            mock_object.values_list.return_value.distinct.return_value = ["Platform"]
+            serializer = OCPQueryParamSerializer(data=query_params, context={"request": req})
+            with self.assertRaises(serializers.ValidationError):
+                serializer.is_valid(raise_exception=True)
 
     def test_invalid_cost_type(self):
         """Test failure while handling invalid cost_type."""

--- a/koku/api/report/test/test_serializers.py
+++ b/koku/api/report/test/test_serializers.py
@@ -17,7 +17,6 @@ from api.report.aws.serializers import AWSFilterSerializer
 from api.report.aws.serializers import AWSGroupBySerializer
 from api.report.aws.serializers import AWSOrderBySerializer
 from api.report.aws.serializers import AWSQueryParamSerializer
-from api.report.ocp.serializers import OCPQueryParamSerializer
 from api.report.serializers import ParamSerializer
 from api.report.serializers import ReportQueryParamSerializer
 from api.utils import DateHelper
@@ -533,16 +532,6 @@ class QueryParamSerializerTest(IamTestCase):
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
-    def test_invalid_category_usage(self):
-        """Test handling invalid category usage on tag endpoint."""
-        query_params = {"category": "Platform"}
-        req = Mock(path="/api/cost-management/v1/tags/openshift/")
-        with patch("reporting.provider.ocp.models.OpenshiftCostCategory.objects") as mock_object:
-            mock_object.values_list.return_value.distinct.return_value = ["Platform"]
-            serializer = OCPQueryParamSerializer(data=query_params, context={"request": req})
-            with self.assertRaises(serializers.ValidationError):
-                serializer.is_valid(raise_exception=True)
-
     def test_invalid_cost_type(self):
         """Test failure while handling invalid cost_type."""
         query_params = {"cost_type": "invalid_cost"}
@@ -785,6 +774,16 @@ class ParamSerializerTest(IamTestCase):
                     serializer = ParamSerializer(data=param, context=self.ctx_w_path)
                     self.assertFalse(serializer.is_valid())
                     serializer.is_valid(raise_exception=True)
+
+    def test_invalid_category_usage(self):
+        """Test handling invalid category usage on tag endpoint."""
+        query_params = {"category": "Platform"}
+        req = Mock(path="/api/cost-management/v1/tags/openshift/")
+        with patch("reporting.provider.ocp.models.OpenshiftCostCategory.objects") as mock_object:
+            mock_object.values_list.return_value.distinct.return_value = ["Platform"]
+            serializer = ParamSerializer(data=query_params, context={"request": req})
+            with self.assertRaises(serializers.ValidationError):
+                serializer.is_valid(raise_exception=True)
 
 
 class ReportQueryParamSerializerTest(IamTestCase):

--- a/koku/api/tags/queries.py
+++ b/koku/api/tags/queries.py
@@ -222,7 +222,6 @@ class TagQueryHandler(QueryHandler):
             composed_category_filters = self._build_namespace_filters_from_category_list(category_list)
             if composed_category_filters:
                 composed_filters = composed_filters & composed_category_filters
-                # TODO: Check with Luke to see if we want to error if the category is not found
 
         LOG.debug(f"_get_filter: {composed_filters}")
         return composed_filters

--- a/koku/api/tags/queries.py
+++ b/koku/api/tags/queries.py
@@ -220,7 +220,9 @@ class TagQueryHandler(QueryHandler):
         )
         if category_list:
             composed_category_filters = self._build_namespace_filters_from_category_list(category_list)
-            composed_filters = composed_filters & composed_category_filters
+            if composed_category_filters:
+                composed_filters = composed_filters & composed_category_filters
+                # TODO: Check with Luke to see if we want to error if the category is not found
 
         LOG.debug(f"_get_filter: {composed_filters}")
         return composed_filters

--- a/koku/api/tags/test/ocp/test_ocp_tag_query_handler.py
+++ b/koku/api/tags/test/ocp/test_ocp_tag_query_handler.py
@@ -390,7 +390,7 @@ class OCPTagQueryHandlerTest(IamTestCase):
 
     def test_category_filter(self):
         """Test that we can filter by category on the tags endpoint"""
-        urls = ["?category=Platform", "?filter[category]=Platform"]
+        urls = ["?filter[category]=Platform"]
         for url in urls:
             with self.subTest(url=url):
                 with tenant_context(self.tenant):

--- a/koku/api/tags/test/test_serializers.py
+++ b/koku/api/tags/test/test_serializers.py
@@ -4,6 +4,7 @@
 #
 """Test the tag serializer."""
 from unittest import TestCase
+from unittest.mock import patch
 
 from dateutil.relativedelta import relativedelta
 from rest_framework import serializers
@@ -221,6 +222,17 @@ class TagsQueryParamSerializerTest(IamTestCase):
         self.request_path = "/api/cost-management/v1/tags/aws/"
         serializer = TagsQueryParamSerializer(data=query_params, context=self.ctx_w_path)
         self.assertTrue(serializer.is_valid())
+
+    def test_invalid_category_usage(self):
+        """Test handling invalid category usage on tag endpoint."""
+        tag_keys = []
+        query_params = {"category": "Platform"}
+        self.request_path = "/api/cost-management/v1/tags/openshift/"
+        with patch("reporting.provider.ocp.models.OpenshiftCostCategory.objects") as mock_object:
+            serializer = OCPTagsQueryParamSerializer(data=query_params, tag_keys=tag_keys, context=self.ctx_w_path)
+            mock_object.values_list.return_value.distinct.return_value = ["Platform"]
+            with self.assertRaises(serializers.ValidationError):
+                serializer.is_valid(raise_exception=True)
 
     def test_query_params_ocp_invalid_fields(self):
         """Test parse of query params for invalid fields."""


### PR DESCRIPTION
## Jira Ticket

[COST-3366](https://issues.redhat.com/browse/COST-3366)
[COST-3367](https://issues.redhat.com/browse/COST-3367)

## Description

This change will fix filter[category]=* on tag endpoints and also disable the usage of category={something} on these endpoints.

## Testing

1. Checkout Branch
2. Restart Koku
3. Make load data
4. See the following throws an error http://localhost:8000/api/cost-management/v1/tags/openshift/?category=Platform
5. See tags filtered by category via http://localhost:8000/api/cost-management/v1/tags/openshift/?filter[category]=Platform

## Notes

...
