### PR TITLE
[COST-3715] Handle unexpected error message data type

### DIFF
--- a/koku/providers/provider_errors.py
+++ b/koku/providers/provider_errors.py
@@ -15,6 +15,7 @@ class ProviderErrors:
     # KEYS
     INVALID_SOURCE_TYPE = "source_type"
     DUPLICATE_AUTH = "source.duplicate"
+    BILLING_SOURCE = "billing_source"
 
     AWS_NO_REPORT_FOUND = "authentication.role_arn.noreportfound"
     AWS_REPORT_CONFIG = "aws.report.configuration"
@@ -22,7 +23,6 @@ class ProviderErrors:
     AWS_MISSING_ROLE_ARN = "authentication.role_arn.missing"
     AWS_ROLE_ARN_UNREACHABLE = "authentication.role_arn.unreachable"
     AWS_BUCKET_MISSING = "billing_source.bucket.missing"
-    AWS_BILLING_SOURCE = "billing_source"
     AWS_BILLING_SOURCE_NOT_FOUND = "billing_source.bucket.notfound"
     AWS_REPORT_NOT_FOUND = "report.notfound"
 
@@ -46,6 +46,8 @@ class ProviderErrors:
 
     # MESSAGES
     INVALID_SOURCE_TYPE_MESSAGE = "The given source type is not supported."
+    BILLING_SOURCE_GENERAL_ERROR = "There is a problem with the given source."
+    REQUIRED_FIELD_MISSING = "The source is missing one or more required fields."
 
     AWS_MISSING_ROLE_ARN_MESSAGE = "Role ARN is a required parameter for AWS and must not be blank."
     AWS_ROLE_ARN_UNREACHABLE_MESSAGE = (

--- a/koku/providers/provider_errors.py
+++ b/koku/providers/provider_errors.py
@@ -22,6 +22,7 @@ class ProviderErrors:
     AWS_MISSING_ROLE_ARN = "authentication.role_arn.missing"
     AWS_ROLE_ARN_UNREACHABLE = "authentication.role_arn.unreachable"
     AWS_BUCKET_MISSING = "billing_source.bucket.missing"
+    AWS_BILLING_SOURCE = "billing_source"
     AWS_BILLING_SOURCE_NOT_FOUND = "billing_source.bucket.notfound"
     AWS_REPORT_NOT_FOUND = "report.notfound"
 

--- a/koku/sources/sources_error_message.py
+++ b/koku/sources/sources_error_message.py
@@ -80,9 +80,9 @@ class SourcesErrorMessage:
             try:
                 err_body = err_dict.get(err_key, [None]).pop()
             except TypeError:
-                err_msg = str(self._error.detail).encode().decode("UTF-8")
+                err_msg = str(self._error.detail)
             else:
-                err_msg = err_body.encode().decode("UTF-8")
+                err_msg = err_body
 
         return err_key, err_msg
 

--- a/koku/sources/sources_error_message.py
+++ b/koku/sources/sources_error_message.py
@@ -68,12 +68,14 @@ class SourcesErrorMessage:
         if isinstance(self._error, ValidationError):
             err_dict = self._error.detail
             LOG.info(f"validation error: {self._error}. Validation detail {err_dict}")
-            err_key = list(err_dict.keys()).pop()
-            err_body = err_dict.get(err_key, []).pop()
-            if err_body:
-                err_msg = err_body.encode().decode("UTF-8")
-            else:
+            err_key = list(err_dict).pop()
+            try:
+                err_body = err_dict.get(err_key, []).pop()
+            except (TypeError, IndexError):
                 err_msg = str(self._error.detail).encode().decode("UTF-8")
+            else:
+                err_msg = err_body.encode().decode("UTF-8")
+
         return err_key, err_msg
 
     def display(self, source_id):

--- a/koku/sources/sources_error_message.py
+++ b/koku/sources/sources_error_message.py
@@ -78,8 +78,8 @@ class SourcesErrorMessage:
             LOG.info(f"validation error: {self._error}. Validation detail {err_dict}")
             err_key = list(err_dict).pop()
             try:
-                err_body = err_dict.get(err_key, []).pop()
-            except (TypeError, IndexError):
+                err_body = err_dict.get(err_key, [None]).pop()
+            except TypeError:
                 err_msg = str(self._error.detail).encode().decode("UTF-8")
             else:
                 err_msg = err_body.encode().decode("UTF-8")

--- a/koku/sources/sources_error_message.py
+++ b/koku/sources/sources_error_message.py
@@ -50,12 +50,17 @@ class SourcesErrorMessage:
         """AWS invalid compression message."""
         return ProviderErrors.AWS_COMPRESSION_REPORT_CONFIG_MESSAGE
 
+    def aws_bucket_missing(self, message):
+        """AWS missing bucket message."""
+        return ProviderErrors.AWS_BUCKET_MISSING
+
     def _display_string_function(self, key):
         """Return function to get user facing string."""
         ui_function_map = {
             ProviderErrors.AZURE_CLIENT_ERROR: self.azure_client_errors,
             ProviderErrors.AWS_ROLE_ARN_UNREACHABLE: self.aws_client_errors,
             ProviderErrors.AWS_BILLING_SOURCE_NOT_FOUND: self.aws_no_billing_source,
+            ProviderErrors.AWS_BILLING_SOURCE: self.aws_bucket_missing,
             ProviderErrors.AWS_COMPRESSION_REPORT_CONFIG: self.aws_invalid_report_compression,
         }
         string_function = ui_function_map.get(key)

--- a/koku/sources/sources_error_message.py
+++ b/koku/sources/sources_error_message.py
@@ -50,9 +50,12 @@ class SourcesErrorMessage:
         """AWS invalid compression message."""
         return ProviderErrors.AWS_COMPRESSION_REPORT_CONFIG_MESSAGE
 
-    def aws_bucket_missing(self, message):
-        """AWS missing bucket message."""
-        return ProviderErrors.AWS_BUCKET_MISSING
+    def general_errors(self, message):
+        msg = ProviderErrors.BILLING_SOURCE_GENERAL_ERROR
+        if "one or more required fields is invalid/missing" in message.lower():
+            msg = ProviderErrors.REQUIRED_FIELD_MISSING
+
+        return msg
 
     def _display_string_function(self, key):
         """Return function to get user facing string."""
@@ -60,8 +63,8 @@ class SourcesErrorMessage:
             ProviderErrors.AZURE_CLIENT_ERROR: self.azure_client_errors,
             ProviderErrors.AWS_ROLE_ARN_UNREACHABLE: self.aws_client_errors,
             ProviderErrors.AWS_BILLING_SOURCE_NOT_FOUND: self.aws_no_billing_source,
-            ProviderErrors.AWS_BILLING_SOURCE: self.aws_bucket_missing,
             ProviderErrors.AWS_COMPRESSION_REPORT_CONFIG: self.aws_invalid_report_compression,
+            ProviderErrors.BILLING_SOURCE: self.general_errors,
         }
         string_function = ui_function_map.get(key)
         return string_function

--- a/koku/sources/test/test_sources_error_message.py
+++ b/koku/sources/test/test_sources_error_message.py
@@ -142,6 +142,9 @@ class SourcesErrorMessageTest(TestCase):
         self.assertEqual(message_obj, "")
 
     def test_error_details_are_dict(self):
+        """Given a ValidationError for billing_source whose details are a dict,
+        return a useful error message.
+        """
         err_dict = {
             "billing_source": {
                 "data_source": {
@@ -158,4 +161,15 @@ class SourcesErrorMessageTest(TestCase):
         message_obj = SourcesErrorMessage(error)
         message = message_obj.display(source_id=1)
 
-        self.assertIn(message, ProviderErrors.AWS_BUCKET_MISSING)
+        self.assertIn(message, ProviderErrors.REQUIRED_FIELD_MISSING)
+
+    def test_error_details_are_dict_general(self):
+        """Given a ValidationError for billing_source whose details are a dict,
+        return a non-specific but helpful error message.
+        """
+        err_dict = {"billing_source": {"data_source": {}}}
+        error = ValidationError(err_dict)
+        message_obj = SourcesErrorMessage(error)
+        message = message_obj.display(source_id=1)
+
+        self.assertIn(message, ProviderErrors.BILLING_SOURCE_GENERAL_ERROR)

--- a/koku/sources/test/test_sources_error_message.py
+++ b/koku/sources/test/test_sources_error_message.py
@@ -140,3 +140,22 @@ class SourcesErrorMessageTest(TestCase):
         """Test an available source message."""
         message_obj = SourcesErrorMessage(None).display(source_id=1)
         self.assertEqual(message_obj, "")
+
+    def test_error_details_are_dict(self):
+        err_dict = {
+            "billing_source": {
+                "data_source": {
+                    "provider.data_source": [
+                        (
+                            'ErrorDetail(string="One or more required fields is invalid/missing. '
+                            "Required fields are ['bucket']\", code='invalid')"
+                        )
+                    ]
+                }
+            }
+        }
+        error = ValidationError(err_dict)
+        message_obj = SourcesErrorMessage(error)
+        message = message_obj.display(source_id=1)
+
+        self.assertIn("One or more required fields is invalid", message)

--- a/koku/sources/test/test_sources_error_message.py
+++ b/koku/sources/test/test_sources_error_message.py
@@ -158,4 +158,4 @@ class SourcesErrorMessageTest(TestCase):
         message_obj = SourcesErrorMessage(error)
         message = message_obj.display(source_id=1)
 
-        self.assertIn("One or more required fields is invalid", message)
+        self.assertIn(message, ProviderErrors.AWS_BUCKET_MISSING)


### PR DESCRIPTION
## Jira Ticket

[COST-3715](https://issues.redhat.com/browse/COST-3715)

The data in `err_dict[err_key]` could be something other than a list or it could be empty. Catch and handle the exception so a good error message is returned to the customer.

## Description

Return a good error message when the data is not a list.

## Testing

```
tox -e py39 -- sources.test.test_sources_error_message
```