### PR TITLE
[COST-3615] aws category serializer sanity

### DIFF
--- a/koku/api/report/test/aws/test_views.py
+++ b/koku/api/report/test/aws/test_views.py
@@ -597,3 +597,9 @@ class AWSReportViewTest(IamTestCase):
             url = reverse("reports-aws-instance-type") + qs
             response = self.client.get(url, **self.headers)
             self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_invalid_aws_category_key(self):
+        """Test invalid aws category key."""
+        url = reverse("reports-aws-costs") + "?group_by[aws_categroy:invalid]=value"
+        response = self.client.get(url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
## Jira Ticket

[COST-3615](https://issues.redhat.com/browse/COST-3615)

## Description

This change will update the aws_category functionality to require that the keys passed in as parameters to exist within the `AWSCategorySummary` model. 

Currently Blocked by:
1. https://github.com/project-koku/koku/pull/4234
2. https://github.com/project-koku/koku/pull/4235

## Notes

...
