### PR TITLE
[COST-3710] - sonarcloud: remove redundant exception

### DIFF
--- a/koku/masu/api/status.py
+++ b/koku/masu/api/status.py
@@ -5,7 +5,6 @@
 """View for server status."""
 import logging
 import platform
-import socket
 import sys
 
 from django.conf import settings
@@ -83,7 +82,7 @@ class ApplicationStatus:
         try:
             conn = celery_app.connection()
             conn.heartbeat_check()
-        except (OSError, socket.timeout):
+        except OSError:
             CELERY_ERRORS_COUNTER.inc()
             return {"Error": BROKER_CONNECTION_ERROR}
         # Now check if Celery workers are running


### PR DESCRIPTION
## Jira Ticket

[COST-3710](https://issues.redhat.com/browse/COST-3710)

## Description

* remove redundant exception: `socket.timeout` inherits from `OSError`, so `OSError` is sufficient for both of these exceptions.
