### PR TITLE
[COST-3769] Add unleash flag to disable a source.

### DIFF
--- a/.unleash/flags.json
+++ b/.unleash/flags.json
@@ -2,6 +2,25 @@
     "version": 1,
     "features": [
         {
+            "name": "cost-management.backend.disable-source",
+            "description": "Toggle to disable processing for a source",
+            "type": "permission",
+            "project": "default",
+            "enabled": true,
+            "stale": false,
+            "strategies": [
+                {
+                    "name": "source-strategy",
+                    "parameters": {
+                        "source-uuid": ""
+                    },
+                    "constraints": []
+                }
+            ],
+            "variants": [],
+            "createdAt": "2023-05-03T11:50:00.756Z"
+        },
+        {
             "name": "cost-management.backend.cost-enable-negative-filtering",
             "description": "Toggle to enable negative filtering in query",
             "type": "permission",
@@ -255,6 +274,18 @@
                     "name": "schema-name",
                     "type": "list",
                     "description": "values must begin with `acct` or `org`",
+                    "required": false
+                }
+            ]
+        },
+        {
+            "name": "source-strategy",
+            "description": "Enablement based on source uuid",
+            "parameters": [
+                {
+                    "name": "source-uuid",
+                    "type": "list",
+                    "description": "UUID of the source.",
                     "required": false
                 }
             ]

--- a/koku/koku/feature_flags.py
+++ b/koku/koku/feature_flags.py
@@ -50,10 +50,23 @@ class SchemaStrategy(Strategy):
         return default_value
 
 
+class SourceStrategy(Strategy):
+    def load_provisioning(self) -> list:
+        return self.parameters["source-uuid"].split(",")
+
+    def apply(self, context) -> bool:
+        default_value = False
+        if source_uuid := context.get("source_uuid"):
+            default_value = source_uuid in self.parsed_provisioning
+        return default_value
+
+
 strategies = {
     # All new strategies should be added here.
-    "schema-strategy": SchemaStrategy
+    "schema-strategy": SchemaStrategy,
+    "source-strategy": SourceStrategy,
 }
+
 headers = {}
 if settings.UNLEASH_TOKEN:
     headers["Authorization"] = f"Bearer {settings.UNLEASH_TOKEN}"

--- a/koku/masu/processor/__init__.py
+++ b/koku/masu/processor/__init__.py
@@ -127,3 +127,16 @@ def enable_aws_category_settings(account):
     context = {"schema": account}
     res = bool(UNLEASH_CLIENT.is_enabled("cost-management.backend.enable_aws_category_settings", context))
     return res
+
+
+def disable_source(source_uuid):
+    """
+    Disable source processing
+
+    params:
+        source_uuid: unique identifer of source or provider
+    """
+    context = {"source_uuid": source_uuid}
+    LOG.info(f"Disabled source UNLEASH check: {context}")
+    res = bool(UNLEASH_CLIENT.is_enabled("cost-management.backend.disable-source", context))
+    return res

--- a/koku/masu/processor/__init__.py
+++ b/koku/masu/processor/__init__.py
@@ -139,4 +139,5 @@ def disable_source(source_uuid):
     context = {"source_uuid": source_uuid}
     LOG.info(f"Disabled source UNLEASH check: {context}")
     res = bool(UNLEASH_CLIENT.is_enabled("cost-management.backend.disable-source", context))
+    LOG.info(f"    Processing {'disabled' if res else 'enabled'} for source {source_uuid}")
     return res

--- a/koku/masu/processor/orchestrator.py
+++ b/koku/masu/processor/orchestrator.py
@@ -97,7 +97,6 @@ class Orchestrator:
                 LOG.info(f"Cloud source processing disabled for {account.get('schema_name')}")
                 continue
             if disable_source(provider_uuid):
-                LOG.info(f"Cloud source processing disabled for {provider_uuid}")
                 continue
             else:
                 if AccountsAccessor().is_polling_account(account):

--- a/koku/masu/processor/orchestrator.py
+++ b/koku/masu/processor/orchestrator.py
@@ -22,6 +22,7 @@ from masu.external.date_accessor import DateAccessor
 from masu.external.report_downloader import ReportDownloader
 from masu.external.report_downloader import ReportDownloaderError
 from masu.processor import disable_cloud_source_processing
+from masu.processor import disable_source
 from masu.processor.tasks import get_report_files
 from masu.processor.tasks import GET_REPORT_FILES_QUEUE
 from masu.processor.tasks import record_all_manifest_files
@@ -94,6 +95,9 @@ class Orchestrator:
         for account in all_accounts:
             if disable_cloud_source_processing(account.get("schema_name")) and not provider_uuid:
                 LOG.info(f"Cloud source processing disabled for {account.get('schema_name')}")
+                continue
+            if disable_source(provider_uuid):
+                LOG.info(f"Cloud source processing disabled for {provider_uuid}")
                 continue
             else:
                 if AccountsAccessor().is_polling_account(account):

--- a/koku/masu/processor/tasks.py
+++ b/koku/masu/processor/tasks.py
@@ -41,6 +41,7 @@ from masu.external.accounts_accessor import AccountsAccessorError
 from masu.external.downloader.report_downloader_base import ReportDownloaderWarning
 from masu.external.report_downloader import ReportDownloaderError
 from masu.processor import disable_ocp_on_cloud_summary
+from masu.processor import disable_source
 from masu.processor import disable_summary_processing
 from masu.processor import is_large_customer
 from masu.processor._tasks.download import _get_report_files
@@ -419,13 +420,15 @@ def update_summary_tables(  # noqa: C901
 
     """
     if disable_summary_processing(schema_name):
-        msg = f"Summary disabled for {schema_name}."
-        LOG.info(msg)
+        LOG.info(f"Summary disabled for {schema_name}.")
+        return
+    if disable_source(provider_uuid):
+        LOG.info(f"{provider_uuid} disabled in unleash.")
         return
     if disable_ocp_on_cloud_summary(schema_name):
-        msg = f"OCP on Cloud summary disabled for {schema_name}."
-        LOG.info(msg)
+        LOG.info(f"OCP on Cloud summary disabled for {schema_name}.")
         ocp_on_cloud = False
+
     worker_stats.REPORT_SUMMARY_ATTEMPTS_COUNTER.labels(provider_type=provider).inc()
     task_name = "masu.processor.tasks.update_summary_tables"
     if isinstance(start_date, str):

--- a/koku/masu/processor/tasks.py
+++ b/koku/masu/processor/tasks.py
@@ -423,7 +423,6 @@ def update_summary_tables(  # noqa: C901
         LOG.info(f"Summary disabled for {schema_name}.")
         return
     if disable_source(provider_uuid):
-        LOG.info(f"{provider_uuid} disabled in unleash.")
         return
     if disable_ocp_on_cloud_summary(schema_name):
         LOG.info(f"OCP on Cloud summary disabled for {schema_name}.")

--- a/koku/masu/test/processor/test_tasks.py
+++ b/koku/masu/test/processor/test_tasks.py
@@ -1607,6 +1607,19 @@ class TestWorkerCacheThrottling(MasuTestCase):
                 )
                 mock_delay.assert_called()
 
+    @patch("masu.processor.tasks.chain")
+    def test_unleash_disable_source(self, mock_chain):
+        """Test unleash flag to disable processing by source_uuid."""
+        provider = Provider.PROVIDER_OCP
+        provider_ocp_uuid = self.ocp_test_provider_uuid
+
+        start_date = DateHelper().last_month_start
+        end_date = DateHelper().last_month_end
+        with patch("masu.processor.tasks.disable_source") as disable_source:
+            disable_source.return_value = True
+            update_summary_tables(self.schema, provider, provider_ocp_uuid, start_date, end_date, synchronous=True)
+            mock_chain.return_value.apply_async.assert_not_called()
+
 
 class TestRemoveStaleTenants(MasuTestCase):
     def setUp(self):


### PR DESCRIPTION
## Jira Ticket

[COST-3769](https://issues.redhat.com/browse/COST-3769)

## Description

This feature is to disable a source given its source_uuid in the backend for Koku. 

## Testing

#### Scenario One: Source clogging up the queues.

We have identified a source that is clogging up summary queue, and we have added it to the disable source unleash flag.

To test this I recommend adding a sleep before the `if disable_source(provider_uuid):`  in the file: `koku/masu/processor/tasks.py`.  (Give yourself enough time to get the source uuid and add it to unleash)

Grab your source_uuid from the logs or here:
```
http://localhost:8000/api/cost-management/v1/sources/
```

Check the logs to see if you have hit your sleep. Then go here
```
http://localhost:4242/#/features
```
Add the source to the `disable_source` flag. 

Wait for the sleep to finish, then check the logs and see:
```
koku-koku-worker-1  | [2023-05-09 18:06:30,932] INFO 52a85775-bc80-47df-8f19-60c2445148aa Summary UNLEASH check: {'schema': 'org1234567'}
koku-koku-worker-1  | [2023-05-09 18:06:30,932] INFO 52a85775-bc80-47df-8f19-60c2445148aa     Summary enabled org1234567
koku-koku-worker-1  | [2023-05-09 18:07:15,946] INFO 52a85775-bc80-47df-8f19-60c2445148aa Disabled source UNLEASH check: {'source_uuid': 'd4c7adc9-f6f3-4306-a070-14aa714e7ee6'}
koku-koku-worker-1  | [2023-05-09 18:16:08,056] INFO 0ffe800e-19fd-44ba-a7cf-c47167dec5be     Processing disabled for source d4c7adc9-f6f3-4306-a070-14aa714e7ee6

```

#### Scenario Two:

The daily download is kicked off, we want to make sure our disabled source is not picked up as a polling source.

Manually trigger a download:
```
http://127.0.0.1:5042/api/cost-management/v1/download/?bill_date=2023-05-01&provider_uuid=d4c7adc9-f6f3-4306-a070-14aa714e7ee6
```

Check the logs:
```
koku-koku-worker-1  | [2023-05-09 18:07:15,946] INFO 52a85775-bc80-47df-8f19-60c2445148aa Disabled source UNLEASH check: {'source_uuid': 'd4c7adc9-f6f3-4306-a070-14aa714e7ee6'}
koku-koku-worker-1  | [2023-05-09 18:16:08,056] INFO 0ffe800e-19fd-44ba-a7cf-c47167dec5be     Processing disabled for source d4c7adc9-f6f3-4306-a070-14aa714e7ee6
```

## Notes
