### PR TITLE
[COST-4445] unlink ReportManifestDBAccessor from KokuDBAccess

### DIFF
--- a/koku/masu/database/report_manifest_db_accessor.py
+++ b/koku/masu/database/report_manifest_db_accessor.py
@@ -27,6 +27,12 @@ LOG = logging.getLogger(__name__)
 class ReportManifestDBAccessor:
     """Class to interact with the koku database for CUR processing statistics."""
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
     def get_manifest(self, assembly_id, provider_uuid):
         """Get the manifest associated with the provided provider and id."""
         return CostUsageReportManifest.objects.filter(provider_id=provider_uuid, assembly_id=assembly_id).first()

--- a/koku/masu/database/report_manifest_db_accessor.py
+++ b/koku/masu/database/report_manifest_db_accessor.py
@@ -15,41 +15,30 @@ from django.db.models import Value
 from django.db.models.expressions import Window
 from django.db.models.functions import Cast
 from django.db.models.functions import RowNumber
-from django_tenants.utils import schema_context
+from django.utils import timezone
 
 from api.common import log_json
-from masu.database.koku_database_access import KokuDBAccess
-from masu.external.date_accessor import DateAccessor
 from reporting_common.models import CostUsageReportManifest
 from reporting_common.models import CostUsageReportStatus
 
 LOG = logging.getLogger(__name__)
 
 
-class ReportManifestDBAccessor(KokuDBAccess):
+class ReportManifestDBAccessor:
     """Class to interact with the koku database for CUR processing statistics."""
-
-    def __init__(self):
-        """Access the AWS report manifest database table."""
-        self._schema = "public"
-        super().__init__(self._schema)
-        self._table = CostUsageReportManifest
-        self.date_accessor = DateAccessor()
 
     def get_manifest(self, assembly_id, provider_uuid):
         """Get the manifest associated with the provided provider and id."""
-        return self._get_db_obj_query().filter(provider_id=provider_uuid, assembly_id=assembly_id).first()
+        return CostUsageReportManifest.objects.filter(provider_id=provider_uuid, assembly_id=assembly_id).first()
 
     def get_manifest_by_id(self, manifest_id):
         """Get the manifest by id."""
-        with schema_context(self._schema):
-            query = self._get_db_obj_query()
-            return query.filter(id=manifest_id).first()
+        return CostUsageReportManifest.objects.filter(id=manifest_id).first()
 
     def mark_manifest_as_updated(self, manifest):
         """Update the updated timestamp."""
         if manifest:
-            updated_datetime = self.date_accessor.today_with_timezone("UTC")
+            updated_datetime = timezone.now()
             ctx = {
                 "manifest_id": manifest.id,
                 "assembly_id": manifest.assembly_id,
@@ -63,9 +52,9 @@ class ReportManifestDBAccessor(KokuDBAccess):
 
     def mark_manifests_as_completed(self, manifest_list):
         """Update the completed timestamp."""
-        completed_datetime = self.date_accessor.today_with_timezone("UTC")
+        completed_datetime = timezone.now()
         if manifest_list:
-            bulk_manifest_query = self._get_db_obj_query().filter(id__in=manifest_list)
+            bulk_manifest_query = CostUsageReportManifest.objects.filter(id__in=manifest_list)
             for manifest in bulk_manifest_query:
                 ctx = {
                     "manifest_id": manifest.id,
@@ -84,30 +73,6 @@ class ReportManifestDBAccessor(KokuDBAccess):
         if manifest:
             manifest.num_total_files = set_num_of_files
             manifest.save(update_fields=["num_total_files"])
-
-    def add(self, **kwargs) -> CostUsageReportManifest:
-        """
-        Add a new row to the CUR stats database.
-
-        Args:
-            kwargs (dict): Fields containing CUR Manifest attributes.
-                Valid keys are: assembly_id,
-                                billing_period_start_datetime,
-                                num_total_files,
-                                provider_uuid,
-        Returns:
-            None
-
-        """
-        if "manifest_creation_datetime" not in kwargs:
-            kwargs["manifest_creation_datetime"] = self.date_accessor.today_with_timezone("UTC")
-
-        # The Django model insists on calling this field provider_id
-        if "provider_uuid" in kwargs:
-            uuid = kwargs.pop("provider_uuid")
-            kwargs["provider_id"] = uuid
-
-        return super().add(**kwargs)
 
     def manifest_ready_for_summary(self, manifest_id):
         """Determine if the manifest is ready to summarize."""
@@ -241,7 +206,6 @@ class ReportManifestDBAccessor(KokuDBAccess):
             log_json(
                 msg=f"s3 bucket should be cleared: {result}",
                 manifest_uuid=manifest.assembly_id,
-                schema=self.schema,
             )
         )
         return result

--- a/koku/masu/test/celery/test_tasks.py
+++ b/koku/masu/test/celery/test_tasks.py
@@ -36,10 +36,9 @@ class FakeManifest:
             "assembly_id": "1234",
             "billing_period_start_datetime": "2020-02-01",
             "num_total_files": 2,
-            "provider_uuid": provider_uuid,
+            "provider_id": provider_uuid,
         }
-        manifest_accessor = ReportManifestDBAccessor()
-        manifest = manifest_accessor.add(**manifest_dict)
+        manifest = baker.make("CostUsageReportManifest", **manifest_dict)
         return [manifest]
 
     def get_manifest_list_for_provider_and_date_range(self, provider_uuid, start_date, end_date):
@@ -49,8 +48,7 @@ class FakeManifest:
             "num_total_files": 2,
             "provider_uuid": provider_uuid,
         }
-        manifest_accessor = ReportManifestDBAccessor()
-        manifest = manifest_accessor.add(**manifest_dict)
+        manifest = baker.make("CostUsageReportManifest", **manifest_dict)
         return [manifest]
 
     def bulk_delete_manifests(self, provider_uuid, manifest_id_list):

--- a/koku/masu/test/celery/test_tasks.py
+++ b/koku/masu/test/celery/test_tasks.py
@@ -266,7 +266,7 @@ class TestCeleryTasks(MasuTestCase):
 
     def test_crawl_account_hierarchy_with_provider_uuid(self):
         """Test that only accounts associated with the provider_uuid are polled."""
-        p = baker.make(Provider, type=Provider.PROVIDER_AWS)
+        p = self.baker.make(Provider, type=Provider.PROVIDER_AWS)
         with patch.object(AWSOrgUnitCrawler, "crawl_account_hierarchy") as mock_crawler:
             mock_crawler.return_value = True
         with self.assertLogs("masu.celery.tasks", "INFO") as captured_logs:
@@ -277,7 +277,7 @@ class TestCeleryTasks(MasuTestCase):
 
     def test_crawl_account_hierarchy_without_provider_uuid(self):
         """Test that all polling accounts for user are used when no provider_uuid is provided."""
-        baker.make(Provider, type=Provider.PROVIDER_AWS)
+        self.baker.make(Provider, type=Provider.PROVIDER_AWS)
         polling_accounts = Provider.polling_objects.all()
         providers = Provider.objects.all()
         for provider in providers:
@@ -313,7 +313,7 @@ class TestCeleryTasks(MasuTestCase):
     def test_cost_model_status_check_without_provider_uuid(self, mock_notification):
         """Test that all polling accounts are used when no provider_uuid is provided."""
         mock_notification.cost_model_notification.return_value = True
-        baker.make("Provider", type=Provider.PROVIDER_OCP, customer=self.customer)
+        self.baker.make("Provider", type=Provider.PROVIDER_OCP, customer=self.customer)
         providers = Provider.objects.filter(infrastructure_id__isnull=True, type=Provider.PROVIDER_OCP).all()
         with self.assertLogs("masu.celery.tasks", "INFO") as captured_logs:
             tasks.check_cost_model_status()

--- a/koku/masu/test/database/test_report_manifest_db_accessor.py
+++ b/koku/masu/test/database/test_report_manifest_db_accessor.py
@@ -125,7 +125,7 @@ class ReportManifestDBAccessorTest(MasuTestCase):
         }
         manifest2 = baker.make("CostUsageReportManifest", **manifest_dict2)
         assembly_ids = self.manifest_accessor.get_last_seen_manifest_ids(self.billing_start)
-        self.assertEqual(assembly_ids, [str(self.manifest.assembly_id), manifest2.assembly_id])
+        self.assertCountEqual(assembly_ids, [str(self.manifest.assembly_id), manifest2.assembly_id])
 
         # test that when the manifest's files have been processed - it is no longer returned
         baker.make(

--- a/koku/masu/test/database/test_report_manifest_db_accessor.py
+++ b/koku/masu/test/database/test_report_manifest_db_accessor.py
@@ -4,94 +4,84 @@
 #
 """Test the ReportManifestDBAccessor."""
 import copy
+import uuid
 
 from dateutil.relativedelta import relativedelta
 from django.utils import timezone
 from faker import Faker
 from model_bakery import baker
 
-from api.iam.test.iam_test_case import IamTestCase
 from api.utils import DateHelper
 from masu.database.report_manifest_db_accessor import ReportManifestDBAccessor
 from masu.external.date_accessor import DateAccessor
+from masu.test import MasuTestCase
 from reporting_common.models import CostUsageReportManifest
 from reporting_common.models import CostUsageReportStatus
 
 FAKE = Faker()
 
 
-class ReportManifestDBAccessorTest(IamTestCase):
+class ReportManifestDBAccessorTest(MasuTestCase):
     """Test cases for the ReportManifestDBAccessor."""
 
     def setUp(self):
         """Set up the test class."""
         super().setUp()
-        self.schema = self.schema_name
         self.billing_start = DateAccessor().today_with_timezone("UTC").replace(day=1)
         self.manifest_dict = {
-            "assembly_id": "1234",
+            "assembly_id": uuid.uuid4(),
             "billing_period_start_datetime": self.billing_start,
             "num_total_files": 2,
-            "provider_uuid": self.provider_uuid,
+            "provider_id": self.ocp_provider_uuid,
         }
         self.manifest_accessor = ReportManifestDBAccessor()
+        self.manifest = baker.make("CostUsageReportManifest", **self.manifest_dict)
 
-    def tearDown(self):
-        """Tear down the test class."""
-        super().tearDown()
-        manifests = self.manifest_accessor._get_db_obj_query().all()
-        for manifest in manifests:
-            self.manifest_accessor.delete(manifest)
-
-    def test_initializer(self):
-        """Test the initializer."""
-        accessor = ReportManifestDBAccessor()
-        self.assertIsNotNone(accessor._table)
+    # def tearDown(self):
+    #     """Tear down the test class."""
+    #     super().tearDown()
+    #     manifests = self.manifest_accessor._get_db_obj_query().all()
+    #     for manifest in manifests:
+    #         self.manifest_accessor.delete(manifest)
 
     def test_get_manifest(self):
         """Test that the right manifest is returned."""
-        added_manifest = self.manifest_accessor.add(**self.manifest_dict)
-
         assembly_id = self.manifest_dict.get("assembly_id")
-        provider_uuid = self.manifest_dict.get("provider_uuid")
-        manifest = self.manifest_accessor.get_manifest(assembly_id, provider_uuid)
+        manifest = self.manifest_accessor.get_manifest(assembly_id, self.ocp_provider_uuid)
 
         self.assertIsNotNone(manifest)
-        self.assertEqual(added_manifest, manifest)
-        self.assertEqual(manifest.assembly_id, assembly_id)
-        self.assertEqual(manifest.provider_id, provider_uuid)
+        self.assertEqual(self.manifest, manifest)
+        self.assertEqual(manifest.assembly_id, str(assembly_id))
+        self.assertEqual(manifest.provider, self.ocp_provider)
         self.assertEqual(manifest.num_total_files, self.manifest_dict.get("num_total_files"))
 
     def test_get_manifest_by_id(self):
         """Test that the right manifest is returned by id."""
-        added_manifest = self.manifest_accessor.add(**self.manifest_dict)
-        manifest = self.manifest_accessor.get_manifest_by_id(added_manifest.id)
+        manifest = self.manifest_accessor.get_manifest_by_id(self.manifest.id)
         self.assertIsNotNone(manifest)
-        self.assertEqual(added_manifest, manifest)
+        self.assertEqual(self.manifest, manifest)
 
     def test_update_number_of_files_for_manifest(self):
         """Test that the number of files for manifest is updated."""
-        manifest = self.manifest_accessor.add(**self.manifest_dict)
-        before_count = CostUsageReportStatus.objects.filter(manifest_id=manifest.id).count()
+        before_count = CostUsageReportStatus.objects.filter(manifest_id=self.manifest.id).count()
         CostUsageReportStatus.objects.create(
             report_name="fake_report.csv",
             last_completed_datetime=self.billing_start,
             last_started_datetime=self.billing_start,
             etag="etag",
-            manifest=manifest,
+            manifest=self.manifest,
         )
-        self.manifest_accessor.update_number_of_files_for_manifest(manifest)
-        after_count = CostUsageReportStatus.objects.filter(manifest_id=manifest.id).count()
-        updated_manifest = self.manifest_accessor.get_manifest_by_id(manifest.id)
+        self.manifest_accessor.update_number_of_files_for_manifest(self.manifest)
+        after_count = CostUsageReportStatus.objects.filter(manifest_id=self.manifest.id).count()
+        updated_manifest = self.manifest_accessor.get_manifest_by_id(self.manifest.id)
         self.assertNotEqual(before_count, after_count)
         self.assertEqual(updated_manifest.num_total_files, after_count)
 
     def test_mark_manifest_as_updated(self):
         """Test that the manifest is marked updated."""
-        manifest = self.manifest_accessor.add(**self.manifest_dict)
         now = DateAccessor().today_with_timezone("UTC")
-        self.manifest_accessor.mark_manifest_as_updated(manifest)
-        self.assertGreater(manifest.manifest_updated_datetime, now)
+        self.manifest_accessor.mark_manifest_as_updated(self.manifest)
+        self.assertGreater(self.manifest.manifest_updated_datetime, now)
 
     def test_mark_manifest_as_updated_none_manifest(self):
         """Test that a none manifest doesn't update failure."""
@@ -110,20 +100,19 @@ class ReportManifestDBAccessorTest(IamTestCase):
     def test_get_manifest_list_for_provider_and_bill_date(self):
         """Test that all manifests are returned for a provider and bill."""
         bill_date = self.manifest_dict["billing_period_start_datetime"].date()
-        manifest_dict = copy.deepcopy(self.manifest_dict)
-        self.manifest_accessor.add(**manifest_dict)
-        result = self.manifest_accessor.get_manifest_list_for_provider_and_bill_date(self.provider_uuid, bill_date)
-        self.assertEqual(len(result), 1)
-
-        manifest_dict["assembly_id"] = "2345"
-        self.manifest_accessor.add(**manifest_dict)
-        result = self.manifest_accessor.get_manifest_list_for_provider_and_bill_date(self.provider_uuid, bill_date)
+        result = self.manifest_accessor.get_manifest_list_for_provider_and_bill_date(self.ocp_provider_uuid, bill_date)
         self.assertEqual(len(result), 2)
 
-        manifest_dict["assembly_id"] = "3456"
-        self.manifest_accessor.add(**manifest_dict)
-        result = self.manifest_accessor.get_manifest_list_for_provider_and_bill_date(self.provider_uuid, bill_date)
+        manifest_dict = copy.deepcopy(self.manifest_dict)
+        manifest_dict["assembly_id"] = "2345"
+        baker.make("CostUsageReportManifest", **manifest_dict)
+        result = self.manifest_accessor.get_manifest_list_for_provider_and_bill_date(self.ocp_provider_uuid, bill_date)
         self.assertEqual(len(result), 3)
+
+        manifest_dict["assembly_id"] = "3456"
+        baker.make("CostUsageReportManifest", **manifest_dict)
+        result = self.manifest_accessor.get_manifest_list_for_provider_and_bill_date(self.ocp_provider_uuid, bill_date)
+        self.assertEqual(len(result), 4)
 
     def test_get_last_seen_manifest_ids(self):
         """Test that get_last_seen_manifest_ids returns the appropriate assembly_ids."""
@@ -132,12 +121,11 @@ class ReportManifestDBAccessorTest(IamTestCase):
             "assembly_id": "5678",
             "billing_period_start_datetime": self.billing_start,
             "num_total_files": 1,
-            "provider_uuid": "00000000-0000-0000-0000-000000000002",
+            "provider_id": self.aws_provider_uuid,
         }
-        manifest = self.manifest_accessor.add(**self.manifest_dict)
-        manifest2 = self.manifest_accessor.add(**manifest_dict2)
+        manifest2 = baker.make("CostUsageReportManifest", **manifest_dict2)
         assembly_ids = self.manifest_accessor.get_last_seen_manifest_ids(self.billing_start)
-        self.assertEqual(assembly_ids, [manifest.assembly_id, manifest2.assembly_id])
+        self.assertEqual(assembly_ids, [str(self.manifest.assembly_id), manifest2.assembly_id])
 
         # test that when the manifest's files have been processed - it is no longer returned
         baker.make(
@@ -148,7 +136,7 @@ class ReportManifestDBAccessorTest(IamTestCase):
         )
 
         assembly_ids = self.manifest_accessor.get_last_seen_manifest_ids(self.billing_start)
-        self.assertEqual(assembly_ids, [manifest.assembly_id])
+        self.assertEqual(assembly_ids, [str(self.manifest.assembly_id)])
 
         # test that of two manifests with the same provider_ids - that only the most recently
         # seen is returned
@@ -156,11 +144,11 @@ class ReportManifestDBAccessorTest(IamTestCase):
             "assembly_id": "91011",
             "billing_period_start_datetime": self.billing_start,
             "num_total_files": 1,
-            "provider_uuid": self.provider_uuid,
+            "provider_id": self.gcp_provider_uuid,
         }
-        manifest3 = self.manifest_accessor.add(**manifest_dict3)
+        manifest3 = baker.make("CostUsageReportManifest", **manifest_dict3)
         assembly_ids = self.manifest_accessor.get_last_seen_manifest_ids(self.billing_start)
-        self.assertEqual(assembly_ids, [manifest3.assembly_id])
+        self.assertIn(manifest3.assembly_id, assembly_ids)
 
         # test that manifests for a different billing month are not returned
         current_month = self.billing_start
@@ -168,7 +156,7 @@ class ReportManifestDBAccessorTest(IamTestCase):
         manifest3.billing_period_start_datetime = calculated_month
         manifest3.save()
         assembly_ids = self.manifest_accessor.get_last_seen_manifest_ids(self.billing_start)
-        self.assertEqual(assembly_ids, [manifest.assembly_id])
+        self.assertEqual(assembly_ids, [str(self.manifest.assembly_id)])
 
     def test_is_last_completed_datetime_null(self):
         """Test is last completed datetime is null."""
@@ -184,13 +172,12 @@ class ReportManifestDBAccessorTest(IamTestCase):
 
     def test_get_s3_csv_cleared(self):
         """Test that s3 CSV clear status is reported."""
-        manifest = self.manifest_accessor.add(**self.manifest_dict)
-        status = self.manifest_accessor.get_s3_csv_cleared(manifest)
+        status = self.manifest_accessor.get_s3_csv_cleared(self.manifest)
         self.assertFalse(status)
 
-        self.manifest_accessor.mark_s3_csv_cleared(manifest)
+        self.manifest_accessor.mark_s3_csv_cleared(self.manifest)
 
-        status = self.manifest_accessor.get_s3_csv_cleared(manifest)
+        status = self.manifest_accessor.get_s3_csv_cleared(self.manifest)
         self.assertTrue(status)
 
     def test_get_s3_parquet_cleared_no_manifest(self):
@@ -200,12 +187,11 @@ class ReportManifestDBAccessorTest(IamTestCase):
 
     def test_get_s3_parquet_cleared_non_ocp(self):
         """Test that s3 CSV clear status is reported."""
-        manifest = self.manifest_accessor.add(**self.manifest_dict)
-        status = self.manifest_accessor.get_s3_parquet_cleared(manifest)
+        status = self.manifest_accessor.get_s3_parquet_cleared(self.manifest)
         self.assertTrue(status)
 
-        self.manifest_accessor.mark_s3_parquet_to_be_cleared(manifest.id)
-        fetch_manifest = self.manifest_accessor.get_manifest_by_id(manifest.id)
+        self.manifest_accessor.mark_s3_parquet_to_be_cleared(self.manifest.id)
+        fetch_manifest = self.manifest_accessor.get_manifest_by_id(self.manifest.id)
 
         status = self.manifest_accessor.get_s3_parquet_cleared(fetch_manifest)
         self.assertFalse(status)
@@ -213,7 +199,8 @@ class ReportManifestDBAccessorTest(IamTestCase):
     def test_get_s3_parquet_cleared_ocp_no_key(self):
         """Test that s3 CSV clear status is reported."""
         self.manifest_dict["cluster_id"] = "cluster_id"
-        manifest = self.manifest_accessor.add(**self.manifest_dict)
+        self.manifest_dict["assembly_id"] = uuid.uuid4()
+        manifest = baker.make("CostUsageReportManifest", **self.manifest_dict)
         status = self.manifest_accessor.get_s3_parquet_cleared(manifest)
         self.assertTrue(status)
 
@@ -230,7 +217,8 @@ class ReportManifestDBAccessorTest(IamTestCase):
         """Test that s3 CSV clear status is reported."""
         key = "my-made-up-report"
         self.manifest_dict["cluster_id"] = "cluster_id"
-        manifest = self.manifest_accessor.add(**self.manifest_dict)
+        self.manifest_dict["assembly_id"] = uuid.uuid4()
+        manifest = baker.make("CostUsageReportManifest", **self.manifest_dict)
         status = self.manifest_accessor.get_s3_parquet_cleared(manifest, key)
         self.assertFalse(status)
 
@@ -248,15 +236,13 @@ class ReportManifestDBAccessorTest(IamTestCase):
 
     def test_mark_s3_parquet_cleared(self):
         """Test mark_s3_parquet_cleared without manifest does not error."""
-        manifest = self.manifest_accessor.add(**self.manifest_dict)
-        self.manifest_accessor.mark_s3_parquet_cleared(manifest)
-        self.assertTrue(self.manifest_accessor.get_s3_parquet_cleared(manifest))
+        self.manifest_accessor.mark_s3_parquet_cleared(self.manifest)
+        self.assertTrue(self.manifest_accessor.get_s3_parquet_cleared(self.manifest))
 
     def test_set_and_get_manifest_daily_archive_start_date(self):
         """Test marking manifest daily archive start date."""
-        manifest = self.manifest_accessor.add(**self.manifest_dict)
         start_date = DateHelper().this_month_start.replace(year=2019, month=7).replace(tzinfo=None)
-        manifest_start = self.manifest_accessor.set_manifest_daily_start_date(manifest.id, start_date)
+        manifest_start = self.manifest_accessor.set_manifest_daily_start_date(self.manifest.id, start_date)
         self.assertEqual(manifest_start, start_date)
 
     def test_should_s3_parquet_be_cleared_no_manifest(self):
@@ -267,29 +253,31 @@ class ReportManifestDBAccessorTest(IamTestCase):
     def test_should_s3_parquet_be_cleared_non_ocp(self):
         """Test that is parquet s3 should be cleared for non-ocp manifest."""
         # non-ocp manifest returns True:
-        manifest = self.manifest_accessor.add(**self.manifest_dict)
-        self.assertTrue(self.manifest_accessor.should_s3_parquet_be_cleared(manifest))
+        self.assertTrue(self.manifest_accessor.should_s3_parquet_be_cleared(self.manifest))
 
     def test_should_s3_parquet_be_cleared_ocp_not_daily(self):
         """Test that is parquet s3 should be cleared for ocp manifest, not daily."""
         # ocp manifest, not daily returns False:
-        manifest = self.manifest_accessor.add(**self.manifest_dict, cluster_id="cluster-id")
+        self.manifest_dict["cluster_id"] = "cluster_id"
+        self.manifest_dict["assembly_id"] = uuid.uuid4()
+        manifest = baker.make("CostUsageReportManifest", **self.manifest_dict)
         self.assertFalse(self.manifest_accessor.should_s3_parquet_be_cleared(manifest))
 
     def test_should_s3_parquet_be_cleared_ocp_is_daily(self):
         """Test that is parquet s3 should be cleared for ocp manifest, is daily."""
         # ocp manifest, daily files returns True:
-        manifest = self.manifest_accessor.add(
-            **self.manifest_dict, cluster_id="cluster-id", operator_daily_reports=True
-        )
+        self.manifest_dict["cluster_id"] = "cluster_id"
+        self.manifest_dict["assembly_id"] = uuid.uuid4()
+        self.manifest_dict["operator_daily_reports"] = True
+        manifest = baker.make("CostUsageReportManifest", **self.manifest_dict)
         self.assertTrue(self.manifest_accessor.should_s3_parquet_be_cleared(manifest))
 
     def test_bulk_delete_manifests(self):
         """Test bulk delete of manifests."""
-        manifest_list = []
-        for fake_assembly_id in ["1234", "12345", "123456"]:
+        manifest_list = [self.manifest.id]
+        for fake_assembly_id in ["12345", "123456"]:
             self.manifest_dict["assembly_id"] = fake_assembly_id
-            manifest = self.manifest_accessor.add(**self.manifest_dict)
+            manifest = baker.make("CostUsageReportManifest", **self.manifest_dict)
             manifest_list.append(manifest.id)
         self.manifest_accessor.bulk_delete_manifests(self.provider_uuid, manifest_list)
         current_manifests = self.manifest_accessor.get_manifest_list_for_provider_and_bill_date(

--- a/koku/masu/test/external/downloader/test_report_downloader_base.py
+++ b/koku/masu/test/external/downloader/test_report_downloader_base.py
@@ -8,7 +8,6 @@ from unittest.mock import patch
 
 from django.db.utils import IntegrityError
 from faker import Faker
-from model_bakery import baker
 
 from masu.database.report_manifest_db_accessor import ReportManifestDBAccessor
 from masu.external.date_accessor import DateAccessor
@@ -47,7 +46,7 @@ class ReportDownloaderBaseTest(MasuTestCase):
             "num_total_files": 2,
             "provider_uuid": self.aws_provider_uuid,
         }
-        self.manifest = baker.make(
+        self.manifest = self.baker.make(
             CostUsageReportManifest,
             assembly_id=self.assembly_id,
             billing_period_start_datetime=self.billing_start,
@@ -56,23 +55,13 @@ class ReportDownloaderBaseTest(MasuTestCase):
         )
         self.manifest_id = self.manifest.id
         for i in [1, 2]:
-            baker.make(
+            self.baker.make(
                 CostUsageReportStatus,
                 report_name=f"{self.assembly_id}_file_{i}.csv.gz",
                 last_completed_datetime=None,
                 last_started_datetime=None,
                 manifest_id=self.manifest_id,
             )
-
-    # def tearDown(self):
-    #     """Tear down each test case."""
-    #     super().tearDown()
-    #     CostUsageReportStatus.objects.filter(report_name=self.report_name, manifest_id=self.manifest_id).delete()
-
-    #     with ReportManifestDBAccessor() as manifest_accessor:
-    #         manifests = manifest_accessor._get_db_obj_query().all()
-    #         for manifest in manifests:
-    #             manifest_accessor.delete(manifest)
 
     def test_report_downloader_base_no_path(self):
         """Test report downloader download_path."""

--- a/koku/masu/test/processor/test_report_summary_updater.py
+++ b/koku/masu/test/processor/test_report_summary_updater.py
@@ -7,11 +7,12 @@ import datetime
 from unittest.mock import patch
 from uuid import uuid4
 
+from model_bakery import baker
+
 from api.provider.models import Provider
 from api.provider.models import ProviderAuthentication
 from api.provider.models import ProviderBillingSource
 from api.utils import DateHelper
-from masu.database.report_manifest_db_accessor import ReportManifestDBAccessor
 from masu.external.date_accessor import DateAccessor
 from masu.processor.aws.aws_report_parquet_summary_updater import AWSReportParquetSummaryUpdater
 from masu.processor.azure.azure_report_parquet_summary_updater import AzureReportParquetSummaryUpdater
@@ -73,10 +74,9 @@ class ReportSummaryUpdaterTest(MasuTestCase):
             "assembly_id": "1234",
             "billing_period_start_datetime": billing_start,
             "num_total_files": 2,
-            "provider_uuid": self.ocp_provider_uuid,
+            "provider_id": self.ocp_provider_uuid,
         }
-        with ReportManifestDBAccessor() as accessor:
-            manifest = accessor.add(**manifest_dict)
+        manifest = baker.make("CostUsageReportManifest", **manifest_dict)
         manifest_id = manifest.id
         with self.assertRaises(ReportSummaryUpdaterError):
             ReportSummaryUpdater(self.schema, no_provider_uuid, manifest_id)

--- a/koku/masu/test/processor/test_report_summary_updater.py
+++ b/koku/masu/test/processor/test_report_summary_updater.py
@@ -7,8 +7,6 @@ import datetime
 from unittest.mock import patch
 from uuid import uuid4
 
-from model_bakery import baker
-
 from api.provider.models import Provider
 from api.provider.models import ProviderAuthentication
 from api.provider.models import ProviderBillingSource
@@ -82,7 +80,7 @@ class ReportSummaryUpdaterTest(MasuTestCase):
             "num_total_files": 2,
             "provider_id": self.ocp_provider_uuid,
         }
-        manifest = baker.make("CostUsageReportManifest", **manifest_dict)
+        manifest = self.baker.make("CostUsageReportManifest", **manifest_dict)
         manifest_id = manifest.id
         with self.assertRaises(ReportSummaryUpdaterError):
             ReportSummaryUpdater(self.schema, no_provider_uuid, manifest_id)

--- a/koku/masu/test/processor/test_tasks.py
+++ b/koku/masu/test/processor/test_tasks.py
@@ -28,7 +28,6 @@ from django.core.cache import caches
 from django.db.utils import IntegrityError
 from django.test.utils import override_settings
 from django_tenants.utils import schema_context
-from model_bakery import baker
 
 from api.iam.models import Tenant
 from api.models import Provider
@@ -1510,7 +1509,7 @@ class TestWorkerCacheThrottling(MasuTestCase):
             "num_total_files": 2,
             "provider_uuid": self.aws_provider_uuid,
         }
-        baker.make("CostUsageReportManifest", **manifest_dict)
+        self.baker.make("CostUsageReportManifest", **manifest_dict)
 
         update_cost_model_costs(self.schema, self.aws_provider_uuid, expected_start_date, expected_end_date)
         mock_delay.assert_not_called()
@@ -1567,7 +1566,7 @@ class TestWorkerCacheThrottling(MasuTestCase):
             "num_total_files": 2,
             "provider_id": self.aws_provider_uuid,
         }
-        baker.make("CostUsageReportManifest", **manifest_dict)
+        self.baker.make("CostUsageReportManifest", **manifest_dict)
 
         update_openshift_on_cloud(
             self.schema,

--- a/koku/masu/test/processor/test_tasks.py
+++ b/koku/masu/test/processor/test_tasks.py
@@ -28,6 +28,7 @@ from django.core.cache import caches
 from django.db.utils import IntegrityError
 from django.test.utils import override_settings
 from django_tenants.utils import schema_context
+from model_bakery import baker
 
 from api.iam.models import Tenant
 from api.models import Provider
@@ -37,7 +38,6 @@ from masu.database import AWS_CUR_TABLE_MAP
 from masu.database import OCP_REPORT_TABLE_MAP
 from masu.database.aws_report_db_accessor import AWSReportDBAccessor
 from masu.database.ocp_report_db_accessor import OCPReportDBAccessor
-from masu.database.report_manifest_db_accessor import ReportManifestDBAccessor
 from masu.exceptions import MasuProcessingError
 from masu.exceptions import MasuProviderError
 from masu.external.downloader.report_downloader_base import ReportDownloaderWarning
@@ -1510,10 +1510,7 @@ class TestWorkerCacheThrottling(MasuTestCase):
             "num_total_files": 2,
             "provider_uuid": self.aws_provider_uuid,
         }
-
-        with ReportManifestDBAccessor() as manifest_accessor:
-            manifest = manifest_accessor.add(**manifest_dict)
-            manifest.save()
+        baker.make("CostUsageReportManifest", **manifest_dict)
 
         update_cost_model_costs(self.schema, self.aws_provider_uuid, expected_start_date, expected_end_date)
         mock_delay.assert_not_called()
@@ -1568,12 +1565,9 @@ class TestWorkerCacheThrottling(MasuTestCase):
             "assembly_id": "12345",
             "billing_period_start_datetime": self.dh.today,
             "num_total_files": 2,
-            "provider_uuid": self.aws_provider_uuid,
+            "provider_id": self.aws_provider_uuid,
         }
-
-        with ReportManifestDBAccessor() as manifest_accessor:
-            manifest = manifest_accessor.add(**manifest_dict)
-            manifest.save()
+        baker.make("CostUsageReportManifest", **manifest_dict)
 
         update_openshift_on_cloud(
             self.schema,


### PR DESCRIPTION
## Jira Ticket

[COST-4445](https://issues.redhat.com/browse/COST-4445)

## Description

This change updates `ReportManifestDBAccessor` to not inherit from `KokuDBAccess`. This PR also moves any tests that use the `ReportManifestDBAccessor` to create fake manifests to model bakery.
