### PR TITLE
[COST-4534] Support filtering with multiple values

### DIFF
--- a/koku/api/settings/cost_groups/serializers.py
+++ b/koku/api/settings/cost_groups/serializers.py
@@ -17,8 +17,8 @@ from reporting.provider.ocp.models import OpenshiftCostCategory
 class CostGroupFilterSerializer(FilterSerializer):
     """Serializer for Cost Group Settings."""
 
-    project = serializers.CharField(required=False)
-    group = serializers.CharField(required=False)
+    project = StringOrListField(child=serializers.CharField(), required=False)
+    group = StringOrListField(child=serializers.CharField(), required=False)
     default = serializers.BooleanField(required=False)
     cluster = StringOrListField(child=serializers.CharField(), required=False)
 

--- a/koku/api/settings/test/cost_groups/test_query_handler.py
+++ b/koku/api/settings/test/cost_groups/test_query_handler.py
@@ -4,8 +4,6 @@
 #
 import json
 from unittest.mock import patch
-from urllib.parse import quote_plus
-from urllib.parse import urlencode
 
 from django.urls import reverse
 from django_tenants.utils import schema_context
@@ -53,12 +51,12 @@ class TestCostGroupsAPI(IamTestCase):
     def test_get_cost_groups(self):
         """Basic test to exercise the API endpoint"""
         with schema_context(self.schema_name):
-            response = self.client.get(self.url, **self.headers)
+            response = self.client.get(self.url, headers=self.headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_get_cost_groups_invalid(self):
         with schema_context(self.schema_name):
-            response = self.client.get(self.url, {"nope": "nope"}, **self.headers)
+            response = self.client.get(self.url, {"nope": "nope"}, headers=self.headers)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -69,9 +67,8 @@ class TestCostGroupsAPI(IamTestCase):
             with self.subTest(parameter=parameter):
                 for filter_option, filter_value in parameter.items():
                     param = {f"filter[{filter_option}]": filter_value}
-                    url = self.url + "?" + urlencode(param, quote_via=quote_plus)
                     with schema_context(self.schema_name):
-                        response = self.client.get(url, **self.headers)
+                        response = self.client.get(self.url, param, headers=self.headers)
                     self.assertEqual(response.status_code, status.HTTP_200_OK)
                     data = response.data.get("data")
                     for item in data:
@@ -92,9 +89,8 @@ class TestCostGroupsAPI(IamTestCase):
 
         def spotcheck_first_data_element(option, value):
             param = {f"order_by[{option}]": value}
-            url = self.url + "?" + urlencode(param, quote_via=quote_plus)
             with schema_context(self.schema_name):
-                response = self.client.get(url, **self.headers)
+                response = self.client.get(self.url, param, headers=self.headers)
 
             return response.status_code, response.data.get("data")[0]
 
@@ -119,9 +115,8 @@ class TestCostGroupsAPI(IamTestCase):
             with self.subTest(parameter=parameter):
                 for exclude_option, exclude_value in parameter.items():
                     param = {f"exclude[{exclude_option}]": exclude_value}
-                    url = self.url + "?" + urlencode(param, quote_via=quote_plus)
                     with schema_context(self.schema_name):
-                        response = self.client.get(url, **self.headers)
+                        response = self.client.get(self.url, param, headers=self.headers)
                     self.assertEqual(response.status_code, status.HTTP_200_OK)
                     data = response.data.get("data")
                     for item in data:
@@ -146,7 +141,7 @@ class TestCostGroupsAPI(IamTestCase):
         _add_additional_projects(self.schema_name)
         body = json.dumps(self.body_format)
         with schema_context(self.schema_name):
-            response = self.client.delete(self.url, body, content_type="application/json", **self.headers)
+            response = self.client.delete(self.url, body, content_type="application/json", headers=self.headers)
             current_count = OpenshiftCostCategoryNamespace.objects.filter(namespace=self.project).count()
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
@@ -183,7 +178,7 @@ class TestCostGroupsAPI(IamTestCase):
         mock_is_customer_large.return_value = False
         with schema_context(self.schema_name):
             body = json.dumps(self.body_format)
-            response = self.client.put(self.url, body, content_type="application/json", **self.headers)
+            response = self.client.put(self.url, body, content_type="application/json", headers=self.headers)
             current_count = OpenshiftCostCategoryNamespace.objects.filter(namespace=self.project).count()
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
@@ -203,7 +198,7 @@ class TestCostGroupsAPI(IamTestCase):
         mock_is_customer_large.return_value = True
         with schema_context(self.schema_name):
             body = json.dumps(self.body_format)
-            response = self.client.put(self.url, body, content_type="application/json", **self.headers)
+            response = self.client.put(self.url, body, content_type="application/json", headers=self.headers)
             current_count = OpenshiftCostCategoryNamespace.objects.filter(namespace=self.project).count()
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)

--- a/koku/api/settings/test/cost_groups/test_query_handler.py
+++ b/koku/api/settings/test/cost_groups/test_query_handler.py
@@ -51,12 +51,12 @@ class TestCostGroupsAPI(IamTestCase):
     def test_get_cost_groups(self):
         """Basic test to exercise the API endpoint"""
         with schema_context(self.schema_name):
-            response = self.client.get(self.url, headers=self.headers)
+            response = self.client.get(self.url, **self.headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_get_cost_groups_invalid(self):
         with schema_context(self.schema_name):
-            response = self.client.get(self.url, {"nope": "nope"}, headers=self.headers)
+            response = self.client.get(self.url, {"nope": "nope"}, **self.headers)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -68,7 +68,7 @@ class TestCostGroupsAPI(IamTestCase):
                 for filter_option, filter_value in parameter.items():
                     param = {f"filter[{filter_option}]": filter_value}
                     with schema_context(self.schema_name):
-                        response = self.client.get(self.url, param, headers=self.headers)
+                        response = self.client.get(self.url, param, **self.headers)
                     self.assertEqual(response.status_code, status.HTTP_200_OK)
                     data = response.data.get("data")
                     for item in data:
@@ -102,7 +102,7 @@ class TestCostGroupsAPI(IamTestCase):
             with self.subTest(parameter=case["value"]):
                 params = {f"filter[{case['field']}]": case["value"]}
                 with schema_context(self.schema_name):
-                    response = self.client.get(self.url, params, headers=self.headers)
+                    response = self.client.get(self.url, params, **self.headers)
 
                 data = response.data.get("data")
                 result = {}
@@ -118,7 +118,7 @@ class TestCostGroupsAPI(IamTestCase):
         def spotcheck_first_data_element(option, value):
             param = {f"order_by[{option}]": value}
             with schema_context(self.schema_name):
-                response = self.client.get(self.url, param, headers=self.headers)
+                response = self.client.get(self.url, param, **self.headers)
 
             return response.status_code, response.data.get("data")[0]
 
@@ -144,7 +144,7 @@ class TestCostGroupsAPI(IamTestCase):
                 for exclude_option, exclude_value in parameter.items():
                     param = {f"exclude[{exclude_option}]": exclude_value}
                     with schema_context(self.schema_name):
-                        response = self.client.get(self.url, param, headers=self.headers)
+                        response = self.client.get(self.url, param, **self.headers)
                     self.assertEqual(response.status_code, status.HTTP_200_OK)
                     data = response.data.get("data")
                     for item in data:
@@ -169,7 +169,7 @@ class TestCostGroupsAPI(IamTestCase):
         _add_additional_projects(self.schema_name)
         body = json.dumps(self.body_format)
         with schema_context(self.schema_name):
-            response = self.client.delete(self.url, body, content_type="application/json", headers=self.headers)
+            response = self.client.delete(self.url, body, content_type="application/json", **self.headers)
             current_count = OpenshiftCostCategoryNamespace.objects.filter(namespace=self.project).count()
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
@@ -206,7 +206,7 @@ class TestCostGroupsAPI(IamTestCase):
         mock_is_customer_large.return_value = False
         with schema_context(self.schema_name):
             body = json.dumps(self.body_format)
-            response = self.client.put(self.url, body, content_type="application/json", headers=self.headers)
+            response = self.client.put(self.url, body, content_type="application/json", **self.headers)
             current_count = OpenshiftCostCategoryNamespace.objects.filter(namespace=self.project).count()
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
@@ -226,7 +226,7 @@ class TestCostGroupsAPI(IamTestCase):
         mock_is_customer_large.return_value = True
         with schema_context(self.schema_name):
             body = json.dumps(self.body_format)
-            response = self.client.put(self.url, body, content_type="application/json", headers=self.headers)
+            response = self.client.put(self.url, body, content_type="application/json", **self.headers)
             current_count = OpenshiftCostCategoryNamespace.objects.filter(namespace=self.project).count()
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)

--- a/koku/api/settings/test/cost_groups/test_serializers.py
+++ b/koku/api/settings/test/cost_groups/test_serializers.py
@@ -20,7 +20,7 @@ class CostGroupFilterSerializerTest(TestCase):
         self.assertFalse(serializer.is_valid())
 
     def test_serialization(self):
-        instance_data = {"project": "example_project", "group": "example_group", "default": True}
+        instance_data = {"project": ["example_project"], "group": ["example_group"], "default": True}
         serializer = CostGroupFilterSerializer(instance_data)
         self.assertEqual(serializer.data, instance_data)
 


### PR DESCRIPTION
## Jira Ticket

[COST-4534](https://issues.redhat.com/browse/COST-4534)

## Description

Support multiple filter values for the `project` and `group` fields on the cost groups API

## Testing

```
curl "http://localhost:8000/api/cost-management/v1/settings/cost-groups/?limit=100&filter%5Bdefault%5D=false&filter%5Bproject%5D=test&filter%5Bproject%5D=cost"

```

