### PR TITLE
use `inclause` sqljinja filter in templates

### DIFF
--- a/koku/masu/database/sql/gcp/openshift/reporting_ocpgcptags_summary.sql
+++ b/koku/masu/database/sql/gcp/openshift/reporting_ocpgcptags_summary.sql
@@ -15,11 +15,7 @@ WITH cte_tag_value AS (
         AND value IS NOT NULL
         AND li.tags ?| (SELECT array_agg(DISTINCT key) FROM {{schema | sqlsafe}}.reporting_gcpenabledtagkeys WHERE enabled=true)
     {% if bill_ids %}
-        AND li.cost_entry_bill_id IN (
-        {%- for bill_id in bill_ids -%}
-        {{bill_id}}{% if not loop.last %},{% endif %}
-        {%- endfor -%}
-    )
+        AND li.cost_entry_bill_id IN {{ bill_ids | inclause }}
     {% endif %}
     GROUP BY key, value, li.cost_entry_bill_id, li.account_id, li.project_id, li.project_name, li.report_period_id, li.namespace, li.node
 ),

--- a/koku/masu/database/sql/oci/reporting_ocicostentryline_item_daily_summary_update_enabled_tags.sql
+++ b/koku/masu/database/sql/oci/reporting_ocicostentryline_item_daily_summary_update_enabled_tags.sql
@@ -11,9 +11,6 @@ update {{schema | sqlsafe}}.reporting_ocicostentrylineitem_daily_summary as lids
    and lids.usage_start >= date({{start_date}})
    and lids.usage_start <= date({{end_date}})
 {% if bill_ids %}
-   and lids.cost_entry_bill_id IN (
-       {%- for bill_id in bill_ids  -%}
-           {{bill_id}}{% if not loop.last %},{% endif %}
-       {%- endfor -%})
+   and lids.cost_entry_bill_id IN {{ bill_ids | inclause }}
 {% endif %}
 ;

--- a/koku/masu/database/sql/oci/reporting_ocienabledtagkeys.sql
+++ b/koku/masu/database/sql/oci/reporting_ocienabledtagkeys.sql
@@ -5,11 +5,7 @@ SELECT DISTINCT(key)
  WHERE lids.usage_start >= date({{start_date}})
    AND lids.usage_start <= date({{end_date}})
    {% if bill_ids %}
-   AND lids.cost_entry_bill_id IN (
-        {%- for bill_id in bill_ids -%}
-          {{bill_id}}{% if not loop.last %},{% endif %}
-        {%- endfor -%}
-       )
+      AND lids.cost_entry_bill_id IN {{ bill_ids | inclause }}
    {% endif %}
    AND NOT EXISTS (
         SELECT key

--- a/koku/masu/database/sql/oci/reporting_ocitags_summary.sql
+++ b/koku/masu/database/sql/oci/reporting_ocitags_summary.sql
@@ -9,11 +9,7 @@ WITH cte_tag_value AS (
         AND li.usage_start <= {{end_date}}
         AND li.tags ?| (SELECT array_agg(DISTINCT key) FROM {{schema | sqlsafe}}.reporting_ocienabledtagkeys WHERE enabled=true)
     {% if bill_ids %}
-        AND li.cost_entry_bill_id IN (
-        {%- for bill_id in bill_ids -%}
-        {{bill_id}}{% if not loop.last %},{% endif %}
-        {%- endfor -%}
-    )
+        AND li.cost_entry_bill_id IN {{ bill_ids | inclause }}
     {% endif %}
     GROUP BY key, value, li.cost_entry_bill_id, li.payer_tenant_id
 ),

--- a/koku/masu/database/sql/reporting_awscategory_summary.sql
+++ b/koku/masu/database/sql/reporting_awscategory_summary.sql
@@ -18,11 +18,7 @@ WITH cte_category_value AS (
         AND li.usage_start <= {{end_date}}
         AND li.cost_category ?| (SELECT array_agg(DISTINCT key) FROM {{schema | sqlsafe}}.reporting_awsenabledcategorykeys WHERE enabled=true)
     {% if bill_ids %}
-        AND li.cost_entry_bill_id IN (
-        {%- for bill_id in bill_ids -%}
-        {{bill_id}}{% if not loop.last %},{% endif %}
-        {%- endfor -%}
-    )
+        AND li.cost_entry_bill_id IN {{ bill_ids | inclause }}
     {% endif %}
     GROUP BY key, value, li.cost_entry_bill_id, li.usage_account_id
 ),

--- a/koku/masu/database/sql/reporting_awscostentryline_item_daily_summary_update_enabled_tags.sql
+++ b/koku/masu/database/sql/reporting_awscostentryline_item_daily_summary_update_enabled_tags.sql
@@ -11,9 +11,6 @@ update {{schema | sqlsafe}}.reporting_awscostentrylineitem_daily_summary as lids
    and lids.usage_start >= date({{start_date}})
    and lids.usage_start <= date({{end_date}})
 {% if bill_ids %}
-   and lids.cost_entry_bill_id IN (
-       {%- for bill_id in bill_ids  -%}
-           {{bill_id}}{% if not loop.last %},{% endif %}
-       {%- endfor -%})
+   and lids.cost_entry_bill_id in {{ bill_ids | inclause }}
 {% endif %}
 ;

--- a/koku/masu/database/sql/reporting_awsenabledtagkeys.sql
+++ b/koku/masu/database/sql/reporting_awsenabledtagkeys.sql
@@ -5,11 +5,7 @@ SELECT DISTINCT(key)
  WHERE lids.usage_start >= date({{start_date}})
    AND lids.usage_start <= date({{end_date}})
    {% if bill_ids %}
-   AND lids.cost_entry_bill_id IN (
-        {%- for bill_id in bill_ids -%}
-          {{bill_id}}{% if not loop.last %},{% endif %}
-        {%- endfor -%}
-       )
+      AND lids.cost_entry_bill_id IN {{ bill_ids | inclause }}
    {% endif %}
    AND NOT EXISTS (
         SELECT key

--- a/koku/masu/database/sql/reporting_awstags_summary.sql
+++ b/koku/masu/database/sql/reporting_awstags_summary.sql
@@ -9,11 +9,7 @@ WITH cte_tag_value AS (
         AND li.usage_start <= {{end_date}}
         AND li.tags ?| (SELECT array_agg(DISTINCT key) FROM {{schema | sqlsafe}}.reporting_awsenabledtagkeys WHERE enabled=true)
     {% if bill_ids %}
-        AND li.cost_entry_bill_id IN (
-        {%- for bill_id in bill_ids -%}
-        {{bill_id}}{% if not loop.last %},{% endif %}
-        {%- endfor -%}
-    )
+        AND li.cost_entry_bill_id IN {{ bill_ids | inclause }}
     {% endif %}
     GROUP BY key, value, li.cost_entry_bill_id, li.usage_account_id
 ),

--- a/koku/masu/database/sql/reporting_azurecostentryline_item_daily_summary_update_enabled_tags.sql
+++ b/koku/masu/database/sql/reporting_azurecostentryline_item_daily_summary_update_enabled_tags.sql
@@ -11,9 +11,6 @@ update {{schema | sqlsafe}}.reporting_azurecostentrylineitem_daily_summary as li
    and lids.usage_start >= date({{start_date}})
    and lids.usage_start <= date({{end_date}})
 {% if bill_ids %}
-   and lids.cost_entry_bill_id IN (
-       {%- for bill_id in bill_ids  -%}
-           {{bill_id}}{% if not loop.last %},{% endif %}
-       {%- endfor -%})
+   and lids.cost_entry_bill_id in {{ bill_ids | inclause }}
 {% endif %}
 ;

--- a/koku/masu/database/sql/reporting_azureenabledtagkeys.sql
+++ b/koku/masu/database/sql/reporting_azureenabledtagkeys.sql
@@ -5,11 +5,7 @@ SELECT DISTINCT(key)
  WHERE lids.usage_start >= date({{start_date}})
    AND lids.usage_start <= date({{end_date}})
    {% if bill_ids %}
-   AND lids.cost_entry_bill_id IN (
-       {%- for bill_id in bill_ids -%}
-         {{bill_id}}{% if not loop.last %},{% endif %}
-       {%- endfor -%}
-       )
+      AND lids.cost_entry_bill_id IN {{ bill_ids | inclause }}
    {% endif %}
    AND NOT EXISTS (
          SELECT key

--- a/koku/masu/database/sql/reporting_azuretags_summary.sql
+++ b/koku/masu/database/sql/reporting_azuretags_summary.sql
@@ -10,11 +10,7 @@ WITH cte_tag_value AS (
         AND li.usage_start <= {{end_date}}
         AND li.tags ?| (SELECT array_agg(DISTINCT key) FROM {{schema | sqlsafe}}.reporting_azureenabledtagkeys WHERE enabled=true)
     {% if bill_ids %}
-        AND li.cost_entry_bill_id IN (
-        {%- for bill_id in bill_ids -%}
-        {{bill_id}}{% if not loop.last %},{% endif %}
-        {%- endfor -%}
-    )
+        AND li.cost_entry_bill_id IN {{ bill_ids | inclause }}
     {% endif %}
     GROUP BY key, value, li.cost_entry_bill_id, li.subscription_guid
 ),

--- a/koku/masu/database/sql/reporting_gcpcostentryline_item_daily_summary_update_enabled_tags.sql
+++ b/koku/masu/database/sql/reporting_gcpcostentryline_item_daily_summary_update_enabled_tags.sql
@@ -11,9 +11,6 @@ update {{schema | sqlsafe}}.reporting_gcpcostentrylineitem_daily_summary as lids
    and lids.usage_start >= date({{start_date}})
    and lids.usage_start <= date({{end_date}})
 {% if bill_ids %}
-   and lids.cost_entry_bill_id IN (
-       {%- for bill_id in bill_ids  -%}
-           {{bill_id}}{% if not loop.last %},{% endif %}
-       {%- endfor -%})
+   and lids.cost_entry_bill_id in {{ bill_ids | inclause }}
 {% endif %}
 ;

--- a/koku/masu/database/sql/reporting_gcpenabledtagkeys.sql
+++ b/koku/masu/database/sql/reporting_gcpenabledtagkeys.sql
@@ -5,11 +5,7 @@ SELECT DISTINCT(key)
  WHERE lids.usage_start >= date({{start_date}})
    AND lids.usage_start <= date({{end_date}})
    {% if bill_ids %}
-   AND lids.cost_entry_bill_id IN (
-       {%- for bill_id in bill_ids -%}
-         {{bill_id}}{% if not loop.last %},{% endif %}
-       {%- endfor -%}
-       )
+      AND lids.cost_entry_bill_id IN {{ bill_ids | inclause }}
    {% endif %}
    AND NOT EXISTS (
          SELECT key

--- a/koku/masu/database/sql/reporting_gcptags_summary.sql
+++ b/koku/masu/database/sql/reporting_gcptags_summary.sql
@@ -12,11 +12,7 @@ WITH cte_tag_value AS (
         AND value IS NOT NULL
         AND li.tags ?| (SELECT array_agg(DISTINCT key) FROM {{schema | sqlsafe}}.reporting_gcpenabledtagkeys WHERE enabled=true)
     {% if bill_ids %}
-        AND li.cost_entry_bill_id IN (
-        {%- for bill_id in bill_ids -%}
-        {{bill_id}}{% if not loop.last %},{% endif %}
-        {%- endfor -%}
-    )
+        AND li.cost_entry_bill_id IN {{ bill_ids | inclause }}
     {% endif %}
     GROUP BY key, value, li.cost_entry_bill_id, li.account_id, li.project_id, li.project_name
 ),

--- a/koku/masu/database/sql/reporting_ocpawstags_summary.sql
+++ b/koku/masu/database/sql/reporting_ocpawstags_summary.sql
@@ -13,11 +13,7 @@ WITH cte_tag_value AS (
         AND li.usage_start <= {{end_date}}
         AND li.tags ?| (SELECT array_agg(DISTINCT key) FROM {{schema | sqlsafe}}.reporting_awsenabledtagkeys WHERE enabled=true)
     {% if bill_ids %}
-        AND li.cost_entry_bill_id IN (
-        {%- for bill_id in bill_ids -%}
-        {{bill_id}}{% if not loop.last %},{% endif %}
-        {%- endfor -%}
-    )
+        AND li.cost_entry_bill_id IN {{ bill_ids | inclause }}
     {% endif %}
     GROUP BY key, value, li.cost_entry_bill_id, li.usage_account_id, li.report_period_id, li.namespace, li.node
 ),

--- a/koku/masu/database/sql/reporting_ocpazuretags_summary.sql
+++ b/koku/masu/database/sql/reporting_ocpazuretags_summary.sql
@@ -12,11 +12,7 @@ WITH cte_tag_value AS (
         AND li.usage_start <= {{end_date}}
         AND li.tags ?| (SELECT array_agg(DISTINCT key) FROM {{schema | sqlsafe}}.reporting_azureenabledtagkeys WHERE enabled=true)
     {% if bill_ids %}
-        AND li.cost_entry_bill_id IN (
-        {%- for bill_id in bill_ids -%}
-        {{bill_id}}{% if not loop.last %},{% endif %}
-        {%- endfor -%}
-    )
+        AND li.cost_entry_bill_id IN {{ bill_ids | inclause }}
     {% endif %}
     GROUP BY key, value, li.cost_entry_bill_id, li.subscription_guid, li.report_period_id, li.namespace, li.node
 ),

--- a/koku/masu/database/sql/reporting_ocpstoragevolumelabel_summary.sql
+++ b/koku/masu/database/sql/reporting_ocpstoragevolumelabel_summary.sql
@@ -8,11 +8,7 @@ create table {{schema | sqlsafe}}.cte_tag_value_{{uuid | sqlsafe}} as
         jsonb_each_text(li.volume_labels) labels
     WHERE li.data_source = 'Storage'
     {% if report_period_ids %}
-        AND li.report_period_id IN (
-        {%- for report_period_id in report_period_ids -%}
-        {{report_period_id}}{% if not loop.last %},{% endif %}
-        {%- endfor -%}
-    )
+        AND li.report_period_id IN {{ report_period_ids | inclause }}
     {% endif %}
         AND li.usage_start >= {{start_date}}
         AND li.usage_start <= {{end_date}}

--- a/koku/masu/database/sql/reporting_ocpusagelineitem_daily_summary_update_enabled_tags.sql
+++ b/koku/masu/database/sql/reporting_ocpusagelineitem_daily_summary_update_enabled_tags.sql
@@ -19,9 +19,6 @@ from cte_enabled_keys as ek
         and lids.usage_start >= date({{start_date}})
         and lids.usage_start <= date({{end_date}})
         {% if report_period_ids %}
-            and lids.report_period_id IN (
-                {%- for rp_id in report_period_ids  -%}
-                    {{rp_id}}{% if not loop.last %},{% endif %}
-                {%- endfor -%})
+            and lids.report_period_id IN {{ report_period_ids | inclause }}
         {% endif %}
 ;

--- a/koku/masu/database/sql/reporting_ocpusagepodlabel_summary.sql
+++ b/koku/masu/database/sql/reporting_ocpusagepodlabel_summary.sql
@@ -8,11 +8,7 @@ create table {{schema | sqlsafe}}.cte_tag_value_{{uuid | sqlsafe}} AS
         jsonb_each_text(li.pod_labels) labels
     WHERE li.data_source = 'Pod'
     {% if report_period_ids %}
-        AND li.report_period_id IN (
-        {%- for report_period_id in report_period_ids -%}
-        {{report_period_id}}{% if not loop.last %},{% endif %}
-        {%- endfor -%}
-        )
+        AND li.report_period_id IN {{ report_period_ids | inclause }}
     {% endif %}
         AND li.usage_start >= {{start_date}}
         AND li.usage_start <= {{end_date}}


### PR DESCRIPTION
## Description

This change will make use of the `inclause` jinjasql jinja filter. This is purely for convenience and makes the template easier to read.
