### PR TITLE
Attempt to fix timing issue with currency smoke test.

### DIFF
--- a/koku/api/settings/utils.py
+++ b/koku/api/settings/utils.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 import typing as t
+from copy import deepcopy
 
 from django.core.exceptions import FieldError
 from django.core.exceptions import ValidationError as DjangoValidationError
@@ -274,7 +275,9 @@ def set_currency(schema, currency_code=KOKU_DEFAULT_CURRENCY):
             raise ValueError(f"{currency_code} is not a supported currency")
 
         if not account_currency_setting:
-            set_default_user_settings()
+            overwrite_default = deepcopy(DEFAULT_USER_SETTINGS)
+            overwrite_default["currency"] = currency_code
+            UserSettings.objects.create(settings=overwrite_default)
         else:
             account_currency_setting.settings["currency"] = currency_code
             account_currency_setting.save()
@@ -336,7 +339,9 @@ def set_cost_type(schema, cost_type_code=KOKU_DEFAULT_COST_TYPE):
             raise ValueError(cost_type_code + " is not a supported cost_type")
 
         if not account_current_setting:
-            set_default_user_settings()
-            account_current_setting = UserSettings.objects.all().first()
-        account_current_setting.settings["cost_type"] = cost_type_code
-        account_current_setting.save()
+            overwrite_default = deepcopy(DEFAULT_USER_SETTINGS)
+            overwrite_default["cost_type"] = cost_type_code
+            UserSettings.objects.create(settings=overwrite_default)
+        else:
+            account_current_setting.settings["cost_type"] = cost_type_code
+            account_current_setting.save()


### PR DESCRIPTION
## Jira Ticket

None

## Description
So, our new currency endpoints just use the preexisting `set_currency` & `set_cost_type` functions to modify the values. 

This change will not ignore the value passed in to the put in favor of the default when there are no settings values in the database. A customer would normally never run into this since they will always have to do a get first which would create the default settings. However, our smoke test is just doing a `PUT` and the currency code is getting overwritten. 

I changed the cost_type one too, because there is no reason to create a row, then immediately update it. 

## Testing

1. Delete your current settings:
```
postgres=# DELETE FROM user_settings WHERE true;
DELETE 1
```

2. Do a put on:
- http://localhost:8000/api/cost-management/v1/account-settings/cost-type/
- http://localhost:8000/api/cost-management/v1/account-settings/currency/

What the initial row get created without the default value. 🎉 

Also the smoke should pass now. 


## Notes

...
