### PR TITLE
[COST-2986] Add `CACHE_TIMEOUT` to deploy config

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -135,6 +135,8 @@ objects:
           value: ${ENHANCED_ORG_ADMIN}
         - name: RBAC_CACHE_TIMEOUT
           value: ${RBAC_CACHE_TIMEOUT}
+        - name: CACHE_TIMEOUT
+          value: ${CACHE_TIMEOUT}
         image: ${IMAGE}:${IMAGE_TAG}
         initContainers:
         - command:
@@ -2904,6 +2906,9 @@ parameters:
 - displayName: RBAC_CACHE_TIMEOUT
   name: RBAC_CACHE_TIMEOUT
   value: "300"
+- displayName: Middleware Timeout
+  name: CACHE_TIMEOUT
+  value: "3600"
 - displayName: Minimum replicas
   name: KOKU_MIN_REPLICAS
   required: true

--- a/deploy/kustomize/base/base.yaml
+++ b/deploy/kustomize/base/base.yaml
@@ -424,3 +424,6 @@ parameters:
 - name: RBAC_CACHE_TIMEOUT
   displayName: RBAC_CACHE_TIMEOUT
   value: "300"
+- name: CACHE_TIMEOUT
+  displayName: Middleware Timeout
+  value: "3600"

--- a/deploy/kustomize/patches/koku.yaml
+++ b/deploy/kustomize/patches/koku.yaml
@@ -135,6 +135,8 @@
           value: ${ENHANCED_ORG_ADMIN}
         - name: RBAC_CACHE_TIMEOUT
           value: ${RBAC_CACHE_TIMEOUT}
+        - name: CACHE_TIMEOUT
+          value: ${CACHE_TIMEOUT}
       livenessProbe:
         httpGet:
           path: ${API_PATH_PREFIX}/v1/status/


### PR DESCRIPTION
## Jira Ticket

[COST-2986](https://issues.redhat.com/browse/COST-2986)

## Description

This allows us to control the sources API timeout in our deployments, helping out with testing.

Related to #3712.
