### PR TITLE
COST-4444: Fix regression related to startswith filter.

### DIFF
--- a/koku/api/tags/queries.py
+++ b/koku/api/tags/queries.py
@@ -168,11 +168,17 @@ class TagQueryHandler(QueryHandler):
             raise NoNamespacesForCategory(f"No namespaces for category: {category_list}")
 
         for namespace in namespaces:
-            namespace_formated = namespace.replace("%", "")  # django is doing `kube-\%%`
-            namespace_filter = QueryFilter(
-                parameter=namespace_formated, **{"field": "namespace", "operation": "startswith"}
-            )
-            category_filters.add(namespace_filter)
+            if "%" in namespace:
+                namespace_formated = namespace.replace("%", "")  # django is doing `kube-\%%`
+                namespace_filter = QueryFilter(
+                    parameter=namespace_formated, **{"field": "namespace", "operation": "startswith"}
+                )
+                category_filters.add(namespace_filter)
+            else:
+                namespace_filter = QueryFilter(
+                    parameter=namespace_formated, **{"field": "namespace", "operation": "exact"}
+                )
+                category_filters.add(namespace_filter)
         return category_filters.compose(logical_operator="or")
 
     def _get_filter(self, delta=False):  # noqa: C901


### PR DESCRIPTION
## Jira Ticket

[COST-4444](https://issues.redhat.com/browse/COST-4444)

## Description

This change will fix a regression I introduced when switching the processing logic over to using the new model. Michael pointed out that we should include the namespace `openshift` as a default platform moving forward. Therefore, `openshift` I added this project in the [new model migration](https://github.com/project-koku/koku/commit/4280dc701f50af98d2a74a13c297c38dbabc8070#diff-34d22883d25ce212f45ab8b70d28950d59fd6b1ac013dd301e71cc6d1f1d63b6R6).

However, when I updated the logic on the django side of the tag filter, I just used the pre-existing "startswith" operation. This was causing tags to be returned with any namespace that started with openshift. I have updated the logic to see if a "%" is in the namespace, those namespaces will use the `startswith` operation, whereas all other namespaces will do an exact match. 

 

## Testing


## Notes

...
