### PR TITLE
[COST-4334] - Adding dtypes for AWS

### DIFF
--- a/koku/masu/util/aws/aws_post_processor.py
+++ b/koku/masu/util/aws/aws_post_processor.py
@@ -258,7 +258,9 @@ class AWSPostProcessor:
         data_frame["costCategory"] = cost_categories
 
         # Make sure we have entries for our required columns
-        data_frame = data_frame.reindex(columns=columns)
+        missing = set(TRINO_REQUIRED_COLUMNS).difference(data_frame)
+        to_add = {k: TRINO_REQUIRED_COLUMNS[k] for k in missing}
+        data_frame = data_frame.assign(**to_add)
 
         columns = list(data_frame)
         column_name_map = {}

--- a/koku/reporting/provider/aws/models.py
+++ b/koku/reporting/provider/aws/models.py
@@ -5,6 +5,7 @@
 """Models for AWS cost entry tables."""
 from uuid import uuid4
 
+import pandas as pd
 from django.contrib.postgres.fields import ArrayField
 from django.contrib.postgres.indexes import GinIndex
 from django.db import models
@@ -32,38 +33,37 @@ TRINO_LINE_ITEM_TABLE = "aws_line_items"
 TRINO_LINE_ITEM_DAILY_TABLE = "aws_line_items_daily"
 TRINO_OCP_ON_AWS_DAILY_TABLE = "aws_openshift_daily"
 
-TRINO_REQUIRED_COLUMNS = (
-    "bill/BillingEntity",
-    "lineItem/UsageStartDate",
-    "lineItem/ProductCode",
-    "product/productFamily",
-    "product/ProductName",
-    "lineItem/UsageAccountId",
-    "lineItem/LegalEntity",
-    "lineItem/LineItemDescription",
-    "lineItem/LineItemType",
-    "lineItem/AvailabilityZone",
-    "product/region",
-    "product/instanceType",
-    "product/physicalCores",
-    "product/vcpu",
-    "pricing/unit",
-    "lineItem/UsageAmount",
-    "lineItem/NormalizationFactor",
-    "lineItem/NormalizedUsageAmount",
-    "lineItem/CurrencyCode",
-    "lineItem/UnblendedRate",
-    "lineItem/UnblendedCost",
-    "lineItem/BlendedRate",
-    "lineItem/BlendedCost",
-    "savingsPlan/SavingsPlanEffectiveCost",
-    "pricing/publicOnDemandCost",
-    "pricing/publicOnDemandRate",
-    "lineItem/ResourceId",
-    "resourceTags",
-    "costCategory",
-    "savingsPlan/SavingsPlanEffectiveCost",
-)
+TRINO_REQUIRED_COLUMNS = {
+    "bill/BillingEntity": "",
+    "lineItem/UsageStartDate": pd.NaT,
+    "lineItem/ProductCode": "",
+    "product/productFamily": "",
+    "product/ProductName": "",
+    "lineItem/UsageAccountId": "",
+    "lineItem/LegalEntity": "",
+    "lineItem/LineItemDescription": "",
+    "lineItem/LineItemType": "",
+    "lineItem/AvailabilityZone": "",
+    "product/region": "",
+    "product/instanceType": "",
+    "product/physicalCores": "",
+    "product/vcpu": "",
+    "pricing/unit": "",
+    "lineItem/UsageAmount": 0.0,
+    "lineItem/NormalizationFactor": 0.0,
+    "lineItem/NormalizedUsageAmount": 0.0,
+    "lineItem/CurrencyCode": "",
+    "lineItem/UnblendedRate": 0.0,
+    "lineItem/UnblendedCost": 0.0,
+    "lineItem/BlendedRate": 0.0,
+    "lineItem/BlendedCost": 0.0,
+    "savingsPlan/SavingsPlanEffectiveCost": 0.0,
+    "pricing/publicOnDemandCost": 0.0,
+    "pricing/publicOnDemandRate": 0.0,
+    "lineItem/ResourceId": "",
+    "resourceTags": "",
+    "costCategory": "",
+}
 
 
 class AWSCostEntryBill(models.Model):


### PR DESCRIPTION
## Jira Ticket

[COST-4335](https://issues.redhat.com/browse/COST-4335)

## Description

This change will commonize dtype handling and correctly set the csv converters for AWS

## Testing

1. Checkout Branch
2. Run koku with updated trino/hive versions
3.  create/load data for AWS provider
4. see data is processed correctly

## Notes
trino diff
deploy/trino/etc/catalog/hive.properties
 
-parquet.optimized-reader.enabled=false
+# parquet.optimized-reader.enabled=false

diff --git a/deploy/trino/etc/jvm.config b/deploy/trino/etc/jvm.config

+-Dfile.encoding=UTF-8

diff --git a/docker-compose.arm.yml b/docker-compose.arm.yml

   hive-metastore:
-    image: quay.io/mskarbek/ubi-hive:3.1.2-metastore-008
+    image: quay.io/mskarbek/ubi-hive:3.1.3-metastore-024
 
   trino:
-    image: quay.io/mskarbek/ubi-trino:411-001
+    image: quay.io/mskarbek/ubi-trino:427-001

diff --git a/docker-compose.yml b/docker-compose.yml
   hive-metastore:
     container_name: hive-metastore
-    image: quay.io/cloudservices/ubi-hive:3.1.2-metastore-008
+    image: quay.io/cloudservices/ubi-hive:latest

   trino:
     container_name: trino
-    image: quay.io/cloudservices/ubi-trino:411-002
+    image: quay.io/cloudservices/ubi-trino:latest
...
