### PR TITLE
[COST-4230] - add cluster-id to basic auth log message

### DIFF
--- a/koku/masu/external/kafka_msg_handler.py
+++ b/koku/masu/external/kafka_msg_handler.py
@@ -204,8 +204,12 @@ def process_cr(report_meta):
 
         auth_type = cr_status.get("authentication", {}).get("type")
         if auth_type == "basic":
-            ctx = {"schema": report_meta.get("schema_name"), "provider_uuid": report_meta.get("provider_uuid")}
-            LOG.warning(log_json(report_meta.get("tracing_id"), msg="cluster is using basic auth", context=ctx))
+            ctx = {
+                "schema": report_meta.get("schema_name"),
+                "provider_uuid": report_meta.get("provider_uuid"),
+                "cluster_id": report_meta.get("cluster_id"),
+            }
+            LOG.info(log_json(report_meta.get("tracing_id"), msg="cluster is using basic auth", context=ctx))
 
     return manifest_info
 

--- a/koku/masu/test/external/test_kafka_msg_handler.py
+++ b/koku/masu/test/external/test_kafka_msg_handler.py
@@ -895,8 +895,10 @@ class KafkaMsgHandlerTest(MasuTestCase):
 
             # test that we warn when basic auth is being used:
             report_meta["cr_status"]["authentication"]["type"] = "basic"
-            with self.assertLogs(logger="masu.external.kafka_msg_handler", level=logging.WARNING):
+            with self.assertLogs(logger="masu.external.kafka_msg_handler", level=logging.INFO) as log:
                 msg_handler.process_cr(report_meta)
+                self.assertEqual(len(log.output), 2)
+                self.assertIn("cluster is using basic auth", log.output[1])
 
     def test_create_cost_and_usage_report_manifest(self):
         manifest = Path("koku/masu/test/data/ocp/payload2/manifest.json")


### PR DESCRIPTION
## Jira Ticket

[COST-4230](https://issues.redhat.com/browse/COST-4230)

## Description

This change adds cluster-id to the log message for basic auth operator payloads and converts to an INFO message rather than WARNING (Kibana is not parsing the keys for these messages and it may be due to the characters used to change the color of the logs)
