### PR TITLE
Revert "[COST-4289] - Skip OCP clusters without a matching billing report date for OCP on Cloud processing"

### DIFF
--- a/koku/masu/processor/ocp/ocp_cloud_parquet_summary_updater.py
+++ b/koku/masu/processor/ocp/ocp_cloud_parquet_summary_updater.py
@@ -119,27 +119,7 @@ class OCPCloudParquetReportSummaryUpdater(PartitionHandlerMixin, OCPCloudUpdater
             self.provider_type in Provider.CLOUD_PROVIDER_LIST and self._provider_uuid not in infra_provider_uuids
         ):
             infra_map = self._generate_ocp_infra_map_from_sql(start_date, end_date)
-
-        summary_infra_map = {}
-        with OCPReportDBAccessor(self._schema) as accessor:
-            # Only include OCP providers for OCP on Cloud summary if we have a matching report period
-            for ocp_provider_uuid in infra_map:
-                if accessor.report_periods_for_provider_uuid(ocp_provider_uuid, start_date):
-                    summary_infra_map[ocp_provider_uuid] = infra_map[ocp_provider_uuid]
-                else:
-                    ctx = {
-                        "schema": self._schema,
-                        "ocp_provider_uuid": ocp_provider_uuid,
-                        "provider_uuid": infra_map[ocp_provider_uuid][0],
-                        "provider_type": infra_map[ocp_provider_uuid][1],
-                    }
-                    LOG.info(
-                        log_json(
-                            msg=f"no matching report periods available for cluster - removing from OCP on {infra_map[ocp_provider_uuid][1]} summary list",  # noqa: E501
-                            context=ctx,
-                        )
-                    )
-        return summary_infra_map
+        return infra_map
 
     def determine_truncates_and_deletes(self, start_date, end_date):
         """Clear out existing data in summary tables."""

--- a/koku/masu/processor/parquet/ocp_cloud_parquet_report_processor.py
+++ b/koku/masu/processor/parquet/ocp_cloud_parquet_report_processor.py
@@ -227,15 +227,6 @@ class OCPCloudParquetReportProcessor(ParquetReportProcessor):
                         )
                     )
                     continue
-                # Check we have data for the ocp provider/cluster matching the current report period
-                if not accessor.report_periods_for_provider_uuid(ocp_provider_uuid, self.start_date):
-                    LOG.info(
-                        log_json(
-                            msg=f"no matching report periods available for cluster - skipping OCP on {self.provider_type} parquet processing",  # noqa: E501
-                            context=ctx,
-                        )
-                    )
-                    continue
                 ocp_provider_uuids.append(ocp_provider_uuid)
         return tuple(ocp_provider_uuids)
 

--- a/koku/masu/test/processor/ocp/test_ocp_cloud_parquet_report_summary_updater.py
+++ b/koku/masu/test/processor/ocp/test_ocp_cloud_parquet_report_summary_updater.py
@@ -518,18 +518,6 @@ class OCPCloudParquetReportSummaryUpdaterTest(MasuTestCase):
         self.assertIn(str(self.ocp_on_aws_ocp_provider.uuid), infra_map)
         self.assertEqual(infra_map.get(str(self.ocp_on_aws_ocp_provider.uuid)), expected_mapping)
 
-    def test_get_infra_map_for_summary(self):
-        """Test that an infrastructure map is returned for active providers."""
-        updater = OCPCloudParquetReportSummaryUpdater(
-            schema=self.schema, provider=self.ocp_on_aws_ocp_provider, manifest=None
-        )
-        start_date = "1900-12-30"
-        end_date = "1900-12-31"
-
-        infra_map = updater.get_infra_map(start_date, end_date)
-        # We shouldnt collect any providers for summary with these given dates.
-        self.assertEqual(len(infra_map.keys()), 0)
-
     def test_partition_handler_str_table(self):
         new_table_sql = f"""
 create table {self.schema}._eek_pt0 (usage_start date not null, id int) partition by range (usage_start);

--- a/koku/masu/test/processor/parquet/test_ocp_cloud_parquet_report_processor.py
+++ b/koku/masu/test/processor/parquet/test_ocp_cloud_parquet_report_processor.py
@@ -307,21 +307,6 @@ class TestOCPCloudParquetReportProcessor(MasuTestCase):
         mock_data_processor.assert_not_called()
         mock_create_parquet.assert_not_called()
 
-    @patch.object(OCPReportDBAccessor, "report_periods_for_provider_uuid")
-    @patch.object(OCPReportDBAccessor, "get_cluster_for_provider")
-    @patch.object(OCPCloudParquetReportProcessor, "create_ocp_on_cloud_parquet")
-    @patch.object(OCPCloudParquetReportProcessor, "ocp_on_cloud_data_processor")
-    def test_process_no_matching_cluster_report_period(
-        self, mock_data_processor, mock_create_parquet, mock_cluster_info, mock_report_periods
-    ):
-        """Test that ocp on cloud data is not processed when there is no matching report period for the cluster."""
-        # this is a yes or no check so false is fine
-        mock_cluster_info.return_value = True
-        mock_report_periods.return_value = False
-        self.report_processor.process("", [pd.DataFrame()])
-        mock_data_processor.assert_not_called()
-        mock_create_parquet.assert_not_called()
-
     @patch.object(OCPReportDBAccessor, "get_cluster_for_provider")
     @patch.object(OCPReportDBAccessor, "get_openshift_topology_for_multiple_providers")
     @patch.object(OCPCloudParquetReportProcessor, "has_enabled_ocp_labels")


### PR DESCRIPTION
Reverts project-koku/koku#4735