### PR TITLE
skip flaky unit test

### DIFF
--- a/koku/masu/test/external/test_date_accessor.py
+++ b/koku/masu/test/external/test_date_accessor.py
@@ -4,6 +4,7 @@
 #
 """Test the DateAccessor object."""
 from datetime import datetime
+from unittest import skip
 from zoneinfo import ZoneInfo
 
 import dateutil
@@ -101,6 +102,7 @@ class DateAccessorTest(MasuTestCase):
         self.assertEqual(today.day, expected_date.day)
         self.assertEqual(today.tzinfo, settings.UTC)
 
+    @skip("flaky test")
     def test_today_override_with_iso8601(self):
         """Test today() with override and using ISO8601 format."""
         fake_tz_name = self.fake.timezone()


### PR DESCRIPTION
* skip `test_today_override_with_iso8601` which has been failing sporadically
