### PR TITLE
[COST-4332] - Adding dtypes for GCP

### DIFF
--- a/koku/masu/processor/gcp/gcp_report_parquet_processor.py
+++ b/koku/masu/processor/gcp/gcp_report_parquet_processor.py
@@ -17,17 +17,20 @@ from reporting.provider.gcp.models import TRINO_OCP_ON_GCP_DAILY_TABLE
 
 
 class GCPReportParquetProcessor(ReportParquetProcessorBase):
+    NUMERIC_COLUMNS = (
+        "cost",
+        "currency_conversion_rate",
+        "usage_amount",
+        "usage_amount_in_pricing_units",
+        "credit_amount",
+        "daily_credits",
+    )
+    DATE_COLUMNS = ("usage_start_time", "usage_end_time", "export_time", "partition_time")
+    BOOLEAN_COLUMNS = "ocp_matched"
+    JSON_COLUMNS = ("project.labels", "labels", "system_labels")
+    CREDITS = "credits"
+
     def __init__(self, manifest_id, account, s3_path, provider_uuid, parquet_local_path):
-        numeric_columns = [
-            "cost",
-            "currency_conversion_rate",
-            "usage_amount",
-            "usage_amount_in_pricing_units",
-            "credit_amount",
-            "daily_credits",
-        ]
-        date_columns = ["usage_start_time", "usage_end_time", "export_time", "partition_time"]
-        boolean_columns = ["ocp_matched"]
         if "openshift" in s3_path:
             table_name = TRINO_OCP_ON_GCP_DAILY_TABLE
         elif "daily" in s3_path:
@@ -35,9 +38,9 @@ class GCPReportParquetProcessor(ReportParquetProcessorBase):
         else:
             table_name = TRINO_LINE_ITEM_TABLE
         column_types = {
-            "numeric_columns": numeric_columns,
-            "date_columns": date_columns,
-            "boolean_columns": boolean_columns,
+            "numeric_columns": self.NUMERIC_COLUMNS,
+            "date_columns": self.DATE_COLUMNS,
+            "boolean_columns": self.BOOLEAN_COLUMNS,
         }
         super().__init__(
             manifest_id=manifest_id,

--- a/koku/masu/util/gcp/gcp_post_processor.py
+++ b/koku/masu/util/gcp/gcp_post_processor.py
@@ -1,50 +1,15 @@
 import json
 import logging
-from json.decoder import JSONDecodeError
 
-import ciso8601
 import pandas as pd
 
 from api.models import Provider
+from masu.processor.gcp.gcp_report_parquet_processor import GCPReportParquetProcessor
+from masu.util.common import get_column_converters_common
 from masu.util.common import populate_enabled_tag_rows_with_false
-from masu.util.common import safe_float
 from masu.util.common import strip_characters_from_column_name
 
 LOG = logging.getLogger(__name__)
-
-
-def process_gcp_labels(label_string):
-    """Convert the report string to a JSON dictionary.
-
-    Args:
-        label_string (str): The raw report string of pod labels
-
-    Returns:
-        (dict): The JSON dictionary made from the label string
-
-    """
-    label_dict = {}
-    try:
-        if label_string:
-            labels = json.loads(label_string)
-            label_dict = {entry.get("key"): entry.get("value") for entry in labels}
-    except JSONDecodeError:
-        LOG.warning("Unable to process GCP labels.")
-
-    return json.dumps(label_dict)
-
-
-def process_gcp_credits(credit_string):
-    """Process the credits column, which is non-standard JSON."""
-    credit_dict = {}
-    try:
-        gcp_credits = json.loads(credit_string.replace("'", '"').replace("None", '"None"'))
-        if gcp_credits:
-            credit_dict = gcp_credits[0]
-    except JSONDecodeError:
-        LOG.warning("Unable to process GCP credits.")
-
-    return json.dumps(credit_dict)
 
 
 class GCPPostProcessor:
@@ -95,24 +60,7 @@ class GCPPostProcessor:
         """
         Return source specific parquet column converters.
         """
-        converters = {
-            "usage_start_time": ciso8601.parse_datetime,
-            "usage_end_time": ciso8601.parse_datetime,
-            "project.labels": process_gcp_labels,
-            "labels": process_gcp_labels,
-            "system_labels": process_gcp_labels,
-            "export_time": ciso8601.parse_datetime,
-            "cost": safe_float,
-            "currency_conversion_rate": safe_float,
-            "usage.amount": safe_float,
-            "usage.amount_in_pricing_units": safe_float,
-            "credits": process_gcp_credits,
-        }
-        csv_converters = {
-            col_name: converters[col_name.lower()] for col_name in col_names if col_name.lower() in converters
-        }
-        csv_converters.update({col: str for col in col_names if col not in csv_converters})
-        return csv_converters, panda_kwargs
+        return get_column_converters_common(col_names, panda_kwargs, GCPReportParquetProcessor, "GCP")
 
     def _generate_daily_data(self, data_frame):
         """


### PR DESCRIPTION
## Jira Ticket

[COST-4332](https://issues.redhat.com/browse/COST-4332)

## Description

This change will commonize dtype handling and correctly set the csv converters for GCP

## Testing

1. Checkout Branch
2. Run koku with updated trino/hive versions
3.  create/load data for GCP provider
4. see data is processed correctly

## Notes
trino diff
deploy/trino/etc/catalog/hive.properties
 
-parquet.optimized-reader.enabled=false
+# parquet.optimized-reader.enabled=false

diff --git a/deploy/trino/etc/jvm.config b/deploy/trino/etc/jvm.config

+-Dfile.encoding=UTF-8

diff --git a/docker-compose.arm.yml b/docker-compose.arm.yml

   hive-metastore:
-    image: quay.io/mskarbek/ubi-hive:3.1.2-metastore-008
+    image: quay.io/mskarbek/ubi-hive:3.1.3-metastore-024
 
   trino:
-    image: quay.io/mskarbek/ubi-trino:411-001
+    image: quay.io/mskarbek/ubi-trino:427-001

diff --git a/docker-compose.yml b/docker-compose.yml
   hive-metastore:
     container_name: hive-metastore
-    image: quay.io/cloudservices/ubi-hive:3.1.2-metastore-008
+    image: quay.io/cloudservices/ubi-hive:latest

   trino:
     container_name: trino
-    image: quay.io/cloudservices/ubi-trino:411-002
+    image: quay.io/cloudservices/ubi-trino:latest
...
