### PR TITLE
add steps to build koku-minio using Dockerfile.minio

### DIFF
--- a/Dockerfile.minio
+++ b/Dockerfile.minio
@@ -7,7 +7,7 @@ USER root
 RUN groupadd -g ${USER_ID} kminio \
     && useradd -m -s /bin/bash -g ${USER_ID} -u ${USER_ID} -G root kminio \
     && mkdir /data || true \
-    && chown root:root /data \
+    && chown kminio:root /data \
     && chmod u+rwx /data \
     && chmod g+rwx /opt
 

--- a/Makefile
+++ b/Makefile
@@ -354,7 +354,7 @@ docker-up-min-no-build: docker-up-db
 	$(DOCKER_COMPOSE) up -d --scale koku-worker=$(scale) redis koku-server masu-server koku-worker trino hive-metastore
 
 # basic dev environment targets
-docker-up-min-with-subs: docker-up-min docker-trino-up
+docker-up-min-with-subs: docker-trino-setup docker-up-min
 	$(DOCKER_COMPOSE) up -d --scale subs-worker=$(scale) subs-worker
 
 docker-up-min-no-build-with-subs: docker-up-min-no-build

--- a/Makefile
+++ b/Makefile
@@ -354,7 +354,7 @@ docker-up-min-no-build: docker-up-db
 	$(DOCKER_COMPOSE) up -d --scale koku-worker=$(scale) redis koku-server masu-server koku-worker trino hive-metastore
 
 # basic dev environment targets
-docker-up-min-with-subs: docker-up-min
+docker-up-min-with-subs: docker-up-min docker-trino-up
 	$(DOCKER_COMPOSE) up -d --scale subs-worker=$(scale) subs-worker
 
 docker-up-min-no-build-with-subs: docker-up-min-no-build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -574,6 +574,8 @@ services:
     build:
         context: .
         dockerfile: Dockerfile.minio
+        args:
+          USER_ID: ${USER_ID-1000}
     container_name: kokuminio
     environment:
       MINIO_ROOT_USER: kokuminioaccess


### PR DESCRIPTION
## Jira Ticket

Note: I run into some error while using pre-commit linting, please run linting yourself before merging

## Description

This is a suggested change to  include the steps to build koku-minio using Dockerfile.minio in this repo

## Testing

BEFORE:
`make docker-up-min-with-subs `
runs the following docker-compose commands:

```
/usr/bin/docker-compose build koku-base
/usr/bin/docker-compose up -d db
/usr/bin/docker-compose up -d unleash
/usr/bin/docker-compose up -d --scale koku-worker=1 redis koku-server masu-server koku-worker trino hive-metastore
/usr/bin/docker-compose up -d --scale subs-worker=1 subs-worker
```

leading to an error in the koku-minio container:
```

73b29e7c6433   local-minio:latest                                   "/usr/bin/docker-ent…"   25 seconds ago   Exited (1) 24 seconds ago                                                                                              kokuminio
((koku) ) [plopezpe@fedora koku]$ docker logs 73b29e7c6433
ERROR Unable to initialize backend: mkdir /data/.minio.sys: permission denied
```

AFTER:
`make docker-up-min-with-subs`
```

/usr/bin/docker-compose build koku-base
/usr/bin/docker-compose up -d db
/usr/bin/docker-compose up -d unleash
/usr/bin/docker-compose up -d --scale koku-worker=1 redis koku-server masu-server koku-worker trino hive-metastore
/usr/bin/docker-compose up --build -d trino hive-metastore
/usr/bin/docker-compose up -d --scale subs-worker=1 subs-worker
```

The instruction /usr/bin/docker-compose up --build -d trino hive-metastore
will use the Dockerfile.minio to build kokuminio because of set up dependencies in docker-compose(hive-> create-parquet-bucket-> koku-minio)


## Notes

...
