### PR TITLE
[COST-3984] Do not update summary tables if there are no AWS bills

### DIFF
--- a/koku/masu/processor/ocp/ocp_cloud_parquet_summary_updater.py
+++ b/koku/masu/processor/ocp/ocp_cloud_parquet_summary_updater.py
@@ -261,7 +261,7 @@ class OCPCloudParquetReportSummaryUpdater(PartitionHandlerMixin, OCPCloudUpdater
                 end_date,
             )
 
-            aws_bill_ids = [str(bill.id) for bill in aws_bills]
+            aws_bill_ids = [bill.id for bill in aws_bills]
             current_aws_bill_id = aws_bill_ids[0] if aws_bills else None
             current_ocp_report_period_id = report_period.id
 

--- a/koku/masu/processor/ocp/ocp_cloud_parquet_summary_updater.py
+++ b/koku/masu/processor/ocp/ocp_cloud_parquet_summary_updater.py
@@ -262,7 +262,7 @@ class OCPCloudParquetReportSummaryUpdater(PartitionHandlerMixin, OCPCloudUpdater
             )
 
             aws_bill_ids = [bill.id for bill in aws_bills]
-            current_aws_bill_id = aws_bill_ids[0] if aws_bills else None
+            current_aws_bill_id = aws_bill_ids[0]
             current_ocp_report_period_id = report_period.id
 
         with CostModelDBAccessor(self._schema, aws_provider_uuid) as cost_model_accessor:

--- a/koku/masu/processor/ocp/ocp_cloud_parquet_summary_updater.py
+++ b/koku/masu/processor/ocp/ocp_cloud_parquet_summary_updater.py
@@ -14,6 +14,7 @@ from django_tenants.utils import schema_context
 from api.common import log_json
 from api.metrics.constants import DEFAULT_DISTRIBUTION_TYPE
 from api.provider.models import Provider
+from api.provider.provider_manager import ProviderManager
 from api.utils import DateHelper
 from koku.pg_partition import PartitionHandlerMixin
 from masu.database.aws_report_db_accessor import AWSReportDBAccessor
@@ -173,6 +174,11 @@ class OCPCloudParquetReportSummaryUpdater(PartitionHandlerMixin, OCPCloudUpdater
 
         """
         if infra_provider_type in (Provider.PROVIDER_AWS, Provider.PROVIDER_AWS_LOCAL):
+            # Do not attempt any processing if there is no available data
+            manager = ProviderManager(infra_provider_uuid)
+            if not manager.get_current_month_data_exists():
+                return
+
             self.update_aws_summary_tables(ocp_provider_uuid, infra_provider_uuid, start_date, end_date)
         elif infra_provider_type in (Provider.PROVIDER_AZURE, Provider.PROVIDER_AZURE_LOCAL):
             self.update_azure_summary_tables(ocp_provider_uuid, infra_provider_uuid, start_date, end_date)

--- a/koku/masu/processor/ocp/ocp_cloud_parquet_summary_updater.py
+++ b/koku/masu/processor/ocp/ocp_cloud_parquet_summary_updater.py
@@ -226,6 +226,16 @@ class OCPCloudParquetReportSummaryUpdater(PartitionHandlerMixin, OCPCloudUpdater
         aws_bills = aws_get_bills_from_provider(aws_provider_uuid, self._schema, start_date, end_date)
         if not aws_bills:
             # Without bill data, we cannot populate the summary table
+            LOG.info(
+                log_json(
+                    msg="no AWS bill data found - skipping AWS summary table update",
+                    schema_name=self._schema,
+                    start_date=start_date,
+                    end_date=end_date,
+                    source_uuid=aws_provider_uuid,
+                    cluster_id=cluster_id,
+                )
+            )
             return
 
         with schema_context(self._schema):

--- a/koku/masu/processor/ocp/ocp_cloud_parquet_summary_updater.py
+++ b/koku/masu/processor/ocp/ocp_cloud_parquet_summary_updater.py
@@ -262,7 +262,7 @@ class OCPCloudParquetReportSummaryUpdater(PartitionHandlerMixin, OCPCloudUpdater
             )
 
             aws_bill_ids = [str(bill.id) for bill in aws_bills]
-            current_aws_bill_id = aws_bills.first().id if aws_bills else None
+            current_aws_bill_id = aws_bill_ids[0] if aws_bills else None
             current_ocp_report_period_id = report_period.id
 
         with CostModelDBAccessor(self._schema, aws_provider_uuid) as cost_model_accessor:

--- a/koku/masu/test/processor/ocp/test_ocp_cloud_parquet_report_summary_updater.py
+++ b/koku/masu/test/processor/ocp/test_ocp_cloud_parquet_report_summary_updater.py
@@ -78,14 +78,9 @@ class OCPCloudParquetReportSummaryUpdaterTest(MasuTestCase):
         mock_cluster_info,
     ):
         """Test that summary tables are properly run for an OCP provider."""
-        fake_bills = MagicMock()
-        fake_bills.__iter__.return_value = [Mock(), Mock()]
-        first = Mock()
-        bill_id = 1
-        first.return_value.id = bill_id
+        fake_bills = [Mock(id=1), Mock(id=2)]
         # this is a yes or no check so true is fine
         mock_cluster_info.return_value = True
-        fake_bills.first = first
         mock_utility.return_value = fake_bills
         start_date = self.dh.today.date()
         end_date = start_date + datetime.timedelta(days=1)
@@ -106,7 +101,7 @@ class OCPCloudParquetReportSummaryUpdaterTest(MasuTestCase):
             self.ocpaws_provider_uuid,
             self.aws_test_provider_uuid,
             current_ocp_report_period_id,
-            bill_id,
+            1,
             decimal.Decimal(0),
             DEFAULT_DISTRIBUTION_TYPE,
         )

--- a/koku/masu/test/processor/ocp/test_ocp_cloud_parquet_report_summary_updater.py
+++ b/koku/masu/test/processor/ocp/test_ocp_cloud_parquet_report_summary_updater.py
@@ -43,37 +43,17 @@ class OCPCloudParquetReportSummaryUpdaterTest(MasuTestCase):
     @patch("masu.processor.ocp.ocp_cloud_parquet_summary_updater.OCPReportDBAccessor.get_cluster_for_provider")
     @patch("masu.processor.ocp.ocp_cloud_updater_base.OCPCloudUpdaterBase.get_infra_map_from_providers")
     @patch(
-        "masu.processor.ocp.ocp_cloud_parquet_summary_updater.AWSReportDBAccessor.populate_ocp_on_aws_tags_summary_table"  # noqa: E501
-    )
-    @patch(
         "masu.processor.ocp.ocp_cloud_parquet_summary_updater.AWSReportDBAccessor.populate_ocp_on_aws_ui_summary_tables_trino"  # noqa: E501
     )
     @patch(
         "masu.processor.ocp.ocp_cloud_parquet_summary_updater.AWSReportDBAccessor.populate_ocp_on_aws_cost_daily_summary_trino"  # noqa: E501
     )
-    @patch(
-        "masu.processor.ocp.ocp_cloud_parquet_summary_updater.OCPReportDBAccessor.populate_ocp_on_all_ui_summary_tables"  # noqa: E501
-    )
-    @patch(
-        "masu.processor.ocp.ocp_cloud_parquet_summary_updater.OCPReportDBAccessor.populate_ocp_on_all_daily_summary"  # noqa: E501
-    )
-    @patch(
-        "masu.processor.ocp.ocp_cloud_parquet_summary_updater.OCPReportDBAccessor.populate_ocp_on_all_project_daily_summary"  # noqa: E501
-    )
-    @patch(
-        "masu.processor.ocp.ocp_cloud_parquet_summary_updater.GCPReportDBAccessor.delete_line_item_daily_summary_entries_for_date_range_raw"  # noqa: E501
-    )
     @patch("masu.processor.ocp.ocp_cloud_parquet_summary_updater.aws_get_bills_from_provider")
     def test_update_aws_summary_tables(
         self,
         mock_utility,
-        mock_delete,
-        mock_ocpall_proj_summ,
-        mock_ocpall_summ,
-        mock_ocpall_persp,
         mock_ocp_on_aws,
         mock_ui_summary,
-        mock_tag_summary,
         mock_map,
         mock_cluster_info,
     ):

--- a/koku/masu/util/aws/common.py
+++ b/koku/masu/util/aws/common.py
@@ -7,6 +7,7 @@ import datetime
 import logging
 import re
 import time
+import typing as t
 import uuid
 from itertools import chain
 
@@ -25,6 +26,7 @@ from masu.database.aws_report_db_accessor import AWSReportDBAccessor
 from masu.database.provider_db_accessor import ProviderDBAccessor
 from masu.util import common as utils
 from masu.util.ocp.common import match_openshift_labels
+from reporting.provider.aws.models import AWSCostEntryBill
 
 LOG = logging.getLogger(__name__)
 
@@ -331,7 +333,12 @@ def get_account_names_by_organization(arn, session=None):
     return all_accounts
 
 
-def get_bills_from_provider(provider_uuid, schema, start_date=None, end_date=None):
+def get_bills_from_provider(
+    provider_uuid: str,
+    schema: str,
+    start_date: t.Union[datetime.datetime, str] = None,
+    end_date: t.Union[datetime.datetime, str] = None,
+) -> list[AWSCostEntryBill]:
     """
     Return the AWS bill IDs given a provider UUID.
 
@@ -372,7 +379,8 @@ def get_bills_from_provider(provider_uuid, schema, start_date=None, end_date=Non
                 bills = bills.filter(billing_period_start__gte=start_date)
             if end_date:
                 bills = bills.filter(billing_period_start__lte=end_date)
-            bills = bills.all()
+
+            bills = list(bills.all())
 
     return bills
 

--- a/koku/masu/util/azure/common.py
+++ b/koku/masu/util/azure/common.py
@@ -103,7 +103,8 @@ def get_bills_from_provider(provider_uuid, schema, start_date=None, end_date=Non
                 bills = bills.filter(billing_period_start__gte=start_date)
             if end_date:
                 bills = bills.filter(billing_period_start__lte=end_date)
-            bills = bills.all()
+
+            bills = list(bills.all())
 
     return bills
 

--- a/koku/masu/util/gcp/common.py
+++ b/koku/masu/util/gcp/common.py
@@ -61,7 +61,8 @@ def get_bills_from_provider(provider_uuid, schema, start_date=None, end_date=Non
             bills = bills.filter(billing_period_start__gte=start_date)
         if end_date:
             bills = bills.filter(billing_period_start__lte=end_date)
-        bills = bills.all()
+
+        bills = list(bills.all())
 
     return bills
 

--- a/koku/masu/util/oci/common.py
+++ b/koku/masu/util/oci/common.py
@@ -60,7 +60,8 @@ def get_bills_from_provider(provider_uuid, schema, start_date=None, end_date=Non
                 bills = bills.filter(billing_period_start__gte=start_date)
             if end_date:
                 bills = bills.filter(billing_period_start__lte=end_date)
-            bills = bills.all()
+
+            bills = list(bills.all())
 
     return bills
 


### PR DESCRIPTION
## Jira Ticket

[COST-3984](https://issues.redhat.com/browse/COST-3984)

## Description

Skip updating the AWS summary tables if we don't have AWS bill data.

## Testing
 
TBD

## Notes

Instead of stopping _all_ processing, only skip the summary tables update. The markup cost and UI summary tables will still be updated. We had some discussion and are thinking that will be ok.
