### PR TITLE
[COST-4430] Support service account source creation and payload ingress

### DIFF
--- a/koku/api/provider/provider_builder.py
+++ b/koku/api/provider/provider_builder.py
@@ -94,6 +94,10 @@ class ProviderBuilder:
                 username = identity.get("system", {}).get("cluster_id")
                 email = ""
 
+            if identity_type == "ServiceAccount":
+                username = identity.get("service_account", {}).get("username")
+                email = ""
+
             try:
                 customer = Customer.objects.filter(org_id=self.org_id).get()
             except Customer.DoesNotExist:

--- a/koku/koku/middleware.py
+++ b/koku/koku/middleware.py
@@ -353,7 +353,7 @@ class IdentityHeaderMiddleware(MiddlewareMixin):
             is_admin = user.get("is_org_admin")
         else:
             service_account = json_rh_auth.get("identity", {}).get("service_account", {})
-            username = service_account.get("client_id")
+            username = service_account.get("username")
             email = ""
 
         if username and email is not None and org_id:

--- a/koku/sources/config.py
+++ b/koku/sources/config.py
@@ -50,3 +50,13 @@ class Config:
     SOURCES_PSK = ENVIRONMENT.get_value("SOURCES_PSK", default="sources-psk")
 
     RETRY_SECONDS = ENVIRONMENT.int("RETRY_SECONDS", default=10)
+
+    SOURCES_FAKE_SERVICE_ACCOUNT_HEADER = ENVIRONMENT.get_value(
+        "SOURCES_FAKE_SERVICE_ACCOUNT_HEADER",
+        default=(
+            "eyJpZGVudGl0eSI6IHsiYWNjb3VudF9udW1iZXIiOiAiMTIzNDUiLCAib3JnX2lkIjogIjMzMzMzMzM"
+            "iLCAidHlwZSI6ICJTZXJ2aWNlQWNjb3VudCIsICJzZXJ2aWNlX2FjY291bnQiOiB7InVzZXJuYW1lIjo"
+            "gIjBiYjI5MTM1LWQ2ZDEtNDc4Yi1iNWI2LTZiZDEyOWNiNmQ1ZCJ9LCAiaW50ZXJuYWwiOiB7Im9yZ19p"
+            "ZCI6ICIzMzMzMzMzIn19fQ=="
+        ),
+    )

--- a/koku/sources/test/test_kafka_source_manager.py
+++ b/koku/sources/test/test_kafka_source_manager.py
@@ -81,6 +81,19 @@ class ProviderBuilderTest(IamTestCase):
             provider = client.create_provider_from_source(mock_source)
             self.assertEqual(provider.name, self.name)
 
+    def test_create_provider_ocp_cluster_register_sa(self):
+        """Test to create an OCP provider with a service account identity."""
+        # Delete tenants
+        Tenant.objects.filter(schema_name="org3333333").delete()  # filtering avoids migrating the template0 again
+        client = ProviderBuilder(
+            auth_header=Config.SOURCES_FAKE_SERVICE_ACCOUNT_HEADER, account_number=self.account, org_id=self.org_id
+        )
+        with patch.object(ProviderAccessor, "cost_usage_source_ready", returns=True):
+            mock_source_auth = {"credentials": {"cluster_id": "0bb29135-d6d1-478b-b5b6-6bd129cb6d5d1001"}}
+            mock_source = MockSourceObject(self.name, Provider.PROVIDER_OCP, mock_source_auth, None)
+            provider = client.create_provider_from_source(mock_source)
+            self.assertEqual(provider.name, self.name)
+
     def test_create_provider_no_tenant(self):
         """Test to create a provider after tenant was removed."""
         client = ProviderBuilder(


### PR DESCRIPTION
## Jira Ticket

[COST-4430](https://issues.redhat.com/browse/COST-4430)

## Description

This change will handle service accounts in identity flows from the kafka messages

## Testing

1. Checkout Branch and deploy in ephemeral
2. Create a source through the sources API
3. Hit endpoint cost management sources API with a service account identity header to see the source was created
4. Upload a payload to ingress with a service account identity header (nise) to see  the payload was processed

## Notes
* Update context flow handling identity via kafka message paths
* Use username for consistency with platform RBAC
