### PR TITLE
Fix masu endpoint

### DIFF
--- a/koku/masu/api/ingress_reports.py
+++ b/koku/masu/api/ingress_reports.py
@@ -53,14 +53,14 @@ def ingress_reports(request):
                 errmsg = "ingress_uuid must be supplied as a parameter for downloads."
                 return Response({"Error": errmsg}, status=status.HTTP_400_BAD_REQUEST)
             with schema_context(schema_name):
-                ingress_report = IngressReports.objects.filter(uuid=ingress_uuid)
-                async_result = check_report_updates.s(
+                ingress_report = IngressReports.objects.filter(uuid=ingress_uuid).first()
+                async_result = check_report_updates.delay(
                     provider_uuid=ingress_report.source_id,
                     bill_date=f"{ingress_report.bill_year}{ingress_report.bill_month}",
                     ingress_reports=ingress_report.reports_list,
                     ingress_report_uuid=ingress_uuid,
                 )
-            return Response({REPORT_DATA_KEY: async_result})
+            return Response({"Ingress Reports Download Request Task ID": str(async_result)})
 
         else:
             with schema_context(schema_name):

--- a/koku/masu/external/downloader/gcp/gcp_report_downloader.py
+++ b/koku/masu/external/downloader/gcp/gcp_report_downloader.py
@@ -476,7 +476,7 @@ class GCPReportDownloader(ReportDownloaderBase, DownloaderInterface):
         directory_path = self._get_local_directory_path()
         os.makedirs(directory_path, exist_ok=True)
         if self.ingress_reports:
-            key = key.split("bucketname/")[-1].replace("-", "_")
+            key = key.split(f"{self.bucket}/")[-1].replace("-", "_")
             try:
                 storage_client = storage.Client(self.credentials.get("project_id"))
                 bucket = storage_client.get_bucket(self.bucket)

--- a/koku/masu/external/downloader/gcp/gcp_report_downloader.py
+++ b/koku/masu/external/downloader/gcp/gcp_report_downloader.py
@@ -476,7 +476,7 @@ class GCPReportDownloader(ReportDownloaderBase, DownloaderInterface):
         directory_path = self._get_local_directory_path()
         os.makedirs(directory_path, exist_ok=True)
         if self.ingress_reports:
-            key = key.split(f"{self.bucket}/")[-1]
+            key = key.split("bucketname/")[-1].replace("-", "_")
             try:
                 storage_client = storage.Client(self.credentials.get("project_id"))
                 bucket = storage_client.get_bucket(self.bucket)

--- a/koku/masu/external/downloader/gcp/gcp_report_downloader.py
+++ b/koku/masu/external/downloader/gcp/gcp_report_downloader.py
@@ -476,7 +476,7 @@ class GCPReportDownloader(ReportDownloaderBase, DownloaderInterface):
         directory_path = self._get_local_directory_path()
         os.makedirs(directory_path, exist_ok=True)
         if self.ingress_reports:
-            key = key.split(f"{self.bucket}/")[-1].replace("-", "_")
+            key = key.split(f"{self.bucket}/")[-1]
             try:
                 storage_client = storage.Client(self.credentials.get("project_id"))
                 bucket = storage_client.get_bucket(self.bucket)


### PR DESCRIPTION
## Jira Ticket

[COST-####](https://issues.redhat.com/browse/COST-####)

## Description

This change will fix the masu endpoint for triggering re-downloads of ingress reports

## Testing

1. Checkout Branch
2. Restart Koku
3. Add storage only source
5. Post ingress reports for that source
6. Hit the masu endpoint to retrigger a download for posted reports.

## Notes
POSTING Source via /api/cost-management/v1/sources/
{
    "name": "GCP Source",
    "source_type": "GCP",
    "authentication": {
        "credentials": {
            "project_id": "my-gcp-project"
        }
    }, "billing_source": {
        "data_source": {"bucket": "my-gcp-bucket", "storage_only": true}
        }
}

Posting reports via /api/cost-management/v1/ingress/reports/
{
    "source": "1",
    "bill_year": "2023",
    "bill_month": "06",
    "reports_list": [
                "my-report.csv"
            ]
}

Masu endpoint retrigger

/api/cost-management/v1/ingress_reports/?schema_name=org1234567&ingress_uuid={UUID-FROM-ABOVE-POST}&download

...
