### PR TITLE
COST-3219: Support scope and export name configuration for Azure cost exports

### DIFF
--- a/dev/scripts/create_sources.py
+++ b/dev/scripts/create_sources.py
@@ -35,6 +35,8 @@ def create_parser():
     )
     parser.add_argument("--resource_group", dest="resource_group", required=False, help="AZURE Storage Resource Group")
     parser.add_argument("--storage_account", dest="storage_account", required=False, help="AZURE Storage Account")
+    parser.add_argument("--scope", dest="scope", required=False, help="AZURE Cost Export Scope")
+    parser.add_argument("--export_name", dest="export_name", required=False, help="AZURE Cost Export Name")
     parser.add_argument("--subscription_id", dest="subscription_id", required=False, help="AZURE Subscription ID")
     parser.add_argument("--client_id", dest="client_id", required=False, help="Azure Client ID")
     parser.add_argument("--client_secret", dest="client_secret", required=False, help="Azure Client Secret")
@@ -75,9 +77,16 @@ class SourcesClientDataGenerator:
         response = requests.patch(url, headers=self._identity_header, json=json_data)
         return response
 
-    def create_azure_storage(self, parameters, resource_group, storage_account):
+    def create_azure_storage(self, parameters, resource_group, storage_account, scope=None, export_name=None):
         json_data = {
-            "billing_source": {"data_source": {"resource_group": resource_group, "storage_account": storage_account}}
+            "billing_source": {
+                "data_source": {
+                    "resource_group": resource_group,
+                    "storage_account": storage_account,
+                    "scope": scope,
+                    "export_name": export_name,
+                }
+            }
         }
 
         url = "{}/{}/".format(self._base_url, parameters.get("source_id"))
@@ -248,10 +257,14 @@ def main(args):  # noqa
         resource_group = parameters.get("resource_group")
         subscription_id = parameters.get("subscription_id")
         source_id_param = parameters.get("source_id")
+        scope = parameters.get("scope")
+        export_name = parameters.get("export_name")
 
         if storage_account and resource_group and source_id_param:
             sources_client = SourcesClientDataGenerator(identity_header)
-            billing_source_response = sources_client.create_azure_storage(parameters, resource_group, storage_account)
+            billing_source_response = sources_client.create_azure_storage(
+                parameters, resource_group, storage_account, scope, export_name
+            )
             print(f"Associating Azure storage account and resource group: {billing_source_response.content}")
             return
 

--- a/koku/masu/external/downloader/azure/azure_report_downloader.py
+++ b/koku/masu/external/downloader/azure/azure_report_downloader.py
@@ -91,9 +91,18 @@ class AzureReportDownloader(ReportDownloaderBase, DownloaderInterface):
         client_secret = credentials.get("client_secret")
         resource_group_name = data_source.get("resource_group")
         storage_account_name = data_source.get("storage_account")
+        scope = data_source.get("scope")
+        export_name = data_source.get("export_name")
 
         service = AzureService(
-            tenant_id, client_id, client_secret, resource_group_name, storage_account_name, subscription_id
+            tenant_id,
+            client_id,
+            client_secret,
+            resource_group_name,
+            storage_account_name,
+            subscription_id,
+            scope=scope,
+            export_name=export_name,
         )
         return service
 

--- a/koku/providers/azure/client.py
+++ b/koku/providers/azure/client.py
@@ -26,12 +26,18 @@ class AzureClientFactory:
         client_id (str): Service Principal Application ID
         client_secret (str): Service Principal Password
         cloud (str): Cloud selector, must be one of ['china', 'germany', 'public', 'usgov']
+        scope (str): Cost Export scope
+        export_name (str): Cost Export name
 
     """
 
-    def __init__(self, subscription_id, tenant_id, client_id, client_secret, cloud="public"):
+    def __init__(
+        self, subscription_id, tenant_id, client_id, client_secret, cloud="public", scope=None, export_name=None
+    ):
         """Constructor."""
         self._subscription_id = subscription_id
+        self._scope = scope
+        self._export_name = export_name
 
         clouds = {
             "china": AZURE_CHINA_CLOUD,
@@ -84,3 +90,13 @@ class AzureClientFactory:
             f"EndpointSuffix=core.windows.net"
         )
         return BlobServiceClient.from_connection_string(connect_str)
+
+    @property
+    def scope(self):
+        """Cost Export scope property."""
+        return self._scope
+
+    @property
+    def export_name(self):
+        """Cost Export name."""
+        return self._export_name

--- a/koku/providers/provider_errors.py
+++ b/koku/providers/provider_errors.py
@@ -76,12 +76,18 @@ class ProviderErrors:
         "Edit your Azure source to include the resource group."
     )
     AZURE_MISSING_SUBSCRIPTION_ID_MESSAGE = (
-        "Cost management requires a subscription ID for this source. "
+        "Cost management requires a subscription ID or scope with"
+        " export name for this source. "
         "Edit your Azure source to include the subscription ID."
     )
+    AZURE_MISSING_EXPORT_NAME_MESSAGE = (
+        "Cost management requeires an export name when a scope is"
+        " provided for a source. "
+        "Edit your Azure source to include an export name."
+    )
     AZURE_MISSING_ALL_PATCH_VALUES_MESSAGE = (
-        "Cost management requires a subscription ID, resource group "
-        "and storage account."
+        "Cost management requires a resource group,  storage account"
+        " and subscription ID or scope with export name. "
         "Edit your Azure source to include these details."
     )
     AZURE_INCORRECT_CLIENT_SECRET_MESSAGE = (

--- a/koku/providers/test/azure/test_client.py
+++ b/koku/providers/test/azure/test_client.py
@@ -117,3 +117,21 @@ class AzureClientFactoryTestCase(TestCase):
         with patch.object(StorageManagementClient, "storage_accounts", return_value=None):
             cloud_account = obj.cloud_storage_account(resource_group_name, storage_account_name)
             self.assertTrue(isinstance(cloud_account, BlobServiceClient))
+
+    @patch("providers.azure.client.ClientSecretCredential.get_token")
+    def test_scope_and_export_name(self, mock_get_token):
+        """Test the scope and export_name properties."""
+        subscription_id = FAKE.uuid4()
+        scope = f"/subscriptions/{subscription_id}"
+        export_name = "cost_export"
+        obj = AzureClientFactory(
+            subscription_id=subscription_id,
+            tenant_id=FAKE.uuid4(),
+            client_id=FAKE.uuid4(),
+            client_secret=FAKE.word(),
+            cloud=random.choice(self.clouds),
+            scope=scope,
+            export_name=export_name,
+        )
+        self.assertTrue(obj.scope, scope)
+        self.assertTrue(obj.export_name, export_name)

--- a/koku/providers/test/azure/test_provider.py
+++ b/koku/providers/test/azure/test_provider.py
@@ -47,13 +47,18 @@ class AzureProviderTestCase(TestCase):
     @patch("providers.azure.provider.AzureService", side_effect=AzureException("test exception"))
     def test_cost_usage_source_is_reachable_exception(self, _):
         """Test that ValidationError is raised when AzureException is raised."""
+        subscription_id = FAKE.uuid4()
+        scope = f"subscriptions/{subscription_id}"
         credentials = {
-            "subscription_id": FAKE.uuid4(),
+            "subscription_id": subscription_id,
             "tenant_id": FAKE.uuid4(),
             "client_id": FAKE.uuid4(),
             "client_secret": FAKE.word(),
         }
-        source_name = {"resource_group": FAKE.word(), "storage_account": FAKE.word()}
+        source_name = {"resource_group": FAKE.word(), "storage_account": FAKE.word(), "scope": scope}
+        with self.assertRaises(ValidationError):
+            AzureProvider().cost_usage_source_is_reachable(credentials, source_name)
+
         with self.assertRaises(ValidationError):
             AzureProvider().cost_usage_source_is_reachable(credentials, source_name)
 

--- a/koku/sources/sources_http_client.py
+++ b/koku/sources/sources_http_client.py
@@ -41,7 +41,7 @@ ENDPOINT_APPLICATION_TYPES = "application_types"
 ENDPOINT_AUTHENTICATIONS = "authentications"
 ENDPOINT_SOURCES = "sources"
 ENDPOINT_SOURCE_TYPES = "source_types"
-OPTIONAL_APP_EXTRA_FIELD_MAP = {
+APP_OPT_EXTRA_FEILD_MAP = {
     Provider.PROVIDER_OCP: [],
     Provider.PROVIDER_AWS: [],
     Provider.PROVIDER_AWS_LOCAL: [],
@@ -185,13 +185,17 @@ class SourcesHTTPClient:
             raise SourcesHTTPClientError(f"No application data for source: {self._source_id}")
         app_settings = applications_data.get("extra") or {}
         required_extras = APP_EXTRA_FIELD_MAP[source_type]
-        optional_extras = OPTIONAL_APP_EXTRA_FIELD_MAP[source_type]
         if any(k not in app_settings for k in required_extras):
             raise SourcesHTTPClientError(
                 f"missing application data for source: {self._source_id}. "
                 f"expected: {required_extras}, got: {list(app_settings.keys())}"
             )
-        return {k: app_settings.get(k) for k in required_extras + optional_extras}
+        optional_extras = APP_OPT_EXTRA_FEILD_MAP[source_type]
+        opt_include = []
+        for opt in optional_extras:
+            if opt in app_settings:
+                opt_include.append(opt)
+        return {k: app_settings.get(k) for k in required_extras + opt_include}
 
     def get_credentials(self, source_type, app_type_id):
         """Get the source credentials."""

--- a/koku/sources/sources_http_client.py
+++ b/koku/sources/sources_http_client.py
@@ -41,6 +41,17 @@ ENDPOINT_APPLICATION_TYPES = "application_types"
 ENDPOINT_AUTHENTICATIONS = "authentications"
 ENDPOINT_SOURCES = "sources"
 ENDPOINT_SOURCE_TYPES = "source_types"
+OPTIONAL_APP_EXTRA_FIELD_MAP = {
+    Provider.PROVIDER_OCP: [],
+    Provider.PROVIDER_AWS: [],
+    Provider.PROVIDER_AWS_LOCAL: [],
+    Provider.PROVIDER_AZURE: ["scope", "export_name"],
+    Provider.PROVIDER_AZURE_LOCAL: ["scope", "export_name"],
+    Provider.PROVIDER_GCP: [],
+    Provider.PROVIDER_GCP_LOCAL: [],
+    Provider.PROVIDER_OCI: [],
+    Provider.PROVIDER_OCI_LOCAL: [],
+}
 
 
 def convert_header_to_dict(header, b64_decode=False):
@@ -174,12 +185,13 @@ class SourcesHTTPClient:
             raise SourcesHTTPClientError(f"No application data for source: {self._source_id}")
         app_settings = applications_data.get("extra") or {}
         required_extras = APP_EXTRA_FIELD_MAP[source_type]
+        optional_extras = OPTIONAL_APP_EXTRA_FIELD_MAP[source_type]
         if any(k not in app_settings for k in required_extras):
             raise SourcesHTTPClientError(
                 f"missing application data for source: {self._source_id}. "
                 f"expected: {required_extras}, got: {list(app_settings.keys())}"
             )
-        return {k: app_settings.get(k) for k in required_extras}
+        return {k: app_settings.get(k) for k in required_extras + optional_extras}
 
     def get_credentials(self, source_type, app_type_id):
         """Get the source credentials."""

--- a/koku/sources/storage.py
+++ b/koku/sources/storage.py
@@ -75,7 +75,7 @@ def azure_settings_ready(provider):
         and authentication
         and (
             set(authentication.keys()) == REQUIRED_AZURE_AUTH_KEYS
-            and set(billing_source.keys()) == REQUIRED_AZURE_BILLING_KEYS
+            and REQUIRED_AZURE_BILLING_KEYS.issubset(set(billing_source.keys()))
         )
     )
 

--- a/koku/sources/test/test_sources_http_client.py
+++ b/koku/sources/test/test_sources_http_client.py
@@ -246,8 +246,6 @@ class SourcesHTTPClientTest(TestCase):
                 "expected": {
                     "resource_group": resource_group,
                     "storage_account": storage_account,
-                    "export_name": None,
-                    "scope": None,
                 },
             },
             {

--- a/koku/sources/test/test_sources_http_client.py
+++ b/koku/sources/test/test_sources_http_client.py
@@ -243,7 +243,12 @@ class SourcesHTTPClientTest(TestCase):
                         "storage_account": storage_account,
                     }
                 },
-                "expected": {"resource_group": resource_group, "storage_account": storage_account},
+                "expected": {
+                    "resource_group": resource_group,
+                    "storage_account": storage_account,
+                    "export_name": None,
+                    "scope": None,
+                },
             },
             {
                 "source-type": Provider.PROVIDER_GCP,


### PR DESCRIPTION
## Jira Ticket

[COST-3219](https://issues.redhat.com/browse/COST-3219)

## Description


* In order to support larger/smaller scoped Cost Export files gather scope and export_name from data_source
* If scope and export name are provided then find cost export with those values

## Testing

1. Checkout Branch
2. Restart Koku
3. Create an Azure source using the new scope and export name parameters
    1. You should see the source processed successfully
4. See that an error is generated if you supply a scope and no export name


### Testing Locally
Setup sources - 
```
git clone https://github.com/RedHatInsights/sources-api-go
export DOCKER_NETWORK_NAME=koku_default
docker-compose up sources-api-db-setup
docker-compose up -d sources-db
docker-compose up -d
docker-compose logs -f sources
```
Koku setup - 
Adjust your `.env` file:
```
SOURCES_API_PREFIX=/api/sources/v1.0
SOURCES_API_HOST=sources
SOURCES_API_PORT=8000
INSIGHTS_KAFKA_HOST=sources-kafka
INSIGHTS_KAFKA_PORT=29092
```
Start koku and sources client:
```
make docker-up-min-trino-no-build && make docker-logs
docker-compose up sources-client
```

In Azure setup a Cost and Export. I created one scoped to a Resource Group.
```
az ad sp create-for-rbac -n "CostManagementRG" --role "Storage Account Contributor"  --scope /subscriptions/1234de71-xxxxx-yyyyy-a104-ususus/resourceGroups/RG1 --query '{"tenant": tenant, "client_id": appId, "secret": password}'
az role assignment create --assignee "<client-id>" --role "Cost Management Reader" --scope subscriptions/1234de71-xxxxx-yyyyy-a104-ususus
```

Configure source:
`POST` @ `http://localhost:3000/api/sources/v3.1/bulk_create`
```
{
	"sources": [{
		"name": "azurerg",
		"app_creation_workflow": "manual_configuration",
		"source_type_name": "azure"
	}],
	"endpoints": [],
	"authentications": [{
		"authtype": "tenant_id_client_id_client_secret",
		"username": "<client_id>",
		"password": "<client_secret>",
		"extra": {
			"azure": {
				"tenant_id": "<tenant_id>"
			}
		},
		"resource_type": "application",
		"resource_name": "/insights/platform/cost-management"
	}],
	"applications": [{
		"application_type_name": "cost-management",
		"extra": {
			"resource_group": "RG1",
			"storage_account": "testrgexport",
			"subscription_id": "1234de71-xxxxx-yyyyy-a104-ususus",
			"scope": "subscriptions/1234de71-xxxxx-yyyyy-a104-ususus/resourceGroups/RG1",
			"export_name": "testrgexport"
		},
		"source_name": "azurerg"
	}]
}
```

Trigger download:
```
http://localhost:5042/api/cost-management/v1/download/
```



