### PR TITLE
[CI] Move SonarCloud to separate workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,29 +277,3 @@ jobs:
         run: |
           gh api "/repos/project-koku/koku/statuses/${{ github.event.pull_request.head.sha }}" -f description="codecov skipped because unit tests were not required" -f context="codecov/patch" -f state="success"
           gh api "/repos/project-koku/koku/statuses/${{ github.event.pull_request.head.sha }}" -f description="codecov skipped because unit tests were not required" -f context="codecov/project" -f state="success"
-
-  sonarcloud:
-    name: SonarCloud
-    needs: [changed-files,units]
-    runs-on: ubuntu-20.04
-    steps:
-
-      - name: Checkout
-        # this checkout is required for the coverage report. If we don't do this, then
-        # the uploaded report is invalid and codecov doesn't know how to process it.
-        if: needs.changed-files.outputs.run_tests == 'true'
-        uses: actions/checkout@v3.1.0
-        with:
-          fetch-depth: 0
-
-      - name: Download coverage result from units
-        if: needs.changed-files.outputs.run_tests == 'true'
-        uses: actions/download-artifact@v3
-        with:
-          name: coverage
-
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,45 @@
+name: SonarCloud
+
+on:
+  workflow_run:
+    workflows:
+      - CI
+    types:
+      - completed
+
+jobs:
+    sonarcloud:
+      name: SonarCloud
+      runs-on: ubuntu-20.04
+      if: github.event.workflow_run.conclusion == 'success'
+      steps:
+        - name: Checkout
+          # this checkout is required for the coverage report. If we don't do this, then
+          # the uploaded report is invalid and codecov doesn't know how to process it.
+          uses: actions/checkout@v3.1.0
+          with:
+            repository: ${{ github.event.workflow_run.head_repository.full_name }}
+            ref: ${{ github.event.workflow_run.head_branch }}
+            fetch-depth: 0
+
+        - name: Download coverage result from units
+          # The offical actions/download-artifact action does not allow downloading
+          # artifacits from other workflow runs.
+          uses: dawidd6/action-download-artifact@v2.27.0
+          with:
+            name: coverage
+            github_token: ${{ secrets.GITHUB_TOKEN }}
+            commit: ${{ github.event.workflow_run.pull_request[0].head.sha }}
+            run_id: ${{ github.event.workflow_run.id }}
+
+        - name: SonarCloud Scan
+          uses: SonarSource/sonarcloud-github-action@v1.9.1
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          with:
+            args: >
+              -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }}
+              -Dsonar.pullrequest.key=${{ github.event.workflow_run.pull_requests[0].number }}
+              -Dsonar.pullrequest.branch=${{ github.event.workflow_run.pull_requests[0].head.ref }}
+              -Dsonar.pullrequest.base=${{ github.event.workflow_run.pull_requests[0].base.ref }}


### PR DESCRIPTION
## Description

Since SonarCloud requires the use of secrets and secrets are not accessible from PRs created in forks, move SonarCloud check to a new workflow that is trigger by pull requests but runs in the context of the main repo.
