### PR TITLE
add the ability to purge a specific queue of tasks

### DIFF
--- a/koku/masu/api/running_celery_tasks.py
+++ b/koku/masu/api/running_celery_tasks.py
@@ -73,11 +73,10 @@ def clear_celery_queues(request):
         clear_all = params.get("clear_all")
         queue = params.get("queue")
 
-        # clear default_celery queue
-        purged_tasks = app.control.purge()
-
         # clear all queues
         if clear_all:
+            # clear default_celery queue
+            purged_tasks = app.control.purge()
             LOG.info(f"Clearing all queues parameter: {clear_all}")
             queue_lengths = list(collect_queue_metrics().values())
             purged_tasks += sum(queue_lengths)

--- a/koku/masu/test/api/test_running_celery_tasks.py
+++ b/koku/masu/test/api/test_running_celery_tasks.py
@@ -56,16 +56,6 @@ class RunningCeleryTasksTests(TestCase):
 
     @patch("koku.middleware.MASU", return_value=True)
     @patch("masu.api.running_celery_tasks.app")
-    def test_clear_celery_queues_default(self, mock_celery, _):
-        """Test the GET of clear_celery_queues endpoint."""
-        mock_celery.control.purge.return_value = 0
-        response = self.client.get(reverse("clear_celery_queues"))
-        mock_celery.control.purge.assert_called_once()
-        self.assertEqual(response.status_code, 200)
-        self.assertIn("purged_tasks", response.data)
-
-    @patch("koku.middleware.MASU", return_value=True)
-    @patch("masu.api.running_celery_tasks.app")
     @patch("masu.api.running_celery_tasks.collect_queue_metrics")
     @patch("masu.api.running_celery_tasks.redis")
     def test_clear_celery_queues_clear_all(self, mock_redis, mock_collect, mock_celery, _):
@@ -87,13 +77,11 @@ class RunningCeleryTasksTests(TestCase):
         mock_redis.flushall.assert_called_once()
 
     @patch("koku.middleware.MASU", return_value=True)
-    @patch("masu.api.running_celery_tasks.app")
     @patch("masu.api.running_celery_tasks.collect_queue_metrics")
     @patch("masu.api.running_celery_tasks.redis")
-    def test_clear_queue(self, mock_redis, mock_collect, mock_celery, _):
+    def test_clear_queue(self, mock_redis, mock_collect, _):
         """Test the GET of clear_celery_queues endpoint with specific queue."""
         expected_key = "purged_tasks"
-        mock_celery.control.purge.return_value = 0
         expected_queue_lengths = {"priority": 2}
         mock_collect.return_value = expected_queue_lengths
         mock_redis = mock_redis.Redis.return_value
@@ -102,7 +90,6 @@ class RunningCeleryTasksTests(TestCase):
         body = response.json()
         self.assertEqual(response.status_code, 200)
         self.assertIn(expected_key, body)
-        mock_celery.control.purge.assert_called_once()
         mock_collect.assert_called_once()
         mock_redis.delete.assert_called_once()
 

--- a/koku/masu/test/api/test_running_celery_tasks.py
+++ b/koku/masu/test/api/test_running_celery_tasks.py
@@ -94,12 +94,10 @@ class RunningCeleryTasksTests(TestCase):
         """Test the GET of clear_celery_queues endpoint with specific queue."""
         expected_key = "purged_tasks"
         mock_celery.control.purge.return_value = 0
-        mock_collect.values.return_value = []
+        expected_queue_lengths = {"priority": 2}
+        mock_collect.return_value = expected_queue_lengths
         mock_redis = mock_redis.Redis.return_value
-        mock_redis.flushall.return_value = "true"
-        params = {"queue": "priority"}
-        query_string = urlencode(params)
-        url = reverse("clear_celery_queues") + "?" + query_string
+        url = reverse("clear_celery_queues") + "?queue=priority"
         response = self.client.get(url)
         body = response.json()
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
## Jira Ticket

[COST-4287](https://issues.redhat.com/browse/COST-4287)

## Description

This change will give us the ability to clear a specific queue of tasks without needing to clear everything via our internal endpoints.

## Testing

1. Checkout Branch
2. Restart Koku
3. Make load some data or add a bunch of summary tasks or w/e to a queue 
4. Hit http://localhost:5042/api/cost-management/v1/clear_celery_queues/?queue=priority OR whatever queue you want to clear. See that queue gets set to 0

## Notes

...
