### PR TITLE
[COST-3534] replace empty string group by value to No-{group by} 

### DIFF
--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -791,7 +791,7 @@ class ReportQueryHandler(QueryHandler):
             return data
 
         for group in groupby:
-            if group in data and pd.isnull(data.get(group)):
+            if group in data and pd.isnull(data.get(group)) or data.get(group) == "":
                 value = self._clean_prefix_grouping_labels(group)
                 group_label = f"No-{value}"
                 data[group] = group_label

--- a/koku/api/report/test/test_queries.py
+++ b/koku/api/report/test/test_queries.py
@@ -545,7 +545,7 @@ class ReportQueryHandlerTest(IamTestCase):
         query_params = self.mocked_query_params(url, GCPCostView)
         handler = GCPReportQueryHandler(query_params)
         groups = ["gcp_project"]
-        data = {"gcp_project": None, "units": "USD"}
+        data = {"gcp_project": "", "units": "USD"}
         expected = {"gcp_project": "No-gcp_project", "units": "USD"}
         out_data = handler._apply_group_null_label(data, groups)
         self.assertEqual(expected, out_data)

--- a/koku/api/report/test/test_queries.py
+++ b/koku/api/report/test/test_queries.py
@@ -539,6 +539,17 @@ class ReportQueryHandlerTest(IamTestCase):
             self.assertIsNotNone(data)
             self.assertNotIn("Platform", data)
 
+    def test_apply_group_null_label_empty_string(self):
+        """Test adding group label for empty string values."""
+        url = "?"
+        query_params = self.mocked_query_params(url, GCPCostView)
+        handler = GCPReportQueryHandler(query_params)
+        groups = ["gcp_project"]
+        data = {"gcp_project": None, "units": "USD"}
+        expected = {"gcp_project": "No-gcp_project", "units": "USD"}
+        out_data = handler._apply_group_null_label(data, groups)
+        self.assertEqual(expected, out_data)
+
     # FIXME: need test for _apply_group_by
     # FIXME: need test for _apply_group_null_label
     # FIXME: need test for _build_custom_filter_list  }


### PR DESCRIPTION
## Jira Ticket

[COST-3534](https://issues.redhat.com/browse/COST-3534)

## Description

This change will replace an empty string value to `No-<group_by>` just like we do with null values on a group by.

## Testing

1. Checkout main
2. Restart Koku
3. Load some test data
4. Alter some records in the DB for gcp_project to have an empty project id and project name:
```
update reporting_gcp_cost_summary_by_project_p set project_id = '', project_name = '' where usage_start='2023-04-23';
```
5. Hit the gcp cost endpoint grouped by gcp_project and see the empty string value for project for the date you updated in step 4.
```
http://localhost:8000/api/cost-management/v1/reports/gcp/costs/?group_by[gcp_project]=*

"gcp_project": "",
```
6. Checkout this branch
7. HIt the endpoint again. see `No-gcp_project` listed as the gcp project instead of empty quotes.
```
"gcp_project": "No-gcp_project",
```

## Notes

...
