### PR TITLE
[COST-3779] Sentry: None is not a valid integer literal

### DIFF
--- a/koku/masu/processor/aws/aws_report_parquet_summary_updater.py
+++ b/koku/masu/processor/aws/aws_report_parquet_summary_updater.py
@@ -105,6 +105,11 @@ class AWSReportParquetSummaryUpdater(PartitionHandlerMixin):
                 bill_ids = [str(bill.id) for bill in bills]
                 current_bill_id = bills.first().id if bills else None
 
+            if current_bill_id is None:
+                msg = f"No bill was found for {start_date}. Skipping summarization"
+                LOG.info(msg)
+                return start_date, end_date
+
             for start, end in date_range_pair(start_date, end_date, step=settings.TRINO_DATE_STEP):
                 LOG.info(
                     "Updating AWS report summary tables from parquet: \n\tSchema: %s"

--- a/koku/masu/processor/azure/azure_report_parquet_summary_updater.py
+++ b/koku/masu/processor/azure/azure_report_parquet_summary_updater.py
@@ -80,6 +80,11 @@ class AzureReportParquetSummaryUpdater(PartitionHandlerMixin):
                 bill_ids = [str(bill.id) for bill in bills]
                 current_bill_id = bills.first().id if bills else None
 
+            if current_bill_id is None:
+                msg = f"No bill was found for {start_date}. Skipping summarization"
+                LOG.info(msg)
+                return start_date, end_date
+
             for start, end in date_range_pair(start_date, end_date, step=settings.TRINO_DATE_STEP):
                 LOG.info(
                     "Updating Azure report summary tables via Trino: \n\tSchema: %s"

--- a/koku/masu/test/processor/aws/test_aws_report_parquet_summary_updater.py
+++ b/koku/masu/test/processor/aws/test_aws_report_parquet_summary_updater.py
@@ -143,3 +143,26 @@ class AWSReportParquetSummaryUpdaterTest(MasuTestCase):
 
         self.assertEqual(start_return, start)
         self.assertEqual(end_return, end)
+
+    @patch("masu.processor.aws.aws_report_parquet_summary_updater.AWSReportDBAccessor.check_for_invoice_id_trino")
+    @patch(
+        "masu.processor.aws.aws_report_parquet_summary_updater.AWSReportDBAccessor.populate_line_item_daily_summary_table_trino"  # noqa: E501
+    )
+    def test_update_summary_tables_no_bills(self, *args):
+        """Test that summarization is skipped if no bill id found."""
+
+        start_str = self.dh.this_month_start.isoformat()
+        end_str = self.dh.this_month_end.isoformat()
+        start, end = self.updater._get_sql_inputs(start_str, end_str)
+
+        with patch(
+            "masu.processor.aws.aws_report_parquet_summary_updater.AWSReportDBAccessor.bills_for_provider_uuid",
+            return_value=[],
+        ):
+            with self.assertLogs("masu.processor.aws.aws_report_parquet_summary_updater", level="INFO") as logs:
+                start_return, end_return = self.updater.update_summary_tables(start_str, end_str)
+                expected_log_msg = f"No bill was found for {start_return}. Skipping summarization"
+
+        self.assertEqual(start_return, start)
+        self.assertEqual(end_return, end)
+        self.assertIn(expected_log_msg, logs.output[-1])


### PR DESCRIPTION
## Jira Ticket

[COST-3779](https://issues.redhat.com/browse/COST-3779)

## Description

This change will add a condition to check for `current_bill_id`

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Notes

...
