### PR TITLE
COST-3366: Tags - nonexistent category returns empty list.

### DIFF
--- a/koku/api/tags/queries.py
+++ b/koku/api/tags/queries.py
@@ -17,6 +17,10 @@ from reporting.provider.ocp.models import OpenshiftCostCategory
 LOG = logging.getLogger(__name__)
 
 
+class NoNamespacesForCategory(Exception):
+    """Returns an empty dictionary."""
+
+
 class TagQueryHandler(QueryHandler):
     """Handles tag queries and responses.
 
@@ -69,8 +73,12 @@ class TagQueryHandler(QueryHandler):
         if not self.parameters.get("start_date") and not self.parameters.get("end_date"):
             self._set_start_and_end_dates()
         # super() needs to be called before calling _get_filter()
-        self.query_filter = self._get_filter()
-        if parameters.kwargs.get("key"):
+        try:
+            self.query_filter = self._get_filter()
+        except NoNamespacesForCategory as err_msg:
+            LOG.debug(err_msg)
+            self.query_filter = None
+        if parameters.kwargs.get("key") and self.query_filter:
             self.key = parameters.kwargs.get("key")
             if not self.parameters.get_filter("value"):
                 self.query_filter = self._get_key_filter()
@@ -151,6 +159,8 @@ class TagQueryHandler(QueryHandler):
         """
         category_filters = QueryFilterCollection()
         namespace_query = OpenshiftCostCategory.objects.filter(name__in=category_list).values("namespace")
+        if not namespace_query:
+            raise NoNamespacesForCategory(f"No namespaces for category: {category_list}")
         for row in namespace_query:
             namespaces = row.get("namespace")
             for namespace in namespaces:
@@ -220,8 +230,7 @@ class TagQueryHandler(QueryHandler):
         )
         if category_list:
             composed_category_filters = self._build_namespace_filters_from_category_list(category_list)
-            if composed_category_filters:
-                composed_filters = composed_filters & composed_category_filters
+            composed_filters = composed_filters & composed_category_filters
 
         LOG.debug(f"_get_filter: {composed_filters}")
         return composed_filters
@@ -445,6 +454,9 @@ class TagQueryHandler(QueryHandler):
             (Dict): Dictionary response of query params and data
 
         """
+        if not self.query_filter:
+            self.query_data = []
+            return self._format_query_response()
         if self.parameters.get("key_only"):
             tag_data = self.get_tag_keys()
             query_data = sorted(tag_data, reverse=self.order_direction == "desc")

--- a/koku/api/tags/test/ocp/test_ocp_tag_query_handler.py
+++ b/koku/api/tags/test/ocp/test_ocp_tag_query_handler.py
@@ -389,31 +389,18 @@ class OCPTagQueryHandlerTest(IamTestCase):
         self.assertEqual(filters._filters, expected)
 
     def test_category_filter(self):
-        """Test that we can filter by category on the tags endpoint"""
-        urls = ["?filter[category]=Platform"]
-        for url in urls:
-            with self.subTest(url=url):
+        """Test that we can filter by category on the tags endpoint."""
+        categories = {
+            "Platform": [
+                {"enabled": True, "key": "app", "values": ["mobile", "temperature"]},
+                {"enabled": True, "key": "storageclass", "values": ["Ruby"]},
+            ],
+            "FAKE_CATEGORY": [],
+        }
+        for category in categories.keys():
+            with self.subTest(category=category):
                 with tenant_context(self.tenant):
-                    query_params = self.mocked_query_params(url, OCPTagView)
+                    query_params = self.mocked_query_params(f"?filter[category]={category}", OCPTagView)
                     handler = OCPTagQueryHandler(query_params)
-                    access = ["my-ocp-cluster-2"]
-                    filt = [
-                        {"field": "report_period__cluster_id", "operation": "in", "composition_key": "cluster_filter"},
-                        {
-                            "field": "report_period__cluster_alias",
-                            "operation": "in",
-                            "composition_key": "cluster_filter",
-                        },
-                    ]
-                    filters = QueryFilterCollection()
-                    handler.set_access_filters(access, filt, filters)
-                    expected = []
-                    expected.append(
-                        QueryFilter(field="report_period__cluster_id", operation="in", parameter=["my-ocp-cluster-2"])
-                    )
-                    expected.append(
-                        QueryFilter(
-                            field="report_period__cluster_alias", operation="in", parameter=["my-ocp-cluster-2"]
-                        )
-                    )
-                    self.assertEqual(filters._filters, expected)
+                    result_value = handler.execute_query().get("data")
+                    self.assertEqual(result_value, categories[category])


### PR DESCRIPTION
## Jira Ticket

[COST-3366](https://issues.redhat.com/browse/COST-3366)

## Description

Fix it to where non existent categories return an empty list. 

## Testing

Example URL:
- http://localhost:8000/api/cost-management/v1/tags/openshift/?filter[category]=whatever

If you change my debug statement to a warning, you should see the following when you hit the endpoint with a bad value:
```
koku_server         | [2023-01-06 15:23:06,836] WARNING None No namespaces for category: ['whatever']
```