### PR TITLE
pr_check.sh - Use string comparison operators

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -185,10 +185,10 @@ if [[ $exit_code == 0 ]]; then
     fi
 fi
 
-if [[ $exit_code > 0 ]]; then
+if [[ $exit_code -gt 0 ]]; then
     echo "PR check failed"
     make_failed_results_xml
-elif [[ $exit_code < 0 ]]; then
+elif [[ $exit_code -lt 0 ]]; then
     echo "PR check skipped"
     make_skipped_xml
     exit_code=0


### PR DESCRIPTION
## Description

SC2071 (error): > is for string comparisons. Use -gt instead.
SC2071 (error): < is for string comparisons. Use -lt instead.

https://www.shellcheck.net/wiki/SC2071

## Testing

1. Run `pr_check.sh`

## Notes

This is currently working as desired but by accident. The `<>` string comparison operators return true or false based on the lexicographical sorting of strings.
