### PR TITLE
Change authorization header format for Unleash 4

### DIFF
--- a/koku/koku/feature_flags.py
+++ b/koku/koku/feature_flags.py
@@ -56,7 +56,7 @@ strategies = {
 }
 headers = {}
 if settings.UNLEASH_TOKEN:
-    headers["Authorization"] = f"Bearer {settings.UNLEASH_TOKEN}"
+    headers["Authorization"] = settings.UNLEASH_TOKEN
 
 UNLEASH_CLIENT = KokuUnleashClient(
     url=settings.UNLEASH_URL,


### PR DESCRIPTION
## Description

With Unleash 4.x, the authorization header just needs the API key, not a "Bearer" string.

## Notes

Depends on https://github.com/app-sre/unleash/pull/43, which needs to be merged and a new image deployed.

The reason this is working in prod/stage currently, which are running Unleash 4.21, is due to a [custom authorization function](https://github.com/app-sre/unleash/blob/cde31fdcba1f60fa994b7a114f973e623dea5e2d/index.js#L133).