### PR TITLE
COST-3733: Fix order by distributed_cost for ranked list.

### DIFF
--- a/koku/api/report/ocp/query_handler.py
+++ b/koku/api/report/ocp/query_handler.py
@@ -75,8 +75,6 @@ class OCPReportQueryHandler(ReportQueryHandler):
         }
         ocp_pack_definitions = copy.deepcopy(self._mapper.PACK_DEFINITIONS)
         ocp_pack_definitions["cost_groups"]["keys"] = ocp_pack_keys
-        ocp_order_by_replacements = copy.deepcopy(self._mapper.ORDER_BY_REPLACEMENTS)
-        ocp_order_by_replacements["distributed_cost"] = "cost_total_distributed"
 
         ocp_delta_replacements = copy.deepcopy(self._mapper.DELTA_REPLACEMENTS)
         ocp_delta_replacements["distributed_cost"] = "cost_total_distributed"
@@ -87,7 +85,6 @@ class OCPReportQueryHandler(ReportQueryHandler):
         # super() needs to be called before _get_group_by is called
 
         self._mapper.PACK_DEFINITIONS = ocp_pack_definitions
-        self._mapper.ORDER_BY_REPLACEMENTS = ocp_order_by_replacements
 
     @property
     def annotations(self):

--- a/koku/api/report/ocp/serializers.py
+++ b/koku/api/report/ocp/serializers.py
@@ -34,7 +34,15 @@ class OCPOrderBySerializer(OrderSerializer):
     project = serializers.ChoiceField(choices=OrderSerializer.ORDER_CHOICES, required=False)
     node = serializers.ChoiceField(choices=OrderSerializer.ORDER_CHOICES, required=False)
     date = serializers.DateField(required=False)
-    distributed_cost = serializers.ChoiceField(choices=OrderSerializer.ORDER_CHOICES, required=False)
+    cost_total_distributed = serializers.ChoiceField(choices=OrderSerializer.ORDER_CHOICES, required=False)
+
+    def to_internal_value(self, data):
+        """Send to internal value."""
+        internal_values = {"distributed_cost": "cost_total_distributed"}
+        for serializer_key, internal_key in internal_values.items():
+            if serializer_key in data.keys():
+                data[internal_key] = data.pop(serializer_key)
+        return super().to_internal_value(data)
 
 
 class InventoryOrderBySerializer(OCPOrderBySerializer):

--- a/koku/api/report/provider_map.py
+++ b/koku/api/report/provider_map.py
@@ -42,7 +42,6 @@ class ProviderMap:
         "usage": {"keys": ["usage", "request", "limit", "capacity"], "units": "usage_units"},
     }
 
-    ORDER_BY_REPLACEMENTS = {"delta": "delta_percent"}
     DELTA_REPLACEMENTS = {"cost": "cost_total"}
 
     def provider_data(self, provider):

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -984,8 +984,7 @@ class ReportQueryHandler(QueryHandler):
         sorted_data = data
         for field in reversed(order_fields):
             reverse = False
-            for key, value in self._mapper.ORDER_BY_REPLACEMENTS.items():
-                field = field.replace(key, value)
+            field = field.replace("delta", "delta_percent")
             if field.startswith("-"):
                 reverse = True
                 field = field[1:]

--- a/koku/api/report/serializers.py
+++ b/koku/api/report/serializers.py
@@ -326,7 +326,7 @@ class ParamSerializer(BaseSerializer):
         "request",
         "limit",
         "capacity",
-        "distributed_cost",
+        "cost_total_distributed",
     )
 
     def validate(self, data):

--- a/koku/api/report/test/ocp/test_views.py
+++ b/koku/api/report/test/ocp/test_views.py
@@ -47,7 +47,7 @@ def string_to_date(dt):
 
 def get_distributed_cost(dikt):
     "given a dictionary with a nested vlaues return distributed cost"
-    return dikt.get("values")[0].get("cost", {}).get("distributed", {}).get("value")
+    return dikt.get("values", [{}])[0].get("cost", {}).get("distributed", {}).get("value")
 
 
 class OCPReportViewTest(IamTestCase):

--- a/koku/api/report/test/ocp/test_views.py
+++ b/koku/api/report/test/ocp/test_views.py
@@ -45,6 +45,11 @@ def string_to_date(dt):
     return datetime.datetime.strptime(dt, "%Y-%m-%d").date()
 
 
+def get_distributed_cost(dikt):
+    "given a dictionary with a nested vlaues return distributed cost"
+    return dikt.get("values")[0].get("cost", {}).get("distributed", {}).get("value")
+
+
 class OCPReportViewTest(IamTestCase):
     """Tests the report view."""
 
@@ -1342,12 +1347,54 @@ class OCPReportViewTest(IamTestCase):
                     self.assertTrue(current_value <= previous_value)
                     previous_value = current_value
 
+    def test_order_by_distributed_cost_ranked_list(self):
+        """Test that data is grouped by & limited using offset.
+
+        - offset here triggers our ranked list logic
+        """
+        limit_size = 2
+        for order_option in ["asc", "desc"]:
+            with self.subTest(order_option=order_option):
+                client = APIClient()
+                params = {
+                    "filter[resolution]": "monthly",
+                    "filter[time_scope_value]": "-1",
+                    "filter[time_scope_units]": "month",
+                    "group_by[project]": "*",
+                    "order_by[distributed_cost]": order_option,
+                    "filter[limit]": limit_size,
+                    "filter[offset]": 0,
+                }
+                url = f'{reverse("reports-openshift-costs")}?' + urlencode(params, quote_via=quote_plus)
+                response = client.get(url, **self.headers)
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+                data = response.json()
+                self.assertTrue(data.get("links", {}).get("next"))
+                self.assertTrue(data.get("links", {}).get("last"))
+                data = data.get("data", [])
+                self.assertTrue(data)
+                projects = data[0].get("projects")
+                self.assertEqual(len(projects), limit_size)
+                # Grab first element
+                for project in projects:
+                    if project.get("project") in ("Others", "No-project"):
+                        continue
+                    previous_value = get_distributed_cost(project)
+                    self.assertIsNotNone(previous_value)
+                    break
+                for entry in projects:
+                    if entry.get("project", "") in ("Others", "No-project"):
+                        continue
+                    current_value = get_distributed_cost(entry)
+                    if order_option == "desc":
+                        self.assertTrue(current_value <= previous_value)
+                    else:
+                        self.assertTrue(current_value >= previous_value)
+                    previous_value = current_value
+
     def test_execute_query_with_group_by_project_order_by_distributed_cost(self):
         """Test that data is grouped by and limited on order by."""
-
-        def get_distributed_cost(dikt):
-            return dikt.get("values")[0].get("cost", {}).get("distributed", {}).get("value")
-
         for order_option in ["asc", "desc"]:
             with self.subTest(order_option=order_option):
                 client = APIClient()
@@ -1369,13 +1416,13 @@ class OCPReportViewTest(IamTestCase):
                 self.assertTrue(data)
                 projects = data[0].get("projects")
                 self.assertIsNotNone(projects)
+                # Grab first element
                 for project in projects:
                     if project.get("project") in ("Others", "No-project"):
                         continue
                     previous_value = get_distributed_cost(project)
                     self.assertIsNotNone(previous_value)
                     break
-                # Grab first element
                 for entry in projects:
                     if entry.get("project", "") in ("Others", "No-project"):
                         continue


### PR DESCRIPTION
## Jira Ticket

[COST-3733](https://issues.redhat.com/browse/COST-3733)

## Description

I spent some time in the Serializer Class and realized there is a way better way to convert a key to an internal value. 

## Testing

1. Checkout Branch
2. load-test-customer-data

Hit this endpoint on main:
```
http://localhost:8000/api/cost-management/v1/reports/openshift/costs/?filter[limit]=2&filter[offset]=0&filter[resolution]=monthly&filter[time_scope_units]=month&filter[time_scope_value]=-1&group_by[project]=*&limit=0&offset=0&order_by[distributed_cost]=asc
```
Notice that it returns an empty list.

checkout this branch, hit the same url. 


## Notes

...
