### PR TITLE
[COST-3082] Add `bucket_region` as an additional parameter for AWS sources

### DIFF
--- a/koku/providers/aws/provider.py
+++ b/koku/providers/aws/provider.py
@@ -50,7 +50,7 @@ def _get_sts_access(role_arn):
     )
 
 
-def _check_s3_access(bucket, credentials, region_name=None):
+def _check_s3_access(bucket, credentials, region_name="us-east-1"):
     """Check for access to s3 bucket."""
     s3_exists = True
     s3_resource = boto3.resource("s3", region_name=region_name, **credentials)

--- a/koku/providers/aws/provider.py
+++ b/koku/providers/aws/provider.py
@@ -136,14 +136,17 @@ class AWSProvider(ProviderInterface):
             internal_message = f"Unable to access account resources with ARN {credential_name}."
             raise serializers.ValidationError(error_obj(key, internal_message))
 
-        region_name = data_source.get("bucket_region")
-        s3_exists = _check_s3_access(storage_resource_name, creds, region_name)
+        region_kwargs = {}
+        if region_name := data_source.get("bucket_region"):
+            region_kwargs["region_name"] = region_name
+
+        s3_exists = _check_s3_access(storage_resource_name, creds, **region_kwargs)
         if not s3_exists:
             key = ProviderErrors.AWS_BILLING_SOURCE_NOT_FOUND
             internal_message = f"Bucket {storage_resource_name} could not be found with {credential_name}."
             raise serializers.ValidationError(error_obj(key, internal_message))
 
-        _check_cost_report_access(credential_name, creds, bucket=storage_resource_name, region_name=region_name)
+        _check_cost_report_access(credential_name, creds, bucket=storage_resource_name, **region_kwargs)
 
         return True
 

--- a/koku/sources/sources_http_client.py
+++ b/koku/sources/sources_http_client.py
@@ -43,8 +43,8 @@ ENDPOINT_SOURCES = "sources"
 ENDPOINT_SOURCE_TYPES = "source_types"
 APP_OPT_EXTRA_FEILD_MAP = {
     Provider.PROVIDER_OCP: [],
-    Provider.PROVIDER_AWS: ["storage_only"],
-    Provider.PROVIDER_AWS_LOCAL: ["storage_only"],
+    Provider.PROVIDER_AWS: ["storage_only", "bucket_region"],
+    Provider.PROVIDER_AWS_LOCAL: ["storage_only", "bucket_region"],
     Provider.PROVIDER_AZURE: ["scope", "export_name", "storage_only"],
     Provider.PROVIDER_AZURE_LOCAL: ["scope", "export_name", "storage_only"],
     Provider.PROVIDER_GCP: ["dataset", "bucket", "storage_only"],

--- a/koku/sources/test/test_sources_http_client.py
+++ b/koku/sources/test/test_sources_http_client.py
@@ -243,6 +243,11 @@ class SourcesHTTPClientTest(TestCase):
                 "expected": {"bucket": bucket, "storage_only": True},
             },
             {
+                "source-type": Provider.PROVIDER_AWS,
+                "json": {"extra": {"bucket": bucket, "bucket_region": "me-south-1"}},
+                "expected": {"bucket": bucket, "bucket_region": "me-south-1"},
+            },
+            {
                 "source-type": Provider.PROVIDER_AZURE,
                 "json": {
                     "extra": {


### PR DESCRIPTION
## Jira Ticket

[COST-3082](https://issues.redhat.com/browse/COST-3082)

## Description

Add `bucket_region` to AWS sources.

## Testing

1. Checkout Branch
2. Restart Koku
3. Start Sources API
4. Start Sources Client
5. Post an AWS source with `bucket_region` to the Sources API

    <details>
      <summary>Post command</summary>

    ```python
    import json
    import urllib.parse
    import urllib.request
    
    url = "http://localhost:3000/api/sources/v3.1/bulk_create"
    headers = {
        "x-rh-identity": (
            "eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjEwMDAxIiwib3JnX2lkIjoiMTIzNDU2NyIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJ1"
            "c2VybmFtZSI6InVzZXJfZGV2IiwiZW1haWwiOiJ1c2VyX2RldkBmb28uY29tIiwiaXNfb3JnX2FkbWluIjp0cnVlLCJhY2Nlc3MiOnsgfX19"
            "LCJlbnRpdGxlbWVudHMiOnsiY29zdF9tYW5hZ2VtZW50Ijp7ImlzX2VudGl0bGVkIjp0cnVlfX19Cg=="
        ),
        "x-rh-sources-psk": "thisMustBeEphemeralOrMinikube",
        "x-rh-sources-account-number": "10001",
        "Content-Type": "text/plain; charset=utf-8",
    }
    data = {
        "sources": [
            {
                "name": "region-test - aws",
                "app_creation_workflow": "manual_configuration",
                "source_type_name": "amazon",
            }
        ],
        "endpoints": [],
        "authentications": [
            {
                "authtype": "arn",
                "username": "arn:aws:iam::589173575008:role/CostManagement",
                "resource_type": "application",
                "resource_name": "/insights/platform/cost-management",
            },
        ],
        "applications": [
            {
                "application_type_name": "cost-management",
                "extra": {
                    "bucket": "cost-usage-bucket",
                    "bucket_region": "us-west-1",
                },
                "source_name": "region-test - aws",
            },
        ]
    }
    b_data = json.dumps(data).encode("utf-8")
    request = urllib.request.Request(url, b_data, headers)
    with urllib.request.urlopen(request) as response:
        response.read()
    ```
    </details>

6. Verify the `bucket_region` field is correctly stored for the source.

    <details>
      <summary>Get sources</summary>
      
    ```python
    import json
    import sys
    import urllib.request
    import urllib.error
    
    url = "http://localhost:8000/api/cost-management/v1/sources/"
    try:
        with urllib.request.urlopen(url) as file:
            data = file.read().decode("utf-8")
    except urllib.request.URLError as error:
        sys.exit(error)
    
    json_data = json.loads(data)
    source = [source for source in json_data["data"] if source["name"] == "region-test - aws"][0]
    
    print(json.dumps(source, indent=2))
    ```

    </details>

```json
      "billing_source": {
        "data_source": {
          "bucket": "cost-usage-bucket",
          "bucket_region": "us-west-1"
        }
      },
```