### PR TITLE
add pid to log messages

### DIFF
--- a/koku/koku/settings.py
+++ b/koku/koku/settings.py
@@ -359,7 +359,7 @@ VERBOSE_FORMATTING = (
     "%(task_id)s %(task_parent_id)s %(task_root_id)s "
     "%(message)s"
 )
-SIMPLE_FORMATTING = "[%(asctime)s] %(levelname)s %(task_root_id)s %(message)s"
+SIMPLE_FORMATTING = "[%(asctime)s] %(levelname)s %(task_root_id)s %(process)d %(message)s"
 
 LOG_DIRECTORY = ENVIRONMENT.get_value("LOG_DIRECTORY", default=BASE_DIR)
 DEFAULT_LOG_FILE = os.path.join(LOG_DIRECTORY, "app.log")


### PR DESCRIPTION
## Description

This change will add the pid number to log messages. See:
```
[2023-07-08 20:02:36,414] INFO None 10 Booting worker with pid: 10
[2023-07-08 20:02:36,415] INFO None 10 Initializing UNLEASH_CLIENT for gunicorn worker.
[2023-07-08 20:02:36,504] INFO None 12 Booting worker with pid: 12
[2023-07-08 20:02:36,505] INFO None 12 Initializing UNLEASH_CLIENT for gunicorn worker.
[2023-07-08 20:02:36,604] INFO None 14 Booting worker with pid: 14
[2023-07-08 20:02:36,606] INFO None 14 Initializing UNLEASH_CLIENT for gunicorn worker.
```
The number between `None` and the log message is the pid number. This will help us to understand what api queries are being performed when a gunicorn worker times-out.
