### PR TITLE
[COST-3385] cache ocp on cloud tag match results

### DIFF
--- a/koku/koku/cache.py
+++ b/koku/koku/cache.py
@@ -116,3 +116,17 @@ def invalidate_view_cache_for_tenant_and_all_source_types(schema_name):
 
     for source_type in non_local_providers:
         invalidate_view_cache_for_tenant_and_source_type(schema_name, source_type)
+
+
+def get_cached_matching_tags(schema_name, provider_type):
+    """Return cached OCP on Cloud matched tags if exists."""
+    cache = caches["default"]
+    cache_key = f"OCP-on-{provider_type}:{schema_name}:matching-tags"
+    return cache.get(cache_key)
+
+
+def set_cached_matching_tags(schema_name, provider_type, matched_tags):
+    """Return cached OCP on Cloud matched tags if exists."""
+    cache = caches["default"]
+    cache_key = f"OCP-on-{provider_type}:{schema_name}:matching-tags"
+    cache.set(cache_key, matched_tags)

--- a/koku/koku/test_cache.py
+++ b/koku/koku/test_cache.py
@@ -13,6 +13,7 @@ from api.iam.test.iam_test_case import IamTestCase
 from api.provider.models import Provider
 from koku.cache import AWS_CACHE_PREFIX
 from koku.cache import AZURE_CACHE_PREFIX
+from koku.cache import get_cached_matching_tags
 from koku.cache import invalidate_view_cache_for_tenant_and_all_source_types
 from koku.cache import invalidate_view_cache_for_tenant_and_cache_key
 from koku.cache import invalidate_view_cache_for_tenant_and_source_type
@@ -22,6 +23,7 @@ from koku.cache import OPENSHIFT_ALL_CACHE_PREFIX
 from koku.cache import OPENSHIFT_AWS_CACHE_PREFIX
 from koku.cache import OPENSHIFT_AZURE_CACHE_PREFIX
 from koku.cache import OPENSHIFT_CACHE_PREFIX
+from koku.cache import set_cached_matching_tags
 
 
 LOG = logging.getLogger(__name__)
@@ -228,3 +230,15 @@ class KokuCacheTest(IamTestCase):
 
             for key in cache_data:
                 self.assertIsNone(self.cache.get(key))
+
+    def test_matching_tags_cache(self):
+        """Test that getting/setting matching tags works."""
+        provider_type = Provider.PROVIDER_AWS
+        initial = get_cached_matching_tags(self.schema_name, provider_type)
+        self.assertIsNone(initial)
+
+        matched_tags = [{"tag_one": "value_one"}, {"tag_two": "value_bananas"}]
+        set_cached_matching_tags(self.schema_name, provider_type, matched_tags)
+
+        cached = get_cached_matching_tags(self.schema_name, provider_type)
+        self.assertEqual(cached, matched_tags)

--- a/koku/masu/processor/parquet/ocp_cloud_parquet_report_processor.py
+++ b/koku/masu/processor/parquet/ocp_cloud_parquet_report_processor.py
@@ -133,6 +133,7 @@ class OCPCloudParquetReportProcessor(ParquetReportProcessor):
         # Get matching tags
         matched_tags = get_cached_matching_tags(self.schema_name, self.provider_type)
         if matched_tags:
+            LOG.info("Retreived matching tags from cache.")
             return matched_tags
         if self.has_enabled_ocp_labels:
             enabled_tags = self.db_accessor.check_for_matching_enabled_keys()

--- a/koku/masu/processor/parquet/ocp_cloud_parquet_report_processor.py
+++ b/koku/masu/processor/parquet/ocp_cloud_parquet_report_processor.py
@@ -11,6 +11,8 @@ from tenant_schemas.utils import schema_context
 
 from api.provider.models import Provider
 from api.utils import DateHelper
+from koku.cache import get_cached_matching_tags
+from koku.cache import set_cached_matching_tags
 from masu.database.aws_report_db_accessor import AWSReportDBAccessor
 from masu.database.azure_report_db_accessor import AzureReportDBAccessor
 from masu.database.gcp_report_db_accessor import GCPReportDBAccessor
@@ -126,6 +128,34 @@ class OCPCloudParquetReportProcessor(ParquetReportProcessor):
         self._write_parquet_to_file(file_path, file_name, data_frame, file_type=self.report_type)
         self.create_parquet_table(file_path, daily=True)
 
+    def get_matched_tags(self, ocp_provider_uuids):
+        """Get tags that match between OCP and the cloud source."""
+        # Get matching tags
+        matched_tags = get_cached_matching_tags(self.schema_name, self.provider_type)
+        if matched_tags:
+            return matched_tags
+        if self.has_enabled_ocp_labels:
+            enabled_tags = self.db_accessor.check_for_matching_enabled_keys()
+            if enabled_tags:
+                LOG.info("Getting matching tags from Postgres.")
+                matched_tags = self.db_accessor.get_openshift_on_cloud_matched_tags(self.bill_id)
+            if not matched_tags and enabled_tags:
+                LOG.info("Matched tags not yet available via Postgres. Getting matching tags from Trino.")
+                if self._provider_type in [Provider.PROVIDER_GCP, Provider.PROVIDER_GCP_LOCAL]:
+                    matched_tags = self.db_accessor.get_openshift_on_cloud_matched_tags_trino(
+                        self.provider_uuid,
+                        ocp_provider_uuids,
+                        self.start_date,
+                        self.end_date,
+                        self.invoice_month_date,
+                    )
+                else:
+                    matched_tags = self.db_accessor.get_openshift_on_cloud_matched_tags_trino(
+                        self.provider_uuid, tuple(ocp_provider_uuids), self.start_date, self.end_date
+                    )
+        set_cached_matching_tags(self.schema_name, self.provider_type, matched_tags)
+        return matched_tags
+
     def process(self, parquet_base_filename, daily_data_frames):
         """Filter data and convert to parquet."""
         ocp_provider_uuids = []
@@ -150,27 +180,7 @@ class OCPCloudParquetReportProcessor(ParquetReportProcessor):
         if ocp_provider_uuids != []:
             with OCPReportDBAccessor(self.schema_name) as accessor:
                 cluster_topology = accessor.get_openshift_topology_for_multiple_providers(ocp_provider_uuids)
-                # Get matching tags
-                matched_tags = []
-                if self.has_enabled_ocp_labels:
-                    enabled_tags = self.db_accessor.check_for_matching_enabled_keys()
-                    if enabled_tags:
-                        LOG.info("Getting matching tags from Postgres.")
-                        matched_tags = self.db_accessor.get_openshift_on_cloud_matched_tags(self.bill_id)
-                    if not matched_tags and enabled_tags:
-                        LOG.info("Matched tags not yet available via Postgres. Getting matching tags from Trino.")
-                        if self._provider_type in [Provider.PROVIDER_GCP, Provider.PROVIDER_GCP_LOCAL]:
-                            matched_tags = self.db_accessor.get_openshift_on_cloud_matched_tags_trino(
-                                self.provider_uuid,
-                                ocp_provider_uuids,
-                                self.start_date,
-                                self.end_date,
-                                self.invoice_month_date,
-                            )
-                        else:
-                            matched_tags = self.db_accessor.get_openshift_on_cloud_matched_tags_trino(
-                                self.provider_uuid, tuple(ocp_provider_uuids), self.start_date, self.end_date
-                            )
+                matched_tags = self.get_matched_tags(ocp_provider_uuids)
                 for i, daily_data_frame in enumerate(daily_data_frames):
                     openshift_filtered_data_frame = self.ocp_on_cloud_data_processor(
                         daily_data_frame, cluster_topology, matched_tags

--- a/koku/masu/test/processor/parquet/test_ocp_cloud_parquet_report_processor.py
+++ b/koku/masu/test/processor/parquet/test_ocp_cloud_parquet_report_processor.py
@@ -286,3 +286,24 @@ class TestOCPCloudParquetReportProcessor(MasuTestCase):
         mock_topology.assert_called()
         mock_data_processor.assert_called()
         mock_create_parquet.assert_called()
+
+    @patch.object(AWSReportDBAccessor, "get_openshift_on_cloud_matched_tags")
+    @patch.object(AWSReportDBAccessor, "check_for_matching_enabled_keys")
+    @patch.object(OCPCloudParquetReportProcessor, "has_enabled_ocp_labels")
+    def test_get_matched_tags(self, mock_has_enabled, mock_matching_enabled, mock_get_tags):
+        """Test that we get matched tags, cached if available."""
+
+        mock_has_enabled.return_value = True
+        mock_matching_enabled.return_Value = True
+
+        self.report_processor.get_matched_tags([])
+        mock_get_tags.assert_called()
+
+        matched_tags = [{"tag_one": "value_one"}, {"tag_two": "value_bananas"}]
+        mock_get_tags.reset_mock()
+        with patch(
+            "masu.processor.parquet.ocp_cloud_parquet_report_processor.get_cached_matching_tags",
+            return_value=matched_tags,
+        ):
+            self.report_processor.get_matched_tags([])
+            mock_get_tags.assert_not_called()

--- a/koku/masu/test/processor/parquet/test_ocp_cloud_parquet_report_processor.py
+++ b/koku/masu/test/processor/parquet/test_ocp_cloud_parquet_report_processor.py
@@ -287,10 +287,11 @@ class TestOCPCloudParquetReportProcessor(MasuTestCase):
         mock_data_processor.assert_called()
         mock_create_parquet.assert_called()
 
+    @patch.object(AWSReportDBAccessor, "get_openshift_on_cloud_matched_tags_trino")
     @patch.object(AWSReportDBAccessor, "get_openshift_on_cloud_matched_tags")
     @patch.object(AWSReportDBAccessor, "check_for_matching_enabled_keys")
     @patch.object(OCPCloudParquetReportProcessor, "has_enabled_ocp_labels")
-    def test_get_matched_tags(self, mock_has_enabled, mock_matching_enabled, mock_get_tags):
+    def test_get_matched_tags(self, mock_has_enabled, mock_matching_enabled, mock_get_tags, mock_get_tags_trino):
         """Test that we get matched tags, cached if available."""
 
         mock_has_enabled.return_value = True
@@ -298,6 +299,31 @@ class TestOCPCloudParquetReportProcessor(MasuTestCase):
 
         self.report_processor.get_matched_tags([])
         mock_get_tags.assert_called()
+        mock_get_tags_trino.assert_not_called()
+
+        matched_tags = [{"tag_one": "value_one"}, {"tag_two": "value_bananas"}]
+        mock_get_tags.reset_mock()
+        with patch(
+            "masu.processor.parquet.ocp_cloud_parquet_report_processor.get_cached_matching_tags",
+            return_value=matched_tags,
+        ):
+            self.report_processor.get_matched_tags([])
+            mock_get_tags.assert_not_called()
+
+    @patch.object(AWSReportDBAccessor, "get_openshift_on_cloud_matched_tags_trino")
+    @patch.object(AWSReportDBAccessor, "get_openshift_on_cloud_matched_tags")
+    @patch.object(AWSReportDBAccessor, "check_for_matching_enabled_keys")
+    @patch.object(OCPCloudParquetReportProcessor, "has_enabled_ocp_labels")
+    def test_get_matched_tags_trino(self, mock_has_enabled, mock_matching_enabled, mock_get_tags, mock_get_tags_trino):
+        """Test that we get matched tags, cached if available."""
+
+        mock_has_enabled.return_value = True
+        mock_matching_enabled.return_Value = True
+        mock_get_tags.return_value = []
+
+        self.report_processor.get_matched_tags([])
+        mock_get_tags.assert_called()
+        mock_get_tags_trino.assert_called()
 
         matched_tags = [{"tag_one": "value_one"}, {"tag_two": "value_bananas"}]
         mock_get_tags.reset_mock()


### PR DESCRIPTION
## Jira Ticket

[COST-3385](https://issues.redhat.com/browse/COST-3385)

## Description

This change will cache matched OCP on Cloud tags from the query run when processing OCP on Cloud parquet. 

## Testing

1. Checkout Branch
2. Have OCP on Cloud data loaded (maybe via load test customer data)
3. Hit http://127.0.0.1:5042/api/cost-management/v1/report/process/openshift_on_cloud/?provider_uuid=8474bc94-dc63-4173-b568-dfbb5fb662d2&schema=org1234567&start_date=2023-01-01&end_date=2023-01-16 for your provider and dates
    a. See log statement that we are getting tags from DB
4. Hit API endpoint again
    a. See that tags are retrieved from cache. 

## Notes

...
