### PR TITLE
[COST-4002] Add check for provider in source status flow

### DIFF
--- a/koku/providers/provider_errors.py
+++ b/koku/providers/provider_errors.py
@@ -16,6 +16,7 @@ class ProviderErrors:
     INVALID_SOURCE_TYPE = "source_type"
     DUPLICATE_AUTH = "source.duplicate"
     BILLING_SOURCE = "billing_source"
+    PROVIDER_NOT_FOUND = "source.provider"
 
     AWS_NO_REPORT_FOUND = "authentication.role_arn.noreportfound"
     AWS_REPORT_CONFIG = "aws.report.configuration"

--- a/koku/sources/test/api/test_source_status.py
+++ b/koku/sources/test/api/test_source_status.py
@@ -145,11 +145,12 @@ class SourcesStatusTest(IamTestCase):
 
             with patch.object(ProviderAccessor, "cost_usage_source_ready", returns=True):
                 with patch.object(SourceStatus, "update_source_name", returns=True):
-                    status_obj = SourceStatus(test_source_id)
-                    status_obj.push_status()
-                    mock_set_source_status.assert_called()
-                    mock_create_account.assert_called()
-                    mock_update_account.assert_not_called()
+                    with patch.object(SourceStatus, "_set_provider_active_status", returns=True):
+                        status_obj = SourceStatus(test_source_id)
+                        status_obj.push_status()
+                        mock_set_source_status.assert_called()
+                        mock_create_account.assert_called()
+                        mock_update_account.assert_not_called()
 
     @patch("sources.api.source_status.SourcesProviderCoordinator.create_account")
     @patch("sources.api.source_status.SourcesProviderCoordinator.update_account")
@@ -175,11 +176,12 @@ class SourcesStatusTest(IamTestCase):
 
             with patch.object(ProviderAccessor, "cost_usage_source_ready", returns=True):
                 with patch.object(SourceStatus, "update_source_name", returns=True):
-                    status_obj = SourceStatus(test_source_id)
-                    status_obj.push_status()
-                    mock_set_source_status.assert_called()
-                    mock_create_account.assert_not_called()
-                    mock_update_account.assert_called()
+                    with patch.object(SourceStatus, "_set_provider_active_status", returns=True):
+                        status_obj = SourceStatus(test_source_id)
+                        status_obj.push_status()
+                        mock_set_source_status.assert_called()
+                        mock_create_account.assert_not_called()
+                        mock_update_account.assert_called()
 
     @patch("sources.api.source_status.SourcesHTTPClient.set_source_status")
     def test_push_status_second_gcp_table_discovery(self, mock_set_source_status):


### PR DESCRIPTION
## Jira Ticket

[COST-4002](https://issues.redhat.com/browse/COST-4002)

## Description

This change will add a check to our source status flow to check if a provider was created on the cost side and set a message based on that result

## Testing

1. Checkout Branch
2. Restart Koku
3. CHEAT method: Create source/provider (make create test customer)
4. delete provider from table
- delete from reporting_tenant_api_provider;
- delete from api_provider;
7. manually trigger the source status checks
- python koku/manage.py shell
- from sources.api.source_status import SourceStatus
- source_stat = SourceStatus(source_id='1')
- source_stat.status()
8. Should see the following

[2023-07-14 13:41:39,275] INFO None 1134663 No provider found for Source ID: 1
rest_framework.exceptions.ValidationError({'source.provider': ['Something went wrong creating your source, please try again.']})

## Notes

...
