### PR TITLE
RHIROS-1292 Make ROS OCP API spec available under Cost-Mgmt API doc

### DIFF
--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -56,6 +56,10 @@
         {
             "name": "Status",
             "description": "Operations about status"
+        },
+        {
+            "name": "Optimizations",
+            "description": "Resource Optimization for Openshift"
         }
     ],
     "paths": {
@@ -5729,7 +5733,13 @@
                         "basic_auth": []
                     }]
                 }
-            }
+            },
+        "/recommendations/openshift": {
+            "$ref": "https://raw.githubusercontent.com/RedHatInsights/ros-ocp-backend/main/openapi.json#/paths/~1recommendations~1openshift"
+        },
+        "/recommendations/openshift/{recommendation-id}": {
+            "$ref": "https://raw.githubusercontent.com/RedHatInsights/ros-ocp-backend/main/openapi.json#/paths/~1recommendations~1openshift~1{recommendation-id}"
+        }
         },
     "externalDocs": {
         "description": "Find out more about Cost Management",


### PR DESCRIPTION
## Jira Ticket

[RHIROS-1292](https://issues.redhat.com/browse/RHIROS-1292) [ROS-OCP] Make API specifications available under Insights API documentation

## Description

This PR consists **Cost-Mgmt** side of ``openapi.json`` file changes to include **ROS-OCP Backend API** endpoints under ``Optimizations`` tag using ``$ref``

https://github.com/RedHatInsights/ros-ocp-backend/pull/133 - Along with **ROS-OCP Backend** side of ``openapi.json`` file changes, whenever the API spec file is updated, the changes will automatically reflect for all **ROS OCP Backend API** endpoints.

## Screenshots
![Screenshot from 2023-10-12 13-11-49](https://github.com/project-koku/koku/assets/53873549/7466c358-bc73-44a6-b988-dc5681b8a7b5)



## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Notes
Need to wait for https://github.com/RedHatInsights/ros-ocp-backend/pull/133 to get merged, then change ``$ref`` to link to https://raw.githubusercontent.com/RedHatInsights/ros-ocp-backend/main/openapi.json
...
