### PR TITLE
[COST-3370] - drop ranking field from query data

### DIFF
--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -1021,9 +1021,9 @@ class ReportQueryHandler(QueryHandler):
             if rank_value not in rankings:
                 rankings.append(rank_value)
                 distinct_ranks.append(rank)
-        return self._ranked_list(data, distinct_ranks)
+        return self._ranked_list(data, distinct_ranks, list(rank_annotations.keys()))
 
-    def _ranked_list(self, data_list, ranks):
+    def _ranked_list(self, data_list, ranks, rank_field):
         """Get list of ranked items less than top.
 
         Args:
@@ -1037,7 +1037,7 @@ class ReportQueryHandler(QueryHandler):
         group_by = self._get_group_by()
         self.max_rank = len(ranks)
         # Columns we drop in favor of the same named column merged in from rank data frame
-        drop_columns = ["cost_units", "source_uuid"]
+        drop_columns = ["cost_units", "source_uuid"] + rank_field
         if self.is_openshift:
             drop_columns.append("clusters")
 

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -1021,9 +1021,9 @@ class ReportQueryHandler(QueryHandler):
             if rank_value not in rankings:
                 rankings.append(rank_value)
                 distinct_ranks.append(rank)
-        return self._ranked_list(data, distinct_ranks, list(rank_annotations.keys()))
+        return self._ranked_list(data, distinct_ranks, list(rank_annotations))
 
-    def _ranked_list(self, data_list, ranks, rank_field):
+    def _ranked_list(self, data_list, ranks, rank_field=None):
         """Get list of ranked items less than top.
 
         Args:
@@ -1033,6 +1033,8 @@ class ReportQueryHandler(QueryHandler):
             List(Dict): List of data points meeting the rank criteria
 
         """
+        if not rank_field:
+            rank_field = []
         is_offset = "offset" in self.parameters.get("filter", {})
         group_by = self._get_group_by()
         self.max_rank = len(ranks)

--- a/koku/api/report/test/ocp/test_ocp_query_handler.py
+++ b/koku/api/report/test/ocp/test_ocp_query_handler.py
@@ -7,6 +7,7 @@ import logging
 from collections import defaultdict
 from datetime import timedelta
 from decimal import Decimal
+from itertools import product
 from unittest.mock import patch
 from unittest.mock import PropertyMock
 
@@ -108,6 +109,23 @@ class OCPReportQueryHandlerTest(IamTestCase):
         self.assertEqual(total.get("request", {}).get("value"), current_totals.get("request"))
         self.assertEqual(total.get("cost", {}).get("value"), current_totals.get("cost"))
         self.assertEqual(total.get("limit", {}).get("value"), current_totals.get("limit"))
+
+    def test_cpu_memory_order_bys(self):
+        """Test that cluster capacity returns capacity by cluster."""
+        views = [OCPCpuView, OCPMemoryView]
+        order_bys = ["usage", "request", "limit"]
+
+        for view, order_by in product(views, order_bys):
+            with self.subTest((view, order_by)):
+                url = f"?group_by[project]=*&order_by[{order_by}]=desc"
+
+                query_params = self.mocked_query_params(url, view)
+                handler = OCPReportQueryHandler(query_params)
+                query_data = handler.execute_query()
+                self.assertIsNotNone(query_data.get("data"))
+                self.assertIsNotNone(query_data.get("total"))
+                total = query_data.get("total")
+                self.assertIsNotNone(total.get(order_by))
 
     def test_execute_sum_query_costs(self):
         """Test that the sum query runs properly for the costs endpoint."""

--- a/koku/api/report/test/ocp/test_ocp_query_handler.py
+++ b/koku/api/report/test/ocp/test_ocp_query_handler.py
@@ -117,7 +117,7 @@ class OCPReportQueryHandlerTest(IamTestCase):
 
         for view, order_by in product(views, order_bys):
             with self.subTest((view, order_by)):
-                url = f"?group_by[project]=*&order_by[{order_by}]=desc"
+                url = f"?filter[limit]=5&filter[offset]=0&group_by[project]=*&order_by[{order_by}]=desc"
 
                 query_params = self.mocked_query_params(url, view)
                 handler = OCPReportQueryHandler(query_params)


### PR DESCRIPTION
## Jira Ticket

[COST-3370](https://issues.redhat.com/browse/COST-3370)

## Description

This change will ensure the ranking field is dropped from the original query data.
This query:
```
/?filter[limit]=50&filter[offset]=0&filter[resolution]=monthly&filter[time_scope_units]=month&filter[time_scope_value]=-2&group_by[project]=*&order_by[request]=desc
```
would result in the  `ranks_by_day` and `data_frame` containing a `request` column. When these dataframes were merged, it resulted in a new DF with `request_x` and `request_y` fields. Further along in the query_handler, when ordering the data, we would try to sort by `request` but this field no longer existed in the data.

## Testing

1. Ingest OCP data.
2. Go to http://localhost:8000/api/cost-management/v1/reports/openshift/compute/?filter[limit]=50&filter[offset]=0&filter[resolution]=monthly&filter[time_scope_units]=month&filter[time_scope_value]=-2&group_by[project]=*&order_by[request]=desc
3. see data.
4. Go to http://localhost:8000/api/cost-management/v1/reports/openshift/compute/?filter[limit]=50&filter[offset]=0&filter[resolution]=monthly&filter[time_scope_units]=month&filter[time_scope_value]=-2&group_by[project]=*&order_by[delta]=desc&delta=request__limit
5. see data.

## Notes

...
