### PR TITLE
[COST-4429] Case insensitive special case tag matching

### DIFF
--- a/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcpcostlineitem_daily_summary_resource_id.sql
+++ b/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcpcostlineitem_daily_summary_resource_id.sql
@@ -546,9 +546,9 @@ FROM hive.{{ schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary as ocp
 JOIN hive.{{schema | sqlsafe}}.gcp_openshift_daily_tag_matched_temp as gcp
     ON gcp.usage_start = ocp.usage_start
         AND (
-                (strpos(gcp.labels, 'openshift_project') != 0 AND strpos(gcp.labels, lower(ocp.namespace)) != 0)
-                OR (strpos(gcp.labels, 'openshift_node') != 0 AND strpos(gcp.labels, lower(ocp.node)) != 0)
-                OR (strpos(gcp.labels, 'openshift_cluster') != 0 AND (strpos(gcp.labels, lower(ocp.cluster_id)) != 0 OR strpos(gcp.labels, lower(ocp.cluster_alias)) != 0))
+                (strpos(lower(gcp.labels), 'openshift_project') != 0 AND strpos(lower(gcp.labels), lower(ocp.namespace)) != 0)
+                OR (strpos(lower(gcp.labels), 'openshift_node') != 0 AND strpos(lower(gcp.labels), lower(ocp.node)) != 0)
+                OR (strpos(lower(gcp.labels), 'openshift_cluster') != 0 AND (strpos(lower(gcp.labels), lower(ocp.cluster_id)) != 0 OR strpos(lower(gcp.labels), lower(ocp.cluster_alias)) != 0))
                 OR (gcp.matched_tag != '' AND any_match(split(gcp.matched_tag, ','), x->strpos(ocp.pod_labels, replace(x, ' ')) != 0))
                 OR (gcp.matched_tag != '' AND any_match(split(gcp.matched_tag, ','), x->strpos(ocp.volume_labels, replace(x, ' ')) != 0))
             )

--- a/koku/masu/database/trino_sql/reporting_ocpawscostlineitem_daily_summary.sql
+++ b/koku/masu/database/trino_sql/reporting_ocpawscostlineitem_daily_summary.sql
@@ -558,11 +558,11 @@ SELECT aws.uuid as aws_uuid,
     JOIN hive.{{schema | sqlsafe}}.aws_openshift_daily_tag_matched_temp as aws
         ON aws.usage_start = ocp.usage_start
             AND (
-                (strpos(aws.tags, 'openshift_project') != 0 AND strpos(aws.tags, lower(ocp.namespace)) != 0)
-                    OR (strpos(aws.tags, 'namespace') != 0 AND strpos(aws.tags, lower(ocp.namespace)) != 0)
-                    OR (strpos(aws.tags, 'openshift_node') != 0 AND strpos(aws.tags, lower(ocp.node)) != 0)
-                    OR (strpos(aws.tags, 'openshift_cluster') != 0 AND (strpos(aws.tags, lower(ocp.cluster_id)) != 0 OR strpos(aws.tags, lower(ocp.cluster_alias)) != 0))
-                    OR (strpos(aws.tags, 'cluster') != 0 AND (strpos(aws.tags, lower(ocp.cluster_id)) != 0 OR strpos(aws.tags, lower(ocp.cluster_alias)) != 0))
+                (strpos(lower(aws.tags), 'openshift_project') != 0 AND strpos(lower(aws.tags), lower(ocp.namespace)) != 0)
+                    OR (strpos(lower(aws.tags), 'namespace') != 0 AND strpos(lower(aws.tags), lower(ocp.namespace)) != 0)
+                    OR (strpos(lower(aws.tags), 'openshift_node') != 0 AND strpos(lower(aws.tags), lower(ocp.node)) != 0)
+                    OR (strpos(lower(aws.tags), 'openshift_cluster') != 0 AND (strpos(lower(aws.tags), lower(ocp.cluster_id)) != 0 OR strpos(lower(aws.tags), lower(ocp.cluster_alias)) != 0))
+                    OR (strpos(lower(aws.tags), 'cluster') != 0 AND (strpos(lower(aws.tags), lower(ocp.cluster_id)) != 0 OR strpos(lower(aws.tags), lower(ocp.cluster_alias)) != 0))
                     OR (aws.matched_tag != '' AND any_match(split(aws.matched_tag, ','), x->strpos(ocp.pod_labels, replace(x, ' ')) != 0))
                     OR (aws.matched_tag != '' AND any_match(split(aws.matched_tag, ','), x->strpos(ocp.volume_labels, replace(x, ' ')) != 0))
             )

--- a/koku/masu/database/trino_sql/reporting_ocpazurecostlineitem_daily_summary.sql
+++ b/koku/masu/database/trino_sql/reporting_ocpazurecostlineitem_daily_summary.sql
@@ -462,9 +462,9 @@ SELECT azure.uuid as azure_uuid,
     JOIN hive.{{schema | sqlsafe}}.azure_openshift_daily_tag_matched_temp as azure
         ON azure.usage_start = ocp.usage_start
         AND (
-                    (strpos(azure.tags, 'openshift_project') !=0 AND strpos(azure.tags, lower(ocp.namespace)) != 0)
-                    OR (strpos(azure.tags, 'openshift_node') != 0 AND strpos(azure.tags,lower(ocp.node)) != 0)
-                    OR (strpos(azure.tags, 'openshift_cluster') != 0 AND (strpos(azure.tags, lower(ocp.cluster_id)) != 0 OR strpos(azure.tags, lower(ocp.cluster_alias)) != 0))
+                    (strpos(lower(azure.tags), 'openshift_project') !=0 AND strpos(lower(azure.tags), lower(ocp.namespace)) != 0)
+                    OR (strpos(lower(azure.tags), 'openshift_node') != 0 AND strpos(lower(azure.tags),lower(ocp.node)) != 0)
+                    OR (strpos(lower(azure.tags), 'openshift_cluster') != 0 AND (strpos(lower(azure.tags), lower(ocp.cluster_id)) != 0 OR strpos(azure.tags, lower(ocp.cluster_alias)) != 0))
                     OR (azure.matched_tag != '' AND any_match(split(azure.matched_tag, ','), x->strpos(ocp.pod_labels, replace(x, ' ')) != 0))
                     OR (azure.matched_tag != '' AND any_match(split(azure.matched_tag, ','), x->strpos(ocp.volume_labels, replace(x, ' ')) != 0))
             )


### PR DESCRIPTION
## Jira Ticket

[COST-4429](https://issues.redhat.com/browse/COST-4429)

## Description

This change will lower the tag string for ocp on cloud tag special case tag matching. We currently lower the values from the OCP side such as cluster id or cluster alias but we are not lowercasing the tags from the cloud provider which can lead to records not properly being identified during summary.

## Testing

1. Checkout Main (NOT THIS BRANCH)
2. Restart Koku
3. Create OCP on Azure data with a matching VM to OCP cluster. In the Azure yaml, create a couple storage generators with tags that match the cluster id you will use but different casing of letters. such as:
```
  - StorageGenerator:
      meter_id: 55555555-4444-3333-2222-111111177777
      resource_location: "US North Central"
      resource_rate: 20
      usage_quantity: 5
      instance_id: '/subscriptions/99999999-9999-9999-9999-999999999995/resourceGroups/koku-99hqd-rg/providers/Microsoft.Storage/storageAccounts/pvc_azure_corey'
      tags: {"openshift_cluster":"ocp_AZURE_cluster", "environment": "failure"}
      additional_info: {"ConsumptionMeter": "1111aaaa-22bb-33cc-44dd-555555fffffg"}
      meter_cache: {"55555555-4444-3333-2222-111111177777": ["General Block Blob", "General Block Blob", "Write Operations", "100000000"]}
  - StorageGenerator:
      meter_id: 55555555-4444-3333-2222-111111177766
      resource_location: "US North Central"
      resource_rate: 20
      usage_quantity: 5
      instance_id: '/subscriptions/99999999-9999-9999-9999-999999999995/resourceGroups/koku-99hqd-rg/providers/Microsoft.Storage/storageAccounts/pvc_azure_corey_two'
      tags: {"openshift_cluster":"ocp_azure_cluster", "environment": "echo"}
      additional_info: {"ConsumptionMeter": "1111aaaa-22bb-33cc-44dd-555555fffffg"}
      meter_cache: {"55555555-4444-3333-2222-111111177777": ["General Block Blob", "General Block Blob", "Write Operations", "100000000"]}
```
5. Ingest OCP data and Azure data, you will notice the tags for the table will not include any of the openshift cluster tags that are special case matched except for the all lowercase tags:
```
select distinct tags from reporting_ocpazurecostlineitem_project_daily_summary_p;
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 {"app": "mobile", "version": "Mars", "nodeclass": "compute", "environment": "echo", "openshift_cluster": "ocp_azure_cluster", "dashed-key-on-azure": "dashed-value"}
 {"app": "mobile", "version": "Mars", "nodeclass": "compute", "environment": "echo", "openshift_cluster": "ocp_azure_cluster"}
 {"app": "mobile", "version": "Mars", "nodeclass": "compute", "environment": "echo", "dashed-key-on-azure": "dashed-value"}
 {"app": "mobile", "version": "Mars", "nodeclass": "compute", "environment": "echo", "storageclass": "Baldur", "openshift_cluster": "ocp_azure_cluster", "dashed-key-on-azure": "dashed-value"}
 {"qa": "approved", "app": "mobile", "version": "Mars", "nodeclass": "compute", "environment": "echo", "dashed-key-on-azure": "dashed-value"}
 {"app": "mobile", "version": "Mars", "nodeclass": "compute", "environment": "echo"}
 {"app": "mobile", "version": "Mars", "nodeclass": "compute", "environment": "echo", "storageclass": "Loki", "openshift_cluster": "ocp_azure_cluster"}
 {"qa": "approved", "app": "mobile", "version": "Mars", "nodeclass": "compute", "environment": "echo"}
(9 rows)
```
6. Checkout this branch
7. Run resummary on your Azure source using the masu endpoint.
8. Check the tags in postgres again and notice the different case tags now match appropriately:
```
postgres=# select distinct tags from reporting_ocpazurecostlineitem_project_daily_summary_p;
                                                                                               tags                                                                                                
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 {"app": "mobile", "version": "Mars", "nodeclass": "compute", "environment": "echo", "openshift_cluster": "ocp_azure_cluster", "dashed-key-on-azure": "dashed-value"}
 {"app": "mobile", "version": "Mars", "nodeclass": "compute", "environment": "failure", "storageclass": "Loki", "openshift_CLUSTER": "ocp_azure_cluster"}
 {"app": "mobile", "version": "Mars", "nodeclass": "compute", "environment": "failure", "storageclass": "Baldur", "openshift_CLUSTER": "ocp_azure_cluster", "dashed-key-on-azure": "dashed-value"}
 {"app": "mobile", "version": "Mars", "nodeclass": "compute", "environment": "echo", "openshift_cluster": "ocp_azure_cluster"}
 {"app": "mobile", "version": "Mars", "nodeclass": "compute", "environment": "echo", "dashed-key-on-azure": "dashed-value"}
 {"app": "mobile", "version": "Mars", "nodeclass": "compute", "environment": "failure", "openshift_CLUSTER": "ocp_azure_cluster"}
 {"app": "mobile", "version": "Mars", "nodeclass": "compute", "environment": "alpha", "openshift_cluster": "ocp_AZURE_cluster", "dashed-key-on-azure": "dashed-value"}
 {"app": "mobile", "version": "Mars", "nodeclass": "compute", "environment": "failure", "openshift_CLUSTER": "ocp_azure_cluster", "dashed-key-on-azure": "dashed-value"}
 {"app": "mobile", "version": "Mars", "nodeclass": "compute", "environment": "echo", "storageclass": "Baldur", "openshift_cluster": "ocp_azure_cluster", "dashed-key-on-azure": "dashed-value"}
 {"app": "mobile", "version": "Mars", "nodeclass": "compute", "environment": "alpha", "openshift_cluster": "ocp_AZURE_cluster"}
 {"app": "mobile", "version": "Mars", "nodeclass": "compute", "environment": "alpha", "storageclass": "Loki", "openshift_cluster": "ocp_AZURE_cluster"}
 {"qa": "approved", "app": "mobile", "version": "Mars", "nodeclass": "compute", "environment": "echo", "dashed-key-on-azure": "dashed-value"}
 {"app": "mobile", "version": "Mars", "nodeclass": "compute", "environment": "echo"}
 {"app": "mobile", "version": "Mars", "nodeclass": "compute", "environment": "echo", "storageclass": "Loki", "openshift_cluster": "ocp_azure_cluster"}
 {"app": "mobile", "version": "Mars", "nodeclass": "compute", "environment": "alpha", "storageclass": "Baldur", "openshift_cluster": "ocp_AZURE_cluster", "dashed-key-on-azure": "dashed-value"}
 {"qa": "approved", "app": "mobile", "version": "Mars", "nodeclass": "compute", "environment": "echo"}
(17 rows)
```
## Notes

...
