### PR TITLE
[COST-3632] Do not insert into `reporting_ocptags_values` on conflict

### DIFF
--- a/koku/masu/database/sql/reporting_ocpstoragevolumelabel_summary.sql
+++ b/koku/masu/database/sql/reporting_ocpstoragevolumelabel_summary.sql
@@ -156,6 +156,7 @@ WHERE not exists (
            WHERE rp.key = tv.key
              AND rp.value = tv.value
       )
+ON CONFLICT DO NOTHING
 ;
 
 


### PR DESCRIPTION
## Jira Ticket

[COST-3632](https://issues.redhat.com/browse/COST-3632)

## Description

Ignore conflicts (specifically duplicate key and value) when inserting into the `reporting_ocptags_values` table.

## Testing

1. Checkout Branch
2. Restart Koku
3. Create test customer data with a local OCP source
4. Insert duplicate record into the `org1234567.reporting_ocptags_values` table that has a value for 'version' 
5. Delete records with a 'version' key from the `org1234567.reporting_ocptags_values` table.
6. Trigger the following API with the correct source UUID: `http://127.0.0.1:5042/api/cost-management/v1/report_data/`
