### PR TITLE
[COST-3963] Fix Azure annotation of subscription name when group_by present and not ordered by name

### DIFF
--- a/koku/api/report/azure/query_handler.py
+++ b/koku/api/report/azure/query_handler.py
@@ -151,6 +151,11 @@ class AzureReportQueryHandler(ReportQueryHandler):
             query_data = query.values(*query_group_by).annotate(**annotations)
             query_sum = self._build_sum(query)
 
+            if "subscription_guid" in query_group_by and not annotations.get("subscription_name"):
+                query_data = query_data.annotate(
+                    subscription_name=Coalesce(F(self._mapper.provider_map.get("alias")), "subscription_guid")
+                )
+
             if self._limit and query_data:
                 query_data = self._group_by_ranks(query, query_data)
                 if not self.parameters.get("order_by"):


### PR DESCRIPTION
## Jira Ticket

[COST-3963](https://issues.redhat.com/browse/COST-3963)

## Description

This change will ...
* Add annotation when not already present and subscription_guid applied


## Testing

1. Checkout Branch
2. Restart Koku
3. Load customer data
```
make create-test-customer
make load-test-customer-data test_source=azure
```
4. Hit endpoint `http://localhost:8000/api/cost-management/v1/reports/azure/costs/?currency=USD&delta=cost&filter[limit]=10&filter[offset]=0&filter[resolution]=monthly&filter[time_scope_units]=month&filter[time_scope_value]=-1&group_by[subscription_guid]=*&order_by[subscription_name]=asc`
    1. You should see subscription data ordered by subscription name
5. Hit endpoint `http://localhost:8000/api/cost-management/v1/reports/azure/costs/?currency=USD&delta=cost&filter[limit]=10&filter[offset]=0&filter[resolution]=monthly&filter[time_scope_units]=month&filter[time_scope_value]=-1&group_by[subscription_guid]=*&order_by[subscription_name]=desc`
    1. You should see subscription data ordered by subscription name in the reverse order as before
6. Hit endpoint `http://localhost:8000/api/cost-management/v1/reports/azure/costs/?currency=USD&delta=cost&filter[limit]=10&filter[offset]=0&filter[resolution]=monthly&filter[time_scope_units]=month&filter[time_scope_value]=-1&group_by[subscription_guid]=*&order_by[cost]=desc`
    1. You should see subscription data still including subscription name