### PR TITLE
[COST-3814] Azure subs processing start 2 days prior to source creation

### DIFF
--- a/koku/subs/subs_data_extractor.py
+++ b/koku/subs/subs_data_extractor.py
@@ -117,6 +117,9 @@ class SUBSDataExtractor(ReportDBAccessorBase):
         self.creation_processing_time = self.provider_created_timestamp.replace(
             microsecond=0, second=0, minute=0, hour=0
         ) - timedelta(days=1)
+        if self.provider_type == Provider.PROVIDER_AZURE:
+            # Since Azure works on days with complete data, use -2 days for initial processing as -1 wont be complete
+            self.creation_processing_time = self.creation_processing_time - timedelta(days=1)
         self.tracing_id = tracing_id
         self.s3_resource = get_s3_resource(
             settings.S3_SUBS_ACCESS_KEY, settings.S3_SUBS_SECRET, settings.S3_SUBS_REGION

--- a/koku/subs/test/test_subs_data_extractor.py
+++ b/koku/subs/test/test_subs_data_extractor.py
@@ -30,9 +30,15 @@ class TestSUBSDataExtractor(SUBSTestCase):
             "provider_type": cls.aws_provider_type,
             "provider_uuid": cls.aws_provider.uuid,
         }
+        azure_context = {
+            "schema": cls.schema,
+            "provider_type": cls.azure_provider_type,
+            "provider_uuid": cls.azure_provider.uuid,
+        }
         with patch("subs.subs_data_extractor.get_s3_resource"):
             with patch("subs.subs_data_extractor.SUBSDataExtractor._execute_trino_raw_sql_query"):
                 cls.extractor = SUBSDataExtractor(cls.tracing_id, context)
+                cls.azure_extractor = SUBSDataExtractor(cls.tracing_id, azure_context)
 
     def test_subs_s3_path(self):
         """Test that the generated s3 path is expected"""
@@ -281,3 +287,14 @@ class TestSUBSDataExtractor(SUBSTestCase):
             )
             self.assertEqual(subs_record_1.latest_processed_time, expected_time)
             self.assertEqual(subs_record_2.latest_processed_time, expected_time)
+
+    def test_provider_creation_time(self):
+        """Test provider processing time for different provider types."""
+        aws_expected = self.aws_provider.created_timestamp.replace(
+            microsecond=0, second=0, minute=0, hour=0
+        ) - timedelta(days=1)
+        azure_expected = self.azure_provider.created_timestamp.replace(
+            microsecond=0, second=0, minute=0, hour=0
+        ) - timedelta(days=2)
+        self.assertEqual(aws_expected, self.extractor.creation_processing_time)
+        self.assertEqual(azure_expected, self.azure_extractor.creation_processing_time)


### PR DESCRIPTION
## Jira Ticket

[COST-3814](https://issues.redhat.com/browse/COST-3814)

## Description

This change will make Azure subs processing start 2 days prior to source creation instead of 1. Azure processing requires the day of data to be "complete" and when a source is created, yesterdays data is unlikely to be completed as the export for today would have to have run already. Using 2 days will process data upon source creation instead of waiting an extra day.

## Testing
Easiest testing is to create an AWS `SUBSDataExtractor()` and an Azure `SUBSDataExtractor()` and see the different in time:

1. Spin up koku and create a test customer, it doesn't need data. `make create-test-customer`
2. Start with `make shell`
3. Check the processing time on an Azure source (substitute your provider_uuid), expected output (today - 2 days): `datetime.datetime(2023, 12, 12, 0, 0, tzinfo=<UTC>)`:
```
from subs.subs_data_extractor import SUBSDataExtractor
schema = "org1234567"
prov_type = "Azure-local"
prov_uuid = "fa6ec55c-470b-4f5d-b300-e5548c52f501"
context = {"schema": schema, "provider_type": prov_type, "provider_uuid": prov_uuid}
sde = SUBSDataExtractor('', context)
sde.creation_processing_time
```

4. Check the AWS source (substitute your provider_uuid), expected output (today - 1 days): `datetime.datetime(2023, 12, 13, 0, 0, tzinfo=<UTC>)`:
```
prov_type_2 = "AWS-local"
prov_uuid_2 = "2d1a54f5-d8bc-4374-a81b-d474245e97eb"
context_2 = {"schema": schema, "provider_type": prov_type_2, "provider_uuid": prov_uuid_2}
sde_2 = SUBSDataExtractor('', context_2)
sde_2.creation_processing_time
```


## Notes

...
