### PR TITLE
COST-3441 (pt2): Update transform data to handle grouping aws_category.

### DIFF
--- a/koku/api/report/aws/openshift/provider_map.py
+++ b/koku/api/report/aws/openshift/provider_map.py
@@ -70,6 +70,7 @@ class OCPAWSProviderMap(ProviderMap):
                 },
                 "group_by_options": ["account", "service", "region", "cluster", "project", "node", "product_family"],
                 "tag_column": "tags",
+                "aws_category_column": "aws_cost_category",
                 "report_type": {
                     "costs": {
                         "aggregates": {

--- a/koku/api/report/aws/provider_map.py
+++ b/koku/api/report/aws/provider_map.py
@@ -73,6 +73,7 @@ class AWSProviderMap(ProviderMap):
                 },
                 "group_by_options": ["service", "account", "region", "az", "product_family", "org_unit_id"],
                 "tag_column": "tags",
+                "aws_category_column": "cost_category",
                 "report_type": {
                     "costs": {
                         "aggregates": {

--- a/koku/api/report/provider_map.py
+++ b/koku/api/report/provider_map.py
@@ -96,11 +96,6 @@ class ProviderMap:
         return report_specific_column if report_specific_column else default
 
     @property
-    def aws_category_column(self):
-        """Return the appropriate query table for the report type."""
-        return self._provider_map.get("aws_category_column")
-
-    @property
     def cost_units_key(self):
         """Return the cost_units_key property."""
         return self._report_type_map.get("cost_units_key")

--- a/koku/api/report/provider_map.py
+++ b/koku/api/report/provider_map.py
@@ -96,6 +96,11 @@ class ProviderMap:
         return report_specific_column if report_specific_column else default
 
     @property
+    def aws_category_column(self):
+        """Return the appropriate query table for the report type."""
+        return self._provider_map.get("aws_category_column")
+
+    @property
     def cost_units_key(self):
         """Return the cost_units_key property."""
         return self._report_type_map.get("cost_units_key")

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -265,16 +265,16 @@ class ReportQueryHandler(QueryHandler):
         )
         # aws_category prefixed filters
         aws_category_exclusion_composed = None
-        if self.is_aws:
+        if aws_category_column := self._mapper.provider_map.get("aws_category_column"):
             aws_category_filters = self.get_aws_category_keys("filter")
             aws_category_group_by = self.get_aws_category_keys("group_by")
             aws_category_filters.extend(aws_category_group_by)
             filter_collection = self._set_prefix_based_filters(
-                filter_collection, self._mapper.aws_category_column, aws_category_filters, AWS_CATEGORY_PREFIX
+                filter_collection, aws_category_column, aws_category_filters, AWS_CATEGORY_PREFIX
             )
             aws_category_exclude_filters = self.get_aws_category_keys("exclude")
             aws_category_exclusion_composed = self._set_prefix_based_exclusions(
-                self._mapper.aws_category_column, aws_category_exclude_filters, AWS_CATEGORY_PREFIX
+                aws_category_column, aws_category_exclude_filters, AWS_CATEGORY_PREFIX
             )
 
         composed_filters = filter_collection.compose()
@@ -668,10 +668,10 @@ class ReportQueryHandler(QueryHandler):
     def _get_aws_category_group_by(self):
         """Return list of aws_category based group by parameters."""
         group_by = []
-        if self._mapper.aws_category_column:
+        if aws_category_column := self._mapper.provider_map.get("aws_category_column"):
             groups = self.get_aws_category_keys("group_by")
             for aws_category in groups:
-                db_name = self._mapper.aws_category_column + "__" + strip_prefix(aws_category, AWS_CATEGORY_PREFIX)
+                db_name = aws_category_column + "__" + strip_prefix(aws_category, AWS_CATEGORY_PREFIX)
                 group_data = self.parameters.get_group_by(aws_category)
                 if group_data:
                     aws_category = quote_plus(aws_category)
@@ -768,8 +768,8 @@ class ReportQueryHandler(QueryHandler):
         """build grouping prefix"""
         check_pack_prefix = None
         prefix_mapping = {TAG_PREFIX: self._mapper.tag_column}
-        if self._mapper.aws_category_column:
-            prefix_mapping[AWS_CATEGORY_PREFIX] = self._mapper.aws_category_column
+        if aws_category_column := self._mapper.provider_map.get("aws_category_column"):
+            prefix_mapping[AWS_CATEGORY_PREFIX] = aws_category_column
         for prefix, db_column in prefix_mapping.items():
             if group.startswith(db_column + "__"):
                 group = group[len(db_column + "__") :]  # noqa


### PR DESCRIPTION
## Jira Ticket

[COST-3441](https://issues.redhat.com/browse/COST-3441)

## Description

This change will update how the data is returned for when we group by aws_category. 

## Testing

1. Checkout Branch
1a. https://github.com/project-koku/nise/pull/431
^ populate data with
3. Hit Endpoint: 
```
http://localhost:8000/api/cost-management/v1/reports/aws/costs/?filter[time_scope_units]=month&filter[resolution]=monthly&group_by[aws_category:ninja]=*
```

## Notes
I attached a sample response from main & this branch to make it easier to see the difference. 
...
[this_branch.txt](https://github.com/project-koku/koku/files/10874525/after.txt)
[main.txt](https://github.com/project-koku/koku/files/10874524/before.txt)
