### PR TITLE
[COST-3864] Dropping OCP from scheduled polling

### DIFF
--- a/koku/koku/celery.py
+++ b/koku/koku/celery.py
@@ -119,7 +119,7 @@ if ENVIRONMENT.bool("SCHEDULE_REPORT_CHECKS", default=False):
     CHECK_REPORT_UPDATES_DEF = {
         "task": download_task,
         "schedule": report_schedule,
-        "kwargs": {},
+        "kwargs": {"scheduled": True},
     }
     app.conf.beat_schedule["check-report-updates-batched"] = CHECK_REPORT_UPDATES_DEF
 

--- a/koku/masu/api/download.py
+++ b/koku/masu/api/download.py
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 """View for temporary force download endpoint."""
+import logging
+
 from django.views.decorators.cache import never_cache
 from rest_framework.decorators import api_view
 from rest_framework.decorators import permission_classes
@@ -12,6 +14,8 @@ from rest_framework.response import Response
 from rest_framework.settings import api_settings
 
 from masu.celery.tasks import check_report_updates
+
+LOG = logging.getLogger(__name__)
 
 
 @never_cache
@@ -24,11 +28,14 @@ def download_report(request):
     provider_uuid = params.get("provider_uuid")
     provider_type = params.get("provider_type")
     bill_date = params.get("bill_date")
+    scheduled = params.get("scheduled", "true").lower()
+    scheduled = True if scheduled == "true" else False
     summarize_reports = params.get("summarize_reports", "true").lower()
     summarize_reports = True if summarize_reports == "true" else False
     async_download_result = check_report_updates.delay(
         provider_uuid=provider_uuid,
         provider_type=provider_type,
+        scheduled=scheduled,
         bill_date=bill_date,
         summarize_reports=summarize_reports,
     )

--- a/koku/masu/external/accounts/db/cur_accounts_db.py
+++ b/koku/masu/external/accounts/db/cur_accounts_db.py
@@ -6,6 +6,7 @@
 import logging
 
 from api.common import log_json
+from api.models import Provider
 from api.utils import DateHelper
 from masu.config import Config
 from masu.database.provider_collector import ProviderCollector
@@ -57,7 +58,7 @@ class CURAccountsDB(CURAccountsInterface):
             provider.save()
         return True
 
-    def get_accounts_from_source(self, provider_uuid=None, provider_type=None):
+    def get_accounts_from_source(self, provider_uuid=None, provider_type=None, scheduled=False):
         """
         Retrieve all accounts from the Koku database.
 
@@ -78,7 +79,7 @@ class CURAccountsDB(CURAccountsInterface):
                 LOG.info(log_json(msg="provider does not exist", provider_uuid=provider_uuid))
                 return []
             elif provider_uuid and provider:
-                if self.is_source_pollable(provider, provider_uuid=provider_uuid):
+                if self.is_source_pollable(provider, provider_uuid):
                     return [self.get_account_information(provider)]
                 return []
 
@@ -89,6 +90,8 @@ class CURAccountsDB(CURAccountsInterface):
             )
 
             for _, provider in all_providers.items():
+                if scheduled and provider.type == Provider.PROVIDER_OCP:
+                    continue
                 if provider_type and provider_type not in provider.type:
                     continue
                 if self.is_source_pollable(provider):

--- a/koku/masu/external/accounts_accessor.py
+++ b/koku/masu/external/accounts_accessor.py
@@ -84,7 +84,7 @@ class AccountsAccessor:
             return True
         return False
 
-    def get_accounts(self, provider_uuid=None, provider_type=None):
+    def get_accounts(self, provider_uuid=None, provider_type=None, scheduled=False):
         """
         Return all of the CUR accounts setup in Koku.
 
@@ -98,7 +98,7 @@ class AccountsAccessor:
 
         """
         try:
-            accounts = self.source.get_accounts_from_source(provider_uuid, provider_type)
+            accounts = self.source.get_accounts_from_source(provider_uuid, provider_type, scheduled)
         except CURAccountsInterfaceError as error:
             raise AccountsAccessorError(str(error))
 

--- a/koku/masu/processor/orchestrator.py
+++ b/koku/masu/processor/orchestrator.py
@@ -49,7 +49,14 @@ class Orchestrator:
     """
 
     def __init__(
-        self, billing_source=None, provider_uuid=None, provider_type=None, bill_date=None, queue_name=None, **kwargs
+        self,
+        billing_source=None,
+        provider_uuid=None,
+        provider_type=None,
+        scheduled=False,
+        bill_date=None,
+        queue_name=None,
+        **kwargs,
     ):
         """
         Orchestrator for processing.
@@ -63,16 +70,20 @@ class Orchestrator:
         self.bill_date = bill_date
         self.provider_uuid = provider_uuid
         self.provider_type = provider_type
+        self.scheduled = scheduled
         self.queue_name = queue_name
         self.ingress_reports = kwargs.get("ingress_reports")
         self.ingress_report_uuid = kwargs.get("ingress_report_uuid")
         self._accounts, self._polling_accounts = self.get_accounts(
-            self.billing_source, self.provider_uuid, self.provider_type
+            self.billing_source,
+            self.provider_uuid,
+            self.provider_type,
+            self.scheduled,
         )
         self._summarize_reports = kwargs.get("summarize_reports", True)
 
     @staticmethod
-    def get_accounts(billing_source=None, provider_uuid=None, provider_type=None):
+    def get_accounts(billing_source=None, provider_uuid=None, provider_type=None, scheduled=False):
         """
         Prepare a list of accounts for the orchestrator to get CUR from.
 
@@ -93,7 +104,7 @@ class Orchestrator:
         all_accounts = []
         polling_accounts = []
         try:
-            all_accounts = AccountsAccessor().get_accounts(provider_uuid, provider_type)
+            all_accounts = AccountsAccessor().get_accounts(provider_uuid, provider_type, scheduled)
         except AccountsAccessorError as error:
             LOG.error("Unable to get accounts. Error: %s", str(error))
 


### PR DESCRIPTION
## Jira Ticket

[COST-3864](https://issues.redhat.com/browse/COST-3864)

## Description

This change will drop OCP providers from the collected polling accounts list from a scheduled task

## Testing

1. Checkout Branch
2. Restart Koku
3. load customer data
4. hit the download endpoint
5. See OCP _IS_ collected in the logs
6. Hit the download endpoint again with ?scheduled=true
7. See OCP _ISNOT_ collect

## Notes

This is what the schedule looks like
'check-report-updates-batched': {'kwargs': {'scheduled': True},
'schedule': <crontab: 0 * * * * (m/h/d/dM/MY)>,
'task': 'masu.celery.tasks.check_report_updates'}
...
