### PR TITLE
[COST-3710] - sonarqube: remove redundant exception

### DIFF
--- a/koku/masu/api/status.py
+++ b/koku/masu/api/status.py
@@ -83,7 +83,7 @@ class ApplicationStatus:
         try:
             conn = celery_app.connection()
             conn.heartbeat_check()
-        except (OSError, ConnectionRefusedError, socket.timeout):
+        except (OSError, socket.timeout):
             CELERY_ERRORS_COUNTER.inc()
             return {"Error": BROKER_CONNECTION_ERROR}
         # Now check if Celery workers are running


### PR DESCRIPTION
## Jira Ticket

[COST-3710](https://issues.redhat.com/browse/COST-3710)

## Description

* `ConnectionRefusedError` is derived from `OSError` so we don't need to except both of these. `except OSError` will catch both.
