### PR TITLE
[COST-3688] revert celery.utils.log.get_task_logger

### DIFF
--- a/koku/masu/processor/report_summary_updater.py
+++ b/koku/masu/processor/report_summary_updater.py
@@ -4,8 +4,7 @@
 #
 """Update reporting summary tables."""
 import datetime
-
-from celery.utils.log import get_task_logger
+import logging
 
 from api.common import log_json
 from api.models import Provider
@@ -20,7 +19,7 @@ from masu.processor.oci.oci_report_parquet_summary_updater import OCIReportParqu
 from masu.processor.ocp.ocp_cloud_parquet_summary_updater import OCPCloudParquetReportSummaryUpdater
 from masu.processor.ocp.ocp_report_parquet_summary_updater import OCPReportParquetSummaryUpdater
 
-LOG = get_task_logger(__name__)
+LOG = logging.getLogger(__name__)
 REPORT_SUMMARY_UPDATER_DICT = {
     Provider.PROVIDER_AWS: AWSReportParquetSummaryUpdater,
     Provider.PROVIDER_AZURE: AzureReportParquetSummaryUpdater,

--- a/koku/masu/processor/tasks.py
+++ b/koku/masu/processor/tasks.py
@@ -4,6 +4,7 @@
 #
 """Asynchronous tasks."""
 import json
+import logging
 import os
 from collections import defaultdict
 from decimal import Decimal
@@ -13,7 +14,6 @@ import ciso8601
 import pandas as pd
 from celery import chain
 from celery import group
-from celery.utils.log import get_task_logger
 from dateutil import parser
 from django.conf import settings
 from django.db import connection
@@ -65,7 +65,7 @@ from masu.util.gcp.common import deduplicate_reports_for_gcp
 from masu.util.oci.common import deduplicate_reports_for_oci
 
 
-LOG = get_task_logger(__name__)
+LOG = logging.getLogger(__name__)
 
 DEFAULT = "celery"
 GET_REPORT_FILES_QUEUE = "download"


### PR DESCRIPTION
## Jira Ticket

[COST-3688](https://issues.redhat.com/browse/COST-3688#)

## Description

Revert the `celery.utils.log.get_task_logger` in favor of logging.getLogger. Using `get_task_logger` is excluding the logs from Kibana.
