### PR TITLE
[COST-4111] Use source_type instead of provider_type in settings tag api

### DIFF
--- a/koku/api/settings/tags/serializers.py
+++ b/koku/api/settings/tags/serializers.py
@@ -20,6 +20,12 @@ class SettingsTagSerializer(serializers.Serializer):
     class Meta:
         model = EnabledTagKeys
 
+    def to_representation(self, instance):
+        representation = super().to_representation(instance)
+        add_source_type = {"source_type": instance.provider_type, **representation}
+        add_source_type.pop("provider_type")
+        return add_source_type
+
 
 class ListUUIDSerializer(serializers.ListField):
     child = serializers.UUIDField(error_messages={"invalid": "invalid uuid supplied."})

--- a/koku/api/settings/tags/serializers.py
+++ b/koku/api/settings/tags/serializers.py
@@ -21,10 +21,9 @@ class SettingsTagSerializer(serializers.Serializer):
         model = EnabledTagKeys
 
     def to_representation(self, instance):
-        representation = super().to_representation(instance)
-        add_source_type = {"source_type": instance.provider_type, **representation}
-        add_source_type.pop("provider_type")
-        return add_source_type
+        data = super().to_representation(instance)
+        data["source_type"] = data.pop("provider_type")
+        return data
 
 
 class ListUUIDSerializer(serializers.ListField):

--- a/koku/api/settings/tags/view.py
+++ b/koku/api/settings/tags/view.py
@@ -24,7 +24,7 @@ LOG = logging.getLogger(__name__)
 
 class SettingsTagFilter(SettingsFilter):
     key = MultipleChoiceFilter(lookup_expr="icontains")
-    provider_type = ModelMultipleChoiceFilter(
+    source_type = ModelMultipleChoiceFilter(
         to_field_name="provider_type",
         queryset=EnabledTagKeys.objects.all(),
     )

--- a/koku/api/settings/test/tags/test_api.py
+++ b/koku/api/settings/test/tags/test_api.py
@@ -68,8 +68,8 @@ class TagsSettings(IamTestCase):
 
     def test_get_tags_filtering(self):
         test_matrix = (
-            {"filter": {"filter[provider_type]": "AWS"}, "key": "provider_type", "expected": {"AWS"}},
-            {"filter": {"filter[provider_type]": ["AWS", "GCP"]}, "key": "provider_type", "expected": {"AWS", "GCP"}},
+            {"filter": {"filter[source_type]": "AWS"}, "key": "source_type", "expected": {"AWS"}},
+            {"filter": {"filter[source_type]": ["AWS", "GCP"]}, "key": "source_type", "expected": {"AWS", "GCP"}},
             {"filter": {"filter[key]": "env"}, "key": "key", "expected": {"env", "Environment"}},
             {"filter": {"filter[enabled]": True}, "key": "enabled", "expected": {True}},
             {"filter": {"filter[enabled]": "true"}, "key": "enabled", "expected": {True}},
@@ -110,15 +110,10 @@ class TagsSettings(IamTestCase):
         test_matrix = (
             {"order": {"order_by": "enabled"}, "key": "enabled", "expected": False},
             {"order": {"order_by": "-enabled"}, "key": "enabled", "expected": True},
-            {
-                "order": {"order_by": ["-provider_type", "-key"]},
-                "keys": ("provider_type", "key"),
-                "expected": ("OCI", "zoo"),
-            },
             {"order": {"order_by[key]": "desc"}, "key": "key", "expected": "zoo"},
             {
-                "order": {"order_by[provider_type]": "asc", "order_by[key]": "desc"},
-                "keys": ("provider_type", "key"),
+                "order": {"order_by[source_type]": "asc", "order_by[key]": "desc"},
+                "keys": ("source_type", "key"),
                 "expected": ("AWS", "zoo"),
             },
         )
@@ -217,7 +212,7 @@ class TagsSettings(IamTestCase):
 
         with schema_context(self.schema_name):
             client = rest_framework.test.APIClient()
-            response = client.get(tags_url, {"filter[provider_type]": "aws"}, **self.headers)
+            response = client.get(tags_url, {"filter[source_type]": "aws"}, **self.headers)
 
         error_detail = response.data.get("errors", [{}])[0].get("detail").lower()
 


### PR DESCRIPTION
## Jira Ticket

[COST-4111](https://issues.redhat.com/browse/COST-41111)

## Description

This change will use source_type instead of provider type in the tag settings api. The `to_field_name` was not getting picked up, so I made some changes to check for it. 

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Notes

...
