### PR TITLE
[COST-3648] Fix dropped pod labels from OCP on cloud resource matching

### DIFF
--- a/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcpcostlineitem_daily_summary.sql
+++ b/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcpcostlineitem_daily_summary.sql
@@ -172,7 +172,7 @@ SELECT gcp.uuid as gcp_uuid,
     cast(NULL as varchar) as persistentvolumeclaim,
     cast(NULL as varchar) as persistentvolume,
     cast(NULL as varchar) as storageclass,
-    max(ocp.pod_labels) as pod_labels,
+    ocp.pod_labels,
     max(ocp.resource_id) as resource_id,
     max(gcp.usage_start_time) as usage_start,
     max(gcp.usage_start_time) as usage_end,
@@ -204,7 +204,7 @@ SELECT gcp.uuid as gcp_uuid,
     sum(ocp.pod_effective_usage_memory_gigabyte_hours) as pod_effective_usage_memory_gigabyte_hours,
     max(ocp.cluster_capacity_cpu_core_hours) as cluster_capacity_cpu_core_hours,
     max(ocp.cluster_capacity_memory_gigabyte_hours) as cluster_capacity_memory_gigabyte_hours,
-    NULL as volume_labels,
+    ocp.volume_labels,
     max(json_format(json_parse(gcp.labels))) as tags,
     max(ocp.cost_category_id) as cost_category_id,
     {{ocp_source_uuid}} as ocp_source,
@@ -228,7 +228,7 @@ WHERE gcp.source = {{gcp_source_uuid}}
     AND lpad(ocp.month, 2, '0') = {{month}} -- Zero pad the month when fewer than 2 characters
     AND ocp.day IN {{days | inclause}}
     AND ocp.data_source = 'Pod' -- this cost is only associated with pod costs
-GROUP BY gcp.uuid, ocp.namespace, gcp.invoice_month, ocp.data_source
+GROUP BY gcp.uuid, ocp.namespace, gcp.invoice_month, ocp.data_source, ocp.pod_labels, ocp.volume_labels
 ;
 
 -- direct tag matching, these costs are split evenly between pod and storage since we don't have the info to quantify them separately

--- a/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcpcostlineitem_daily_summary_by_node.sql
+++ b/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcpcostlineitem_daily_summary_by_node.sql
@@ -164,7 +164,7 @@ SELECT gcp.uuid as gcp_uuid,
     cast(NULL as varchar) as persistentvolumeclaim,
     cast(NULL as varchar) as persistentvolume,
     cast(NULL as varchar) as storageclass,
-    max(ocp.pod_labels) as pod_labels,
+    ocp.pod_labels,
     max(ocp.resource_id) as resource_id,
     max(gcp.usage_start_time) as usage_start,
     max(gcp.usage_start_time) as usage_end,
@@ -195,7 +195,7 @@ SELECT gcp.uuid as gcp_uuid,
     sum(ocp.pod_effective_usage_memory_gigabyte_hours) as pod_effective_usage_memory_gigabyte_hours,
     max(ocp.cluster_capacity_cpu_core_hours) as cluster_capacity_cpu_core_hours,
     max(ocp.cluster_capacity_memory_gigabyte_hours) as cluster_capacity_memory_gigabyte_hours,
-    NULL as volume_labels,
+    ocp.volume_labels,
     max(json_format(json_parse(gcp.labels))) as tags,
     max(ocp.cost_category_id) as cost_category_id,
     max(gcp.year) as year,
@@ -221,7 +221,7 @@ WHERE gcp.source = {{gcp_source_uuid}}
     AND lpad(ocp.month, 2, '0') = {{month}} -- Zero pad the month when fewer than 2 characters
     AND ocp.day IN {{days | inclause}}
     AND ocp.data_source = 'Pod' -- this cost is only associated with pod costs
-GROUP BY gcp.uuid, ocp.namespace, gcp.invoice_month, ocp.data_source
+GROUP BY gcp.uuid, ocp.namespace, gcp.invoice_month, ocp.data_source, ocp.pod_labels, ocp.volume_labels
 ;
 
 -- direct tag matching, these costs are split evenly between pod and storage since we don't have the info to quantify them separately

--- a/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcpcostlineitem_daily_summary_resource_id.sql
+++ b/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcpcostlineitem_daily_summary_resource_id.sql
@@ -379,7 +379,7 @@ SELECT gcp.uuid as gcp_uuid,
     max(nullif(ocp.persistentvolumeclaim, '')) as persistentvolumeclaim,
     max(nullif(ocp.persistentvolume, '')) as persistentvolume,
     max(nullif(ocp.storageclass, '')) as storageclass,
-    max(ocp.pod_labels) as pod_labels,
+    ocp.pod_labels,
     max(ocp.resource_id) as resource_id,
     max(gcp.usage_start) as usage_start,
     max(gcp.usage_start) as usage_end,
@@ -413,7 +413,7 @@ SELECT gcp.uuid as gcp_uuid,
     max(ocp.cluster_capacity_memory_gigabyte_hours) as cluster_capacity_memory_gigabyte_hours,
     max(ocp.node_capacity_cpu_core_hours) as node_capacity_cpu_core_hours,
     max(ocp.node_capacity_memory_gigabyte_hours) as node_capacity_memory_gigabyte_hours,
-    NULL as volume_labels,
+    ocp.volume_labels,
     max(gcp.labels) as tags,
     max(ocp.cost_category_id) as cost_category_id,
     max(gcp.ocp_matched) as ocp_matched,
@@ -435,7 +435,7 @@ WHERE ocp.source = {{ocp_source_uuid}}
     AND gcp.ocp_source = {{ocp_source_uuid}}
     AND gcp.year = {{year}}
     AND gcp.month = {{month}}
-GROUP BY gcp.uuid, ocp.namespace, ocp.data_source
+GROUP BY gcp.uuid, ocp.namespace, ocp.data_source, ocp.pod_labels, ocp.volume_labels
 ;
 
 -- direct tag matching, these costs are split evenly between pod and storage since we don't have the info to quantify them separately

--- a/koku/masu/database/trino_sql/reporting_ocpawscostlineitem_daily_summary.sql
+++ b/koku/masu/database/trino_sql/reporting_ocpawscostlineitem_daily_summary.sql
@@ -396,7 +396,7 @@ SELECT aws.uuid as aws_uuid,
         max(ocp.node_capacity_memory_gigabyte_hours) as node_capacity_memory_gigabyte_hours,
         max(ocp.cluster_capacity_cpu_core_hours) as cluster_capacity_cpu_core_hours,
         max(ocp.cluster_capacity_memory_gigabyte_hours) as cluster_capacity_memory_gigabyte_hours,
-        max(ocp.pod_labels) as pod_labels,
+        ocp.pod_labels,
         NULL as volume_labels,
         max(aws.tags) as tags,
         max(aws.aws_cost_category) as aws_cost_category,
@@ -417,7 +417,7 @@ SELECT aws.uuid as aws_uuid,
         AND aws.ocp_source = {{ocp_source_uuid}}
         AND aws.year = {{year}}
         AND aws.month = {{month}}
-    GROUP BY aws.uuid, ocp.namespace
+    GROUP BY aws.uuid, ocp.namespace, ocp.pod_labels
 ;
 
 -- Tag matching

--- a/koku/masu/database/trino_sql/reporting_ocpazurecostlineitem_daily_summary.sql
+++ b/koku/masu/database/trino_sql/reporting_ocpazurecostlineitem_daily_summary.sql
@@ -175,8 +175,8 @@ SELECT azure.uuid as azure_uuid,
     max(ocp.node_capacity_memory_gigabyte_hours) as node_capacity_memory_gigabyte_hours,
     max(ocp.cluster_capacity_cpu_core_hours) as cluster_capacity_cpu_core_hours,
     max(ocp.cluster_capacity_memory_gigabyte_hours) as cluster_capacity_memory_gigabyte_hours,
-    max(ocp.pod_labels) as pod_labels,
-    max(ocp.volume_labels) as volume_labels,
+    ocp.pod_labels,
+    ocp.volume_labels,
     max(azure.tags) as tags,
     max(azure.resource_id_matched) as resource_id_matched,
     max(ocp.cost_category_id) as cost_category_id,
@@ -201,7 +201,7 @@ SELECT azure.uuid as azure_uuid,
         AND ocp.usage_start >= {{start_date}}
         AND ocp.usage_start < date_add('day', 1, {{end_date}})
         AND (ocp.resource_id IS NOT NULL AND ocp.resource_id != '')
-    GROUP BY azure.uuid, ocp.namespace, ocp.data_source
+    GROUP BY azure.uuid, ocp.namespace, ocp.data_source, ocp.pod_labels, ocp.volume_labels
 ;
 
 -- Tag matching


### PR DESCRIPTION
## Jira Ticket

[COST-3648](https://issues.redhat.com/browse/COST-3648)

## Description

This change will fix a bug where pod labels get dropped if there are multiple ocp line items matching a single AWS resource id.

## Testing

1. Checkout Branch
2. Restart Koku
3. Create ocp on cloud data with multiple distinct OCP pod values for the same key that share the same resource id 
4. Check we match both lines when doing resource matching.

## Notes
Before this change:
```
trino:org1234567> select usage_start, cluster_alias, data_source, namespace, node, resource_id, pod_labels from reporting_ocpusagelineitem_daily_summary where date(usage_start) = date('2023-04-21');
 usage_start |        cluster_alias         | data_source |      namespace       |  node   | resource_id |                              pod_labels                               
-------------+------------------------------+-------------+----------------------+---------+-------------+-----------------------------------------------------------------------
 2023-04-21  | test_cost_ocp_on_aws_cluster | Pod         | Platform unallocated | ocp-nod | i-99995555  | NULL                                                                  
 2023-04-21  | test_cost_ocp_on_aws_cluster | Pod         | openshift-ocp_prod   | ocp-nod | i-99995555  | {"app":"nod","node_role_kubernetes_io":"infra","nodeclass":"testing"} 
 2023-04-21  | test_cost_ocp_on_aws_cluster | Pod         | openshift-ocp_prod   | ocp-nod | i-99995555  | {"app":"gdi","node_role_kubernetes_io":"infra","nodeclass":"testing"} 
(3 rows)
```

```
trino:org1234567> select usage_start, cluster_alias, data_source, namespace, node, resource_id, pod_labels from reporting_ocpawscostlineitem_project_daily_summary where date(usage_start) = date('2023-04-21');
       usage_start       |        cluster_alias         | data_source |      namespace       |  node   | resource_id |                              pod_labels                               
-------------------------+------------------------------+-------------+----------------------+---------+-------------+-----------------------------------------------------------------------
 2023-04-21 00:00:00.000 | test_cost_ocp_on_aws_cluster | Pod         | openshift-ocp_prod   | ocp-nod | i-99995555  | {"app":"nod","node_role_kubernetes_io":"infra","nodeclass":"testing"} 
 2023-04-21 00:00:00.000 | test_cost_ocp_on_aws_cluster | Pod         | Platform unallocated | ocp-nod | i-99995555  | NULL                                                                  
(2 rows)
```

After this change:
```
trino:org1234567> select usage_start, cluster_alias, data_source, namespace, node, resource_id, pod_labels from reporting_ocpawscostlineitem_project_daily_summary where date(usage_start) = date('2023-04-21');
       usage_start       |        cluster_alias         | data_source |      namespace       |  node   | resource_id |                              pod_labels                               
-------------------------+------------------------------+-------------+----------------------+---------+-------------+-----------------------------------------------------------------------
 2023-04-21 00:00:00.000 | test_cost_ocp_on_aws_cluster | Pod         | openshift-ocp_prod   | ocp-nod | i-99995555  | {"app":"gdi","node_role_kubernetes_io":"infra","nodeclass":"testing"} 
 2023-04-21 00:00:00.000 | test_cost_ocp_on_aws_cluster | Pod         | Platform unallocated | ocp-nod | i-99995555  | NULL                                                                  
 2023-04-21 00:00:00.000 | test_cost_ocp_on_aws_cluster | Pod         | openshift-ocp_prod   | ocp-nod | i-99995555  | {"app":"nod","node_role_kubernetes_io":"infra","nodeclass":"testing"} 
(3 rows)
```
...
