### PR TITLE
COST: Allow nginx to listen on 9000 port for metrics endpoint

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -2761,6 +2761,7 @@ objects:
         server {
           error_log  stderr;
           listen 8000;
+          listen 9000;
 
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
           proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;

--- a/deploy/kustomize/base/base.yaml
+++ b/deploy/kustomize/base/base.yaml
@@ -165,6 +165,7 @@ objects:
         server {
           error_log  stderr;
           listen 8000;
+          listen 9000;
 
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
           proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;


### PR DESCRIPTION
* Allow nginx to listen on 9000 port for metrics endpoint