### PR TITLE
[COST-4252] Add tag counts to meta in GET response

### DIFF
--- a/koku/api/settings/tags/view.py
+++ b/koku/api/settings/tags/view.py
@@ -24,6 +24,10 @@ from reporting.provider.all.models import EnabledTagKeys
 LOG = logging.getLogger(__name__)
 
 
+def get_enabled_tags_count() -> int:
+    return EnabledTagKeys.objects.filter(enabled=True).count()
+
+
 class SettingsTagFilter(SettingsFilter):
     key = NonValidatedMultipleChoiceFilter(lookup_expr="icontains")
     uuid = AllValuesMultipleFilter()
@@ -49,9 +53,15 @@ class SettingsTagView(generics.GenericAPIView):
         serializer = self.serializer_class(filtered_qset, many=True)
 
         paginator = ListPaginator(serializer.data, request)
-        paginated_data = paginator.paginate_queryset(serializer.data, request)
+        response = paginator.paginated_response
 
-        return paginator.get_paginated_response(paginated_data)
+        additional_meta = {
+            "enabled_tags_count": get_enabled_tags_count(),
+            "enabled_tags_limit": Config.ENABLED_TAG_LIMIT,
+        }
+        response.data["meta"].update(additional_meta)
+
+        return response
 
 
 class SettingsTagUpdateView(APIView):
@@ -79,20 +89,17 @@ class SettingsEnableTagView(SettingsTagUpdateView):
         if Config.ENABLED_TAG_LIMIT > 0:
             # Only count UUIDs requested to be enabled that are currently disabled.
             records_to_update_count = qs.filter(enabled=False).count()
-            future_enabled_tags_count = self.enabled_tags_count + records_to_update_count
+            enabled_tags_count = get_enabled_tags_count()
+            future_enabled_tags_count = enabled_tags_count + records_to_update_count
             if future_enabled_tags_count > Config.ENABLED_TAG_LIMIT:
                 return Response(
                     {
                         "error": f"The maximum number of enabled tags is {Config.ENABLED_TAG_LIMIT}.",
-                        "enabled": self.enabled_tags_count,
+                        "enabled": enabled_tags_count,
                         "limit": Config.ENABLED_TAG_LIMIT,
                     },
                     status=status.HTTP_412_PRECONDITION_FAILED,
                 )
-
-    @property
-    def enabled_tags_count(self):
-        return EnabledTagKeys.objects.filter(enabled=True).count()
 
 
 class SettingsDisableTagView(SettingsTagUpdateView):

--- a/koku/api/settings/test/tags/test_api.py
+++ b/koku/api/settings/test/tags/test_api.py
@@ -63,6 +63,7 @@ class TagsSettings(IamTestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(self.total_record_length, meta["count"])
+        self.assertTrue({"enabled_tags_count", "enabled_tags_limit"}.issubset(meta))
         self.assertTrue(len(data) > 0)
         self.assertTrue(returned_keys == set(self.keys))
 


### PR DESCRIPTION
Return the current tag limit as well as the number of enabled tags in the meta section of the GET response.

## Jira Ticket

[COST-4252](https://issues.redhat.com/browse/COST-4252)

## Description

Add `enabled_tags_count` and `enabled_tags_limit` to the `meta` section of the GET response for the `/settings/tags/` API.
## Testing

1. Checkout Branch
2. Restart Koku

```
> curl -sSLg localhost:8000/api/cost-management/v1/settings/tags/ | jello
{
  "meta": {
    "count": 23,
    "limit": 10,
    "offset": 0,
    "enabled_tags_count": 19,
    "enabled_tags_limit": 200
  },
  "links": {
...
```