### PR TITLE
[COST-3896] bump nise version to include subs columns in test data

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -2410,11 +2410,11 @@
         },
         "koku-nise": {
             "hashes": [
-                "sha256:54f826b0b69f1e0d0e0054e4d4565fbe903ff0a9f3202e26825b23f75aaa933f",
-                "sha256:c7ad2915d8f05bd1b0e3ca18e0941dd4e894cd850e01bc97c8753875a929d6d4"
+                "sha256:7947d693713f97e6978ccb0c29cd242ba93e6af961c9e3d11ce4bb68ae588f64",
+                "sha256:efa9baba8c9ad471548ec050b3735f928b82b55fd8ebf29c409a608f907724a7"
             ],
             "index": "pypi",
-            "version": "==4.2.8"
+            "version": "==4.3.1"
         },
         "kubernetes": {
             "hashes": [

--- a/dev/scripts/nise_ymls/org_tree_aws_static_data.yml
+++ b/dev/scripts/nise_ymls/org_tree_aws_static_data.yml
@@ -15,6 +15,7 @@ generators:
       family: General Purpose
       inst_type: m5.large
       memory: 8 GiB
+      physical_cores: 1
       rate: 0.5
       storage: EBS Only
       vcpu: 2
@@ -35,6 +36,7 @@ generators:
       family: General Purpose
       inst_type: m5.large
       memory: 8 GiB
+      physical_cores: 1
       rate: 0.5
       storage: EBS Only
       vcpu: 2


### PR DESCRIPTION
## Jira Ticket

[COST-3896](https://issues.redhat.com/browse/COST-3896)

## Description

This change will bump `koku-nise` to the current version that includes SUBS columns in the generated test data, added in [#453](https://github.com/project-koku/nise/pull/453)



## Notes

...
