### PR TITLE
[COST-4118] - Clear S3 files before downloading

### DIFF
--- a/koku/api/test_utils.py
+++ b/koku/api/test_utils.py
@@ -230,6 +230,9 @@ class DateHelperTest(TestCase):
         today_str = today_date.strftime("%Y-%m-%d")
         self.assertEqual(self.date_helper.latest_date_in_month(today_str), expected)
 
+        in_date = datetime.datetime(1970, 1, 1)
+        self.assertEqual(self.date_helper.latest_date_in_month(in_date), DateHelper().now.date())
+
     def test_datetime_from_date(self):
         """Test getting datetime from date."""
         today = self.date_helper.today

--- a/koku/api/test_utils.py
+++ b/koku/api/test_utils.py
@@ -220,6 +220,27 @@ class DateHelperTest(TestCase):
         expected = datetime.date(1970, 1, 31)
         self.assertEqual(self.date_helper.month_end(today_str), expected)
 
+    def test_latest_date_in_month(self):
+        """Test latest date in month."""
+        in_date = datetime.datetime(1969, 1, 10)
+        expected = datetime.datetime(1969, 1, 31).date()
+        self.assertEqual(self.date_helper.latest_date_in_month(in_date), expected)
+
+        today_date = in_date.date()
+        today_str = today_date.strftime("%Y-%m-%d")
+        self.assertEqual(self.date_helper.latest_date_in_month(today_str), expected)
+
+    def test_datetime_from_date(self):
+        """Test getting datetime from date."""
+        today = self.date_helper.today
+
+        today_date = today.date()
+        expected = datetime.datetime(1970, 1, 10)
+        self.assertEqual(self.date_helper.datetime_from_date(today_date), expected)
+
+        today_str = today_date.strftime("%Y-%m-%d")
+        self.assertEqual(self.date_helper.datetime_from_date(today_str), expected)
+
     def test_midnight(self):
         """Test midnight property."""
         expected = datetime.time(0, 0, 0, 0)

--- a/koku/api/utils.py
+++ b/koku/api/utils.py
@@ -197,6 +197,22 @@ class DateHelper:
             return in_date.replace(microsecond=0, second=0, minute=0, hour=0, day=month_end)
         return in_date.replace(day=month_end)
 
+    def latest_date_in_month(self, in_date):
+        """Last day of giving month date or current date (today)."""
+        if isinstance(in_date, str):
+            in_date = parser.parse(in_date).date()
+        if in_date.year < self.today.year or in_date.month < self.today.month:
+            latest_month_date = in_date.replace(day=self.days_in_month(in_date))
+        else:
+            latest_month_date = self.now.date()
+        return latest_month_date
+
+    def datetime_from_date(self, in_date):
+        """convert date to datetime."""
+        if isinstance(in_date, str):
+            in_date = parser.parse(in_date).date()
+        return datetime.datetime.fromordinal(in_date.toordinal())
+
     def next_month(self, in_date):
         """Return the first of the next month from the in_date.
 

--- a/koku/api/utils.py
+++ b/koku/api/utils.py
@@ -200,9 +200,9 @@ class DateHelper:
     def latest_date_in_month(self, in_date):
         """Last day of giving month date or current date (today)."""
         if isinstance(in_date, str):
-            in_date = parser.parse(in_date).date()
+            in_date = parser.parse(in_date)
         if in_date.year < self.today.year or in_date.month < self.today.month:
-            latest_month_date = in_date.replace(day=self.days_in_month(in_date))
+            latest_month_date = in_date.replace(day=self.days_in_month(in_date)).date()
         else:
             latest_month_date = self.now.date()
         return latest_month_date

--- a/koku/masu/external/downloader/azure/azure_report_downloader.py
+++ b/koku/masu/external/downloader/azure/azure_report_downloader.py
@@ -39,9 +39,7 @@ class AzureReportDownloaderNoFileError(Exception):
     """Azure Report Downloader error for missing file."""
 
 
-def get_processing_date(
-    local_file, s3_csv_path, manifest_id, provider_uuid, start_date, end_date, context, tracing_id
-):
+def get_processing_date(local_file, manifest_id, provider_uuid, start_date):
     """
     Fetch initial dataframe from CSV plus start_delta and time_inteval.
 

--- a/koku/masu/external/downloader/azure/azure_report_downloader.py
+++ b/koku/masu/external/downloader/azure/azure_report_downloader.py
@@ -99,9 +99,7 @@ def create_daily_archives(
     s3_csv_path = com_utils.get_path_prefix(
         account, Provider.PROVIDER_AZURE, provider_uuid, start_date, Config.CSV_DATA_TYPE
     )
-    time_interval, process_date = get_processing_date(
-        local_file, s3_csv_path, manifest_id, provider_uuid, start_date, end_date, context, tracing_id
-    )
+    time_interval, process_date = get_processing_date(local_file, manifest_id, provider_uuid, start_date)
     with pd.read_csv(
         local_file, chunksize=settings.PARQUET_PROCESSING_BATCH_SIZE, parse_dates=[time_interval]
     ) as reader:

--- a/koku/masu/test/external/downloader/aws/test_aws_report_downloader.py
+++ b/koku/masu/test/external/downloader/aws/test_aws_report_downloader.py
@@ -654,7 +654,6 @@ class AWSReportDownloaderTest(MasuTestCase):
         expected_cols = copy.deepcopy(utils.RECOMMENDED_COLUMNS) | copy.deepcopy(utils.OPTIONAL_COLS)
         expected_cols |= {"costCategory/qe_source", "costCategory/name", "costCategory/cost_env"}
         start_date = DateHelper().this_month_start.replace(year=2023, month=6, tzinfo=None)
-        end_date = DateHelper().this_month_start.replace(year=2023, month=6, day=2, tzinfo=None)
         expected_date = DateHelper().this_month_start.replace(year=2023, month=6, day=1, tzinfo=None)
         with patch("masu.util.common.check_setup_complete", return_Value=True):
             with patch("masu.util.aws.common.get_or_clear_daily_s3_by_date", return_value=expected_date):
@@ -663,7 +662,7 @@ class AWSReportDownloaderTest(MasuTestCase):
                     return_value=expected_date,
                 ):
                     use_cols, time_interval, process_date = get_processing_date(
-                        temp_path, None, 1, self.aws_provider_uuid, start_date, end_date, None, "tracing_id"
+                        temp_path, 1, self.aws_provider_uuid, start_date, "context", "tracing_id"
                     )
                     self.assertEqual(use_cols, expected_cols)
                     self.assertEqual(time_interval, expected_interval)

--- a/koku/masu/test/external/downloader/azure/test_azure_report_downloader.py
+++ b/koku/masu/test/external/downloader/azure/test_azure_report_downloader.py
@@ -1,4 +1,3 @@
-
 #
 # Copyright 2021 Red Hat Inc.
 # SPDX-License-Identifier: Apache-2.0

--- a/koku/masu/test/external/downloader/azure/test_azure_report_downloader.py
+++ b/koku/masu/test/external/downloader/azure/test_azure_report_downloader.py
@@ -428,13 +428,8 @@ class AzureReportDownloaderTest(MasuTestCase):
             os.remove(daily_file)
         os.remove(temp_path)
 
-    @patch(
-        "masu.database.report_manifest_db_accessor.ReportManifestDBAccessor.get_manifest_daily_start_date",
-        return_value=None,
-    )
-    @patch("masu.external.downloader.azure.azure_report_downloader.get_or_clear_daily_s3_by_date")
     @patch("masu.database.report_manifest_db_accessor.ReportManifestDBAccessor.set_manifest_daily_start_date")
-    def test_get_processing_date(self, mock_set_start, mock_daily_start, mock_manifest_start):
+    def test_get_processing_date(self, mock_set_start):
         """Test getting dataframe with date for processing."""
         file_name = "costreport_a243c6f2-199f-4074-9a2c-40e671cf1584.csv"
         file_path = f"./koku/masu/test/data/azure/{file_name}"
@@ -443,14 +438,9 @@ class AzureReportDownloaderTest(MasuTestCase):
         shutil.copy2(file_path, temp_path)
         expected_interval = "UsageDateTime"
         start_date = DateHelper().this_month_start.replace(year=2123, month=12, tzinfo=None)
-        end_date = DateHelper().this_month_start.replace(year=2123, month=12, day=2, tzinfo=None)
         expected_date = DateHelper().this_month_start.replace(year=2123, month=12, day=1, tzinfo=None)
-        mock_daily_start.return_value = expected_date
         with patch("masu.util.common.check_setup_complete", return_Value=True):
-            time_interval, process_date = get_processing_date(
-                temp_path, None, 1, self.azure_provider_uuid, start_date, end_date, None, "tracing_id"
-            )
-            mock_daily_start.assert_called()
+            time_interval, process_date = get_processing_date(temp_path, 1, self.azure_provider_uuid, start_date)
             self.assertEqual(time_interval, expected_interval)
             self.assertEqual(process_date, expected_date)
             os.remove(temp_path)

--- a/koku/masu/test/external/downloader/azure/test_azure_report_downloader.py
+++ b/koku/masu/test/external/downloader/azure/test_azure_report_downloader.py
@@ -1,3 +1,4 @@
+
 #
 # Copyright 2021 Red Hat Inc.
 # SPDX-License-Identifier: Apache-2.0
@@ -463,7 +464,7 @@ class AzureReportDownloaderTest(MasuTestCase):
                     return_value=expected_date,
                 ):
                     time_interval, process_date = get_processing_date(
-                        temp_path, None, 1, self.azure_provider_uuid, start_date, end_date, None, "tracing_id"
+                        temp_path, 1, self.azure_provider_uuid, start_date
                     )
                     self.assertEqual(time_interval, expected_interval)
                     self.assertEqual(process_date, expected_date)

--- a/koku/masu/test/external/downloader/azure/test_azure_report_downloader.py
+++ b/koku/masu/test/external/downloader/azure/test_azure_report_downloader.py
@@ -455,7 +455,6 @@ class AzureReportDownloaderTest(MasuTestCase):
         shutil.copy2(file_path, temp_path)
         expected_interval = "date"
         start_date = DateHelper().this_month_start.replace(year=2023, month=9, tzinfo=None)
-        end_date = DateHelper().this_month_start.replace(year=2023, month=9, day=2, tzinfo=None)
         expected_date = DateHelper().this_month_start.replace(year=2023, month=9, day=1, tzinfo=None)
         with patch("masu.util.common.check_setup_complete", return_Value=True):
             with patch("masu.util.aws.common.get_or_clear_daily_s3_by_date", return_value=expected_date):

--- a/koku/masu/test/util/aws/test_common.py
+++ b/koku/masu/test/util/aws/test_common.py
@@ -480,7 +480,15 @@ class TestAWSUtils(MasuTestCase):
                 matching_summary,
             ]
             with patch("masu.util.aws.common.delete_s3_objects") as mock_delete:
-                utils.clear_s3_files(s3_csv_path, self.aws_provider_uuid, start_date, context, "requiest_id")
+                utils.clear_s3_files(
+                    s3_csv_path,
+                    self.schema_name,
+                    self.aws_provider.type,
+                    self.aws_provider_uuid,
+                    start_date,
+                    context,
+                    "requiest_id",
+                )
                 mock_delete.assert_called
 
     def test_remove_s3_objects_matching_metadata(self):
@@ -709,14 +717,15 @@ class TestAWSUtils(MasuTestCase):
         ):
             result = utils.get_or_clear_daily_s3_by_date(
                 "None",
+                "test",
                 "provider_uuid",
+                "AWS",
                 start_date,
                 end_date,
                 1,
-                {"account": "test", "provider_type": "AWS"},
                 "request_id",
             )
-            self.assertEqual(result, start_date)
+            self.assertEqual(result, start_date.date())
 
 
 class AwsArnTest(TestCase):


### PR DESCRIPTION
## Jira Ticket

[COST-4118](https://issues.redhat.com/browse/COST-4118)

## Description

This change will clear S3 files for processing ranges at the manifest creation level BEFORE download tasks are started!

## Testing

1. Checkout Branch
2. Restart Koku
3. Create OCP on Azure/AWS sources + data
4. See we process the full month
5. Create new Azure/AWS files
6. Hit download
7. See in the logs we clear the processing range of S3 files BEFORE triggering the download tasks
8. Additionally add some sleeps around the deletions to confirm selected files are removed

## Notes

...
