### PR TITLE
[COST-3963] Include Azure subscription name in API

### DIFF
--- a/koku/api/report/azure/provider_map.py
+++ b/koku/api/report/azure/provider_map.py
@@ -35,12 +35,13 @@ class AzureProviderMap(ProviderMap):
         self._mapping = [
             {
                 "provider": Provider.PROVIDER_AZURE,
-                "alias": "subscription_guid",  # FIXME: probably wrong
+                "alias": "subscription_name",
                 "annotations": {},
                 "end_date": "costentrybill__billing_period_start",
                 "filters": {
                     "subscription_guid": [
-                        {"field": "subscription_guid", "operation": "icontains", "composition_key": "account_filter"}
+                        {"field": "subscription_guid", "operation": "icontains", "composition_key": "account_filter"},
+                        {"field": "subscription_name", "operation": "icontains", "composition_key": "account_filter"},
                     ],
                     "service_name": {"field": "service_name", "operation": "icontains"},
                     "resource_location": {"field": "resource_location", "operation": "icontains"},

--- a/koku/api/report/azure/query_handler.py
+++ b/koku/api/report/azure/query_handler.py
@@ -149,6 +149,12 @@ class AzureReportQueryHandler(ReportQueryHandler):
 
             annotations = self._mapper.report_type_map.get("annotations")
             query_data = query.values(*query_group_by).annotate(**annotations)
+
+            if "subscription_guid" in query_group_by:
+                query_data = query_data.annotate(
+                    subscripton_name=Coalesce(F(self._mapper.provider_map.get("alias")), "subscription_guid")
+                )
+
             query_sum = self._build_sum(query)
 
             if self._limit and query_data:

--- a/koku/api/report/test/util/model_bakery_loader.py
+++ b/koku/api/report/test/util/model_bakery_loader.py
@@ -272,6 +272,7 @@ class ModelBakeryDataLoader(DataLoader):
             linked_openshift_provider=linked_openshift_provider,
         )
         sub_guid = self.faker.uuid4()
+        sub_name = f"{self.faker.company()} subscription"
         for start_date, end_date, bill_date in self.dates:
             LOG.info(f"load azure data for start: {start_date}, end: {end_date}")
             self.create_manifest(provider, bill_date)
@@ -289,6 +290,7 @@ class ModelBakeryDataLoader(DataLoader):
                         tags=cycle(self.tags),
                         currency=self.currency,
                         source_uuid=provider.uuid,
+                        subscription_name=sub_name,
                     )
         bill_ids = [bill.id for bill in bills]
         with AzureReportDBAccessor(self.schema) as accessor:


### PR DESCRIPTION
## Jira Ticket

[COST-3963](https://issues.redhat.com/browse/COST-3963)

## Description

This change will ...

* When performing a group_by subscription_guid we should also include the subscription name
* Enable filter by subscription_guid to also support a icontains against the subscription name

## Testing

1. Checkout Branch
2. Restart Koku
3. Load test data
```
make create-test-customer
make load-test-customer-data test_source=azure
```
4. Hit endpoint `http://localhost:8000/api/cost-management/v1/reports/azure/costs/?filter[resolution]=monthly&filter[time_scope_units]=month&filter[time_scope_value]=-1&group_by[subscription_guid]=*`
    1. You should see `subscription_name` included in the individual entries
5. Lastly, you should can also filter using the subscription_name: `http://localhost:8000/api/cost-management/v1/reports/azure/costs/?filter[resolution]=monthly&filter[time_scope_units]=month&filter[time_scope_value]=-1&group_by[subscription_guid]=Coleman-Foster`

<img width="1515" alt="image" src="https://github.com/project-koku/koku/assets/29379759/a9947e59-8e95-4a18-9535-2e31fa29c6fa">


