### PR TITLE
[COST-4070] - clear gcp files for ingress flow

### DIFF
--- a/koku/masu/database/report_manifest_db_accessor.py
+++ b/koku/masu/database/report_manifest_db_accessor.py
@@ -307,7 +307,7 @@ class ReportManifestDBAccessor(KokuDBAccess):
             counter = manifest.report_tracker[day]
             manifest.report_tracker[day] = counter + 1
             manifest.save(update_fields=["report_tracker"])
-            return f"{day}_{counter}.csv"
+            return f"{day}_manifestid-{manifest_id}_{counter}.csv"
 
     def update_and_get_parquet_batch_counter(self, day, manifest_id):
         """This is needed for OCP on Cloud filtered daily parquet files"""

--- a/koku/masu/external/downloader/gcp/gcp_report_downloader.py
+++ b/koku/masu/external/downloader/gcp/gcp_report_downloader.py
@@ -28,6 +28,7 @@ from masu.database.report_manifest_db_accessor import ReportManifestDBAccessor
 from masu.external import UNCOMPRESSED
 from masu.external.downloader.downloader_interface import DownloaderInterface
 from masu.external.downloader.report_downloader_base import ReportDownloaderBase
+from masu.util.aws.common import clear_s3_files
 from masu.util.aws.common import copy_local_report_file_to_s3_bucket
 from masu.util.common import get_path_prefix
 from masu.util.gcp.common import add_label_columns
@@ -104,6 +105,18 @@ def create_daily_archives(
                 )
                 day_file = f"{invoice_month}_{partition_date}_{file_name}"
                 if ingress_reports:
+                    # Ingress flow needs to clear s3 files prior to processing
+                    date_time = datetime.datetime.strptime(partition_date, "%Y-%m-%d")
+                    clear_s3_files(
+                        s3_csv_path,
+                        provider_uuid,
+                        date_time,
+                        "manifestid",
+                        manifest_id,
+                        context,
+                        tracing_id,
+                        invoice_month,
+                    )
                     partition_filename = ReportManifestDBAccessor().update_and_get_day_file(
                         partition_date, manifest_id
                     )

--- a/koku/masu/test/util/aws/test_common.py
+++ b/koku/masu/test/util/aws/test_common.py
@@ -485,6 +485,33 @@ class TestAWSUtils(MasuTestCase):
                 )
                 mock_delete.assert_called
 
+    def test_clear_s3_files_gcp(self):
+        """Test clearing s3 GCP ingress files."""
+        metadata_key = "manifestid"
+        metadata_value = "manifest_id"
+        prov_uuid = self.gcp_provider_uuid
+        prov_type = self.gcp_provider.type
+        context = {"account": self.account_id, "provider_type": prov_type}
+        date_accessor = DateAccessor()
+        start_date = date_accessor.today_with_timezone("UTC").replace(day=1).replace(tzinfo=None)
+        s3_csv_path = get_path_prefix(self.account_id, "GCP", prov_uuid, start_date, Config.CSV_DATA_TYPE)
+        expected_key = "not_matching_key"
+        mock_object = Mock(metadata={metadata_key: "this will be deleted"}, key=expected_key)
+        not_matching_summary = Mock()
+        not_matching_summary.Object.return_value = mock_object
+        not_expected_key = "matching_key"
+        mock_object = Mock(metadata={metadata_key: metadata_value}, key=not_expected_key)
+        matching_summary = Mock()
+        matching_summary.Object.return_value = mock_object
+        with patch("masu.util.aws.common.get_s3_resource") as mock_s3:
+            mock_s3.return_value.Bucket.return_value.objects.filter.return_value = [
+                not_matching_summary,
+                matching_summary,
+            ]
+            with patch("masu.util.aws.common.delete_s3_objects") as mock_delete:
+                utils.clear_s3_files(s3_csv_path, prov_uuid, start_date, "manifestid", 1, context, "requiest_id")
+                mock_delete.assert_called
+
     def test_remove_s3_objects_matching_metadata(self):
         """Test remove_s3_objects_matching_metadata."""
         metadata_key = "manifestid"

--- a/koku/masu/util/aws/common.py
+++ b/koku/masu/util/aws/common.py
@@ -769,8 +769,10 @@ def delete_s3_objects(request_id, keys_to_delete, context) -> list[str]:
     return []
 
 
-def clear_s3_files(csv_s3_path, provider_uuid, start_date, metadata_key, metadata_value_check, context, request_id):
-    """Clear s3 files for daily archive processing AWS/Azure ONLY"""
+def clear_s3_files(
+    csv_s3_path, provider_uuid, start_date, metadata_key, metadata_value_check, context, request_id, invoice_month=None
+):
+    """Clear s3 files for daily archive processing"""
     account = context.get("account")
     # This fixes local providers s3/minio paths for deletes
     provider_type = context.get("provider_type").strip("-local")
@@ -783,9 +785,16 @@ def clear_s3_files(csv_s3_path, provider_uuid, start_date, metadata_key, metadat
     )
     s3_prefixes = []
     dh = DateHelper()
-    list_days = dh.list_days(start_date, dh.now.replace(tzinfo=None))
-    for day in list_days:
-        path = f"/{day.date()}"
+    list_datetimes = dh.list_days(start_date, dh.now.replace(tzinfo=None))
+    path = "/"
+    if provider_type == "GCP":
+        path += f"{invoice_month}_"
+        # GCP openshift data is partitioned by day
+        day = start_date.strftime("%d")
+        parquet_ocp_on_cloud_path_s3 += f"/day={day}"
+        list_datetimes = [start_date]
+    for date_time in list_datetimes:
+        path += f"{date_time.date()}"
         s3_prefixes.append(csv_s3_path + path)
         s3_prefixes.append(parquet_path_s3 + path)
         s3_prefixes.append(parquet_daily_path_s3 + path)

--- a/koku/masu/util/aws/common.py
+++ b/koku/masu/util/aws/common.py
@@ -786,15 +786,15 @@ def clear_s3_files(
     s3_prefixes = []
     dh = DateHelper()
     list_datetimes = dh.list_days(start_date, dh.now.replace(tzinfo=None))
-    path = "/"
+    og_path = "/"
     if provider_type == "GCP":
-        path += f"{invoice_month}_"
+        og_path += f"{invoice_month}_"
         # GCP openshift data is partitioned by day
         day = start_date.strftime("%d")
         parquet_ocp_on_cloud_path_s3 += f"/day={day}"
         list_datetimes = [start_date]
     for date_time in list_datetimes:
-        path += f"{date_time.date()}"
+        path = f"{og_path}{date_time.date()}"
         s3_prefixes.append(csv_s3_path + path)
         s3_prefixes.append(parquet_path_s3 + path)
         s3_prefixes.append(parquet_daily_path_s3 + path)


### PR DESCRIPTION
## Jira Ticket

[COST-4070](https://issues.redhat.com/browse/COST-4070)

## Description

This change will remove GCP s3 files for matching date ranges before processing, this prevents us duplicating data in our customer filtered ingress flow.

## Testing

1. Checkout Branch
2. Restart Koku
3. Create OCP provider and data that can match with a GCP provider
4. Create storage only GCP provider
5. Post GCP reports for your GCP source.

Alternatively test using IQE:
1. Put a PDB in this test `test_api_ocp_on_gcp_ingest_single_source`
2. Run the above test
3. Create Storage only GCP source ```{
    "name": "GCP Source",
    "source_type": "GCP",
    "authentication": {
        "credentials": {
            "project_id": "dev-project-id"
        }
    }, "billing_source": {
        "data_source": {"bucket": "Get-bucket-name-from-luke", "storage_only": true}
        }
}```
4. Post reports for GCP source via `/api/cost-management/v1/ingress/reports/`
```
{
    "source": "2",
    "bill_year": "2023",
    "bill_month": "09",
    "reports_list": ["testing/gcp-nise-1.csv", "testing/gcp-nise-2.csv", "testing/gcp-nise-3.csv", "testing/gcp-nise-4.csv", "testing/gcp-nise-5.csv", "testing/gcp-nise-6.csv", "testing/gcp-nise-7.csv"]
}
```
5. Check CSV/Parquet files in minio including OCP on GCP files
6. Rearrange the posted list of files above (so they process in a different order) Then Post them again.
7. See the files are deleted and recreated. 

Before this change we would get duplicate files

## Notes
THIS ONLY AFFECTS INGRESS FLOW
...
