### PR TITLE
fix `cannot call jsonb_object_keys on a scalar`

### DIFF
--- a/koku/masu/database/sql/reporting_ocpusagelineitem_daily_summary_update_enabled_tags.sql
+++ b/koku/masu/database/sql/reporting_ocpusagelineitem_daily_summary_update_enabled_tags.sql
@@ -4,8 +4,8 @@ with cte_enabled_keys as (
       from {{schema | sqlsafe}}.reporting_ocpenabledtagkeys
 )
 update {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary as lids
-   set pod_labels = pod_labels - array_subtract(array(select jsonb_object_keys(coalesce(pod_labels, '{}'::jsonb)))::text[], keys::text[]),
-       volume_labels = volume_labels - array_subtract(array(select jsonb_object_keys(coalesce(volume_labels, '{}'::jsonb)))::text[], keys::text[])
+   set pod_labels = pod_labels - array_subtract(array(select jsonb_object_keys(coalesce(nullif(pod_labels, '"{}"')::jsonb, '{}'::jsonb)))::text[], keys::text[]),
+       volume_labels = volume_labels - array_subtract(array(select jsonb_object_keys(coalesce(nullif(volume_labels, '"{}"')::jsonb, '{}'::jsonb)))::text[], keys::text[])
   from cte_enabled_keys as ek
  where ek.keys != '{}'::text[]
    and lids.usage_start >= date({{start_date}})


### PR DESCRIPTION
## Jira Ticket

[COST-####](https://issues.redhat.com/browse/COST-####)

## Description

The `reporting_ocpusagelineitem_daily_summary` table contains some `pod_labels` or `volume_labels` whose values are `"{}"`.

```
postgres=# select array(select jsonb_object_keys(coalesce('"{}"', '{}'::jsonb)))::text[];
ERROR:  cannot call jsonb_object_keys on a scalar
```

This fix uses `nullif` in the coalesce to convert the `"{}"` values to null which allows the coalesce to work:
```
postgres=# select array(select jsonb_object_keys(coalesce(nullif('"{}"', '"{}"')::jsonb, '{}'::jsonb)))::text[];
 array 
-------
 {}
(1 row)
```


## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Notes

...
