### PR TITLE
[COST-4333] Fix OCP on Azure matching by resource-ids

### DIFF
--- a/koku/masu/test/util/aws/test_common.py
+++ b/koku/masu/test/util/aws/test_common.py
@@ -13,7 +13,6 @@ from unittest.mock import PropertyMock
 from uuid import uuid4
 
 import boto3
-import numpy as np
 import pandas as pd
 from botocore.exceptions import ClientError
 from dateutil.relativedelta import relativedelta
@@ -755,7 +754,7 @@ class TestAWSUtils(MasuTestCase):
 
         matched_tags = [{"key": "value"}]
         data = [
-            {"lineitem_resourceid": np.nan, "lineitem_unblendedcost": 1, "resourcetags": '{"key": "value"}'},
+            {"lineitem_resourceid": "", "lineitem_unblendedcost": 1, "resourcetags": '{"key": "value"}'},
         ]
 
         df = pd.DataFrame(data)
@@ -779,7 +778,7 @@ class TestAWSUtils(MasuTestCase):
 
         matched_tags = [{"key": "value"}]
         data = [
-            {"lineitem_resourceid": "id1", "lineitem_unblendedcost": 1, "resourcetags": np.nan},
+            {"lineitem_resourceid": "id1", "lineitem_unblendedcost": 1, "resourcetags": ""},
         ]
 
         df = pd.DataFrame(data)

--- a/koku/masu/test/util/azure/test_common.py
+++ b/koku/masu/test/util/azure/test_common.py
@@ -3,7 +3,6 @@
 # Copyright 2021 Red Hat Inc.
 # SPDX-License-Identifier: Apache-2.0
 #
-import numpy as np
 import pandas as pd
 from django_tenants.utils import schema_context
 
@@ -116,9 +115,9 @@ class TestAzureUtils(MasuTestCase):
         ]
         matched_tags = []
         data = [
-            {"resourceid": np.nan, "instanceid": "id1", "pretaxcost": 1, "tags": '{"key": "value"}'},
-            {"resourceid": np.nan, "instanceid": "id2", "pretaxcost": 1, "tags": '{"key": "other_value"}'},
-            {"resourceid": np.nan, "instanceid": "id3", "pretaxcost": 1, "tags": '{"keyz": "value"}'},
+            {"resourceid": "", "instanceid": "id1", "pretaxcost": 1, "tags": '{"key": "value"}'},
+            {"resourceid": "", "instanceid": "id2", "pretaxcost": 1, "tags": '{"key": "other_value"}'},
+            {"resourceid": "", "instanceid": "id3", "pretaxcost": 1, "tags": '{"keyz": "value"}'},
         ]
 
         df = pd.DataFrame(data)
@@ -148,7 +147,7 @@ class TestAzureUtils(MasuTestCase):
 
         matched_tags = [{"key": "value"}]
         data = [
-            {"resourceid": "id1", "pretaxcost": 1, "tags": np.nan},
+            {"resourceid": "id1", "pretaxcost": 1, "tags": ""},
         ]
 
         df = pd.DataFrame(data)

--- a/koku/masu/util/aws/common.py
+++ b/koku/masu/util/aws/common.py
@@ -881,7 +881,7 @@ def match_openshift_resources_and_labels(data_frame, cluster_topologies, matched
     resource_ids = tuple(resource_ids)
     data_frame["resource_id_matched"] = False
     resource_id_df = data_frame["lineitem_resourceid"]
-    if not resource_id_df.isna().replace("", nan).values.all():
+    if not resource_id_df.replace("", nan).isna().values.all():
         LOG.info("Matching OpenShift on AWS by resource ID.")
         resource_id_matched = resource_id_df.str.endswith(resource_ids)
         data_frame["resource_id_matched"] = resource_id_matched
@@ -904,7 +904,7 @@ def match_openshift_resources_and_labels(data_frame, cluster_topologies, matched
             tag_values.extend(list(tag.values()))
 
         any_tag_matched = None
-        if not tags.isna().replace("", nan).values.all():
+        if not tags.replace("", nan).isna().values.all():
             tag_matched = tags.str.contains("|".join(tag_keys)) & tags.str.contains("|".join(tag_values))
             data_frame["tag_matched"] = tag_matched
             any_tag_matched = tag_matched.any()

--- a/koku/masu/util/aws/common.py
+++ b/koku/masu/util/aws/common.py
@@ -21,7 +21,6 @@ from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.db import IntegrityError
 from django_tenants.utils import schema_context
-from numpy import nan
 
 from api.common import log_json
 from api.provider.models import Provider
@@ -881,14 +880,14 @@ def match_openshift_resources_and_labels(data_frame, cluster_topologies, matched
     resource_ids = tuple(resource_ids)
     data_frame["resource_id_matched"] = False
     resource_id_df = data_frame["lineitem_resourceid"]
-    if not resource_id_df.replace("", nan).isna().values.all():
+    if not resource_id_df.eq("").all():
         LOG.info("Matching OpenShift on AWS by resource ID.")
         resource_id_matched = resource_id_df.str.endswith(resource_ids)
         data_frame["resource_id_matched"] = resource_id_matched
 
     data_frame["special_case_tag_matched"] = False
     tags = data_frame["resourcetags"]
-    if not tags.replace("", nan).isna().values.all():
+    if not tags.eq("").all():
         tags = tags.str.lower()
         LOG.info("Matching OpenShift on AWS by tags.")
         special_case_tag_matched = tags.str.contains(
@@ -904,7 +903,7 @@ def match_openshift_resources_and_labels(data_frame, cluster_topologies, matched
             tag_values.extend(list(tag.values()))
 
         any_tag_matched = None
-        if not tags.replace("", nan).isna().values.all():
+        if not tags.eq("").all():
             tag_matched = tags.str.contains("|".join(tag_keys)) & tags.str.contains("|".join(tag_values))
             data_frame["tag_matched"] = tag_matched
             any_tag_matched = tag_matched.any()

--- a/koku/masu/util/aws/common.py
+++ b/koku/masu/util/aws/common.py
@@ -21,6 +21,7 @@ from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.db import IntegrityError
 from django_tenants.utils import schema_context
+from numpy import nan
 
 from api.common import log_json
 from api.provider.models import Provider
@@ -880,14 +881,14 @@ def match_openshift_resources_and_labels(data_frame, cluster_topologies, matched
     resource_ids = tuple(resource_ids)
     data_frame["resource_id_matched"] = False
     resource_id_df = data_frame["lineitem_resourceid"]
-    if not resource_id_df.isna().values.all():
+    if not resource_id_df.isna().replace("", nan).values.all():
         LOG.info("Matching OpenShift on AWS by resource ID.")
         resource_id_matched = resource_id_df.str.endswith(resource_ids)
         data_frame["resource_id_matched"] = resource_id_matched
 
     data_frame["special_case_tag_matched"] = False
     tags = data_frame["resourcetags"]
-    if not tags.isna().values.all():
+    if not tags.replace("", nan).isna().values.all():
         tags = tags.str.lower()
         LOG.info("Matching OpenShift on AWS by tags.")
         special_case_tag_matched = tags.str.contains(
@@ -903,7 +904,7 @@ def match_openshift_resources_and_labels(data_frame, cluster_topologies, matched
             tag_values.extend(list(tag.values()))
 
         any_tag_matched = None
-        if not tags.isna().values.all():
+        if not tags.isna().replace("", nan).values.all():
             tag_matched = tags.str.contains("|".join(tag_keys)) & tags.str.contains("|".join(tag_values))
             data_frame["tag_matched"] = tag_matched
             any_tag_matched = tag_matched.any()

--- a/koku/masu/util/azure/common.py
+++ b/koku/masu/util/azure/common.py
@@ -12,6 +12,7 @@ from itertools import chain
 
 import pandas as pd
 from django_tenants.utils import schema_context
+from numpy import nan
 
 from api.models import Provider
 from masu.database.azure_report_db_accessor import AzureReportDBAccessor
@@ -181,17 +182,17 @@ def match_openshift_resources_and_labels(data_frame, cluster_topologies, matched
     matchable_resources = list(nodes) + list(volumes)
     data_frame["resource_id_matched"] = False
     resource_id_df = data_frame["resourceid"]
-    if resource_id_df.isna().values.all():
+    if resource_id_df.replace("", nan).isna().values.all():
         resource_id_df = data_frame["instanceid"]
 
-    if not resource_id_df.isna().values.all():
+    if not resource_id_df.replace("", nan).isna().values.all():
         LOG.info("Matching OpenShift on Azure by resource ID.")
         resource_id_matched = resource_id_df.str.contains("|".join(matchable_resources))
         data_frame["resource_id_matched"] = resource_id_matched
 
     data_frame["special_case_tag_matched"] = False
     tags = data_frame["tags"]
-    if not tags.isna().values.all():
+    if not tags.replace("", nan).isna().values.all():
         tags = tags.str.lower()
         LOG.info("Matching OpenShift on Azure by tags.")
         special_case_tag_matched = tags.str.contains(
@@ -207,7 +208,7 @@ def match_openshift_resources_and_labels(data_frame, cluster_topologies, matched
             tag_values.extend(list(tag.values()))
 
         any_tag_matched = None
-        if not tags.isna().values.all():
+        if not tags.replace("", nan).isna().values.all():
             tag_matched = tags.str.contains("|".join(tag_keys)) & tags.str.contains("|".join(tag_values))
             data_frame["tag_matched"] = tag_matched
             any_tag_matched = tag_matched.any()

--- a/koku/masu/util/azure/common.py
+++ b/koku/masu/util/azure/common.py
@@ -12,7 +12,6 @@ from itertools import chain
 
 import pandas as pd
 from django_tenants.utils import schema_context
-from numpy import nan
 
 from api.models import Provider
 from masu.database.azure_report_db_accessor import AzureReportDBAccessor
@@ -182,17 +181,17 @@ def match_openshift_resources_and_labels(data_frame, cluster_topologies, matched
     matchable_resources = list(nodes) + list(volumes)
     data_frame["resource_id_matched"] = False
     resource_id_df = data_frame["resourceid"]
-    if resource_id_df.replace("", nan).isna().values.all():
+    if resource_id_df.eq("").all():
         resource_id_df = data_frame["instanceid"]
 
-    if not resource_id_df.replace("", nan).isna().values.all():
+    if not resource_id_df.eq("").all():
         LOG.info("Matching OpenShift on Azure by resource ID.")
         resource_id_matched = resource_id_df.str.contains("|".join(matchable_resources))
         data_frame["resource_id_matched"] = resource_id_matched
 
     data_frame["special_case_tag_matched"] = False
     tags = data_frame["tags"]
-    if not tags.replace("", nan).isna().values.all():
+    if not tags.eq("").all():
         tags = tags.str.lower()
         LOG.info("Matching OpenShift on Azure by tags.")
         special_case_tag_matched = tags.str.contains(
@@ -208,7 +207,7 @@ def match_openshift_resources_and_labels(data_frame, cluster_topologies, matched
             tag_values.extend(list(tag.values()))
 
         any_tag_matched = None
-        if not tags.replace("", nan).isna().values.all():
+        if not tags.eq("").all():
             tag_matched = tags.str.contains("|".join(tag_keys)) & tags.str.contains("|".join(tag_values))
             data_frame["tag_matched"] = tag_matched
             any_tag_matched = tag_matched.any()


### PR DESCRIPTION
## Jira Ticket

[COST-4333](https://issues.redhat.com/browse/COST-4333)

## Description

This change should fix the regression caused by #4817 
Azure report v1 uses "InstanceId" instead of "ResourceId" column name. The resourceid column is added to TRINO_REQUIRED_COLUMNS. After the change introduced in the PR #4817, the resourceid column for Azure v1 reports contains empty strings instead of nulls. 
The code for matching of Azure with OCP first check if resourceid column has some data - if it doesn't has data, it checks instanceid column. Since the code expected NANs as an indicator of an empty column, it incorrectly evaluated empty resourceid column (with empty strings) as a column containing data and used this column for OCP on Azure matching by resource-id


## Testing

Run azure-smoke-tests
Since there is a small change in AWS part too, potentially run also aws-smoke-tests

## Notes

...
