### PR TITLE
[COST-4543] ignore errors when dropping "tmp_ocp_matched" column

### DIFF
--- a/koku/masu/test/util/gcp/test_common.py
+++ b/koku/masu/test/util/gcp/test_common.py
@@ -156,7 +156,7 @@ class TestGCPUtils(MasuTestCase):
         # tag matching
         self.assertFalse((matched_df["matched_tag"] != "").any())
 
-        # COST-4543 - no topologies, no alerts on missing `tmp`
+        # COST-4543 - ensure we don't fail when dropping `tmp_ocp_matched`
         try:
             utils.match_openshift_resources_and_labels(pd.DataFrame(data), {}, [])
         except Exception as err:

--- a/koku/masu/util/gcp/common.py
+++ b/koku/masu/util/gcp/common.py
@@ -103,7 +103,7 @@ def match_openshift_resources_and_labels(data_frame, cluster_topologies, matched
 
     # Consildate the columns per cluster into a single column
     data_frame["ocp_matched"] = data_frame["ocp_source_uuid"].str.len() > 0
-    data_frame = data_frame.drop(columns=tmp_match_col_name)
+    data_frame = data_frame.drop(columns=tmp_match_col_name, errors="ignore")
 
     special_case_tag_matched = tags.str.contains(
         "|".join(


### PR DESCRIPTION
## Jira Ticket

[COST-4543](https://issues.redhat.com/browse/COST-4543)

## Description

This change will ignore errors while dropping `tmp_ocp_matched` if this column does not exist.
