### PR TITLE
[COST-4442] - Pass JOB_NAME and BUILD_NUMBER to IQE CJI's 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
 
         IQE_PLUGINS="cost_management"
         IQE_CJI_TIMEOUT="120m"
-        IQE_ENV_VARS="JOB_NAME=koku_pipeline_pr_check,BUILD_NUMBER=1234"  # custom set of extra environment variables to set on IQE pod
+        IQE_ENV_VARS="JOB_NAME=koku_pipeline_pr_check,BUILD_NUMBER=1234"  // custom set of extra environment variables to set on IQE pod
 
 
         GITHUB_API_ROOT='https://api.github.com/repos/project-koku/koku'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
 
         IQE_PLUGINS="cost_management"
         IQE_CJI_TIMEOUT="120m"
-        IQE_ENV_VARS="JOB_NAME=koku_pipeline_pr_check,BUILD_NUMBER=1234"
+        IQE_ENV_VARS="JOB_NAME=${JOB_NAME},BUILD_NUMBER=${BUILD_NUMBER}"
 
         GITHUB_API_ROOT='https://api.github.com/repos/project-koku/koku'
         CICD_URL="https://raw.githubusercontent.com/RedHatInsights/cicd-tools/main"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,8 +42,7 @@ pipeline {
 
         IQE_PLUGINS="cost_management"
         IQE_CJI_TIMEOUT="120m"
-        IQE_ENV_VARS="JOB_NAME=koku_pipeline_pr_check,BUILD_NUMBER=1234"  // custom set of extra environment variables to set on IQE pod
-
+        IQE_ENV_VARS="JOB_NAME=koku_pipeline_pr_check,BUILD_NUMBER=1234"
 
         GITHUB_API_ROOT='https://api.github.com/repos/project-koku/koku'
         CICD_URL="https://raw.githubusercontent.com/RedHatInsights/cicd-tools/main"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,6 +42,8 @@ pipeline {
 
         IQE_PLUGINS="cost_management"
         IQE_CJI_TIMEOUT="120m"
+        IQE_ENV_VARS="JOB_NAME=koku_pipeline_pr_check,BUILD_NUMBER=1234"  # custom set of extra environment variables to set on IQE pod
+
 
         GITHUB_API_ROOT='https://api.github.com/repos/project-koku/koku'
         CICD_URL="https://raw.githubusercontent.com/RedHatInsights/cicd-tools/main"

--- a/smoke_test.sh
+++ b/smoke_test.sh
@@ -10,7 +10,7 @@ IQE_PLUGINS="cost_management"
 IQE_MARKER_EXPRESSION="cost_smoke"
 IQE_FILTER_EXPRESSION=""
 IQE_CJI_TIMEOUT="5h"
-IQE_ENV_VARS="JOB_NAME=koku_smoke_test,BUILD_NUMBER=1234"
+IQE_ENV_VARS="JOB_NAME=${JOB_NAME},BUILD_NUMBER=${BUILD_NUMBER}"
 
 # Get bonfire helper scripts
 CICD_URL="https://raw.githubusercontent.com/RedHatInsights/cicd-tools/main"

--- a/smoke_test.sh
+++ b/smoke_test.sh
@@ -10,6 +10,7 @@ IQE_PLUGINS="cost_management"
 IQE_MARKER_EXPRESSION="cost_smoke"
 IQE_FILTER_EXPRESSION=""
 IQE_CJI_TIMEOUT="5h"
+IQE_ENV_VARS="JOB_NAME=koku_smoke_test,BUILD_NUMBER=1234"  # custom set of extra environment variables to set on IQE pod
 
 # Get bonfire helper scripts
 CICD_URL="https://raw.githubusercontent.com/RedHatInsights/cicd-tools/main"

--- a/smoke_test.sh
+++ b/smoke_test.sh
@@ -10,7 +10,7 @@ IQE_PLUGINS="cost_management"
 IQE_MARKER_EXPRESSION="cost_smoke"
 IQE_FILTER_EXPRESSION=""
 IQE_CJI_TIMEOUT="5h"
-IQE_ENV_VARS="JOB_NAME=koku_smoke_test,BUILD_NUMBER=1234"  # custom set of extra environment variables to set on IQE pod
+IQE_ENV_VARS="JOB_NAME=koku_smoke_test,BUILD_NUMBER=1234"
 
 # Get bonfire helper scripts
 CICD_URL="https://raw.githubusercontent.com/RedHatInsights/cicd-tools/main"


### PR DESCRIPTION
## Jira Ticket

[COST-####](https://issues.redhat.com/browse/COST-####)

## Description

Bonfire now enables to pass own custom environment variables to IQE CJI's at runtime. This way we could pass JOB_NAME and BUILD_NUMBER which should be in turn added to Ibutsu Object data and thus enable us to create an Ibutsu Dashboard for PR-checks as well as daily ephemeral job


## Testing
1. run hot-fix-smokes-tests pr-check
2. check logs, the iqe deploy command should contain `--env-var JOB_NAME=koku-pipeline-pr-check-main --env-var BUILD_NUMBER=number_of_the_build`
3. check pr-check results for a given run in Ibtusu - you should see that "Run object" -> "jenkins" section has filled "build_number" and "job_name" 
Example from my pr-check (ibutsu run id bb40439e-27ef-431c-a899-a0990808eb61):
```
"jenkins":{
    3 items
    "build_number":"103"
    "build_url":NULL
   "job_name":"koku-pipeline-pr-check-main"
}
```

