### PR TITLE
[COST-4547] - insert distinct namespaces into namespace ArrayField

### DIFF
--- a/koku/masu/database/sql/openshift/all/reporting_ocpallcostlineitem_daily_summary_aws.sql
+++ b/koku/masu/database/sql/openshift/all/reporting_ocpallcostlineitem_daily_summary_aws.sql
@@ -39,7 +39,7 @@ INSERT
 SELECT 'AWS'::text AS source_type,
        aws.cluster_id,
        {{cluster_alias}},
-       array_agg(aws.namespace),
+       array_agg(distinct aws.namespace),
        aws.node,
        aws.resource_id,
        aws.usage_start,

--- a/koku/masu/database/sql/openshift/all/reporting_ocpallcostlineitem_daily_summary_azure.sql
+++ b/koku/masu/database/sql/openshift/all/reporting_ocpallcostlineitem_daily_summary_azure.sql
@@ -39,7 +39,7 @@ INSERT
 SELECT 'Azure'::text AS source_type,
        azure.cluster_id,
        {{cluster_alias}},
-       array_agg(azure.namespace),
+       array_agg(distinct azure.namespace),
        azure.node,
        azure.resource_id,
        azure.usage_start,

--- a/koku/masu/database/sql/openshift/all/reporting_ocpallcostlineitem_daily_summary_gcp.sql
+++ b/koku/masu/database/sql/openshift/all/reporting_ocpallcostlineitem_daily_summary_gcp.sql
@@ -39,7 +39,7 @@ INSERT
 SELECT 'GCP'::text AS source_type,
        gcp.cluster_id,
        {{cluster_alias}},
-       array_agg(gcp.namespace),
+       array_agg(distinct gcp.namespace),
        gcp.node,
        gcp.resource_id,
        gcp.usage_start,


### PR DESCRIPTION
## Jira Ticket

[COST-4547](https://issues.redhat.com/browse/COST-4547)

## Description

This change will insert distinct namespaces into the `namespace` field of `reporting_ocpallcostlineitem_daily_summary_p`. This PR does not change/modify any data currently in the db.

Today we are inserting hundreds of the same namespace into this column for individual rows leading to errors trying to create the index on the namespace field.

## Testing
1. on main, ingest OCP-on-GCP data `$ make load-test-customer-data test_source=GCP`
2. run sql:
```
postgres=# select * from org1234567.reporting_ocpallcostlineitem_daily_summary_p order by greatest(array_length(namespace, 1)) desc limit 1;
-[ RECORD 1 ]-----+-------------------------------------
id                | ea2cb13b-037f-4217-b8ed-4827b0d8471d
source_type       | GCP
cluster_id        | test-ocp-gcp-cluster
cluster_alias     | Test OCP on GCP
namespace         | {analytics,analytics} <<<<< BAD!
...
```

3. Checkout Branch
4. delete data and re-ingest
```
$ make delete-test-customer-data; make delete-testing; make delete-trino-data; make delete-redis-cache
$ make create-test-customer; make load-test-customer-data test_source=GCP
```

5. check the table again:
```
postgres=# select * from org1234567.reporting_ocpallcostlineitem_daily_summary_p order by greatest(array_length(namespace, 1)) desc limit 1;
-[ RECORD 1 ]-----+-------------------------------------
id                | 1154c17a-0b9e-4c78-96d8-f51f8ba7f0c3
source_type       | GCP
cluster_id        | test-ocp-gcp-cluster
cluster_alias     | Test OCP on GCP
namespace         | {analytics} <<<<< GOOD!
```
There should only be a single namespace in this array.

(might need to ingest more data if the `reporting_ocpallcostlineitem_daily_summary_p` table is empty) 

## Notes

...
