### PR TITLE
update nise yaml default StorageClass by cloud type

### DIFF
--- a/dev/scripts/nise_ymls/ocp/ocp_on_premise.yml
+++ b/dev/scripts/nise_ymls/ocp/ocp_on_premise.yml
@@ -23,7 +23,7 @@ generators:
               volumes:
                 - volume:
                   volume_name: pvc-volume_1
-                  storage_class: gp2
+                  storage_class: hostpath
                   volume_request_gig: 20
                   labels: label_environment:Production|label_app:OpenCart|label_version:Production|label_storageclass:gold|label_dashed-key-on-prem:dashed-value
                   volume_claims:
@@ -45,7 +45,7 @@ generators:
               volumes:
                 - volume:
                   volume_name: pvc-volume_2
-                  storage_class: gp2
+                  storage_class: hostpath
                   volume_request_gig: 20
                   labels: label_environment:Development|label_app:Phoenix|label_version:Development|label_storageclass:silver
                   volume_claims:
@@ -73,7 +73,7 @@ generators:
               volumes:
                 - volume:
                   volume_name: pvc-volume_3
-                  storage_class: gp2
+                  storage_class: hostpath
                   volume_request_gig: 20
                   labels: label_environment:Development|label_app:Candlepin|label_version:Development|label_storageclass:bronze
                   volume_claims:
@@ -95,7 +95,7 @@ generators:
               volumes:
                 - volume:
                   volume_name: pvc-volume_4
-                  storage_class: gp2
+                  storage_class: hostpath
                   volume_request_gig: 20
                   labels: label_environment:Production|label_app:Candlepin|label_version:Production|label_storageclass:gold
                   volume_claims:
@@ -123,7 +123,7 @@ generators:
               volumes:
                 - volume:
                   volume_name: pvc-volume_5
-                  storage_class: gp2
+                  storage_class: hostpath
                   volume_request_gig: 20
                   labels: label_environment:Production|label_app:Cygwin|label_version:Production|label_storageclass:gold
                   volume_claims:
@@ -145,7 +145,7 @@ generators:
               volumes:
                 - volume:
                   volume_name: pvc-volume_6
-                  storage_class: gp2
+                  storage_class: hostpath
                   volume_request_gig: 20
                   labels: label_environment:QA|label_app:Phoenix|label_version:QA|label_storageclass:silver
                   volume_claims:
@@ -173,7 +173,7 @@ generators:
               volumes:
                 - volume:
                   volume_name: pvc-volume_7
-                  storage_class: gp2
+                  storage_class: hostpath
                   volume_request_gig: 20
                   labels: label_environment:Production|label_app:CMSapp|label_version:Production|label_storageclass:gold
                   volume_claims:
@@ -195,7 +195,7 @@ generators:
               volumes:
                 - volume:
                   volume_name: pvc-volume_8
-                  storage_class: gp2
+                  storage_class: hostpath
                   volume_request_gig: 20
                   labels: label_environment:Test|label_app:Atomic|label_version:Test|label_storageclass:bronze
                   volume_claims:
@@ -223,7 +223,7 @@ generators:
               volumes:
                 - volume:
                   volume_name: pvc-volume_9
-                  storage_class: gp2
+                  storage_class: hostpath
                   volume_request_gig: 20
                   labels: label_environment:Production|label_app:Wordpress|label_version:Production|label_storageclass:gold
                   volume_claims:
@@ -245,7 +245,7 @@ generators:
               volumes:
                 - volume:
                   volume_name: pvc-volume_10
-                  storage_class: gp2
+                  storage_class: hostpath
                   volume_request_gig: 20
                   labels: label_environment:QA|label_app:Wordpress|label_version:QA|label_storageclass:silver
                   volume_claims:
@@ -273,7 +273,7 @@ generators:
               volumes:
                 - volume:
                   volume_name: pvc-volume_11
-                  storage_class: gp2
+                  storage_class: hostpath
                   volume_request_gig: 20
                   labels: label_environment:Production|label_app:MongoDB|label_version:Production|label_storageclass:gold
                   volume_claims:
@@ -295,7 +295,7 @@ generators:
               volumes:
                 - volume:
                   volume_name: pvc-volume_12
-                  storage_class: gp2
+                  storage_class: hostpath
                   volume_request_gig: 20
                   labels: label_environment:Development|label_app:Istio|label_version:Development|label_storageclass:silver
                   volume_claims:

--- a/dev/scripts/nise_ymls/ocp_on_azure/ocp_static_data.yml
+++ b/dev/scripts/nise_ymls/ocp_on_azure/ocp_static_data.yml
@@ -32,7 +32,7 @@ generators:
               volumes:
                 - volume:
                   volume_name: pvc-volume_1
-                  storage_class: gp2
+                  storage_class: managed
                   volume_request_gig: 20
                   labels: label_environment:Jupiter|label_app:mobile|label_version:Mars|label_storageclass:Baldur|label_dashed-key-on-azure:dashed-value
                   volume_claims:
@@ -62,7 +62,7 @@ generators:
               volumes:
                 - volume:
                   volume_name: pvc-volume_2
-                  storage_class: gp2
+                  storage_class: managed
                   volume_request_gig: 20
                   labels: label_environment:Jupiter|label_app:mobile|label_version:Mars|label_storageclass:Loki
                   volume_claims:
@@ -99,7 +99,7 @@ generators:
               volumes:
                 - volume:
                   volume_name: pvc-volume_1
-                  storage_class: gp2
+                  storage_class: managed
                   volume_request_gig: 20
                   labels: label_environment:Jupiter|label_app:mobile|label_version:Mars|label_storageclass:Baldur
                   volume_claims:
@@ -110,7 +110,7 @@ generators:
                     capacity_gig: 20
                 - volume:
                   volume_name: pvc-volume_3
-                  storage_class: gp2
+                  storage_class: managed
                   volume_request_gig: 20
                   labels: label_environment:qe|label_app:banking|label_version:MilkyWay|label_storageclass:Odin
                   volume_claims:
@@ -147,7 +147,7 @@ generators:
               volumes:
                 - volume:
                   volume_name: pvc-volume_1
-                  storage_class: gp2
+                  storage_class: managed
                   volume_request_gig: 20
                   labels: label_environment:Jupiter|label_app:mobile|label_version:Mars|label_storageclass:Baldur
                   volume_claims:
@@ -158,7 +158,7 @@ generators:
                     capacity_gig: 20
                 - volume:
                   volume_name: pvc-volume_4
-                  storage_class: gp2
+                  storage_class: managed
                   volume_request_gig: 20
                   labels: label_environment:Mars|label_app:weather|label_version:Andromeda|label_storageclass:Thor
                   volume_claims:

--- a/dev/scripts/nise_ymls/ocp_on_gcp/ocp_static_data.yml
+++ b/dev/scripts/nise_ymls/ocp_on_gcp/ocp_static_data.yml
@@ -30,7 +30,7 @@ generators:
               volumes:
                 - volume:
                   volume_name: pvc-volume_1
-                  storage_class: gp2
+                  storage_class: pd-standard
                   volume_request_gig: 20
                   labels: label_environment:ruby|label_app:fall|label_version:red|label_storageclass:banana
                   volume_claims:
@@ -60,7 +60,7 @@ generators:
               volumes:
                 - volume:
                   volume_name: pvc-volume_2
-                  storage_class: gp2
+                  storage_class: pd-standard
                   volume_request_gig: 20
                   labels: label_environment:ruby|label_app:snowdown|label_version:red|label_storageclass:watermelon
                   volume_claims:
@@ -95,7 +95,7 @@ generators:
               volumes:
                 - volume:
                   volume_name: pvc-volume_3
-                  storage_class: gp2
+                  storage_class: pd-standard
                   volume_request_gig: 20
                   labels: label_environment:clyde|label_app:winter|label_version:green|label_storageclass:apple
                   volume_claims:
@@ -131,7 +131,7 @@ generators:
               volumes:
                 - volume:
                   volume_name: pvc-volume_4
-                  storage_class: gp2
+                  storage_class: pd-standard
                   volume_request_gig: 20
                   labels: label_environment:murphy|label_app:spring|label_version:blue|label_storageclass:orange
                   volume_claims:


### PR DESCRIPTION
## Jira Ticket

Related to [COST-3609](https://issues.redhat.com/browse/COST-3609)

## Description

All of our nise yamls currently define the StorageClass as `gp2` which is specific to AWS. This PR updates our nise yamls to use StorageClasses that are more closely related to the infrastructure on which these mock clusters would be running.

Reference:
https://kubernetes.io/docs/concepts/storage/storage-classes/#parameters

defaults used:
```
gcp -> pd-standard
azure -> managed
on-prem -> hostpath
```
