### PR TITLE
[COST-3711] Order by distributed cost

### DIFF
--- a/koku/api/report/ocp/query_handler.py
+++ b/koku/api/report/ocp/query_handler.py
@@ -75,12 +75,15 @@ class OCPReportQueryHandler(ReportQueryHandler):
         }
         ocp_pack_definitions = copy.deepcopy(self._mapper.PACK_DEFINITIONS)
         ocp_pack_definitions["cost_groups"]["keys"] = ocp_pack_keys
+        ocp_order_by_replacements = copy.deepcopy(self._mapper.ORDER_BY_REPLACEMENTS)
+        ocp_order_by_replacements["distributed_cost"] = "cost_total_distributed"
 
         # super() needs to be called after _mapper and _limit is set
         super().__init__(parameters)
         # super() needs to be called before _get_group_by is called
 
         self._mapper.PACK_DEFINITIONS = ocp_pack_definitions
+        self._mapper.ORDER_BY_REPLACEMENTS = ocp_order_by_replacements
 
     @property
     def annotations(self):

--- a/koku/api/report/ocp/serializers.py
+++ b/koku/api/report/ocp/serializers.py
@@ -28,12 +28,13 @@ class OCPGroupBySerializer(GroupSerializer):
 class OCPOrderBySerializer(OrderSerializer):
     """Serializer for handling query parameter order_by."""
 
-    _opfields = ("project", "cluster", "node", "date")
+    _opfields = ("project", "cluster", "node", "date", "distributed_cost")
 
     cluster = serializers.ChoiceField(choices=OrderSerializer.ORDER_CHOICES, required=False)
     project = serializers.ChoiceField(choices=OrderSerializer.ORDER_CHOICES, required=False)
     node = serializers.ChoiceField(choices=OrderSerializer.ORDER_CHOICES, required=False)
     date = serializers.DateField(required=False)
+    distributed_cost = serializers.ChoiceField(choices=OrderSerializer.ORDER_CHOICES, required=False)
 
 
 class InventoryOrderBySerializer(OCPOrderBySerializer):

--- a/koku/api/report/provider_map.py
+++ b/koku/api/report/provider_map.py
@@ -42,6 +42,8 @@ class ProviderMap:
         "usage": {"keys": ["usage", "request", "limit", "capacity"], "units": "usage_units"},
     }
 
+    ORDER_BY_REPLACEMENTS = {"delta": "delta_percent"}
+
     def provider_data(self, provider):
         """Return provider portion of map structure."""
         for item in self._mapping:

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -978,12 +978,14 @@ class ReportQueryHandler(QueryHandler):
             "sup_total",
             "infra_total",
             "cost_total",
+            "cost_total_distributed",
         ]
         db_tag_prefix = self._mapper.tag_column + "__"
         sorted_data = data
         for field in reversed(order_fields):
             reverse = False
-            field = field.replace("delta", "delta_percent")
+            for key, value in self._mapper.ORDER_BY_REPLACEMENTS.items():
+                field = field.replace(key, value)
             if field.startswith("-"):
                 reverse = True
                 field = field[1:]

--- a/koku/api/report/serializers.py
+++ b/koku/api/report/serializers.py
@@ -317,7 +317,17 @@ class ParamSerializer(BaseSerializer):
     currency = serializers.ChoiceField(choices=CURRENCY_CHOICES, required=False)
     category = StringOrListField(child=serializers.CharField(), required=False)
 
-    order_by_allowlist = ("cost", "supplementary", "infrastructure", "delta", "usage", "request", "limit", "capacity")
+    order_by_allowlist = (
+        "cost",
+        "supplementary",
+        "infrastructure",
+        "delta",
+        "usage",
+        "request",
+        "limit",
+        "capacity",
+        "distributed_cost",
+    )
 
     def validate(self, data):
         """Validate incoming data.

--- a/koku/api/report/test/ocp/test_views.py
+++ b/koku/api/report/test/ocp/test_views.py
@@ -1252,41 +1252,42 @@ class OCPReportViewTest(IamTestCase):
             return dikt.get("values")[0].get("cost", {}).get("distributed", {}).get("value")
 
         for order_option in ["asc", "desc"]:
-            client = APIClient()
-            params = {
-                "filter[resolution]": "monthly",
-                "filter[time_scope_value]": "-1",
-                "filter[time_scope_units]": "month",
-                "group_by[project]": "*",
-                "order_by[distributed_cost]": order_option,
-                "filter[limit]": 5,
-            }
+            with self.subTest(order_option=order_option):
+                client = APIClient()
+                params = {
+                    "filter[resolution]": "monthly",
+                    "filter[time_scope_value]": "-1",
+                    "filter[time_scope_units]": "month",
+                    "group_by[project]": "*",
+                    "order_by[distributed_cost]": order_option,
+                    "filter[limit]": 5,
+                }
 
-            url = f'{reverse("reports-openshift-costs")}?' + urlencode(params, quote_via=quote_plus)
-            response = client.get(url, **self.headers)
-            self.assertEqual(response.status_code, status.HTTP_200_OK)
+                url = f'{reverse("reports-openshift-costs")}?' + urlencode(params, quote_via=quote_plus)
+                response = client.get(url, **self.headers)
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-            data = response.json()
-            data = data.get("data", [])
-            self.assertTrue(data)
-            projects = data[0].get("projects")
-            self.assertIsNotNone(projects)
-            for project in projects:
-                if project.get("project") in ("Others", "No-project"):
-                    continue
-                previous_value = get_distributed_cost(project)
-                self.assertIsNotNone(previous_value)
-                break
-            # Grab first element
-            for entry in projects:
-                if entry.get("project", "") in ("Others", "No-project"):
-                    continue
-                current_value = get_distributed_cost(entry)
-                if order_option == "desc":
-                    self.assertTrue(current_value <= previous_value)
-                else:
-                    self.assertTrue(current_value >= previous_value)
-                previous_value = current_value
+                data = response.json()
+                data = data.get("data", [])
+                self.assertTrue(data)
+                projects = data[0].get("projects")
+                self.assertIsNotNone(projects)
+                for project in projects:
+                    if project.get("project") in ("Others", "No-project"):
+                        continue
+                    previous_value = get_distributed_cost(project)
+                    self.assertIsNotNone(previous_value)
+                    break
+                # Grab first element
+                for entry in projects:
+                    if entry.get("project", "") in ("Others", "No-project"):
+                        continue
+                    current_value = get_distributed_cost(entry)
+                    if order_option == "desc":
+                        self.assertTrue(current_value <= previous_value)
+                    else:
+                        self.assertTrue(current_value >= previous_value)
+                    previous_value = current_value
 
     def test_execute_query_with_order_by(self):
         """Test that the possible order by options work."""


### PR DESCRIPTION
## Jira Ticket

[COST-3711](https://issues.redhat.com/browse/COST-3711)

## Description

Order the cost by the distributed cost instead of the traditional cost total. 

## Testing

- http://localhost:8000/api/cost-management/v1/reports/openshift/costs/?filter[time_scope_units]=month&delta=cost&filter[time_scope_value]=-1&group_by[project]=*&filter[cluster]%3D=Test%20OCP%20on%20Premises&order_by[distributed_cost]=desc
- http://localhost:8000/api/cost-management/v1/reports/openshift/costs/?filter[time_scope_units]=month&delta=cost&filter[time_scope_value]=-1&group_by[project]=*&filter[cluster]%3D=Test%20OCP%20on%20Premises&order_by[distributed_cost]=asc

## Notes

- https://ci.ext.devshift.net/job/project-koku-koku-pr-check/9110/#showFailuresLink
