### PR TITLE
[COST-4209] Fix Masu download endpoint query params

### DIFF
--- a/koku/api/provider/models.py
+++ b/koku/api/provider/models.py
@@ -77,14 +77,16 @@ class ProviderObjectsPollingManager(ProviderObjectsManager):
         excludes = {} if settings.DEBUG else {"type": Provider.PROVIDER_OCP}
         return super().get_queryset().filter(active=True, paused=False).exclude(**excludes)
 
-    def get_polling_batch(self, limit=-1, offset=0):
+    def get_polling_batch(self, limit=-1, offset=0, filters=None):
         """Return a Queryset of pollable Providers that have not polled in the last 24 hours."""
         polling_delta = datetime.now(tz=settings.UTC) - timedelta(seconds=settings.POLLING_TIMER)
+        if not filters:
+            filters = {}
         if limit < 1:
             # Django can't do negative indexing, so just return all the Providers.
             # A limit of 0 doesn't make sense either. That would just return an empty QuerySet.
-            return self.exclude(polling_timestamp__gt=polling_delta)
-        return self.exclude(polling_timestamp__gt=polling_delta)[offset : limit + offset]
+            return self.filter(**filters).exclude(polling_timestamp__gt=polling_delta)
+        return self.filter(**filters).exclude(polling_timestamp__gt=polling_delta)[offset : limit + offset]
 
 
 class Provider(models.Model):

--- a/koku/masu/api/download.py
+++ b/koku/masu/api/download.py
@@ -28,14 +28,12 @@ def download_report(request):
     provider_uuid = params.get("provider_uuid")
     provider_type = params.get("provider_type")
     bill_date = params.get("bill_date")
-    scheduled = params.get("scheduled", "false").lower()
-    scheduled = True if scheduled == "true" else False
     summarize_reports = params.get("summarize_reports", "true").lower()
     summarize_reports = True if summarize_reports == "true" else False
     async_download_result = check_report_updates.delay(
         provider_uuid=provider_uuid,
         provider_type=provider_type,
-        scheduled=scheduled,
+        scheduled=False,
         bill_date=bill_date,
         summarize_reports=summarize_reports,
     )

--- a/koku/masu/celery/tasks.py
+++ b/koku/masu/celery/tasks.py
@@ -12,6 +12,7 @@ from celery.exceptions import MaxRetriesExceededError
 from django.conf import settings
 from django_tenants.utils import schema_context
 
+from api.common import log_json
 from api.currency.currencies import VALID_CURRENCIES
 from api.currency.models import ExchangeRates
 from api.currency.utils import exchange_dictionary
@@ -56,7 +57,7 @@ PROVIDER_REPORT_TYPE_MAP = {
 def check_report_updates(*args, **kwargs):
     """Scheduled task to initiate scanning process on a regular interval."""
     orchestrator = Orchestrator(*args, **kwargs)
-    LOG.info("checking for report updates")
+    LOG.info(log_json(msg="checking for report updates", args=args, kwargs=kwargs))
     orchestrator.prepare()
 
 

--- a/koku/masu/celery/tasks.py
+++ b/koku/masu/celery/tasks.py
@@ -44,7 +44,6 @@ from reporting.models import TRINO_MANAGED_TABLES
 from sources.tasks import delete_source
 
 LOG = logging.getLogger(__name__)
-_DB_FETCH_BATCH_SIZE = 2000
 
 PROVIDER_REPORT_TYPE_MAP = {
     Provider.PROVIDER_OCP: OCP_REPORT_TYPES,
@@ -57,6 +56,7 @@ PROVIDER_REPORT_TYPE_MAP = {
 def check_report_updates(*args, **kwargs):
     """Scheduled task to initiate scanning process on a regular interval."""
     orchestrator = Orchestrator(*args, **kwargs)
+    LOG.info("checking for report updates")
     orchestrator.prepare()
 
 

--- a/koku/masu/processor/orchestrator.py
+++ b/koku/masu/processor/orchestrator.py
@@ -67,7 +67,6 @@ class Orchestrator:
         self.queue_name = queue_name
         self.ingress_reports = kwargs.get("ingress_reports")
         self.ingress_report_uuid = kwargs.get("ingress_report_uuid")
-        self._polling_accounts = Provider.polling_objects.get_accounts()
         self._summarize_reports = kwargs.get("summarize_reports", True)
 
     def get_polling_batch(self):

--- a/koku/masu/processor/orchestrator.py
+++ b/koku/masu/processor/orchestrator.py
@@ -70,15 +70,13 @@ class Orchestrator:
         self._summarize_reports = kwargs.get("summarize_reports", True)
 
     def get_polling_batch(self):
-        if self.scheduled:
-            providers = Provider.polling_objects.get_polling_batch(settings.POLLING_BATCH_SIZE)
+        if not self.scheduled and self.provider_uuid:
+            providers = Provider.objects.filter(uuid=self.provider_uuid)
         else:
             filters = {}
             if self.provider_type:
                 filters["type"] = self.provider_type
-            if self.provider_uuid:
-                filters["uuid"] = self.provider_uuid
-            providers = Provider.objects.filter(**filters)
+            providers = Provider.polling_objects.get_polling_batch(settings.POLLING_BATCH_SIZE, filters=filters)
 
         batch = []
         for provider in providers:

--- a/koku/masu/processor/orchestrator.py
+++ b/koku/masu/processor/orchestrator.py
@@ -290,8 +290,9 @@ class Orchestrator:
         """
         accounts = self.get_polling_batch()
         if not accounts:
-            LOG.info("no accounts to be polled")
+            LOG.info(log_json(msg="no accounts to be polled"))
 
+        LOG.info(log_json(msg="polling accounts", count=len(accounts)))
         for account in accounts:
             provider_uuid = account.get("provider_uuid")
             provider_type = account.get("provider_type")

--- a/koku/masu/test/processor/test_orchestrator.py
+++ b/koku/masu/test/processor/test_orchestrator.py
@@ -496,3 +496,19 @@ class OrchestratorTest(MasuTestCase):
         orchestrator = Orchestrator(bill_date=dh.today)
         result = orchestrator.get_reports(self.aws_provider_uuid)
         self.assertEqual(result, expected)
+
+    @patch("masu.processor.orchestrator.WorkerCache")
+    def test_orchestrator_args_polling_batch(self, *args):
+        """Test that args to Orchestrator change the polling-batch result"""
+        o = Orchestrator(
+            provider_uuid=self.aws_provider_uuid,
+            scheduled=False,
+        )
+        p = o.get_polling_batch()
+        self.assertEqual(len(p), 1)
+
+        expected_providers = Provider.objects.filter(type=Provider.PROVIDER_AWS)
+        o = Orchestrator(scheduled=False, provider_type="AWS")
+
+        p = o.get_polling_batch()
+        self.assertEqual(len(p), expected_providers.count())

--- a/koku/masu/test/processor/test_orchestrator.py
+++ b/koku/masu/test/processor/test_orchestrator.py
@@ -74,62 +74,6 @@ class OrchestratorTest(MasuTestCase):
             },
         ]
 
-    @patch("masu.processor.worker_cache.CELERY_INSPECT")  # noqa: C901
-    def test_initializer(self, mock_inspect):  # noqa: C901
-        """Test to init."""
-        orchestrator = Orchestrator()
-        provider_count = Provider.objects.filter(active=True).exclude(type=Provider.PROVIDER_OCP).count()
-        if len(orchestrator._polling_accounts) != provider_count:
-            self.fail("Unexpected number of test accounts")
-
-        for account in orchestrator._polling_accounts:
-            with self.subTest(provider_type=account.get("provider_type")):
-                if account.get("provider_type") in (Provider.PROVIDER_AWS, Provider.PROVIDER_AWS_LOCAL):
-                    self.assertEqual(account.get("credentials"), self.aws_credentials)
-                    self.assertEqual(account.get("data_source"), self.aws_data_source)
-                    self.assertEqual(account.get("customer_name"), self.schema)
-                elif account.get("provider_type") == Provider.PROVIDER_OCP:
-                    self.assertIn(account.get("credentials"), self.ocp_credentials)
-                    self.assertEqual(account.get("data_source"), self.ocp_data_source)
-                    self.assertEqual(account.get("customer_name"), self.schema)
-                elif account.get("provider_type") in (Provider.PROVIDER_AZURE, Provider.PROVIDER_AZURE_LOCAL):
-                    self.assertEqual(account.get("credentials"), self.azure_credentials)
-                    self.assertEqual(account.get("data_source"), self.azure_data_source)
-                    self.assertEqual(account.get("customer_name"), self.schema)
-                elif account.get("provider_type") in (Provider.PROVIDER_GCP, Provider.PROVIDER_GCP_LOCAL):
-                    self.assertEqual(account.get("credentials"), self.gcp_credentials)
-                    self.assertEqual(account.get("data_source"), self.gcp_data_source)
-                    self.assertEqual(account.get("customer_name"), self.schema)
-                elif account.get("provider_type") in (Provider.PROVIDER_OCI, Provider.PROVIDER_OCI_LOCAL):
-                    self.assertEqual(account.get("data_source"), self.oci_data_source)
-                    self.assertEqual(account.get("customer_name"), self.schema)
-                else:
-                    self.fail("Unexpected provider")
-
-        # Result is 4 because that matches the number of non OCP sources
-        if len(orchestrator._polling_accounts) != 4:
-            self.fail("Unexpected number of listener test accounts")
-
-        for account in orchestrator._polling_accounts:
-            with self.subTest(provider_type=account.get("provider_type")):
-                if account.get("provider_type") in (Provider.PROVIDER_AWS, Provider.PROVIDER_AWS_LOCAL):
-                    self.assertEqual(account.get("credentials"), self.aws_credentials)
-                    self.assertEqual(account.get("data_source"), self.aws_data_source)
-                    self.assertEqual(account.get("customer_name"), self.schema)
-                elif account.get("provider_type") in (Provider.PROVIDER_AZURE, Provider.PROVIDER_AZURE_LOCAL):
-                    self.assertEqual(account.get("credentials"), self.azure_credentials)
-                    self.assertEqual(account.get("data_source"), self.azure_data_source)
-                    self.assertEqual(account.get("customer_name"), self.schema)
-                elif account.get("provider_type") in (Provider.PROVIDER_GCP, Provider.PROVIDER_GCP_LOCAL):
-                    self.assertEqual(account.get("credentials"), self.gcp_credentials)
-                    self.assertEqual(account.get("data_source"), self.gcp_data_source)
-                    self.assertEqual(account.get("customer_name"), self.schema)
-                elif account.get("provider_type") in (Provider.PROVIDER_OCI, Provider.PROVIDER_OCI_LOCAL):
-                    self.assertEqual(account.get("data_source"), self.oci_data_source)
-                    self.assertEqual(account.get("customer_name"), self.schema)
-                else:
-                    self.fail("Unexpected provider")
-
     @patch("masu.processor.orchestrator.AccountLabel")
     @patch("masu.processor.worker_cache.CELERY_INSPECT")
     @patch("masu.external.report_downloader.ReportDownloader._set_downloader", return_value=FakeDownloader)


### PR DESCRIPTION
## Jira Ticket

[COST-4209](https://issues.redhat.com/browse/COST-4209)

## Description

The download endpoint should:
1. when providing a provider_uuid arg, will override the polling timestamp
2. when providing a provider_type, will only return those providers, and will respect the polling_timestamp and batch-size

This PR fixes the /download endpoint to respect the above criteria. It also adds some logging to show args passed to the orchestrator and how many accounts will be polled.

## Testing

set polling timer to a long period:
```
POLLING_TIMER=86400  # 24 hours
```

```
make create-test-customer;
```

some endpoints to test:
```
these will only poll the providers when they are older than the polling timestamp
(ocp only works when DEVELOPMENT=True)
http://localhost:5042/api/cost-management/v1/download/?provider_type=OCP
http://localhost:5042/api/cost-management/v1/download/?provider_type=AWS
http://localhost:5042/api/cost-management/v1/download/?provider_type=AWS-local

this always polls the provider:
http://localhost:5042/api/cost-management/v1/download/?provider_uuid={a uuid}

```

## Notes

...
