### PR TITLE
Make ROS OCP API available in koku openapi.json

### DIFF
--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -56,6 +56,10 @@
         {
             "name": "Status",
             "description": "Operations about status"
+        },
+        {
+            "name": "Optimizations",
+            "description": "Resource Optimization for Openshift"
         }
     ],
     "paths": {
@@ -5729,7 +5733,13 @@
                         "basic_auth": []
                     }]
                 }
-            }
+            },
+        "/recommendations/openshift": {
+            "$ref": "/api/cost-management/v1/recommendations/openshift/openapi.json#/paths/~1recommendations~1openshift"
+        },
+        "/recommendations/openshift/{recommendation-id}": {
+            "$ref": "/api/cost-management/v1/recommendations/openshift/openapi.json#/paths/~1recommendations~1openshift~1{recommendation-id}"
+        }
         },
     "externalDocs": {
         "description": "Find out more about Cost Management",


### PR DESCRIPTION
## This PR should be merged only after [RHCLOUD-29490](https://issues.redhat.com/browse/RHCLOUD-29490) is completed.

## Jira Ticket

[RHIROS-1292](https://issues.redhat.com/browse/RHIROS-1292) - [ROS-OCP] Make API specifications available under Insights API documentation

[RHCLOUD-29490](https://issues.redhat.com/browse/RHCLOUD-29490) - [Gateway] Allow no-auth for ROS-OCP openapi.json



## Description

This change will make ROS-OCP APIs from their openapi.json available under Cost-Mgmt openapi.json file so that users can access ROS-OCP API endpoints as well.

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Notes
This PR should be merged only after [RHCLOUD-29490](https://issues.redhat.com/browse/RHCLOUD-29490) is completed.

Keeping in loop - @chambridge @pgarciaq @patilsuraj767