### PR TITLE
[COST-2665] Clowder now applying annotations from deployment spec level

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -412,7 +412,11 @@ objects:
           enabled: false
         public:
           enabled: false
-    - name: clowder-masu
+    - metadata:
+        annotations:
+          ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses
+            1 pod as currently it supports only internal administrative api
+      name: clowder-masu
       podSpec:
         env:
         - name: CLOWDER_ENABLED
@@ -603,7 +607,15 @@ objects:
           enabled: true
         public:
           enabled: false
-    - name: clowder-scheduler
+    - metadata:
+        annotations:
+          ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses
+            1 pod as currently scheduling is a singleton
+          ignore-check.kube-linter.io/no-liveness-probe: This deployment uses celery
+            beat which does not easily support liveness checks
+          ignore-check.kube-linter.io/no-readiness-probe: This deployment uses celery
+            beat which does not easily support readiness checks
+      name: clowder-scheduler
       podSpec:
         command:
         - /bin/bash
@@ -770,7 +782,11 @@ objects:
           enabled: false
         public:
           enabled: false
-    - name: clowder-sources-client
+    - metadata:
+        annotations:
+          ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses
+            1 pod at times for cost saving purposes
+      name: clowder-sources-client
       podSpec:
         env:
         - name: CLOWDER_ENABLED
@@ -938,7 +954,12 @@ objects:
           enabled: true
         public:
           enabled: false
-    - name: clowder-sources-listener
+    - metadata:
+        annotations:
+          ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses
+            1 pod as currently sources integration requires in order message handling,
+            which can fail with multiple consumers due to race conditions
+      name: clowder-sources-listener
       podSpec:
         command:
         - /bin/bash
@@ -1109,7 +1130,11 @@ objects:
           enabled: false
         public:
           enabled: false
-    - name: clowder-worker-celery
+    - metadata:
+        annotations:
+          ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses
+            1 pod at times for cost saving purposes
+      name: clowder-worker-celery
       podSpec:
         command:
         - /bin/bash
@@ -1286,7 +1311,11 @@ objects:
           enabled: false
         public:
           enabled: false
-    - name: clowder-worker-cost-model
+    - metadata:
+        annotations:
+          ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses
+            1 pod at times for cost saving purposes
+      name: clowder-worker-cost-model
       podSpec:
         command:
         - /bin/bash
@@ -1465,7 +1494,11 @@ objects:
           enabled: false
         public:
           enabled: false
-    - name: clowder-worker-cost-model-xl
+    - metadata:
+        annotations:
+          ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses
+            1 pod at times for cost saving purposes
+      name: clowder-worker-cost-model-xl
       podSpec:
         command:
         - /bin/bash
@@ -1644,7 +1677,11 @@ objects:
           enabled: false
         public:
           enabled: false
-    - name: clowder-worker-download
+    - metadata:
+        annotations:
+          ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses
+            1 pod at times for cost saving purposes
+      name: clowder-worker-download
       podSpec:
         command:
         - /bin/bash
@@ -1821,7 +1858,11 @@ objects:
           enabled: false
         public:
           enabled: false
-    - name: clowder-worker-download-xl
+    - metadata:
+        annotations:
+          ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses
+            1 pod at times for cost saving purposes
+      name: clowder-worker-download-xl
       podSpec:
         command:
         - /bin/bash
@@ -1998,7 +2039,11 @@ objects:
           enabled: false
         public:
           enabled: false
-    - name: clowder-worker-ocp
+    - metadata:
+        annotations:
+          ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses
+            1 pod at times for cost saving purposes
+      name: clowder-worker-ocp
       podSpec:
         command:
         - /bin/bash
@@ -2177,7 +2222,11 @@ objects:
           enabled: false
         public:
           enabled: false
-    - name: clowder-worker-ocp-xl
+    - metadata:
+        annotations:
+          ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses
+            1 pod at times for cost saving purposes
+      name: clowder-worker-ocp-xl
       podSpec:
         command:
         - /bin/bash
@@ -2356,7 +2405,11 @@ objects:
           enabled: false
         public:
           enabled: false
-    - name: clowder-worker-priority
+    - metadata:
+        annotations:
+          ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses
+            1 pod at times for cost saving purposes
+      name: clowder-worker-priority
       podSpec:
         command:
         - /bin/bash
@@ -2533,7 +2586,11 @@ objects:
           enabled: false
         public:
           enabled: false
-    - name: clowder-worker-priority-xl
+    - metadata:
+        annotations:
+          ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses
+            1 pod at times for cost saving purposes
+      name: clowder-worker-priority-xl
       podSpec:
         command:
         - /bin/bash
@@ -2710,7 +2767,11 @@ objects:
           enabled: false
         public:
           enabled: false
-    - name: clowder-worker-refresh
+    - metadata:
+        annotations:
+          ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses
+            1 pod at times for cost saving purposes
+      name: clowder-worker-refresh
       podSpec:
         command:
         - /bin/bash
@@ -2889,7 +2950,11 @@ objects:
           enabled: false
         public:
           enabled: false
-    - name: clowder-worker-refresh-xl
+    - metadata:
+        annotations:
+          ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses
+            1 pod at times for cost saving purposes
+      name: clowder-worker-refresh-xl
       podSpec:
         command:
         - /bin/bash
@@ -3068,7 +3133,11 @@ objects:
           enabled: false
         public:
           enabled: false
-    - name: clowder-worker-summary
+    - metadata:
+        annotations:
+          ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses
+            1 pod at times for cost saving purposes
+      name: clowder-worker-summary
       podSpec:
         command:
         - /bin/bash
@@ -3247,7 +3316,11 @@ objects:
           enabled: false
         public:
           enabled: false
-    - name: clowder-worker-summary-xl
+    - metadata:
+        annotations:
+          ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses
+            1 pod at times for cost saving purposes
+      name: clowder-worker-summary-xl
       podSpec:
         command:
         - /bin/bash
@@ -3426,7 +3499,11 @@ objects:
           enabled: false
         public:
           enabled: false
-    - name: clowder-worker-hcs
+    - metadata:
+        annotations:
+          ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses
+            1 pod at times for cost saving purposes
+      name: clowder-worker-hcs
       podSpec:
         command:
         - /bin/bash

--- a/deploy/kustomize/patches/masu.yaml
+++ b/deploy/kustomize/patches/masu.yaml
@@ -2,6 +2,9 @@
   path: /objects/0/spec/deployments/-
   value:
     name: clowder-masu
+    metadata:
+      annotations:
+        ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses 1 pod as currently it supports only internal administrative api
     replicas: ${{MASU_REPLICAS}}
     webServices:
       public:

--- a/deploy/kustomize/patches/scheduler.yaml
+++ b/deploy/kustomize/patches/scheduler.yaml
@@ -2,6 +2,11 @@
   path: /objects/0/spec/deployments/-
   value:
     name: clowder-scheduler
+    metadata:
+      annotations:
+        ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses 1 pod as currently scheduling is a singleton
+        ignore-check.kube-linter.io/no-readiness-probe: This deployment uses celery beat which does not easily support readiness checks
+        ignore-check.kube-linter.io/no-liveness-probe: This deployment uses celery beat which does not easily support liveness checks
     replicas: ${{SCHEDULER_REPLICAS}}
     webServices:
       public:

--- a/deploy/kustomize/patches/sources-client.yaml
+++ b/deploy/kustomize/patches/sources-client.yaml
@@ -2,6 +2,9 @@
   path: /objects/0/spec/deployments/-
   value:
     name: clowder-sources-client
+    metadata:
+      annotations:
+        ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses 1 pod at times for cost saving purposes
     replicas: ${{SOURCES_CLIENT_REPLICAS}}
     webServices:
       public:

--- a/deploy/kustomize/patches/sources-listener.yaml
+++ b/deploy/kustomize/patches/sources-listener.yaml
@@ -2,6 +2,9 @@
   path: /objects/0/spec/deployments/-
   value:
     name: clowder-sources-listener
+    metadata:
+      annotations:
+        ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses 1 pod as currently sources integration requires in order message handling, which can fail with multiple consumers due to race conditions
     replicas: ${{SOURCES_LISTENER_REPLICAS}}
     webServices:
       public:

--- a/deploy/kustomize/patches/worker-celery.yaml
+++ b/deploy/kustomize/patches/worker-celery.yaml
@@ -2,6 +2,9 @@
   path: /objects/0/spec/deployments/-
   value:
     name: clowder-worker-celery
+    metadata:
+      annotations:
+        ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses 1 pod at times for cost saving purposes
     replicas: ${{WORKER_CELERY_REPLICAS}}
     webServices:
       public:

--- a/deploy/kustomize/patches/worker-cost-model-xl.yaml
+++ b/deploy/kustomize/patches/worker-cost-model-xl.yaml
@@ -2,6 +2,9 @@
   path: /objects/0/spec/deployments/-
   value:
     name: clowder-worker-cost-model-xl
+    metadata:
+      annotations:
+        ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses 1 pod at times for cost saving purposes
     replicas: ${{WORKER_COST_MODEL_XL_REPLICAS}}
     webServices:
       public:

--- a/deploy/kustomize/patches/worker-cost-model.yaml
+++ b/deploy/kustomize/patches/worker-cost-model.yaml
@@ -2,6 +2,9 @@
   path: /objects/0/spec/deployments/-
   value:
     name: clowder-worker-cost-model
+    metadata:
+      annotations:
+        ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses 1 pod at times for cost saving purposes
     replicas: ${{WORKER_COST_MODEL_REPLICAS}}
     webServices:
       public:

--- a/deploy/kustomize/patches/worker-download-xl.yaml
+++ b/deploy/kustomize/patches/worker-download-xl.yaml
@@ -2,6 +2,9 @@
   path: /objects/0/spec/deployments/-
   value:
     name: clowder-worker-download-xl
+    metadata:
+      annotations:
+        ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses 1 pod at times for cost saving purposes
     replicas: ${{WORKER_DOWNLOAD_XL_REPLICAS}}
     webServices:
       public:

--- a/deploy/kustomize/patches/worker-download.yaml
+++ b/deploy/kustomize/patches/worker-download.yaml
@@ -2,6 +2,9 @@
   path: /objects/0/spec/deployments/-
   value:
     name: clowder-worker-download
+    metadata:
+      annotations:
+        ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses 1 pod at times for cost saving purposes
     replicas: ${{WORKER_DOWNLOAD_REPLICAS}}
     webServices:
       public:

--- a/deploy/kustomize/patches/worker-hcs.yaml
+++ b/deploy/kustomize/patches/worker-hcs.yaml
@@ -2,6 +2,9 @@
   path: /objects/0/spec/deployments/-
   value:
     name: clowder-worker-hcs
+    metadata:
+      annotations:
+        ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses 1 pod at times for cost saving purposes
     replicas: ${{WORKER_HCS_REPLICAS}}
     webServices:
       public:

--- a/deploy/kustomize/patches/worker-ocp-xl.yaml
+++ b/deploy/kustomize/patches/worker-ocp-xl.yaml
@@ -2,6 +2,9 @@
   path: /objects/0/spec/deployments/-
   value:
     name: clowder-worker-ocp-xl
+    metadata:
+      annotations:
+        ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses 1 pod at times for cost saving purposes
     replicas: ${{WORKER_OCP_XL_REPLICAS}}
     webServices:
       public:

--- a/deploy/kustomize/patches/worker-ocp.yaml
+++ b/deploy/kustomize/patches/worker-ocp.yaml
@@ -2,6 +2,9 @@
   path: /objects/0/spec/deployments/-
   value:
     name: clowder-worker-ocp
+    metadata:
+      annotations:
+        ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses 1 pod at times for cost saving purposes
     replicas: ${{WORKER_OCP_REPLICAS}}
     webServices:
       public:

--- a/deploy/kustomize/patches/worker-priority-xl.yaml
+++ b/deploy/kustomize/patches/worker-priority-xl.yaml
@@ -2,6 +2,9 @@
   path: /objects/0/spec/deployments/-
   value:
     name: clowder-worker-priority-xl
+    metadata:
+      annotations:
+        ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses 1 pod at times for cost saving purposes
     replicas: ${{WORKER_PRIORITY_XL_REPLICAS}}
     webServices:
       public:

--- a/deploy/kustomize/patches/worker-priority.yaml
+++ b/deploy/kustomize/patches/worker-priority.yaml
@@ -2,6 +2,9 @@
   path: /objects/0/spec/deployments/-
   value:
     name: clowder-worker-priority
+    metadata:
+      annotations:
+        ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses 1 pod at times for cost saving purposes
     replicas: ${{WORKER_PRIORITY_REPLICAS}}
     webServices:
       public:

--- a/deploy/kustomize/patches/worker-refresh-xl.yaml
+++ b/deploy/kustomize/patches/worker-refresh-xl.yaml
@@ -2,6 +2,9 @@
   path: /objects/0/spec/deployments/-
   value:
     name: clowder-worker-refresh-xl
+    metadata:
+      annotations:
+        ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses 1 pod at times for cost saving purposes
     replicas: ${{WORKER_REFRESH_XL_REPLICAS}}
     webServices:
       public:

--- a/deploy/kustomize/patches/worker-refresh.yaml
+++ b/deploy/kustomize/patches/worker-refresh.yaml
@@ -2,6 +2,9 @@
   path: /objects/0/spec/deployments/-
   value:
     name: clowder-worker-refresh
+    metadata:
+      annotations:
+        ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses 1 pod at times for cost saving purposes
     replicas: ${{WORKER_REFRESH_REPLICAS}}
     webServices:
       public:

--- a/deploy/kustomize/patches/worker-summary-xl.yaml
+++ b/deploy/kustomize/patches/worker-summary-xl.yaml
@@ -2,6 +2,9 @@
   path: /objects/0/spec/deployments/-
   value:
     name: clowder-worker-summary-xl
+    metadata:
+      annotations:
+        ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses 1 pod at times for cost saving purposes
     replicas: ${{WORKER_SUMMARY_XL_REPLICAS}}
     webServices:
       public:

--- a/deploy/kustomize/patches/worker-summary.yaml
+++ b/deploy/kustomize/patches/worker-summary.yaml
@@ -2,6 +2,9 @@
   path: /objects/0/spec/deployments/-
   value:
     name: clowder-worker-summary
+    metadata:
+      annotations:
+        ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses 1 pod at times for cost saving purposes
     replicas: ${{WORKER_SUMMARY_REPLICAS}}
     webServices:
       public:


### PR DESCRIPTION
## Jira Ticket

[COST-2665](https://issues.redhat.com/browse/COST-2665)

## Description

This change will ...

* Moved annotations up to spec level
* Left existing pod level annotations as it seems to have applied for older versions

See: https://github.com/RedHatInsights/clowder/pull/729

## Testing

1. Deploy PR to ephemeral environment with bonfire
```
bonfire namespace reserve --duration 24h
bonfire deploy hccm --set-template-ref koku=cost-2665-kube-lint-ignore --set-parameter koku/IMAGE_TAG=pr-4548-latest   --no-remove-resources koku \
  --no-remove-resources presto \
  --no-remove-resources hive-metastore
```
2. Note annotations on deployments.