### PR TITLE
Initial report ingest stub

### DIFF
--- a/koku/api/ingress/reports/serializers.py
+++ b/koku/api/ingress/reports/serializers.py
@@ -14,7 +14,7 @@ from reporting.ingress.models import IngressReports
 
 LOG = logging.getLogger(__name__)
 
-PROVIDER_LIST = ["aws", "aws-local"]
+PROVIDER_LIST = ["aws", "aws-local", "azure", "azure-local"]
 
 
 class IngressReportsSerializer(serializers.ModelSerializer):

--- a/koku/api/utils.py
+++ b/koku/api/utils.py
@@ -318,7 +318,7 @@ class DateHelper:
             current = next_month
         return months
 
-    def days_in_month(self, date):
+    def days_in_month(self, date, year=None, month=None):
         """Return the number of days in the month.
 
         Args:
@@ -329,7 +329,10 @@ class DateHelper:
 
         """
         # monthrange returns (day_of_week, num_days)
-        _, num_days = calendar.monthrange(date.year, date.month)
+        if year and month:
+            _, num_days = calendar.monthrange(year, month)
+        else:
+            _, num_days = calendar.monthrange(date.year, date.month)
         return num_days
 
     def relative_month_start(self, month_seek, dt=None):

--- a/koku/masu/external/downloader/azure_local/azure_local_report_downloader.py
+++ b/koku/masu/external/downloader/azure_local/azure_local_report_downloader.py
@@ -106,8 +106,9 @@ class AzureLocalReportDownloader(AzureReportDownloader):
             (String): The path and file name of the saved file
 
         """
+        container_name = self.container_name
         local_filename = utils.get_local_file_name(key)
-        full_file_path = f"{self._get_exports_data_directory()}/{local_filename}"
+        full_file_path = f"{self._get_exports_data_directory(container_name)}/{local_filename}"
 
         etag_hasher = hashlib.new("ripemd160")
         etag_hasher.update(bytes(local_filename, "utf-8"))

--- a/koku/masu/test/external/downloader/aws/test_aws_report_downloader.py
+++ b/koku/masu/test/external/downloader/aws/test_aws_report_downloader.py
@@ -179,7 +179,7 @@ class AWSReportDownloaderTest(MasuTestCase):
                 "provider_uuid": self.aws_provider_uuid,
             }
         )
-        self.aws_storage_ony_report_downloader = AWSReportDownloader(
+        self.aws_storage_only_report_downloader = AWSReportDownloader(
             **{
                 "customer_name": self.fake_customer_name,
                 "credentials": self.credentials,
@@ -578,7 +578,7 @@ class AWSReportDownloaderTest(MasuTestCase):
         """Test _get_manifest method w storage only."""
         mock_datetime = DateAccessor().today()
 
-        result = self.aws_storage_ony_report_downloader.get_manifest_context_for_date(mock_datetime)
+        result = self.aws_storage_only_report_downloader.get_manifest_context_for_date(mock_datetime)
         self.assertEqual(result, {})
 
     @patch("masu.external.downloader.aws.aws_report_downloader.AWSReportDownloader._remove_manifest_file")

--- a/koku/providers/azure/provider.py
+++ b/koku/providers/azure/provider.py
@@ -10,6 +10,7 @@ from azure.common import AzureException
 from azure.core.exceptions import AzureError
 from azure.core.exceptions import HttpResponseError
 from msrest.exceptions import ClientException
+from rest_framework import serializers
 from rest_framework.serializers import ValidationError
 
 from ..provider_errors import ProviderErrors
@@ -118,13 +119,18 @@ class AzureProvider(ProviderInterface):
 
         self._verify_patch_entries(subscription_id, resource_group, storage_account, scope, export_name)
 
+        storage_only = data_source.get("storage-only")
+        if storage_only:
+            # Limited storage access
+            return True
+
         try:
             azure_service = AzureService(
                 **credentials,
                 resource_group_name=resource_group,
                 storage_account_name=storage_account,
                 scope=scope,
-                export_name=export_name
+                export_name=export_name,
             )
             azure_client = AzureClientFactory(**credentials)
             storage_accounts = azure_client.storage_client.storage_accounts
@@ -186,3 +192,24 @@ class AzureProvider(ProviderInterface):
 
         """
         return []
+
+    def is_file_reachable(self, source, reports_list):
+        """Verify that report files are accessible in Azure."""
+        resource_group = source.billing_source.data_source.get("resource_group")
+        storage_account = source.billing_source.data_source.get("storage_account")
+        subscription_id = source.authentication.credentials.get("subscription_id")
+        tenant_id = source.authentication.credentials.get("tenant_id")
+        client_id = source.authentication.credentials.get("client_id")
+        client_secret = source.authentication.credentials.get("client_secret")
+        azure_client = AzureClientFactory(subscription_id, tenant_id, client_id, client_secret)
+        storage_client = azure_client.cloud_storage_account(resource_group, storage_account)
+
+        for report in reports_list:
+            try:
+                container_name = report.split("/")[0]
+                report_key = report.split(container_name)[-1]
+                storage_client.get_blob_client(container_name, report_key)
+            except AzureCostReportNotFound:
+                internal_message = f"File {report_key} could not be found within container {container_name}."
+                key = ProviderErrors.AZURE_REPORT_NOT_FOUND
+                raise serializers.ValidationError(error_obj(key, internal_message))

--- a/koku/providers/provider_errors.py
+++ b/koku/providers/provider_errors.py
@@ -31,6 +31,7 @@ class ProviderErrors:
     AZURE_BILLING_SOURCE_NOT_FOUND = "billing_source.data_source.notfound"
     AZURE_CREDENTAL_UNREACHABLE = "authentication.credentials.unreachable"
     AZURE_CLIENT_ERROR = "azure.exception"
+    AZURE_REPORT_NOT_FOUND = "report.notfound"
 
     GCP_INCORRECT_IAM_PERMISSIONS = "gcp.iam.permissions"
 


### PR DESCRIPTION
## Jira Ticket

[COST-3502](https://issues.redhat.com/browse/COST-3502)

## Description

This change will enable Azure storage only sources with post reports

## Testing

1.  Checkout Branch
2. Restart Koku
3. Create a storage-only Azure source - data-source includes
    {
    "resource_group":"group",
    "storage_account":"store-account",
    "storage-only": "True"
    },
4. Post to the new endpoint a marketplace report stored in S3
    a. Endpoint: /api/cost-management/v1/ingress/reports/
    b. Example: {"provider": "9e7159f1-c5fe-4455-9881-ee730654cf84", "reports_list": ["MY_container/2023/01/18/34472771-acab-4ca4-8c6a-8721d9b91188/cc3ecf82-9960-4f02-9a31-b9163f75e6b7.csv"]}
5. See that the data is ingested correctly


## Notes

...
