### PR TITLE
[COST-3883] Fixing Start date for Azure/AWS

### DIFF
--- a/koku/api/test_utils.py
+++ b/koku/api/test_utils.py
@@ -344,12 +344,8 @@ class GetMonthsInDateRangeTest(unittest.TestCase):
             "schema": "org1234567",
             "provider_uuid": "f3da28f7-00c7-43ba-a1de-f0be0b9d6060",
         }
-        _start_date_1 = self.first_of_year - datetime.timedelta(days=2)
-        expected_start_1 = _start_date_1.strftime("%Y-%m-%d")
-        _end_date_1 = _start_date_1 + relativedelta(day=31)
-        expected_end_1 = _end_date_1.date().strftime("%Y-%m-%d")
         expected_date_2 = self.first_of_year.strftime("%Y-%m-%d")
-        expected_months = [(expected_start_1, expected_end_1, None), (expected_date_2, expected_date_2, None)]
+        expected_months = [(expected_date_2, expected_date_2, None)]
 
         returned_months = get_months_in_date_range(test_report)
 
@@ -363,18 +359,14 @@ class GetMonthsInDateRangeTest(unittest.TestCase):
         with a report missing start, end or both dates
         returns list of month tuples during first of a month
         """
-
-        mock_dh_today.return_value = self.first_of_month
+        end_date = self.first_of_month.replace(day=3)
+        mock_dh_today.return_value = end_date
         test_report = {
             "schema": "org1234567",
             "provider_uuid": "f3da28f7-00c7-43ba-a1de-f0be0b9d6060",
         }
-        _start_date_1 = self.first_of_month - datetime.timedelta(days=2)
-        expected_start_1 = _start_date_1.strftime("%Y-%m-%d")
-        _end_date_1 = _start_date_1 + relativedelta(day=31)
-        expected_end_1 = _end_date_1.date().strftime("%Y-%m-%d")
-        expected_date_2 = self.first_of_month.strftime("%Y-%m-%d")
-        expected_months = [(expected_start_1, expected_end_1, None), (expected_date_2, expected_date_2, None)]
+        expected_date = self.first_of_month.strftime("%Y-%m-%d")
+        expected_months = [(expected_date, end_date, None)]
 
         returned_months = get_months_in_date_range(test_report)
 

--- a/koku/api/test_utils.py
+++ b/koku/api/test_utils.py
@@ -366,7 +366,7 @@ class GetMonthsInDateRangeTest(unittest.TestCase):
             "provider_uuid": "f3da28f7-00c7-43ba-a1de-f0be0b9d6060",
         }
         expected_date = self.first_of_month.strftime("%Y-%m-%d")
-        expected_months = [(expected_date, end_date, None)]
+        expected_months = [(expected_date, end_date.strftime("%Y-%m-%d"), None)]
 
         returned_months = get_months_in_date_range(test_report)
 

--- a/koku/api/utils.py
+++ b/koku/api/utils.py
@@ -483,7 +483,7 @@ def get_months_in_date_range(
                 )
         else:
             LOG.info("generating start and end dates for manifest")
-            dt_start = dh.today - datetime.timedelta(days=2)
+            dt_start = dh.today - datetime.timedelta(days=2) if dh.today.date().day > 2 else dh.today.replace(day=1)
             dt_end = dh.today
 
     elif dt_invoice_month:

--- a/koku/masu/test/processor/test_tasks.py
+++ b/koku/masu/test/processor/test_tasks.py
@@ -424,7 +424,7 @@ class ProcessReportFileTests(MasuTestCase):
 
         summarize_reports(reports_to_summarize)
 
-        mock_update_summary.s.assert_called_once()
+        mock_update_summary.s.assert_called()
 
     @patch("masu.processor.tasks.update_summary_tables")
     def test_summarize_reports_processing_list_only_none(self, mock_update_summary):


### PR DESCRIPTION
## Jira Ticket

[COST-3883](https://issues.redhat.com/browse/COST-3883)

## Description

This change will prevent us generating multiple months for Azure/AWS manifest when we shouldnt be. This created a side affect for the first two days of a month where we would end up triggering summary twice per manifest.

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Notes

...
