### PR TITLE
[COST-4535] Add filtering on the clusters field for cost_group

### DIFF
--- a/koku/api/settings/cost_groups/query_handler.py
+++ b/koku/api/settings/cost_groups/query_handler.py
@@ -9,6 +9,7 @@ from django.db.models import F
 from django.db.models import Q
 from django.db.models import Value
 from django.db.models import When
+from django.db.models.functions import Coalesce
 
 from api.models import Provider
 from api.query_filter import QueryFilter
@@ -98,6 +99,7 @@ class CostGroupsQueryHandler:
             "group": MappingProxyType({"field": "group", "operation": "icontains"}),
             "default": MappingProxyType({"field": "default", "operation": "exact"}),
             "project": MappingProxyType({"field": "project", "operation": "icontains"}),
+            "cluster": MappingProxyType({"field": "clusters", "operation": "icontains"}),
         }
     )
 
@@ -192,7 +194,7 @@ class CostGroupsQueryHandler:
             .annotate(
                 group=Case(*self.build_when_conditions(cost_group_projects, "group")),
                 default=Case(*self.build_when_conditions(cost_group_projects, "default")),
-                clusters=ArrayAgg(F("cluster__cluster_alias"), distinct=True),
+                clusters=ArrayAgg(Coalesce(F("cluster__cluster_alias"), F("cluster__cluster_id")), distinct=True),
             )
             .values("project", "group", "clusters", "default")
             .distinct()

--- a/koku/api/settings/cost_groups/serializers.py
+++ b/koku/api/settings/cost_groups/serializers.py
@@ -9,6 +9,7 @@ from api.report.serializers import ExcludeSerializer
 from api.report.serializers import FilterSerializer
 from api.report.serializers import OrderSerializer
 from api.report.serializers import ReportQueryParamSerializer
+from api.report.serializers import StringOrListField
 from reporting.provider.ocp.models import OCPProject
 from reporting.provider.ocp.models import OpenshiftCostCategory
 
@@ -19,6 +20,7 @@ class CostGroupFilterSerializer(FilterSerializer):
     project = serializers.CharField(required=False)
     group = serializers.CharField(required=False)
     default = serializers.BooleanField(required=False)
+    cluster = StringOrListField(child=serializers.CharField(), required=False)
 
 
 class CostGroupExcludeSerializer(ExcludeSerializer):
@@ -27,6 +29,7 @@ class CostGroupExcludeSerializer(ExcludeSerializer):
     project = serializers.CharField(required=False)
     group = serializers.CharField(required=False)
     default = serializers.BooleanField(required=False)
+    cluster = StringOrListField(child=serializers.CharField(), required=False)
 
 
 class CostGroupOrderSerializer(OrderSerializer):

--- a/koku/api/settings/test/cost_groups/test_query_handler.py
+++ b/koku/api/settings/test/cost_groups/test_query_handler.py
@@ -80,9 +80,8 @@ class TestCostGroupsAPI(IamTestCase):
     def test_get_cost_groups_filter_cluster(self):
         """Basic test to exercise the API endpoint"""
         param = {"filter[cluster]": OCP_ON_GCP_CLUSTER_ID}
-        url = self.url + "?" + urlencode(param, quote_via=quote_plus)
         with schema_context(self.schema_name):
-            response = self.client.get(url, **self.headers)
+            response = self.client.get(self.url, param, headers=self.headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.data.get("data")
         for item in data:

--- a/koku/api/settings/test/cost_groups/test_query_handler.py
+++ b/koku/api/settings/test/cost_groups/test_query_handler.py
@@ -81,7 +81,7 @@ class TestCostGroupsAPI(IamTestCase):
         """Basic test to exercise the API endpoint"""
         param = {"filter[cluster]": OCP_ON_GCP_CLUSTER_ID}
         with schema_context(self.schema_name):
-            response = self.client.get(self.url, param, headers=self.headers)
+            response = self.client.get(self.url, param, **self.headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.data.get("data")
         for item in data:

--- a/koku/api/settings/test/cost_groups/test_query_handler.py
+++ b/koku/api/settings/test/cost_groups/test_query_handler.py
@@ -18,6 +18,7 @@ from api.report.test.util.constants import OCP_PLATFORM_NAMESPACE
 from api.settings.cost_groups.query_handler import _remove_default_projects
 from api.settings.cost_groups.query_handler import put_openshift_namespaces
 from api.utils import DateHelper
+from koku.koku_test_runner import OCP_ON_GCP_CLUSTER_ID
 from masu.processor.tasks import OCP_QUEUE
 from masu.processor.tasks import OCP_QUEUE_XL
 from reporting.provider.ocp.models import OCPProject
@@ -63,7 +64,7 @@ class TestCostGroupsAPI(IamTestCase):
 
     def test_get_cost_groups_filters(self):
         """Basic test to exercise the API endpoint"""
-        parameters = [{"group": "Platform"}, {"default": True}, {"project": OCP_PLATFORM_NAMESPACE}]
+        parameters = [{"group": self.default_cost_group}, {"default": True}, {"project": OCP_PLATFORM_NAMESPACE}, {}]
         for parameter in parameters:
             with self.subTest(parameter=parameter):
                 for filter_option, filter_value in parameter.items():
@@ -75,6 +76,17 @@ class TestCostGroupsAPI(IamTestCase):
                     data = response.data.get("data")
                     for item in data:
                         self.assertEqual(item.get(filter_option), filter_value)
+
+    def test_get_cost_groups_filter_cluster(self):
+        """Basic test to exercise the API endpoint"""
+        param = {"filter[cluster]": OCP_ON_GCP_CLUSTER_ID}
+        url = self.url + "?" + urlencode(param, quote_via=quote_plus)
+        with schema_context(self.schema_name):
+            response = self.client.get(url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.data.get("data")
+        for item in data:
+            self.assertIn(OCP_ON_GCP_CLUSTER_ID, item.get("clusters"))
 
     def test_get_cost_groups_order(self):
         """Basic test to exercise the API endpoint"""
@@ -98,7 +110,12 @@ class TestCostGroupsAPI(IamTestCase):
 
     def test_get_cost_groups_exclude_functionality(self):
         """Test that values can be excluded in the return."""
-        parameters = [{"group": "Platform"}, {"default": True}, {"project": "koku"}]
+        parameters = [
+            {"group": "Platform"},
+            {"default": True},
+            {"project": "koku"},
+            {"cluster": OCP_ON_GCP_CLUSTER_ID},
+        ]
         for parameter in parameters:
             with self.subTest(parameter=parameter):
                 for exclude_option, exclude_value in parameter.items():

--- a/koku/koku/koku_test_runner.py
+++ b/koku/koku/koku_test_runner.py
@@ -22,6 +22,11 @@ from api.report.test.util.model_bakery_loader import ModelBakeryDataLoader
 from koku.env import ENVIRONMENT
 
 
+OCP_ON_AWS_CLUSTER_ID = "OCP-on-AWS"
+OCP_ON_AZURE_CLUSTER_ID = "OCP-on-Azure"
+OCP_ON_GCP_CLUSTER_ID = "OCP-on-GCP"
+OCP_ON_PREM_CLUSTER_ID = "OCP-on-Prem"
+
 GITHUB_ACTIONS = ENVIRONMENT.bool("GITHUB_ACTIONS", default=False)
 LOG = logging.getLogger(__name__)
 
@@ -89,25 +94,21 @@ def setup_databases(verbosity, interactive, keepdb=False, debug_sql=False, paral
                         tree_yaml = read_yaml.import_yaml(yaml_file_path="dev/scripts/aws_org_tree.yml")
                         day_list = tree_yaml["account_structure"]["days"]
                         bakery_data_loader = ModelBakeryDataLoader(KokuTestRunner.schema, customer)
-                        ocp_on_aws_cluster_id = "OCP-on-AWS"
-                        ocp_on_azure_cluster_id = "OCP-on-Azure"
-                        ocp_on_gcp_cluster_id = "OCP-on-GCP"
-                        ocp_on_prem_cluster_id = "OCP-on-Prem"
 
                         ocp_on_aws_ocp_provider, ocp_on_aws_report_periods = bakery_data_loader.load_openshift_data(
-                            ocp_on_aws_cluster_id, on_cloud=True
+                            OCP_ON_AWS_CLUSTER_ID, on_cloud=True
                         )
 
                         (
                             ocp_on_azure_ocp_provider,
                             ocp_on_azure_report_periods,
-                        ) = bakery_data_loader.load_openshift_data(ocp_on_azure_cluster_id, on_cloud=True)
+                        ) = bakery_data_loader.load_openshift_data(OCP_ON_AZURE_CLUSTER_ID, on_cloud=True)
 
                         ocp_on_gcp_ocp_provider, ocp_on_gcp_report_periods = bakery_data_loader.load_openshift_data(
-                            ocp_on_gcp_cluster_id, on_cloud=True
+                            OCP_ON_GCP_CLUSTER_ID, on_cloud=True
                         )
 
-                        bakery_data_loader.load_openshift_data(ocp_on_prem_cluster_id, on_cloud=False)
+                        bakery_data_loader.load_openshift_data(OCP_ON_PREM_CLUSTER_ID, on_cloud=False)
 
                         aws_bills = bakery_data_loader.load_aws_data(
                             linked_openshift_provider=ocp_on_aws_ocp_provider, day_list=day_list
@@ -119,16 +120,16 @@ def setup_databases(verbosity, interactive, keepdb=False, debug_sql=False, paral
                         gcp_bills = bakery_data_loader.load_gcp_data(linked_openshift_provider=ocp_on_gcp_ocp_provider)
 
                         bakery_data_loader.load_openshift_on_cloud_data(
-                            Provider.PROVIDER_AWS_LOCAL, ocp_on_aws_cluster_id, aws_bills, ocp_on_aws_report_periods
+                            Provider.PROVIDER_AWS_LOCAL, OCP_ON_AWS_CLUSTER_ID, aws_bills, ocp_on_aws_report_periods
                         )
                         bakery_data_loader.load_openshift_on_cloud_data(
                             Provider.PROVIDER_AZURE_LOCAL,
-                            ocp_on_azure_cluster_id,
+                            OCP_ON_AZURE_CLUSTER_ID,
                             azure_bills,
                             ocp_on_azure_report_periods,
                         )
                         bakery_data_loader.load_openshift_on_cloud_data(
-                            Provider.PROVIDER_GCP_LOCAL, ocp_on_gcp_cluster_id, gcp_bills, ocp_on_gcp_report_periods
+                            Provider.PROVIDER_GCP_LOCAL, OCP_ON_GCP_CLUSTER_ID, gcp_bills, ocp_on_gcp_report_periods
                         )
 
                         # OCI


### PR DESCRIPTION
## Jira Ticket

[COST-4535](https://issues.redhat.com/browse/COST-4535)

## Description

This change will add the ability to filter and exclude by a cluster to the cost group settings api. 

## Testing

1. Checkout Branch
2. load test customer data
```
http://localhost:8000/api/cost-management/v1/settings/cost-groups/?limit=100&filter[cluster]=Test OCP on AWS
```
```
http://localhost:8000/api/cost-management/v1/settings/cost-groups/?limit=100&exclude[cluster]=Test OCP on AWS
```

## Notes

...
