### PR TITLE
[COST-4452] catch and log foreign key violation as warning

### DIFF
--- a/koku/koku/celery.py
+++ b/koku/koku/celery.py
@@ -16,6 +16,7 @@ from croniter import croniter
 from django.conf import settings
 from kombu.exceptions import OperationalError
 
+from .database import FKViolation
 from koku import sentry  # noqa: F401
 from koku.env import ENVIRONMENT
 from koku.probe_server import ProbeResponse
@@ -31,7 +32,10 @@ class LogErrorsTask(Task):  # pragma: no cover
 
     def on_failure(self, exc, task_id, args, kwargs, einfo):
         """Log exceptions when a celery task fails."""
-        LOG.exception("Task failed: %s", exc, exc_info=exc)
+        if fk_violation := FKViolation(exc):
+            LOG.warning("task failed: %s", fk_violation)
+        else:
+            LOG.exception("Task failed: %s", exc, exc_info=exc)
         super().on_failure(exc, task_id, args, kwargs, einfo)
 
 


### PR DESCRIPTION
## Jira Ticket

[COST-4452](https://issues.redhat.com/browse/COST-4452)

## Description

This change will log a foreign key violation as a warning instead of an exception.

The FKViolation explicitly looks for:
```
violates foreign key constraint ... is not present in table ... 
```
If we're missing the key, more than likely that means the source was deleted so we should just log this as a warning and move on.

## Testing

1. 😅 

...
