### PR TITLE
Refactor label check

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -46,14 +46,16 @@ function set_label_flags() {
     elif grep -E 'ok-to-skip-smokes' <<< "$PR_LABELS"; then
         SKIP_PR_CHECK='true'
         echo "smokes not required"
+    elif ! grep -E '.*smoke-tests' <<< "$PR_LABELS"; then
+        echo "WARNING! No smoke-tests labels found!, PR smoke tests will be skipped"
+        SKIP_SMOKE_TESTS='true'
+        EXIT_CODE=2
+    elif _set_IQE_filter_expressions_for_smoke_labels "$PR_LABELS"; then
+        echo "Smoke tests will run"
     else
-        if _set_IQE_filter_expressions_for_smoke_labels "$PR_LABELS"; then
-            echo "Smoke tests will run"
-        else
-            echo "WARNING! No known smoke-tests labels found!, PR smoke tests will be skipped"
-            SKIP_SMOKE_TESTS='true'
-            EXIT_CODE=2
-        fi
+        echo "Error setting IQE filters from PR_LABELS: $PR_LABELS"
+        SKIP_SMOKE_TESTS='true'
+        EXIT_CODE=2
     fi
 }
 

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -208,15 +208,11 @@ configure_stages
 if [[ -z "$SKIP_PR_CHECK" ]]; then
 
     if [[ -z "$SKIP_IMAGE_BUILD" ]]; then
-        # TODO: remove mock
-        echo "MOCK: building image ...."
-        #run_build_image_stage
+        run_build_image_stage
     fi
 
     if [[ -z "$SKIP_SMOKE_TESTS" ]]; then
-        # TODO: remove mock
-        echo "MOCK: running smoke tests ...."
-        #run_smoke_tests_stage
+        run_smoke_tests_stage
     fi
 fi
 

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -148,7 +148,8 @@ function generate_junit_report_from_code() {
 
     local CODE="$1"
 
-    "${JUNIT_REPORT_GENERATOR}" "$CODE" > "${ARTIFACTS_DIR}/junit-pr_check.xml"
+    mkdir -p "$ARTIFACTS_DIR"
+    "$JUNIT_REPORT_GENERATOR" "$CODE" > "${ARTIFACTS_DIR}/junit-pr_check.xml"
 }
 
 _github_api_request() {


### PR DESCRIPTION
## Jira Ticket

[COST-####](https://issues.redhat.com/browse/COST-####)

## Description

This change will refactor the logic that changes the behavior of which parts of the `pr_check.sh` script runs based on the PR labels.

After some analysis, I believe that with a reasonable accuracy, the workflow followed by this script can be described as a linear, 2 stage flow, being these two stages a "build image" and a "run smoke tests" which also make use of a "setup" stage where, according to the PR labels found, both can deactivate either stage, or even skip the entire pipeline, with different combinations of codes used to being used both for generating dummy JUnit XML reports, and as the effective exit code of the script. 

my conclusion is that the current status of the `pr_check.sh` system should behave according to the following table:

|label                         |pr_check_run|build_image_runs|smoke_tests_runs|Dummy JUnit report generated|Exit code|
|---------------------------|--------------------|------------------------|--------------------------|----------------------------------------------|-------------|
|none                        |       no             |             no             |            no               | Yes: code 1                                    |       1       |
|pr-check-build       |       yes            |           yes              |           no               | Yes: code 2                                    |       2       |
|lgtm                         |       yes            |           yes              |           no               | Yes: code 2                                    |       2       |
|ok-to-skip-smokes |       no            |           no                |           no               | Yes: code 0 [0]                                  |       0       |
|*smoke-tests           |       yes            |           yes              |           yes             | no                                                   |        2       |
| "any other different tag" | no        |           no              |           no               | Yes: code 1                                    |       1         |      

**Notes and Remarks:**
- [0] There's really no 0 code associated with "skipped" status, so any code different than 1,2 or 3 will generate this report if the script is invoked.
- There's a control for when the PR commit doesn't match HEAD ref, that generates a dummy JUnit report (code 3), and exits with exit code 3. This is not included in the table as it does not relate to the actual label system.

- There are some additional checks added:
  - There is a new check in place to ensure the script is invoked from a PR in order to run, otherwise it aborts execution with code 1. This makes sense due to the tight relation of the execution flow and the label system. To enable local testing, simply set a couple of environment variables to bypass the initial checks:
   ```
    ghprbActualCommit=$(git rev-parse HEAD) ghprbPullId=4470 bash -x pr_check.sh
   ```
  - There are additional controls to handle if the labels can't download (for example, if the Github API is not reachable. The script will now follow the logic as if it there would be no labels, and a log message has been added to reflect it.
 

## Testing

To test "most" of the script, effectively focusing on testing the actually flow and labeling logic I suggest to "mock" the "run_stage" functions, doing something as:

```
    if [[ -z "$SKIP_IMAGE_BUILD" ]]; then
        # TODO: remove mock
        echo "MOCK: building image ...."   <========= "mock"
        #run_build_image_stage                 <=========  comment this!
    fi

    if [[ -z "$SKIP_SMOKE_TESTS" ]]; then
        # TODO: remove mock
        echo "MOCK: running smoke tests ...." <============= "mock"
        #run_smoke_tests_stage                         <============= comment this!
````
And then simply change the PR labels. One can test this locally by following the previously suggested method, having checked out locally the PR branch:
   ```
    ghprbActualCommit=$(git rev-parse HEAD) ghprbPullId=4470 bash -x pr_check.sh
   ```

## Notes

This work, aside from trying to simplify the logic and improve maintainability, is expected to be used to facilitate the migration to a Jenkinsfile format with #4400 