### PR TITLE
[COST-3585] Handle validation errors in custom filter syntax

### DIFF
--- a/koku/api/settings/test/tags/test_api.py
+++ b/koku/api/settings/test/tags/test_api.py
@@ -212,6 +212,18 @@ class TagsSettings(IamTestCase):
         self.assertEqual(enable_response.status_code, status.HTTP_400_BAD_REQUEST, enable_response.data)
         self.assertIn("invalid uuid supplied", error_details)
 
+    def test_get_tags_bad_filter_value(self):
+        tags_url = reverse("settings-tags")
+
+        with schema_context(self.schema_name):
+            client = rest_framework.test.APIClient()
+            response = client.get(tags_url, {"filter[provider_type]": "aws"}, **self.headers)
+
+        error_detail = response.data.get("errors", [{}])[0].get("detail").lower()
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("select a valid choice", error_detail)
+
     @patch("api.settings.tags.view.Config", ENABLED_TAG_LIMIT=1)
     def test_enable_tags_over_limit(self, mock_enabled_limit):
         """Given more tags enabled than are allowed by the limit,


### PR DESCRIPTION
## Jira Ticket

[COST-3752](https://issues.redhat.com/browse/COST-3752)

## Description

Handle validation errors that come from invalid data passed in the `filter` dictionary in the same manner as values provided using the standard filter syntax.

## Testing

1. Checkout Branch
2. Restart Koku

Both of these requests should result in the same error and a status code of 400.
```
curl -gsSL 'http://localhost:8000/api/cost-management/v1/settings/tags/?fprovider_type=aws'
curl -gsSL 'http://localhost:8000/api/cost-management/v1/settings/tags/?filter[provider_type]=aws'
```
