### PR TITLE
[COST-4014] Resolve account alias issues with various APIs

### DIFF
--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -1133,7 +1133,7 @@ class ReportQueryHandler(QueryHandler):
                 distinct_ranks.append(rank)
         return self._ranked_list(data, distinct_ranks, set(rank_annotations))
 
-    def _ranked_list(self, data_list, ranks, rank_fields=None):
+    def _ranked_list(self, data_list, ranks, rank_fields=None):  # noqa C901
         """Get list of ranked items less than top.
 
         Args:
@@ -1193,8 +1193,17 @@ class ReportQueryHandler(QueryHandler):
 
         # Merge our data frame to "zero-fill" missing data for each rank field
         # per day in the query, using a RIGHT JOIN
+        account_aliases = None
+        merge_on = group_by + ["date"]
+        if self.is_aws and "account" in group_by:
+            account_aliases = data_frame[["account", "account_alias"]]
+            account_aliases = account_aliases.drop_duplicates(subset="account")
         data_frame.drop(columns=drop_columns, inplace=True, errors="ignore")
-        data_frame = data_frame.merge(ranks_by_day, how="right", on=(group_by + ["date"]))
+        data_frame = data_frame.merge(ranks_by_day, how="right", on=merge_on)
+
+        if self.is_aws and "account" in group_by:
+            data_frame.drop(columns=["account_alias"], inplace=True, errors="ignore")
+            data_frame = data_frame.merge(account_aliases, on="account", how="left")
 
         if is_offset:
             data_frame = data_frame[


### PR DESCRIPTION
## Jira Ticket

[COST-4014](https://issues.redhat.com/browse/COST-4014)

## Description

This change will xorrectly populate account alias in pandas _ranked_list code

## Testing

1. Checkout Branch
2. Restart Koku
3. Load customer data
```
make create-test-customer
make load-test-customer-data test_source=azure
```
4. Hit endpoint `http://localhost:8000/api/cost-management/v1/reports/openshift/infrastructures/aws/costs/?group_by[account]=*&order_by[account_alias]=desc&filter[limit]=10`
    1. You should see value for the `account_alias`
5. Hit endpoint `http://localhost:8000/api/cost-management/v1/reports/aws/costs/?group_by[account]=*&order_by[cost]=desc&filter[offset]=0`
    1. You should see value for the `account_alias`
