### PR TITLE
[COST-4038] Make sure API documentation references to sources is updated to integrations

### DIFF
--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -3986,7 +3986,7 @@
                 "tags": [
                     "Integrations"
                 ],
-                "summary": "Get a source",
+                "summary": "Get an integration",
                 "operationId": "getSource",
                 "parameters": [{
                     "name": "source_id",
@@ -4044,7 +4044,7 @@
                 "tags": [
                     "Integrations"
                 ],
-                "summary": "Get a source statistics",
+                "summary": "Get integration statistics",
                 "operationId": "getSourceStats",
                 "parameters": [{
                     "name": "source_id",

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -30,8 +30,8 @@
             "description": "Operations about OCI report interactions"
         },
         {
-            "name": "Sources",
-            "description": "Operations about platform sources interactions"
+            "name": "Integrations",
+            "description": "Operations about platform integrations interactions"
         },
         {
             "name": "Cost Models",
@@ -3925,9 +3925,9 @@
         "/sources/": {
             "get": {
                 "tags": [
-                    "Sources"
+                    "Integrations"
                 ],
-                "summary": "List the sources",
+                "summary": "List the integrations",
                 "operationId": "listSources",
                 "parameters": [{
                         "name": "type",
@@ -3984,7 +3984,7 @@
         "/sources/{source_id}/": {
             "get": {
                 "tags": [
-                    "Sources"
+                    "Integrations"
                 ],
                 "summary": "Get a source",
                 "operationId": "getSource",
@@ -4042,7 +4042,7 @@
         "/sources/{source_id}/stats/": {
             "get": {
                 "tags": [
-                    "Sources"
+                    "Integrations"
                 ],
                 "summary": "Get a source statistics",
                 "operationId": "getSourceStats",
@@ -4112,7 +4112,7 @@
         "/sources/aws-s3-regions/":{
             "get": {
                 "tags": [
-                    "Sources"
+                    "Integrations"
                 ],
                 "summary": "List available AWS S3 regions",
                 "operationId": "getAWSS3Regions",


### PR DESCRIPTION
## Jira Ticket

[COST-4038](https://issues.redhat.com/browse/COST-4038)

## Description

This change will update the openapi spec to reference integrations instead of sources

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint for the openapi spec
    1. You should see references to Integrations (this does not change API paths or content)
