### PR TITLE
Cost-3425: OCI resource types in open api docs

### DIFF
--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -3343,7 +3343,7 @@
                 }
             }
         },
-        "/resource-types/oci-tenant-ids/": {
+        "/resource-types/oci-payer-tenant-ids/": {
             "get": {
                 "tags": [
                     "Resource Type"


### PR DESCRIPTION
## Jira Ticket

[COST-3425](https://issues.redhat.com/browse/COST-3425)

## Description

This change will fix OCI resource type name in open api docs

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Notes

...
