### PR TITLE
[COST-3956] others included in ordering by cost & limit

### DIFF
--- a/koku/api/report/ocp/query_handler.py
+++ b/koku/api/report/ocp/query_handler.py
@@ -278,9 +278,8 @@ class OCPReportQueryHandler(ReportQueryHandler):
                 query_data = self._project_classification_annotation(query_data)
             if self._limit and query_data:
                 query_data = self._group_by_ranks(query, query_data)
-                if not self.parameters.get("order_by") or self.parameters.get("order_by", {}).get(
-                    "cost_total_distributed"
-                ):
+                order_by = self.parameters.get("order_by")
+                if not order_by or set(order_by.keys()).intersection(["cost_total", "cost_total_distributed"]):
                     # https://issues.redhat.com/browse/COST-3901
                     # order_by[distributed_cost] is required for distributing platform cost,
                     # therefore others must be at the end.


### PR DESCRIPTION
## Jira Ticket

[COST-3956](https://issues.redhat.com/browse/COST-3956)

## Description

This change will:

- top items are consistent across the time range
- the order of items is consistent across the time range and correspond to their overall cost
- Other(s) are always listed as a last item

## Testing

Eva was kind enough to write a smoke test to test/validate this one:
```
 test_api_ocp_cost_filtered_top_projects_order_by_cost
```

My results locally:
```
```

## Notes

...
