### PR TITLE
[COST-3577] - Respect OCPEnabledTagKeys for OCP on cloud

### DIFF
--- a/koku/api/report/all/openshift/view.py
+++ b/koku/api/report/all/openshift/view.py
@@ -11,6 +11,7 @@ from api.report.view import ReportView
 from reporting.models import AWSEnabledTagKeys
 from reporting.models import AzureEnabledTagKeys
 from reporting.models import GCPEnabledTagKeys
+from reporting.models import OCPEnabledTagKeys
 
 
 class OCPAllView(ReportView):
@@ -20,7 +21,7 @@ class OCPAllView(ReportView):
     provider = Provider.OCP_ALL
     serializer = OCPAllQueryParamSerializer
     query_handler = OCPAllReportQueryHandler
-    tag_handler = [AWSEnabledTagKeys, AzureEnabledTagKeys, GCPEnabledTagKeys]
+    tag_handler = [AWSEnabledTagKeys, AzureEnabledTagKeys, GCPEnabledTagKeys, OCPEnabledTagKeys]
 
 
 class OCPAllCostView(OCPAllView):

--- a/koku/api/report/aws/openshift/view.py
+++ b/koku/api/report/aws/openshift/view.py
@@ -10,6 +10,7 @@ from api.report.aws.openshift.query_handler import OCPAWSReportQueryHandler
 from api.report.aws.openshift.serializers import OCPAWSQueryParamSerializer
 from api.report.view import ReportView
 from reporting.models import AWSEnabledTagKeys
+from reporting.models import OCPEnabledTagKeys
 
 
 class OCPAWSView(ReportView):
@@ -19,7 +20,7 @@ class OCPAWSView(ReportView):
     provider = Provider.OCP_AWS
     serializer = OCPAWSQueryParamSerializer
     query_handler = OCPAWSReportQueryHandler
-    tag_handler = [AWSEnabledTagKeys]
+    tag_handler = [AWSEnabledTagKeys, OCPEnabledTagKeys]
 
 
 class OCPAWSCostView(OCPAWSView):

--- a/koku/api/report/azure/openshift/view.py
+++ b/koku/api/report/azure/openshift/view.py
@@ -10,6 +10,7 @@ from api.report.azure.openshift.query_handler import OCPAzureReportQueryHandler
 from api.report.azure.openshift.serializers import OCPAzureQueryParamSerializer
 from api.report.view import ReportView
 from reporting.models import AzureEnabledTagKeys
+from reporting.models import OCPEnabledTagKeys
 
 
 class OCPAzureView(ReportView):
@@ -19,7 +20,7 @@ class OCPAzureView(ReportView):
     provider = Provider.OCP_AZURE
     serializer = OCPAzureQueryParamSerializer
     query_handler = OCPAzureReportQueryHandler
-    tag_handler = [AzureEnabledTagKeys]
+    tag_handler = [AzureEnabledTagKeys, OCPEnabledTagKeys]
 
 
 class OCPAzureCostView(OCPAzureView):

--- a/koku/api/report/gcp/openshift/view.py
+++ b/koku/api/report/gcp/openshift/view.py
@@ -11,6 +11,7 @@ from api.report.gcp.openshift.query_handler import OCPGCPReportQueryHandler
 from api.report.gcp.openshift.serializers import OCPGCPQueryParamSerializer
 from api.report.view import ReportView
 from reporting.models import GCPEnabledTagKeys
+from reporting.models import OCPEnabledTagKeys
 
 
 class OCPGCPView(ReportView):
@@ -20,7 +21,7 @@ class OCPGCPView(ReportView):
     provider = Provider.OCP_GCP
     serializer = OCPGCPQueryParamSerializer
     query_handler = OCPGCPReportQueryHandler
-    tag_handler = [GCPEnabledTagKeys]
+    tag_handler = [GCPEnabledTagKeys, OCPEnabledTagKeys]
 
 
 class OCPGCPCostView(OCPGCPView):

--- a/koku/api/tags/all/openshift/view.py
+++ b/koku/api/tags/all/openshift/view.py
@@ -7,6 +7,7 @@ from api.common.permissions.openshift_all_access import OpenshiftAllAccessPermis
 from api.tags.all.openshift.queries import OCPAllTagQueryHandler
 from api.tags.all.openshift.serializers import OCPAllTagsQueryParamSerializer
 from api.tags.view import TagView
+from reporting.models import OCPEnabledTagKeys
 from reporting.provider.aws.models import AWSEnabledTagKeys
 from reporting.provider.azure.models import AzureEnabledTagKeys
 from reporting.provider.gcp.models import GCPEnabledTagKeys
@@ -18,5 +19,5 @@ class OCPAllTagView(TagView):
     provider = "ocp_all"
     serializer = OCPAllTagsQueryParamSerializer
     query_handler = OCPAllTagQueryHandler
-    tag_handler = [AWSEnabledTagKeys, AzureEnabledTagKeys, GCPEnabledTagKeys]
+    tag_handler = [AWSEnabledTagKeys, AzureEnabledTagKeys, GCPEnabledTagKeys, OCPEnabledTagKeys]
     permission_classes = [OpenshiftAllAccessPermission]

--- a/koku/api/tags/aws/openshift/view.py
+++ b/koku/api/tags/aws/openshift/view.py
@@ -8,6 +8,7 @@ from api.common.permissions.openshift_access import OpenShiftAccessPermission
 from api.tags.aws.openshift.queries import OCPAWSTagQueryHandler
 from api.tags.aws.openshift.serializers import OCPAWSTagsQueryParamSerializer
 from api.tags.view import TagView
+from reporting.models import OCPEnabledTagKeys
 from reporting.provider.aws.models import AWSEnabledTagKeys
 
 
@@ -17,5 +18,5 @@ class OCPAWSTagView(TagView):
     provider = "ocp_aws"
     serializer = OCPAWSTagsQueryParamSerializer
     query_handler = OCPAWSTagQueryHandler
-    tag_handler = [AWSEnabledTagKeys]
+    tag_handler = [AWSEnabledTagKeys, OCPEnabledTagKeys]
     permission_classes = [AwsAccessPermission & OpenShiftAccessPermission]

--- a/koku/api/tags/azure/openshift/view.py
+++ b/koku/api/tags/azure/openshift/view.py
@@ -8,6 +8,7 @@ from api.common.permissions.openshift_access import OpenShiftAccessPermission
 from api.tags.azure.openshift.queries import OCPAzureTagQueryHandler
 from api.tags.azure.openshift.serializers import OCPAzureTagsQueryParamSerializer
 from api.tags.view import TagView
+from reporting.models import OCPEnabledTagKeys
 from reporting.provider.azure.models import AzureEnabledTagKeys
 
 
@@ -17,5 +18,5 @@ class OCPAzureTagView(TagView):
     provider = "ocp_azure"
     serializer = OCPAzureTagsQueryParamSerializer
     query_handler = OCPAzureTagQueryHandler
-    tag_handler = [AzureEnabledTagKeys]
+    tag_handler = [AzureEnabledTagKeys, OCPEnabledTagKeys]
     permission_classes = [AzureAccessPermission & OpenShiftAccessPermission]

--- a/koku/api/tags/gcp/openshift/view.py
+++ b/koku/api/tags/gcp/openshift/view.py
@@ -8,6 +8,7 @@ from api.common.permissions.openshift_access import OpenShiftAccessPermission
 from api.tags.gcp.openshift.queries import OCPGCPTagQueryHandler
 from api.tags.gcp.openshift.serializers import OCPGCPTagsQueryParamSerializer
 from api.tags.view import TagView
+from reporting.models import OCPEnabledTagKeys
 from reporting.provider.gcp.models import GCPEnabledTagKeys
 
 
@@ -17,5 +18,5 @@ class OCPGCPTagView(TagView):
     provider = "ocp_gcp"
     serializer = OCPGCPTagsQueryParamSerializer
     query_handler = OCPGCPTagQueryHandler
-    tag_handler = [GCPEnabledTagKeys]
+    tag_handler = [GCPEnabledTagKeys, OCPEnabledTagKeys]
     permission_classes = [GcpAccessPermission & OpenShiftAccessPermission]


### PR DESCRIPTION
## Jira Ticket

[COST-3577](https://issues.redhat.com/browse/COST-3577)

## Description

This change will fix an issue where OCP label keys are being blocked from OCP on Cloud API calls. 

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Notes

...
