### PR TITLE
Use hive specific env var

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -559,9 +559,9 @@ services:
       - S3_BUCKET_PATH=${S3_BUCKET_PATH-data}
       - POSTGRES_SQL_SERVICE_HOST=db
       - POSTGRES_SQL_SERVICE_PORT=5432
-      - DATABASE_NAME=${DATABASE_NAME-hive}
-      - DATABASE_USER=${DATABASE_USER-hive}
-      - DATABASE_PASSWORD=${DATABASE_PASSWORD-hive}
+      - DATABASE_NAME=${HIVE_DATABASE_NAME-hive}
+      - DATABASE_USER=${HIVE_DATABASE_USER-hive}
+      - DATABASE_PASSWORD=${HIVE_DATABASE_PASSWORD-hive}
     depends_on:
       - koku-create-parquet-bucket
 


### PR DESCRIPTION
## Jira Ticket

[COST-####](https://issues.redhat.com/browse/COST-####)

## Description

This change will default to sending Hive metastore data to the hive DB when you have env vars set for your koku DB. Currently hive metastore data is going to the koku DB's public schema when env vars are set for the koku DB.

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Notes

...
