### PR TITLE
[COST-3814] Add 1s to Azure last processed time

### DIFF
--- a/koku/subs/subs_data_extractor.py
+++ b/koku/subs/subs_data_extractor.py
@@ -152,11 +152,7 @@ class SUBSDataExtractor(ReportDBAccessorBase):
                 # and we want to gather new data we have not processed yet
                 # so we add one second to the last timestamp to ensure the time range processed
                 # is all new data
-                if self.provider_type != Provider.PROVIDER_AZURE:
-                    lpt_dict[rid] = latest_time + timedelta(seconds=1)
-                # Azure is daily timestamps so we do not need to increase this by 1 since this was the previous end
-                else:
-                    lpt_dict[rid] = latest_time
+                lpt_dict[rid] = latest_time + timedelta(seconds=1)
         return lpt_dict
 
     def determine_latest_processed_time_for_provider(self, rid, year, month):

--- a/koku/subs/test/test_subs_data_extractor.py
+++ b/koku/subs/test/test_subs_data_extractor.py
@@ -298,3 +298,22 @@ class TestSUBSDataExtractor(SUBSTestCase):
         ) - timedelta(days=2)
         self.assertEqual(aws_expected, self.extractor.creation_processing_time)
         self.assertEqual(azure_expected, self.azure_extractor.creation_processing_time)
+
+    def test_get_latest_processed_dict_for_provider(self):
+        """Test that one second is appropriately added to last processed time."""
+        year = "2023"
+        month = "06"
+        rid = "fake_rid"
+        base_time = datetime.datetime(2023, 6, 3, 15, tzinfo=datetime.timezone.utc)
+        with schema_context(self.schema):
+            SubsLastProcessed.objects.create(
+                source_uuid_id=self.aws_provider.uuid,
+                resource_id=rid,
+                year=year,
+                month=month,
+                latest_processed_time=base_time,
+            ).save()
+        lpt_dict = self.extractor.get_latest_processed_dict_for_provider("2023", "06")
+        actual_time = lpt_dict.get(rid)
+        # One second should be added to the stored time to avoid processing overlaps
+        self.assertEqual(base_time + timedelta(seconds=1), actual_time)


### PR DESCRIPTION
## Jira Ticket

[COST-3814](https://issues.redhat.com/browse/COST-3814)

## Description

This change will also add 1 second to Azure last processed time since testing showed we were getting overlapping data.
