### PR TITLE
[COST-3465] - sources: check if header item is None before decoding

### DIFF
--- a/koku/kafka_utils/test/test_utils.py
+++ b/koku/kafka_utils/test/test_utils.py
@@ -35,3 +35,37 @@ class KafkaUtilsTest(TestCase):
         utils.is_kafka_connected(TEST_HOST, TEST_PORT)
         connection_errors_after = WORKER_REGISTRY.get_sample_value("kafka_connection_errors_total")
         self.assertEqual(connection_errors_after - connection_errors_before, 1)
+
+    def test_extract_from_header(self):
+        """Test test_extract_from_header."""
+        encoded_value = bytes("value", "utf-8")
+        test_table = [
+            {
+                "test": [
+                    ["key", encoded_value],
+                ],
+                "key": "key",
+                "expected": "value",
+            },
+            {
+                "test": [
+                    ["key", None],
+                ],
+                "key": "key",
+                "expected": None,
+            },
+            {
+                "test": None,
+                "key": "key",
+                "expected": None,
+            },
+            {
+                "test": [["not-key", encoded_value], ["not-key-2", encoded_value]],
+                "key": "key",
+                "expected": None,
+            },
+        ]
+        for test in test_table:
+            with self.subTest(test=test):
+                result = utils.extract_from_header(test["test"], test["key"])
+                self.assertEqual(result, test["expected"])

--- a/koku/kafka_utils/utils.py
+++ b/koku/kafka_utils/utils.py
@@ -120,7 +120,7 @@ def extract_from_header(headers, header_type):
     for header in headers:
         if header_type in header:
             for item in header:
-                if item == header_type:
+                if item == header_type or item is None:
                     continue
                 else:
                     return item.decode("ascii")


### PR DESCRIPTION
## Jira Ticket

[COST-3465](https://issues.redhat.com/browse/COST-3465)

## Description

This change will prevent `'NoneType' object has no attribute 'decode'` when decoding Kafka headers when the value in the key:value pairs is `None`