### PR TITLE
switching ocp on gcp to trino sql

### DIFF
--- a/koku/masu/database/gcp_report_db_accessor.py
+++ b/koku/masu/database/gcp_report_db_accessor.py
@@ -522,6 +522,34 @@ class GCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
                     table_name, summary_sql, bind_params=list(summary_sql_params), operation="DELETE/INSERT"
                 )
 
+    def populate_ocp_on_gcp_ui_summary_tables_trino(
+        self, start_date, end_date, openshift_provider_uuid, gcp_provider_uuid, tables=OCPGCP_UI_SUMMARY_TABLES
+    ):
+        """Populate our UI summary tables (formerly materialized views)."""
+        year = start_date.strftime("%Y")
+        month = start_date.strftime("%m")
+        days = self.date_helper.list_days(start_date, end_date)
+        days_tup = tuple(str(day.day) for day in days)
+        invoice_month_list = self.date_helper.gcp_find_invoice_months_in_date_range(start_date, end_date)
+        for invoice_month in invoice_month_list:
+            for table_name in tables:
+                summary_sql_params = {
+                    "schema_name": self.schema,
+                    "start_date": start_date,
+                    "end_date": end_date,
+                    "year": year,
+                    "month": month,
+                    "days": days_tup,
+                    "invoice_month": invoice_month,
+                    "azure_source_uuid": gcp_provider_uuid,
+                    "ocp_source_uuid": openshift_provider_uuid,
+                }
+                summary_sql = pkgutil.get_data("masu.database", f"trino_sql/gcp/openshift/{table_name}.sql")
+                summary_sql = summary_sql.decode("utf-8")
+                self._execute_trino_raw_sql_query(
+                    summary_sql, sql_params=summary_sql_params, log_ref=f"{table_name}.sql"
+                )
+
     def delete_ocp_on_gcp_hive_partition_by_day(self, days, gcp_source, ocp_source, year, month):
         """Deletes partitions individually for each day in days list."""
         table = "reporting_ocpgcpcostlineitem_project_daily_summary"

--- a/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_compute_summary_p.sql
+++ b/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_compute_summary_p.sql
@@ -1,0 +1,51 @@
+-- Populate the daily aggregate line item data
+INSERT INTO postgres.{{schema_name | sqlsafe}}.reporting_ocpgcp_compute_summary_p (
+    id,
+    account_id,
+    cluster_id,
+    cluster_alias,
+    usage_start,
+    usage_end,
+    usage_amount,
+    unit,
+    instance_type,
+    unblended_cost,
+    markup_cost,
+    currency,
+    source_uuid,
+    credit_amount,
+    invoice_month
+)
+    SELECT uuid() as id,
+        account_id,
+        cluster_id,
+        cluster_alias,
+        usage_start,
+        usage_end,
+        sum(usage_amount) as usage_amount,
+        max(unit) as unit,
+        instance_type,
+        sum(unblended_cost) as unblended_cost,
+        sum(markup_cost) as markup_cost,
+        max(currency) as currency,
+        source_uuid,
+        sum(credit_amount) as credit_amount,
+        invoice_month
+    FROM hive.{{schema_name | sqlsafe}}.reporting_ocpgcpcostlineitem_project_daily_summary_p
+    WHERE gcp_source = {{gcp_source_uuid}}
+        AND ocp_source = {{ocp_source_uuid}}
+        AND invoice_month = {{invoice_month}}
+        AND year = {{year}}
+        AND lpad(month, 2, '0') = {{month}} -- Zero pad the month when fewer than 2 characters
+        AND day in {{days | inclause}}
+        AND usage_start >= {{start_date}}
+        AND usage_start <= date_add('day', 1, {{end_date}})
+    GROUP BY cluster_id,
+        account_id,
+        cluster_alias,
+        usage_start,
+        usage_end,
+        source_uuid,
+        instance_type,
+        invoice_month
+;

--- a/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_cost_summary_by_account_p.sql
+++ b/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_cost_summary_by_account_p.sql
@@ -1,0 +1,45 @@
+-- Clear out old entries first
+-- Populate the daily aggregate line item data
+INSERT INTO postgres.{{schema_name | sqlsafe}}.reporting_ocpgcp_cost_summary_by_account_p (
+    id,
+    cluster_id,
+    cluster_alias,
+    usage_start,
+    usage_end,
+    account_id,
+    unblended_cost,
+    markup_cost,
+    currency,
+    source_uuid,
+    credit_amount,
+    invoice_month
+)
+    SELECT uuid() as id,
+        cluster_id,
+        cluster_alias,
+        usage_start,
+        usage_end,
+        account_id,
+        sum(unblended_cost) as unblended_cost,
+        sum(markup_cost) as markup_cost,
+        max(currency) as currency,
+        source_uuid,
+        sum(credit_amount) as credit_amount,
+        invoice_month
+    FROM hive.{{schema_name | sqlsafe}}.reporting_ocpgcpcostlineitem_project_daily_summary_p
+    WHERE gcp_source = {{gcp_source_uuid}}
+        AND ocp_source = {{ocp_source_uuid}}
+        AND invoice_month = {{invoice_month}}
+        AND year = {{year}}
+        AND lpad(month, 2, '0') = {{month}} -- Zero pad the month when fewer than 2 characters
+        AND day in {{days | inclause}}
+        AND usage_start >= {{start_date}}
+        AND usage_start <= date_add('day', 1, {{end_date}})
+    GROUP BY cluster_id,
+        cluster_alias,
+        usage_start,
+        usage_end,
+        account_id,
+        source_uuid,
+        invoice_month
+;

--- a/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_cost_summary_by_gcp_project_p.sql
+++ b/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_cost_summary_by_gcp_project_p.sql
@@ -1,0 +1,47 @@
+-- Populate the daily aggregate line item data
+INSERT INTO postgres.{{schema_name | sqlsafe}}.reporting_ocpgcp_cost_summary_by_gcp_project_p (
+    id,
+    cluster_id,
+    cluster_alias,
+    usage_start,
+    usage_end,
+    project_id,
+    project_name,
+    unblended_cost,
+    markup_cost,
+    currency,
+    source_uuid,
+    credit_amount,
+    invoice_month
+)
+    SELECT uuid() as id,
+        cluster_id,
+        cluster_alias,
+        usage_start,
+        usage_end,
+        project_id,
+        project_name,
+        sum(unblended_cost) as unblended_cost,
+        sum(markup_cost) as markup_cost,
+        max(currency) as currency,
+        source_uuid,
+        sum(credit_amount) as credit_amount,
+        invoice_month
+    FROM hive.{{schema_name | sqlsafe}}.reporting_ocpgcpcostlineitem_project_daily_summary_p
+    WHERE gcp_source = {{gcp_source_uuid}}
+        AND ocp_source = {{ocp_source_uuid}}
+        AND invoice_month = {{invoice_month}}
+        AND year = {{year}}
+        AND lpad(month, 2, '0') = {{month}} -- Zero pad the month when fewer than 2 characters
+        AND day in {{days | inclause}}
+        AND usage_start >= {{start_date}}
+        AND usage_start <= date_add('day', 1, {{end_date}})
+    GROUP BY cluster_id,
+        cluster_alias,
+        usage_start,
+        usage_end,
+        project_id,
+        project_name,
+        source_uuid,
+        invoice_month
+;

--- a/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_cost_summary_by_region_p.sql
+++ b/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_cost_summary_by_region_p.sql
@@ -1,0 +1,47 @@
+-- Populate the daily aggregate line item data
+INSERT INTO postgres.{{schema_name | sqlsafe}}.reporting_ocpgcp_cost_summary_by_region_p (
+    id,
+    cluster_id,
+    cluster_alias,
+    usage_start,
+    usage_end,
+    account_id,
+    region,
+    unblended_cost,
+    markup_cost,
+    currency,
+    source_uuid,
+    credit_amount,
+    invoice_month
+)
+    SELECT uuid() as id,
+        cluster_id,
+        cluster_alias,
+        usage_start,
+        usage_end,
+        account_id,
+        region,
+        sum(unblended_cost) as unblended_cost,
+        sum(markup_cost) as markup_cost,
+        max(currency) as currency,
+        source_uuid,
+        sum(credit_amount) as credit_amount,
+        invoice_month
+    FROM hive.{{schema_name | sqlsafe}}.reporting_ocpgcpcostlineitem_project_daily_summary_p
+    WHERE gcp_source = {{gcp_source_uuid}}
+        AND ocp_source = {{ocp_source_uuid}}
+        AND invoice_month = {{invoice_month}}
+        AND year = {{year}}
+        AND lpad(month, 2, '0') = {{month}} -- Zero pad the month when fewer than 2 characters
+        AND day in {{days | inclause}}
+        AND usage_start >= {{start_date}}
+        AND usage_start <= date_add('day', 1, {{end_date}})
+    GROUP BY cluster_id,
+        cluster_alias,
+        usage_start,
+        usage_end,
+        account_id,
+        region,
+        source_uuid,
+        invoice_month
+;

--- a/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_cost_summary_by_service_p.sql
+++ b/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_cost_summary_by_service_p.sql
@@ -1,0 +1,51 @@
+-- Clear out old entries first
+-- Populate the daily aggregate line item data
+INSERT INTO postgres.{{schema_name | sqlsafe}}.reporting_ocpgcp_cost_summary_by_service_p (
+    id,
+    cluster_id,
+    cluster_alias,
+    usage_start,
+    usage_end,
+    account_id,
+    service_id,
+    service_alias,
+    unblended_cost,
+    markup_cost,
+    currency,
+    source_uuid,
+    credit_amount,
+    invoice_month
+)
+    SELECT uuid() as id,
+        cluster_id,
+        cluster_alias,
+        usage_start,
+        usage_end,
+        account_id,
+        service_id,
+        service_alias,
+        sum(unblended_cost) as unblended_cost,
+        sum(markup_cost) as markup_cost,
+        max(currency) as currency,
+        source_uuid,
+        sum(credit_amount) as credit_amount,
+        invoice_month
+    FROM hive.{{schema_name | sqlsafe}}.reporting_ocpgcpcostlineitem_project_daily_summary_p
+    WHERE gcp_source = {{gcp_source_uuid}}
+        AND ocp_source = {{ocp_source_uuid}}
+        AND invoice_month = {{invoice_month}}
+        AND year = {{year}}
+        AND lpad(month, 2, '0') = {{month}} -- Zero pad the month when fewer than 2 characters
+        AND day in {{days | inclause}}
+        AND usage_start >= {{start_date}}
+        AND usage_start <= date_add('day', 1, {{end_date}})
+    GROUP BY cluster_id,
+        cluster_alias,
+        usage_start,
+        usage_end,
+        account_id,
+        service_id,
+        service_alias,
+        source_uuid,
+        invoice_month
+;

--- a/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_cost_summary_p.sql
+++ b/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_cost_summary_p.sql
@@ -1,0 +1,43 @@
+-- Populate the daily aggregate line item data
+INSERT INTO postgres.{{schema_name | sqlsafe}}.reporting_ocpgcp_cost_summary_p (
+    id,
+    cluster_id,
+    cluster_alias,
+    usage_start,
+    usage_end,
+    unblended_cost,
+    markup_cost,
+    currency,
+    source_uuid,
+    credit_amount,
+    invoice_month,
+    cost_category_id
+)
+    SELECT uuid() as id,
+        cluster_id,
+        cluster_alias,
+        usage_start,
+        usage_end,
+        sum(unblended_cost) as unblended_cost,
+        sum(markup_cost) as markup_cost,
+        max(currency) as currency,
+        source_uuid,
+        sum(credit_amount) as credit_amount,
+        invoice_month,
+        max(cost_category_id)
+    FROM hive.{{schema_name | sqlsafe}}.reporting_ocpgcpcostlineitem_project_daily_summary_p
+    WHERE gcp_source = {{gcp_source_uuid}}
+        AND ocp_source = {{ocp_source_uuid}}
+        AND invoice_month = {{invoice_month}}
+        AND year = {{year}}
+        AND lpad(month, 2, '0') = {{month}} -- Zero pad the month when fewer than 2 characters
+        AND day in {{days | inclause}}
+        AND usage_start >= {{start_date}}
+        AND usage_start <= date_add('day', 1, {{end_date}})
+    GROUP BY cluster_id,
+        cluster_alias,
+        usage_start,
+        usage_end,
+        source_uuid,
+        invoice_month
+;

--- a/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_database_summary_p.sql
+++ b/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_database_summary_p.sql
@@ -1,0 +1,62 @@
+-- Populate the daily aggregate line item data
+INSERT INTO postgres.{{schema_name | sqlsafe}}.reporting_ocpgcp_database_summary_p (
+    id,
+    cluster_id,
+    cluster_alias,
+    usage_start,
+    usage_end,
+    usage_amount,
+    unit,
+    account_id,
+    service_id,
+    service_alias,
+    unblended_cost,
+    markup_cost,
+    currency,
+    source_uuid,
+    credit_amount,
+    invoice_month
+)
+    SELECT uuid() as id,
+        cluster_id,
+        cluster_alias,
+        usage_start,
+        usage_end,
+        sum(usage_amount) as usage_amount,
+        max(unit) as unit,
+        account_id,
+        service_id,
+        service_alias,
+        sum(unblended_cost) as unblended_cost,
+        sum(markup_cost) as markup_cost,
+        max(currency) as currency,
+        source_uuid,
+        sum(credit_amount) as credit_amount,
+        invoice_month
+    FROM hive.{{schema_name | sqlsafe}}.reporting_ocpgcpcostlineitem_project_daily_summary_p
+    -- Get data for this month or last month
+    WHERE gcp_source = {{gcp_source_uuid}}
+        AND ocp_source = {{ocp_source_uuid}}
+        AND invoice_month = {{invoice_month}}
+        AND year = {{year}}
+        AND lpad(month, 2, '0') = {{month}} -- Zero pad the month when fewer than 2 characters
+        AND day in {{days | inclause}}
+        AND usage_start >= {{start_date}}
+        AND usage_start <= date_add('day', 1, {{end_date}})
+        AND (service_alias LIKE '%%SQL%%'
+        OR service_alias LIKE '%%Spanner%%'
+        OR service_alias LIKE '%%Bigtable%%'
+        OR service_alias LIKE '%%Firestore%%'
+        OR service_alias LIKE '%%Firebase%%'
+        OR service_alias LIKE '%%Memorystore%%'
+        OR service_alias LIKE '%%MongoDB%%')
+    GROUP BY cluster_id,
+        cluster_alias,
+        usage_start,
+        usage_end,
+        account_id,
+        service_id,
+        service_alias,
+        source_uuid,
+        invoice_month
+;

--- a/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_network_summary_p.sql
+++ b/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_network_summary_p.sql
@@ -1,0 +1,68 @@
+-- Populate the daily aggregate line item data
+INSERT INTO postgres.{{schema_name | sqlsafe}}.reporting_ocpgcp_network_summary_p (
+    id,
+    cluster_id,
+    cluster_alias,
+    usage_start,
+    usage_end,
+    usage_amount,
+    unit,
+    account_id,
+    service_id,
+    service_alias,
+    unblended_cost,
+    markup_cost,
+    currency,
+    source_uuid,
+    credit_amount,
+    invoice_month
+)
+    SELECT uuid() as id,
+        cluster_id,
+        cluster_alias,
+        usage_start,
+        usage_end,
+        sum(usage_amount) as usage_amount,
+        max(unit) as unit,
+        account_id,
+        service_id,
+        service_alias,
+        sum(unblended_cost) as unblended_cost,
+        sum(markup_cost) as markup_cost,
+        max(currency) as currency,
+        source_uuid,
+        sum(credit_amount) as credit_amount,
+        invoice_month
+    FROM hive.{{schema_name | sqlsafe}}.reporting_ocpgcpcostlineitem_project_daily_summary_p
+    -- Get data for this month or last month
+    WHERE gcp_source = {{gcp_source_uuid}}
+        AND ocp_source = {{ocp_source_uuid}}
+        AND invoice_month = {{invoice_month}}
+        AND year = {{year}}
+        AND lpad(month, 2, '0') = {{month}} -- Zero pad the month when fewer than 2 characters
+        AND day in {{days | inclause}}
+        AND usage_start >= {{start_date}}
+        AND usage_start <= date_add('day', 1, {{end_date}})
+        AND (service_alias LIKE '%%Network%%'
+        OR service_alias LIKE '%%VPC%%'
+        OR service_alias LIKE '%%Firewall%%'
+        OR service_alias LIKE '%%Route%%'
+        OR service_alias LIKE '%%IP%%'
+        OR service_alias LIKE '%%DNS%%'
+        OR service_alias LIKE '%%CDN%%'
+        OR service_alias LIKE '%%NAT%%'
+        OR service_alias LIKE '%%Traffic Director%%'
+        OR service_alias LIKE '%%Service Discovery%%'
+        OR service_alias LIKE '%%Cloud Domains%%'
+        OR service_alias LIKE '%%Private Service Connect%%'
+        OR service_alias LIKE '%%Cloud Armor%%')
+    GROUP BY cluster_id,
+        cluster_alias,
+        usage_start,
+        usage_end,
+        account_id,
+        service_id,
+        service_alias,
+        source_uuid,
+        invoice_month
+;

--- a/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_storage_summary_p.sql
+++ b/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_storage_summary_p.sql
@@ -1,0 +1,56 @@
+-- Populate the daily aggregate line item data
+INSERT INTO postgres.{{schema_name | sqlsafe}}.reporting_ocpgcp_storage_summary_p (
+    id,
+    cluster_id,
+    cluster_alias,
+    usage_start,
+    usage_end,
+    usage_amount,
+    unit,
+    account_id,
+    service_id,
+    service_alias,
+    unblended_cost,
+    markup_cost,
+    currency,
+    source_uuid,
+    credit_amount,
+    invoice_month
+)
+    SELECT uuid() as id,
+        cluster_id,
+        cluster_alias,
+        usage_start,
+        usage_end,
+        sum(usage_amount) as usage_amount,
+        max(unit) as unit,
+        account_id,
+        service_id,
+        service_alias,
+        sum(unblended_cost) as unblended_cost,
+        sum(markup_cost) as markup_cost,
+        max(currency) as currency,
+        source_uuid,
+        sum(credit_amount) as credit_amount,
+        invoice_month
+    FROM hive.{{schema_name | sqlsafe}}.reporting_ocpgcpcostlineitem_project_daily_summary_p
+    -- Get data for this month or last month
+    WHERE gcp_source = {{gcp_source_uuid}}
+        AND ocp_source = {{ocp_source_uuid}}
+        AND invoice_month = {{invoice_month}}
+        AND year = {{year}}
+        AND lpad(month, 2, '0') = {{month}} -- Zero pad the month when fewer than 2 characters
+        AND day in {{days | inclause}}
+        AND usage_start >= {{start_date}}
+        AND usage_start <= date_add('day', 1, {{end_date}})
+        AND service_alias IN ('Filestore', 'Storage', 'Cloud Storage', 'Data Transfer')
+    GROUP BY cluster_id,
+        cluster_alias,
+        usage_start,
+        usage_end,
+        account_id,
+        service_id,
+        service_alias,
+        source_uuid,
+        invoice_month
+;

--- a/koku/masu/processor/ocp/ocp_cloud_parquet_summary_updater.py
+++ b/koku/masu/processor/ocp/ocp_cloud_parquet_summary_updater.py
@@ -525,7 +525,9 @@ class OCPCloudParquetReportSummaryUpdater(PartitionHandlerMixin, OCPCloudUpdater
                 sql_params["start_date"] = start
                 sql_params["end_date"] = end
                 accessor.back_populate_ocp_infrastructure_costs(start, end, current_ocp_report_period_id)
-                accessor.populate_ocp_on_gcp_ui_summary_tables(sql_params)
+                accessor.populate_ocp_on_gcp_ui_summary_tables_trino(
+                    start, end, openshift_provider_uuid, gcp_provider_uuid
+                )
                 accessor.populate_ocp_on_gcp_tags_summary_table(gcp_bill_ids, start, end)
 
             with OCPReportDBAccessor(self._schema) as ocp_accessor:

--- a/koku/masu/test/database/test_gcp_report_db_accessor.py
+++ b/koku/masu/test/database/test_gcp_report_db_accessor.py
@@ -184,6 +184,21 @@ class GCPReportDBAccessorTest(MasuTestCase):
         )
         mock_trino.assert_called()
 
+    @patch("masu.database.gcp_report_db_accessor.GCPReportDBAccessor._execute_trino_raw_sql_query")
+    def test_populate_ocp_on_gcp_ui_summary_tables_trino(self, mock_trino):
+        """Test that Trino is used to populate UI summary."""
+        dh = DateHelper()
+        start_date = dh.this_month_start.date()
+        end_date = dh.this_month_end.date()
+
+        self.accessor.populate_ocp_on_gcp_ui_summary_tables_trino(
+            start_date,
+            end_date,
+            self.ocp_provider_uuid,
+            self.gcp_provider_uuid,
+        )
+        mock_trino.assert_called()
+
     def test_populate_enabled_tag_keys(self):
         """Test that enabled tag keys are populated."""
         dh = DateHelper()

--- a/koku/masu/test/processor/ocp/test_ocp_cloud_parquet_report_summary_updater.py
+++ b/koku/masu/test/processor/ocp/test_ocp_cloud_parquet_report_summary_updater.py
@@ -265,6 +265,9 @@ class OCPCloudParquetReportSummaryUpdaterTest(MasuTestCase):
         "masu.processor.ocp.ocp_cloud_parquet_summary_updater.GCPReportDBAccessor.populate_ocp_on_gcp_tags_summary_table"  # noqa: E501
     )
     @patch(
+        "masu.processor.ocp.ocp_cloud_parquet_summary_updater.GCPReportDBAccessor.populate_ocp_on_gcp_ui_summary_tables_trino"  # noqa: E501
+    )
+    @patch(
         "masu.processor.ocp.ocp_cloud_parquet_summary_updater.GCPReportDBAccessor.populate_ocp_on_gcp_ui_summary_tables"
     )
     @patch(
@@ -284,6 +287,7 @@ class OCPCloudParquetReportSummaryUpdaterTest(MasuTestCase):
         mock_back_populate,
         mock_ocp_on_gcp,
         mock_ui_tables,
+        mock_ui_summary,
         mock_tag_summary,
         mock_map,
         mock_ocpallproj,
@@ -445,6 +449,9 @@ class OCPCloudParquetReportSummaryUpdaterTest(MasuTestCase):
         "masu.processor.ocp.ocp_cloud_parquet_summary_updater.GCPReportDBAccessor.populate_ocp_on_gcp_tags_summary_table"  # noqa: E501
     )
     @patch(
+        "masu.processor.ocp.ocp_cloud_parquet_summary_updater.GCPReportDBAccessor.populate_ocp_on_gcp_ui_summary_tables_trino"  # noqa: E501
+    )
+    @patch(
         "masu.processor.ocp.ocp_cloud_parquet_summary_updater.GCPReportDBAccessor.populate_ocp_on_gcp_ui_summary_tables"
     )
     @patch(
@@ -464,6 +471,7 @@ class OCPCloudParquetReportSummaryUpdaterTest(MasuTestCase):
         mock_back_populate,
         mock_ocp_on_gcp,
         mock_ui_tables,
+        mock_ui_summary,
         mock_tag_summary,
         mock_map,
         mock_ocpallproj,


### PR DESCRIPTION
## Jira Ticket

[COST-3785](https://issues.redhat.com/browse/COST-3785)

## Description

This change will switch to using Trino to populate the OCP on GCP UI summary tables.

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Notes

...
