### PR TITLE
Remove scheduled task that removes stale tenants

### DIFF
--- a/koku/koku/celery.py
+++ b/koku/koku/celery.py
@@ -193,12 +193,6 @@ app.conf.beat_schedule["get_daily_currency_rates"] = {
     "schedule": crontab(hour=1, minute=0),
 }
 
-# Beat used to remove stale tenant data
-app.conf.beat_schedule["remove_stale_tenants"] = {
-    "task": "masu.processor.tasks.remove_stale_tenants",
-    "schedule": crontab(hour=0, minute=0),
-}
-
 # Beat used for HCS report finalization
 app.conf.beat_schedule["finalize_hcs_reports"] = {
     "task": "hcs.tasks.collect_hcs_report_finalization",

--- a/koku/masu/processor/tasks.py
+++ b/koku/masu/processor/tasks.py
@@ -1010,7 +1010,7 @@ def remove_stale_tenants():
         JOIN api_tenant t
             ON c.schema_name = t.schema_name
         LEFT JOIN api_sources s
-            ON c.ord_id = s.ord_id
+            ON c.org_id = s.org_id
         WHERE s.source_id IS null
             AND c.date_updated < now() - INTERVAL '2 weeks'
         ;

--- a/koku/masu/processor/tasks.py
+++ b/koku/masu/processor/tasks.py
@@ -1010,7 +1010,7 @@ def remove_stale_tenants():
         JOIN api_tenant t
             ON c.schema_name = t.schema_name
         LEFT JOIN api_sources s
-            ON c.account_id = s.account_id
+            ON c.ord_id = s.ord_id
         WHERE s.source_id IS null
             AND c.date_updated < now() - INTERVAL '2 weeks'
         ;


### PR DESCRIPTION
## Description

No longer remove stale tenants regularly. This is currently removing tenants incorrectly since `remote_stale_tenants` is joining on `tenant_id` and we switched to `org_id`.