### PR TITLE
remove `metrics` from webServices

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -197,8 +197,6 @@ objects:
             secretName: koku-oci
       replicas: ${{KOKU_REPLICAS}}
       webServices:
-        metrics:
-          enabled: true
         private:
           enabled: false
         public:
@@ -255,8 +253,6 @@ objects:
           name: koku-api-nginx-conf
       replicas: ${{NGINX_REPLICAS}}
       webServices:
-        metrics:
-          enabled: true
         private:
           enabled: false
         public:
@@ -422,8 +418,6 @@ objects:
             secretName: koku-oci
       replicas: ${{LISTENER_REPLICAS}}
       webServices:
-        metrics:
-          enabled: true
         private:
           enabled: false
         public:
@@ -615,8 +609,6 @@ objects:
             secretName: koku-oci
       replicas: ${{MASU_REPLICAS}}
       webServices:
-        metrics:
-          enabled: true
         private:
           enabled: true
         public:
@@ -796,8 +788,6 @@ objects:
             secretName: koku-oci
       replicas: ${{SCHEDULER_REPLICAS}}
       webServices:
-        metrics:
-          enabled: false
         private:
           enabled: false
         public:
@@ -962,8 +952,6 @@ objects:
             secretName: koku-oci
       replicas: ${{SOURCES_CLIENT_REPLICAS}}
       webServices:
-        metrics:
-          enabled: true
         private:
           enabled: true
         public:
@@ -1135,8 +1123,6 @@ objects:
             secretName: koku-oci
       replicas: ${{SOURCES_LISTENER_REPLICAS}}
       webServices:
-        metrics:
-          enabled: true
         private:
           enabled: false
         public:
@@ -1322,8 +1308,6 @@ objects:
             secretName: koku-oci
       replicas: ${{WORKER_CELERY_REPLICAS}}
       webServices:
-        metrics:
-          enabled: true
         private:
           enabled: false
         public:
@@ -1511,8 +1495,6 @@ objects:
             secretName: koku-oci
       replicas: ${{WORKER_COST_MODEL_REPLICAS}}
       webServices:
-        metrics:
-          enabled: true
         private:
           enabled: false
         public:
@@ -1698,8 +1680,6 @@ objects:
             secretName: koku-oci
       replicas: ${{WORKER_DOWNLOAD_REPLICAS}}
       webServices:
-        metrics:
-          enabled: true
         private:
           enabled: false
         public:
@@ -1887,8 +1867,6 @@ objects:
             secretName: koku-oci
       replicas: ${{WORKER_OCP_REPLICAS}}
       webServices:
-        metrics:
-          enabled: true
         private:
           enabled: false
         public:
@@ -2074,8 +2052,6 @@ objects:
             secretName: koku-oci
       replicas: ${{WORKER_PRIORITY_REPLICAS}}
       webServices:
-        metrics:
-          enabled: true
         private:
           enabled: false
         public:
@@ -2263,8 +2239,6 @@ objects:
             secretName: koku-oci
       replicas: ${{WORKER_REFRESH_REPLICAS}}
       webServices:
-        metrics:
-          enabled: true
         private:
           enabled: false
         public:
@@ -2452,8 +2426,6 @@ objects:
             secretName: koku-oci
       replicas: ${{WORKER_SUMMARY_REPLICAS}}
       webServices:
-        metrics:
-          enabled: true
         private:
           enabled: false
         public:
@@ -2643,8 +2615,6 @@ objects:
             secretName: koku-oci
       replicas: ${{WORKER_HCS_REPLICAS}}
       webServices:
-        metrics:
-          enabled: true
         private:
           enabled: false
         public:

--- a/deploy/kustomize/patches/koku.yaml
+++ b/deploy/kustomize/patches/koku.yaml
@@ -8,8 +8,6 @@
         enabled: true
       private:
         enabled: false
-      metrics:
-        enabled: true
     podSpec:
       image: ${IMAGE}:${IMAGE_TAG}
       initContainers:

--- a/deploy/kustomize/patches/listener.yaml
+++ b/deploy/kustomize/patches/listener.yaml
@@ -8,8 +8,6 @@
         enabled: false
       private:
         enabled: false
-      metrics:
-        enabled: true
     podSpec:
       image: ${IMAGE}:${IMAGE_TAG}
       command:

--- a/deploy/kustomize/patches/masu.yaml
+++ b/deploy/kustomize/patches/masu.yaml
@@ -8,8 +8,6 @@
         enabled: false
       private:
         enabled: true
-      metrics:
-        enabled: true
     podSpec:
       metadata:
         annotations:

--- a/deploy/kustomize/patches/nginx.yaml
+++ b/deploy/kustomize/patches/nginx.yaml
@@ -9,8 +9,6 @@
         apiPath: cost-management
       private:
         enabled: false
-      metrics:
-        enabled: true
     podSpec:
       image: quay.io/app-sre/ubi8-nginx-118
       command:

--- a/deploy/kustomize/patches/scheduler.yaml
+++ b/deploy/kustomize/patches/scheduler.yaml
@@ -8,8 +8,6 @@
         enabled: false
       private:
         enabled: false
-      metrics:
-        enabled: false
     podSpec:
       metadata:
         annotations:

--- a/deploy/kustomize/patches/sources-client.yaml
+++ b/deploy/kustomize/patches/sources-client.yaml
@@ -8,8 +8,6 @@
         enabled: false
       private:
         enabled: true
-      metrics:
-        enabled: true
     podSpec:
       image: ${IMAGE}:${IMAGE_TAG}
       env:

--- a/deploy/kustomize/patches/sources-listener.yaml
+++ b/deploy/kustomize/patches/sources-listener.yaml
@@ -8,8 +8,6 @@
         enabled: false
       private:
         enabled: false
-      metrics:
-        enabled: true
     podSpec:
       metadata:
         annotations:

--- a/deploy/kustomize/patches/worker-celery.yaml
+++ b/deploy/kustomize/patches/worker-celery.yaml
@@ -8,8 +8,6 @@
         enabled: false
       private:
         enabled: false
-      metrics:
-        enabled: true
     podSpec:
       image: ${IMAGE}:${IMAGE_TAG}
       command:

--- a/deploy/kustomize/patches/worker-cost-model.yaml
+++ b/deploy/kustomize/patches/worker-cost-model.yaml
@@ -8,8 +8,6 @@
         enabled: false
       private:
         enabled: false
-      metrics:
-        enabled: true
     podSpec:
       image: ${IMAGE}:${IMAGE_TAG}
       command:

--- a/deploy/kustomize/patches/worker-download.yaml
+++ b/deploy/kustomize/patches/worker-download.yaml
@@ -8,8 +8,6 @@
         enabled: false
       private:
         enabled: false
-      metrics:
-        enabled: true
     podSpec:
       image: ${IMAGE}:${IMAGE_TAG}
       command:

--- a/deploy/kustomize/patches/worker-hcs.yaml
+++ b/deploy/kustomize/patches/worker-hcs.yaml
@@ -8,8 +8,6 @@
         enabled: false
       private:
         enabled: false
-      metrics:
-        enabled: true
     podSpec:
       image: ${IMAGE}:${IMAGE_TAG}
       command:

--- a/deploy/kustomize/patches/worker-ocp.yaml
+++ b/deploy/kustomize/patches/worker-ocp.yaml
@@ -8,8 +8,6 @@
         enabled: false
       private:
         enabled: false
-      metrics:
-        enabled: true
     podSpec:
       image: ${IMAGE}:${IMAGE_TAG}
       command:

--- a/deploy/kustomize/patches/worker-priority.yaml
+++ b/deploy/kustomize/patches/worker-priority.yaml
@@ -8,8 +8,6 @@
         enabled: false
       private:
         enabled: false
-      metrics:
-        enabled: true
     podSpec:
       image: ${IMAGE}:${IMAGE_TAG}
       command:

--- a/deploy/kustomize/patches/worker-refresh.yaml
+++ b/deploy/kustomize/patches/worker-refresh.yaml
@@ -8,8 +8,6 @@
         enabled: false
       private:
         enabled: false
-      metrics:
-        enabled: true
     podSpec:
       image: ${IMAGE}:${IMAGE_TAG}
       command:

--- a/deploy/kustomize/patches/worker-summary.yaml
+++ b/deploy/kustomize/patches/worker-summary.yaml
@@ -8,8 +8,6 @@
         enabled: false
       private:
         enabled: false
-      metrics:
-        enabled: true
     podSpec:
       image: ${IMAGE}:${IMAGE_TAG}
       command:


### PR DESCRIPTION
## Description

This change removes `metrics` from the `webServices` stanza of each deployment because it's not a thing:
```
unknown field "spec.deployments[0].webServices.metrics.enabled"
```

Metrics are enabled by default. See [here](https://github.com/RedHatInsights/clowder/blob/f6286418d053d63935cf5c7500e8e29ddb3cf931/apis/cloud.redhat.com/v1alpha1/clowdapp_types.go#L168-L172).
