### PR TITLE
Azure fix assembly_id for customer filtered data

### DIFF
--- a/koku/masu/external/downloader/azure/azure_report_downloader.py
+++ b/koku/masu/external/downloader/azure/azure_report_downloader.py
@@ -150,7 +150,6 @@ class AzureReportDownloader(ReportDownloaderBase, DownloaderInterface):
 
         """
         manifest = {}
-        manifest["assemblyId"] = None
         if self.ingress_reports:
             report = self.ingress_reports[0].split(f"{self.container_name}/")[1]
             year = date_time.strftime("%Y")
@@ -217,7 +216,6 @@ class AzureReportDownloader(ReportDownloaderBase, DownloaderInterface):
                 LOG.info(log_json(self.tracing_id, f"Found cost export {report_name}", self.context))
                 manifest["reportKeys"] = [report_name]
 
-        if not manifest["assemblyId"]:
             try:
                 manifest["assemblyId"] = extract_uuids_from_string(report_name).pop()
             except IndexError:

--- a/koku/masu/test/external/downloader/azure/test_azure_report_downloader.py
+++ b/koku/masu/test/external/downloader/azure/test_azure_report_downloader.py
@@ -205,7 +205,6 @@ class AzureReportDownloaderTest(MasuTestCase):
         expected_start, expected_end = self.mock_data.month_range.split("-")
         manifest, _ = self.ingress_downloader._get_manifest(self.mock_data.test_date)
 
-        self.assertEqual(manifest.get("assemblyId"), self.mock_data.export_uuid)
         self.assertEqual(manifest.get("reportKeys"), [self.mock_data.ingress_report])
         self.assertEqual(manifest.get("Compression"), "PLAIN")
         self.assertEqual(manifest.get("billingPeriod").get("start"), expected_start)
@@ -217,7 +216,7 @@ class AzureReportDownloaderTest(MasuTestCase):
         self.ingress_downloader.tracing_id = "1111-2222-4444-5555"
         self.ingress_downloader._azure_client.get_file_for_key = Mock(side_effect=AzureCostReportNotFound("Oops!"))
         manifest, last_modified = self.ingress_downloader._get_manifest(self.mock_data.test_date)
-        self.assertEqual(manifest, {})
+        self.assertEqual(manifest, {"assemblyId": None})
         self.assertEqual(last_modified, None)
         call_arg = mock_log.info.call_args.args[0]
         self.assertEqual(call_arg.get("tracing_id"), self.ingress_downloader.tracing_id)
@@ -267,7 +266,7 @@ class AzureReportDownloaderTest(MasuTestCase):
             side_effect=AzureCostReportNotFound("Oops!")
         )
         manifest, last_modified = self.downloader._get_manifest(self.mock_data.test_date)
-        self.assertEqual(manifest, {})
+        self.assertEqual(manifest, {"assemblyId": None})
         self.assertEqual(last_modified, None)
         call_arg = log_mock.info.call_args.args[0]
         self.assertEqual(call_arg.get("tracing_id"), self.downloader.tracing_id)

--- a/koku/masu/test/external/downloader/azure/test_azure_report_downloader.py
+++ b/koku/masu/test/external/downloader/azure/test_azure_report_downloader.py
@@ -216,7 +216,7 @@ class AzureReportDownloaderTest(MasuTestCase):
         self.ingress_downloader.tracing_id = "1111-2222-4444-5555"
         self.ingress_downloader._azure_client.get_file_for_key = Mock(side_effect=AzureCostReportNotFound("Oops!"))
         manifest, last_modified = self.ingress_downloader._get_manifest(self.mock_data.test_date)
-        self.assertEqual(manifest, {"assemblyId": None})
+        self.assertEqual(manifest, {})
         self.assertEqual(last_modified, None)
         call_arg = mock_log.info.call_args.args[0]
         self.assertEqual(call_arg.get("tracing_id"), self.ingress_downloader.tracing_id)
@@ -266,7 +266,7 @@ class AzureReportDownloaderTest(MasuTestCase):
             side_effect=AzureCostReportNotFound("Oops!")
         )
         manifest, last_modified = self.downloader._get_manifest(self.mock_data.test_date)
-        self.assertEqual(manifest, {"assemblyId": None})
+        self.assertEqual(manifest, {})
         self.assertEqual(last_modified, None)
         call_arg = log_mock.info.call_args.args[0]
         self.assertEqual(call_arg.get("tracing_id"), self.downloader.tracing_id)


### PR DESCRIPTION
## Jira Ticket

[COST-3596](https://issues.redhat.com/browse/COST-3596)

## Description

This change will add assembly ids for customer filtered data reports.

## Testing

1. Checkout Branch
2. Restart Koku
3. Add azure storage only source
4. post a report for your Azure container without a UUID in the filename

## Notes

...
