### PR TITLE
Constrain kombu

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -56,6 +56,7 @@ unleashclient = "<5"  # new version breaks for unknown reason
 watchtower = "==1.0.6"  # new version breaks for unknown reason
 whitenoise = ">=5.0"
 # Constraints on indirect dependencies
+kombu = "<5.3"  # UUID and datetime objects are now correctly preserved. We expect them to be strings in many places.
 jinja2 = "<3"   # jinjasql is not compatible with Jinja >=3 https://github.com/sripathikrishnan/jinjasql/pull/53
 markupsafe = "<2.1"  # jinja2 <3 tries to import markupsafe.soft_unicode which was removed in markupsafe 2.1
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "613abf618b3ab1b566c2a95bec4e1b97fc3bee85fb3a5b28855da3b79e1cb9cf"
+            "sha256": "b3f8011743e697fb44d5e8cd7f3bf2fc27413d9fbf9d6729168edbc5fe7af23c"
         },
         "pipfile-spec": 6,
         "requires": {


### PR DESCRIPTION
## Description

Kombu 5.3 fixed bugs that incorrectly cast UUID and datetime objects to strings. We expect those to be strings in many places.

https://github.com/celery/kombu/pull/1575
https://github.com/celery/kombu/pull/1515
https://github.com/celery/kombu/releases/tag/v5.3.0

Closes #4539.