### PR TITLE
[COST-3709] - sonarqube: specify python version as 3.9

### DIFF
--- a/sonarqube.sh
+++ b/sonarqube.sh
@@ -25,6 +25,7 @@ podman run \
  -Dsonar.sources=/usr/src/. \
  -Dsonar.tests=/usr/src/. \
  -Dsonar.test.inclusions=**/test_*.py \
+ -Dsonar.python.version=3.9 \
  -Dsonar.python.tests.reportPaths=/usr/src/coverage.json \
  -Dsonar.python.coverage.reportPaths=/usr/src/coverage.txt \
  -Dsonar.exclusions=**/test_*.py,**/*.html,**/*.yml,**/*.yaml,**/*.json,**/*suite*,**/scripts*,**/*.sql" \


### PR DESCRIPTION
## Jira Ticket

[COST-3709](https://issues.redhat.com/browse/COST-3709)

## Description

Set the sonarqube python version to 3.9 to generate more accurate reports.
