### PR TITLE
Clean up bad cluster records

### DIFF
--- a/koku/masu/database/ocp_report_db_accessor.py
+++ b/koku/masu/database/ocp_report_db_accessor.py
@@ -1004,7 +1004,7 @@ class OCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
             LOG.info(log_json(msg="fetching entry in reporting_ocp_cluster", provider_uuid=provider.uuid))
             clusters = OCPCluster.objects.filter(provider_id=provider.uuid)
             if clusters.count() > 1:
-                clusters_to_delete = clusters.exclude(cluster_alias=provider.name)
+                clusters_to_delete = clusters.exclude(cluster_alias=cluster_alias)
                 LOG.info(
                     log_json(
                         msg="attempting to delete duplicate entries in reporting_ocp_cluster",

--- a/koku/masu/database/ocp_report_db_accessor.py
+++ b/koku/masu/database/ocp_report_db_accessor.py
@@ -1006,6 +1006,12 @@ class OCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
             if len(clusters) > 1:
                 for cluster_iter in clusters:
                     if cluster_iter.cluster_alias != provider.name:
+                        LOG.info(
+                            log_json(
+                                msg="Atempting to delete duplicate entry in reporting_ocp_cluster",
+                                provider_uuid=provider.uuid,
+                            )
+                        )
                         cluster_iter.delete()
                     else:
                         cluster = cluster_iter

--- a/koku/masu/database/ocp_report_db_accessor.py
+++ b/koku/masu/database/ocp_report_db_accessor.py
@@ -1002,7 +1002,15 @@ class OCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
         """Get or create an entry in the OCP cluster table."""
         with schema_context(self.schema):
             LOG.info(log_json(msg="fetching entry in reporting_ocp_cluster", provider_uuid=provider.uuid))
-            cluster = OCPCluster.objects.filter(provider_id=provider.uuid).first()
+            clusters = OCPCluster.objects.filter(provider_id=provider.uuid)
+            if len(clusters) > 1:
+                for cluster_iter in clusters:
+                    if cluster_iter.cluster_alias != provider.name:
+                        cluster_iter.delete()
+                    else:
+                        cluster = cluster_iter
+            else:
+                cluster = clusters.first()
             msg = "fetched entry in reporting_ocp_cluster"
             if not cluster:
                 cluster, created = OCPCluster.objects.get_or_create(

--- a/koku/masu/database/ocp_report_db_accessor.py
+++ b/koku/masu/database/ocp_report_db_accessor.py
@@ -1008,7 +1008,7 @@ class OCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
                     if cluster_iter.cluster_alias != provider.name:
                         LOG.info(
                             log_json(
-                                msg="Atempting to delete duplicate entry in reporting_ocp_cluster",
+                                msg="attempting to delete duplicate entry in reporting_ocp_cluster",
                                 provider_uuid=provider.uuid,
                             )
                         )

--- a/koku/masu/test/database/test_ocp_report_db_accessor.py
+++ b/koku/masu/test/database/test_ocp_report_db_accessor.py
@@ -800,9 +800,9 @@ select * from eek where val1 in {{report_period_id}} ;
         cluster_id = str(uuid.uuid4())
         new_cluster_alias = "new_cluster_alias"
         cluster = self.accessor.populate_cluster_table(self.aws_provider, cluster_id, "cluster_alias")
-        # Forcefully create a second entry
-        OCPCluster.objects.get_or_create(cluster_id, "cluster_alias", self.aws_provider)
         with schema_context(self.schema):
+            # Forcefully create a second entry
+            OCPCluster.objects.get_or_create(cluster_id, "cluster_alias", self.aws_provider)
             self.accessor.populate_cluster_table(self.aws_provider, cluster_id, new_cluster_alias)
             cluster = OCPCluster.objects.filter(cluster_id=cluster_id)
             self.assertEqual(len(cluster), 1)

--- a/koku/masu/test/database/test_ocp_report_db_accessor.py
+++ b/koku/masu/test/database/test_ocp_report_db_accessor.py
@@ -799,13 +799,16 @@ select * from eek where val1 in {{report_period_id}} ;
         """Test updating cluster alias for duplicate entry in the cluster table."""
         cluster_id = str(uuid.uuid4())
         new_cluster_alias = "new_cluster_alias"
-        cluster = self.accessor.populate_cluster_table(self.aws_provider, cluster_id, "cluster_alias")
+        self.accessor.populate_cluster_table(self.aws_provider, cluster_id, "cluster_alias")
         with schema_context(self.schema):
             # Forcefully create a second entry
-            OCPCluster.objects.get_or_create(cluster_id, "cluster_alias", self.aws_provider)
+            OCPCluster.objects.get_or_create(
+                cluster_id=cluster_id, cluster_alias=self.aws_provider.name, provider_id=self.aws_provider_uuid
+            )
             self.accessor.populate_cluster_table(self.aws_provider, cluster_id, new_cluster_alias)
-            cluster = OCPCluster.objects.filter(cluster_id=cluster_id)
-            self.assertEqual(len(cluster), 1)
+            clusters = OCPCluster.objects.filter(cluster_id=cluster_id)
+            self.assertEqual(len(clusters), 1)
+            cluster = clusters.first()
             self.assertEqual(cluster.cluster_alias, new_cluster_alias)
 
     def test_populate_node_table_second_time_no_change(self):


### PR DESCRIPTION
## Jira Ticket

[COST-3793](https://issues.redhat.com/browse/COST-3793)

## Description

This change will clean up old duplicate records when trying to fetch single clusters from the reporting_ocp_clusters table.

## Testing

1. Checkout Branch
2. Restart Koku
3. add ocp cluster
4. Add additional bad/dup entry in the DB
5. Update the cluster_alias entry (source name for your real ocp source) OR manually trigger 'populate_cluster_table' method

## Notes

...
