### PR TITLE
[COST-3082] Correct pagination of AWS S3 regions API

### DIFF
--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -4029,16 +4029,24 @@
                 ],
                 "summary": "List available AWS S3 regions",
                 "operationId": "getAWSS3Regions",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/QueryLimit"
+                    },
+                    {
+                        "$ref": "#/components/parameters/QueryOffset"
+                    }
+                ],
                 "responses": {
                     "200": {
-                        "description": "An object containing available regions",
+                        "description": "List of available S3 regions",
                         "content": {
                             "application/json": {
                                 "schema": {
                                     "type": "object",
-                                    "description": "Dictionary key is 'regions'. Value is list of available regions.",
+                                    "description": "List of available S3 regions.",
                                     "example": {
-                                        "regions": [
+                                        "data": [
                                             "af-south-1",
                                             "ap-east-1",
                                             "ap-northeast-1",

--- a/koku/sources/api/view.py
+++ b/koku/sources/api/view.py
@@ -126,7 +126,7 @@ class SourcesViewSet(*MIXIN_LIST):
     @action(methods=["get"], detail=False, permission_classes=[AllowAny], url_path="aws-s3-regions")
     def aws_s3_regions(self, request):
         regions = get_available_regions("s3")
-        return ListPaginator([{"regions": regions}], request).paginated_response
+        return ListPaginator(regions, request).paginated_response
 
     def get_serializer_class(self):
         """Return the appropriate serializer depending on the method."""

--- a/koku/sources/test/api/test_view.py
+++ b/koku/sources/test/api/test_view.py
@@ -117,7 +117,8 @@ class SourcesViewTests(IamTestCase):
             self.assertEqual(body.get("meta").get("count"), 1)
 
     def test_aws_s3_regions(self):
-        expected_subset = {
+        """Given a request for AWS S3 regions, a subset of all available regions should be returned"""
+        all_regions = {
             "af-south-1",
             "ap-east-1",
             "ap-northeast-1",
@@ -147,11 +148,25 @@ class SourcesViewTests(IamTestCase):
             "us-west-2",
         }
         response = self.client.get(reverse("sources-aws-s3-regions"), **self.request_context["request"].META)
-        data = response.json()["data"]
-        regions = data[0]["regions"]
+        regions = response.json()["data"]
+        count = response.json()["meta"]["count"]
 
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(expected_subset.issubset(regions))
+        self.assertTrue(set(regions).issubset(all_regions))
+        self.assertTrue(len(all_regions) >= count)
+
+    def test_aws_s3_regions_pagination(self):
+        """Test that the API response is paginated"""
+        limit = 4
+
+        response = self.client.get(
+            reverse("sources-aws-s3-regions"),
+            {"limit": limit},
+            **self.request_context["request"].META,
+        )
+        regions = response.json()["data"]
+
+        self.assertEqual(len(regions), limit)
 
     def test_source_list_other_header(self):
         """Test the LIST endpoint with other auth header not matching test data."""


### PR DESCRIPTION
## Jira Ticket

[COST-3082](https://issues.redhat.com/browse/COST-3082)

## Description
Return the data directly in the data key so it will be properly paginated. Add tests to verify desired behavior.

## Testing

1. Checkout Branch
2. Restart Koku
3. Query the API with no parameters
```
> curl -s localhost:8000/api/cost-management/v1/sources/aws-s3-regions/ | jello
```

<details>
  <summary>Response</summary>

```  
{
  "meta": {
    "count": 27
  },
  "links": {
    "first": "/api/cost-management/v1/sources/aws-s3-regions/?limit=10&offset=0",
    "next": "/api/cost-management/v1/sources/aws-s3-regions/?limit=10&offset=10",
    "previous": null,
    "last": "/api/cost-management/v1/sources/aws-s3-regions/?limit=10&offset=17"
  },
  "data": [
    "af-south-1",
    "ap-east-1",
    "ap-northeast-1",
    "ap-northeast-2",
    "ap-northeast-3",
    "ap-south-1",
    "ap-south-2",
    "ap-southeast-1",
    "ap-southeast-2",
    "ap-southeast-3"
  ]
}
```
</details>

4. Query the API with `limit` and/or `offset` parameters:
```
> curl -s localhost:8000/api/cost-management/v1/sources/aws-s3-regions/'?limit=3' | jello
```
<details>
  <summary>Response</summary>
  
```
{
  "meta": {
    "count": 27
  },
  "links": {
    "first": "/api/cost-management/v1/sources/aws-s3-regions/?limit=3&offset=0",
    "next": "/api/cost-management/v1/sources/aws-s3-regions/?limit=3&offset=3",
    "previous": null,
    "last": "/api/cost-management/v1/sources/aws-s3-regions/?limit=3&offset=24"
  },
  "data": [
    "af-south-1",
    "ap-east-1",
    "ap-northeast-1"
  ]
}
```
</details>
