### PR TITLE
Check image GitHub Action fix to remove ENV variable

### DIFF
--- a/.github/workflows/check-image.yml
+++ b/.github/workflows/check-image.yml
@@ -14,7 +14,7 @@ jobs:
         run: sudo apt-get install -y skopeo
       - name: Check change
         run: |
-          BASE_IMAGE="registry.access.redhat.com/ubi8/ubi-minimal:latest" skopeo inspect "docker://${BASE_IMAGE}" | grep -Po '(?<="Digest": ")([^"]+)' > .baseimagedigest
+          skopeo inspect "docker://registry.access.redhat.com/ubi8/ubi-minimal:latest" | grep -Po '(?<="Digest": ")([^"]+)' > .baseimagedigest
           docker run --rm --entrypoint sh -u 0 quay.io/cloudservices/koku:latest -c \
             'yum upgrade -y --security > /dev/null; rpm -qa | sort | sha256sum' \
             >> .baseimagedigest


### PR DESCRIPTION
* Fix skopeo error with ENV variable

Fixes issue from this run: https://github.com/project-koku/koku/actions/runs/3907637132
```
Run BASE_IMAGE="registry.access.redhat.com/ubi8/ubi-minimal:latest" skopeo inspect "docker://${BASE_IMAGE}" | grep -Po '(?<="Digest": ")([^"]+)' > .baseimagedigest
time="2023-01-13T01:49:5[7](https://github.com/project-koku/koku/actions/runs/3907637132/jobs/6677060594#step:4:8)Z" level=fatal msg="Error parsing image name \"docker://\": invalid reference format"
Error: Process completed with exit code 1.
```