### PR TITLE
[COST-3630] use legacy types for HCS trino queries

### DIFF
--- a/koku/hcs/database/report_db_accessor.py
+++ b/koku/hcs/database/report_db_accessor.py
@@ -64,6 +64,7 @@ class HCSReportDBAccessor(ReportDBAccessorBase):
         )
 
         try:
+            conn_params = {"legacy_primitive_types": True}
             sql = pkgutil.get_data("hcs.database", sql_summary_file)
             sql = sql.decode("utf-8")
             table = HCS_TABLE_MAP.get(provider)
@@ -85,7 +86,9 @@ class HCSReportDBAccessor(ReportDBAccessorBase):
             LOG.debug(log_json(tracing_id, f"SQL params: {sql_params}"))
 
             sql, sql_params = self.jinja_sql.prepare_query(sql, sql_params)
-            data, description = self._execute_trino_raw_sql_query_with_description(sql, sql_params=sql_params)
+            data, description = self._execute_trino_raw_sql_query_with_description(
+                sql, sql_params=sql_params, conn_params=conn_params
+            )
             # The format for the description is:
             # [(name, type_code, display_size, internal_size, precision, scale, null_ok)]
             # col[0] grabs the column names from the query results

--- a/koku/koku/trino_database.py
+++ b/koku/koku/trino_database.py
@@ -51,6 +51,7 @@ def connect(**connect_args):
             or IsolationLevel.AUTOCOMMIT
         ),
         "schema": connect_args["schema"],
+        "legacy_primitive_types": connect_args.get("legacy_primitive_types", False),
     }
     return trino.dbapi.connect(**trino_connect_args)
 

--- a/koku/masu/database/report_db_accessor_base.py
+++ b/koku/masu/database/report_db_accessor_base.py
@@ -377,14 +377,16 @@ class ReportDBAccessorBase(KokuDBAccess):
         return results
 
     def _execute_trino_raw_sql_query_with_description(
-        self, sql, *, sql_params=None, log_ref="Trino query", attempts_left=0
+        self, sql, *, sql_params=None, log_ref="Trino query", attempts_left=0, conn_params=None
     ):
         """Execute a single trino query and return cur.fetchall and cur.description"""
         if sql_params is None:
             sql_params = {}
+        if conn_params is None:
+            conn_params = {}
         sql, bind_params = self.trino_prepare_query(sql, sql_params)
         t1 = time.time()
-        trino_conn = trino_db.connect(schema=self.schema)
+        trino_conn = trino_db.connect(schema=self.schema, **conn_params)
         try:
             trino_cur = trino_conn.cursor()
             trino_cur.execute(sql, bind_params)


### PR DESCRIPTION
## Jira Ticket

[COST-3630](https://issues.redhat.com/browse/COST-3630)

## Description

This change will use `legacy_primitive_types` when connecting to trino for HCS purposes so we do not change the format of the timestamps in the produced CSV. We jumped to release 321 and that included a breaking change that is impacting the way the HCS timestamps are presented causing an issue for processing down the line. https://github.com/trinodb/trino-python-client/blob/master/CHANGES.md#breaking-changes 

## Testing

1. Checkout Branch
2. set in your .env: `ENABLE_HCS_DEBUG=True`
3. Restart Koku
4. Create and load test customer data: `make create-test-customer` followed by `make load-test-customer-data`
5. Once data loads, you should be able to go to minio and check the HCS files and see the timestamps on relevant columns show in the expected format: `yyyy-MM-dd HH:mm:ss.SSS` 
6. On main the format would be `yyyy-MM-dd`
7. For example the `lineitem_usagestartdate` column for AWS would be a column to check.

## Notes

...
