### PR TITLE
[COST-4098] Add last processed date for cost model sources.

### DIFF
--- a/koku/cost_models/cost_model_manager.py
+++ b/koku/cost_models/cost_model_manager.py
@@ -122,5 +122,8 @@ class CostModelManager:
         providers_query = CostModelMap.objects.filter(cost_model=self._model)
         provider_uuids = [provider.provider_uuid for provider in providers_query]
         providers_qs_list = Provider.objects.filter(uuid__in=provider_uuids)
-        provider_names_uuids = [{"uuid": str(provider.uuid), "name": provider.name} for provider in providers_qs_list]
+        provider_names_uuids = [
+            {"uuid": str(provider.uuid), "name": provider.name, "last_processed": provider.data_updated_timestamp}
+            for provider in providers_qs_list
+        ]
         return provider_names_uuids

--- a/koku/cost_models/test/test_cost_model_manager.py
+++ b/koku/cost_models/test/test_cost_model_manager.py
@@ -96,7 +96,7 @@ class CostModelManagerTest(IamTestCase):
             self.assertEqual(cost_model_map.first().provider_uuid, provider_uuid)
             self.assertEqual(
                 CostModelManager(cost_model_obj.uuid).get_provider_names_uuids(),
-                [{"uuid": str(provider_uuid), "name": "sample_provider"}],
+                [{"uuid": str(provider_uuid), "name": "sample_provider", "last_processed": None}],
             )
 
     def test_create_second_cost_model_same_provider(self):
@@ -107,7 +107,9 @@ class CostModelManagerTest(IamTestCase):
 
         # Get Provider UUID
         provider_uuid = provider.uuid
-        provider_names_uuids = [{"uuid": str(provider.uuid), "name": provider.name}]
+        provider_names_uuids = [
+            {"uuid": str(provider.uuid), "name": provider.name, "last_processed": provider.data_updated_timestamp}
+        ]
         metric = metric_constants.OCP_METRIC_CPU_CORE_USAGE_HOUR
         source_type = Provider.PROVIDER_OCP
         tiered_rates = [{"unit": "USD", "value": 0.22}]


### PR DESCRIPTION
## Jira Ticket

[COST-4098](https://issues.redhat.com/browse/COST-4098)

## Description

This change will add last processed date for cost model sources.

## Testing

http://127.0.0.1:8000/api/cost-management/v1/cost-models/
```
"sources": [
                {
                    "uuid": "05edd16a-21f4-4ce8-b24e-ab0831efc112",
                    "name": "Test AWS Source",
                    "last_processed": "2023-08-15T15:05:07.070751Z"
                }
            ]
```

## Notes

...
