### PR TITLE
[COST-4328] Fix where clause SQL and check for results before attempting to upload

### DIFF
--- a/koku/subs/subs_data_extractor.py
+++ b/koku/subs/subs_data_extractor.py
@@ -113,7 +113,7 @@ class SUBSDataExtractor(ReportDBAccessorBase):
         where_clause = (
             "WHERE source={{provider_uuid}} AND year={{year}} AND month={{month}} AND"
             " lineitem_productcode = 'AmazonEC2' AND lineitem_lineitemtype IN ('Usage', 'SavingsPlanCoveredUsage') AND"
-            " product_vcpu IS NOT NULL AND strpos(lower(resourcetags), 'com_redhat_rhel') > 0 AND"
+            " product_vcpu != '' AND strpos(lower(resourcetags), 'com_redhat_rhel') > 0 AND"
             " lineitem_usagestartdate > {{latest_processed_time}} AND"
             " lineitem_usagestartdate <= {{end_time}} AND lineitem_resourceid = {{rid}}"
         )
@@ -191,8 +191,8 @@ class SUBSDataExtractor(ReportDBAccessorBase):
             # [(name, type_code, display_size, internal_size, precision, scale, null_ok)]
             # col[0] grabs the column names from the query results
             cols = [col[0] for col in description]
-
-            upload_keys.append(self.copy_data_to_subs_s3_bucket(results, cols, f"{filename}{i}.csv"))
+            if results:
+                upload_keys.append(self.copy_data_to_subs_s3_bucket(results, cols, f"{filename}{i}.csv"))
         return upload_keys
 
     def bulk_update_latest_processed_time(self, resources, year, month):

--- a/koku/subs/test/test_subs_data_extractor.py
+++ b/koku/subs/test/test_subs_data_extractor.py
@@ -101,7 +101,7 @@ class TestSUBSDataExtractor(SUBSTestCase):
         expected_clause = (
             "WHERE source={{provider_uuid}} AND year={{year}} AND month={{month}} AND"
             " lineitem_productcode = 'AmazonEC2' AND lineitem_lineitemtype IN ('Usage', 'SavingsPlanCoveredUsage') AND"
-            " product_vcpu IS NOT NULL AND strpos(lower(resourcetags), 'com_redhat_rhel') > 0 AND"
+            " product_vcpu != '' AND strpos(lower(resourcetags), 'com_redhat_rhel') > 0 AND"
             " lineitem_usagestartdate > {{latest_processed_time}} AND"
             " lineitem_usagestartdate <= {{end_time}} AND lineitem_resourceid = {{rid}}"
         )
@@ -211,6 +211,30 @@ class TestSUBSDataExtractor(SUBSTestCase):
         mock_trino.assert_called_once()
         mock_copy.assert_called_once()
         self.assertEqual([expected_key], upload_keys)
+
+    @patch("subs.subs_data_extractor.SUBSDataExtractor.copy_data_to_subs_s3_bucket")
+    @patch("subs.subs_data_extractor.SUBSDataExtractor._execute_trino_raw_sql_query_with_description")
+    @patch("subs.subs_data_extractor.SUBSDataExtractor.determine_line_item_count")
+    @patch("subs.subs_data_extractor.SUBSDataExtractor.determine_where_clause_and_params")
+    def test_gather_and_upload_for_resource_no_result(self, mock_where_clause, mock_li_count, mock_trino, mock_copy):
+        """Test uploading does not attempt with empty values from trino query."""
+        self.dh.month_start(self.yesterday)
+        rid = "12345"
+        year = "2023"
+        month = "04"
+        start_time = datetime.datetime(2023, 4, 3, tzinfo=datetime.timezone.utc)
+        end_time = datetime.datetime(2023, 4, 5, tzinfo=datetime.timezone.utc)
+        mock_li_count.return_value = 10
+        expected_key = "fake_key"
+        mock_copy.return_value = expected_key
+        mock_trino.return_value = ([], [("fake_col1",), ("fake_col2",)])
+        mock_where_clause.return_value = (MagicMock(), MagicMock())
+        upload_keys = self.extractor.gather_and_upload_for_resource(rid, year, month, start_time, end_time)
+        mock_where_clause.assert_called_once()
+        mock_li_count.assert_called_once()
+        mock_trino.assert_called_once()
+        mock_copy.assert_not_called()
+        self.assertEqual(upload_keys, [])
 
     def test_copy_data_to_subs_s3_bucket(self):
         """Test copy_data_to_subs_s3_bucket."""


### PR DESCRIPTION
## Jira Ticket

[COST-4328](https://issues.redhat.com/browse/COST-4328)

## Description

This change will fix the where clause in the `get_where_clause` as well as check for results before attempting to create and upload to S3.

## Testing
The SQL clause here matches the update from yesterday it was just missed. The check for results before attempting to upload shouldn't happen with the updated SQL clause, but it catches an edge case scenario that no results come back from the SQL (which may also be addressed by the SQL clause here, but this is to be safe). Testing that via manual python should be sufficient.

1. Have koku up and running with some test customer data.
2. Exec into a worker pod: `docker exec -it koku-koku-worker-1 /bin/bash`
3. Inside the pod use manage.py to create a shell `python manage.py shell`
4. Once inside the shell recreate the edge case running the following steps to mimic no data being returned:
```
from masu.database.report_db_accessor_base import ReportDBAccessorBase
dba = ReportDBAccessorBase('org1234567')
results, des = dba._execute_trino_raw_sql_query_with_description("SELECT * FROM aws_line_items WHERE lineitem_resourceid = '1234'")
cols = [col[0] for col in des]
import pandas as pd
my_df = pd.DataFrame(results)
my_df.to_csv('fake_filename.csv', header=cols, index=False)
```
5. After running the last step above you should see a traceback like this:
```
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/opt/koku/.venv/lib64/python3.9/site-packages/pandas/core/generic.py", line 3902, in to_csv
    return DataFrameRenderer(formatter).to_csv(
  File "/opt/koku/.venv/lib64/python3.9/site-packages/pandas/io/formats/format.py", line 1152, in to_csv
    csv_formatter.save()
  File "/opt/koku/.venv/lib64/python3.9/site-packages/pandas/io/formats/csvs.py", line 266, in save
    self._save()
  File "/opt/koku/.venv/lib64/python3.9/site-packages/pandas/io/formats/csvs.py", line 270, in _save
    self._save_header()
  File "/opt/koku/.venv/lib64/python3.9/site-packages/pandas/io/formats/csvs.py", line 275, in _save_header
    self.writer.writerow(self.encoded_labels)
  File "/opt/koku/.venv/lib64/python3.9/site-packages/pandas/io/formats/csvs.py", line 238, in encoded_labels
    encoded_labels += list(self.write_cols)
  File "/opt/koku/.venv/lib64/python3.9/site-packages/pandas/io/formats/csvs.py", line 220, in write_cols
    raise ValueError(
ValueError: Writing 0 cols but got 55 aliases
```

6. So this is addressed by checking for results before attempting to run CSV conversion.
## Notes

...
