### PR TITLE
[COST-3344] OCP Volume report capacity not respecting group bys

### DIFF
--- a/koku/api/report/ocp/provider_map.py
+++ b/koku/api/report/ocp/provider_map.py
@@ -2097,8 +2097,8 @@ class OCPProviderMap(ProviderMap):
                             ),
                             "usage": Sum("persistentvolumeclaim_usage_gigabyte_months"),
                             "request": Sum("volume_request_storage_gigabyte_months"),
+                            "capacity": Sum("persistentvolumeclaim_capacity_gigabyte_months"),
                         },
-                        "capacity_aggregate": {"capacity": Sum("persistentvolumeclaim_capacity_gigabyte_months")},
                         "default_ordering": {"usage": "desc"},
                         "annotations": {
                             "sup_raw": Value(0, output_field=DecimalField()),

--- a/koku/api/report/test/ocp/test_ocp_query_handler.py
+++ b/koku/api/report/test/ocp/test_ocp_query_handler.py
@@ -5,6 +5,7 @@
 """Test the Report Queries."""
 import logging
 from collections import defaultdict
+from datetime import datetime
 from datetime import timedelta
 from decimal import Decimal
 from itertools import product
@@ -188,6 +189,170 @@ class OCPReportQueryHandlerTest(IamTestCase):
                 self.assertEqual(capacity, capacity_by_cluster[cluster_name])
 
         self.assertEqual(query_data.get("total", {}).get("capacity", {}).get("value"), total_capacity)
+
+    def test_get_cluster_capacity_daily_volume_group_bys(self):
+        """Test the volume capacities of a daily volume report with various group bys matches expected"""
+        base_url = "?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=daily"
+        group_bys = [
+            ["cluster"],
+            ["node"],
+            ["project"],
+            ["cluster", "node"],
+            ["cluster", "project"],
+            ["node", "project"],
+        ]
+        GB_MAP = {"project": "namespace", "cluster": "cluster_id", "node": "node"}
+        with tenant_context(self.tenant):
+            for group_by in group_bys:
+                url_group_by = "".join([f"&group_by[{gb}]=*" for gb in group_by])
+                url = base_url + url_group_by
+                query_params = self.mocked_query_params(url, OCPVolumeView)
+                handler = OCPReportQueryHandler(query_params)
+                query_data = handler.execute_query()
+
+                annotations = {"capacity": Sum("persistentvolumeclaim_capacity_gigabyte_months")}
+                q_table = handler._mapper.provider_map.get("tables").get("query")
+                query_filter = handler.query_filter
+                query = q_table.objects.filter(query_filter)
+                query_group_by = ["usage_start"]
+                for gb in group_by:
+                    query_group_by.append(GB_MAP.get(gb))
+                query_results = query.values(*query_group_by).annotate(**annotations)
+                with self.subTest(group_by=group_by):
+                    for entry in query_data.get("data", []):
+                        date = entry.get("date")
+                        for item in entry.get(f"{group_by[0]}s", []):
+                            filter_dict = {GB_MAP.get(group_by[0]): item.get(group_by[0])}
+                            if len(group_by) > 1:
+                                for element in item.get(f"{group_by[1]}s")[0].get("values"):
+                                    filter_dict[GB_MAP.get(group_by[1])] = element.get(group_by[1])
+                                    capacity = element.get("capacity", {}).get("value")
+                                    expected = query_results.get(usage_start=date, **filter_dict).get(
+                                        "capacity", 0.0
+                                    ) or Decimal(0.0)
+                                    self.assertAlmostEqual(capacity, expected)
+                            else:
+                                for element in item.get("values"):
+                                    capacity = element.get("capacity", {}).get("value")
+                                    expected = query_results.get(usage_start=date, **filter_dict).get(
+                                        "capacity", 0.0
+                                    ) or Decimal(0.0)
+                                    self.assertAlmostEqual(capacity, expected)
+
+    def test_get_cluster_capacity_monthly_volume_group_bys(self):
+        """Test the volume capacities of a monthly volume report with various group bys"""
+        base_url = "?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly"
+        group_bys = [
+            ["cluster"],
+            ["node"],
+            ["project"],
+            ["cluster", "node"],
+            ["cluster", "project"],
+            ["node", "project"],
+        ]
+        GB_MAP = {"project": "namespace", "cluster": "cluster_id", "node": "node"}
+        with tenant_context(self.tenant):
+            for group_by in group_bys:
+                url_group_by = "".join([f"&group_by[{gb}]=*" for gb in group_by])
+                url = base_url + url_group_by
+                query_params = self.mocked_query_params(url, OCPVolumeView)
+                handler = OCPReportQueryHandler(query_params)
+                query_data = handler.execute_query()
+
+                annotations = {"capacity": Sum("persistentvolumeclaim_capacity_gigabyte_months")}
+                q_table = handler._mapper.provider_map.get("tables").get("query")
+                query_filter = handler.query_filter
+                query = q_table.objects.filter(query_filter)
+                query_group_by = ["usage_start"]
+                for gb in group_by:
+                    query_group_by.append(GB_MAP.get(gb))
+                query_results = query.values(*query_group_by).annotate(**annotations)
+                with self.subTest(group_by=group_by):
+                    for entry in query_data.get("data", []):
+                        date = entry.get("date") + "-01"
+                        for item in entry.get(f"{group_by[0]}s", []):
+                            filter_dict = {GB_MAP.get(group_by[0]): item.get(group_by[0])}
+                            if len(group_by) > 1:
+                                for element in item.get(f"{group_by[1]}s")[0].get("values"):
+                                    filter_dict[GB_MAP.get(group_by[1])] = element.get(group_by[1])
+                                    capacity = element.get("capacity", {}).get("value")
+                                    monthly_vals = [
+                                        element.get("capacity") or Decimal(0.0)
+                                        for element in query_results.filter(usage_start__gte=date, **filter_dict)
+                                    ]
+                                    self.assertAlmostEqual(capacity, sum(monthly_vals))
+                            else:
+                                for element in item.get("values"):
+                                    capacity = element.get("capacity", {}).get("value")
+                                    monthly_vals = [
+                                        element.get("capacity") or Decimal(0.0)
+                                        for element in query_results.filter(usage_start__gte=date, **filter_dict)
+                                    ]
+                                    self.assertAlmostEqual(capacity, sum(monthly_vals))
+
+    def test_get_cluster_capacity_monthly_start_and_end_volume_group_bys(self):
+        """Test the volume capacities of a monthly volume report with various group bys"""
+        base_url = (
+            f"?start_date={self.dh.last_month_end.date()}&end_date={self.dh.today.date()}"
+            f"&filter[resolution]=monthly"
+        )
+        group_bys = [
+            ["cluster"],
+            ["node"],
+            ["project"],
+            ["cluster", "node"],
+            ["cluster", "project"],
+            ["node", "project"],
+        ]
+        GB_MAP = {"project": "namespace", "cluster": "cluster_id", "node": "node"}
+        with tenant_context(self.tenant):
+            for group_by in group_bys:
+                url_group_by = "".join([f"&group_by[{gb}]=*" for gb in group_by])
+                url = base_url + url_group_by
+                query_params = self.mocked_query_params(url, OCPVolumeView)
+                handler = OCPReportQueryHandler(query_params)
+                query_data = handler.execute_query()
+
+                annotations = {"capacity": Sum("persistentvolumeclaim_capacity_gigabyte_months")}
+                q_table = handler._mapper.provider_map.get("tables").get("query")
+                query_filter = handler.query_filter
+                query = q_table.objects.filter(query_filter)
+                query_group_by = ["usage_start"]
+                for gb in group_by:
+                    query_group_by.append(GB_MAP.get(gb))
+                query_results = query.values(*query_group_by).annotate(**annotations)
+                with self.subTest(group_by=group_by):
+                    for entry in query_data.get("data", []):
+                        entry_date = entry.get("date")
+                        if entry_date == datetime.strftime(self.dh.today.date(), "%Y-%m"):
+                            date = entry.get("date") + "-01"
+                            end = self.dh.tomorrow.date()
+                        else:
+                            date = self.dh.last_month_end.date()
+                            end = self.dh.this_month_start.date()
+                        for item in entry.get(f"{group_by[0]}s", []):
+                            filter_dict = {GB_MAP.get(group_by[0]): item.get(group_by[0])}
+                            if len(group_by) > 1:
+                                for element in item.get(f"{group_by[1]}s")[0].get("values"):
+                                    filter_dict[GB_MAP.get(group_by[1])] = element.get(group_by[1])
+                                    capacity = element.get("capacity", {}).get("value")
+                                    monthly_vals = [
+                                        element.get("capacity") or Decimal(0.0)
+                                        for element in query_results.filter(
+                                            usage_start__gte=date, usage_start__lt=end, **filter_dict
+                                        )
+                                    ]
+                                    self.assertAlmostEqual(capacity, sum(monthly_vals))
+                            else:
+                                for element in item.get("values"):
+                                    capacity = element.get("capacity", {}).get("value")
+                                    monthly_vals = [
+                                        element.get("capacity") or Decimal(0.0)
+                                        for element in query_results.filter(
+                                            usage_start__gte=date, usage_start__lt=end, **filter_dict
+                                        )
+                                    ]
+                                    self.assertAlmostEqual(capacity, sum(monthly_vals))
 
     def test_get_cluster_capacity_monthly_resolution_start_end_date(self):
         """Test that cluster capacity returns capacity by month."""


### PR DESCRIPTION
## Jira Ticket

[COST-3344](https://issues.redhat.com/browse/COST-3344)

## Description

This change will remove the capacity aggregate field from the volume report provider map and add capacity to the annotations. 

## Testing

1. Checkout Branch
2. Restart Koku
3. Create some test customer data with the `make create-test-customer` and `make load-test-customer-data` commands
4. Check the OCP volumes endpoint with a few different group bys and start/end dates and monthly resolutions and ensure the data matches up with what you see in the db:
- http://localhost:8000/api/cost-management/v1/reports/openshift/volumes/?group_by[cluster_id]=*&group_by[node]=*
- http://localhost:8000/api/cost-management/v1/reports/openshift/volumes/?group_by[node]=*&group_by[project]=* 
- http://localhost:8000/api/cost-management/v1/reports/openshift/volumes/?group_by[project]=*
- http://localhost:8000/api/cost-management/v1/reports/openshift/volumes/?group_by[cluster]=*&filter[resolution]=monthly&filter[time_scope_value]=-1&filter[time_scope_units]=month
- http://localhost:8000/api/cost-management/v1/reports/openshift/volumes/?group_by[node]=*&filter[resolution]=monthly&start_date=2022-12-15&end_date=2023-01-24
- http://localhost:8000/api/cost-management/v1/reports/openshift/volumes/?group_by[tag:app]=*
5. Some potentially helpful DB queries:
- this months data grouped by node, cluster_id and usage start: 
```
select sum(persistentvolumeclaim_capacity_gigabyte_months), usage_start, node, cluster_id from reporting_ocpusagelineitem_daily_summary where usage_start >= '2023-01-01' group by usage_start, node, cluster_id order by usage_start, cluster_id, node;
```
- this months data grouped by node and project:
```
select sum(persistentvolumeclaim_capacity_gigabyte_months), usage_start, node, namespace from reporting_ocpusagelineitem_daily_summary where usage_start >= '2023-01-01' group by usage_start, node, namespace order by usage_start, node, namespace;
```
- the sum of this months capacity grouped by cluster:
```
select sum(persistentvolumeclaim_capacity_gigabyte_months), cluster_id from reporting_ocpusagelineitem_daily_summary where usage_start >= '2023-01-01' group by cluster_id order by cluster_id;
```
- the sum of volume capacities for a specific day grouped by a specific tag keys values, in this case app:
```
select sum(persistentvolumeclaim_capacity_gigabyte_months), json_agg(volume_labels) from reporting_ocpusagelineitem_daily_summary where usage_start = '2023-01-16' and volume_labels ? 'app' group by volume_labels #>> '{app}'
```

## Notes

...
