### PR TITLE
[COST-3247] Reduce complexity of `_get_manifest()`

### DIFF
--- a/koku/masu/test/external/downloader/azure/test_azure_report_downloader.py
+++ b/koku/masu/test/external/downloader/azure/test_azure_report_downloader.py
@@ -188,7 +188,7 @@ class AzureReportDownloaderTest(MasuTestCase):
     def test_get_manifest_json_manifest(self, mock_azure_service):
         self.downloader._get_manifest(self.mock_data.manifest_test_date)
 
-    @patch.object(MockAzureService, "download_file", side_effect=AzureReportDownloaderError)
+    @patch.object(MockAzureService, "download_file", side_effect=AzureCostReportNotFound("Raised intentionally"))
     @patch("masu.external.downloader.azure.azure_report_downloader.AzureService", new_callable=MockAzureService)
     def test_get_manifest_json_manifest_not_found(self, mock_azure_service, mock_download_file):
         result = self.downloader._get_manifest(self.mock_data.manifest_test_date)
@@ -200,8 +200,9 @@ class AzureReportDownloaderTest(MasuTestCase):
             "masu.external.downloader.azure.azure_report_downloader.json.load",
             side_effect=json.JSONDecodeError("Raised intentionally", "doc", 42),
         ):
-            with self.assertRaisesRegex(AzureReportDownloaderError, "Raised intentionally"):
-                self.downloader._get_manifest(self.mock_data.manifest_test_date)
+            result = self.downloader._get_manifest(self.mock_data.manifest_test_date)
+
+        self.assertEqual(result, ({}, None))
 
     @patch("masu.external.downloader.azure.azure_report_downloader.LOG")
     def test_get_manifest_report_not_found(self, log_mock):


### PR DESCRIPTION
## Jira Ticket

[COST-3247](https://issues.redhat.com/browse/COST-3247)

## Description
Follow up to #4064.

Move cost export blob and JSON manifest processing logic into separate methods

Refine exception handling by catching exceptions that can be raised a couple layers deep in the call stack. For the most part, log and return rather than raising `AzureReportDownloaderError`. I’m not confident this is the correct pattern. Do we want to raise `AzureReportDownloaderError` and have that be unhandled, or is it better to log and return an empty manifest which results in a no-op for processing?

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

