### PR TITLE
[COST-4242] Performance enhancements for resource id subs processing

### DIFF
--- a/koku/subs/subs_data_extractor.py
+++ b/koku/subs/subs_data_extractor.py
@@ -163,7 +163,7 @@ class SUBSDataExtractor(ReportDBAccessorBase):
             log_json(
                 self.tracing_id,
                 msg=f"identified {total_count} matching records for metered rhel",
-                context=self.context,
+                context=self.context | {"resource_id": rid},
             )
         )
         upload_keys = []
@@ -174,11 +174,11 @@ class SUBSDataExtractor(ReportDBAccessorBase):
         for i, offset in enumerate(range(0, total_count, settings.PARQUET_PROCESSING_BATCH_SIZE)):
             sql_params = {
                 "schema": self.schema,
-                "provider_uuid": self.provider_uuid,
+                "source_uuid": self.provider_uuid,
                 "year": year,
                 "month": month,
-                "start_time": start_time,
-                "end_time": end_time,
+                "start_date": start_time,
+                "end_date": end_time,
                 "offset": offset,
                 "limit": settings.PARQUET_PROCESSING_BATCH_SIZE,
                 "rid": rid,
@@ -192,7 +192,7 @@ class SUBSDataExtractor(ReportDBAccessorBase):
             # col[0] grabs the column names from the query results
             cols = [col[0] for col in description]
 
-            upload_keys.append(self.copy_data_to_subs_s3_bucket(results, cols, f"{filename}{i}.csv"))
+            upload_keys.append((self.copy_data_to_subs_s3_bucket(results, cols, f"{filename}{i}.csv"), rid))
         return upload_keys
 
     def bulk_update_latest_processed_time(self, resources, year, month):

--- a/koku/subs/subs_data_extractor.py
+++ b/koku/subs/subs_data_extractor.py
@@ -69,12 +69,12 @@ class SUBSDataExtractor(ReportDBAccessorBase):
             )
             sql = (
                 "SELECT DISTINCT lineitem_usageaccountid FROM aws_line_items WHERE"
-                " source={{provider_uuid}} AND year={{year}} AND month={{month}}"
+                " source={{source_uuid}} AND year={{year}} AND month={{month}}"
             )
             if excluded_ids:
                 sql += "AND lineitem_usageaccountid NOT IN {{excluded_ids | inclause}}"
             sql_params = {
-                "provider_uuid": self.provider_uuid,
+                "source_uuid": self.provider_uuid,
                 "year": year,
                 "month": month,
                 "excluded_ids": excluded_ids,
@@ -111,14 +111,14 @@ class SUBSDataExtractor(ReportDBAccessorBase):
     def determine_where_clause_and_params(self, latest_processed_time, end_time, year, month, rid):
         """Determine the where clause to use when processing subs data"""
         where_clause = (
-            "WHERE source={{provider_uuid}} AND year={{year}} AND month={{month}} AND"
+            "WHERE source={{source_uuid}} AND year={{year}} AND month={{month}} AND"
             " lineitem_productcode = 'AmazonEC2' AND lineitem_lineitemtype IN ('Usage', 'SavingsPlanCoveredUsage') AND"
             " product_vcpu IS NOT NULL AND strpos(lower(resourcetags), 'com_redhat_rhel') > 0 AND"
             " lineitem_usagestartdate > {{latest_processed_time}} AND"
             " lineitem_usagestartdate <= {{end_time}} AND lineitem_resourceid = {{rid}}"
         )
         sql_params = {
-            "provider_uuid": self.provider_uuid,
+            "source_uuid": self.provider_uuid,
             "year": year,
             "month": month,
             "latest_processed_time": latest_processed_time,
@@ -136,7 +136,7 @@ class SUBSDataExtractor(ReportDBAccessorBase):
             )
             sql = (
                 "SELECT lineitem_resourceid, max(lineitem_usagestartdate) FROM aws_line_items WHERE"
-                " source={{provider_uuid}} AND year={{year}} AND month={{month}}"
+                " source={{source_uuid}} AND year={{year}} AND month={{month}}"
                 " AND lineitem_productcode = 'AmazonEC2' AND strpos(lower(resourcetags), 'com_redhat_rhel') > 0"
                 " AND lineitem_usageaccountid = {{usage_account}}"
             )
@@ -144,7 +144,7 @@ class SUBSDataExtractor(ReportDBAccessorBase):
                 sql += "AND lineitem_resourceid NOT IN {{excluded_ids | inclause}}"
             sql += " GROUP BY lineitem_resourceid"
             sql_params = {
-                "provider_uuid": self.provider_uuid,
+                "source_uuid": self.provider_uuid,
                 "year": year,
                 "month": month,
                 "excluded_ids": excluded_ids,

--- a/koku/subs/subs_data_messenger.py
+++ b/koku/subs/subs_data_messenger.py
@@ -37,9 +37,10 @@ class SUBSDataMessenger:
 
     def process_and_send_subs_message(self, upload_keys):
         """
-        Takes a list of object keys, reads the objects from the S3 bucket and processes a message to kafka.
+        Takes a list of tuples (key, resource_id),reads the objects from the S3 bucket and processes a message to kafka.
         """
-        for i, obj_key in enumerate(upload_keys):
+        for i, obj_tuple in enumerate(upload_keys):
+            obj_key, rid = obj_tuple
             csv_path = f"{self.download_path}/subs_{self.tracing_id}_{i}.csv"
             self.s3_resource.Bucket(settings.S3_SUBS_BUCKET_NAME).download_file(obj_key, csv_path)
             with open(csv_path) as csv_file:
@@ -71,7 +72,7 @@ class SUBSDataMessenger:
                 log_json(
                     self.tracing_id,
                     msg=f"sent {msg_count} kafka messages for subs",
-                    context=self.context,
+                    context=self.context | {"resource_id": rid},
                 )
             )
             os.remove(csv_path)

--- a/koku/subs/test/test_subs_data_extractor.py
+++ b/koku/subs/test/test_subs_data_extractor.py
@@ -91,7 +91,7 @@ class TestSUBSDataExtractor(SUBSTestCase):
         end_time = self.today + timedelta(days=2)
         rid = "45678"
         expected_sql_params = {
-            "provider_uuid": self.aws_provider.uuid,
+            "source_uuid": self.aws_provider.uuid,
             "year": year,
             "month": month,
             "latest_processed_time": latest_processed_time,
@@ -99,7 +99,7 @@ class TestSUBSDataExtractor(SUBSTestCase):
             "rid": rid,
         }
         expected_clause = (
-            "WHERE source={{provider_uuid}} AND year={{year}} AND month={{month}} AND"
+            "WHERE source={{source_uuid}} AND year={{year}} AND month={{month}} AND"
             " lineitem_productcode = 'AmazonEC2' AND lineitem_lineitemtype IN ('Usage', 'SavingsPlanCoveredUsage') AND"
             " product_vcpu IS NOT NULL AND strpos(lower(resourcetags), 'com_redhat_rhel') > 0 AND"
             " lineitem_usagestartdate > {{latest_processed_time}} AND"

--- a/koku/subs/test/test_subs_data_extractor.py
+++ b/koku/subs/test/test_subs_data_extractor.py
@@ -210,7 +210,8 @@ class TestSUBSDataExtractor(SUBSTestCase):
         mock_li_count.assert_called_once()
         mock_trino.assert_called_once()
         mock_copy.assert_called_once()
-        self.assertEqual([expected_key], upload_keys)
+        expected_result = [(expected_key, rid)]
+        self.assertEqual(expected_result, upload_keys)
 
     def test_copy_data_to_subs_s3_bucket(self):
         """Test copy_data_to_subs_s3_bucket."""

--- a/koku/subs/test/test_subs_data_messenger.py
+++ b/koku/subs/test/test_subs_data_messenger.py
@@ -29,7 +29,7 @@ class TestSUBSDataMessenger(SUBSTestCase):
     @patch("subs.subs_data_messenger.SUBSDataMessenger.build_subs_msg")
     def test_process_and_send_subs_message(self, mock_msg_builder, mock_reader, mock_producer, mock_remove):
         """Tests that the proper functions are called when running process_and_send_subs_message"""
-        upload_keys = ["fake_key"]
+        upload_keys = [("fake_key", "i-55555556")]
         mock_reader.return_value = [
             {
                 "subs_start_time": "2023-07-01T01:00:00Z",

--- a/koku/subs/trino_sql/aws_subs_summary.sql
+++ b/koku/subs/trino_sql/aws_subs_summary.sql
@@ -51,14 +51,4 @@ FROM
       AND lineitem_productcode = 'AmazonEC2'
       AND lineitem_lineitemtype IN ('Usage', 'SavingsPlanCoveredUsage')
       and product_vcpu IS NOT NULL
-      AND lineitem_usagestartdate >= {{ start_date }}
-      AND lineitem_usagestartdate <= {{ end_date }}
       AND strpos(lower(resourcetags), 'com_redhat_rhel') > 0
-      AND lineitem_resourceid = {{ rid }}
-    OFFSET
-      {{ offset }}
-    LIMIT
-      {{ limit }}
-  )
--- this ensures the required `com_redhat_rhel` tag exists in the set of tags since the above match is not exact
-WHERE json_extract_scalar(tags, '$.com_redhat_rhel') IS NOT NULL

--- a/koku/subs/trino_sql/aws_subs_summary.sql
+++ b/koku/subs/trino_sql/aws_subs_summary.sql
@@ -45,14 +45,14 @@ FROM
     from
       hive.{{schema | sqlsafe}}.aws_line_items
     WHERE
-      source = {{ provider_uuid }}
+      source = {{ source_uuid }}
       AND year = {{ year }}
       AND month = {{ month }}
       AND lineitem_productcode = 'AmazonEC2'
       AND lineitem_lineitemtype IN ('Usage', 'SavingsPlanCoveredUsage')
       and product_vcpu IS NOT NULL
-      AND lineitem_usagestartdate >= {{ start_time }}
-      AND lineitem_usagestartdate <= {{ end_time }}
+      AND lineitem_usagestartdate >= {{ start_date }}
+      AND lineitem_usagestartdate <= {{ end_date }}
       AND strpos(lower(resourcetags), 'com_redhat_rhel') > 0
       AND lineitem_resourceid = {{ rid }}
     OFFSET


### PR DESCRIPTION
## Jira Ticket

[COST-4242](https://issues.redhat.com/browse/COST-4242)

## Description

This change will not hit postgres inside a loop when the value doesn't change and batches the trino query into groups of 500 resource ids at a time to enhance processing.

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Notes

...
