### PR TITLE
[COST-3373] - accept reports with node-role

### DIFF
--- a/koku/masu/database/ocp_report_db_accessor.py
+++ b/koku/masu/database/ocp_report_db_accessor.py
@@ -2436,11 +2436,11 @@ class OCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
             SELECT ocp.node,
                 ocp.resource_id,
                 max(ocp.node_capacity_cpu_cores) as node_capacity_cpu_cores,
-                CASE
+                coalesce(max(ocp.node_role), CASE
                     WHEN contains(array_agg(DISTINCT ocp.namespace), 'openshift-kube-apiserver') THEN 'master'
                     WHEN any_match(array_agg(DISTINCT nl.node_labels), element -> element like  '%"node_role_kubernetes_io": "infra"%') THEN 'infra'
                     ELSE 'worker'
-                END as node_role
+                END) as node_role
             FROM hive.{self.schema}.openshift_pod_usage_line_items_daily as ocp
             LEFT JOIN hive.{self.schema}.openshift_node_labels_line_items_daily as nl
                 ON ocp.node = nl.node

--- a/koku/masu/test/util/ocp/test_common.py
+++ b/koku/masu/test/util/ocp/test_common.py
@@ -278,3 +278,31 @@ class OCPUtilTests(MasuTestCase):
                     expected = "ERROR:masu.util.ocp.common:Unable to extract manifest data"
                     utils.get_report_details(manifest_path)
                     self.assertIn(expected, logger.output[0])
+
+    def test_detect_type_pod_usage(self):
+        "Test that we detect the correct report type from csv"
+        expected_result = "pod_usage"
+        test_table = [
+            copy.deepcopy(utils.CPU_MEM_USAGE_COLUMNS),
+            copy.deepcopy(utils.CPU_MEM_USAGE_COLUMNS).union(utils.CPU_MEM_USAGE_NEWV_COLUMNS),
+        ]
+        for test in test_table:
+            with self.subTest(test=test):
+                with patch("masu.util.ocp.common.pd.read_csv") as mock_csv:
+                    mock_csv.return_value.columns = test
+                    result, _ = utils.detect_type("")
+                    self.assertEqual(result, expected_result)
+
+    def test_detect_type(self):
+        "Test that we detect the correct report type from csv"
+        test_table = {
+            "storage_usage": copy.deepcopy(utils.STORAGE_COLUMNS),
+            "node_labels": copy.deepcopy(utils.NODE_LABEL_COLUMNS),
+            "namespace_labels": copy.deepcopy(utils.NAMESPACE_LABEL_COLUMNS),
+        }
+        for expected, test in test_table.items():
+            with self.subTest(test=test):
+                with patch("masu.util.ocp.common.pd.read_csv") as mock_csv:
+                    mock_csv.return_value.columns = test
+                    result, _ = utils.detect_type("")
+                    self.assertEqual(result, expected)

--- a/koku/masu/util/ocp/common.py
+++ b/koku/masu/util/ocp/common.py
@@ -494,7 +494,7 @@ def ocp_generate_daily_data(data_frame, report_type):
     new_cols = report.get("new_required_columns")
     for col in new_cols:
         if col not in daily_data_frame:
-            daily_data_frame[col] = ""
+            daily_data_frame[col] = None
 
     return daily_data_frame
 

--- a/koku/masu/util/ocp/common.py
+++ b/koku/masu/util/ocp/common.py
@@ -35,7 +35,7 @@ class OCPReportTypes(Enum):
     NAMESPACE_LABELS = 4
 
 
-STORAGE_COLUMNS = [
+STORAGE_COLUMNS = {
     "report_period_start",
     "report_period_end",
     "interval_start",
@@ -51,7 +51,7 @@ STORAGE_COLUMNS = [
     "persistentvolumeclaim_usage_byte_seconds",
     "persistentvolume_labels",
     "persistentvolumeclaim_labels",
-]
+}
 
 STORAGE_GROUP_BY = [
     "namespace",
@@ -72,7 +72,7 @@ STORAGE_AGG = {
     "persistentvolumeclaim_usage_byte_seconds": ["sum"],
 }
 
-CPU_MEM_USAGE_COLUMNS = [
+CPU_MEM_USAGE_COLUMNS = {
     "report_period_start",
     "report_period_end",
     "pod",
@@ -92,7 +92,7 @@ CPU_MEM_USAGE_COLUMNS = [
     "node_capacity_memory_bytes",
     "node_capacity_memory_byte_seconds",
     "pod_labels",
-]
+}
 
 POD_GROUP_BY = ["namespace", "node", "pod", "pod_labels"]
 
@@ -114,28 +114,28 @@ POD_AGG = {
     "node_capacity_memory_byte_seconds": ["sum"],
 }
 
-NODE_LABEL_COLUMNS = [
+NODE_LABEL_COLUMNS = {
     "report_period_start",
     "report_period_end",
     "node",
     "interval_start",
     "interval_end",
     "node_labels",
-]
+}
 
 NODE_GROUP_BY = ["node", "node_labels"]
 
 NODE_AGG = {"report_period_start": ["max"], "report_period_end": ["max"]}
 
 
-NAMESPACE_LABEL_COLUMNS = [
+NAMESPACE_LABEL_COLUMNS = {
     "report_period_start",
     "report_period_end",
     "interval_start",
     "interval_end",
     "namespace",
     "namespace_labels",
-]
+}
 
 NAMESPACE_GROUP_BY = ["namespace", "namespace_labels"]
 
@@ -362,12 +362,11 @@ def detect_type(report_path):
     """
     Detects the OCP report type.
     """
-    sorted_columns = sorted(pd.read_csv(report_path, nrows=0).columns)
+    columns = pd.read_csv(report_path, nrows=0).columns
     for report_type, report_def in REPORT_TYPES.items():
-        report_columns = sorted(report_def.get("columns"))
-        report_enum = report_def.get("enum")
-        if report_columns == sorted_columns:
-            return report_type, report_enum
+        report_columns = report_def.get("columns")
+        if report_columns.issubset(columns):
+            return report_type, report_def.get("enum")
     return None, OCPReportTypes.UNKNOWN
 
 

--- a/koku/masu/util/ocp/common.py
+++ b/koku/masu/util/ocp/common.py
@@ -112,6 +112,7 @@ POD_AGG = {
     "node_capacity_cpu_core_seconds": ["sum"],
     "node_capacity_memory_bytes": ["max"],
     "node_capacity_memory_byte_seconds": ["sum"],
+    "node_role": ["max"],
 }
 
 NODE_LABEL_COLUMNS = {
@@ -466,7 +467,9 @@ def ocp_generate_daily_data(data_frame, report_type):
     group_bys = copy.deepcopy(REPORT_TYPES.get(report_type, {}).get("group_by", []))
     group_bys.append(pd.Grouper(key="interval_start", freq="D"))
     aggs = copy.deepcopy(REPORT_TYPES.get(report_type, {}).get("agg", {}))
-    daily_data_frame = data_frame.groupby(group_bys, dropna=False).agg(aggs)
+    daily_data_frame = data_frame.groupby(group_bys, dropna=False).agg(
+        {k: v for k, v in aggs.items() if k in data_frame.columns}
+    )
 
     columns = daily_data_frame.columns.droplevel(1)
     daily_data_frame.columns = columns

--- a/koku/masu/util/ocp/common.py
+++ b/koku/masu/util/ocp/common.py
@@ -146,6 +146,11 @@ NAMESPACE_GROUP_BY = ["namespace", "namespace_labels"]
 
 NAMESPACE_AGG = {"report_period_start": ["max"], "report_period_end": ["max"]}
 
+
+# new_required_columns are columns that appear in new operator reports.
+# today, we cannot guarantee that all reports received will contain all
+# of these new columns, so this field is used to add the necessary columns
+# to the data frames.
 REPORT_TYPES = {
     "storage_usage": {
         "columns": STORAGE_COLUMNS,

--- a/scripts/cji_scripts/migrate_trino.py
+++ b/scripts/cji_scripts/migrate_trino.py
@@ -118,22 +118,22 @@ def main():
     logging.info("Running against the following schemas")
     logging.info(schemas)
 
-    tables_to_drop = [
-        "reporting_ocpazurecostlineitem_project_daily_summary_temp",
-        "reporting_ocpawscostlineitem_project_daily_summary_temp",
-        "reporting_ocpgcpcostlineitem_project_daily_summary_temp",
-    ]
+    # tables_to_drop = [
+    #     "reporting_ocpazurecostlineitem_project_daily_summary_temp",
+    #     "reporting_ocpawscostlineitem_project_daily_summary_temp",
+    #     "reporting_ocpgcpcostlineitem_project_daily_summary_temp",
+    # ]
     # columns_to_drop = ["ocp_matched"]
-    # columns_to_add = {
-    #     "node_capacity_cpu_core_hours": "double",
-    #     "node_capacity_memory_gigabyte_hours": "double",
-    # }
+    columns_to_add = {
+        "node_role": "varchar",
+    }
 
     for schema in schemas:
         CONNECT_PARAMS["schema"] = schema
-        # logging.info(f"*** Adding column to tables for schema {schema} ***")
-        logging.info(f"*** Dropping tables {tables_to_drop} for schema {schema} ***")
-        drop_tables(tables_to_drop, CONNECT_PARAMS)
+        logging.info(f"*** Adding column to tables for schema {schema} ***")
+        add_columns_to_table(columns_to_add, "openshift_pod_usage_line_items_daily", CONNECT_PARAMS)
+        # logging.info(f"*** Dropping tables {tables_to_drop} for schema {schema} ***")
+        # drop_tables(tables_to_drop, CONNECT_PARAMS)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Jira Ticket

[COST-3373](https://issues.redhat.com/browse/COST-3373)

## Description

This change will enable ingesting old and new reports.

## Testing

1. Checkout Branch
2. Create an OCP source with cluster-id `9682ea7d-cb13-4f31-a060-dd30bec3fc3d` and send the attached payload to ingress
3. monitor logs and see:
```
Create Parquet Table SQL: 
CREATE TABLE IF NOT EXISTS org1234567.openshift_pod_usage_line_items_daily (
  namespace varchar,
  node varchar,
  pod varchar,
  pod_labels varchar,
  interval_start timestamp,
  report_period_start timestamp,
  report_period_end timestamp,
  resource_id varchar,
  pod_usage_cpu_core_seconds double,
  pod_request_cpu_core_seconds double,
  pod_effective_usage_cpu_core_seconds double,
  pod_limit_cpu_core_seconds double,
  pod_usage_memory_byte_seconds double,
  pod_request_memory_byte_seconds double,
  pod_effective_usage_memory_byte_seconds double,
  pod_limit_memory_byte_seconds double,
  node_capacity_cpu_cores double,
  node_capacity_cpu_core_seconds double,
  node_capacity_memory_bytes double,
  node_capacity_memory_byte_seconds double,
  node_role varchar, <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< this is the new field being created
  source varchar,
  year varchar,
  month varchar
) WITH(external_location = 's3a://koku-reports/data/parquet/daily/org1234567/OCP/pod_usage', format = 'PARQUET', partitioned_by=ARRAY['source', 'year', 'month']
```