### PR TITLE
[COST-3847] Create separate processing queues for large customers

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -1443,6 +1443,177 @@ objects:
           enabled: false
         public:
           enabled: false
+    - name: clowder-worker-cost-model-xl
+      podSpec:
+        command:
+        - /bin/bash
+        - -c
+        - |
+          PYTHONPATH=${APP_HOME} celery -A koku worker --without-gossip -E -l $CELERY_LOG_LEVEL -Q $WORKER_QUEUES
+        env:
+        - name: CLOWDER_ENABLED
+          value: ${CLOWDER_ENABLED}
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              key: aws-access-key-id
+              name: koku-aws
+              optional: false
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: aws-secret-access-key
+              name: koku-aws
+              optional: false
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: ${GOOGLE_APPLICATION_CREDENTIALS}
+        - name: APP_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: DEVELOPMENT
+          value: ${DEVELOPMENT}
+        - name: CELERY_LOG_LEVEL
+          value: ${CELERY_LOG_LEVEL}
+        - name: KOKU_LOG_LEVEL
+          value: ${KOKU_LOG_LEVEL}
+        - name: UNLEASH_LOG_LEVEL
+          value: ${UNLEASH_LOG_LEVEL}
+        - name: PROMETHEUS_MULTIPROC_DIR
+          value: ${PROMETHEUS_DIR}
+        - name: REQUESTED_BUCKET
+          value: ${S3_BUCKET_NAME}
+        - name: ENABLE_S3_ARCHIVING
+          value: ${ENABLE_S3_ARCHIVING}
+        - name: PARQUET_PROCESSING_BATCH_SIZE
+          value: ${PARQUET_PROCESSING_BATCH_SIZE}
+        - name: TRINO_DATE_STEP
+          value: ${TRINO_DATE_STEP}
+        - name: KOKU_CELERY_ENABLE_SENTRY
+          value: ${ENABLE_CELERY_SENTRY}
+        - name: KOKU_SENTRY_ENVIRONMENT
+          value: ${KOKU_SENTRY_ENV}
+        - name: KOKU_CELERY_SENTRY_DSN
+          valueFrom:
+            secretKeyRef:
+              key: celery-sentry-dsn
+              name: koku-sentry
+              optional: true
+        - name: DEMO_ACCOUNTS
+          value: ${DEMO_ACCOUNTS}
+        - name: WORKER_QUEUES
+          value: ${WORKER_COST_MODEL_XL_WORKER_QUEUE}
+        - name: WORKER_PROC_ALIVE_TIMEOUT
+          value: ${WORKER_PROC_ALIVE_TIMEOUT}
+        - name: DATE_OVERRIDE
+          value: ${DATE_OVERRIDE}
+        - name: RETAIN_NUM_MONTHS
+          value: ${RETAIN_NUM_MONTHS}
+        - name: INITIAL_INGEST_NUM_MONTHS
+          value: ${INITIAL_INGEST_NUM_MONTHS}
+        - name: INITIAL_INGEST_OVERRIDE
+          value: ${INITIAL_INGEST_OVERRIDE}
+        - name: TRINO_HOST
+          value: ${TRINO_HOST}
+        - name: TRINO_PORT
+          value: ${TRINO_PORT}
+        - name: AUTO_DATA_INGEST
+          value: ${AUTO_DATA_INGEST}
+        - name: REPORT_PROCESSING_BATCH_SIZE
+          value: ${REPORT_PROCESSING_BATCH_SIZE}
+        - name: PROMETHEUS_PUSHGATEWAY
+          value: ${PROMETHEUS_PUSHGATEWAY}
+        - name: SOURCES_API_PREFIX
+          value: ${SOURCES_API_PREFIX}
+        - name: UNLEASH_CACHE_DIR
+          value: ${UNLEASH_CACHE_DIR}
+        - name: WORKER_CACHE_TIMEOUT
+          value: ${WORKER_CACHE_TIMEOUT}
+        - name: QE_SCHEMA
+          value: ${QE_SCHEMA}
+        - name: OCI_CLI_USER
+          valueFrom:
+            secretKeyRef:
+              key: oci-cli-user
+              name: koku-oci
+        - name: OCI_CLI_FINGERPRINT
+          valueFrom:
+            secretKeyRef:
+              key: oci-cli-fingerprint
+              name: koku-oci
+        - name: OCI_CLI_TENANCY
+          valueFrom:
+            secretKeyRef:
+              key: oci-cli-tenancy
+              name: koku-oci
+        - name: OCI_CLI_KEY_FILE
+          value: ${OCI_CLI_KEY_FILE}
+        - name: OCI_PYTHON_SDK_NO_SERVICE_IMPORTS
+          value: "true"
+        - name: ENHANCED_ORG_ADMIN
+          value: ${ENHANCED_ORG_ADMIN}
+        image: ${IMAGE}:${IMAGE_TAG}
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /livez
+            port: metrics
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 20
+          successThreshold: 1
+          timeoutSeconds: 10
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /readyz
+            port: metrics
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 20
+          successThreshold: 1
+          timeoutSeconds: 10
+        resources:
+          limits:
+            cpu: ${WORKER_COST_MODEL_XL_CPU_LIMIT}
+            memory: ${WORKER_COST_MODEL_XL_MEMORY_LIMIT}
+          requests:
+            cpu: ${WORKER_COST_MODEL_XL_CPU_REQUEST}
+            memory: ${WORKER_COST_MODEL_XL_MEMORY_REQUEST}
+        volumeMounts:
+        - mountPath: /var/tmp/masu/
+          name: koku-worker-data
+        - mountPath: /etc/gcp
+          name: gcp-credentials
+          readOnly: true
+        - mountPath: /etc/oci
+          name: oci-credentials
+          readOnly: true
+        - mountPath: ${TMP_DIR}
+          name: tmp-data
+        volumes:
+        - emptyDir: {}
+          name: tmp-data
+        - emptyDir: {}
+          name: koku-worker-data
+        - name: gcp-credentials
+          secret:
+            items:
+            - key: gcp-credentials
+              path: gcp-credentials.json
+            secretName: koku-gcp
+        - name: oci-credentials
+          secret:
+            items:
+            - key: oci-credentials
+              path: oci-credentials.pem
+            secretName: koku-oci
+      replicas: ${{WORKER_COST_MODEL_XL_REPLICAS}}
+      webServices:
+        private:
+          enabled: false
+        public:
+          enabled: false
     - name: clowder-worker-download
       podSpec:
         command:
@@ -1607,6 +1778,175 @@ objects:
               path: oci-credentials.pem
             secretName: koku-oci
       replicas: ${{WORKER_DOWNLOAD_REPLICAS}}
+      webServices:
+        private:
+          enabled: false
+        public:
+          enabled: false
+    - name: clowder-worker-download-xl
+      podSpec:
+        command:
+        - /bin/bash
+        - -c
+        - |
+          PYTHONPATH=${APP_HOME} celery -A koku worker --without-gossip -E -l $CELERY_LOG_LEVEL -Q $WORKER_QUEUES
+        env:
+        - name: CLOWDER_ENABLED
+          value: ${CLOWDER_ENABLED}
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              key: aws-access-key-id
+              name: koku-aws
+              optional: false
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: aws-secret-access-key
+              name: koku-aws
+              optional: false
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: ${GOOGLE_APPLICATION_CREDENTIALS}
+        - name: APP_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: DEVELOPMENT
+          value: ${DEVELOPMENT}
+        - name: CELERY_LOG_LEVEL
+          value: ${CELERY_LOG_LEVEL}
+        - name: KOKU_LOG_LEVEL
+          value: ${KOKU_LOG_LEVEL}
+        - name: UNLEASH_LOG_LEVEL
+          value: ${UNLEASH_LOG_LEVEL}
+        - name: PROMETHEUS_MULTIPROC_DIR
+          value: ${PROMETHEUS_DIR}
+        - name: REQUESTED_BUCKET
+          value: ${S3_BUCKET_NAME}
+        - name: ENABLE_S3_ARCHIVING
+          value: ${ENABLE_S3_ARCHIVING}
+        - name: PARQUET_PROCESSING_BATCH_SIZE
+          value: ${PARQUET_PROCESSING_BATCH_SIZE}
+        - name: TRINO_DATE_STEP
+          value: ${TRINO_DATE_STEP}
+        - name: KOKU_CELERY_ENABLE_SENTRY
+          value: ${ENABLE_CELERY_SENTRY}
+        - name: KOKU_SENTRY_ENVIRONMENT
+          value: ${KOKU_SENTRY_ENV}
+        - name: KOKU_CELERY_SENTRY_DSN
+          valueFrom:
+            secretKeyRef:
+              key: celery-sentry-dsn
+              name: koku-sentry
+              optional: true
+        - name: DEMO_ACCOUNTS
+          value: ${DEMO_ACCOUNTS}
+        - name: WORKER_QUEUES
+          value: ${WORKER_DOWNLOAD_XL_WORKER_QUEUE}
+        - name: WORKER_PROC_ALIVE_TIMEOUT
+          value: ${WORKER_PROC_ALIVE_TIMEOUT}
+        - name: DATE_OVERRIDE
+          value: ${DATE_OVERRIDE}
+        - name: RETAIN_NUM_MONTHS
+          value: ${RETAIN_NUM_MONTHS}
+        - name: INITIAL_INGEST_NUM_MONTHS
+          value: ${INITIAL_INGEST_NUM_MONTHS}
+        - name: INITIAL_INGEST_OVERRIDE
+          value: ${INITIAL_INGEST_OVERRIDE}
+        - name: TRINO_HOST
+          value: ${TRINO_HOST}
+        - name: TRINO_PORT
+          value: ${TRINO_PORT}
+        - name: AUTO_DATA_INGEST
+          value: ${AUTO_DATA_INGEST}
+        - name: REPORT_PROCESSING_BATCH_SIZE
+          value: ${REPORT_PROCESSING_BATCH_SIZE}
+        - name: PROMETHEUS_PUSHGATEWAY
+          value: ${PROMETHEUS_PUSHGATEWAY}
+        - name: SOURCES_API_PREFIX
+          value: ${SOURCES_API_PREFIX}
+        - name: UNLEASH_CACHE_DIR
+          value: ${UNLEASH_CACHE_DIR}
+        - name: QE_SCHEMA
+          value: ${QE_SCHEMA}
+        - name: OCI_CLI_USER
+          valueFrom:
+            secretKeyRef:
+              key: oci-cli-user
+              name: koku-oci
+        - name: OCI_CLI_FINGERPRINT
+          valueFrom:
+            secretKeyRef:
+              key: oci-cli-fingerprint
+              name: koku-oci
+        - name: OCI_CLI_TENANCY
+          valueFrom:
+            secretKeyRef:
+              key: oci-cli-tenancy
+              name: koku-oci
+        - name: OCI_CLI_KEY_FILE
+          value: ${OCI_CLI_KEY_FILE}
+        - name: OCI_PYTHON_SDK_NO_SERVICE_IMPORTS
+          value: "true"
+        - name: ENHANCED_ORG_ADMIN
+          value: ${ENHANCED_ORG_ADMIN}
+        image: ${IMAGE}:${IMAGE_TAG}
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /livez
+            port: metrics
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 20
+          successThreshold: 1
+          timeoutSeconds: 10
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /readyz
+            port: metrics
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 20
+          successThreshold: 1
+          timeoutSeconds: 10
+        resources:
+          limits:
+            cpu: ${WORKER_DOWNLOAD_XL_CPU_LIMIT}
+            memory: ${WORKER_DOWNLOAD_XL_MEMORY_LIMIT}
+          requests:
+            cpu: ${WORKER_DOWNLOAD_XL_CPU_REQUEST}
+            memory: ${WORKER_DOWNLOAD_XL_MEMORY_REQUEST}
+        volumeMounts:
+        - mountPath: /var/tmp/masu/
+          name: koku-worker-data
+        - mountPath: /etc/gcp
+          name: gcp-credentials
+          readOnly: true
+        - mountPath: /etc/oci
+          name: oci-credentials
+          readOnly: true
+        - mountPath: ${TMP_DIR}
+          name: tmp-data
+        volumes:
+        - emptyDir: {}
+          name: tmp-data
+        - emptyDir: {}
+          name: koku-worker-data
+        - name: gcp-credentials
+          secret:
+            items:
+            - key: gcp-credentials
+              path: gcp-credentials.json
+            secretName: koku-gcp
+        - name: oci-credentials
+          secret:
+            items:
+            - key: oci-credentials
+              path: oci-credentials.pem
+            secretName: koku-oci
+      replicas: ${{WORKER_DOWNLOAD_XL_REPLICAS}}
       webServices:
         private:
           enabled: false
@@ -1778,6 +2118,177 @@ objects:
               path: oci-credentials.pem
             secretName: koku-oci
       replicas: ${{WORKER_OCP_REPLICAS}}
+      webServices:
+        private:
+          enabled: false
+        public:
+          enabled: false
+    - name: clowder-worker-ocp-xl
+      podSpec:
+        command:
+        - /bin/bash
+        - -c
+        - |
+          PYTHONPATH=${APP_HOME} celery -A koku worker --without-gossip -E -l $CELERY_LOG_LEVEL -Q $WORKER_QUEUES
+        env:
+        - name: CLOWDER_ENABLED
+          value: ${CLOWDER_ENABLED}
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              key: aws-access-key-id
+              name: koku-aws
+              optional: false
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: aws-secret-access-key
+              name: koku-aws
+              optional: false
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: ${GOOGLE_APPLICATION_CREDENTIALS}
+        - name: APP_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: DEVELOPMENT
+          value: ${DEVELOPMENT}
+        - name: CELERY_LOG_LEVEL
+          value: ${CELERY_LOG_LEVEL}
+        - name: KOKU_LOG_LEVEL
+          value: ${KOKU_LOG_LEVEL}
+        - name: UNLEASH_LOG_LEVEL
+          value: ${UNLEASH_LOG_LEVEL}
+        - name: PROMETHEUS_MULTIPROC_DIR
+          value: ${PROMETHEUS_DIR}
+        - name: REQUESTED_BUCKET
+          value: ${S3_BUCKET_NAME}
+        - name: ENABLE_S3_ARCHIVING
+          value: ${ENABLE_S3_ARCHIVING}
+        - name: PARQUET_PROCESSING_BATCH_SIZE
+          value: ${PARQUET_PROCESSING_BATCH_SIZE}
+        - name: TRINO_DATE_STEP
+          value: ${TRINO_DATE_STEP}
+        - name: KOKU_CELERY_ENABLE_SENTRY
+          value: ${ENABLE_CELERY_SENTRY}
+        - name: KOKU_SENTRY_ENVIRONMENT
+          value: ${KOKU_SENTRY_ENV}
+        - name: KOKU_CELERY_SENTRY_DSN
+          valueFrom:
+            secretKeyRef:
+              key: celery-sentry-dsn
+              name: koku-sentry
+              optional: true
+        - name: DEMO_ACCOUNTS
+          value: ${DEMO_ACCOUNTS}
+        - name: WORKER_QUEUES
+          value: ${WORKER_OCP_XL_WORKER_QUEUE}
+        - name: WORKER_PROC_ALIVE_TIMEOUT
+          value: ${WORKER_PROC_ALIVE_TIMEOUT}
+        - name: DATE_OVERRIDE
+          value: ${DATE_OVERRIDE}
+        - name: RETAIN_NUM_MONTHS
+          value: ${RETAIN_NUM_MONTHS}
+        - name: INITIAL_INGEST_NUM_MONTHS
+          value: ${INITIAL_INGEST_NUM_MONTHS}
+        - name: INITIAL_INGEST_OVERRIDE
+          value: ${INITIAL_INGEST_OVERRIDE}
+        - name: TRINO_HOST
+          value: ${TRINO_HOST}
+        - name: TRINO_PORT
+          value: ${TRINO_PORT}
+        - name: AUTO_DATA_INGEST
+          value: ${AUTO_DATA_INGEST}
+        - name: REPORT_PROCESSING_BATCH_SIZE
+          value: ${REPORT_PROCESSING_BATCH_SIZE}
+        - name: PROMETHEUS_PUSHGATEWAY
+          value: ${PROMETHEUS_PUSHGATEWAY}
+        - name: SOURCES_API_PREFIX
+          value: ${SOURCES_API_PREFIX}
+        - name: UNLEASH_CACHE_DIR
+          value: ${UNLEASH_CACHE_DIR}
+        - name: WORKER_CACHE_TIMEOUT
+          value: ${WORKER_CACHE_TIMEOUT}
+        - name: QE_SCHEMA
+          value: ${QE_SCHEMA}
+        - name: OCI_CLI_USER
+          valueFrom:
+            secretKeyRef:
+              key: oci-cli-user
+              name: koku-oci
+        - name: OCI_CLI_FINGERPRINT
+          valueFrom:
+            secretKeyRef:
+              key: oci-cli-fingerprint
+              name: koku-oci
+        - name: OCI_CLI_TENANCY
+          valueFrom:
+            secretKeyRef:
+              key: oci-cli-tenancy
+              name: koku-oci
+        - name: OCI_CLI_KEY_FILE
+          value: ${OCI_CLI_KEY_FILE}
+        - name: OCI_PYTHON_SDK_NO_SERVICE_IMPORTS
+          value: "true"
+        - name: ENHANCED_ORG_ADMIN
+          value: ${ENHANCED_ORG_ADMIN}
+        image: ${IMAGE}:${IMAGE_TAG}
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /livez
+            port: metrics
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 20
+          successThreshold: 1
+          timeoutSeconds: 10
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /readyz
+            port: metrics
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 20
+          successThreshold: 1
+          timeoutSeconds: 10
+        resources:
+          limits:
+            cpu: ${WORKER_OCP_XL_CPU_LIMIT}
+            memory: ${WORKER_OCP_XL_MEMORY_LIMIT}
+          requests:
+            cpu: ${WORKER_OCP_XL_CPU_REQUEST}
+            memory: ${WORKER_OCP_XL_MEMORY_REQUEST}
+        volumeMounts:
+        - mountPath: /var/tmp/masu/
+          name: koku-worker-data
+        - mountPath: /etc/gcp
+          name: gcp-credentials
+          readOnly: true
+        - mountPath: /etc/oci
+          name: oci-credentials
+          readOnly: true
+        - mountPath: ${TMP_DIR}
+          name: tmp-data
+        volumes:
+        - emptyDir: {}
+          name: tmp-data
+        - emptyDir: {}
+          name: koku-worker-data
+        - name: gcp-credentials
+          secret:
+            items:
+            - key: gcp-credentials
+              path: gcp-credentials.json
+            secretName: koku-gcp
+        - name: oci-credentials
+          secret:
+            items:
+            - key: oci-credentials
+              path: oci-credentials.pem
+            secretName: koku-oci
+      replicas: ${{WORKER_OCP_XL_REPLICAS}}
       webServices:
         private:
           enabled: false
@@ -1956,6 +2467,179 @@ objects:
           enabled: false
         public:
           enabled: false
+    - name: clowder-worker-priority-xl
+      podSpec:
+        command:
+        - /bin/bash
+        - -c
+        - |
+          PYTHONPATH=${APP_HOME} celery -A koku worker --without-gossip -E -l $CELERY_LOG_LEVEL -Q $WORKER_QUEUES
+        env:
+        - name: CLOWDER_ENABLED
+          value: ${CLOWDER_ENABLED}
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              key: aws-access-key-id
+              name: koku-aws
+              optional: false
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: aws-secret-access-key
+              name: koku-aws
+              optional: false
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: ${GOOGLE_APPLICATION_CREDENTIALS}
+        - name: APP_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: DEVELOPMENT
+          value: ${DEVELOPMENT}
+        - name: CELERY_LOG_LEVEL
+          value: ${CELERY_LOG_LEVEL}
+        - name: KOKU_LOG_LEVEL
+          value: ${KOKU_LOG_LEVEL}
+        - name: UNLEASH_LOG_LEVEL
+          value: ${UNLEASH_LOG_LEVEL}
+        - name: PROMETHEUS_MULTIPROC_DIR
+          value: ${PROMETHEUS_DIR}
+        - name: REQUESTED_BUCKET
+          value: ${S3_BUCKET_NAME}
+        - name: ENABLE_S3_ARCHIVING
+          value: ${ENABLE_S3_ARCHIVING}
+        - name: PARQUET_PROCESSING_BATCH_SIZE
+          value: ${PARQUET_PROCESSING_BATCH_SIZE}
+        - name: TRINO_DATE_STEP
+          value: ${TRINO_DATE_STEP}
+        - name: KOKU_CELERY_ENABLE_SENTRY
+          value: ${ENABLE_CELERY_SENTRY}
+        - name: KOKU_SENTRY_ENVIRONMENT
+          value: ${KOKU_SENTRY_ENV}
+        - name: KOKU_CELERY_SENTRY_DSN
+          valueFrom:
+            secretKeyRef:
+              key: celery-sentry-dsn
+              name: koku-sentry
+              optional: true
+        - name: DEMO_ACCOUNTS
+          value: ${DEMO_ACCOUNTS}
+        - name: WORKER_QUEUES
+          value: ${WORKER_PRIORITY_XL_WORKER_QUEUE}
+        - name: WORKER_PROC_ALIVE_TIMEOUT
+          value: ${WORKER_PROC_ALIVE_TIMEOUT}
+        - name: DATE_OVERRIDE
+          value: ${DATE_OVERRIDE}
+        - name: RETAIN_NUM_MONTHS
+          value: ${RETAIN_NUM_MONTHS}
+        - name: INITIAL_INGEST_NUM_MONTHS
+          value: ${INITIAL_INGEST_NUM_MONTHS}
+        - name: INITIAL_INGEST_OVERRIDE
+          value: ${INITIAL_INGEST_OVERRIDE}
+        - name: TRINO_HOST
+          value: ${TRINO_HOST}
+        - name: TRINO_PORT
+          value: ${TRINO_PORT}
+        - name: AUTO_DATA_INGEST
+          value: ${AUTO_DATA_INGEST}
+        - name: REPORT_PROCESSING_BATCH_SIZE
+          value: ${REPORT_PROCESSING_BATCH_SIZE}
+        - name: PROMETHEUS_PUSHGATEWAY
+          value: ${PROMETHEUS_PUSHGATEWAY}
+        - name: SOURCES_API_PREFIX
+          value: ${SOURCES_API_PREFIX}
+        - name: UNLEASH_CACHE_DIR
+          value: ${UNLEASH_CACHE_DIR}
+        - name: QE_SCHEMA
+          value: ${QE_SCHEMA}
+        - name: OCI_CLI_USER
+          valueFrom:
+            secretKeyRef:
+              key: oci-cli-user
+              name: koku-oci
+        - name: OCI_CLI_FINGERPRINT
+          valueFrom:
+            secretKeyRef:
+              key: oci-cli-fingerprint
+              name: koku-oci
+        - name: OCI_CLI_TENANCY
+          valueFrom:
+            secretKeyRef:
+              key: oci-cli-tenancy
+              name: koku-oci
+        - name: OCI_CLI_KEY_FILE
+          value: ${OCI_CLI_KEY_FILE}
+        - name: OCI_PYTHON_SDK_NO_SERVICE_IMPORTS
+          value: "true"
+        - name: ENHANCED_ORG_ADMIN
+          value: ${ENHANCED_ORG_ADMIN}
+        image: ${IMAGE}:${IMAGE_TAG}
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /livez
+            port: metrics
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 20
+          successThreshold: 1
+          timeoutSeconds: 10
+        metadata:
+          annotations:
+            ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses
+              1 pod at times for cost saving purposes
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /readyz
+            port: metrics
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 20
+          successThreshold: 1
+          timeoutSeconds: 10
+        resources:
+          limits:
+            cpu: ${WORKER_PRIORITY_XL_CPU_LIMIT}
+            memory: ${WORKER_PRIORITY_XL_MEMORY_LIMIT}
+          requests:
+            cpu: ${WORKER_PRIORITY_XL_CPU_REQUEST}
+            memory: ${WORKER_PRIORITY_XL_MEMORY_REQUEST}
+        volumeMounts:
+        - mountPath: /var/tmp/masu/
+          name: koku-worker-data
+        - mountPath: /etc/gcp
+          name: gcp-credentials
+          readOnly: true
+        - mountPath: /etc/oci
+          name: oci-credentials
+          readOnly: true
+        - mountPath: ${TMP_DIR}
+          name: tmp-data
+        volumes:
+        - emptyDir: {}
+          name: tmp-data
+        - emptyDir: {}
+          name: koku-worker-data
+        - name: gcp-credentials
+          secret:
+            items:
+            - key: gcp-credentials
+              path: gcp-credentials.json
+            secretName: koku-gcp
+        - name: oci-credentials
+          secret:
+            items:
+            - key: oci-credentials
+              path: oci-credentials.pem
+            secretName: koku-oci
+      replicas: ${{WORKER_PRIORITY_XL_REPLICAS}}
+      webServices:
+        private:
+          enabled: false
+        public:
+          enabled: false
     - name: clowder-worker-refresh
       podSpec:
         command:
@@ -2127,6 +2811,177 @@ objects:
           enabled: false
         public:
           enabled: false
+    - name: clowder-worker-refresh-xl
+      podSpec:
+        command:
+        - /bin/bash
+        - -c
+        - |
+          PYTHONPATH=${APP_HOME} celery -A koku worker --without-gossip -E -l $CELERY_LOG_LEVEL -Q $WORKER_QUEUES
+        env:
+        - name: CLOWDER_ENABLED
+          value: ${CLOWDER_ENABLED}
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              key: aws-access-key-id
+              name: koku-aws
+              optional: false
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: aws-secret-access-key
+              name: koku-aws
+              optional: false
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: ${GOOGLE_APPLICATION_CREDENTIALS}
+        - name: APP_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: DEVELOPMENT
+          value: ${DEVELOPMENT}
+        - name: CELERY_LOG_LEVEL
+          value: ${CELERY_LOG_LEVEL}
+        - name: KOKU_LOG_LEVEL
+          value: ${KOKU_LOG_LEVEL}
+        - name: UNLEASH_LOG_LEVEL
+          value: ${UNLEASH_LOG_LEVEL}
+        - name: PROMETHEUS_MULTIPROC_DIR
+          value: ${PROMETHEUS_DIR}
+        - name: REQUESTED_BUCKET
+          value: ${S3_BUCKET_NAME}
+        - name: ENABLE_S3_ARCHIVING
+          value: ${ENABLE_S3_ARCHIVING}
+        - name: PARQUET_PROCESSING_BATCH_SIZE
+          value: ${PARQUET_PROCESSING_BATCH_SIZE}
+        - name: TRINO_DATE_STEP
+          value: ${TRINO_DATE_STEP}
+        - name: KOKU_CELERY_ENABLE_SENTRY
+          value: ${ENABLE_CELERY_SENTRY}
+        - name: KOKU_SENTRY_ENVIRONMENT
+          value: ${KOKU_SENTRY_ENV}
+        - name: KOKU_CELERY_SENTRY_DSN
+          valueFrom:
+            secretKeyRef:
+              key: celery-sentry-dsn
+              name: koku-sentry
+              optional: true
+        - name: DEMO_ACCOUNTS
+          value: ${DEMO_ACCOUNTS}
+        - name: WORKER_QUEUES
+          value: ${WORKER_REFRESH_XL_WORKER_QUEUE}
+        - name: WORKER_PROC_ALIVE_TIMEOUT
+          value: ${WORKER_PROC_ALIVE_TIMEOUT}
+        - name: DATE_OVERRIDE
+          value: ${DATE_OVERRIDE}
+        - name: RETAIN_NUM_MONTHS
+          value: ${RETAIN_NUM_MONTHS}
+        - name: INITIAL_INGEST_NUM_MONTHS
+          value: ${INITIAL_INGEST_NUM_MONTHS}
+        - name: INITIAL_INGEST_OVERRIDE
+          value: ${INITIAL_INGEST_OVERRIDE}
+        - name: TRINO_HOST
+          value: ${TRINO_HOST}
+        - name: TRINO_PORT
+          value: ${TRINO_PORT}
+        - name: AUTO_DATA_INGEST
+          value: ${AUTO_DATA_INGEST}
+        - name: REPORT_PROCESSING_BATCH_SIZE
+          value: ${REPORT_PROCESSING_BATCH_SIZE}
+        - name: PROMETHEUS_PUSHGATEWAY
+          value: ${PROMETHEUS_PUSHGATEWAY}
+        - name: SOURCES_API_PREFIX
+          value: ${SOURCES_API_PREFIX}
+        - name: UNLEASH_CACHE_DIR
+          value: ${UNLEASH_CACHE_DIR}
+        - name: WORKER_CACHE_TIMEOUT
+          value: ${WORKER_CACHE_TIMEOUT}
+        - name: QE_SCHEMA
+          value: ${QE_SCHEMA}
+        - name: OCI_CLI_USER
+          valueFrom:
+            secretKeyRef:
+              key: oci-cli-user
+              name: koku-oci
+        - name: OCI_CLI_FINGERPRINT
+          valueFrom:
+            secretKeyRef:
+              key: oci-cli-fingerprint
+              name: koku-oci
+        - name: OCI_CLI_TENANCY
+          valueFrom:
+            secretKeyRef:
+              key: oci-cli-tenancy
+              name: koku-oci
+        - name: OCI_CLI_KEY_FILE
+          value: ${OCI_CLI_KEY_FILE}
+        - name: OCI_PYTHON_SDK_NO_SERVICE_IMPORTS
+          value: "true"
+        - name: ENHANCED_ORG_ADMIN
+          value: ${ENHANCED_ORG_ADMIN}
+        image: ${IMAGE}:${IMAGE_TAG}
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /livez
+            port: metrics
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 20
+          successThreshold: 1
+          timeoutSeconds: 10
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /readyz
+            port: metrics
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 20
+          successThreshold: 1
+          timeoutSeconds: 10
+        resources:
+          limits:
+            cpu: ${WORKER_REFRESH_XL_CPU_LIMIT}
+            memory: ${WORKER_REFRESH_XL_MEMORY_LIMIT}
+          requests:
+            cpu: ${WORKER_REFRESH_XL_CPU_REQUEST}
+            memory: ${WORKER_REFRESH_XL_MEMORY_REQUEST}
+        volumeMounts:
+        - mountPath: /var/tmp/masu/
+          name: koku-worker-data
+        - mountPath: /etc/gcp
+          name: gcp-credentials
+          readOnly: true
+        - mountPath: /etc/oci
+          name: oci-credentials
+          readOnly: true
+        - mountPath: ${TMP_DIR}
+          name: tmp-data
+        volumes:
+        - emptyDir: {}
+          name: tmp-data
+        - emptyDir: {}
+          name: koku-worker-data
+        - name: gcp-credentials
+          secret:
+            items:
+            - key: gcp-credentials
+              path: gcp-credentials.json
+            secretName: koku-gcp
+        - name: oci-credentials
+          secret:
+            items:
+            - key: oci-credentials
+              path: oci-credentials.pem
+            secretName: koku-oci
+      replicas: ${{WORKER_REFRESH_XL_REPLICAS}}
+      webServices:
+        private:
+          enabled: false
+        public:
+          enabled: false
     - name: clowder-worker-summary
       podSpec:
         command:
@@ -2293,6 +3148,177 @@ objects:
               path: oci-credentials.pem
             secretName: koku-oci
       replicas: ${{WORKER_SUMMARY_REPLICAS}}
+      webServices:
+        private:
+          enabled: false
+        public:
+          enabled: false
+    - name: clowder-worker-summary-xl
+      podSpec:
+        command:
+        - /bin/bash
+        - -c
+        - |
+          PYTHONPATH=${APP_HOME} celery -A koku worker --without-gossip -E -l $CELERY_LOG_LEVEL -Q $WORKER_QUEUES
+        env:
+        - name: CLOWDER_ENABLED
+          value: ${CLOWDER_ENABLED}
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              key: aws-access-key-id
+              name: koku-aws
+              optional: false
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: aws-secret-access-key
+              name: koku-aws
+              optional: false
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: ${GOOGLE_APPLICATION_CREDENTIALS}
+        - name: APP_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: DEVELOPMENT
+          value: ${DEVELOPMENT}
+        - name: CELERY_LOG_LEVEL
+          value: ${CELERY_LOG_LEVEL}
+        - name: KOKU_LOG_LEVEL
+          value: ${KOKU_LOG_LEVEL}
+        - name: UNLEASH_LOG_LEVEL
+          value: ${UNLEASH_LOG_LEVEL}
+        - name: PROMETHEUS_MULTIPROC_DIR
+          value: ${PROMETHEUS_DIR}
+        - name: REQUESTED_BUCKET
+          value: ${S3_BUCKET_NAME}
+        - name: ENABLE_S3_ARCHIVING
+          value: ${ENABLE_S3_ARCHIVING}
+        - name: PARQUET_PROCESSING_BATCH_SIZE
+          value: ${PARQUET_PROCESSING_BATCH_SIZE}
+        - name: TRINO_DATE_STEP
+          value: ${TRINO_DATE_STEP}
+        - name: KOKU_CELERY_ENABLE_SENTRY
+          value: ${ENABLE_CELERY_SENTRY}
+        - name: KOKU_SENTRY_ENVIRONMENT
+          value: ${KOKU_SENTRY_ENV}
+        - name: KOKU_CELERY_SENTRY_DSN
+          valueFrom:
+            secretKeyRef:
+              key: celery-sentry-dsn
+              name: koku-sentry
+              optional: true
+        - name: DEMO_ACCOUNTS
+          value: ${DEMO_ACCOUNTS}
+        - name: WORKER_QUEUES
+          value: ${WORKER_SUMMARY_XL_WORKER_QUEUE}
+        - name: WORKER_PROC_ALIVE_TIMEOUT
+          value: ${WORKER_PROC_ALIVE_TIMEOUT}
+        - name: DATE_OVERRIDE
+          value: ${DATE_OVERRIDE}
+        - name: RETAIN_NUM_MONTHS
+          value: ${RETAIN_NUM_MONTHS}
+        - name: INITIAL_INGEST_NUM_MONTHS
+          value: ${INITIAL_INGEST_NUM_MONTHS}
+        - name: INITIAL_INGEST_OVERRIDE
+          value: ${INITIAL_INGEST_OVERRIDE}
+        - name: TRINO_HOST
+          value: ${TRINO_HOST}
+        - name: TRINO_PORT
+          value: ${TRINO_PORT}
+        - name: AUTO_DATA_INGEST
+          value: ${AUTO_DATA_INGEST}
+        - name: REPORT_PROCESSING_BATCH_SIZE
+          value: ${REPORT_PROCESSING_BATCH_SIZE}
+        - name: PROMETHEUS_PUSHGATEWAY
+          value: ${PROMETHEUS_PUSHGATEWAY}
+        - name: SOURCES_API_PREFIX
+          value: ${SOURCES_API_PREFIX}
+        - name: UNLEASH_CACHE_DIR
+          value: ${UNLEASH_CACHE_DIR}
+        - name: WORKER_CACHE_TIMEOUT
+          value: ${WORKER_CACHE_TIMEOUT}
+        - name: QE_SCHEMA
+          value: ${QE_SCHEMA}
+        - name: OCI_CLI_USER
+          valueFrom:
+            secretKeyRef:
+              key: oci-cli-user
+              name: koku-oci
+        - name: OCI_CLI_FINGERPRINT
+          valueFrom:
+            secretKeyRef:
+              key: oci-cli-fingerprint
+              name: koku-oci
+        - name: OCI_CLI_TENANCY
+          valueFrom:
+            secretKeyRef:
+              key: oci-cli-tenancy
+              name: koku-oci
+        - name: OCI_CLI_KEY_FILE
+          value: ${OCI_CLI_KEY_FILE}
+        - name: OCI_PYTHON_SDK_NO_SERVICE_IMPORTS
+          value: "true"
+        - name: ENHANCED_ORG_ADMIN
+          value: ${ENHANCED_ORG_ADMIN}
+        image: ${IMAGE}:${IMAGE_TAG}
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /livez
+            port: metrics
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 20
+          successThreshold: 1
+          timeoutSeconds: 10
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /readyz
+            port: metrics
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 20
+          successThreshold: 1
+          timeoutSeconds: 10
+        resources:
+          limits:
+            cpu: ${WORKER_SUMMARY_XL_CPU_LIMIT}
+            memory: ${WORKER_SUMMARY_XL_MEMORY_LIMIT}
+          requests:
+            cpu: ${WORKER_SUMMARY_XL_CPU_REQUEST}
+            memory: ${WORKER_SUMMARY_XL_MEMORY_REQUEST}
+        volumeMounts:
+        - mountPath: /var/tmp/masu/
+          name: koku-worker-data
+        - mountPath: /etc/gcp
+          name: gcp-credentials
+          readOnly: true
+        - mountPath: /etc/oci
+          name: oci-credentials
+          readOnly: true
+        - mountPath: ${TMP_DIR}
+          name: tmp-data
+        volumes:
+        - emptyDir: {}
+          name: tmp-data
+        - emptyDir: {}
+          name: koku-worker-data
+        - name: gcp-credentials
+          secret:
+            items:
+            - key: gcp-credentials
+              path: gcp-credentials.json
+            secretName: koku-gcp
+        - name: oci-credentials
+          secret:
+            items:
+            - key: oci-credentials
+              path: oci-credentials.pem
+            secretName: koku-oci
+      replicas: ${{WORKER_SUMMARY_XL_REPLICAS}}
       webServices:
         private:
           enabled: false
@@ -3037,7 +4063,7 @@ parameters:
 - displayName: Worker Queue
   name: SCHEDULER_WORKER_QUEUE
   required: true
-  value: cost_model,download,hcs,ocp,priority,refresh,summary
+  value: cost_model,cost_model_xl,download,download_xl,hcs,ocp,ocp_xl,priority,priority_xl,refresh,refresh_xl,summary,summary_xl
 - displayName: Scheduler report checks
   name: SCHEDULE_REPORT_CHECKS
   value: "True"
@@ -3141,6 +4167,30 @@ parameters:
   required: true
   value: cost_model
 - displayName: Minimum replicas
+  name: WORKER_COST_MODEL_XL_REPLICAS
+  required: true
+  value: "2"
+- displayName: Memory Request
+  name: WORKER_COST_MODEL_XL_MEMORY_REQUEST
+  required: true
+  value: 256Mi
+- displayName: Memory Limit
+  name: WORKER_COST_MODEL_XL_MEMORY_LIMIT
+  required: true
+  value: 512Mi
+- displayName: CPU Request
+  name: WORKER_COST_MODEL_XL_CPU_REQUEST
+  required: true
+  value: 100m
+- displayName: CPU Limit
+  name: WORKER_COST_MODEL_XL_CPU_LIMIT
+  required: true
+  value: 200m
+- displayName: Worker Queue
+  name: WORKER_COST_MODEL_XL_WORKER_QUEUE
+  required: true
+  value: cost_model_xl
+- displayName: Minimum replicas
   name: WORKER_DOWNLOAD_REPLICAS
   required: true
   value: "2"
@@ -3164,6 +4214,30 @@ parameters:
   name: WORKER_DOWNLOAD_WORKER_QUEUE
   required: true
   value: download
+- displayName: Minimum replicas
+  name: WORKER_DOWNLOAD_XL_REPLICAS
+  required: true
+  value: "2"
+- displayName: Memory Request
+  name: WORKER_DOWNLOAD_XL_MEMORY_REQUEST
+  required: true
+  value: 512Mi
+- displayName: Memory Limit
+  name: WORKER_DOWNLOAD_XL_MEMORY_LIMIT
+  required: true
+  value: 1Gi
+- displayName: CPU Request
+  name: WORKER_DOWNLOAD_XL_CPU_REQUEST
+  required: true
+  value: 200m
+- displayName: CPU Limit
+  name: WORKER_DOWNLOAD_XL_CPU_LIMIT
+  required: true
+  value: 400m
+- displayName: Worker Queue
+  name: WORKER_DOWNLOAD_XL_WORKER_QUEUE
+  required: true
+  value: download_xl
 - displayName: Minimum replicas
   name: WORKER_OCP_REPLICAS
   required: true
@@ -3189,6 +4263,30 @@ parameters:
   required: true
   value: ocp
 - displayName: Minimum replicas
+  name: WORKER_OCP_XL_REPLICAS
+  required: true
+  value: "2"
+- displayName: Memory Request
+  name: WORKER_OCP_XL_MEMORY_REQUEST
+  required: true
+  value: 256Mi
+- displayName: Memory Limit
+  name: WORKER_OCP_XL_MEMORY_LIMIT
+  required: true
+  value: 512Mi
+- displayName: CPU Request
+  name: WORKER_OCP_XL_CPU_REQUEST
+  required: true
+  value: 100m
+- displayName: CPU Limit
+  name: WORKER_OCP_XL_CPU_LIMIT
+  required: true
+  value: 200m
+- displayName: Worker Queue
+  name: WORKER_OCP_XL_WORKER_QUEUE
+  required: true
+  value: ocp_xl
+- displayName: Minimum replicas
   name: WORKER_PRIORITY_REPLICAS
   required: true
   value: "2"
@@ -3212,6 +4310,30 @@ parameters:
   name: WORKER_PRIORITY_WORKER_QUEUE
   required: true
   value: priority
+- displayName: Minimum replicas
+  name: WORKER_PRIORITY_XL_REPLICAS
+  required: true
+  value: "2"
+- displayName: Memory Request
+  name: WORKER_PRIORITY_XL_MEMORY_REQUEST
+  required: true
+  value: 400Mi
+- displayName: Memory Limit
+  name: WORKER_PRIORITY_XL_MEMORY_LIMIT
+  required: true
+  value: 750Mi
+- displayName: CPU Request
+  name: WORKER_PRIORITY_XL_CPU_REQUEST
+  required: true
+  value: 150m
+- displayName: CPU Limit
+  name: WORKER_PRIORITY_XL_CPU_LIMIT
+  required: true
+  value: 300m
+- displayName: Worker Queue
+  name: WORKER_PRIORITY_XL_WORKER_QUEUE
+  required: true
+  value: priority_xl
 - displayName: Minimum replicas
   name: WORKER_REFRESH_REPLICAS
   required: true
@@ -3237,6 +4359,30 @@ parameters:
   required: true
   value: refresh
 - displayName: Minimum replicas
+  name: WORKER_REFRESH_XL_REPLICAS
+  required: true
+  value: "2"
+- displayName: Memory Request
+  name: WORKER_REFRESH_XL_MEMORY_REQUEST
+  required: true
+  value: 256Mi
+- displayName: Memory Limit
+  name: WORKER_REFRESH_XL_MEMORY_LIMIT
+  required: true
+  value: 512Mi
+- displayName: CPU Request
+  name: WORKER_REFRESH_XL_CPU_REQUEST
+  required: true
+  value: 100m
+- displayName: CPU Limit
+  name: WORKER_REFRESH_XL_CPU_LIMIT
+  required: true
+  value: 200m
+- displayName: Worker Queue
+  name: WORKER_REFRESH_XL_WORKER_QUEUE
+  required: true
+  value: refresh_xl
+- displayName: Minimum replicas
   name: WORKER_SUMMARY_REPLICAS
   required: true
   value: "2"
@@ -3260,6 +4406,30 @@ parameters:
   name: WORKER_SUMMARY_WORKER_QUEUE
   required: true
   value: summary
+- displayName: Minimum replicas
+  name: WORKER_SUMMARY_XL_REPLICAS
+  required: true
+  value: "2"
+- displayName: Memory Request
+  name: WORKER_SUMMARY_XL_MEMORY_REQUEST
+  required: true
+  value: 500Mi
+- displayName: Memory Limit
+  name: WORKER_SUMMARY_XL_MEMORY_LIMIT
+  required: true
+  value: 750Mi
+- displayName: CPU Request
+  name: WORKER_SUMMARY_XL_CPU_REQUEST
+  required: true
+  value: 100m
+- displayName: CPU Limit
+  name: WORKER_SUMMARY_XL_CPU_LIMIT
+  required: true
+  value: 200m
+- displayName: Worker Queue
+  name: WORKER_SUMMARY_XL_WORKER_QUEUE
+  required: true
+  value: summary_xl
 - displayName: Minimum replicas
   name: WORKER_HCS_REPLICAS
   required: true

--- a/deploy/kustomize/kustomization.yaml
+++ b/deploy/kustomize/kustomization.yaml
@@ -38,7 +38,15 @@ patches:
   target:
     version: v1
     kind: Template
+- path: patches/worker-cost-model-xl.yaml
+  target:
+    version: v1
+    kind: Template
 - path: patches/worker-download.yaml
+  target:
+    version: v1
+    kind: Template
+- path: patches/worker-download-xl.yaml
   target:
     version: v1
     kind: Template
@@ -46,7 +54,15 @@ patches:
   target:
     version: v1
     kind: Template
+- path: patches/worker-ocp-xl.yaml
+  target:
+    version: v1
+    kind: Template
 - path: patches/worker-priority.yaml
+  target:
+    version: v1
+    kind: Template
+- path: patches/worker-priority-xl.yaml
   target:
     version: v1
     kind: Template
@@ -54,7 +70,15 @@ patches:
   target:
     version: v1
     kind: Template
+- path: patches/worker-refresh-xl.yaml
+  target:
+    version: v1
+    kind: Template
 - path: patches/worker-summary.yaml
+  target:
+    version: v1
+    kind: Template
+- path: patches/worker-summary-xl.yaml
   target:
     version: v1
     kind: Template

--- a/deploy/kustomize/patches/worker-cost-model-xl.yaml
+++ b/deploy/kustomize/patches/worker-cost-model-xl.yaml
@@ -1,26 +1,21 @@
 - op: add
   path: /objects/0/spec/deployments/-
   value:
-    name: clowder-scheduler
-    replicas: ${{SCHEDULER_REPLICAS}}
+    name: clowder-worker-cost-model-xl
+    replicas: ${{WORKER_COST_MODEL_XL_REPLICAS}}
     webServices:
       public:
         enabled: false
       private:
         enabled: false
     podSpec:
-      metadata:
-        annotations:
-          ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses 1 pod as currently scheduling is a singleton
-          ignore-check.kube-linter.io/no-readiness-probe: This deployment uses celery beat which does not easily support readiness checks
-          ignore-check.kube-linter.io/no-liveness-probe: This deployment uses celery beat which does not easily support liveness checks
       image: ${IMAGE}:${IMAGE_TAG}
       command:
         - /bin/bash
         - -c
         - > # ${APP_HOME} is `/opt/koku/koku` which is defined in the Dockerfile
           PYTHONPATH=${APP_HOME}
-          celery -A koku beat -l $CELERY_LOG_LEVEL
+          celery -A koku worker --without-gossip -E -l $CELERY_LOG_LEVEL -Q $WORKER_QUEUES
       env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
@@ -73,27 +68,9 @@
         - name: DEMO_ACCOUNTS
           value: ${DEMO_ACCOUNTS}
         - name: WORKER_QUEUES
-          value: ${SCHEDULER_WORKER_QUEUE}
-        - name: REPORT_DOWNLOAD_SCHEDULE_GCP
-          value: ${REPORT_DOWNLOAD_SCHEDULE_GCP}
-        - name: REPORT_DOWNLOAD_SCHEDULE_AWS
-          value: ${REPORT_DOWNLOAD_SCHEDULE_AWS}
-        - name: REPORT_DOWNLOAD_SCHEDULE_AZURE
-          value: ${REPORT_DOWNLOAD_SCHEDULE_AZURE}
-        - name: REPORT_DOWNLOAD_SCHEDULE_OCI
-          value: ${REPORT_DOWNLOAD_SCHEDULE_OCI}
-        - name: SCHEDULE_REPORT_CHECKS
-          value: ${SCHEDULE_REPORT_CHECKS}
-        - name: SOURCE_STATUS_FREQUENCY_MINUTES
-          value: ${SOURCE_STATUS_FREQUENCY_MINUTES}
-        - name: REMOVE_EXPIRED_REPORT_DATA_ON_DAY
-          value: ${REMOVE_EXPIRED_REPORT_DATA_ON_DAY}
-        - name: REMOVE_EXPIRED_REPORT_UTC_TIME
-          value: ${REMOVE_EXPIRED_REPORT_UTC_TIME}
-        - name: VACUUM_DATA_DAY_OF_WEEK
-          value: ${VACUUM_DATA_DAY_OF_WEEK}
-        - name: VACUUM_DATA_UTC_TIME
-          value: ${VACUUM_DATA_UTC_TIME}
+          value: ${WORKER_COST_MODEL_XL_WORKER_QUEUE}
+        - name: WORKER_PROC_ALIVE_TIMEOUT
+          value: ${WORKER_PROC_ALIVE_TIMEOUT}
         - name: DATE_OVERRIDE
           value: ${DATE_OVERRIDE}
         - name: RETAIN_NUM_MONTHS
@@ -112,8 +89,12 @@
           value: ${REPORT_PROCESSING_BATCH_SIZE}
         - name: PROMETHEUS_PUSHGATEWAY
           value: ${PROMETHEUS_PUSHGATEWAY}
+        - name: SOURCES_API_PREFIX
+          value: ${SOURCES_API_PREFIX}
         - name: UNLEASH_CACHE_DIR
           value: ${UNLEASH_CACHE_DIR}
+        - name: WORKER_CACHE_TIMEOUT
+          value: ${WORKER_CACHE_TIMEOUT}
         - name: QE_SCHEMA
           value: ${QE_SCHEMA}
         - name: OCI_CLI_USER
@@ -137,14 +118,36 @@
           value: 'true'
         - name: ENHANCED_ORG_ADMIN
           value: ${ENHANCED_ORG_ADMIN}
+      livenessProbe:
+        httpGet:
+          path: /livez
+          port: metrics
+          scheme: HTTP
+        initialDelaySeconds: 30
+        periodSeconds: 20
+        successThreshold: 1
+        failureThreshold: 5
+        timeoutSeconds: 10
+      readinessProbe:
+        httpGet:
+          path: /readyz
+          port: metrics
+          scheme: HTTP
+        initialDelaySeconds: 30
+        periodSeconds: 20
+        successThreshold: 1
+        failureThreshold: 5
+        timeoutSeconds: 10
       resources:
         limits:
-          cpu: ${SCHEDULER_CPU_LIMIT}
-          memory: ${SCHEDULER_MEMORY_LIMIT}
+          cpu: ${WORKER_COST_MODEL_XL_CPU_LIMIT}
+          memory: ${WORKER_COST_MODEL_XL_MEMORY_LIMIT}
         requests:
-          cpu: ${SCHEDULER_CPU_REQUEST}
-          memory: ${SCHEDULER_MEMORY_REQUEST}
+          cpu: ${WORKER_COST_MODEL_XL_CPU_REQUEST}
+          memory: ${WORKER_COST_MODEL_XL_MEMORY_REQUEST}
       volumeMounts:
+      - mountPath: /var/tmp/masu/
+        name: koku-worker-data
       - name: gcp-credentials
         mountPath: /etc/gcp
         readOnly: true
@@ -155,6 +158,8 @@
         mountPath: ${TMP_DIR}
       volumes:
       - name: tmp-data
+        emptyDir: {}
+      - name: koku-worker-data
         emptyDir: {}
       - name: gcp-credentials
         secret:
@@ -173,53 +178,41 @@
   path: /parameters/-
   value:
     displayName: Minimum replicas
-    name: SCHEDULER_REPLICAS
+    name: WORKER_COST_MODEL_XL_REPLICAS
     required: true
-    value: '1'
+    value: '2'
 - op: add
   path: /parameters/-
   value:
     displayName: Memory Request
-    name: SCHEDULER_MEMORY_REQUEST
+    name: WORKER_COST_MODEL_XL_MEMORY_REQUEST
     required: true
-    value: 200Mi
+    value: 256Mi
 - op: add
   path: /parameters/-
   value:
     displayName: Memory Limit
-    name: SCHEDULER_MEMORY_LIMIT
+    name: WORKER_COST_MODEL_XL_MEMORY_LIMIT
     required: true
-    value: 400Mi
+    value: 512Mi
 - op: add
   path: /parameters/-
   value:
     displayName: CPU Request
-    name: SCHEDULER_CPU_REQUEST
-    required: true
-    value: 50m
-- op: add
-  path: /parameters/-
-  value:
-    displayName: CPU Limit
-    name: SCHEDULER_CPU_LIMIT
+    name: WORKER_COST_MODEL_XL_CPU_REQUEST
     required: true
     value: 100m
 - op: add
   path: /parameters/-
   value:
-    displayName: Worker Queue
-    name: SCHEDULER_WORKER_QUEUE
+    displayName: CPU Limit
+    name: WORKER_COST_MODEL_XL_CPU_LIMIT
     required: true
-    value: 'cost_model,cost_model_xl,download,download_xl,hcs,ocp,ocp_xl,priority,priority_xl,refresh,refresh_xl,summary,summary_xl'
+    value: 200m
 - op: add
   path: /parameters/-
   value:
-    displayName: Scheduler report checks
-    name: SCHEDULE_REPORT_CHECKS
-    value: "True"
-- op: add
-  path: /parameters/-
-  value:
-    displayName: Frequency to check sources availability (minutes)
-    name: SOURCE_STATUS_FREQUENCY_MINUTES
-    value: '60'
+    displayName: Worker Queue
+    name: WORKER_COST_MODEL_XL_WORKER_QUEUE
+    required: true
+    value: 'cost_model_xl'

--- a/deploy/kustomize/patches/worker-download-xl.yaml
+++ b/deploy/kustomize/patches/worker-download-xl.yaml
@@ -1,26 +1,21 @@
 - op: add
   path: /objects/0/spec/deployments/-
   value:
-    name: clowder-scheduler
-    replicas: ${{SCHEDULER_REPLICAS}}
+    name: clowder-worker-download-xl
+    replicas: ${{WORKER_DOWNLOAD_XL_REPLICAS}}
     webServices:
       public:
         enabled: false
       private:
         enabled: false
     podSpec:
-      metadata:
-        annotations:
-          ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses 1 pod as currently scheduling is a singleton
-          ignore-check.kube-linter.io/no-readiness-probe: This deployment uses celery beat which does not easily support readiness checks
-          ignore-check.kube-linter.io/no-liveness-probe: This deployment uses celery beat which does not easily support liveness checks
       image: ${IMAGE}:${IMAGE_TAG}
       command:
         - /bin/bash
         - -c
         - > # ${APP_HOME} is `/opt/koku/koku` which is defined in the Dockerfile
           PYTHONPATH=${APP_HOME}
-          celery -A koku beat -l $CELERY_LOG_LEVEL
+          celery -A koku worker --without-gossip -E -l $CELERY_LOG_LEVEL -Q $WORKER_QUEUES
       env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
@@ -73,27 +68,9 @@
         - name: DEMO_ACCOUNTS
           value: ${DEMO_ACCOUNTS}
         - name: WORKER_QUEUES
-          value: ${SCHEDULER_WORKER_QUEUE}
-        - name: REPORT_DOWNLOAD_SCHEDULE_GCP
-          value: ${REPORT_DOWNLOAD_SCHEDULE_GCP}
-        - name: REPORT_DOWNLOAD_SCHEDULE_AWS
-          value: ${REPORT_DOWNLOAD_SCHEDULE_AWS}
-        - name: REPORT_DOWNLOAD_SCHEDULE_AZURE
-          value: ${REPORT_DOWNLOAD_SCHEDULE_AZURE}
-        - name: REPORT_DOWNLOAD_SCHEDULE_OCI
-          value: ${REPORT_DOWNLOAD_SCHEDULE_OCI}
-        - name: SCHEDULE_REPORT_CHECKS
-          value: ${SCHEDULE_REPORT_CHECKS}
-        - name: SOURCE_STATUS_FREQUENCY_MINUTES
-          value: ${SOURCE_STATUS_FREQUENCY_MINUTES}
-        - name: REMOVE_EXPIRED_REPORT_DATA_ON_DAY
-          value: ${REMOVE_EXPIRED_REPORT_DATA_ON_DAY}
-        - name: REMOVE_EXPIRED_REPORT_UTC_TIME
-          value: ${REMOVE_EXPIRED_REPORT_UTC_TIME}
-        - name: VACUUM_DATA_DAY_OF_WEEK
-          value: ${VACUUM_DATA_DAY_OF_WEEK}
-        - name: VACUUM_DATA_UTC_TIME
-          value: ${VACUUM_DATA_UTC_TIME}
+          value: ${WORKER_DOWNLOAD_XL_WORKER_QUEUE}
+        - name: WORKER_PROC_ALIVE_TIMEOUT
+          value: ${WORKER_PROC_ALIVE_TIMEOUT}
         - name: DATE_OVERRIDE
           value: ${DATE_OVERRIDE}
         - name: RETAIN_NUM_MONTHS
@@ -112,6 +89,8 @@
           value: ${REPORT_PROCESSING_BATCH_SIZE}
         - name: PROMETHEUS_PUSHGATEWAY
           value: ${PROMETHEUS_PUSHGATEWAY}
+        - name: SOURCES_API_PREFIX
+          value: ${SOURCES_API_PREFIX}
         - name: UNLEASH_CACHE_DIR
           value: ${UNLEASH_CACHE_DIR}
         - name: QE_SCHEMA
@@ -137,14 +116,36 @@
           value: 'true'
         - name: ENHANCED_ORG_ADMIN
           value: ${ENHANCED_ORG_ADMIN}
+      livenessProbe:
+        httpGet:
+          path: /livez
+          port: metrics
+          scheme: HTTP
+        initialDelaySeconds: 30
+        periodSeconds: 20
+        successThreshold: 1
+        failureThreshold: 5
+        timeoutSeconds: 10
+      readinessProbe:
+        httpGet:
+          path: /readyz
+          port: metrics
+          scheme: HTTP
+        initialDelaySeconds: 30
+        periodSeconds: 20
+        successThreshold: 1
+        failureThreshold: 5
+        timeoutSeconds: 10
       resources:
         limits:
-          cpu: ${SCHEDULER_CPU_LIMIT}
-          memory: ${SCHEDULER_MEMORY_LIMIT}
+          cpu: ${WORKER_DOWNLOAD_XL_CPU_LIMIT}
+          memory: ${WORKER_DOWNLOAD_XL_MEMORY_LIMIT}
         requests:
-          cpu: ${SCHEDULER_CPU_REQUEST}
-          memory: ${SCHEDULER_MEMORY_REQUEST}
+          cpu: ${WORKER_DOWNLOAD_XL_CPU_REQUEST}
+          memory: ${WORKER_DOWNLOAD_XL_MEMORY_REQUEST}
       volumeMounts:
+      - mountPath: /var/tmp/masu/
+        name: koku-worker-data
       - name: gcp-credentials
         mountPath: /etc/gcp
         readOnly: true
@@ -155,6 +156,8 @@
         mountPath: ${TMP_DIR}
       volumes:
       - name: tmp-data
+        emptyDir: {}
+      - name: koku-worker-data
         emptyDir: {}
       - name: gcp-credentials
         secret:
@@ -173,53 +176,41 @@
   path: /parameters/-
   value:
     displayName: Minimum replicas
-    name: SCHEDULER_REPLICAS
+    name: WORKER_DOWNLOAD_XL_REPLICAS
     required: true
-    value: '1'
+    value: '2'
 - op: add
   path: /parameters/-
   value:
     displayName: Memory Request
-    name: SCHEDULER_MEMORY_REQUEST
+    name: WORKER_DOWNLOAD_XL_MEMORY_REQUEST
     required: true
-    value: 200Mi
+    value: 512Mi
 - op: add
   path: /parameters/-
   value:
     displayName: Memory Limit
-    name: SCHEDULER_MEMORY_LIMIT
+    name: WORKER_DOWNLOAD_XL_MEMORY_LIMIT
     required: true
-    value: 400Mi
+    value: 1Gi
 - op: add
   path: /parameters/-
   value:
     displayName: CPU Request
-    name: SCHEDULER_CPU_REQUEST
+    name: WORKER_DOWNLOAD_XL_CPU_REQUEST
     required: true
-    value: 50m
+    value: 200m
 - op: add
   path: /parameters/-
   value:
     displayName: CPU Limit
-    name: SCHEDULER_CPU_LIMIT
+    name: WORKER_DOWNLOAD_XL_CPU_LIMIT
     required: true
-    value: 100m
+    value: 400m
 - op: add
   path: /parameters/-
   value:
     displayName: Worker Queue
-    name: SCHEDULER_WORKER_QUEUE
+    name: WORKER_DOWNLOAD_XL_WORKER_QUEUE
     required: true
-    value: 'cost_model,cost_model_xl,download,download_xl,hcs,ocp,ocp_xl,priority,priority_xl,refresh,refresh_xl,summary,summary_xl'
-- op: add
-  path: /parameters/-
-  value:
-    displayName: Scheduler report checks
-    name: SCHEDULE_REPORT_CHECKS
-    value: "True"
-- op: add
-  path: /parameters/-
-  value:
-    displayName: Frequency to check sources availability (minutes)
-    name: SOURCE_STATUS_FREQUENCY_MINUTES
-    value: '60'
+    value: 'download_xl'

--- a/deploy/kustomize/patches/worker-ocp-xl.yaml
+++ b/deploy/kustomize/patches/worker-ocp-xl.yaml
@@ -1,26 +1,21 @@
 - op: add
   path: /objects/0/spec/deployments/-
   value:
-    name: clowder-scheduler
-    replicas: ${{SCHEDULER_REPLICAS}}
+    name: clowder-worker-ocp-xl
+    replicas: ${{WORKER_OCP_XL_REPLICAS}}
     webServices:
       public:
         enabled: false
       private:
         enabled: false
     podSpec:
-      metadata:
-        annotations:
-          ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses 1 pod as currently scheduling is a singleton
-          ignore-check.kube-linter.io/no-readiness-probe: This deployment uses celery beat which does not easily support readiness checks
-          ignore-check.kube-linter.io/no-liveness-probe: This deployment uses celery beat which does not easily support liveness checks
       image: ${IMAGE}:${IMAGE_TAG}
       command:
         - /bin/bash
         - -c
         - > # ${APP_HOME} is `/opt/koku/koku` which is defined in the Dockerfile
           PYTHONPATH=${APP_HOME}
-          celery -A koku beat -l $CELERY_LOG_LEVEL
+          celery -A koku worker --without-gossip -E -l $CELERY_LOG_LEVEL -Q $WORKER_QUEUES
       env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
@@ -73,27 +68,9 @@
         - name: DEMO_ACCOUNTS
           value: ${DEMO_ACCOUNTS}
         - name: WORKER_QUEUES
-          value: ${SCHEDULER_WORKER_QUEUE}
-        - name: REPORT_DOWNLOAD_SCHEDULE_GCP
-          value: ${REPORT_DOWNLOAD_SCHEDULE_GCP}
-        - name: REPORT_DOWNLOAD_SCHEDULE_AWS
-          value: ${REPORT_DOWNLOAD_SCHEDULE_AWS}
-        - name: REPORT_DOWNLOAD_SCHEDULE_AZURE
-          value: ${REPORT_DOWNLOAD_SCHEDULE_AZURE}
-        - name: REPORT_DOWNLOAD_SCHEDULE_OCI
-          value: ${REPORT_DOWNLOAD_SCHEDULE_OCI}
-        - name: SCHEDULE_REPORT_CHECKS
-          value: ${SCHEDULE_REPORT_CHECKS}
-        - name: SOURCE_STATUS_FREQUENCY_MINUTES
-          value: ${SOURCE_STATUS_FREQUENCY_MINUTES}
-        - name: REMOVE_EXPIRED_REPORT_DATA_ON_DAY
-          value: ${REMOVE_EXPIRED_REPORT_DATA_ON_DAY}
-        - name: REMOVE_EXPIRED_REPORT_UTC_TIME
-          value: ${REMOVE_EXPIRED_REPORT_UTC_TIME}
-        - name: VACUUM_DATA_DAY_OF_WEEK
-          value: ${VACUUM_DATA_DAY_OF_WEEK}
-        - name: VACUUM_DATA_UTC_TIME
-          value: ${VACUUM_DATA_UTC_TIME}
+          value: ${WORKER_OCP_XL_WORKER_QUEUE}
+        - name: WORKER_PROC_ALIVE_TIMEOUT
+          value: ${WORKER_PROC_ALIVE_TIMEOUT}
         - name: DATE_OVERRIDE
           value: ${DATE_OVERRIDE}
         - name: RETAIN_NUM_MONTHS
@@ -112,8 +89,12 @@
           value: ${REPORT_PROCESSING_BATCH_SIZE}
         - name: PROMETHEUS_PUSHGATEWAY
           value: ${PROMETHEUS_PUSHGATEWAY}
+        - name: SOURCES_API_PREFIX
+          value: ${SOURCES_API_PREFIX}
         - name: UNLEASH_CACHE_DIR
           value: ${UNLEASH_CACHE_DIR}
+        - name: WORKER_CACHE_TIMEOUT
+          value: ${WORKER_CACHE_TIMEOUT}
         - name: QE_SCHEMA
           value: ${QE_SCHEMA}
         - name: OCI_CLI_USER
@@ -137,14 +118,36 @@
           value: 'true'
         - name: ENHANCED_ORG_ADMIN
           value: ${ENHANCED_ORG_ADMIN}
+      livenessProbe:
+        httpGet:
+          path: /livez
+          port: metrics
+          scheme: HTTP
+        initialDelaySeconds: 30
+        periodSeconds: 20
+        successThreshold: 1
+        failureThreshold: 5
+        timeoutSeconds: 10
+      readinessProbe:
+        httpGet:
+          path: /readyz
+          port: metrics
+          scheme: HTTP
+        initialDelaySeconds: 30
+        periodSeconds: 20
+        successThreshold: 1
+        failureThreshold: 5
+        timeoutSeconds: 10
       resources:
         limits:
-          cpu: ${SCHEDULER_CPU_LIMIT}
-          memory: ${SCHEDULER_MEMORY_LIMIT}
+          cpu: ${WORKER_OCP_XL_CPU_LIMIT}
+          memory: ${WORKER_OCP_XL_MEMORY_LIMIT}
         requests:
-          cpu: ${SCHEDULER_CPU_REQUEST}
-          memory: ${SCHEDULER_MEMORY_REQUEST}
+          cpu: ${WORKER_OCP_XL_CPU_REQUEST}
+          memory: ${WORKER_OCP_XL_MEMORY_REQUEST}
       volumeMounts:
+      - mountPath: /var/tmp/masu/
+        name: koku-worker-data
       - name: gcp-credentials
         mountPath: /etc/gcp
         readOnly: true
@@ -155,6 +158,8 @@
         mountPath: ${TMP_DIR}
       volumes:
       - name: tmp-data
+        emptyDir: {}
+      - name: koku-worker-data
         emptyDir: {}
       - name: gcp-credentials
         secret:
@@ -173,53 +178,41 @@
   path: /parameters/-
   value:
     displayName: Minimum replicas
-    name: SCHEDULER_REPLICAS
+    name: WORKER_OCP_XL_REPLICAS
     required: true
-    value: '1'
+    value: '2'
 - op: add
   path: /parameters/-
   value:
     displayName: Memory Request
-    name: SCHEDULER_MEMORY_REQUEST
+    name: WORKER_OCP_XL_MEMORY_REQUEST
     required: true
-    value: 200Mi
+    value: 256Mi
 - op: add
   path: /parameters/-
   value:
     displayName: Memory Limit
-    name: SCHEDULER_MEMORY_LIMIT
+    name: WORKER_OCP_XL_MEMORY_LIMIT
     required: true
-    value: 400Mi
+    value: 512Mi
 - op: add
   path: /parameters/-
   value:
     displayName: CPU Request
-    name: SCHEDULER_CPU_REQUEST
-    required: true
-    value: 50m
-- op: add
-  path: /parameters/-
-  value:
-    displayName: CPU Limit
-    name: SCHEDULER_CPU_LIMIT
+    name: WORKER_OCP_XL_CPU_REQUEST
     required: true
     value: 100m
 - op: add
   path: /parameters/-
   value:
-    displayName: Worker Queue
-    name: SCHEDULER_WORKER_QUEUE
+    displayName: CPU Limit
+    name: WORKER_OCP_XL_CPU_LIMIT
     required: true
-    value: 'cost_model,cost_model_xl,download,download_xl,hcs,ocp,ocp_xl,priority,priority_xl,refresh,refresh_xl,summary,summary_xl'
+    value: 200m
 - op: add
   path: /parameters/-
   value:
-    displayName: Scheduler report checks
-    name: SCHEDULE_REPORT_CHECKS
-    value: "True"
-- op: add
-  path: /parameters/-
-  value:
-    displayName: Frequency to check sources availability (minutes)
-    name: SOURCE_STATUS_FREQUENCY_MINUTES
-    value: '60'
+    displayName: Worker Queue
+    name: WORKER_OCP_XL_WORKER_QUEUE
+    required: true
+    value: 'ocp_xl'

--- a/deploy/kustomize/patches/worker-priority-xl.yaml
+++ b/deploy/kustomize/patches/worker-priority-xl.yaml
@@ -1,8 +1,8 @@
 - op: add
   path: /objects/0/spec/deployments/-
   value:
-    name: clowder-scheduler
-    replicas: ${{SCHEDULER_REPLICAS}}
+    name: clowder-worker-priority-xl
+    replicas: ${{WORKER_PRIORITY_XL_REPLICAS}}
     webServices:
       public:
         enabled: false
@@ -11,16 +11,14 @@
     podSpec:
       metadata:
         annotations:
-          ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses 1 pod as currently scheduling is a singleton
-          ignore-check.kube-linter.io/no-readiness-probe: This deployment uses celery beat which does not easily support readiness checks
-          ignore-check.kube-linter.io/no-liveness-probe: This deployment uses celery beat which does not easily support liveness checks
+          ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses 1 pod at times for cost saving purposes
       image: ${IMAGE}:${IMAGE_TAG}
       command:
         - /bin/bash
         - -c
         - > # ${APP_HOME} is `/opt/koku/koku` which is defined in the Dockerfile
           PYTHONPATH=${APP_HOME}
-          celery -A koku beat -l $CELERY_LOG_LEVEL
+          celery -A koku worker --without-gossip -E -l $CELERY_LOG_LEVEL -Q $WORKER_QUEUES
       env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
@@ -73,27 +71,9 @@
         - name: DEMO_ACCOUNTS
           value: ${DEMO_ACCOUNTS}
         - name: WORKER_QUEUES
-          value: ${SCHEDULER_WORKER_QUEUE}
-        - name: REPORT_DOWNLOAD_SCHEDULE_GCP
-          value: ${REPORT_DOWNLOAD_SCHEDULE_GCP}
-        - name: REPORT_DOWNLOAD_SCHEDULE_AWS
-          value: ${REPORT_DOWNLOAD_SCHEDULE_AWS}
-        - name: REPORT_DOWNLOAD_SCHEDULE_AZURE
-          value: ${REPORT_DOWNLOAD_SCHEDULE_AZURE}
-        - name: REPORT_DOWNLOAD_SCHEDULE_OCI
-          value: ${REPORT_DOWNLOAD_SCHEDULE_OCI}
-        - name: SCHEDULE_REPORT_CHECKS
-          value: ${SCHEDULE_REPORT_CHECKS}
-        - name: SOURCE_STATUS_FREQUENCY_MINUTES
-          value: ${SOURCE_STATUS_FREQUENCY_MINUTES}
-        - name: REMOVE_EXPIRED_REPORT_DATA_ON_DAY
-          value: ${REMOVE_EXPIRED_REPORT_DATA_ON_DAY}
-        - name: REMOVE_EXPIRED_REPORT_UTC_TIME
-          value: ${REMOVE_EXPIRED_REPORT_UTC_TIME}
-        - name: VACUUM_DATA_DAY_OF_WEEK
-          value: ${VACUUM_DATA_DAY_OF_WEEK}
-        - name: VACUUM_DATA_UTC_TIME
-          value: ${VACUUM_DATA_UTC_TIME}
+          value: ${WORKER_PRIORITY_XL_WORKER_QUEUE}
+        - name: WORKER_PROC_ALIVE_TIMEOUT
+          value: ${WORKER_PROC_ALIVE_TIMEOUT}
         - name: DATE_OVERRIDE
           value: ${DATE_OVERRIDE}
         - name: RETAIN_NUM_MONTHS
@@ -112,6 +92,8 @@
           value: ${REPORT_PROCESSING_BATCH_SIZE}
         - name: PROMETHEUS_PUSHGATEWAY
           value: ${PROMETHEUS_PUSHGATEWAY}
+        - name: SOURCES_API_PREFIX
+          value: ${SOURCES_API_PREFIX}
         - name: UNLEASH_CACHE_DIR
           value: ${UNLEASH_CACHE_DIR}
         - name: QE_SCHEMA
@@ -137,14 +119,36 @@
           value: 'true'
         - name: ENHANCED_ORG_ADMIN
           value: ${ENHANCED_ORG_ADMIN}
+      livenessProbe:
+        httpGet:
+          path: /livez
+          port: metrics
+          scheme: HTTP
+        initialDelaySeconds: 30
+        periodSeconds: 20
+        successThreshold: 1
+        failureThreshold: 5
+        timeoutSeconds: 10
+      readinessProbe:
+        httpGet:
+          path: /readyz
+          port: metrics
+          scheme: HTTP
+        initialDelaySeconds: 30
+        periodSeconds: 20
+        successThreshold: 1
+        failureThreshold: 5
+        timeoutSeconds: 10
       resources:
         limits:
-          cpu: ${SCHEDULER_CPU_LIMIT}
-          memory: ${SCHEDULER_MEMORY_LIMIT}
+          cpu: ${WORKER_PRIORITY_XL_CPU_LIMIT}
+          memory: ${WORKER_PRIORITY_XL_MEMORY_LIMIT}
         requests:
-          cpu: ${SCHEDULER_CPU_REQUEST}
-          memory: ${SCHEDULER_MEMORY_REQUEST}
+          cpu: ${WORKER_PRIORITY_XL_CPU_REQUEST}
+          memory: ${WORKER_PRIORITY_XL_MEMORY_REQUEST}
       volumeMounts:
+      - mountPath: /var/tmp/masu/
+        name: koku-worker-data
       - name: gcp-credentials
         mountPath: /etc/gcp
         readOnly: true
@@ -155,6 +159,8 @@
         mountPath: ${TMP_DIR}
       volumes:
       - name: tmp-data
+        emptyDir: {}
+      - name: koku-worker-data
         emptyDir: {}
       - name: gcp-credentials
         secret:
@@ -173,53 +179,41 @@
   path: /parameters/-
   value:
     displayName: Minimum replicas
-    name: SCHEDULER_REPLICAS
+    name: WORKER_PRIORITY_XL_REPLICAS
     required: true
-    value: '1'
+    value: '2'
 - op: add
   path: /parameters/-
   value:
     displayName: Memory Request
-    name: SCHEDULER_MEMORY_REQUEST
-    required: true
-    value: 200Mi
-- op: add
-  path: /parameters/-
-  value:
-    displayName: Memory Limit
-    name: SCHEDULER_MEMORY_LIMIT
+    name: WORKER_PRIORITY_XL_MEMORY_REQUEST
     required: true
     value: 400Mi
 - op: add
   path: /parameters/-
   value:
-    displayName: CPU Request
-    name: SCHEDULER_CPU_REQUEST
+    displayName: Memory Limit
+    name: WORKER_PRIORITY_XL_MEMORY_LIMIT
     required: true
-    value: 50m
+    value: 750Mi
+- op: add
+  path: /parameters/-
+  value:
+    displayName: CPU Request
+    name: WORKER_PRIORITY_XL_CPU_REQUEST
+    required: true
+    value: 150m
 - op: add
   path: /parameters/-
   value:
     displayName: CPU Limit
-    name: SCHEDULER_CPU_LIMIT
+    name: WORKER_PRIORITY_XL_CPU_LIMIT
     required: true
-    value: 100m
+    value: 300m
 - op: add
   path: /parameters/-
   value:
     displayName: Worker Queue
-    name: SCHEDULER_WORKER_QUEUE
+    name: WORKER_PRIORITY_XL_WORKER_QUEUE
     required: true
-    value: 'cost_model,cost_model_xl,download,download_xl,hcs,ocp,ocp_xl,priority,priority_xl,refresh,refresh_xl,summary,summary_xl'
-- op: add
-  path: /parameters/-
-  value:
-    displayName: Scheduler report checks
-    name: SCHEDULE_REPORT_CHECKS
-    value: "True"
-- op: add
-  path: /parameters/-
-  value:
-    displayName: Frequency to check sources availability (minutes)
-    name: SOURCE_STATUS_FREQUENCY_MINUTES
-    value: '60'
+    value: 'priority_xl'

--- a/deploy/kustomize/patches/worker-refresh-xl.yaml
+++ b/deploy/kustomize/patches/worker-refresh-xl.yaml
@@ -1,26 +1,21 @@
 - op: add
   path: /objects/0/spec/deployments/-
   value:
-    name: clowder-scheduler
-    replicas: ${{SCHEDULER_REPLICAS}}
+    name: clowder-worker-refresh-xl
+    replicas: ${{WORKER_REFRESH_XL_REPLICAS}}
     webServices:
       public:
         enabled: false
       private:
         enabled: false
     podSpec:
-      metadata:
-        annotations:
-          ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses 1 pod as currently scheduling is a singleton
-          ignore-check.kube-linter.io/no-readiness-probe: This deployment uses celery beat which does not easily support readiness checks
-          ignore-check.kube-linter.io/no-liveness-probe: This deployment uses celery beat which does not easily support liveness checks
       image: ${IMAGE}:${IMAGE_TAG}
       command:
         - /bin/bash
         - -c
         - > # ${APP_HOME} is `/opt/koku/koku` which is defined in the Dockerfile
           PYTHONPATH=${APP_HOME}
-          celery -A koku beat -l $CELERY_LOG_LEVEL
+          celery -A koku worker --without-gossip -E -l $CELERY_LOG_LEVEL -Q $WORKER_QUEUES
       env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
@@ -73,27 +68,9 @@
         - name: DEMO_ACCOUNTS
           value: ${DEMO_ACCOUNTS}
         - name: WORKER_QUEUES
-          value: ${SCHEDULER_WORKER_QUEUE}
-        - name: REPORT_DOWNLOAD_SCHEDULE_GCP
-          value: ${REPORT_DOWNLOAD_SCHEDULE_GCP}
-        - name: REPORT_DOWNLOAD_SCHEDULE_AWS
-          value: ${REPORT_DOWNLOAD_SCHEDULE_AWS}
-        - name: REPORT_DOWNLOAD_SCHEDULE_AZURE
-          value: ${REPORT_DOWNLOAD_SCHEDULE_AZURE}
-        - name: REPORT_DOWNLOAD_SCHEDULE_OCI
-          value: ${REPORT_DOWNLOAD_SCHEDULE_OCI}
-        - name: SCHEDULE_REPORT_CHECKS
-          value: ${SCHEDULE_REPORT_CHECKS}
-        - name: SOURCE_STATUS_FREQUENCY_MINUTES
-          value: ${SOURCE_STATUS_FREQUENCY_MINUTES}
-        - name: REMOVE_EXPIRED_REPORT_DATA_ON_DAY
-          value: ${REMOVE_EXPIRED_REPORT_DATA_ON_DAY}
-        - name: REMOVE_EXPIRED_REPORT_UTC_TIME
-          value: ${REMOVE_EXPIRED_REPORT_UTC_TIME}
-        - name: VACUUM_DATA_DAY_OF_WEEK
-          value: ${VACUUM_DATA_DAY_OF_WEEK}
-        - name: VACUUM_DATA_UTC_TIME
-          value: ${VACUUM_DATA_UTC_TIME}
+          value: ${WORKER_REFRESH_XL_WORKER_QUEUE}
+        - name: WORKER_PROC_ALIVE_TIMEOUT
+          value: ${WORKER_PROC_ALIVE_TIMEOUT}
         - name: DATE_OVERRIDE
           value: ${DATE_OVERRIDE}
         - name: RETAIN_NUM_MONTHS
@@ -112,8 +89,12 @@
           value: ${REPORT_PROCESSING_BATCH_SIZE}
         - name: PROMETHEUS_PUSHGATEWAY
           value: ${PROMETHEUS_PUSHGATEWAY}
+        - name: SOURCES_API_PREFIX
+          value: ${SOURCES_API_PREFIX}
         - name: UNLEASH_CACHE_DIR
           value: ${UNLEASH_CACHE_DIR}
+        - name: WORKER_CACHE_TIMEOUT
+          value: ${WORKER_CACHE_TIMEOUT}
         - name: QE_SCHEMA
           value: ${QE_SCHEMA}
         - name: OCI_CLI_USER
@@ -137,14 +118,36 @@
           value: 'true'
         - name: ENHANCED_ORG_ADMIN
           value: ${ENHANCED_ORG_ADMIN}
+      livenessProbe:
+        httpGet:
+          path: /livez
+          port: metrics
+          scheme: HTTP
+        initialDelaySeconds: 30
+        periodSeconds: 20
+        successThreshold: 1
+        failureThreshold: 5
+        timeoutSeconds: 10
+      readinessProbe:
+        httpGet:
+          path: /readyz
+          port: metrics
+          scheme: HTTP
+        initialDelaySeconds: 30
+        periodSeconds: 20
+        successThreshold: 1
+        failureThreshold: 5
+        timeoutSeconds: 10
       resources:
         limits:
-          cpu: ${SCHEDULER_CPU_LIMIT}
-          memory: ${SCHEDULER_MEMORY_LIMIT}
+          cpu: ${WORKER_REFRESH_XL_CPU_LIMIT}
+          memory: ${WORKER_REFRESH_XL_MEMORY_LIMIT}
         requests:
-          cpu: ${SCHEDULER_CPU_REQUEST}
-          memory: ${SCHEDULER_MEMORY_REQUEST}
+          cpu: ${WORKER_REFRESH_XL_CPU_REQUEST}
+          memory: ${WORKER_REFRESH_XL_MEMORY_REQUEST}
       volumeMounts:
+      - mountPath: /var/tmp/masu/
+        name: koku-worker-data
       - name: gcp-credentials
         mountPath: /etc/gcp
         readOnly: true
@@ -155,6 +158,8 @@
         mountPath: ${TMP_DIR}
       volumes:
       - name: tmp-data
+        emptyDir: {}
+      - name: koku-worker-data
         emptyDir: {}
       - name: gcp-credentials
         secret:
@@ -173,53 +178,41 @@
   path: /parameters/-
   value:
     displayName: Minimum replicas
-    name: SCHEDULER_REPLICAS
+    name: WORKER_REFRESH_XL_REPLICAS
     required: true
-    value: '1'
+    value: '2'
 - op: add
   path: /parameters/-
   value:
     displayName: Memory Request
-    name: SCHEDULER_MEMORY_REQUEST
+    name: WORKER_REFRESH_XL_MEMORY_REQUEST
     required: true
-    value: 200Mi
+    value: 256Mi
 - op: add
   path: /parameters/-
   value:
     displayName: Memory Limit
-    name: SCHEDULER_MEMORY_LIMIT
+    name: WORKER_REFRESH_XL_MEMORY_LIMIT
     required: true
-    value: 400Mi
+    value: 512Mi
 - op: add
   path: /parameters/-
   value:
     displayName: CPU Request
-    name: SCHEDULER_CPU_REQUEST
-    required: true
-    value: 50m
-- op: add
-  path: /parameters/-
-  value:
-    displayName: CPU Limit
-    name: SCHEDULER_CPU_LIMIT
+    name: WORKER_REFRESH_XL_CPU_REQUEST
     required: true
     value: 100m
 - op: add
   path: /parameters/-
   value:
-    displayName: Worker Queue
-    name: SCHEDULER_WORKER_QUEUE
+    displayName: CPU Limit
+    name: WORKER_REFRESH_XL_CPU_LIMIT
     required: true
-    value: 'cost_model,cost_model_xl,download,download_xl,hcs,ocp,ocp_xl,priority,priority_xl,refresh,refresh_xl,summary,summary_xl'
+    value: 200m
 - op: add
   path: /parameters/-
   value:
-    displayName: Scheduler report checks
-    name: SCHEDULE_REPORT_CHECKS
-    value: "True"
-- op: add
-  path: /parameters/-
-  value:
-    displayName: Frequency to check sources availability (minutes)
-    name: SOURCE_STATUS_FREQUENCY_MINUTES
-    value: '60'
+    displayName: Worker Queue
+    name: WORKER_REFRESH_XL_WORKER_QUEUE
+    required: true
+    value: 'refresh_xl'

--- a/deploy/kustomize/patches/worker-summary-xl.yaml
+++ b/deploy/kustomize/patches/worker-summary-xl.yaml
@@ -1,26 +1,21 @@
 - op: add
   path: /objects/0/spec/deployments/-
   value:
-    name: clowder-scheduler
-    replicas: ${{SCHEDULER_REPLICAS}}
+    name: clowder-worker-summary-xl
+    replicas: ${{WORKER_SUMMARY_XL_REPLICAS}}
     webServices:
       public:
         enabled: false
       private:
         enabled: false
     podSpec:
-      metadata:
-        annotations:
-          ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses 1 pod as currently scheduling is a singleton
-          ignore-check.kube-linter.io/no-readiness-probe: This deployment uses celery beat which does not easily support readiness checks
-          ignore-check.kube-linter.io/no-liveness-probe: This deployment uses celery beat which does not easily support liveness checks
       image: ${IMAGE}:${IMAGE_TAG}
       command:
         - /bin/bash
         - -c
         - > # ${APP_HOME} is `/opt/koku/koku` which is defined in the Dockerfile
           PYTHONPATH=${APP_HOME}
-          celery -A koku beat -l $CELERY_LOG_LEVEL
+          celery -A koku worker --without-gossip -E -l $CELERY_LOG_LEVEL -Q $WORKER_QUEUES
       env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
@@ -73,27 +68,9 @@
         - name: DEMO_ACCOUNTS
           value: ${DEMO_ACCOUNTS}
         - name: WORKER_QUEUES
-          value: ${SCHEDULER_WORKER_QUEUE}
-        - name: REPORT_DOWNLOAD_SCHEDULE_GCP
-          value: ${REPORT_DOWNLOAD_SCHEDULE_GCP}
-        - name: REPORT_DOWNLOAD_SCHEDULE_AWS
-          value: ${REPORT_DOWNLOAD_SCHEDULE_AWS}
-        - name: REPORT_DOWNLOAD_SCHEDULE_AZURE
-          value: ${REPORT_DOWNLOAD_SCHEDULE_AZURE}
-        - name: REPORT_DOWNLOAD_SCHEDULE_OCI
-          value: ${REPORT_DOWNLOAD_SCHEDULE_OCI}
-        - name: SCHEDULE_REPORT_CHECKS
-          value: ${SCHEDULE_REPORT_CHECKS}
-        - name: SOURCE_STATUS_FREQUENCY_MINUTES
-          value: ${SOURCE_STATUS_FREQUENCY_MINUTES}
-        - name: REMOVE_EXPIRED_REPORT_DATA_ON_DAY
-          value: ${REMOVE_EXPIRED_REPORT_DATA_ON_DAY}
-        - name: REMOVE_EXPIRED_REPORT_UTC_TIME
-          value: ${REMOVE_EXPIRED_REPORT_UTC_TIME}
-        - name: VACUUM_DATA_DAY_OF_WEEK
-          value: ${VACUUM_DATA_DAY_OF_WEEK}
-        - name: VACUUM_DATA_UTC_TIME
-          value: ${VACUUM_DATA_UTC_TIME}
+          value: ${WORKER_SUMMARY_XL_WORKER_QUEUE}
+        - name: WORKER_PROC_ALIVE_TIMEOUT
+          value: ${WORKER_PROC_ALIVE_TIMEOUT}
         - name: DATE_OVERRIDE
           value: ${DATE_OVERRIDE}
         - name: RETAIN_NUM_MONTHS
@@ -112,8 +89,12 @@
           value: ${REPORT_PROCESSING_BATCH_SIZE}
         - name: PROMETHEUS_PUSHGATEWAY
           value: ${PROMETHEUS_PUSHGATEWAY}
+        - name: SOURCES_API_PREFIX
+          value: ${SOURCES_API_PREFIX}
         - name: UNLEASH_CACHE_DIR
           value: ${UNLEASH_CACHE_DIR}
+        - name: WORKER_CACHE_TIMEOUT
+          value: ${WORKER_CACHE_TIMEOUT}
         - name: QE_SCHEMA
           value: ${QE_SCHEMA}
         - name: OCI_CLI_USER
@@ -137,14 +118,36 @@
           value: 'true'
         - name: ENHANCED_ORG_ADMIN
           value: ${ENHANCED_ORG_ADMIN}
+      livenessProbe:
+        httpGet:
+          path: /livez
+          port: metrics
+          scheme: HTTP
+        initialDelaySeconds: 30
+        periodSeconds: 20
+        successThreshold: 1
+        failureThreshold: 5
+        timeoutSeconds: 10
+      readinessProbe:
+        httpGet:
+          path: /readyz
+          port: metrics
+          scheme: HTTP
+        initialDelaySeconds: 30
+        periodSeconds: 20
+        successThreshold: 1
+        failureThreshold: 5
+        timeoutSeconds: 10
       resources:
         limits:
-          cpu: ${SCHEDULER_CPU_LIMIT}
-          memory: ${SCHEDULER_MEMORY_LIMIT}
+          cpu: ${WORKER_SUMMARY_XL_CPU_LIMIT}
+          memory: ${WORKER_SUMMARY_XL_MEMORY_LIMIT}
         requests:
-          cpu: ${SCHEDULER_CPU_REQUEST}
-          memory: ${SCHEDULER_MEMORY_REQUEST}
+          cpu: ${WORKER_SUMMARY_XL_CPU_REQUEST}
+          memory: ${WORKER_SUMMARY_XL_MEMORY_REQUEST}
       volumeMounts:
+      - mountPath: /var/tmp/masu/
+        name: koku-worker-data
       - name: gcp-credentials
         mountPath: /etc/gcp
         readOnly: true
@@ -155,6 +158,8 @@
         mountPath: ${TMP_DIR}
       volumes:
       - name: tmp-data
+        emptyDir: {}
+      - name: koku-worker-data
         emptyDir: {}
       - name: gcp-credentials
         secret:
@@ -173,53 +178,41 @@
   path: /parameters/-
   value:
     displayName: Minimum replicas
-    name: SCHEDULER_REPLICAS
+    name: WORKER_SUMMARY_XL_REPLICAS
     required: true
-    value: '1'
+    value: '2'
 - op: add
   path: /parameters/-
   value:
     displayName: Memory Request
-    name: SCHEDULER_MEMORY_REQUEST
+    name: WORKER_SUMMARY_XL_MEMORY_REQUEST
     required: true
-    value: 200Mi
+    value: 500Mi
 - op: add
   path: /parameters/-
   value:
     displayName: Memory Limit
-    name: SCHEDULER_MEMORY_LIMIT
+    name: WORKER_SUMMARY_XL_MEMORY_LIMIT
     required: true
-    value: 400Mi
+    value: 750Mi
 - op: add
   path: /parameters/-
   value:
     displayName: CPU Request
-    name: SCHEDULER_CPU_REQUEST
-    required: true
-    value: 50m
-- op: add
-  path: /parameters/-
-  value:
-    displayName: CPU Limit
-    name: SCHEDULER_CPU_LIMIT
+    name: WORKER_SUMMARY_XL_CPU_REQUEST
     required: true
     value: 100m
 - op: add
   path: /parameters/-
   value:
-    displayName: Worker Queue
-    name: SCHEDULER_WORKER_QUEUE
+    displayName: CPU Limit
+    name: WORKER_SUMMARY_XL_CPU_LIMIT
     required: true
-    value: 'cost_model,cost_model_xl,download,download_xl,hcs,ocp,ocp_xl,priority,priority_xl,refresh,refresh_xl,summary,summary_xl'
+    value: 200m
 - op: add
   path: /parameters/-
   value:
-    displayName: Scheduler report checks
-    name: SCHEDULE_REPORT_CHECKS
-    value: "True"
-- op: add
-  path: /parameters/-
-  value:
-    displayName: Frequency to check sources availability (minutes)
-    name: SOURCE_STATUS_FREQUENCY_MINUTES
-    value: '60'
+    displayName: Worker Queue
+    name: WORKER_SUMMARY_XL_WORKER_QUEUE
+    required: true
+    value: 'summary_xl'

--- a/koku/cost_models/cost_model_manager.py
+++ b/koku/cost_models/cost_model_manager.py
@@ -13,7 +13,9 @@ from api.provider.models import Provider
 from api.utils import DateHelper
 from cost_models.models import CostModel
 from cost_models.models import CostModelMap
+from masu.processor import is_customer_large
 from masu.processor.tasks import PRIORITY_QUEUE
+from masu.processor.tasks import PRIORITY_QUEUE_XL
 from masu.processor.tasks import update_cost_model_costs
 
 
@@ -86,6 +88,9 @@ class CostModelManager:
             else:
                 if provider.active:
                     schema_name = provider.customer.schema_name
+                    fallback_queue = PRIORITY_QUEUE
+                    if is_customer_large(schema_name):
+                        fallback_queue = PRIORITY_QUEUE_XL
                     # Because this is triggered from the UI, we use the priority queue
                     LOG.info(
                         f"provider {provider_uuid} update for cost model {self._cost_model_uuid} "
@@ -98,8 +103,8 @@ class CostModelManager:
                         start_date,
                         end_date,
                         tracing_id=tracing_id,
-                        queue_name=PRIORITY_QUEUE,
-                    ).set(queue=PRIORITY_QUEUE).apply_async()
+                        queue_name=fallback_queue,
+                    ).set(queue=fallback_queue).apply_async()
 
     def update(self, **data):
         """Update the cost model object."""

--- a/koku/masu/api/process_openshift_on_cloud.py
+++ b/koku/masu/api/process_openshift_on_cloud.py
@@ -20,7 +20,9 @@ from rest_framework.settings import api_settings
 from api.provider.models import Provider
 from api.utils import DateHelper
 from api.utils import get_months_in_date_range
+from masu.processor import is_customer_large
 from masu.processor.tasks import GET_REPORT_FILES_QUEUE
+from masu.processor.tasks import GET_REPORT_FILES_QUEUE_XL
 from masu.processor.tasks import process_daily_openshift_on_cloud as process_daily_openshift_on_cloud_task
 from masu.processor.tasks import process_openshift_on_cloud as process_openshift_on_cloud_task
 from masu.processor.tasks import QUEUE_LIST
@@ -41,7 +43,10 @@ def process_openshift_on_cloud(request):
     schema_name = params.get("schema")
     start_date = params.get("start_date")
     end_date = params.get("end_date")
-    queue_name = params.get("queue") or GET_REPORT_FILES_QUEUE
+    fallback_queue = GET_REPORT_FILES_QUEUE
+    if is_customer_large(schema_name):
+        fallback_queue = GET_REPORT_FILES_QUEUE_XL
+    queue_name = params.get("queue") or fallback_queue
 
     if cloud_provider_uuid is None:
         errmsg = "provider_uuid is a required parameter."

--- a/koku/masu/api/update_cost_model_costs.py
+++ b/koku/masu/api/update_cost_model_costs.py
@@ -17,7 +17,9 @@ from rest_framework.settings import api_settings
 from api.provider.models import Provider
 from api.utils import DateHelper
 from api.utils import get_months_in_date_range
+from masu.processor import is_customer_large
 from masu.processor.tasks import PRIORITY_QUEUE
+from masu.processor.tasks import PRIORITY_QUEUE_XL
 from masu.processor.tasks import QUEUE_LIST
 from masu.processor.tasks import update_cost_model_costs as cost_task
 
@@ -39,7 +41,10 @@ def update_cost_model_costs(request):
     default_end_date = DateHelper().today.strftime("%Y-%m-%d")
     start_date = params.get("start_date", default=default_start_date)
     end_date = params.get("end_date", default=default_end_date)
-    queue_name = params.get("queue") or PRIORITY_QUEUE
+    fallback_queue = PRIORITY_QUEUE
+    if is_customer_large(schema_name):
+        fallback_queue = PRIORITY_QUEUE_XL
+    queue_name = params.get("queue") or fallback_queue
 
     if provider_uuid is None or schema_name is None:
         errmsg = "provider_uuid and schema are required parameters."

--- a/koku/masu/api/update_openshift_on_cloud.py
+++ b/koku/masu/api/update_openshift_on_cloud.py
@@ -20,10 +20,12 @@ from rest_framework.settings import api_settings
 
 from api.provider.models import Provider
 from api.utils import get_months_in_date_range
+from masu.processor import is_customer_large
 from masu.processor.ocp.ocp_cloud_parquet_summary_updater import DELETE_TABLE
 from masu.processor.ocp.ocp_cloud_parquet_summary_updater import OCPCloudParquetReportSummaryUpdater
 from masu.processor.tasks import delete_openshift_on_cloud_data
 from masu.processor.tasks import PRIORITY_QUEUE
+from masu.processor.tasks import PRIORITY_QUEUE_XL
 from masu.processor.tasks import QUEUE_LIST
 from masu.processor.tasks import update_openshift_on_cloud as update_openshift_on_cloud_task
 
@@ -45,7 +47,10 @@ def update_openshift_on_cloud(request):
         schema_name = params.get("schema")
         start_date = params.get("start_date")
         end_date = params.get("end_date")
-        queue_name = params.get("queue") or PRIORITY_QUEUE
+        fallback_queue = PRIORITY_QUEUE
+        if is_customer_large(schema_name):
+            fallback_queue = PRIORITY_QUEUE_XL
+        queue_name = params.get("queue") or fallback_queue
 
         if openshift_provider_uuid is None:
             errmsg = "provider_uuid is a required parameter."
@@ -110,7 +115,7 @@ def update_openshift_on_cloud(request):
             summaries = group(summary_signature)
             c = chain(deletes, summaries)
 
-            async_result = c.apply_async(queue=queue_name or PRIORITY_QUEUE)
+            async_result = c.apply_async(queue=queue_name or fallback_queue)
             async_results.append({str(month): str(async_result)})
 
         return Response({REPORT_DATA_KEY: async_results})

--- a/koku/masu/processor/orchestrator.py
+++ b/koku/masu/processor/orchestrator.py
@@ -22,14 +22,17 @@ from masu.external.date_accessor import DateAccessor
 from masu.external.report_downloader import ReportDownloader
 from masu.external.report_downloader import ReportDownloaderError
 from masu.processor import is_cloud_source_processing_disabled
+from masu.processor import is_customer_large
 from masu.processor import is_source_disabled
 from masu.processor.tasks import get_report_files
 from masu.processor.tasks import GET_REPORT_FILES_QUEUE
+from masu.processor.tasks import GET_REPORT_FILES_QUEUE_XL
 from masu.processor.tasks import record_all_manifest_files
 from masu.processor.tasks import record_report_status
 from masu.processor.tasks import remove_expired_data
 from masu.processor.tasks import summarize_reports
 from masu.processor.tasks import SUMMARIZE_REPORTS_QUEUE
+from masu.processor.tasks import SUMMARIZE_REPORTS_QUEUE_XL
 from masu.processor.worker_cache import WorkerCache
 
 LOG = logging.getLogger(__name__)
@@ -178,6 +181,9 @@ class Orchestrator:
             SUMMARY_QUEUE = SUMMARIZE_REPORTS_QUEUE
             REPORT_QUEUE = GET_REPORT_FILES_QUEUE
             HCS_Q = HCS_QUEUE
+            if is_customer_large(schema_name):
+                SUMMARY_QUEUE = SUMMARIZE_REPORTS_QUEUE_XL
+                REPORT_QUEUE = GET_REPORT_FILES_QUEUE_XL
         reports_tasks_queued = False
         downloader = ReportDownloader(
             customer_name=customer_name,

--- a/koku/masu/prometheus_stats.py
+++ b/koku/masu/prometheus_stats.py
@@ -56,9 +56,21 @@ DOWNLOAD_BACKLOG = Gauge(
     registry=WORKER_REGISTRY,
     multiprocess_mode="livesum",
 )
+DOWNLOAD_XL_BACKLOG = Gauge(
+    "download_xl_backlog",
+    "Number of celery tasks in the download_xl queue",
+    registry=WORKER_REGISTRY,
+    multiprocess_mode="livesum",
+)
 SUMMARY_BACKLOG = Gauge(
     "summary_backlog",
     "Number of celery tasks in the summary queue",
+    registry=WORKER_REGISTRY,
+    multiprocess_mode="livesum",
+)
+SUMMARY_XL_BACKLOG = Gauge(
+    "summary_xl_backlog",
+    "Number of celery tasks in the summary_xl queue",
     registry=WORKER_REGISTRY,
     multiprocess_mode="livesum",
 )
@@ -68,15 +80,33 @@ PRIORITY_BACKLOG = Gauge(
     registry=WORKER_REGISTRY,
     multiprocess_mode="livesum",
 )
+PRIORITY_XL_BACKLOG = Gauge(
+    "priority_xl_backlog",
+    "Number of celery tasks in the priority_xl queue",
+    registry=WORKER_REGISTRY,
+    multiprocess_mode="livesum",
+)
 REFRESH_BACKLOG = Gauge(
     "refresh_backlog",
     "Number of celery tasks in the refresh queue",
     registry=WORKER_REGISTRY,
     multiprocess_mode="livesum",
 )
+REFRESH_XL_BACKLOG = Gauge(
+    "refresh_xl_backlog",
+    "Number of celery tasks in the refresh_xl queue",
+    registry=WORKER_REGISTRY,
+    multiprocess_mode="livesum",
+)
 COST_MODEL_BACKLOG = Gauge(
     "cost_model_backlog",
-    "Number of celery tasks in the cost model queue",
+    "Number of celery tasks in the cost_model queue",
+    registry=WORKER_REGISTRY,
+    multiprocess_mode="livesum",
+)
+COST_MODEL_XL_BACKLOG = Gauge(
+    "cost_model_xl_backlog",
+    "Number of celery tasks in the cost_model_xl queue",
     registry=WORKER_REGISTRY,
     multiprocess_mode="livesum",
 )
@@ -89,6 +119,12 @@ DEFAULT_BACKLOG = Gauge(
 OCP_BACKLOG = Gauge(
     "ocp_backlog", "Number of celery tasks in the OCP queue", registry=WORKER_REGISTRY, multiprocess_mode="livesum"
 )
+OCP_XL_BACKLOG = Gauge(
+    "ocp_xl_backlog",
+    "Number of celery tasks in the OCP_xl queue",
+    registry=WORKER_REGISTRY,
+    multiprocess_mode="livesum",
+)
 
 HCS_BACKLOG = Gauge(
     "hcs_backlog", "Number of celery tasks in the HCS queue", registry=WORKER_REGISTRY, multiprocess_mode="livesum"
@@ -96,12 +132,18 @@ HCS_BACKLOG = Gauge(
 
 QUEUES = {
     "download": DOWNLOAD_BACKLOG,
+    "download_xl": DOWNLOAD_XL_BACKLOG,
     "summary": SUMMARY_BACKLOG,
+    "summary_xl": SUMMARY_XL_BACKLOG,
     "priority": PRIORITY_BACKLOG,
+    "priority_xl": PRIORITY_XL_BACKLOG,
     "refresh": REFRESH_BACKLOG,
+    "refresh_x;": REFRESH_XL_BACKLOG,
     "cost_model": COST_MODEL_BACKLOG,
+    "cost_model_xl": COST_MODEL_XL_BACKLOG,
     "celery": DEFAULT_BACKLOG,
     "ocp": OCP_BACKLOG,
+    "ocp_xl": OCP_XL_BACKLOG,
     "hcs": HCS_BACKLOG,
 }
 

--- a/koku/masu/test/api/test_update_openshift_on_cloud.py
+++ b/koku/masu/test/api/test_update_openshift_on_cloud.py
@@ -10,7 +10,6 @@ from django.test.utils import override_settings
 from django.urls import reverse
 
 from api.utils import DateHelper
-from masu.processor.tasks import PRIORITY_QUEUE_XL
 from masu.processor.tasks import QUEUE_LIST
 from masu.test import MasuTestCase
 
@@ -119,25 +118,3 @@ class UpdateOpenShiftOnCloudTest(MasuTestCase):
         self.assertIn(expected_key, body)
         self.assertEqual(body[expected_key], expected_message)
         mock_update.delay.assert_not_called()
-
-    @patch("koku.middleware.MASU", return_value=True)
-    @patch("masu.api.update_openshift_on_cloud.chain")
-    def test_get_update_openshift_on_cloud_with_XL_queue(self, mock_update, _):
-        """Test GET update_openshift_on_cloud with XL queue."""
-        params = {
-            "schema": self.schema,
-            "provider_uuid": self.ocpaws_provider_uuid,
-            "start_date": "2022-01-01",
-        }
-        response = self.client.get(reverse("update_openshift_on_cloud"), params)
-        response.json()
-        with patch("masu.api.update_openshift_on_cloud.is_customer_large", return_value=True):
-            response = self.client.get(reverse("update_cost_model_costs"), params)
-            response.json()
-            mock_update.s.assert_called_with(
-                params["schema"],
-                params["provider_uuid"],
-                params["start_date"],
-                DateHelper().today.date().strftime("%Y-%m-%d"),
-                queue_name=PRIORITY_QUEUE_XL,
-            )


### PR DESCRIPTION
## Jira Ticket

[COST-3847](https://issues.redhat.com/browse/COST-3847)

## Description

This change will ...
* Leverage unleash flag with the is_customer_large method
* Route large customers to *_XL queues
* Add new deployments to support the new XL queues
* Capture prometheus metrics for new queues
* Route Masu endpoints to XL queue if a large customer

## Testing

1. Deploy to ephemeral environment
```
bonfire namespace reserve --duration 24h
bonfire deploy hccm --set-template-ref koku=cost-3847-large-customer-queue --set-parameter koku/IMAGE_TAG=pr-4452-1021a7b   --no-remove-resources koku \
  --no-remove-resources presto \
  --no-remove-resources hive-metastore
```
2. Kick off smoke tests `oc apply -f cji-smoke.yml`
```
apiVersion: cloud.redhat.com/v1alpha1
kind: ClowdJobInvocation
metadata:
  name: cost-mgmt-smoke
spec:
  appName: koku
  testing:
    iqe:
      ui:
        enabled: false
      marker: "cost_smoke"
      dynaconfEnvName: "clowder_smoke"
      filter: "test_api"
```
3. Gather results for test when going through regular pipeline and workers ✅ 
`= 194 failed, 4098 passed, 25 skipped, 1200 deselected, 1838 xfailed, 19677 warnings, 3426 errors in 12723.95s (3:32:03) =` and verify no traffic in xl workers
4. Connect to unleash to setup large customer check
`oc port-forward service/env-${NAMESPACE}-featureflags 4242:4242`
5. Add `cost-management.backend.large-customer` to default project as "Operational" feature and set it to "On" for "development" and "production" values (essentially meaning it will always return true.
6. Create new CJI (just change the name) to rerun smokes but now the flow should go through the XL queues and workers
7. Gather results for tests and validate traffic in XL workers ✅ 
`= 87 failed, 4208 passed, 25 skipped, 1200 deselected, 4672 xfailed, 20906 warnings, 589 errors in 16127.07s (4:28:47) =`
verify that while the Orchestrator.prepare() logic does hit the priority queue the download_xl and summary_xl queues and workers handle the traffic and the regular workers had no traffic.
