### PR TITLE
[COST-4133] Fix old ocp/cloud daily parquet file names

### DIFF
--- a/koku/masu/database/report_manifest_db_accessor.py
+++ b/koku/masu/database/report_manifest_db_accessor.py
@@ -309,6 +309,20 @@ class ReportManifestDBAccessor(KokuDBAccess):
             manifest.save(update_fields=["report_tracker"])
             return f"{day}_{counter}.csv"
 
+    def update_and_get_parquet_batch_counter(self, day, manifest_id):
+        """This is needed for OCP on Cloud filtered daily parquet files"""
+        with transaction.atomic():
+            # With split payloads, we could have a race condition trying to update the `report_tracker`.
+            # using a transaction and `select_for_update` should minimize the risk of multiple
+            # workers trying to update this field at the same time by locking the manifest during update.
+            manifest = CostUsageReportManifest.objects.select_for_update().get(id=manifest_id)
+            if not manifest.report_tracker.get(day):
+                manifest.report_tracker[day] = 0
+            counter = manifest.report_tracker[day]
+            manifest.report_tracker[day] = counter + 1
+            manifest.save(update_fields=["report_tracker"])
+            return counter
+
     def get_manifest_list_for_provider_and_date_range(self, provider_uuid, start_date, end_date):
         """Return a list of GCP manifests for a date range."""
         manifests = (

--- a/koku/masu/processor/parquet/ocp_cloud_parquet_report_processor.py
+++ b/koku/masu/processor/parquet/ocp_cloud_parquet_report_processor.py
@@ -181,7 +181,6 @@ class OCPCloudParquetReportProcessor(ParquetReportProcessor):
         }
         date_field = date_fields[self.provider_type]
         unique_usage_days = data_frame[date_field].unique()
-
         for usage_day in unique_usage_days:
             usage_date = pd.to_datetime(usage_day).date()
             # Uniqueify manifest report counter dict entry with p for parquet (dont colide with csvs)

--- a/koku/masu/processor/parquet/ocp_cloud_parquet_report_processor.py
+++ b/koku/masu/processor/parquet/ocp_cloud_parquet_report_processor.py
@@ -138,7 +138,7 @@ class OCPCloudParquetReportProcessor(ParquetReportProcessor):
                 parquet_base_filename = (
                     f"{data_frame['invoice_month'].values[0]}{parquet_base_filename[parquet_base_filename.find('_'):]}"
                 )
-        file_name = f"{parquet_base_filename}_{file_number}_{PARQUET_EXT}"
+        file_name = f"{parquet_base_filename}_{file_number}{PARQUET_EXT}"
         file_path = f"{self.local_path}/{file_name}"
         self._write_parquet_to_file(file_path, file_name, data_frame, file_type=self.report_type)
         self.create_parquet_table(file_path, daily=True, partition_map=self.partition_map)
@@ -173,7 +173,7 @@ class OCPCloudParquetReportProcessor(ParquetReportProcessor):
         set_cached_matching_tags(self.schema_name, self.provider_type, matched_tags)
         return matched_tags
 
-    def create_partitioned_ocp_on_cloud_parquet(self, data_frame, parquet_base_filename, file_number):
+    def create_partitioned_ocp_on_cloud_parquet(self, data_frame, parquet_base_filename, manifest_id):
         """Create a parquet file for daily aggregated data for each partition."""
         date_fields = {
             Provider.PROVIDER_AWS: "lineitem_usagestartdate",
@@ -185,9 +185,17 @@ class OCPCloudParquetReportProcessor(ParquetReportProcessor):
 
         for usage_day in unique_usage_days:
             usage_date = pd.to_datetime(usage_day).date()
+            # Uniqueify manifest report counter dict entry with p for parquet (dont colide with csvs)
+            # We use the manifest to hold dated file counts for multiple workers processing the same dates in files
+            base_filename = f"{usage_date}_p"
+            counter = ReportManifestDBAccessor().update_and_get_parquet_batch_counter(base_filename, manifest_id)
+            # Parquet base filename dates here DO NOT match the data written to them
+            base_file_date = parquet_base_filename.split("_")[0]
+            non_date_base_name = parquet_base_filename.removeprefix(base_file_date)
+            usage_day_file_name = f"{usage_date}{non_date_base_name}"
             self.start_date = usage_date
             df = data_frame[data_frame[date_field] == usage_day]
-            self.create_ocp_on_cloud_parquet(df, parquet_base_filename, file_number)
+            self.create_ocp_on_cloud_parquet(df, usage_day_file_name, counter)
 
     def get_ocp_provider_uuids_tuple(self):
         """Get a list of provider UUIDs to process against."""
@@ -219,7 +227,7 @@ class OCPCloudParquetReportProcessor(ParquetReportProcessor):
                 ocp_provider_uuids.append(ocp_provider_uuid)
         return tuple(ocp_provider_uuids)
 
-    def process(self, parquet_base_filename, daily_data_frames):
+    def process(self, parquet_base_filename, daily_data_frames, manifest_id=None):
         """Filter data and convert to parquet."""
         if not (ocp_provider_uuids := self.get_ocp_provider_uuids_tuple()):
             return
@@ -234,14 +242,21 @@ class OCPCloudParquetReportProcessor(ParquetReportProcessor):
                 cluster_topology = accessor.get_openshift_topology_for_multiple_providers(ocp_provider_uuids)
             # Get matching tags
             matched_tags = self.get_matched_tags(ocp_provider_uuids)
-            for i, daily_data_frame in enumerate(daily_data_frames):
-                openshift_filtered_data_frame = self.ocp_on_cloud_data_processor(
-                    daily_data_frame, cluster_topology, matched_tags
-                )
+            daily_data_frames = pd.concat(daily_data_frames, ignore_index=True)
+            openshift_filtered_data_frame = self.ocp_on_cloud_data_processor(
+                daily_data_frames, cluster_topology, matched_tags
+            )
 
-                if self.provider_type in (Provider.PROVIDER_GCP, Provider.PROVIDER_GCP_LOCAL):
-                    self.create_partitioned_ocp_on_cloud_parquet(
-                        openshift_filtered_data_frame, parquet_base_filename, i
-                    )
-                else:
-                    self.create_ocp_on_cloud_parquet(openshift_filtered_data_frame, parquet_base_filename, i)
+            if self.provider_type in (
+                Provider.PROVIDER_GCP,
+                Provider.PROVIDER_GCP_LOCAL,
+                Provider.PROVIDER_AWS,
+                Provider.PROVIDER_AWS_LOCAL,
+                Provider.PROVIDER_AZURE,
+                Provider.PROVIDER_AZURE_LOCAL,
+            ):
+                self.create_partitioned_ocp_on_cloud_parquet(
+                    openshift_filtered_data_frame, parquet_base_filename, manifest_id
+                )
+            else:
+                self.create_ocp_on_cloud_parquet(openshift_filtered_data_frame, parquet_base_filename, file_number=0)

--- a/koku/masu/processor/report_processor.py
+++ b/koku/masu/processor/report_processor.py
@@ -112,7 +112,7 @@ class ReportProcessor:
         try:
             parquet_base_filename, daily_data_frames = self._processor.process()
             if self.ocp_on_cloud_processor:
-                self.ocp_on_cloud_processor.process(parquet_base_filename, daily_data_frames)
+                self.ocp_on_cloud_processor.process(parquet_base_filename, daily_data_frames, self.manifest_id)
             return daily_data_frames != []
         except ReportsAlreadyProcessed:
             LOG.info(log_json(msg="report already processed", context=self.context))

--- a/koku/masu/test/processor/parquet/test_ocp_cloud_parquet_report_processor.py
+++ b/koku/masu/test/processor/parquet/test_ocp_cloud_parquet_report_processor.py
@@ -168,14 +168,14 @@ class TestOCPCloudParquetReportProcessor(MasuTestCase):
         df = pd.DataFrame({"test": [1, 2, 3]})
         self.report_processor.create_ocp_on_cloud_parquet(df, base_file_name, 0)
         mock_write.assert_called()
-        expected = f"{file_path}/{self.ocp_provider_uuid}_0_{PARQUET_EXT}"
+        expected = f"{file_path}/{self.ocp_provider_uuid}_0{PARQUET_EXT}"
         mock_create_table.assert_called_with(expected, daily=True, partition_map=None)
 
     @patch.object(OCPCloudParquetReportProcessor, "create_parquet_table")
     @patch.object(OCPCloudParquetReportProcessor, "_write_parquet_to_file")
     def test_create_ocp_on_cloud_parquet_gcp_valid_idx(self, mock_write, mock_create_table):
         """Test that we write OCP on Cloud data for a GCP provider and create a table."""
-        test_date = "2023_01_01"
+        test_date = "2023-01-01"
         base_file_name = f"{self.gcp_provider_uuid}_{test_date}"
         report_processor = OCPCloudParquetReportProcessor(
             schema_name=self.schema,
@@ -190,7 +190,7 @@ class TestOCPCloudParquetReportProcessor(MasuTestCase):
         df = pd.DataFrame({"test": [1], "invoice_month": [invoice_month]})
         report_processor.create_ocp_on_cloud_parquet(df, base_file_name, 0)
         mock_write.assert_called()
-        expected = f"{file_path}/{invoice_month}_{test_date}_0_{PARQUET_EXT}"
+        expected = f"{file_path}/{invoice_month}_{base_file_name}_0{PARQUET_EXT}"
         mock_create_table.assert_called_with(
             expected,
             daily=True,
@@ -200,7 +200,9 @@ class TestOCPCloudParquetReportProcessor(MasuTestCase):
     @patch.object(OCPCloudParquetReportProcessor, "create_ocp_on_cloud_parquet")
     def test_create_partitioned_ocp_on_cloud_parquet_gcp(self, mock_create_table):
         """Test that we write partitioned OCP on Cloud data and create a table."""
-        base_file_name = f"{self.gcp_provider_uuid}"
+        test_date = "2023-01-01"
+        invoice_month = "202301"
+        base_file_name = f"{invoice_month}_{test_date}_{self.gcp_provider_uuid}"
         report_processor = OCPCloudParquetReportProcessor(
             schema_name=self.schema,
             report_path=self.report_path,
@@ -209,20 +211,19 @@ class TestOCPCloudParquetReportProcessor(MasuTestCase):
             manifest_id=self.manifest_id,
             context={"request_id": self.request_id, "start_date": self.start_date, "create_table": True},
         )
-        invoice_month = "202301"
         df = pd.DataFrame({"test": [1], "invoice_month": [invoice_month], "usage_start_time": "2023-01-01"})
-        report_processor.create_partitioned_ocp_on_cloud_parquet(df, base_file_name, 0)
+        report_processor.create_partitioned_ocp_on_cloud_parquet(df, base_file_name, self.manifest_id)
         mock_create_table.assert_called_once()
         args, kwargs = mock_create_table.call_args
         call_df, call_base_file_name, call_number = args
         self.assertTrue(call_df.equals(df))
-        self.assertEqual(base_file_name, call_base_file_name)
+        self.assertEqual(base_file_name, f"{invoice_month}_{call_base_file_name}")
         self.assertEqual(call_number, 0)
 
     @patch.object(AWSReportDBAccessor, "get_openshift_on_cloud_matched_tags_trino")
     @patch.object(OCPReportDBAccessor, "get_cluster_for_provider")
     @patch.object(OCPReportDBAccessor, "get_openshift_topology_for_multiple_providers")
-    @patch.object(OCPCloudParquetReportProcessor, "create_ocp_on_cloud_parquet")
+    @patch.object(OCPCloudParquetReportProcessor, "create_partitioned_ocp_on_cloud_parquet")
     @patch.object(OCPCloudParquetReportProcessor, "ocp_on_cloud_data_processor")
     def test_process(
         self, mock_data_processor, mock_create_parquet, mock_topology, mock_cluster_info, mock_trino_tags

--- a/koku/masu/util/aws/common.py
+++ b/koku/masu/util/aws/common.py
@@ -771,7 +771,8 @@ def delete_s3_objects(request_id, keys_to_delete, context) -> list[str]:
 def clear_s3_files(csv_s3_path, provider_uuid, start_date, context, request_id):
     """Clear s3 files for daily archive processing AWS/Azure ONLY"""
     account = context.get("account")
-    provider_type = context.get("provider_type")
+    # This fixes local providers s3/minio paths for deletes
+    provider_type = context.get("provider_type").strip("-local")
     parquet_path_s3 = get_path_prefix(account, provider_type, provider_uuid, start_date, "parquet")
     parquet_daily_path_s3 = get_path_prefix(
         account, provider_type, provider_uuid, start_date, "parquet", report_type="raw", daily=True


### PR DESCRIPTION
## Jira Ticket

[COST-4133](https://issues.redhat.com/browse/COST-4133)

## Description

This change will address parquet files not getting named with the correct date for the contained daily data.

Before this change we were writing ocp/cloud daily parquet files with random days in each _batched_ file BUT always used the LAST base parquet file name. This meant all files looked like this for the entire processed range `2023-08-26_0_{batch_num}_.parquet` but also these files could contain data for ANY day in the range not just a single day.

Before example:
2023-08-13_0_0_.parquet
2023-08-13_0_1_.parquet
2023-08-13_0_2_.parquet


Now we create correctly dated files and write the relevant dates to said files!

For example:
2023-08-23_0_0.parquet
2023-08-23_0_1.parquet
2023-08-24_0_0.parquet
2023-08-24_0_1.parquet
2023-08-25_0_0.parquet
2023-08-25_0_1.parquet
2023-08-26_0_0.parquet  
2023-08-26_0_1.parquet  

These files above only contain data for the date in the file name.

## Testing

1. Checkout Branch
2. Restart Koku
3. Make create-test-customer + make load-test-customer-data
4. See the files in `koku-bucket/data/parquet/daily/org1234567/AWS/openshift/source=9ee6fc64-7e69-4f45-a041-9b984ca58828/year=2023/month=08` For example are named correctly and contain the correct data relevant to the files name.

If your running with multiple files across multiple workers its also worth checking the manifest entry for file counts in our report_tracker:

`{"2023-08-22_p": 1, "2023-08-23_p": 1, "2023-08-24_p": 1, "2023-08-25_p": 1, "2023-08-26_p": 1}`

## Notes
The `_p` in the report_tracker above is to distinguish between csv/parquet file counts
...
