### PR TITLE
[COST-3688] make `msg` a required arg to log_json

### DIFF
--- a/koku/api/common/__init__.py
+++ b/koku/api/common/__init__.py
@@ -12,7 +12,7 @@ def error_obj(key, message):
     return {key: [_(message)]}
 
 
-def log_json(tracing_id="", msg="", context=None, **kwargs):
+def log_json(tracing_id="", *, msg, context=None, **kwargs):
     """Create JSON object for logging data."""
     stmt = {"message": msg, "tracing_id": tracing_id}
     if context:

--- a/koku/hcs/csv_file_handler.py
+++ b/koku/hcs/csv_file_handler.py
@@ -37,7 +37,7 @@ class CSVFileHandler:
             f"hcs/csv/{self._schema_name}/{self._provider}/source={self._provider_uuid}/year={year}/month={month}"
         )
 
-        LOG.info(log_json(tracing_id, "preparing to write file to object storage"))
+        LOG.info(log_json(tracing_id, msg="preparing to write file to object storage"))
         my_df.to_csv(filename, header=cols, index=False)
         copy_local_hcs_report_file_to_s3_bucket(tracing_id, s3_csv_path, filename, filename, finalize, date)
         os.remove(filename)

--- a/koku/hcs/daily_report.py
+++ b/koku/hcs/daily_report.py
@@ -43,7 +43,7 @@ class ReportHCS:
                     )
 
             except HCSTableNotFoundError as tnfe:
-                LOG.info(log_json(self._tracing_id, f"{tnfe}, skipping..."))
+                LOG.info(log_json(self._tracing_id, msg=f"{tnfe}, skipping..."))
 
             except Exception as e:
-                LOG.error(log_json(self._tracing_id, "get_hcs_daily_summary exception"), exc_info=e)
+                LOG.warning(log_json(self._tracing_id, msg="get_hcs_daily_summary exception"), exc_info=e)

--- a/koku/hcs/daily_report.py
+++ b/koku/hcs/daily_report.py
@@ -46,4 +46,4 @@ class ReportHCS:
                 LOG.info(log_json(self._tracing_id, f"{tnfe}, skipping..."))
 
             except Exception as e:
-                LOG.error(log_json(self._tracing_id, e))
+                LOG.error(log_json(self._tracing_id, "get_hcs_daily_summary exception"), exc_info=e)

--- a/koku/hcs/test/database/test_report_db_accessor.py
+++ b/koku/hcs/test/database/test_report_db_accessor.py
@@ -65,9 +65,8 @@ class TestHCSReportDBAccessor(HCSTestCase):
                 "sql/reporting_aws_hcs_daily_summary.sql",
                 "1234-1234-1234",
             )
-            self.assertIn("acquiring marketplace data...", _logs.output[0])
-            self.assertIn(f"schema: {self.schema}, provider: {self.provider}, date: {self.today}", _logs.output[1])
-            self.assertIn("no data found for date", _logs.output[2])
+            self.assertIn("acquiring marketplace data", _logs.output[0])
+            self.assertIn("no data found", _logs.output[1])
 
     @patch("hcs.csv_file_handler.CSVFileHandler")
     @patch("hcs.csv_file_handler.CSVFileHandler.write_csv_to_s3")
@@ -85,6 +84,5 @@ class TestHCSReportDBAccessor(HCSTestCase):
                 "sql/reporting_aws_hcs_daily_summary.sql",
                 "1234-1234-1234",
             )
-            self.assertIn("acquiring marketplace data...", _logs.output[0])
-            self.assertIn(f"schema: {self.schema}, provider: {self.provider}, date: {self.today}", _logs.output[1])
-            self.assertIn("data found for date", _logs.output[2])
+            self.assertIn("acquiring marketplace data", _logs.output[0])
+            self.assertIn("data found", _logs.output[1])

--- a/koku/hcs/test/test_tasks.py
+++ b/koku/hcs/test/test_tasks.py
@@ -45,7 +45,7 @@ class TestHCSTasks(HCSTestCase):
                 self.schema, self.aws_provider_type, str(self.aws_provider.uuid), start_date, end_date
             )
 
-            self.assertIn("[collect_hcs_report_data]", _logs.output[0])
+            self.assertIn("collecting hcs report data", _logs.output[0])
 
     def test_get_report_no_start_date(self, mock_ehp, mock_report):
         """Test no start or end dates provided"""
@@ -54,7 +54,7 @@ class TestHCSTasks(HCSTestCase):
         with self.assertLogs("hcs.tasks", "INFO") as _logs:
             collect_hcs_report_data(self.schema, self.aws_provider_type, str(self.aws_provider.uuid))
 
-            self.assertIn("[collect_hcs_report_data]", _logs.output[0])
+            self.assertIn("collecting hcs report data", _logs.output[0])
 
     def test_get_report_no_tracing_id(self, mock_ehp, mock_report):
         """Test that tracing_id is added to log output when not provided"""
@@ -85,7 +85,7 @@ class TestHCSTasks(HCSTestCase):
             start_date = self.yesterday
             collect_hcs_report_data(self.schema, self.aws_provider_type, str(self.aws_provider.uuid), start_date)
 
-            self.assertIn("[collect_hcs_report_data]", _logs.output[0])
+            self.assertIn("collecting hcs report data", _logs.output[0])
 
     def test_get_report_invalid_provider(self, mock_ehp, mock_report):
         """Test invalid provider"""
@@ -95,7 +95,7 @@ class TestHCSTasks(HCSTestCase):
             start_date = self.yesterday
             collect_hcs_report_data(self.schema, "bogus", str(self.aws_provider.uuid), start_date)
 
-            self.assertIn("[SKIPPED] HCS report generation", _logs.output[0])
+            self.assertIn("skipping hcs report generation", _logs.output[0])
 
     def test_get_report_schema_no_acct_prefix(self, mock_ehp, mock_report):
         """Test no schema name prefix provided"""
@@ -124,12 +124,12 @@ class TestHCSTasks(HCSTestCase):
         with self.assertLogs("hcs.tasks", "INFO") as _logs:
             collect_hcs_report_data_from_manifest(manifests)
 
-            self.assertIn("[collect_hcs_report_data_from_manifest]", _logs.output[0])
-            self.assertIn(f"schema_name: {self.schema}", _logs.output[0])
-            self.assertIn(f"provider_type: {self.aws_provider_type}", _logs.output[0])
-            self.assertIn(f"provider_uuid: {str(self.aws_provider.uuid)}", _logs.output[0])
-            self.assertIn("start:", _logs.output[0])
-            self.assertIn("end:", _logs.output[0])
+            self.assertIn("collect hcs report data from manifest", _logs.output[0])
+            self.assertIn(f"'schema_name': '{self.schema}'", _logs.output[0])
+            self.assertIn(f"'provider_type': '{self.aws_provider_type}'", _logs.output[0])
+            self.assertIn(f"'provider_uuid': '{str(self.aws_provider.uuid)}'", _logs.output[0])
+            self.assertIn("'start_date':", _logs.output[0])
+            self.assertIn("'end_date':", _logs.output[0])
 
     @patch("hcs.tasks.collect_hcs_report_data")
     def test_get_report_with_manifest_and_dates(self, rd, mock_ehp, mock_report):
@@ -187,11 +187,10 @@ class TestHCSTasks(HCSTestCase):
         with self.assertLogs("hcs.tasks", "INFO") as _logs:
             collect_hcs_report_finalization()
 
-            self.assertIn("[collect_hcs_report_finalization]:", _logs.output[0])
-            self.assertIn("schema_name:", _logs.output[0])
-            self.assertIn("provider_type:", _logs.output[0])
-            self.assertIn("provider_uuid:", _logs.output[0])
-            self.assertIn("dates:", _logs.output[0])
+            self.assertIn("collecting hcs report finalization", _logs.output[0])
+            self.assertIn("'schema_name':", _logs.output[0])
+            self.assertIn("'provider_type':", _logs.output[0])
+            self.assertIn("'provider_uuid':", _logs.output[0])
 
     @patch("hcs.tasks.collect_hcs_report_data")
     def test_hcs_report_finalization_tracing_id(self, rd, mock_ehp, mock_report):
@@ -237,7 +236,8 @@ class TestHCSTasks(HCSTestCase):
 
         with self.assertLogs("hcs.tasks", "INFO") as _logs:
             collect_hcs_report_finalization(provider_type=self.aws_provider_type, month=10, year=2021)
-            self.assertIn(f"dates: {start_date} - {end_date}", _logs.output[0])
+            self.assertIn(f"'start_date': '{start_date}'", _logs.output[0])
+            self.assertIn(f"'end_date': '{end_date}'", _logs.output[0])
 
     @patch("hcs.tasks.collect_hcs_report_data")
     def test_hcs_report_report_finalization_provider_type(self, rd, mock_ehp, mock_report):
@@ -249,7 +249,7 @@ class TestHCSTasks(HCSTestCase):
             collect_hcs_report_finalization(provider_type=self.aws_provider_type)
 
             self.assertIn(f"provided provider_type: {self.aws_provider_type}", _logs.output[0])
-            self.assertIn(f"provider_type: {self.aws_provider_type}", _logs.output[1])
+            self.assertIn(f"'provider_type': '{self.aws_provider_type}'", _logs.output[1])
 
     @patch("hcs.tasks.collect_hcs_report_data")
     def test_hcs_report_finalization_provider_negative(self, rd, mock_ehp, mock_report):
@@ -273,7 +273,6 @@ class TestHCSTasks(HCSTestCase):
             collect_hcs_report_finalization(provider_uuid=str(self.aws_provider.uuid))
 
             self.assertIn(f"provided provider_uuid: {str(self.aws_provider.uuid)}", _logs.output[0])
-            self.assertIn(f"provider_uuid: {self.aws_provider.uuid}", _logs.output[1])
 
     @patch("hcs.tasks.collect_hcs_report_data")
     def test_hcs_report_finalization_provider_uuid_negative(self, rd, mock_ehp, mock_report):
@@ -300,8 +299,8 @@ class TestHCSTasks(HCSTestCase):
                 f"provided schema_name: {self.schema}, provided provider_type: {self.aws_provider_type}",
                 _logs.output[0],
             )
-            self.assertIn(f"schema_name: {self.schema}", _logs.output[1])
-            self.assertIn(f"provider_type: {self.aws_provider_type}", _logs.output[1])
+            self.assertIn(f"'schema_name': '{self.schema}'", _logs.output[1])
+            self.assertIn(f"'provider_type': '{self.aws_provider_type}'", _logs.output[1])
 
     @patch("hcs.tasks.collect_hcs_report_data")
     def test_hcs_report_finalization_schema_name(self, rd, mock_ehp, mock_report):
@@ -313,7 +312,7 @@ class TestHCSTasks(HCSTestCase):
             collect_hcs_report_finalization(schema_name=self.schema)
 
             self.assertIn(f"provided schema_name: {self.schema}", _logs.output[0])
-            self.assertIn(f"schema_name: {self.schema}", _logs.output[1])
+            self.assertIn(f"'schema_name': '{self.schema}'", _logs.output[1])
 
     @patch("hcs.tasks.collect_hcs_report_data")
     def test_hcs_report_finalization_schema_no_acct_prefix(self, rd, mock_ehp, mock_report):
@@ -337,7 +336,7 @@ class TestHCSTasks(HCSTestCase):
             collect_hcs_report_finalization(schema_name="org1234567")
 
             self.assertIn(f"provided schema_name: {self.schema}", _logs.output[0])
-            self.assertIn(f"schema_name: {self.schema}", _logs.output[1])
+            self.assertIn(f"'schema_name': '{self.schema}'", _logs.output[1])
 
     @patch("hcs.tasks.collect_hcs_report_data")
     def test_hcs_report_finalization_schema_name_negative(self, rd, mock_ehp, mock_report):

--- a/koku/masu/database/report_db_accessor_base.py
+++ b/koku/masu/database/report_db_accessor_base.py
@@ -127,7 +127,7 @@ class ReportDBAccessorBase(KokuDBAccess):
                 t2 = time.time()
             except OperationalError as exc:
                 db_exc = get_extended_exception_by_type(exc)
-                LOG.error(log_json(os.getpid(), str(db_exc), context=db_exc.as_dict()))
+                LOG.error(log_json(os.getpid(), msg=str(db_exc), context=db_exc.as_dict()))
                 raise db_exc
 
         LOG.info("Finished %s on %s in %f seconds.", operation, table, t2 - t1)

--- a/koku/masu/external/downloader/aws/aws_report_downloader.py
+++ b/koku/masu/external/downloader/aws/aws_report_downloader.py
@@ -144,10 +144,10 @@ class AWSReportDownloader(ReportDownloaderBase, DownloaderInterface):
         except ClientError as ex:
             if ex.response["Error"]["Code"] == "AccessDenied":
                 msg = f"Unable to access S3 Bucket {self.bucket}: (AccessDenied)"
-                LOG.info(log_json(self.tracing_id, msg, self.context))
+                LOG.info(log_json(self.tracing_id, msg=msg, context=self.context))
                 raise AWSReportDownloaderNoFileError(msg)
             msg = f"Error downloading file: Error: {str(ex)}"
-            LOG.error(log_json(self.tracing_id, msg, self.context))
+            LOG.error(log_json(self.tracing_id, msg=msg, context=self.context))
             raise AWSReportDownloaderError(str(ex))
 
         if size < 0:
@@ -184,13 +184,13 @@ class AWSReportDownloader(ReportDownloaderBase, DownloaderInterface):
         """
         manifest = f"{self._get_report_path(date_time)}/{self.report_name}-Manifest.json"
         msg = f"Will attempt to download manifest: {manifest}"
-        LOG.info(log_json(self.tracing_id, msg, self.context))
+        LOG.info(log_json(self.tracing_id, msg=msg, context=self.context))
 
         try:
             manifest_file, _, manifest_modified_timestamp, __, ___ = self.download_file(manifest)
         except AWSReportDownloaderNoFileError as err:
             msg = f"Unable to get report manifest. Reason: {str(err)}"
-            LOG.info(log_json(self.tracing_id, msg, self.context))
+            LOG.info(log_json(self.tracing_id, msg=msg, context=self.context))
             return "", self.empty_manifest, None
 
         manifest_json = None
@@ -206,7 +206,7 @@ class AWSReportDownloader(ReportDownloaderBase, DownloaderInterface):
             LOG.debug("Deleted manifest file at %s", manifest_file)
         except OSError:
             msg = f"Could not delete manifest file at {manifest_file}"
-            LOG.info(log_json(self.tracing_id, msg, self.context))
+            LOG.info(log_json(self.tracing_id, msg=msg, context=self.context))
 
         return None
 
@@ -244,7 +244,7 @@ class AWSReportDownloader(ReportDownloaderBase, DownloaderInterface):
 
         local_s3_filename = utils.get_local_file_name(key)
         msg = f"Local S3 filename: {local_s3_filename}"
-        LOG.info(log_json(self.tracing_id, msg, self.context))
+        LOG.info(log_json(self.tracing_id, msg=msg, context=self.context))
         full_file_path = f"{directory_path}/{local_s3_filename}"
 
         # Make sure the data directory exists
@@ -258,24 +258,24 @@ class AWSReportDownloader(ReportDownloaderBase, DownloaderInterface):
         except ClientError as ex:
             if ex.response["Error"]["Code"] == "NoSuchKey":
                 msg = f"Unable to find {s3_filename} in S3 Bucket: {self.bucket}"
-                LOG.info(log_json(self.tracing_id, msg, self.context))
+                LOG.info(log_json(self.tracing_id, msg=msg, context=self.context))
                 raise AWSReportDownloaderNoFileError(msg)
             if ex.response["Error"]["Code"] == "AccessDenied":
                 msg = f"Unable to access S3 Bucket {self.bucket}: (AccessDenied)"
-                LOG.info(log_json(self.tracing_id, msg, self.context))
+                LOG.info(log_json(self.tracing_id, msg=msg, context=self.context))
                 raise AWSReportDownloaderNoFileError(msg)
             msg = f"Error downloading file: Error: {str(ex)}"
-            LOG.error(log_json(self.tracing_id, msg, self.context))
+            LOG.error(log_json(self.tracing_id, msg=msg, context=self.context))
             raise AWSReportDownloaderError(str(ex))
 
         if not self._check_size(key, check_inflate=True):
             msg = f"Insufficient disk space to download file: {s3_file}"
-            LOG.error(log_json(self.tracing_id, msg, self.context))
+            LOG.error(log_json(self.tracing_id, msg=msg, context=self.context))
             raise AWSReportDownloaderError(msg)
 
         if s3_etag != stored_etag or not os.path.isfile(full_file_path):
             msg = f"Downloading key: {key} to file path: {full_file_path}"
-            LOG.info(log_json(self.tracing_id, msg, self.context))
+            LOG.info(log_json(self.tracing_id, msg=msg, context=self.context))
             self.s3_client.download_file(self.bucket, key, full_file_path)
             # Push to S3
             s3_csv_path = get_path_prefix(
@@ -292,7 +292,7 @@ class AWSReportDownloader(ReportDownloaderBase, DownloaderInterface):
                 utils.remove_files_not_in_set_from_s3_bucket(self.tracing_id, s3_csv_path, manifest_id)
                 manifest_accessor.mark_s3_csv_cleared(manifest)
         msg = f"Download complete for {key}"
-        LOG.info(log_json(self.tracing_id, msg, self.context))
+        LOG.info(log_json(self.tracing_id, msg=msg, context=self.context))
         return full_file_path, s3_etag, file_creation_date, [], {}
 
     def get_manifest_context_for_date(self, date):

--- a/koku/masu/external/downloader/aws_local/aws_local_report_downloader.py
+++ b/koku/masu/external/downloader/aws_local/aws_local_report_downloader.py
@@ -59,7 +59,7 @@ class AWSLocalReportDownloader(ReportDownloaderBase, DownloaderInterface):
         self.report_prefix = prefix
 
         msg = f"Found report name: {self.report_name}, report prefix: {self.report_prefix}"
-        LOG.info(log_json(self.tracing_id, msg, self.context))
+        LOG.info(log_json(self.tracing_id, msg=msg, context=self.context))
         if self.report_prefix:
             self.base_path = f"{bucket}/{self.report_prefix}/"
         else:
@@ -118,7 +118,7 @@ class AWSLocalReportDownloader(ReportDownloaderBase, DownloaderInterface):
             manifest_file, _, manifest_modified_timestamp, __, ___ = self.download_file(manifest)
         except AWSReportDownloaderNoFileError as err:
             msg = f"Unable to get report manifest. Reason: {str(err)}"
-            LOG.info(log_json(self.tracing_id, msg, self.context))
+            LOG.info(log_json(self.tracing_id, msg=msg, context=self.context))
             return "", self.empty_manifest, None
 
         manifest_json = None
@@ -177,10 +177,10 @@ class AWSLocalReportDownloader(ReportDownloaderBase, DownloaderInterface):
         try:
             os.remove(manifest_file)
             msg = f"Deleted manifest file at {manifest_file}"
-            LOG.info(log_json(self.tracing_id, msg, self.context))
+            LOG.info(log_json(self.tracing_id, msg=msg, context=self.context))
         except OSError:
             msg = f"Could not delete manifest file at {manifest_file}"
-            LOG.info(log_json(self.tracing_id, msg, self.context))
+            LOG.info(log_json(self.tracing_id, msg=msg, context=self.context))
 
         return None
 
@@ -228,7 +228,7 @@ class AWSLocalReportDownloader(ReportDownloaderBase, DownloaderInterface):
         file_creation_date = None
         if s3_etag != stored_etag or not os.path.isfile(full_file_path):
             msg = f"Downloading {key} to {full_file_path}"
-            LOG.info(log_json(self.tracing_id, msg, self.context))
+            LOG.info(log_json(self.tracing_id, msg=msg, context=self.context))
             shutil.copy2(key, full_file_path)
             file_creation_date = datetime.datetime.fromtimestamp(os.path.getmtime(full_file_path))
             # Push to S3

--- a/koku/masu/external/downloader/azure/azure_report_downloader.py
+++ b/koku/masu/external/downloader/azure/azure_report_downloader.py
@@ -163,7 +163,7 @@ class AzureReportDownloader(ReportDownloaderBase, DownloaderInterface):
                 blob = self._azure_client.get_file_for_key(report, self.container_name)
             except AzureCostReportNotFound as ex:
                 msg = f"Unable to find report. Error: {ex}"
-                LOG.info(log_json(self.tracing_id, msg, self.context))
+                LOG.info(log_json(self.tracing_id, msg=msg, context=self.context))
                 return manifest, None
             report_name = blob.name
             last_modified = blob.last_modified
@@ -184,7 +184,7 @@ class AzureReportDownloader(ReportDownloaderBase, DownloaderInterface):
             if json_manifest:
                 report_name = json_manifest.name
                 last_modified = json_manifest.last_modified
-                LOG.info(log_json(self.tracing_id, f"Found JSON manifest {report_name}", self.context))
+                LOG.info(log_json(self.tracing_id, msg=f"Found JSON manifest {report_name}", context=self.context))
                 # Download the manifest and extract the list of files.
                 try:
                     manifest_tmp = self._azure_client.download_file(
@@ -192,7 +192,7 @@ class AzureReportDownloader(ReportDownloaderBase, DownloaderInterface):
                     )
                 except AzureReportDownloaderError as err:
                     msg = f"Unable to get report manifest for {self._provider_uuid}. Reason: {str(err)}"
-                    LOG.info(log_json(self.tracing_id, msg, self.context))
+                    LOG.info(log_json(self.tracing_id, msg=msg, context=self.context))
                     return {}, None
                 # Extract data from the JSON file
                 try:
@@ -209,11 +209,11 @@ class AzureReportDownloader(ReportDownloaderBase, DownloaderInterface):
                     blob = self._azure_client.get_latest_cost_export_for_path(report_path, self.container_name)
                 except AzureCostReportNotFound as ex:
                     msg = f"Unable to find manifest. Error: {ex}"
-                    LOG.info(log_json(self.tracing_id, msg, self.context))
+                    LOG.info(log_json(self.tracing_id, msg=msg, context=self.context))
                     return manifest, None
                 report_name = blob.name
                 last_modified = blob.last_modified
-                LOG.info(log_json(self.tracing_id, f"Found cost export {report_name}", self.context))
+                LOG.info(log_json(self.tracing_id, msg=f"Found cost export {report_name}", context=self.context))
                 manifest["reportKeys"] = [report_name]
 
             try:
@@ -232,10 +232,10 @@ class AzureReportDownloader(ReportDownloaderBase, DownloaderInterface):
         try:
             os.unlink(manifest_file)
             msg = f"Deleted manifest file '{manifest_file}'"
-            LOG.info(log_json(self.tracing_id, msg, self.context))
+            LOG.info(log_json(self.tracing_id, msg=msg, context=self.context))
         except OSError:
             msg = f"Could not delete manifest file '{manifest_file}'"
-            LOG.info(log_json(self.tracing_id, msg, self.context))
+            LOG.info(log_json(self.tracing_id, msg=msg, context=self.context))
 
     def get_manifest_context_for_date(self, date):
         """
@@ -319,13 +319,13 @@ class AzureReportDownloader(ReportDownloaderBase, DownloaderInterface):
                 file_creation_date = blob.last_modified
             except AzureCostReportNotFound as ex:
                 msg = f"Error when downloading Azure report for key: {key}. Error {ex}"
-                LOG.error(log_json(self.tracing_id, msg, self.context))
+                LOG.error(log_json(self.tracing_id, msg=msg, context=self.context))
                 raise AzureReportDownloaderError(msg)
 
         local_filename = utils.get_local_file_name(key)
         full_file_path = f"{self._get_exports_data_directory()}/{local_filename}"
         msg = f"Downloading {key} to {full_file_path}"
-        LOG.info(log_json(self.tracing_id, msg, self.context))
+        LOG.info(log_json(self.tracing_id, msg=msg, context=self.context))
         self._azure_client.download_file(
             key, self.container_name, destination=full_file_path, ingress_reports=self.ingress_reports
         )
@@ -345,5 +345,5 @@ class AzureReportDownloader(ReportDownloaderBase, DownloaderInterface):
             manifest_accessor.mark_s3_csv_cleared(manifest)
 
         msg = f"Returning full_file_path: {full_file_path}, etag: {etag}"
-        LOG.info(log_json(self.tracing_id, msg, self.context))
+        LOG.info(log_json(self.tracing_id, msg=msg, context=self.context))
         return full_file_path, etag, file_creation_date, [], {}

--- a/koku/masu/external/downloader/azure_local/azure_local_report_downloader.py
+++ b/koku/masu/external/downloader/azure_local/azure_local_report_downloader.py
@@ -68,7 +68,7 @@ class AzureLocalReportDownloader(AzureReportDownloader):
 
         if not os.path.exists(local_path):
             msg = f"Unable to find manifest: {local_path}."
-            LOG.info(log_json(self.request_id, msg, self.context))
+            LOG.info(log_json(self.request_id, msg=msg, context=self.context))
             return manifest, None
 
         manifest_modified_timestamp = None
@@ -116,7 +116,7 @@ class AzureLocalReportDownloader(AzureReportDownloader):
         file_creation_date = None
         if etag != stored_etag:
             msg = f"Downloading {key} to {full_file_path}"
-            LOG.info(log_json(self.request_id, msg, self.context))
+            LOG.info(log_json(self.request_id, msg=msg, context=self.context))
             shutil.copy2(key, full_file_path)
             file_creation_date = datetime.datetime.fromtimestamp(os.path.getmtime(full_file_path))
             # Push to S3
@@ -135,5 +135,5 @@ class AzureLocalReportDownloader(AzureReportDownloader):
                 manifest_accessor.mark_s3_csv_cleared(manifest)
 
         msg = f"Returning full_file_path: {full_file_path}, etag: {etag}"
-        LOG.info(log_json(self.request_id, msg, self.context))
+        LOG.info(log_json(self.request_id, msg=msg, context=self.context))
         return full_file_path, etag, file_creation_date, [], {}

--- a/koku/masu/external/downloader/gcp/gcp_report_downloader.py
+++ b/koku/masu/external/downloader/gcp/gcp_report_downloader.py
@@ -180,7 +180,7 @@ class GCPReportDownloader(ReportDownloaderBase, DownloaderInterface):
         except ValidationError as ex:
             msg = "GCP source for  is not reachable."
             extra_context = {"customer": self.customer_name, "response": str(ex)}
-            LOG.warning(log_json(self.tracing_id, msg, self.context | extra_context))
+            LOG.warning(log_json(self.tracing_id, msg=msg, context=self.context | extra_context))
             raise GCPReportDownloaderError(str(ex))
         self.big_query_export_time = None
         if self.ingress_reports:
@@ -267,10 +267,10 @@ class GCPReportDownloader(ReportDownloaderBase, DownloaderInterface):
             for row in eq_result:
                 mapping[row[0]] = row[1].replace(tzinfo=settings.UTC)
         except GoogleCloudError as err:
-            err_msg = "Could not query table for partition date information."
+            msg = "Could not query table for partition date information."
             extra_context = {"customer": self.customer_name, "response": err.message}
-            LOG.warning(log_json(self.tracing_id, err_msg, self.context | extra_context))
-            raise GCPReportDownloaderError(err_msg)
+            LOG.warning(log_json(self.tracing_id, msg=msg, context=self.context | extra_context))
+            raise GCPReportDownloaderError(msg)
         return mapping
 
     def collect_new_manifests(self, current_manifests, bigquery_mappings):
@@ -297,14 +297,14 @@ class GCPReportDownloader(ReportDownloaderBase, DownloaderInterface):
                 }
                 new_manifests.append(manifest_metadata)
         if not new_manifests:
-            stmt = "No new manifests created."
+            msg = "No new manifests created."
             extra_context = {
                 "scan_start": str(self.scan_start),
                 "scan_end": str(self.scan_end),
                 "bigquery mapping count": len(bigquery_mappings),
                 "current manifest count": len(current_manifests),
             }
-            LOG.info(log_json(self.tracing_id, stmt, self.context | extra_context))
+            LOG.info(log_json(self.tracing_id, msg=msg, context=self.context | extra_context))
         return new_manifests
 
     def get_manifest_context_for_date(self, date):
@@ -324,13 +324,13 @@ class GCPReportDownloader(ReportDownloaderBase, DownloaderInterface):
         """
         reports_list = []
         if self.storage_only and not self.ingress_reports:
-            log_msg = "Skipping ingest as source is storage_only and requires ingress reports"
-            LOG.info(log_json(self.tracing_id, log_msg, self.context))
+            msg = "Skipping ingest as source is storage_only and requires ingress reports"
+            LOG.info(log_json(self.tracing_id, msg=msg, context=self.context))
             return reports_list
         dh = DateHelper()
         if isinstance(date, datetime.datetime):
             date = date.date()
-        log_msg = "New manifest to be created."
+        msg = "New manifest to be created."
         extra_context = {
             "scan_start": str(self.scan_start),
             "scan_end": str(self.scan_end),
@@ -340,7 +340,7 @@ class GCPReportDownloader(ReportDownloaderBase, DownloaderInterface):
             manifest = self._generate_monthly_pseudo_manifest(date)
             extra_context["manifest_data"] = manifest
             assembly_id = manifest.get("assembly_id")
-            LOG.info(log_json(self.tracing_id, log_msg, self.context | extra_context))
+            LOG.info(log_json(self.tracing_id, msg=msg, context=self.context | extra_context))
             manifest_id = self._process_manifest_db_record(
                 assembly_id,
                 date.strftime("%Y-%m-%d"),
@@ -362,7 +362,7 @@ class GCPReportDownloader(ReportDownloaderBase, DownloaderInterface):
             new_manifest_list = self.collect_new_manifests(current_manifests, bigquery_mapping)
             for manifest in new_manifest_list:
                 extra_context["manifest_data"] = manifest
-                LOG.info(log_json(self.tracing_id, log_msg, self.context | extra_context))
+                LOG.info(log_json(self.tracing_id, msg=msg, context=self.context | extra_context))
                 manifest_id = self._process_manifest_db_record(
                     manifest["assembly_id"],
                     manifest["bill_date"],
@@ -442,10 +442,10 @@ class GCPReportDownloader(ReportDownloaderBase, DownloaderInterface):
                 full_local_path = self._get_local_file_path(directory_path, key)
                 blob.download_to_filename(full_local_path)
             except GoogleCloudError as err:
-                err_msg = "Could not find or download file from bucket."
+                msg = "Could not find or download file from bucket."
                 extra_context = {"customer": self.customer_name, "response": err.message}
-                LOG.warning(log_json(self.tracing_id, err_msg, self.context | extra_context))
-                raise GCPReportDownloaderError(err_msg)
+                LOG.warning(log_json(self.tracing_id, msg=msg, context=self.context | extra_context))
+                raise GCPReportDownloaderError(msg)
             paths_list.append(full_local_path)
         else:
             try:
@@ -459,33 +459,33 @@ class GCPReportDownloader(ReportDownloaderBase, DownloaderInterface):
                 client = bigquery.Client()
                 query_job = client.query(query).result()
             except GoogleCloudError as err:
-                err_msg = "Could not query table for billing information."
+                msg = "Could not query table for billing information."
                 extra_context = {"customer": self.customer_name, "response": err.message}
-                LOG.warning(log_json(self.tracing_id, err_msg, self.context | extra_context))
-                raise GCPReportDownloaderError(err_msg)
+                LOG.warning(log_json(self.tracing_id, msg=msg, context=self.context | extra_context))
+                raise GCPReportDownloaderError(msg)
             except UnboundLocalError:
-                err_msg = f"Error recovering start and end date from csv key ({key})."
-                raise GCPReportDownloaderError(err_msg)
+                msg = f"Error recovering start and end date from csv key ({key})."
+                raise GCPReportDownloaderError(msg)
             try:
                 column_list = self.gcp_big_query_columns.copy()
                 column_list.append("partition_date")
                 for i, rows in enumerate(batch(query_job, settings.PARQUET_PROCESSING_BATCH_SIZE)):
                     full_local_path = self._get_local_file_path(directory_path, partition_date, i)
                     msg = f"Downloading subset of {partition_date} to {full_local_path}"
-                    LOG.info(log_json(self.tracing_id, msg, self.context))
+                    LOG.info(log_json(self.tracing_id, msg=msg, context=self.context))
                     with open(full_local_path, "w") as f:
                         writer = csv.writer(f)
                         writer.writerow(column_list)
                         writer.writerows(rows)
                     paths_list.append(full_local_path)
             except OSError as exc:
-                err_msg = (
+                msg = (
                     "Could not create GCP billing data csv file."
                     f"\n  Provider: {self._provider_uuid}"
                     f"\n  Customer: {self.customer_name}"
                     f"\n  Response: {exc}"
                 )
-                raise GCPReportDownloaderError(err_msg)
+                raise GCPReportDownloaderError(msg)
 
         file_names, date_range = create_daily_archives(
             self.tracing_id,
@@ -530,7 +530,7 @@ class GCPReportDownloader(ReportDownloaderBase, DownloaderInterface):
         else:
             local_file_name = key.replace("/", "_") + f"_{str(iterable_num)}.csv"
         msg = f"Local filename: {local_file_name}"
-        LOG.info(log_json(self.tracing_id, msg, self.context))
+        LOG.info(log_json(self.tracing_id, msg=msg, context=self.context))
         full_local_path = os.path.join(directory_path, local_file_name)
         return full_local_path
 

--- a/koku/masu/external/downloader/gcp_local/gcp_local_report_downloader.py
+++ b/koku/masu/external/downloader/gcp_local/gcp_local_report_downloader.py
@@ -236,7 +236,7 @@ class GCPLocalReportDownloader(ReportDownloaderBase, DownloaderInterface):
         etag = report_name.split("_")[1]
         full_local_path = self._get_local_file_path(key, etag)
         msg = f"Returning full_file_path: {full_local_path}"
-        LOG.info(log_json(self.request_id, msg, self.context))
+        LOG.info(log_json(self.request_id, msg=msg, context=self.context))
         dh = DateHelper()
 
         file_names, date_range = create_daily_archives(
@@ -270,7 +270,7 @@ class GCPLocalReportDownloader(ReportDownloaderBase, DownloaderInterface):
             final_path = f"{self.storage_location}"
         local_file_name = key.replace("/", "_")
         msg = f"Local filename: {local_file_name}"
-        LOG.info(log_json(self.request_id, msg, self.context))
+        LOG.info(log_json(self.request_id, msg=msg, context=self.context))
         full_local_path = os.path.join(final_path, local_file_name)
         return full_local_path
 
@@ -279,8 +279,8 @@ class GCPLocalReportDownloader(ReportDownloaderBase, DownloaderInterface):
         try:
             os.remove(manifest_file)
             msg = f"Deleted manifest file at {manifest_file}"
-            LOG.info(log_json(self.request_id, msg, self.context))
+            LOG.info(log_json(self.request_id, msg=msg, context=self.context))
         except OSError:
             msg = f"Could not delete manifest file at {manifest_file}"
-            LOG.info(log_json(self.request_id, msg, self.context))
+            LOG.info(log_json(self.request_id, msg=msg, context=self.context))
         return None

--- a/koku/masu/external/downloader/ibm/ibm_report_downloader.py
+++ b/koku/masu/external/downloader/ibm/ibm_report_downloader.py
@@ -141,7 +141,7 @@ class IBMReportDownloader(ReportDownloaderBase, DownloaderInterface):
             IBMProvider().cost_usage_source_is_reachable(self.credentials, self.data_source)
         except ValidationError as ex:
             msg = f"IBM source ({self._provider_uuid}) for {customer_name} is not reachable. Error: {str(ex)}"
-            LOG.error(log_json(self.request_id, msg, self.context))
+            LOG.error(log_json(self.request_id, msg=msg, context=self.context))
             raise IBMReportDownloaderError(str(ex))
 
     def get_manifest_context_for_date(self, date):
@@ -204,14 +204,14 @@ class IBMReportDownloader(ReportDownloaderBase, DownloaderInterface):
         fallback_date = "-".join(key.split("_")[0].split("-")[0:2])
         invoice_month = start_date.strftime("%Y-%m") if start_date else fallback_date
         msg = f"Downloading {key} to {full_local_path}"
-        LOG.info(log_json(self.request_id, msg, self.context))
+        LOG.info(log_json(self.request_id, msg=msg, context=self.context))
 
         page_downloader = page_downloader_factory(self.credentials, self.data_source, invoice_month)
         csv_file_writer = writer_factory(full_local_path)
         download_pages_from(page_downloader, csv_file_writer, 1)
 
         msg = f"Returning full_file_path: {full_local_path}"
-        LOG.info(log_json(self.request_id, msg, self.context))
+        LOG.info(log_json(self.request_id, msg=msg, context=self.context))
         dh = DateHelper()
         file_names = create_daily_archives(
             self.request_id,

--- a/koku/masu/external/downloader/oci/oci_report_downloader.py
+++ b/koku/masu/external/downloader/oci/oci_report_downloader.py
@@ -151,7 +151,7 @@ class OCIReportDownloader(ReportDownloaderBase, DownloaderInterface):
             OCIProvider().cost_usage_source_is_reachable(self.credentials, self.data_source)
         except ValidationError as ex:
             msg = f"OCI source ({self._provider_uuid}) for {self.customer_name} is not reachable. Error: {ex}"
-            LOG.warning(log_json(self.tracing_id, msg, self.context))
+            LOG.warning(log_json(self.tracing_id, msg=msg, context=self.context))
             raise OCIReportDownloaderError(str(ex))
 
     @staticmethod
@@ -388,9 +388,9 @@ class OCIReportDownloader(ReportDownloaderBase, DownloaderInterface):
 
             file_creation_date = None
             msg = f"Returning full_file_path: {full_local_path}"
-            LOG.info(log_json(self.request_id, msg, self.context))
+            LOG.info(log_json(self.request_id, msg=msg, context=self.context))
             msg = f"Downloading {key} to {full_local_path}"
-            LOG.info(log_json(self.tracing_id, msg, self.context))
+            LOG.info(log_json(self.tracing_id, msg=msg, context=self.context))
             report_file = self._oci_client.get_object(bucket_namespace, bucket, key)
 
             with open(full_local_path, "wb") as f:
@@ -453,6 +453,6 @@ class OCIReportDownloader(ReportDownloaderBase, DownloaderInterface):
         """
         local_file_name = key.replace("/", "_")
         msg = f"Local filename: {local_file_name}"
-        LOG.info(log_json(self.tracing_id, msg, self.context))
+        LOG.info(log_json(self.tracing_id, msg=msg, context=self.context))
         full_local_path = os.path.join(directory_path, local_file_name)
         return full_local_path

--- a/koku/masu/external/downloader/oci_local/oci_local_report_downloader.py
+++ b/koku/masu/external/downloader/oci_local/oci_local_report_downloader.py
@@ -221,10 +221,10 @@ class OCILocalReportDownloader(ReportDownloaderBase, DownloaderInterface):
 
         file_creation_date = None
         msg = f"Returning full_file_path: {full_file_path}"
-        LOG.info(log_json(self.request_id, msg, self.context))
+        LOG.info(log_json(self.request_id, msg=msg, context=self.context))
         if not os.path.isfile(full_file_path):
             msg = f"Downloading {base_path} to {full_file_path}"
-            LOG.info(log_json(self.tracing_id, msg, self.context))
+            LOG.info(log_json(self.tracing_id, msg=msg, context=self.context))
             shutil.copy2(base_path, full_file_path)
             file_creation_date = datetime.datetime.fromtimestamp(os.path.getmtime(full_file_path))
 
@@ -245,8 +245,8 @@ class OCILocalReportDownloader(ReportDownloaderBase, DownloaderInterface):
         try:
             os.remove(manifest_file)
             msg = f"Deleted manifest file at {manifest_file}"
-            LOG.info(log_json(self.request_id, msg, self.context))
+            LOG.info(log_json(self.request_id, msg=msg, context=self.context))
         except OSError:
             msg = f"Could not delete manifest file at {manifest_file}"
-            LOG.info(log_json(self.request_id, msg, self.context))
+            LOG.info(log_json(self.request_id, msg=msg, context=self.context))
         return None

--- a/koku/masu/external/downloader/ocp/ocp_report_downloader.py
+++ b/koku/masu/external/downloader/ocp/ocp_report_downloader.py
@@ -109,7 +109,7 @@ def process_cr(report_meta):
             channel: (str or None)
             errors: (Dict or None)
     """
-    LOG.info(log_json(report_meta.get("tracing_id"), "Processing the manifest"))
+    LOG.info(log_json(report_meta.get("tracing_id"), msg="Processing the manifest"))
     operator_versions = {
         "084bca2e1c48caab18c237453c17ceef61747fe2": "costmanagement-metrics-operator:1.1.3",
         "77ec351f8d332796dc522e5623f1200c2fab4042": "costmanagement-metrics-operator:1.1.4",
@@ -185,7 +185,7 @@ class OCPReportDownloader(ReportDownloaderBase, DownloaderInterface):
         dates = utils.month_date_range(date_time)
         directory = f"{REPORTS_DIR}/{self.cluster_id}/{dates}"
         msg = f"Looking for manifest at {directory}"
-        LOG.info(log_json(self.tracing_id, msg, self.context))
+        LOG.info(log_json(self.tracing_id, msg=msg, context=self.context))
         report_meta = utils.get_report_details(directory)
         self.context["version"] = report_meta.get("version")
         return report_meta
@@ -239,10 +239,10 @@ class OCPReportDownloader(ReportDownloaderBase, DownloaderInterface):
         try:
             os.remove(manifest_path)
             msg = f"Deleted manifest file at {directory}"
-            LOG.debug(log_json(self.tracing_id, msg, self.context))
+            LOG.debug(log_json(self.tracing_id, msg=msg, context=self.context))
         except OSError:
             msg = f"Could not delete manifest file at {directory}"
-            LOG.info(log_json(self.tracing_id, msg, self.context))
+            LOG.info(log_json(self.tracing_id, msg=msg, context=self.context))
 
         return None
 
@@ -259,12 +259,12 @@ class OCPReportDownloader(ReportDownloaderBase, DownloaderInterface):
         """
         dates = utils.month_date_range(date_time)
         msg = f"Looking for cluster {self.cluster_id} report for date {str(dates)}"
-        LOG.debug(log_json(self.tracing_id, msg, self.context))
+        LOG.debug(log_json(self.tracing_id, msg=msg, context=self.context))
         directory = f"{REPORTS_DIR}/{self.cluster_id}/{dates}"
 
         manifest = self._get_manifest(date_time)
         msg = f"manifest found: {str(manifest)}"
-        LOG.info(log_json(self.tracing_id, msg, self.context))
+        LOG.info(log_json(self.tracing_id, msg=msg, context=self.context))
 
         reports = []
         for file in manifest.get("files", []):
@@ -301,7 +301,7 @@ class OCPReportDownloader(ReportDownloaderBase, DownloaderInterface):
         file_creation_date = None
         if ocp_etag != stored_etag or not os.path.isfile(full_file_path):
             msg = f"Downloading {key} to {full_file_path}"
-            LOG.info(log_json(self.tracing_id, msg, self.context))
+            LOG.info(log_json(self.tracing_id, msg=msg, context=self.context))
             shutil.move(key, full_file_path)
             file_creation_date = datetime.datetime.fromtimestamp(os.path.getmtime(full_file_path))
 

--- a/koku/masu/external/downloader/report_downloader_base.py
+++ b/koku/masu/external/downloader/report_downloader_base.py
@@ -77,14 +77,14 @@ class ReportDownloaderBase:
     ):
         """Insert or update the manifest DB record."""
         msg = f"Inserting/updating manifest in database for assembly_id: {assembly_id}"
-        LOG.info(log_json(self.tracing_id, msg))
+        LOG.info(log_json(self.tracing_id, msg=msg))
 
         with ReportManifestDBAccessor() as manifest_accessor:
             manifest_entry = manifest_accessor.get_manifest(assembly_id, self._provider_uuid)
 
             if not manifest_entry:
                 msg = f"No manifest entry found in database. Adding for bill period start: {billing_start}"
-                LOG.info(log_json(self.tracing_id, msg, self.context))
+                LOG.info(log_json(self.tracing_id, msg=msg, context=self.context))
                 manifest_dict = {
                     "assembly_id": assembly_id,
                     "billing_period_start_datetime": billing_start,
@@ -104,7 +104,7 @@ class ReportDownloaderBase:
                         f"Manifest entry uniqueness collision: Error {error}. "
                         "Manifest already added, getting manifest_entry_id."
                     )
-                    LOG.warning(log_json(self.tracing_id, msg, self.context))
+                    LOG.warning(log_json(self.tracing_id, msg=msg, context=self.context))
                     with ReportManifestDBAccessor() as manifest_accessor:
                         manifest_entry = manifest_accessor.get_manifest(assembly_id, self._provider_uuid)
             if not manifest_entry:
@@ -113,9 +113,9 @@ class ReportDownloaderBase:
                     provider = provider_accessor.get_provider()
                     if not provider:
                         msg = f"Provider entry not found for {self._provider_uuid}."
-                        LOG.warning(log_json(self.tracing_id, msg, self.context))
+                        LOG.warning(log_json(self.tracing_id, msg=msg, context=self.context))
                         raise ReportDownloaderError(msg)
-                LOG.warning(log_json(self.tracing_id, msg, self.context))
+                LOG.warning(log_json(self.tracing_id, msg=msg, context=self.context))
                 raise IntegrityError(msg)
             else:
                 if num_of_files != manifest_entry.num_total_files:

--- a/koku/masu/external/kafka_msg_handler.py
+++ b/koku/masu/external/kafka_msg_handler.py
@@ -117,12 +117,9 @@ def get_account_from_cluster_id(cluster_id, manifest_uuid, context={}):
 
     """
     account = None
-    provider_uuid = utils.get_provider_uuid_from_cluster_id(cluster_id)
-    if provider_uuid:
-        msg = f"Found provider_uuid: {str(provider_uuid)} for cluster_id: {str(cluster_id)}"
-        LOG.info(log_json(manifest_uuid, msg, context))
-        if context:
-            context["provider_uuid"] = provider_uuid
+    if provider_uuid := utils.get_provider_uuid_from_cluster_id(cluster_id):
+        context |= {"provider_uuid": provider_uuid, "cluster_id": cluster_id}
+        LOG.info(log_json(manifest_uuid, msg="found provider for cluster-id", context=context))
         account = get_account(provider_uuid, manifest_uuid, context)
     return account
 
@@ -152,7 +149,7 @@ def download_payload(request_id, url, context={}):
     except requests.exceptions.HTTPError as err:
         shutil.rmtree(temp_dir)
         msg = f"Unable to download file. Error: {str(err)}"
-        LOG.warning(log_json(request_id, msg))
+        LOG.warning(log_json(request_id, msg=msg), exc_info=err)
         raise KafkaMsgHandlerError(msg)
 
     sanitized_request_id = re.sub("[^A-Za-z0-9]+", "", request_id)
@@ -165,7 +162,7 @@ def download_payload(request_id, url, context={}):
     except OSError as error:
         shutil.rmtree(temp_dir)
         msg = f"Unable to write file. Error: {str(error)}"
-        LOG.warning(log_json(request_id, msg, context))
+        LOG.warning(log_json(request_id, msg=msg, context=context), exc_info=error)
         raise KafkaMsgHandlerError(msg)
 
     return (temp_dir, temp_file, gzip_filename)
@@ -189,7 +186,7 @@ def extract_payload_contents(request_id, out_dir, tarball_path, tarball, context
 
     if not os.path.isfile(tarball_path):
         msg = f"Unable to find tar file {tarball_path}."
-        LOG.warning(log_json(request_id, msg, context))
+        LOG.warning(log_json(request_id, msg=msg, context=context))
         raise KafkaMsgHandlerError("Extraction failure, file not found.")
 
     try:
@@ -199,13 +196,13 @@ def extract_payload_contents(request_id, out_dir, tarball_path, tarball, context
         manifest_path = [manifest for manifest in files if "manifest.json" in manifest]
     except (ReadError, EOFError, OSError) as error:
         msg = f"Unable to untar file {tarball_path}. Reason: {str(error)}"
-        LOG.warning(log_json(request_id, msg, context))
+        LOG.warning(log_json(request_id, msg=msg, context=context))
         shutil.rmtree(out_dir)
         raise KafkaMsgHandlerError("Extraction failure.")
 
     if not manifest_path:
         msg = "No manifest found in payload."
-        LOG.warning(log_json(request_id, msg, context))
+        LOG.warning(log_json(request_id, msg=msg, context=context))
         raise KafkaMsgHandlerError("No manifest found in payload.")
 
     return manifest_path
@@ -285,19 +282,23 @@ def extract_payload(url, request_id, b64_identity, context={}):  # noqa: C901
     # Filter and get account from payload's cluster-id
     cluster_id = report_meta.get("cluster_id")
     manifest_uuid = report_meta.get("uuid", request_id)
+    context |= {
+        "request_id": request_id,
+        "cluster_id": cluster_id,
+        "manifest_uuid": manifest_uuid,
+    }
     LOG.info(
         log_json(
             request_id,
-            f"Payload with the request id {request_id} from cluster {cluster_id}"
+            msg=f"Payload with the request id {request_id} from cluster {cluster_id}"
             + f" is part of the report with manifest id {manifest_uuid}",
+            context=context,
         )
     )
-    if context:
-        context["cluster_id"] = cluster_id
     account = get_account_from_cluster_id(cluster_id, manifest_uuid, context)
     if not account:
         msg = f"Recieved unexpected OCP report from {cluster_id}"
-        LOG.warning(log_json(manifest_uuid, msg, context))
+        LOG.warning(log_json(manifest_uuid, msg=msg, context=context))
         shutil.rmtree(temp_dir)
         return None, manifest_uuid
     schema_name = account.get("schema_name")
@@ -344,7 +345,7 @@ def extract_payload(url, request_id, b64_identity, context={}):  # noqa: C901
     except Exception as e:
         # If a ROS report fails to process, this should not prevent Koku processing from continuing.
         msg = f"ROS reports not processed for payload. Reason: {e}"
-        LOG.warning(log_json(manifest_uuid, msg, context))
+        LOG.warning(log_json(manifest_uuid, msg=msg, context=context))
     for report_file in manifest_files:
         current_meta = report_meta.copy()
         payload_source_path = f"{subdirectory}/{report_file}"
@@ -357,12 +358,12 @@ def extract_payload(url, request_id, b64_identity, context={}):  # noqa: C901
                 # Report already processed
                 continue
             msg = f"Successfully extracted OCP for {report_meta.get('cluster_id')}/{usage_month}"
-            LOG.info(log_json(manifest_uuid, msg, context))
+            LOG.info(log_json(manifest_uuid, msg=msg, context=context))
             construct_parquet_reports(request_id, context, report_meta, payload_destination_path, report_file)
             report_metas.append(current_meta)
         except FileNotFoundError:
             msg = f"File {str(report_file)} has not downloaded yet."
-            LOG.debug(log_json(manifest_uuid, msg, context))
+            LOG.debug(log_json(manifest_uuid, msg=msg, context=context))
     # Remove temporary directory and files
     shutil.rmtree(temp_dir)
     return report_metas, manifest_uuid
@@ -438,18 +439,18 @@ def handle_message(kmsg):
     context = {"account": account, "org_id": org_id}
     try:
         msg = f"Extracting Payload for msg: {str(value)}"
-        LOG.info(log_json(request_id, msg, context))
+        LOG.info(log_json(request_id, msg=msg, context=context))
         report_metas, manifest_uuid = extract_payload(value["url"], request_id, value["b64_identity"], context)
         return SUCCESS_CONFIRM_STATUS, report_metas, manifest_uuid
     except (OperationalError, InterfaceError) as error:
         close_and_set_db_connection()
         msg = f"Unable to extract payload, db closed. {type(error).__name__}: {error}"
-        LOG.warning(log_json(request_id, msg, context))
+        LOG.warning(log_json(request_id, msg=msg, context=context))
         raise KafkaMsgHandlerError(msg) from error
     except Exception as error:  # noqa
         traceback.print_exc()
         msg = f"Unable to extract payload. Error: {type(error).__name__}: {error}"
-        LOG.warning(log_json(request_id, msg, context))
+        LOG.warning(log_json(request_id, msg=msg, context=context))
         return FAILURE_CONFIRM_STATUS, None, None
 
 
@@ -477,7 +478,7 @@ def get_account(provider_uuid, manifest_uuid, context={}):
         all_accounts = AccountsAccessor().get_accounts(provider_uuid)
     except AccountsAccessorError as error:
         msg = f"Unable to get accounts. Error: {str(error)}"
-        LOG.warning(log_json(manifest_uuid, msg, context))
+        LOG.warning(log_json(manifest_uuid, msg=msg, context=context))
         return None
 
     return all_accounts.pop() if all_accounts else None
@@ -532,18 +533,18 @@ def summarize_manifest(report_meta, manifest_uuid):
                         # The full CR status is logged below, but we should limit our alert to just the query.
                         # We can check the full manifest to get the full error.
                         LOG.error(msg)
-                        LOG.info(log_json(manifest_uuid, msg, context))
+                        LOG.info(log_json(manifest_uuid, msg=msg, context=context))
                     LOG.info(
-                        log_json(manifest_uuid, f"CR Status for invalid manifest: {json.dumps(cr_status)}", context)
+                        log_json(
+                            manifest_uuid,
+                            msg=f"CR Status for invalid manifest: {json.dumps(cr_status)}",
+                            context=context,
+                        )
                     )
                     return  # an invalid payload will fail to summarize, so return before we try
-                LOG.info(
-                    log_json(
-                        manifest_uuid,
-                        f"Summarizing OCP reports from {str(start_date)}-{str(end_date)} for provider: {provider_uuid}",
-                        context,
-                    )
-                )
+                context["start_date"] = start_date
+                context["end_date"] = end_date
+                LOG.info(log_json(manifest_uuid, msg="summarizing ocp reports", context=context))
                 new_report_meta["start"] = start_date
                 new_report_meta["end"] = end_date
                 new_report_meta["manifest_uuid"] = manifest_uuid
@@ -658,19 +659,19 @@ def process_messages(msg):
     if report_metas:
         for report_meta in report_metas:
             report_meta["process_complete"] = process_report(request_id, report_meta)
-            LOG.info(log_json(tracing_id, f"Processing: {report_meta.get('current_file')} complete."))
+            LOG.info(log_json(tracing_id, msg=f"Processing: {report_meta.get('current_file')} complete."))
         process_complete = report_metas_complete(report_metas)
         summary_task_id = summarize_manifest(report_meta, tracing_id)
         if summary_task_id:
-            LOG.info(log_json(tracing_id, f"Summarization celery uuid: {summary_task_id}"))
+            LOG.info(log_json(tracing_id, msg=f"Summarization celery uuid: {summary_task_id}"))
 
     if status:
         if report_metas:
             file_list = [meta.get("current_file") for meta in report_metas]
             files_string = ",".join(map(str, file_list))
-            LOG.info(log_json(tracing_id, f"Sending Ingress Service confirmation for: {files_string}"))
+            LOG.info(log_json(tracing_id, msg=f"Sending Ingress Service confirmation for: {files_string}"))
         else:
-            LOG.info(log_json(tracing_id, f"Sending Ingress Service confirmation for: {value}"))
+            LOG.info(log_json(tracing_id, msg=f"Sending Ingress Service confirmation for: {value}"))
         send_confirmation(value["request_id"], status)
 
     return process_complete

--- a/koku/masu/external/report_downloader.py
+++ b/koku/masu/external/report_downloader.py
@@ -174,7 +174,7 @@ class ReportDownloader:
         """
         date_time = report_context.get("date")
         msg = f"Attempting to get {self.provider_type} manifest for {str(date_time)}."
-        LOG.info(log_json(self.tracing_id, msg, self.context))
+        LOG.info(log_json(self.tracing_id, msg=msg, context=self.context))
 
         manifest_id = report_context.get("manifest_id")
         report = report_context.get("current_file")

--- a/koku/masu/external/ros_report_shipper.py
+++ b/koku/masu/external/ros_report_shipper.py
@@ -79,10 +79,10 @@ class ROSReportShipper:
         """
         if not reports_to_upload:
             msg = "No ROS reports to handle in the current payload."
-            LOG.info(log_json(self.request_id, msg, self.context))
+            LOG.info(log_json(self.request_id, msg=msg, context=self.context))
             return
         msg = "Preparing to upload ROS reports to S3 bucket."
-        LOG.info(log_json(self.request_id, msg, self.context))
+        LOG.info(log_json(self.request_id, msg=msg, context=self.context))
         report_urls = []
         upload_keys = []
         for filename, report in reports_to_upload:
@@ -91,17 +91,17 @@ class ROSReportShipper:
                 upload_keys.append(upload_tuple[1])
         if not report_urls:
             msg = "ROS reports did not upload cleanly to S3, skipping kafka message."
-            LOG.info(log_json(self.request_id, msg, self.context))
+            LOG.info(log_json(self.request_id, msg=msg, context=self.context))
             return
 
         if not UNLEASH_CLIENT.is_enabled("cost-management.backend.ros-data-processing", self.context):
             msg = "ROS report handling gated by unleash - not sending kafka msg"
-            LOG.info(log_json(self.request_id, msg, self.context))
+            LOG.info(log_json(self.request_id, msg=msg, context=self.context))
             return
 
         kafka_msg = self.build_ros_msg(report_urls, upload_keys)
         msg = f"{len(report_urls)} reports uploaded to S3 for ROS, sending kafka message."
-        LOG.info(log_json(self.request_id, msg, self.context))
+        LOG.info(log_json(self.request_id, msg=msg, context=self.context))
         self.send_kafka_message(kafka_msg)
 
     def copy_local_report_file_to_ros_s3_bucket(self, filename, report):
@@ -119,7 +119,7 @@ class ROSReportShipper:
             uploaded_obj_url = generate_s3_object_url(self.s3_client, upload_key)
         except (EndpointConnectionError, ClientError) as err:
             msg = f"Unable to copy data to {upload_key} in bucket {settings.S3_ROS_BUCKET_NAME}.  Reason: {str(err)}"
-            LOG.warning(log_json(self.request_id, msg))
+            LOG.warning(log_json(self.request_id, msg=msg))
             return
         return uploaded_obj_url, upload_key
 

--- a/koku/masu/processor/_tasks/download.py
+++ b/koku/masu/processor/_tasks/download.py
@@ -49,32 +49,29 @@ def _get_report_files(
     """
     # Existing schema will start with acct and we strip that prefix for use later
     # new customers include the org prefix in case an org-id and an account number might overlap
-    context = {}
+    context = {
+        "schema": customer_name,
+        "provider_uuid": provider_uuid,
+        "provider_type": provider_type,
+        "date": report_month,
+        "report_month": report_month.strftime("%B %Y"),
+    }
     if customer_name.startswith("acct"):
         context["account"] = customer_name[4:]
         download_acct = customer_name[4:]
     else:
         context["org_id"] = customer_name[3:]
         download_acct = customer_name
-    context["provider_uuid"] = provider_uuid
-    month_string = report_month.strftime("%B %Y")
+
     report_context["date"] = report_month
     function_name = "masu.processor._tasks.download._get_report_files"
-    log_statement = (
-        f"{function_name}: "
-        f"Downloading report for: "
-        f" schema_name: {customer_name} "
-        f" provider: {provider_type} "
-        f" account (provider uuid): {provider_uuid} "
-        f" report_month: {month_string} "
-    )
-    LOG.info(log_json(tracing_id, log_statement, context))
+    LOG.info(log_json(tracing_id, msg="downloading report", context=context))
     try:
         disk = psutil.disk_usage(Config.DATA_DIR)
         disk_msg = f"{function_name}: Available disk space: {disk.free} bytes ({100 - disk.percent}%)"
     except OSError:
         disk_msg = f"{function_name}: Unable to find available disk space. {Config.DATA_DIR} does not exist"
-    LOG.info(log_json(tracing_id, disk_msg, context))
+    LOG.info(log_json(tracing_id, msg=disk_msg, context=context))
 
     downloader = ReportDownloader(
         customer_name=customer_name,

--- a/koku/masu/processor/parquet/parquet_report_processor.py
+++ b/koku/masu/processor/parquet/parquet_report_processor.py
@@ -160,7 +160,7 @@ class ParquetReportProcessor:
             return
         except (ValueError, TypeError):
             msg = "Parquet processing is enabled, but the start_date was not a valid date string ISO 8601 format."
-            LOG.error(log_json(self.tracing_id, msg, self.error_context))
+            LOG.error(log_json(self.tracing_id, msg=msg, context=self.error_context))
             raise ParquetReportProcessorError(msg)
 
     @property
@@ -178,7 +178,7 @@ class ParquetReportProcessor:
             return CSV_GZIP_EXT
         else:
             msg = f"File {first_file} is not valid CSV. Conversion to parquet skipped."
-            LOG.error(log_json(self.tracing_id, msg, self.error_context))
+            LOG.error(log_json(self.tracing_id, msg=msg, context=self.error_context))
             raise ParquetReportProcessorError(msg)
 
     @property
@@ -315,7 +315,7 @@ class ParquetReportProcessor:
                 f"Invalid paths provided to convert_csv_to_parquet."
                 f"CSV path={self.csv_path_s3}, Parquet path={self.parquet_path_s3}, and local_path={self.local_path}."
             )
-            LOG.error(log_json(self.tracing_id, msg, self.error_context))
+            LOG.error(log_json(self.tracing_id, msg=msg, context=self.error_context))
             return "", pd.DataFrame()
 
         manifest_accessor = ReportManifestDBAccessor()
@@ -346,7 +346,7 @@ class ParquetReportProcessor:
         for csv_filename in self.file_list:
             if self.provider_type == Provider.PROVIDER_OCP and self.report_type is None:
                 msg = f"Could not establish report type for {csv_filename}."
-                LOG.warn(log_json(self.tracing_id, msg, self.error_context))
+                LOG.warn(log_json(self.tracing_id, msg=msg, context=self.error_context))
                 failed_conversion.append(csv_filename)
                 continue
             if self.provider_type == Provider.PROVIDER_OCI:
@@ -361,7 +361,7 @@ class ParquetReportProcessor:
 
         if failed_conversion:
             msg = f"Failed to convert the following files to parquet:{','.join(failed_conversion)}."
-            LOG.warn(log_json(self.tracing_id, msg, self.error_context))
+            LOG.warn(log_json(self.tracing_id, msg=msg, context=self.error_context))
         return parquet_base_filename, daily_data_frames
 
     def create_parquet_table(self, parquet_file, daily=False, partition_map=None):
@@ -400,7 +400,7 @@ class ParquetReportProcessor:
             kwargs = {"compression": "gzip"}
 
         msg = f"Running convert_csv_to_parquet on file {csv_filename}."
-        LOG.info(log_json(self.tracing_id, msg, self.error_context))
+        LOG.info(log_json(self.tracing_id, msg=msg, context=self.error_context))
 
         try:
             col_names = pd.read_csv(csv_filename, nrows=0, **kwargs).columns
@@ -434,7 +434,7 @@ class ParquetReportProcessor:
             msg = (
                 f"File {csv_filename} could not be written as parquet to temp file {parquet_file}. Reason: {str(err)}"
             )
-            LOG.warn(log_json(self.tracing_id, msg, self.error_context))
+            LOG.warn(log_json(self.tracing_id, msg=msg, context=self.error_context))
             return parquet_base_filename, daily_data_frames, False
 
         return parquet_base_filename, daily_data_frames, True
@@ -507,11 +507,11 @@ class ParquetReportProcessor:
                     self.tracing_id, s3_path, file_name, fin, manifest_id=self.manifest_id, context=self.error_context
                 )
                 msg = f"{file_path} sent to S3."
-                LOG.info(log_json(self.tracing_id, msg, self.error_context))
+                LOG.info(log_json(self.tracing_id, msg=msg, context=self.error_context))
         except Exception as err:
             s3_key = f"{self.parquet_path_s3}/{file_path}"
             msg = f"File {file_name} could not be written as parquet to S3 {s3_key}. Reason: {str(err)}"
-            LOG.warn(log_json(self.tracing_id, msg, self.error_context))
+            LOG.warn(log_json(self.tracing_id, msg=msg, context=self.error_context))
             return False
         finally:
             self.files_to_remove.append(file_path)

--- a/koku/masu/processor/parquet/parquet_report_processor.py
+++ b/koku/masu/processor/parquet/parquet_report_processor.py
@@ -388,7 +388,7 @@ class ParquetReportProcessor:
                 "provider_type": self.provider_type,
                 "provider_uuid": self.provider_uuid,
             }
-            LOG.warn(log_json(self.tracing_id, msg, context))
+            LOG.warn(log_json(self.tracing_id, msg=msg, context=context))
             return None, None, False
 
         daily_data_frames = []

--- a/koku/masu/processor/report_processor.py
+++ b/koku/masu/processor/report_processor.py
@@ -107,7 +107,7 @@ class ReportProcessor:
 
         """
         msg = f"Report processing started for {self.report_path}"
-        LOG.info(log_json(self.tracing_id, msg))
+        LOG.info(log_json(self.tracing_id, msg=msg))
         try:
             parquet_base_filename, daily_data_frames = self._processor.process()
             if self.ocp_on_cloud_processor:
@@ -120,7 +120,7 @@ class ReportProcessor:
             raise ReportProcessorDBError(f"Interface error: {err}") from err
         except OperationalError as o_err:
             db_exc = get_extended_exception_by_type(o_err)
-            LOG.error(log_json(self.tracing_id, f"Operation error: {db_exc}", context=db_exc.as_dict()))
+            LOG.error(log_json(self.tracing_id, msg=f"Operation error: {db_exc}", context=db_exc.as_dict()))
             raise db_exc from o_err
         except Exception as err:
             raise ReportProcessorError(f"Unknown processor error: {err}") from err

--- a/koku/masu/processor/report_summary_updater.py
+++ b/koku/masu/processor/report_summary_updater.py
@@ -141,11 +141,11 @@ class ReportSummaryUpdater:
             "end_date": end_date,
             "invoice_month": invoice_month,
         }
-        LOG.info(log_json(tracing_id, "summary processing starting", context))
+        LOG.info(log_json(tracing_id, msg="summary processing starting", context=context))
 
         start_date, end_date = self._updater.update_summary_tables(start_date, end_date, invoice_month=invoice_month)
 
-        LOG.info(log_json(tracing_id, "summary processing complete", context))
+        LOG.info(log_json(tracing_id, msg="summary processing complete", context=context))
 
         invalidate_view_cache_for_tenant_and_source_type(self._schema, self._provider.type)
 
@@ -164,7 +164,7 @@ class ReportSummaryUpdater:
                 "start_date": start_date,
                 "end_date": end_date,
             }
-            LOG.info(log_json(tracing_id, "getting OCP-on-Cloud infra map", context))
+            LOG.info(log_json(tracing_id, msg="getting OCP-on-Cloud infra map", context=context))
             return self._ocp_cloud_updater.get_infra_map(start_date, end_date)
         except Exception as ex:
             raise ReportSummaryUpdaterCloudError(str(ex)) from ex
@@ -189,7 +189,7 @@ class ReportSummaryUpdater:
                 f"{infra_provider_type} is not in {Provider.OPENSHIFT_ON_CLOUD_PROVIDER_LIST}.",
                 "Not running OpenShift on Cloud summary.",
             )
-            LOG.info(log_json(self._tracing_id, msg))
+            LOG.info(log_json(self._tracing_id, msg=msg))
             return
 
         start_date, end_date = self._format_dates(start_date, end_date)
@@ -200,13 +200,21 @@ class ReportSummaryUpdater:
             "end_date": end_date,
         }
 
-        LOG.info(log_json(tracing_id, f"OpenShift on {infra_provider_type} summary processing starting", context))
+        LOG.info(
+            log_json(
+                tracing_id, msg=f"OpenShift on {infra_provider_type} summary processing starting", context=context
+            )
+        )
 
         try:
             self._ocp_cloud_updater.update_summary_tables(
                 start_date, end_date, ocp_provider_uuid, infra_provider_uuid, infra_provider_type
             )
-            LOG.info(log_json(tracing_id, f"OpenShift on {infra_provider_type} summary processing complete", context))
+            LOG.info(
+                log_json(
+                    tracing_id, msg=f"OpenShift on {infra_provider_type} summary processing complete", context=context
+                )
+            )
             invalidate_view_cache_for_tenant_and_source_type(self._schema, self._provider.type)
         except Exception as ex:
             raise ReportSummaryUpdaterCloudError(str(ex)) from ex

--- a/koku/masu/util/aws/common.py
+++ b/koku/masu/util/aws/common.py
@@ -400,7 +400,7 @@ def copy_data_to_s3_bucket(request_id, path, filename, data, manifest_id=None, c
         upload.upload_fileobj(data, ExtraArgs=extra_args)
     except (EndpointConnectionError, ClientError) as err:
         msg = f"Unable to copy data to {upload_key} in bucket {settings.S3_BUCKET_NAME}.  Reason: {str(err)}"
-        LOG.info(log_json(request_id, msg, context))
+        LOG.info(log_json(request_id, msg=msg, context=context))
     return upload
 
 
@@ -431,7 +431,7 @@ def copy_hcs_data_to_s3_bucket(request_id, path, filename, data, finalize=False,
         upload.upload_fileobj(data, ExtraArgs=extra_args)
     except (EndpointConnectionError, ClientError) as err:
         msg = f"Unable to copy data to {upload_key} in bucket {settings.S3_BUCKET_NAME}.  Reason: {str(err)}"
-        LOG.info(log_json(request_id, msg, context))
+        LOG.info(log_json(request_id, msg=msg, context=context))
     return upload
 
 
@@ -467,10 +467,10 @@ def remove_files_not_in_set_from_s3_bucket(request_id, s3_path, manifest_id, con
                     removed.append(key)
             if removed:
                 msg = f"Removed files from s3 bucket {settings.S3_BUCKET_NAME}: {','.join(removed)}."
-                LOG.info(log_json(request_id, msg, context))
+                LOG.info(log_json(request_id, msg=msg, context=context))
         except (EndpointConnectionError, ClientError) as err:
             msg = f"Unable to remove data in bucket {settings.S3_BUCKET_NAME}.  Reason: {str(err)}"
-            LOG.info(log_json(request_id, msg, context))
+            LOG.info(log_json(request_id, msg=msg, context=context))
     return removed
 
 


### PR DESCRIPTION
## Jira Ticket

[COST-3688](https://issues.redhat.com/browse/COST-3688)

## Description

This PR contains several logging updates:

* `msg` is a required arg in `log_json`
* This change should fix useless Sentry alerts which only contain this information:
```
{"message": null, "tracing_id": "40d56b1f-0632-47f1-9c3a-f8579bdbc40b"}
```
this log message was also converted to a warning instead of error.
* convert many formatted strings to a simple statement + context.
* add `exc_info=` to several errors and warnings
