### PR TITLE
[COST-4118] - make all the workers attempt deletes before creating new files

### DIFF
--- a/koku/masu/test/external/downloader/azure/test_azure_report_downloader.py
+++ b/koku/masu/test/external/downloader/azure/test_azure_report_downloader.py
@@ -455,10 +455,12 @@ class AzureReportDownloaderTest(MasuTestCase):
             self.assertEqual(process_date, expected_date)
             os.remove(temp_path)
 
-    def test_get_processing_date_alt_columns(self):
+    @patch("masu.util.aws.common.get_s3_resource")
+    def test_get_processing_date_alt_columns(self, mock_resource):
         """Test getting dataframe with date for processing."""
         file_name = "camel_azure_version_2.csv"
         file_path = f"./koku/masu/test/data/azure/{file_name}"
+        context = {"account": self.schema_name, "provider_type": self.azure_provider.type}
         temp_dir = tempfile.gettempdir()
         temp_path = os.path.join(temp_dir, file_name)
         shutil.copy2(file_path, temp_path)
@@ -473,7 +475,7 @@ class AzureReportDownloaderTest(MasuTestCase):
                     return_value=expected_date,
                 ):
                     time_interval, process_date = get_processing_date(
-                        temp_path, None, 1, self.azure_provider_uuid, start_date, end_date, None, "tracing_id"
+                        temp_path, "csv_path", 1, self.azure_provider_uuid, start_date, end_date, context, "tracing_id"
                     )
                     self.assertEqual(time_interval, expected_interval)
                     self.assertEqual(process_date, expected_date)

--- a/koku/masu/test/util/aws/test_common.py
+++ b/koku/masu/test/util/aws/test_common.py
@@ -480,7 +480,9 @@ class TestAWSUtils(MasuTestCase):
                 matching_summary,
             ]
             with patch("masu.util.aws.common.delete_s3_objects") as mock_delete:
-                utils.clear_s3_files(s3_csv_path, self.aws_provider_uuid, start_date, context, "requiest_id")
+                utils.clear_s3_files(
+                    s3_csv_path, self.aws_provider_uuid, start_date, "manifestid", 1, context, "requiest_id"
+                )
                 mock_delete.assert_called
 
     def test_remove_s3_objects_matching_metadata(self):

--- a/koku/masu/util/aws/common.py
+++ b/koku/masu/util/aws/common.py
@@ -581,6 +581,7 @@ def get_or_clear_daily_s3_by_date(csv_s3_path, provider_uuid, start_date, end_da
     # We do this if we have multiple workers running different files for a single manifest.
     processing_date = ReportManifestDBAccessor().get_manifest_daily_start_date(manifest_id)
     if processing_date:
+        clear_s3_files(csv_s3_path, provider_uuid, processing_date, "manifestid", manifest_id, context, request_id)
         return processing_date
     processing_date = start_date.replace(tzinfo=None)
     try:
@@ -601,7 +602,7 @@ def get_or_clear_daily_s3_by_date(csv_s3_path, provider_uuid, start_date, end_da
             ).replace(tzinfo=None)
             ReportManifestDBAccessor().set_manifest_daily_start_date(manifest_id, processing_date)
             # clear s3 files for processing dates
-            clear_s3_files(csv_s3_path, provider_uuid, processing_date, context, request_id)
+            clear_s3_files(csv_s3_path, provider_uuid, processing_date, "manifestid", manifest_id, context, request_id)
     except (EndpointConnectionError, ClientError, AttributeError, ValueError):
         msg = (
             "unable to fetch date from objects, "
@@ -768,7 +769,7 @@ def delete_s3_objects(request_id, keys_to_delete, context) -> list[str]:
     return []
 
 
-def clear_s3_files(csv_s3_path, provider_uuid, start_date, context, request_id):
+def clear_s3_files(csv_s3_path, provider_uuid, start_date, metadata_key, metadata_value_check, context, request_id):
     """Clear s3 files for daily archive processing AWS/Azure ONLY"""
     account = context.get("account")
     provider_type = context.get("provider_type")
@@ -791,7 +792,10 @@ def clear_s3_files(csv_s3_path, provider_uuid, start_date, context, request_id):
     to_delete = []
     for prefix in s3_prefixes:
         for obj_summary in _get_s3_objects(prefix):
-            to_delete.append(obj_summary.Object().key)
+            existing_object = obj_summary.Object()
+            metadata_value = existing_object.metadata.get(metadata_key)
+            if metadata_value != metadata_value_check:
+                to_delete.append(existing_object.key)
     delete_s3_objects(request_id, to_delete, context)
 
 


### PR DESCRIPTION
## Jira Ticket

[COST-4118](https://issues.redhat.com/browse/COST-4118)

## Description

This change will prevent any worker moving to create any parquet files until all previous files have been deleted! Essentially we tell all workers to delete any file in a certain path that DOES NOT match the processing manifest. 

## Testing

1. Checkout Branch
2. Restart Koku ideally with multiple workers
3. create ocp on aws/azure sources
4. ingest data that has multiple files per manifest
5. see in the logs that all deletions complete before creating new files.

## Notes
Running with multiple workers locally you should see something like this in the logs:

```
koku-koku-worker-4  | [2023-08-28 16:29:54,808] INFO c1390fbe-d1fc-4602-909b-a295288885dd 181 {'message': 'removed files from s3 bucket', 'tracing_id': '57088a4d-491d-415e-a9fb-436401482310', 'provider_uuid': 'cc24a00b-4b34-470c-8101-69779f83b0fe', 'provider_type': 'AWS-local', 'account': 'org1234567', 'bucket': 'koku-bucket', 'file_list': ['data/csv/org1234567/AWS/source=cc24a00b-4b34-470c-8101-69779f83b0fe/year=2023/month=08/2023-08-28_3.csv']}
koku-koku-worker-2  | [2023-08-28 16:29:54,854] INFO c1390fbe-d1fc-4602-909b-a295288885dd 313 {'message': 'removed files from s3 bucket', 'tracing_id': '57088a4d-491d-415e-a9fb-436401482310', 'provider_uuid': 'cc24a00b-4b34-470c-8101-69779f83b0fe', 'provider_type': 'AWS-local', 'account': 'org1234567', 'bucket': 'koku-bucket', 'file_list': ['data/csv/org1234567/AWS/source=cc24a00b-4b34-470c-8101-69779f83b0fe/year=2023/month=08/2023-08-28_3.csv']}
koku-koku-worker-3  | [2023-08-28 16:29:54,870] INFO c1390fbe-d1fc-4602-909b-a295288885dd 117 {'message': 'removed files from s3 bucket', 'tracing_id': '57088a4d-491d-415e-a9fb-436401482310', 'provider_uuid': 'cc24a00b-4b34-470c-8101-69779f83b0fe', 'provider_type': 'AWS-local', 'account': 'org1234567', 'bucket': 'koku-bucket', 'file_list': ['data/csv/org1234567/AWS/source=cc24a00b-4b34-470c-8101-69779f83b0fe/year=2023/month=08/2023-08-28_3.csv']}
koku-koku-worker-1  | [2023-08-28 16:29:54,874] INFO c1390fbe-d1fc-4602-909b-a295288885dd 470 {'message': 'removed files from s3 bucket', 'tracing_id': '57088a4d-491d-415e-a9fb-436401482310', 'provider_uuid': 'cc24a00b-4b34-470c-8101-69779f83b0fe', 'provider_type': 'AWS-local', 'account': 'org1234567', 'bucket': 'koku-bucket', 'file_list': ['data/csv/org1234567/AWS/source=cc24a00b-4b34-470c-8101-69779f83b0fe/year=2023/month=08/2023-08-28_3.csv']}
```

As you can see all workers downloading a file attempt to delete old files before processing.
Side note I condensed the output on the files list, so you will see more than this.
...
