### PR TITLE
Azure date fix + delete try/except

### DIFF
--- a/koku/masu/processor/parquet/ocp_cloud_parquet_report_processor.py
+++ b/koku/masu/processor/parquet/ocp_cloud_parquet_report_processor.py
@@ -180,7 +180,7 @@ class OCPCloudParquetReportProcessor(ParquetReportProcessor):
         }
         date_field = date_fields[self.provider_type]
         if self.provider_type == Provider.PROVIDER_AZURE and date_field not in data_frame.columns:
-            date_field = "usagestarttime"
+            date_field = "usagedatetime"
         unique_usage_days = data_frame[date_field].unique()
         for usage_day in unique_usage_days:
             usage_date = pd.to_datetime(usage_day).date()

--- a/koku/masu/processor/parquet/ocp_cloud_parquet_report_processor.py
+++ b/koku/masu/processor/parquet/ocp_cloud_parquet_report_processor.py
@@ -135,7 +135,6 @@ class OCPCloudParquetReportProcessor(ParquetReportProcessor):
         """Create a parquet file for daily aggregated data."""
         if self._provider_type in {Provider.PROVIDER_GCP, Provider.PROVIDER_GCP_LOCAL}:
             if data_frame.first_valid_index() is not None:
-                # TODO This may case us to overwrite partial GCP files
                 parquet_base_filename = f"{data_frame['invoice_month'].values[0]}_{parquet_base_filename}"
         file_name = f"{parquet_base_filename}_{file_number}{PARQUET_EXT}"
         file_path = f"{self.local_path}/{file_name}"
@@ -180,6 +179,8 @@ class OCPCloudParquetReportProcessor(ParquetReportProcessor):
             Provider.PROVIDER_GCP: "usage_start_time",
         }
         date_field = date_fields[self.provider_type]
+        if self.provider_type == Provider.PROVIDER_AZURE and date_field not in data_frame.columns:
+            date_field = "usagestarttime"
         unique_usage_days = data_frame[date_field].unique()
         for usage_day in unique_usage_days:
             usage_date = pd.to_datetime(usage_day).date()

--- a/koku/masu/test/processor/parquet/test_ocp_cloud_parquet_report_processor.py
+++ b/koku/masu/test/processor/parquet/test_ocp_cloud_parquet_report_processor.py
@@ -220,6 +220,28 @@ class TestOCPCloudParquetReportProcessor(MasuTestCase):
         self.assertEqual(base_file_name, f"{invoice_month}_{call_base_file_name}")
         self.assertEqual(call_number, 0)
 
+    @patch.object(OCPCloudParquetReportProcessor, "create_ocp_on_cloud_parquet")
+    def test_create_partitioned_ocp_on_cloud_parquet_azure(self, mock_create_table):
+        """Test that we write partitioned OCP on Cloud data and create a table."""
+        test_date = "2023-01-01"
+        base_file_name = f"{test_date}_{self.azure_provider_uuid}"
+        report_processor = OCPCloudParquetReportProcessor(
+            schema_name=self.schema,
+            report_path=self.report_path,
+            provider_uuid=self.azure_provider_uuid,
+            provider_type=Provider.PROVIDER_AZURE_LOCAL,
+            manifest_id=self.manifest_id,
+            context={"request_id": self.request_id, "start_date": self.start_date, "create_table": True},
+        )
+        df = pd.DataFrame({"test": [1], "usagedatetime": "2023-01-01"})
+        report_processor.create_partitioned_ocp_on_cloud_parquet(df, base_file_name, self.manifest_id)
+        mock_create_table.assert_called_once()
+        args, kwargs = mock_create_table.call_args
+        call_df, call_base_file_name, call_number = args
+        self.assertTrue(call_df.equals(df))
+        self.assertEqual(base_file_name, f"{call_base_file_name}")
+        self.assertEqual(call_number, 0)
+
     @patch.object(AWSReportDBAccessor, "get_openshift_on_cloud_matched_tags_trino")
     @patch.object(OCPReportDBAccessor, "get_cluster_for_provider")
     @patch.object(OCPReportDBAccessor, "get_openshift_topology_for_multiple_providers")


### PR DESCRIPTION
## Jira Ticket

[COST-####](https://issues.redhat.com/browse/COST-####)

## Description

This change will add `usagedatetime` to azure ocp/cloud processing logic (because we pass both date and usagedatetime instead of normalising those)

This change also adds a try/except block around the delete s3 files logic because we have one more alert firing, where one worker deletes a file while another is reading it for deletion. Right now the processing bombs out but in reality as long as the file is deleted we should just continue. 

## Testing

1. Checkout Branch
2. Restart Koku
3. create ocp on Azure data ideally with v1 and v2 reports
4. make sure it ingests correctly for both date types

Test 2 much harder to be reproduced (need a lot of luck)
1. Create ocp on aws data
2. ingest everything
3. Change this line `process_date - datetime.timedelta(days=3) if process_date.day > 3 else process_date.replace(day=1)` to this `process_date - datetime.timedelta(days=28) if process_date.day > 28 else process_date.replace(day=1)` in the code (make the date range 28 days to increase your luck)
4. Generate new AWS data with many split files. Something like this `nise -lll report aws --aws-s3-bucket-name ~/local/dir/koku/testing/local_providers/aws_local --aws-s3-report-name UalJYjZa --static-report-file /home/lcouzens/local/dir/data/aws/aws_static_report_basic.yml --file-row-limit 500`
5. Hit download and follow the logs, if you are lucky you should see `unable to get matching object, likely deleted by another worker`
6. Regardless of this log we should continue processing and summarise data.

## Notes

...
