### PR TITLE
Remove deprecation for rbac setting

### DIFF
--- a/koku/api/common/permissions/settings_access.py
+++ b/koku/api/common/permissions/settings_access.py
@@ -21,28 +21,11 @@ class SettingsAccessPermission(permissions.BasePermission):
             return False
 
         if request.method in permissions.SAFE_METHODS:
-            if request.user.access.get(self.resource_type, {}).get("read", []):
-                return True
+            # TODO: Uncomment this during deprecated setting removal
+            # if request.user.access.get(self.resource_type, {}).get("read", []):
+            return True
         else:
             setting_write = request.user.access.get(self.resource_type, {}).get("write", [])
             if "*" in setting_write:
                 return True
-        return False
-
-
-# TODO: Remove after settings switch over
-# Deprecated check:
-class DeprecatedSettingsAccessPermission(permissions.BasePermission):
-    """Determines if a user can update Settings data."""
-
-    resource_type = "settings"
-
-    def has_permission(self, request, view):
-        """Check permission to view and update settings data."""
-        if request.user.admin:
-            return True
-
-        if request.method in permissions.SAFE_METHODS:
-            return True
-
         return False

--- a/koku/api/common/permissions/settings_access.py
+++ b/koku/api/common/permissions/settings_access.py
@@ -21,9 +21,8 @@ class SettingsAccessPermission(permissions.BasePermission):
             return False
 
         if request.method in permissions.SAFE_METHODS:
-            # TODO: Uncomment this during deprecated setting removal
-            # if request.user.access.get(self.resource_type, {}).get("read", []):
-            return True
+            if request.user.access.get(self.resource_type, {}).get("read", []):
+                return True
         else:
             setting_write = request.user.access.get(self.resource_type, {}).get("write", [])
             if "*" in setting_write:

--- a/koku/api/common/permissions/test/test_settings_access.py
+++ b/koku/api/common/permissions/test/test_settings_access.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock
 
 from django.test import TestCase
 
-from api.common.permissions.settings_access import DeprecatedSettingsAccessPermission
+from api.common.permissions.settings_access import SettingsAccessPermission
 from api.iam.models import User
 
 
@@ -18,7 +18,7 @@ class SettingsAccessPermissionTest(TestCase):
         """Test that an admin user can execute."""
         user = Mock(spec=User, admin=True)
         req = Mock(user=user)
-        accessPerm = DeprecatedSettingsAccessPermission()
+        accessPerm = SettingsAccessPermission()
         result = accessPerm.has_permission(request=req, view=None)
         self.assertTrue(result)
 
@@ -26,7 +26,7 @@ class SettingsAccessPermissionTest(TestCase):
         """Test that a user read."""
         user = Mock(spec=User, admin=False)
         req = Mock(user=user, method="GET")
-        accessPerm = DeprecatedSettingsAccessPermission()
+        accessPerm = SettingsAccessPermission()
         result = accessPerm.has_permission(request=req, view=None)
         self.assertTrue(result)
 
@@ -34,6 +34,6 @@ class SettingsAccessPermissionTest(TestCase):
         """Test that a user cannot execute POST."""
         user = Mock(spec=User, admin=False)
         req = Mock(user=user, method="POST", META={"PATH_INFO": "http://localhost/api/v1/settings/"})
-        accessPerm = DeprecatedSettingsAccessPermission()
+        accessPerm = SettingsAccessPermission()
         result = accessPerm.has_permission(request=req, view=None)
         self.assertFalse(result)

--- a/koku/api/common/permissions/test/test_settings_access.py
+++ b/koku/api/common/permissions/test/test_settings_access.py
@@ -24,15 +24,15 @@ class SettingsAccessPermissionTest(TestCase):
 
     def test_has_perm_with_access_on_get(self):
         """Test that a user read."""
-        user = Mock(spec=User, admin=False)
+        user = Mock(spec=User, admin=False, access={})
         req = Mock(user=user, method="GET")
         accessPerm = SettingsAccessPermission()
         result = accessPerm.has_permission(request=req, view=None)
-        self.assertTrue(result)
+        self.assertFalse(result)
 
     def test_has_perm_with_no_access_on_post(self):
         """Test that a user cannot execute POST."""
-        user = Mock(spec=User, admin=False)
+        user = Mock(spec=User, admin=False, access={})
         req = Mock(user=user, method="POST", META={"PATH_INFO": "http://localhost/api/v1/settings/"})
         accessPerm = SettingsAccessPermission()
         result = accessPerm.has_permission(request=req, view=None)

--- a/koku/api/settings/view.py
+++ b/koku/api/settings/view.py
@@ -10,7 +10,7 @@ from rest_framework.response import Response
 from rest_framework.serializers import ValidationError
 from rest_framework.views import APIView
 
-from api.common.permissions.settings_access import DeprecatedSettingsAccessPermission
+from api.common.permissions.settings_access import SettingsAccessPermission
 from api.settings.settings import Settings
 
 SETTINGS_GENERATORS = {"settings": Settings}
@@ -21,7 +21,7 @@ class SettingsView(APIView):
     View to interact with settings for a customer.
     """
 
-    permission_classes = [DeprecatedSettingsAccessPermission]
+    permission_classes = [SettingsAccessPermission]
 
     @method_decorator(never_cache)
     def get(self, request):

--- a/koku/api/user_settings/test/test_views.py
+++ b/koku/api/user_settings/test/test_views.py
@@ -159,7 +159,7 @@ class AccountSettingsViewTestRBACTest(IamTestCase):
                 url = self.base_url + f"{acct_setting}/"
                 client = APIClient()
                 response = client.get(url, **self.headers)
-                self.assertEqual(response.status_code, status.HTTP_200_OK)
+                self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @RbacPermissions(read)
     def test_read_accesss_to_get_request(self):
@@ -190,7 +190,6 @@ class AccountSettingsViewTestRBACTest(IamTestCase):
                 response = client.put(url, data, format="json", **self.headers)
                 self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
-    # Deprecated permissions
     @RbacPermissions(write)
     def test_write_on_get_request(self):
         for acct_setting in self.account_settings:
@@ -198,7 +197,7 @@ class AccountSettingsViewTestRBACTest(IamTestCase):
                 url = self.base_url + f"{acct_setting}/"
                 client = APIClient()
                 response = client.get(url, **self.headers)
-                self.assertEqual(response.status_code, status.HTTP_200_OK)
+                self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @RbacPermissions(read_write)
     def test_read_and_write_on_get_request(self):

--- a/koku/api/user_settings/views.py
+++ b/koku/api/user_settings/views.py
@@ -18,7 +18,6 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from api.common.pagination import ListPaginator
-from api.common.permissions.settings_access import DeprecatedSettingsAccessPermission
 from api.common.permissions.settings_access import SettingsAccessPermission
 from api.provider.models import Provider
 from api.settings.utils import set_cost_type
@@ -84,12 +83,7 @@ class SettingParamsHandler:
 class AccountSettings(APIView):
     """Settings views for all user settings."""
 
-    def get_permissions(self):
-        if self.request.method.lower() == "get":
-            permission_classes = [DeprecatedSettingsAccessPermission]
-        else:
-            permission_classes = [SettingsAccessPermission]
-        return [permission() for permission in permission_classes]
+    permission_classes = [SettingsAccessPermission]
 
     def get(self, request, *args, **kwargs):
         """Gets a list of users current settings."""


### PR DESCRIPTION
## Jira Ticket

None 😓 

## Description

This change will remove unnecessary logic I added to try to keep the current settings behavior. 

Looking at console dot's config: https://github.com/RedHatInsights/cloud-services-config/blob/ci-beta/main.yml#L92-L93

You have to be an org admin to access the Cost Management DDF settings. Therefore, we can just transition to the new settings permissions without concern. 

## Testing

Log outputs:
```
koku_server         | [2023-07-14 17:40:10,840] INFO None 95 Identity: {"identity": {"account_number": "10001", "type": "User", "user": {"username": "user_dev", "email": "user_dev@foo.com", "access": {"settings": {"read": ["*"], "write": ["*"]}}}}, "entitlements": {"cost_management": {"is_entitled": "True"}}}
koku_server         | [2023-07-14 17:40:10,865] INFO None 95 {'method': 'PUT', 'path': '/api/cost-management/v1/settings/aws_category_keys/disable/', 'status': 204, 'request_id': 'DEVELOPMENT', 'account': '10001', 'org_id': '1234567', 'username': 'user_dev', 'is_admin': False, 'response_time': 29}
koku_server         | [2023-07-14 17:40:10,865] INFO None 95 "PUT /api/cost-management/v1/settings/aws_category_keys/disable/ HTTP/1.1" 204 0
koku_server         | [2023-07-14 17:40:17,813] INFO None 95 Identity: {"identity": {"account_number": "10001", "type": "User", "user": {"username": "user_dev", "email": "user_dev@foo.com", "access": {"settings": {"read": ["*"], "write": ["*"]}}}}, "entitlements": {"cost_management": {"is_entitled": "True"}}}
koku_server         | [2023-07-14 17:40:17,824] INFO None 95 {'method': 'GET', 'path': '/api/cost-management/v1/settings/aws_category_keys/', 'status': 200, 'request_id': 'DEVELOPMENT', 'account': '10001', 'org_id': '1234567', 'username': 'user_dev', 'is_admin': False, 'response_time': 10}
koku_server         | [2023-07-14 17:40:17,825] INFO None 95 "GET /api/cost-management/v1/settings/aws_category_keys/ HTTP/1.1" 200 626
koku_server         | [2023-07-14 17:40:38,769] INFO None 95 Identity: {"identity": {"account_number": "10001", "type": "User", "user": {"username": "user_dev", "email": "user_dev@foo.com", "access": {"settings": {"read": ["*"], "write": ["*"]}}}}, "entitlements": {"cost_management": {"is_entitled": "True"}}}
koku_server         | [2023-07-14 17:40:38,809] INFO None 95 {'method': 'PUT', 'path': '/api/cost-management/v1/settings/aws_category_keys/disable/', 'status': 204, 'request_id': 'DEVELOPMENT', 'account': '10001', 'org_id': '1234567', 'username': 'user_dev', 'is_admin': False, 'response_time': 42}
koku_server         | [2023-07-14 17:40:38,810] INFO None 95 "PUT /api/cost-management/v1/settings/aws_category_keys/disable/ HTTP/1.1" 204 0
koku_server         | [2023-07-14 17:40:43,628] INFO None 95 Identity: {"identity": {"account_number": "10001", "type": "User", "user": {"username": "user_dev", "email": "user_dev@foo.com", "access": {"settings": {"read": ["*"], "write": ["*"]}}}}, "entitlements": {"cost_management": {"is_entitled": "True"}}}
koku_server         | [2023-07-14 17:40:43,637] INFO None 95 {'method': 'GET', 'path': '/api/cost-management/v1/settings/aws_category_keys/', 'status': 200, 'request_id': 'DEVELOPMENT', 'account': '10001', 'org_id': '1234567', 'username': 'user_dev', 'is_admin': False, 'response_time': 9}
koku_server         | [2023-07-14 17:40:43,639] INFO None 95 "GET /api/cost-management/v1/settings/aws_category_keys/ HTTP/1.1" 200 627
koku_server         | [2023-07-14 17:40:55,603] INFO None 95 Identity: {"identity": {"account_number": "10001", "type": "User", "user": {"username": "user_dev", "email": "user_dev@foo.com", "access": {"settings": {"read": ["*"], "write": ["*"]}}}}, "entitlements": {"cost_management": {"is_entitled": "True"}}}
koku_server         | [2023-07-14 17:40:55,622] INFO None 95 {'method': 'PUT', 'path': '/api/cost-management/v1/settings/aws_category_keys/enable/', 'status': 204, 'request_id': 'DEVELOPMENT', 'account': '10001', 'org_id': '1234567', 'username': 'user_dev', 'is_admin': False, 'response_time': 18}
```

## Notes

...
