### PR TITLE
[COST-4430] Handle service account in API identity header

### DIFF
--- a/koku/koku/middleware.py
+++ b/koku/koku/middleware.py
@@ -341,11 +341,20 @@ class IdentityHeaderMiddleware(MiddlewareMixin):
 
         account = json_rh_auth.get("identity", {}).get("account_number")
         org_id = json_rh_auth.get("identity", {}).get("org_id")
-        user = json_rh_auth.get("identity", {}).get("user", {})
-        username = user.get("username")
-        email = user.get("email")
-        is_admin = user.get("is_org_admin")
+        token_type = str(json_rh_auth.get("identity", {}).get("type", "user")).lower()
+        user = None
+        email = None
+        is_admin = False
         req_id = None
+        if token_type == "user":
+            user = json_rh_auth.get("identity", {}).get("user", {})
+            username = user.get("username")
+            email = user.get("email")
+            is_admin = user.get("is_org_admin")
+        else:
+            service_account = json_rh_auth.get("identity", {}).get("service_account", {})
+            username = service_account.get("client_id")
+            email = ""
 
         if username and email and org_id:
             # Get request ID

--- a/koku/koku/middleware.py
+++ b/koku/koku/middleware.py
@@ -356,7 +356,7 @@ class IdentityHeaderMiddleware(MiddlewareMixin):
             username = service_account.get("client_id")
             email = ""
 
-        if username and email and org_id:
+        if username and email is not None and org_id:
             # Get request ID
             req_id = request.META.get("HTTP_X_RH_INSIGHTS_REQUEST_ID")
             # Check for customer creation & user creation


### PR DESCRIPTION
* Check for type in identity header
* Gather data from service account object

## Jira Ticket

[COST-4430](https://issues.redhat.com/browse/COST-4430)

## Description

This change will our ability to handle requests from service accoutn objects

## Testing

1. Checkout Branch
2. Restart Koku
3. Set `DEVELOPMENT_IDENTITY` object with a service account object
```
DEVELOPMENT_IDENTITY='{ "identity": { "account_number": "10001", "org_id": "1234567", "type": "ServiceAccount", "service_account": { "client_id": "93930000", "username": "service_account_user_dev", } }, "entitlements": { "cost_management": { "is_entitled": "True" } } }'
```
4. Hit endpoint with identity header that contains a service account object
