### PR TITLE
[COST-4209] remove schedule flag from orchestrator

### DIFF
--- a/koku/api/provider/models.py
+++ b/koku/api/provider/models.py
@@ -240,6 +240,9 @@ class Provider(models.Model):
         super().save(*args, **kwargs)
 
         if settings.AUTO_DATA_INGEST and should_ingest and self.active:
+            if self.type == Provider.PROVIDER_OCP and not settings.DEBUG:
+                # OCP Providers are not pollable, so shouldn't go thru check_report_updates
+                return
             # Local import of task function to avoid potential import cycle.
             from masu.celery.tasks import check_report_updates
 

--- a/koku/koku/celery.py
+++ b/koku/koku/celery.py
@@ -119,7 +119,7 @@ if ENVIRONMENT.bool("SCHEDULE_REPORT_CHECKS", default=False):
     CHECK_REPORT_UPDATES_DEF = {
         "task": download_task,
         "schedule": report_schedule,
-        "kwargs": {"scheduled": True},
+        "kwargs": {},
     }
     app.conf.beat_schedule["check-report-updates-batched"] = CHECK_REPORT_UPDATES_DEF
 

--- a/koku/masu/api/download.py
+++ b/koku/masu/api/download.py
@@ -33,7 +33,6 @@ def download_report(request):
     async_download_result = check_report_updates.delay(
         provider_uuid=provider_uuid,
         provider_type=provider_type,
-        scheduled=False,
         bill_date=bill_date,
         summarize_reports=summarize_reports,
     )

--- a/koku/masu/processor/orchestrator.py
+++ b/koku/masu/processor/orchestrator.py
@@ -54,7 +54,6 @@ class Orchestrator:
         self,
         provider_uuid=None,
         provider_type=None,
-        scheduled=True,
         bill_date=None,
         queue_name=None,
         **kwargs,
@@ -63,14 +62,13 @@ class Orchestrator:
         self.bill_date = bill_date
         self.provider_uuid = provider_uuid
         self.provider_type = provider_type
-        self.scheduled = scheduled
         self.queue_name = queue_name
         self.ingress_reports = kwargs.get("ingress_reports")
         self.ingress_report_uuid = kwargs.get("ingress_report_uuid")
         self._summarize_reports = kwargs.get("summarize_reports", True)
 
     def get_polling_batch(self):
-        if not self.scheduled and self.provider_uuid:
+        if self.provider_uuid:
             providers = Provider.objects.filter(uuid=self.provider_uuid)
         else:
             filters = {}

--- a/koku/masu/test/processor/test_orchestrator.py
+++ b/koku/masu/test/processor/test_orchestrator.py
@@ -445,16 +445,13 @@ class OrchestratorTest(MasuTestCase):
     def test_orchestrator_args_polling_batch(self, *args):
         """Test that args to Orchestrator change the polling-batch result"""
         # providing a UUID overrides the polling timestamp
-        o = Orchestrator(
-            provider_uuid=self.aws_provider_uuid,
-            scheduled=False,
-        )
+        o = Orchestrator(provider_uuid=self.aws_provider_uuid)
         p = o.get_polling_batch()
         self.assertEqual(len(p), 1)
 
         # provider provider-type does NOT override polling timestamp
         # so this query will provide zero pollable providers
-        o = Orchestrator(scheduled=False, provider_type="AWS-local")
+        o = Orchestrator(provider_type="AWS-local")
         p = o.get_polling_batch()
         self.assertEqual(len(p), 0)
 
@@ -465,7 +462,7 @@ class OrchestratorTest(MasuTestCase):
         p.polling_timestamp = None
         p.save()
 
-        o = Orchestrator(scheduled=False, provider_type="AWS-local")
+        o = Orchestrator(provider_type="AWS-local")
         p = o.get_polling_batch()
         self.assertGreater(len(p), 0)
         self.assertEqual(len(p), expected_providers.count())


### PR DESCRIPTION
## Jira Ticket

[COST-4209](https://issues.redhat.com/browse/COST-4209)

## Description

Remove the `scheduled` flag from the Orchestrator. When a Provider is being saved, it sends the provider_uuid to `check_report_updates` but we're missing the `scheduled=False` flag. Doing this causes us to trigger download in the priority queue for a batch of providers. If we're sending the uuid to the orchestrator, we should only care about that provider. The scheduled flag is not necessary any more.

## Testing

in ephemeral:
1. create a real AWS source
2. see ingestion in priority queue
3. in the koku-db, edit the provider to set the polling timestamp to null:
```
sh-4.2$ psql -d koku
psql (13.7)
Type "help" for help.

koku=# update api_provider set polling_timestamp = null;
UPDATE 1
```
4. create an OCP source. Do NOT see any ingestion anywhere, and in the db verify that the polling_timestamps for the 2 providers are both null
5. create a real Azure source. See ingestion in the priority queue for that Azure provider ONLY. In the DB verify that the polling_timestamp for AWS and OCP are still null, but the Azure provider is populated.

These last steps verify that the auto-ingest is working correctly for the Providers. OCP should not be polling because it is not a pollable Provider, and the initial ingest of the other Providers is only triggered for those specific Providers, not a batch.

## Notes

...
