### PR TITLE
action: add retry for manifest sanity check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,11 @@ jobs:
           SETUPTOOLS_USE_DISTUTILS: stdlib
 
       - name: Check clowdapp manifest
-        run: bash .github/scripts/check_clowdapp.sh
+        uses: nick-fields/retry@v2.8.3
+        with:
+          retry_wait_seconds: 120  # since unit tests take >10 min, this wait time + max attempts will still finish before unit tests
+          max_attempts: 3
+          command: bash .github/scripts/check_clowdapp.sh
 
   smokes-labeler:
     name: Smoke Test Label

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,10 @@ jobs:
       - name: Check clowdapp manifest
         uses: nick-fields/retry@v2.8.3
         with:
-          retry_wait_seconds: 120  # since unit tests take >10 min, this wait time + max attempts will still finish before unit tests
-          max_attempts: 3
           command: bash .github/scripts/check_clowdapp.sh
+          max_attempts: 3
+          retry_wait_seconds: 120  # since unit tests take >10 min, this wait time + max attempts will still finish before unit tests
+          timeout_minutes: 1
 
   smokes-labeler:
     name: Smoke Test Label


### PR DESCRIPTION
The Sanity CI check has failed due to rate limiting on a few occasions. This PR adds a retry to the Sanity check so we can hopefully avoid having to manually restart the check.