### PR TITLE
[COST-3963] Enable order_by for subscription_name with Azure

### DIFF
--- a/koku/api/report/azure/query_handler.py
+++ b/koku/api/report/azure/query_handler.py
@@ -149,12 +149,6 @@ class AzureReportQueryHandler(ReportQueryHandler):
 
             annotations = self._mapper.report_type_map.get("annotations")
             query_data = query.values(*query_group_by).annotate(**annotations)
-
-            if "subscription_guid" in query_group_by:
-                query_data = query_data.annotate(
-                    subscription_name=Coalesce(F(self._mapper.provider_map.get("alias")), "subscription_guid")
-                )
-
             query_sum = self._build_sum(query)
 
             if self._limit and query_data:

--- a/koku/api/report/azure/serializers.py
+++ b/koku/api/report/azure/serializers.py
@@ -27,9 +27,17 @@ class AzureGroupBySerializer(GroupSerializer):
 class AzureOrderBySerializer(OrderSerializer):
     """Serializer for handling query parameter order_by."""
 
-    _opfields = ("subscription_guid", "resource_location", "instance_type", "service_name", "date")
+    _opfields = (
+        "subscription_guid",
+        "subscription_name",
+        "resource_location",
+        "instance_type",
+        "service_name",
+        "date",
+    )
 
     subscription_guid = serializers.ChoiceField(choices=OrderSerializer.ORDER_CHOICES, required=False)
+    subscription_name = serializers.ChoiceField(choices=OrderSerializer.ORDER_CHOICES, required=False)
     resource_location = serializers.ChoiceField(choices=OrderSerializer.ORDER_CHOICES, required=False)
     instance_type = serializers.ChoiceField(choices=OrderSerializer.ORDER_CHOICES, required=False)
     service_name = serializers.ChoiceField(choices=OrderSerializer.ORDER_CHOICES, required=False)

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -1108,6 +1108,9 @@ class ReportQueryHandler(QueryHandler):
         if tag_column in gb[0]:
             rank_orders.append(self.get_tag_order_by(gb[0]))
 
+        if self.order_field == "subscription_name":
+            group_by_value.append("subscription_name")
+
         rank_by_total = Window(expression=RowNumber(), order_by=rank_orders)
         ranks = (
             query.annotate(**self.annotations)

--- a/koku/api/report/serializers.py
+++ b/koku/api/report/serializers.py
@@ -500,6 +500,10 @@ class ParamSerializer(BaseSerializer):
 
                 # special case: we order by account_alias, but we group by account.
                 if key == "account_alias" and ("account" in group_keys or "account" in or_keys):
+                    continue  # special case: we order by subscription_name, but we group by subscription_guid.
+                if key == "subscription_name" and (
+                    "subscription_guid" in group_keys or "subscription_guid" in or_keys
+                ):
                     continue
                 # sepcial case: we order by date, but we group by an allowed param.
                 if key == "date" and group_keys:

--- a/koku/api/report/test/azure/test_azure_query_handler.py
+++ b/koku/api/report/test/azure/test_azure_query_handler.py
@@ -786,6 +786,26 @@ class AzureReportQueryHandlerTest(IamTestCase):
                 self.assertIsInstance(month_item.get("values"), list)
                 self.assertIsInstance(month_item.get("values")[0].get("delta_value"), Decimal)
 
+    def test_execute_query_orderby_subscription_name(self):
+        """Test execute_query with ordering by subscription_name ascending."""
+        url = "?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&order_by[subscription_name]=asc&group_by[subscription_guid]=*"  # noqa: E501
+        path = reverse("reports-azure-costs")
+        query_params = self.mocked_query_params(url, AzureCostView, path)
+        handler = AzureReportQueryHandler(query_params)
+        query_output = handler.execute_query()
+        data = query_output.get("data")
+        self.assertIsNotNone(data)
+        cmonth_str = self.dh.this_month_start.strftime("%Y-%m")
+        for data_item in data:
+            month_val = data_item.get("date")
+            month_data = data_item.get("subscription_guids")
+            self.assertEqual(month_val, cmonth_str)
+            self.assertIsInstance(month_data, list)
+            for month_item in month_data:
+                self.assertIsInstance(month_item.get("subscription_guid"), str)
+                self.assertIsInstance(month_item.get("values"), list)
+                self.assertIsInstance(month_item.get("values")[0].get("subscription_name"), str)
+
     def test_calculate_total(self):
         """Test that calculated totals return correctly."""
         url = "?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly"

--- a/koku/api/report/test/test_serializers.py
+++ b/koku/api/report/test/test_serializers.py
@@ -17,6 +17,7 @@ from api.report.aws.serializers import AWSFilterSerializer
 from api.report.aws.serializers import AWSGroupBySerializer
 from api.report.aws.serializers import AWSOrderBySerializer
 from api.report.aws.serializers import AWSQueryParamSerializer
+from api.report.azure.serializers import AzureOrderBySerializer
 from api.report.serializers import ParamSerializer
 from api.report.serializers import ReportQueryParamSerializer
 from api.utils import DateHelper
@@ -440,6 +441,12 @@ class OrderBySerializerTest(TestCase):
         """Test parse of a order_by param successfully."""
         order_params = {"usage": "asc"}
         serializer = AWSOrderBySerializer(data=order_params)
+        self.assertTrue(serializer.is_valid())
+
+    def test_parse_azure_order_by_params_success(self):
+        """Test parse of a order_by param successfully."""
+        order_params = {"subscription_name": "asc"}
+        serializer = AzureOrderBySerializer(data=order_params)
         self.assertTrue(serializer.is_valid())
 
     def test_order_by_params_invalid_fields(self):


### PR DESCRIPTION
## Jira Ticket

[COST-3963](https://issues.redhat.com/browse/COST-3963)

## Description

This change will ...
* Update code to support order_by for subscription_name

## Testing

1. Checkout Branch
2. Restart Koku
3. Load customer data
```
make create-test-customer
make load-test-customer-data test_source=azure
```
4. Hit endpoint `http://localhost:8000/api/cost-management/v1/reports/azure/costs/?currency=USD&delta=cost&filter[limit]=10&filter[offset]=0&filter[resolution]=monthly&filter[time_scope_units]=month&filter[time_scope_value]=-1&group_by[subscription_guid]=*&order_by[subscription_name]=asc`
    1. You should see subscription data ordered by subscription name
5. Hit endpoint `http://localhost:8000/api/cost-management/v1/reports/azure/costs/?currency=USD&delta=cost&filter[limit]=10&filter[offset]=0&filter[resolution]=monthly&filter[time_scope_units]=month&filter[time_scope_value]=-1&group_by[subscription_guid]=*&order_by[subscription_name]=desc`
    1. You should see subscription data ordered by subscription name in the reverse order as before
