### PR TITLE
[COST-3833] Remove link from API Documentation

### DIFF
--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -1,7 +1,7 @@
 {
     "openapi": "3.0.0",
     "info": {
-        "description": "The API for Project Koku and OpenShift cost management. You can find out more about Project Koku at [https://github.com/project-koku/](https://github.com/project-koku/).",
+        "description": "The API for Cost Management",
         "version": "1.0.2",
         "title": "Cost Management",
         "license": {


### PR DESCRIPTION
## Jira Ticket

[COST-3833](https://issues.redhat.com/browse/COST-3833)

## Description

The new API catalog doesn't render a markdown link as the previous one did. No other project is promoting their opensource project link here so I'm removing it.

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint openapi spec endpoint
4. You should see the updated text.

