### PR TITLE
[COST-4122] - fixing date range for aws/azure batch processing

### DIFF
--- a/koku/masu/external/downloader/aws/aws_report_downloader.py
+++ b/koku/masu/external/downloader/aws/aws_report_downloader.py
@@ -132,8 +132,8 @@ def create_daily_archives(
                 )
                 daily_file_names.append(day_filepath)
     date_range = {
-        "start": min(dates) if dates != () else None,
-        "end": max(dates) if dates != () else None,
+        "start": min(dates),
+        "end": max(dates),
         "invoice_month": None,
     }
     return daily_file_names, date_range

--- a/koku/masu/external/downloader/aws/aws_report_downloader.py
+++ b/koku/masu/external/downloader/aws/aws_report_downloader.py
@@ -100,7 +100,6 @@ def create_daily_archives(
     """
     end_date = DateHelper().now.replace(tzinfo=None)
     daily_file_names = []
-    date_range = {}
     dates = set()
     s3_csv_path = com_utils.get_path_prefix(
         account, Provider.PROVIDER_AWS, provider_uuid, start_date, Config.CSV_DATA_TYPE
@@ -122,7 +121,6 @@ def create_daily_archives(
             if not dates:
                 return [], {}
             directory = os.path.dirname(local_file)
-            date_range = {"start": min(dates), "end": max(dates), "invoice_month": None}
             data_frame = data_frame[data_frame[time_interval].str.contains("|".join(dates))]
             for date in dates:
                 daily_data = data_frame[data_frame[time_interval].str.match(date)]
@@ -133,6 +131,11 @@ def create_daily_archives(
                     tracing_id, s3_csv_path, day_filepath, day_file, manifest_id, start_date, context
                 )
                 daily_file_names.append(day_filepath)
+    date_range = {
+        "start": min(dates) if dates != () else None,
+        "end": max(dates) if dates != () else None,
+        "invoice_month": None,
+    }
     return daily_file_names, date_range
 
 

--- a/koku/masu/external/downloader/azure/azure_report_downloader.py
+++ b/koku/masu/external/downloader/azure/azure_report_downloader.py
@@ -140,8 +140,8 @@ def create_daily_archives(
                 )
                 daily_file_names.append(day_filepath)
     date_range = {
-        "start": min(batch_date_range) if batch_date_range != () else None,
-        "end": max(batch_date_range) if batch_date_range != () else None,
+        "start": min(batch_date_range),
+        "end": max(batch_date_range),
         "invoice_month": None,
     }
     return daily_file_names, date_range

--- a/koku/masu/external/downloader/azure/azure_report_downloader.py
+++ b/koku/masu/external/downloader/azure/azure_report_downloader.py
@@ -104,8 +104,8 @@ def create_daily_archives(
     """
     end_date = DateHelper().now.replace(tzinfo=None)
     daily_file_names = []
-    date_range = {}
     dates = set()
+    batch_date_range = set()
     s3_csv_path = com_utils.get_path_prefix(
         account, Provider.PROVIDER_AZURE, provider_uuid, start_date, Config.CSV_DATA_TYPE
     )
@@ -126,12 +126,8 @@ def create_daily_archives(
                 return [], {}
 
             dates = data_frame[time_interval].unique()
-            date_range = {
-                "start": data_frame.index[0].strftime(DATE_FORMAT),
-                "end": data_frame.index[-1].strftime(DATE_FORMAT),
-                "invoice_month": None,
-            }
-
+            batch_date_range.add(data_frame.index[0].strftime(DATE_FORMAT))
+            batch_date_range.add(data_frame.index[-1].strftime(DATE_FORMAT))
             directory = os.path.dirname(local_file)
             for date in dates:
                 daily_data = data_frame.loc[date]
@@ -143,6 +139,11 @@ def create_daily_archives(
                     tracing_id, s3_csv_path, day_filepath, day_file, manifest_id, start_date, context
                 )
                 daily_file_names.append(day_filepath)
+    date_range = {
+        "start": min(batch_date_range) if batch_date_range != () else None,
+        "end": max(batch_date_range) if batch_date_range != () else None,
+        "invoice_month": None,
+    }
     return daily_file_names, date_range
 
 

--- a/koku/masu/processor/tasks.py
+++ b/koku/masu/processor/tasks.py
@@ -345,8 +345,8 @@ def summarize_reports(  # noqa: C901
                 if report.get("start") and report.get("end"):
                     starts.append(report.get("start"))
                     ends.append(report.get("end"))
-                start = min(starts) if starts != [] else None
-                end = max(ends) if ends != [] else None
+            start = min(starts) if starts != [] else None
+            end = max(ends) if ends != [] else None
             reports_deduplicated.append(
                 {
                     "manifest_id": report.get("manifest_id"),

--- a/koku/masu/test/external/downloader/aws/test_aws_report_downloader.py
+++ b/koku/masu/test/external/downloader/aws/test_aws_report_downloader.py
@@ -210,12 +210,14 @@ class AWSReportDownloaderTest(MasuTestCase):
         """Remove test generated data."""
         shutil.rmtree(DATA_DIR, ignore_errors=True)
 
+    @patch("masu.external.downloader.aws.aws_report_downloader.create_daily_archives")
     @patch("masu.external.downloader.aws.aws_report_downloader.AWSReportDownloader._check_size")
     @patch("masu.external.downloader.aws.aws_report_downloader.utils.remove_files_not_in_set_from_s3_bucket")
     @patch("masu.util.aws.common.get_assume_role_session", return_value=FakeSession)
-    def test_download_file(self, fake_session, mock_remove, mock_check_size):
+    def test_download_file(self, fake_session, mock_remove, mock_check_size, mock_daily_archives):
         """Test the download file method."""
         mock_check_size.return_value = True
+        mock_daily_archives.return_value = [], {}
         downloader = AWSReportDownloader(self.fake_customer_name, self.credentials, self.data_source)
         with patch("masu.external.downloader.aws.aws_report_downloader.pd.read_csv"):
             downloader.download_file(self.fake.file_path(), manifest_id=1)


### PR DESCRIPTION
COST-4122 Jira Ticket

[COST-4122](https://issues.redhat.com/browse/COST-4122)

## Description

This change will move the date_range min/max for daily archive processing outside the batching logic so we grab the full range instead of the range of the last batched file. 

## Testing

1. Checkout Branch
2. Restart Koku
3. Create Azure provider
4. Create large file that needs to be opened in multiple batches
5. See in the logs we correctly summarise the full range of data. Should see things like `'start_date': '2023-08-01', 'end_date': '2023-08-22'`

Pre-this change we would see `'start_date': '2023-08-16', 'end_date': '2023-08-22'` Even though the data started from the beginning of the month.

## Notes
I was testing this with our internal account data from Prod.
...
