### PR TITLE
[SWATCH-1779] - Enable result upload to Report portal for daily eph job

### DIFF
--- a/smoke_test.sh
+++ b/smoke_test.sh
@@ -11,6 +11,7 @@ IQE_MARKER_EXPRESSION="cost_smoke"
 IQE_FILTER_EXPRESSION=""
 IQE_CJI_TIMEOUT="5h"
 IQE_ENV_VARS="JOB_NAME=${JOB_NAME},BUILD_NUMBER=${BUILD_NUMBER}"
+IQE_RP_ARGS="true"
 
 # Get bonfire helper scripts
 CICD_URL="https://raw.githubusercontent.com/RedHatInsights/cicd-tools/main"
@@ -36,6 +37,7 @@ OCI_CREDENTIALS_EPH=$(jq -r '."oci-credentials"' < oci-creds.json)
 OCI_CLI_USER_EPH=$(jq -r '."oci-cli-user"' < oci-creds.json | base64 -d)
 OCI_CLI_FINGERPRINT_EPH=$(jq -r '."oci-cli-fingerprint"' < oci-creds.json | base64 -d)
 OCI_CLI_TENANCY_EPH=$(jq -r '."oci-cli-tenancy"' < oci-creds.json | base64 -d)
+IQE_IBUTSU_SOURCE="cost-ephemeral-${IMAGE_TAG}"
 
 bonfire deploy \
     ${APP_NAME} \


### PR DESCRIPTION
## Jira Ticket

[SWATCH-1779](https://issues.redhat.com/browse/SWATCH-1779)

## Description

This change will enable daily ephemeral IQE results to upload to Report Portal.

## Testing

Verify bonfire deploy-iqe-cji has --rp-args true and --ibutsu-source as cost-ephemeral-$IMAGE_TAG + verify that the test results of daily ephemeral job were uploaded to Report portal

