### PR TITLE
Add AWS cache to cost categories resource-types

### DIFF
--- a/koku/api/resource_types/aws_category/view.py
+++ b/koku/api/resource_types/aws_category/view.py
@@ -134,7 +134,12 @@ class AWSCategoryView(generics.ListAPIView):
             annotate = {
                 "enabled": Exists(AWSEnabledCategoryKeys.objects.filter(key=OuterRef("key")).filter(enabled=True))
             }
-            self.queryset = AWSCategorySummary.objects.values_list("key", flat=True).annotate(**annotate).distinct()
+            self.queryset = (
+                AWSCategorySummary.objects.values_list("key", flat=True)
+                .annotate(**annotate)
+                .filter(enabled=True)
+                .distinct()
+            )
             self.SUPPORTED_FILTERS = ["limit", self.KEY_ONLY_PARAM, "account"]
         # Check for only supported query_params
         if self.request.query_params:

--- a/koku/api/urls.py
+++ b/koku/api/urls.py
@@ -346,7 +346,11 @@ urlpatterns = [
     path("resource-types/", ResourceTypeView.as_view(), name="resource-types"),
     path("user-access/", UserAccessView.as_view(), name="user-access"),
     path("resource-types/aws-accounts/", AWSAccountView.as_view(), name="aws-accounts"),
-    path("resource-types/aws-categories/", AWSCategoryView.as_view(), name="aws-categories"),
+    path(
+        "resource-types/aws-categories/",
+        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=AWS_CACHE_PREFIX)(AWSCategoryView.as_view()),
+        name="aws-categories",
+    ),
     path("resource-types/gcp-accounts/", GCPAccountView.as_view(), name="gcp-accounts"),
     path("resource-types/gcp-projects/", GCPProjectsView.as_view(), name="gcp-projects"),
     # TODO gcp-gcp-projects should be removed after UI is pushed to prod.


### PR DESCRIPTION
## Jira Ticket

When disabling & reenabling the resource-types endpoint was not getting updated due to the cache not getting invalidated. We may want to consider if some of these other cloud specific providers want to 

## Description

This change will add the aws cache prefix to the resource-types type ahead. 

## Testing
1. load test customer data
2. On main hit this endpoint:
```
http://localhost:8000/api/cost-management/v1/resource-types/aws-categories/
```
"key": "env",
"key": "Organization",

These two keys are in the test dummy data.
3. Now send a post to the settings endpoint:
```
- http://localhost:8000/api/cost-management/v1/settings/
```
```
{
    "api": {
        "settings": {
            "currency": "USD",
            "tag-management": {
                "enabled": [
                ]
            },
            "cost_type": "savingsplan_effective_cost",
            "aws-category-management": {
                "enabled": [
                    "aws-env",
                    "aws-OUs"
                ]
            }
        }
    }
}
```
This should disable the `Organization` key.
4. Hit the resource-types endpoint again, and notice the same two keys show up.
5. Checkout this branch.
Clear out the django cache
```
make shell
from django.core.cache import cache
cache.clear()
```
6. Hit the resource-types endpoint:
```
"data": [
        {
            "key": "env",
            "values": [
                "ephemeral",
                "prod",
                "stage"
            ],
            "enabled": "True"
        },
        {
            "key": "Organization",
            "values": [
                "Ninja"
            ],
            "enabled": "False"
        }
    ]
```
Check that the key only param only returns enabled keys:
http://localhost:8000/api/cost-management/v1/resource-types/aws-categories/?key_only=True
```
"data": [
        "env"
    ]
```

Notice that enabled is now `False`.
Now send another post to the settings endpoint enabling Organization:
```
{
    "api": {
        "settings": {
            "currency": "USD",
            "tag-management": {
                "enabled": [
                ]
            },
            "cost_type": "savingsplan_effective_cost",
            "aws-category-management": {
                "enabled": [
                    "aws-env",
                    "aws-Organization"
                ]
            }
        }
    }
}
```
Check the logs:
```
koku_server         | [2023-05-09 13:18:43,083] INFO None Updating enabled tag keys records
koku_server         | [2023-05-09 13:18:43,084] INFO None Updating 1 keys to ENABLED
koku_server         | [2023-05-09 13:18:43,087] INFO None Updating 3 keys to DISABLED
koku_server         | [2023-05-09 13:18:43,093] INFO None Invalidated request cache for
koku_server         | 	tenant: org1234567
koku_server         | 	cache_key_prefix: aws-view
koku_server         | [2023-05-09 13:18:43,095] INFO None Invalidated request cache for
koku_server         | 	tenant: org1234567
koku_server         | 	cache_key_prefix: openshift-aws-view
koku_server         | [2023-05-09 13:18:43,097] INFO None Invalidated request cache for
koku_server         | 	tenant: org1234567
koku_server         | 	cache_key_prefix: openshift-all-view
```
Recheck the resource-types endpoints:
http://localhost:8000/api/cost-management/v1/resource-types/aws-categories/?key_only=True

```
"data": [
        "env",
        "Organization"
    ]
```
http://localhost:8000/api/cost-management/v1/resource-types/aws-categories/
```
"data": [
        {
            "key": "env",
            "values": [
                "stage",
                "ephemeral",
                "prod"
            ],
            "enabled": "True"
        },
        {
            "key": "Organization",
            "values": [
                "Ninja"
            ],
            "enabled": "True"
        }
    ]
```


 

## Notes

...
