### PR TITLE
Enhance README with Fedora configuration info

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ do the following:
 
         brew install openssl librdkafka postgresql@13
 
+3.  (Fedora only) Install libraries for building wheels on Linux:
+
+        dnf install openssl-devel libpq-devel postgresql golang-sigs-k8s-kustomize
+
 4.  (macOS only) Also add the following to your `.env` or shell profile:
 
         LDFLAGS="-L$(brew --prefix openssl)/lib -L$(brew --prefix librdkafka)/lib -L$(brew --prefix postgresql@13)/lib"


### PR DESCRIPTION
## Jira Ticket

None

## Description

This change adds configuration options for development on Fedora Linux.

## Testing

On Fedora 38, just follow the steps in the README. Without the additions in this PR, `make docker-up-min` will fail to build some containers due to missing Postgres, OpenSSL and Kustomize.

## Notes

...
