### PR TITLE
setting GCP etag to None as unused

### DIFF
--- a/koku/masu/external/downloader/gcp/gcp_report_downloader.py
+++ b/koku/masu/external/downloader/gcp/gcp_report_downloader.py
@@ -499,7 +499,7 @@ class GCPReportDownloader(ReportDownloaderBase, DownloaderInterface):
             self.ingress_reports,
         )
 
-        return key, filename, DateHelper().today, file_names, date_range
+        return key, None, DateHelper().today, file_names, date_range
 
     def _get_local_directory_path(self):
         """


### PR DESCRIPTION
## Jira Ticket

## Description

This change will set GCP etag to None since its not used and we currently store the full filename which is useless :sweat_smile: 

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Notes

...
