### PR TITLE
update cluster_alias in OCPUsageReportPeriod if the source name changed

### DIFF
--- a/koku/masu/processor/ocp/ocp_report_parquet_processor.py
+++ b/koku/masu/processor/ocp/ocp_report_parquet_processor.py
@@ -3,11 +3,13 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 """Processor for OCP Parquet files."""
+import contextlib
 import datetime
 import logging
 
 import ciso8601
 from django.conf import settings
+from django.db.utils import IntegrityError
 from django_tenants.utils import schema_context
 
 from api.common import log_json
@@ -92,10 +94,13 @@ class OCPReportParquetProcessor(ReportParquetProcessorBase):
             )
         )
         with schema_context(self._schema_name):
-            OCPUsageReportPeriod.objects.get_or_create(
-                cluster_id=cluster_id,
-                cluster_alias=cluster_alias,
-                report_period_start=report_period_start,
-                report_period_end=report_period_end,
-                provider_id=provider.uuid,
-            )
+            with contextlib.suppress(IntegrityError):
+                # IntegrityError caused by race condition creating this report.
+                # Skipping this error is fine because the report exists.
+                OCPUsageReportPeriod.objects.get_or_create(
+                    cluster_id=cluster_id,
+                    cluster_alias=cluster_alias,
+                    report_period_start=report_period_start,
+                    report_period_end=report_period_end,
+                    provider_id=provider.uuid,
+                )


### PR DESCRIPTION
## Jira Ticket

[COST-####](https://issues.redhat.com/browse/COST-####)

## Description

If we have created an OCPUsageReportPeriod entry for a given month, then a customer changes the name of that OCP Source in the middle of that month, we will raise an IntegrityError in the `create_bill` method during parquet processing which prevents the Hive partition syncing. 



## Testing

1. `make create-test-customer; make load-test-customer-data test_source=ONPREM`
2. check the reporting periods and see that the cluster_alias is `Test OCP on Premises`:
```
# select * from org1234567.reporting_ocpusagereportperiod;
-[ RECORD 1 ]------------------+-------------------------------------
id                             | 15
cluster_id                     | my-ocp-cluster-3
cluster_alias                  | Test OCP on Premises
report_period_start            | 2023-09-01 00:00:00+00
report_period_end              | 2023-10-01 00:00:00+00
ocp_on_cloud_updated_datetime  | 
summary_data_creation_datetime | 2023-09-05 19:00:46.676902+00
summary_data_updated_datetime  | 2023-09-05 19:01:23.560631+00
derived_cost_datetime          | 2023-09-05 19:01:30.085539+00
provider_id                    | ec27eb7d-f03d-44e2-9e6e-5dec31d1bcf3
-[ RECORD 2 ]------------------+-------------------------------------
id                             | 16
cluster_id                     | my-ocp-cluster-3
cluster_alias                  | Test OCP on Premises
report_period_start            | 2023-08-01 00:00:00+00
report_period_end              | 2023-09-01 00:00:00+00
ocp_on_cloud_updated_datetime  | 
summary_data_creation_datetime | 
summary_data_updated_datetime  | 
derived_cost_datetime          | 
provider_id                    | ec27eb7d-f03d-44e2-9e6e-5dec31d1bcf3
```
3. Change the name of the source (aka cluster_alias):
```
postgres=# update api_sources set name='new name' where koku_uuid='ec27eb7d-f03d-44e2-9e6e-5dec31d1bcf3';
UPDATE 1
postgres=# update api_provider set name='new name' where uuid='ec27eb7d-f03d-44e2-9e6e-5dec31d1bcf3';
UPDATE 1
postgres=# update org1234567.reporting_tenant_api_provider set name='new name' where uuid='ec27eb7d-f03d-44e2-9e6e-5dec31d1bcf3';
UPDATE 1
```
4. create new data: `make load-test-customer-data test_source=ONPREM` and then hit download:
http://localhost:5042/api/cost-management/v1/download/
5. check the report periods again, and see that the cluster_alias was updated to reflect the new name:
```postgres
postgres=# select * from org1234567.reporting_ocpusagereportperiod;
-[ RECORD 1 ]------------------+-------------------------------------
id                             | 16
cluster_id                     | my-ocp-cluster-3
cluster_alias                  | new name
report_period_start            | 2023-08-01 00:00:00+00
report_period_end              | 2023-09-01 00:00:00+00
ocp_on_cloud_updated_datetime  | 
summary_data_creation_datetime | 
summary_data_updated_datetime  | 
derived_cost_datetime          | 
provider_id                    | ec27eb7d-f03d-44e2-9e6e-5dec31d1bcf3
-[ RECORD 2 ]------------------+-------------------------------------
id                             | 15
cluster_id                     | my-ocp-cluster-3
cluster_alias                  | new name
report_period_start            | 2023-09-01 00:00:00+00
report_period_end              | 2023-10-01 00:00:00+00
ocp_on_cloud_updated_datetime  | 
summary_data_creation_datetime | 2023-09-05 19:00:46.676902+00
summary_data_updated_datetime  | 2023-09-05 19:31:00.636644+00
derived_cost_datetime          | 2023-09-05 19:31:03.494648+00
provider_id                    | ec27eb7d-f03d-44e2-9e6e-5dec31d1bcf3

```

Doing all of the above on main, you will see the following error during ingestion:
```
koku-koku-worker-1  | [1;33m[2023-09-05 20:07:17,369] WARNING 6452d0e1-a77c-4470-8644-a75f41d6319d 2539 {'message': 'could not write parquet to temp file', 'tracing_id': 'dc19680a-1888-464d-9335-69768bc7bf7b', 'account': 'org1234567', 'provider_uuid': 'cd03c45b-7833-4fd5-a2ad-c49249f9d31e', 'provider_type': 'OCP', 'file_name': '/testing/data/processing/org1234567/ocp/my-ocp-cluster-3/20230801-20230901_dc19680a-1888-464d-9335-69768bc7bf7b_openshift_report.1.csv'}
koku-koku-worker-1  | Traceback (most recent call last):
koku-koku-worker-1  |   File "/opt/koku/.venv/lib/python3.9/site-packages/django/db/models/query.py", line 581, in get_or_create
koku-koku-worker-1  |     return self.get(**kwargs), False
koku-koku-worker-1  |   File "/opt/koku/.venv/lib/python3.9/site-packages/django/db/models/query.py", line 435, in get
koku-koku-worker-1  |     raise self.model.DoesNotExist(
koku-koku-worker-1  | reporting.provider.ocp.models.OCPUsageReportPeriod.DoesNotExist: OCPUsageReportPeriod matching query does not exist.
koku-koku-worker-1  | 
....
....
koku-koku-worker-1  | django.db.utils.IntegrityError: duplicate key value violates unique constraint "reporting_ocpusagereportperio_cluster_id_report_period_star_key"
koku-koku-worker-1  | DETAIL:  Key (cluster_id, report_period_start, provider_id)=(my-ocp-cluster-3, 2023-08-01 00:00:00+00, cd03c45b-7833-4fd5-a2ad-c49249f9d31e) already exists.
```
## Notes

...
