### PR TITLE
[COST-4358] Provide operator version in the messages to ROS

### DIFF
--- a/koku/masu/external/downloader/ocp/ocp_report_downloader.py
+++ b/koku/masu/external/downloader/ocp/ocp_report_downloader.py
@@ -30,6 +30,39 @@ REPORTS_DIR = Config.INSIGHTS_LOCAL_REPORT_DIR
 
 LOG = logging.getLogger(__name__)
 
+OPERATOR_VERSIONS = {
+    "5806b175a7b31e6ee112c798fa4222cc652b40a6": "costmanagement-metrics-operator:2.0.0",
+    "e3450f6e3422b6c39c582028ec4ce19b8d09d57d": "costmanagement-metrics-operator:1.2.0",
+    "61099eb07331b140cf66104bc1056c3f3211c94e": "costmanagement-metrics-operator:1.1.9",
+    "6d38c76be52e5981eaf19377a559dc681f1be405": "costmanagement-metrics-operator:1.1.8",
+    "0159d5e55ce6a5a18f989e6f04146f47983ebdf3": "costmanagement-metrics-operator:1.1.7",
+    "2a702a3aac89f724a08b08650b77a0bd33f5b5e5": "costmanagement-metrics-operator:1.1.6",
+    "f8d1f7c5d8685f758ecc36a14aca3b6b86614613": "costmanagement-metrics-operator:1.1.5",
+    "77ec351f8d332796dc522e5623f1200c2fab4042": "costmanagement-metrics-operator:1.1.4",
+    "084bca2e1c48caab18c237453c17ceef61747fe2": "costmanagement-metrics-operator:1.1.3",
+    "6f10d07e3af3ea4f073d4ffda9019d8855f52e7f": "costmanagement-metrics-operator:1.1.0",
+    "fd764dcd7e9b993025f3e05f7cd674bb32fad3be": "costmanagement-metrics-operator:1.0.0",
+    "26502d500672019af5c11319b558dec873409e38": "koku-metrics-operator:v2.0.0",
+    "2acd43ccec2d6fe6ec292aece951b3cf0b869071": "koku-metrics-operator:v1.2.0",
+    "ebe8dab6aebfeacf9a3428d66cc8be7da682c2ad": "koku-metrics-operator:v1.1.9",
+    "ccc78b4fd4b63a6cb1516574d5e38a9b1078ea16": "koku-metrics-operator:v1.1.8",
+    "2003f0ea23efc49b7ba1337a16b1c90c6899824b": "koku-metrics-operator:v1.1.7",
+    "45cc7a72ced124a267acf0976d90504f134e1076": "koku-metrics-operator:v1.1.6",
+    "2c52da1481d0c90099e130f6989416cdd3cd7b5a": "koku-metrics-operator:v1.1.5",
+    "12b9463a9501f8e9acecbfa4f7e7ae7509d559fa": "koku-metrics-operator:v1.1.4",
+    "3430d17b8ad52ee912fc816da6ed31378fd28367": "koku-metrics-operator:v1.1.3",
+    "02f315aa5a7f0bf5adecd3668b0a769799b54be8": "koku-metrics-operator:v1.1.2",
+    "7c413e966e2ec0a709f5a25cbf5a487c646306d1": "koku-metrics-operator:v1.1.1",
+    "f73a992e7b2fc19028b31c7fb87963ae19bba251": "koku-metrics-operator:v0.9.8",
+    "d37e6d6fd90d65b0d6794347f5fe00a472ce9d33": "koku-metrics-operator:v0.9.7",
+    "1019682a6aa1eeb7533724b07d98cfb54dbe0e94": "koku-metrics-operator:v0.9.6",
+    "513e7dffddb6ecc090b9e8f20a2fba2fe8ec6053": "koku-metrics-operator:v0.9.5",
+    "eaef8ea323b3531fa9513970078a55758afea665": "koku-metrics-operator:v0.9.4",
+    "4f1cc5580da20a11e6dfba50d04d8ae50f2e5fa5": "koku-metrics-operator:v0.9.2",
+    "0419bb957f5cdfade31e26c0f03b755528ec0d7f": "koku-metrics-operator:v0.9.1",
+    "bfdc1e54e104c2a6c8bf830ab135cf56a97f41d2": "koku-metrics-operator:v0.9.0",
+}
+
 
 def divide_csv_daily(file_path: os.PathLike, manifest_id: int):
     """
@@ -143,44 +176,13 @@ def process_cr(report_meta):
             errors: (Dict or None)
     """
     LOG.info(log_json(report_meta.get("tracing_id"), msg="Processing the manifest"))
-    operator_versions = {
-        "5806b175a7b31e6ee112c798fa4222cc652b40a6": "costmanagement-metrics-operator:2.0.0",
-        "e3450f6e3422b6c39c582028ec4ce19b8d09d57d": "costmanagement-metrics-operator:1.2.0",
-        "61099eb07331b140cf66104bc1056c3f3211c94e": "costmanagement-metrics-operator:1.1.9",
-        "6d38c76be52e5981eaf19377a559dc681f1be405": "costmanagement-metrics-operator:1.1.8",
-        "0159d5e55ce6a5a18f989e6f04146f47983ebdf3": "costmanagement-metrics-operator:1.1.7",
-        "2a702a3aac89f724a08b08650b77a0bd33f5b5e5": "costmanagement-metrics-operator:1.1.6",
-        "f8d1f7c5d8685f758ecc36a14aca3b6b86614613": "costmanagement-metrics-operator:1.1.5",
-        "77ec351f8d332796dc522e5623f1200c2fab4042": "costmanagement-metrics-operator:1.1.4",
-        "084bca2e1c48caab18c237453c17ceef61747fe2": "costmanagement-metrics-operator:1.1.3",
-        "6f10d07e3af3ea4f073d4ffda9019d8855f52e7f": "costmanagement-metrics-operator:1.1.0",
-        "fd764dcd7e9b993025f3e05f7cd674bb32fad3be": "costmanagement-metrics-operator:1.0.0",
-        "26502d500672019af5c11319b558dec873409e38": "koku-metrics-operator:v2.0.0",
-        "2acd43ccec2d6fe6ec292aece951b3cf0b869071": "koku-metrics-operator:v1.2.0",
-        "ebe8dab6aebfeacf9a3428d66cc8be7da682c2ad": "koku-metrics-operator:v1.1.9",
-        "ccc78b4fd4b63a6cb1516574d5e38a9b1078ea16": "koku-metrics-operator:v1.1.8",
-        "2003f0ea23efc49b7ba1337a16b1c90c6899824b": "koku-metrics-operator:v1.1.7",
-        "45cc7a72ced124a267acf0976d90504f134e1076": "koku-metrics-operator:v1.1.6",
-        "2c52da1481d0c90099e130f6989416cdd3cd7b5a": "koku-metrics-operator:v1.1.5",
-        "12b9463a9501f8e9acecbfa4f7e7ae7509d559fa": "koku-metrics-operator:v1.1.4",
-        "3430d17b8ad52ee912fc816da6ed31378fd28367": "koku-metrics-operator:v1.1.3",
-        "02f315aa5a7f0bf5adecd3668b0a769799b54be8": "koku-metrics-operator:v1.1.2",
-        "7c413e966e2ec0a709f5a25cbf5a487c646306d1": "koku-metrics-operator:v1.1.1",
-        "f73a992e7b2fc19028b31c7fb87963ae19bba251": "koku-metrics-operator:v0.9.8",
-        "d37e6d6fd90d65b0d6794347f5fe00a472ce9d33": "koku-metrics-operator:v0.9.7",
-        "1019682a6aa1eeb7533724b07d98cfb54dbe0e94": "koku-metrics-operator:v0.9.6",
-        "513e7dffddb6ecc090b9e8f20a2fba2fe8ec6053": "koku-metrics-operator:v0.9.5",
-        "eaef8ea323b3531fa9513970078a55758afea665": "koku-metrics-operator:v0.9.4",
-        "4f1cc5580da20a11e6dfba50d04d8ae50f2e5fa5": "koku-metrics-operator:v0.9.2",
-        "0419bb957f5cdfade31e26c0f03b755528ec0d7f": "koku-metrics-operator:v0.9.1",
-        "bfdc1e54e104c2a6c8bf830ab135cf56a97f41d2": "koku-metrics-operator:v0.9.0",
-    }
+
     version = report_meta.get("version")
     manifest_info = {
         "cluster_id": report_meta.get("cluster_id"),
         "operator_certified": report_meta.get("certified"),
-        "operator_version": operator_versions.get(
-            version, version  # if version is not defined in operator_versions, fallback to what is in the report-meta
+        "operator_version": OPERATOR_VERSIONS.get(
+            version, version  # if version is not defined in OPERATOR_VERSIONS, fallback to what is in the report-meta
         ),
         "cluster_channel": None,
         "operator_airgapped": None,

--- a/koku/masu/external/ros_report_shipper.py
+++ b/koku/masu/external/ros_report_shipper.py
@@ -19,6 +19,7 @@ from kafka_utils.utils import get_producer
 from koku.feature_flags import UNLEASH_CLIENT
 from masu.config import Config as masu_config
 from masu.database.provider_db_accessor import ProviderDBAccessor
+from masu.external.downloader.ocp.ocp_report_downloader import OPERATOR_VERSIONS
 from masu.prometheus_stats import KAFKA_CONNECTION_ERRORS_COUNTER
 
 
@@ -61,12 +62,17 @@ class ROSReportShipper:
         self.provider_uuid = str(report_meta["provider_uuid"])
         self.request_id = report_meta["request_id"]
         self.schema_name = report_meta["schema_name"]
+        version = report_meta.get("version")
         self.metadata = {
             "account": context["account"],
             "org_id": context["org_id"],
             "source_id": self.source_id,
             "provider_uuid": self.provider_uuid,
             "cluster_uuid": report_meta["cluster_id"],
+            "operator_version": OPERATOR_VERSIONS.get(
+                version,
+                version,  # if version is not defined in OPERATOR_VERSIONS, fallback to what is in the report-meta
+            ),
         }
         self.s3_client = get_ros_s3_client()
         self.dh = DateHelper()


### PR DESCRIPTION
* Make OPERATOR_VERSIONS a reusable dictionary
* Gather the version and provide in the metadata

## Jira Ticket

[COST-4358](https://issues.redhat.com/browse/COST-4358)

## Description

This change will add the `operator_version` key/value to the kafka message sent

## Testing

1. Checkout Branch
2. Restart Koku
3. Process an OCP payload with ROS data
4. Review the ROS topic kafka message
