### PR TITLE
[COST-4209] enable OCP polling ingest only when DEBUG is true

### DIFF
--- a/koku/api/provider/models.py
+++ b/koku/api/provider/models.py
@@ -74,7 +74,8 @@ class ProviderObjectsPollingManager(ProviderObjectsManager):
 
     def get_queryset(self):
         """Return a Queryset of non-OCP and active and non-paused Providers."""
-        return super().get_queryset().filter(active=True, paused=False).exclude(type=Provider.PROVIDER_OCP)
+        excludes = {} if settings.DEBUG else {"type": Provider.PROVIDER_OCP}
+        return super().get_queryset().filter(active=True, paused=False).exclude(**excludes)
 
     def get_polling_batch(self, limit=-1, offset=0):
         """Return a Queryset of pollable Providers that have not polled in the last 24 hours."""

--- a/koku/api/provider/test/test_models.py
+++ b/koku/api/provider/test/test_models.py
@@ -11,6 +11,7 @@ from uuid import UUID
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
+from django.test.utils import override_settings
 from django_tenants.utils import tenant_context
 from faker import Faker
 
@@ -144,6 +145,13 @@ class ProviderModelTest(MasuTestCase):
         self.assertEqual(pollable.count(), non_ocp_providers_count)
         for p in pollable:
             self.assertNotEqual(p.type, Provider.PROVIDER_OCP)
+
+    @override_settings(DEBUG=True)
+    def test_get_pollable_providers_debug(self):
+        """Test that the pollable manager returns non-OCP providers only."""
+        all_providers_count = Provider.objects.count()
+        pollable = Provider.polling_objects.get_polling_batch(0)
+        self.assertEqual(pollable.count(), all_providers_count)
 
     def test_get_pollable_providers_with_timestamps(self):
         """Test that the pollable manager returns non-OCP providers only."""

--- a/koku/api/provider/test/test_models.py
+++ b/koku/api/provider/test/test_models.py
@@ -148,7 +148,7 @@ class ProviderModelTest(MasuTestCase):
 
     @override_settings(DEBUG=True)
     def test_get_pollable_providers_debug(self):
-        """Test that the pollable manager returns non-OCP providers only."""
+        """Test that the pollable manager returns OCP providers with DEBUG=True"""
         all_providers_count = Provider.objects.count()
         pollable = Provider.polling_objects.get_polling_batch(0)
         self.assertEqual(pollable.count(), all_providers_count)


### PR DESCRIPTION
## Jira Ticket

[COST-4209](https://issues.redhat.com/browse/COST-4209)

## Description

This change will enable OCP polling ingest when settings.DEBUG is True.

## Testing

locally:
1. `make create-test-customer; make load-test-customer-data test_source=ONPREM`
2. see data ingest

## Notes

...
