### PR TITLE
[COST-3468] Adding max group by options

### DIFF
--- a/koku/api/report/all/openshift/serializers.py
+++ b/koku/api/report/all/openshift/serializers.py
@@ -92,5 +92,9 @@ class OCPAllQueryParamSerializer(awsser.AWSQueryParamSerializer):
             (ValidationError): if group_by field inputs are invalid
 
         """
+        if len(value) > 2:
+            # Max support group_bys is 2
+            error = {"group_by": ("Cost Management supports a max of two group_by options.")}
+            raise serializers.ValidationError(error)
         validate_field(self, "group_by", self.GROUP_BY_SERIALIZER, value, tag_keys=self.tag_keys)
         return value

--- a/koku/api/report/aws/openshift/serializers.py
+++ b/koku/api/report/aws/openshift/serializers.py
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 """OCP-on-AWS Report Serializers."""
+from rest_framework import serializers
+
 import api.report.aws.serializers as awsser
 import api.report.ocp.serializers as ocpser
 from api.report.serializers import validate_field
@@ -94,5 +96,9 @@ class OCPAWSQueryParamSerializer(awsser.AWSQueryParamSerializer):
             (ValidationError): if group_by field inputs are invalid
 
         """
+        if len(value) > 2:
+            # Max support group_bys is 2
+            error = {"group_by": ("Cost Management supports a max of two group_by options.")}
+            raise serializers.ValidationError(error)
         validate_field(self, "group_by", self.GROUP_BY_SERIALIZER, value, tag_keys=self.tag_keys)
         return value

--- a/koku/api/report/aws/serializers.py
+++ b/koku/api/report/aws/serializers.py
@@ -135,6 +135,10 @@ class AWSQueryParamSerializer(ReportQueryParamSerializer):
             (ValidationError): if group_by field inputs are invalid
 
         """
+        if len(value) > 2:
+            # Max support group_bys is 2
+            error = {"group_by": ("Cost Management supports a max of two group_by options.")}
+            raise serializers.ValidationError(error)
         validate_field(
             self,
             "group_by",

--- a/koku/api/report/serializers.py
+++ b/koku/api/report/serializers.py
@@ -454,6 +454,10 @@ class ParamSerializer(BaseSerializer):
             (ValidationError): if group_by field inputs are invalid
 
         """
+        if len(value) > 2:
+            # Max support group_bys is 2
+            error = {"group_by": ("Cost Management supports a max of two group_by options.")}
+            raise serializers.ValidationError(error)
         validate_field(self, "group_by", self.GROUP_BY_SERIALIZER, value, tag_keys=self.tag_keys)
         return value
 

--- a/koku/api/report/test/all/openshift/test_serializers.py
+++ b/koku/api/report/test/all/openshift/test_serializers.py
@@ -109,3 +109,14 @@ class OCPAllQueryParamSerializerTest(IamTestCase):
         serializer = OCPAllQueryParamSerializer(data=query_params)
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
+
+    def test_fail_with_max_group_by(self):
+        """Test fail if more than 2 group bys given."""
+        query_params = {
+            "group_by": {"account": ["account1"], "service": ["ser"], "region": ["reg"]},
+        }
+        self.request_path = "/api/cost-management/v1/reports/openshift/infrastructures/aws/costs/"
+        with self.assertRaises(serializers.ValidationError):
+            serializer = OCPAllQueryParamSerializer(data=query_params, context=self.ctx_w_path)
+            self.assertFalse(serializer.is_valid())
+            serializer.is_valid(raise_exception=True)

--- a/koku/api/report/test/aws/openshift/test_serializers.py
+++ b/koku/api/report/test/aws/openshift/test_serializers.py
@@ -264,3 +264,14 @@ class OCPAWSQueryParamSerializerTest(IamTestCase):
                     serializer = OCPAWSQueryParamSerializer(data=param, context=self.ctx_w_path)
                     self.assertFalse(serializer.is_valid())
                     serializer.is_valid(raise_exception=True)
+
+    def test_fail_with_max_group_by(self):
+        """Test fail if more than 2 group bys given."""
+        query_params = {
+            "group_by": {"account": ["account1"], "service": ["ser"], "region": ["reg"]},
+        }
+        self.request_path = "/api/cost-management/v1/reports/openshift/infrastructures/aws/costs/"
+        with self.assertRaises(serializers.ValidationError):
+            serializer = OCPAWSQueryParamSerializer(data=query_params, context=self.ctx_w_path)
+            self.assertFalse(serializer.is_valid())
+            serializer.is_valid(raise_exception=True)

--- a/koku/api/report/test/ocp/test_ocp_query_handler.py
+++ b/koku/api/report/test/ocp/test_ocp_query_handler.py
@@ -942,17 +942,17 @@ class OCPReportQueryHandlerTest(IamTestCase):
         """Test the apply_group_by handles different grouping scenerios."""
         mock_is_openshift.return_value = True
         group_by_list = [
-            ("project", "cluster", "node"),
-            ("project", "node", "cluster"),
-            ("cluster", "project", "node"),
-            ("cluster", "node", "project"),
-            ("node", "cluster", "project"),
-            ("node", "project", "cluster"),
+            ("project", "cluster"),
+            ("project", "node"),
+            ("cluster", "project"),
+            ("cluster", "node"),
+            ("node", "cluster"),
+            ("node", "project"),
         ]
         base_url = "?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[limit]=3"  # noqa: E501
         tolerance = 1
         for group_by in group_by_list:
-            sub_url = "&group_by[%s]=*&group_by[%s]=*&group_by[%s]=*" % group_by
+            sub_url = "&group_by[%s]=*&group_by[%s]=*" % group_by
             url = base_url + sub_url
             query_params = self.mocked_query_params(url, OCPCpuView)
             handler = OCPReportQueryHandler(query_params)

--- a/koku/api/report/test/ocp/test_serializers.py
+++ b/koku/api/report/test/ocp/test_serializers.py
@@ -324,6 +324,17 @@ class OCPQueryParamSerializerTest(IamTestCase):
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
+    def test_fail_with_max_group_by(self):
+        """Test fail if more than 2 group bys given."""
+        query_params = {
+            "group_by": {"cluster": ["cluster"], "node": ["node"], "project": ["project"]},
+        }
+        self.request_path = "/api/cost-management/v1/reports/openshift/infrastructures/aws/costs/"
+        with self.assertRaises(serializers.ValidationError):
+            serializer = OCPQueryParamSerializer(data=query_params, context=self.ctx_w_path)
+            self.assertFalse(serializer.is_valid())
+            serializer.is_valid(raise_exception=True)
+
 
 class OCPInventoryQueryParamSerializerTest(IamTestCase):
     """Tests for the handling inventory query parameter parsing serializer."""

--- a/koku/api/report/test/test_serializers.py
+++ b/koku/api/report/test/test_serializers.py
@@ -562,6 +562,17 @@ class QueryParamSerializerTest(IamTestCase):
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
+    def test_fail_with_max_group_by(self):
+        """Test fail if more than 2 group bys given."""
+        query_params = {
+            "group_by": {"account": ["account1"], "service": ["ser"], "region": ["reg"]},
+        }
+        self.request_path = "/api/cost-management/v1/reports/openshift/infrastructures/aws/costs/"
+        with self.assertRaises(serializers.ValidationError):
+            serializer = AWSQueryParamSerializer(data=query_params, context=self.ctx_w_path)
+            self.assertFalse(serializer.is_valid())
+            serializer.is_valid(raise_exception=True)
+
     def test_multiple_group_by_with_matching_sort_or(self):
         """Test multiple group by with a matching sort for or group_by parameters."""
         query_params = {


### PR DESCRIPTION
## Jira Ticket

[COST-3468](https://issues.redhat.com/browse/COST-3468)

## Description

This change will limit the number of group bys supported

## Testing

1. Checkout Branch
2. Restart Koku
3. load test customer data
4. hit any API endpoint with more than 2 group_by options.

## Notes
Today you _can_ use more than two group_bys but this tends to build expensive queries and often gives weird unreliable results. Also the UI only supports a single group by today, so two is still useful via the API I could of made this one. :rofl: 
...
