### PR TITLE
[COST-4446] - suppress `missing cluster-id` alert

### DIFF
--- a/koku/api/iam/test/iam_test_case.py
+++ b/koku/api/iam/test/iam_test_case.py
@@ -18,6 +18,7 @@ from django.test import override_settings
 from django.test import RequestFactory
 from django.test import TestCase
 from faker import Faker
+from model_bakery import baker
 
 from api.common import RH_IDENTITY_HEADER
 from api.iam.serializers import create_schema_name
@@ -71,6 +72,7 @@ class IamTestCase(TestCase):
 
     fake = Faker()
     dh = DateHelper()
+    baker = baker
 
     @classmethod
     def setUpClass(cls):

--- a/koku/masu/processor/ocp/ocp_report_parquet_summary_updater.py
+++ b/koku/masu/processor/ocp/ocp_report_parquet_summary_updater.py
@@ -23,6 +23,10 @@ from reporting.provider.ocp.models import UI_SUMMARY_TABLES
 LOG = logging.getLogger(__name__)
 
 
+class OCPReportParquetSummaryUpdaterClusterNotFound(Exception):
+    pass
+
+
 class OCPReportParquetSummaryUpdater(PartitionHandlerMixin):
     """Class to update OCP report summary data from Trino/Parquet data."""
 
@@ -39,14 +43,15 @@ class OCPReportParquetSummaryUpdater(PartitionHandlerMixin):
 
         self._cluster_id = get_cluster_id_from_provider(self._provider.uuid)
         if not self._cluster_id:
-            msg = f"Missing cluster_id for provider: {self._provider.uuid}"
-            LOG.error(
+            msg = "missing cluster_id for provider"
+            LOG.warning(
                 log_json(
-                    msg=msg,
+                    msg="missing cluster_id for provider",
                     provider_uuid=provider.uuid,
+                    schema=schema,
                 )
             )
-            raise ValueError(msg)
+            raise OCPReportParquetSummaryUpdaterClusterNotFound(msg)
 
         self._cluster_alias = get_cluster_alias_from_cluster_id(self._cluster_id)
         self._date_accessor = DateAccessor()

--- a/koku/masu/processor/ocp/ocp_report_parquet_summary_updater.py
+++ b/koku/masu/processor/ocp/ocp_report_parquet_summary_updater.py
@@ -44,13 +44,7 @@ class OCPReportParquetSummaryUpdater(PartitionHandlerMixin):
         self._cluster_id = get_cluster_id_from_provider(self._provider.uuid)
         if not self._cluster_id:
             msg = "missing cluster_id for provider"
-            LOG.warning(
-                log_json(
-                    msg="missing cluster_id for provider",
-                    provider_uuid=provider.uuid,
-                    schema=schema,
-                )
-            )
+            LOG.warning(log_json(msg=msg, provider_uuid=provider.uuid, schema=schema))
             raise OCPReportParquetSummaryUpdaterClusterNotFound(msg)
 
         self._cluster_alias = get_cluster_alias_from_cluster_id(self._cluster_id)

--- a/koku/masu/processor/report_summary_updater.py
+++ b/koku/masu/processor/report_summary_updater.py
@@ -17,6 +17,7 @@ from masu.processor.gcp.gcp_report_parquet_summary_updater import GCPReportParqu
 from masu.processor.oci.oci_report_parquet_summary_updater import OCIReportParquetSummaryUpdater
 from masu.processor.ocp.ocp_cloud_parquet_summary_updater import OCPCloudParquetReportSummaryUpdater
 from masu.processor.ocp.ocp_report_parquet_summary_updater import OCPReportParquetSummaryUpdater
+from masu.processor.ocp.ocp_report_parquet_summary_updater import OCPReportParquetSummaryUpdaterClusterNotFound
 
 LOG = logging.getLogger(__name__)
 REPORT_SUMMARY_UPDATER_DICT = {
@@ -74,6 +75,10 @@ class ReportSummaryUpdater:
 
         try:
             self._updater, self._ocp_cloud_updater = self._set_updater()
+        except OCPReportParquetSummaryUpdaterClusterNotFound as e:
+            raise ReportSummaryUpdaterProviderNotFoundError(
+                f"provider data for uuid '{self._provider_uuid}' not found"
+            ) from e
         except Exception as err:
             raise ReportSummaryUpdaterError(err) from err
 

--- a/koku/masu/test/processor/ocp/test_ocp_report_parquet_summary_updater.py
+++ b/koku/masu/test/processor/ocp/test_ocp_report_parquet_summary_updater.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 from masu.database.report_manifest_db_accessor import ReportManifestDBAccessor
 from masu.processor.ocp.ocp_cloud_updater_base import OCPCloudUpdaterBase
 from masu.processor.ocp.ocp_report_parquet_summary_updater import OCPReportParquetSummaryUpdater
+from masu.processor.ocp.ocp_report_parquet_summary_updater import OCPReportParquetSummaryUpdaterClusterNotFound
 from masu.test import MasuTestCase
 from masu.util.ocp.common import get_cluster_alias_from_cluster_id
 from masu.util.ocp.common import get_cluster_id_from_provider
@@ -46,10 +47,10 @@ class OCPReportParquetSummaryUpdaterTest(MasuTestCase):
         """Test the initialization of OCPReportParquetSummaryUpdater with no cluster_id."""
 
         mock_get_cluster_id.return_value = None
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaises(OCPReportParquetSummaryUpdaterClusterNotFound) as context:
             OCPReportParquetSummaryUpdater(self.schema_name, self.ocp_provider, "test_manifest")
 
-        expected_error_msg = f"Missing cluster_id for provider: {self.ocp_provider.uuid}"
+        expected_error_msg = "missing cluster_id for provider"
         self.assertEqual(str(context.exception), expected_error_msg)
 
     @patch("masu.processor.ocp.ocp_report_parquet_summary_updater.OCPReportDBAccessor")

--- a/koku/masu/test/processor/test_report_summary_updater.py
+++ b/koku/masu/test/processor/test_report_summary_updater.py
@@ -65,6 +65,12 @@ class ReportSummaryUpdaterTest(MasuTestCase):
         with self.assertRaises(ReportSummaryUpdaterProviderNotFoundError):
             _ = ReportSummaryUpdater(self.schema, uuid4())
 
+    def test_bad_ocp_provider(self):
+        """Test that an OCP provider without cluster-id throws an error."""
+        p = self.baker.make("Provider", type="OCP")
+        with self.assertRaises(ReportSummaryUpdaterProviderNotFoundError):
+            _ = ReportSummaryUpdater(self.schema, p.uuid)
+
     def test_no_provider_on_create(self):
         """Test that an error is raised when no provider exists."""
         billing_start = DateAccessor().today_with_timezone("UTC").replace(day=1)


### PR DESCRIPTION
## Jira Ticket

[COST-4446](https://issues.redhat.com/browse/COST-4446)

## Description

Log the initial message as a warning and raise as `OCPReportParquetSummaryUpdaterClusterNotFound` instead of value error. Catch `OCPReportParquetSummaryUpdaterClusterNotFound` and re-raise as `ReportSummaryUpdaterProviderNotFoundError`. We already catch `ReportSummaryUpdaterProviderNotFoundError` [here](https://github.com/project-koku/koku/blob/c4cdd46061f3718b0490bd86303e292fd6df4796/koku/masu/processor/tasks.py#L523) which stops processing.

