### PR TITLE
[COST-4360] - Adding dtypes for OCI

### DIFF
--- a/koku/masu/util/oci/oci_post_processor.py
+++ b/koku/masu/util/oci/oci_post_processor.py
@@ -95,8 +95,10 @@ class OCIPostProcessor:
         resource_tags_dict = resource_tags_dict.where(resource_tags_dict.notna(), lambda _: [{}])
 
         data_frame["tags"] = resource_tags_dict.apply(json.dumps)
-        # Make sure we have entries for our required columns
-        data_frame = data_frame.reindex(columns=columns)
+
+        missing = set(TRINO_REQUIRED_COLUMNS).difference(data_frame)
+        to_add = {k: TRINO_REQUIRED_COLUMNS[k] for k in missing}
+        data_frame = data_frame.assign(**to_add)
 
         columns = list(data_frame)
         column_name_map = {}

--- a/koku/reporting/provider/oci/models.py
+++ b/koku/reporting/provider/oci/models.py
@@ -5,6 +5,7 @@
 """Models for OCI cost entry tables."""
 from uuid import uuid4
 
+import pandas as pd
 from django.contrib.postgres.fields import ArrayField
 from django.contrib.postgres.indexes import GinIndex
 from django.db import models
@@ -28,38 +29,38 @@ UI_SUMMARY_TABLES = (
 TRINO_LINE_ITEM_TABLE_MAP = {"cost": "oci_cost_line_items", "usage": "oci_usage_line_items"}
 TRINO_LINE_ITEM_DAILY_TABLE_MAP = {"cost": "oci_cost_line_items_daily", "usage": "oci_usage_line_items_daily"}
 
-TRINO_REQUIRED_COLUMNS = (
-    "lineItem/referenceNo",
-    "lineItem/tenantId",
-    "lineItem/intervalUsageStart",
-    "lineItem/intervalUsageEnd",
-    "product/service",
-    "product/resource",
-    "product/compartmentId",
-    "product/compartmentName",
-    "product/region",
-    "product/availabilityDomain",
-    "product/resourceId",
-    "usage/consumedQuantity",
-    "usage/billedQuantity",
-    "usage/billedQuantityOverage",
-    "usage/consumedQuantityUnits",
-    "usage/consumedQuantityMeasure",
-    "cost/subscriptionId",
-    "cost/productSku",
-    "product/Description",
-    "cost/unitPrice",
-    "cost/unitPriceOverage",
-    "cost/myCost",
-    "cost/myCostOverage",
-    "cost/currencyCode",
-    "cost/billingUnitReadable",
-    "cost/skuUnitDescription",
-    "cost/overageFlag",
-    "lineItem/isCorrection",
-    "lineItem/backreferenceNo",
-    "tags",
-)
+TRINO_REQUIRED_COLUMNS = {
+    "lineItem/referenceNo": "",
+    "lineItem/tenantId": "",
+    "lineItem/intervalUsageStart": pd.NaT,
+    "lineItem/intervalUsageEnd": pd.NaT,
+    "product/service": "",
+    "product/resource": "",
+    "product/compartmentId": "",
+    "product/compartmentName": "",
+    "product/region": "",
+    "product/availabilityDomain": "",
+    "product/resourceId": "",
+    "usage/consumedQuantity": 0.0,
+    "usage/billedQuantity": 0.0,
+    "usage/billedQuantityOverage": 0.0,
+    "usage/consumedQuantityUnits": "",
+    "usage/consumedQuantityMeasure": "",
+    "cost/subscriptionId": "",
+    "cost/productSku": "",
+    "product/Description": "",
+    "cost/unitPrice": 0.0,
+    "cost/unitPriceOverage": 0.0,
+    "cost/myCost": 0.0,
+    "cost/myCostOverage": 0.0,
+    "cost/currencyCode": "",
+    "cost/billingUnitReadable": "",
+    "cost/skuUnitDescription": "",
+    "cost/overageFlag": "",
+    "lineItem/isCorrection": "",
+    "lineItem/backreferenceNo": "",
+    "tags": "",
+}
 
 
 class OCICostEntryBill(models.Model):


### PR DESCRIPTION
## Jira Ticket

[COST-4360](https://issues.redhat.com/browse/COST-4360)

## Description

This change will commonize dtype handling and correctly set the csv converters for OCI

## Testing

1. Checkout Branch
2. Run koku with updated trino/hive versions
3.  create/load data for OCI provider
4. see data is processed correctly

## Notes
trino diff
deploy/trino/etc/catalog/hive.properties
 
-parquet.optimized-reader.enabled=false
+# parquet.optimized-reader.enabled=false

diff --git a/deploy/trino/etc/jvm.config b/deploy/trino/etc/jvm.config

+-Dfile.encoding=UTF-8

diff --git a/docker-compose.arm.yml b/docker-compose.arm.yml

   hive-metastore:
-    image: quay.io/mskarbek/ubi-hive:3.1.2-metastore-008
+    image: quay.io/mskarbek/ubi-hive:3.1.3-metastore-024
 
   trino:
-    image: quay.io/mskarbek/ubi-trino:411-001
+    image: quay.io/mskarbek/ubi-trino:427-001

diff --git a/docker-compose.yml b/docker-compose.yml
   hive-metastore:
     container_name: hive-metastore
-    image: quay.io/cloudservices/ubi-hive:3.1.2-metastore-008
+    image: quay.io/cloudservices/ubi-hive:latest

   trino:
     container_name: trino
-    image: quay.io/cloudservices/ubi-trino:411-002
+    image: quay.io/cloudservices/ubi-trino:latest
...
