### PR TITLE
[COST-4540] Fix year range in Ingress flow

### DIFF
--- a/koku/api/ingress/reports/serializers.py
+++ b/koku/api/ingress/reports/serializers.py
@@ -60,7 +60,7 @@ class IngressReportsSerializer(serializers.ModelSerializer):
         ]
         year_message = year_range[0]
         if dh.bill_year_from_date(dh.this_month_start) not in year_range:
-            year_range.append(dh.bill_year_from_date(dh.last_month_start))
+            year_range.append(dh.bill_year_from_date(dh.this_month_start))
             year_message = f"{year_range[0]} or {year_range[1]}"
         if bill_month in month_range and bill_year in year_range:
             interface = ProviderAccessor(source.type)


### PR DESCRIPTION
## Jira Ticket

[COST-4540](https://issues.redhat.com/browse/COST-4540)

## Description

This change will fix determination of year range in Ingress flow

## Testing

1. deploy main branch to eph and run test_api_aws_hcs_customer_filtered_report test
- you will hit the following ApiException when posting current moth report to ingress endpoint
`
E           iqe_cost_management_api.exceptions.ApiException: (400)
E           Reason: Bad Request
E           HTTP response headers: HTTPHeaderDict({'Date': 'Tue, 02 Jan 2024 10:13:36 GMT', 'Server': 'WSGIServer/0.2 CPython/3.9.18', 'Content-Type': 'application/json', 'Vary': 'Accept, origin', 'Allow': 'GET, POST, HEAD, OPTIONS', 'X-Frame-Options': 'DENY', 'Content-Length': '128', 'X-Content-Type-Options': 'nosniff', 'Referrer-Policy': 'same-origin'})
E           HTTP response body: {"errors":[{"detail":"Invalid bill, year must be 2023 or 2023 and month must be 12 or 01","source":"bill_period","status":400}]}
`
2. deploy this branch to eph env and run test_api_aws_hcs_customer_filtered_report test 
- the test will pass
## Notes

...
