### PR TITLE
[COST-4556] Add azure tenant id to subs message

### DIFF
--- a/koku/subs/subs_data_messenger.py
+++ b/koku/subs/subs_data_messenger.py
@@ -64,7 +64,6 @@ class SUBSDataMessenger:
             if self.local_prov:
                 return "", tenant_id
             subscription_id = credentials.get("subscription_id")
-            tenant_id = credentials.get("tenant_id")
             client_id = credentials.get("client_id")
             client_secret = credentials.get("client_secret")
             _factory = AzureClientFactory(subscription_id, tenant_id, client_id, client_secret)

--- a/koku/subs/test/__init__.py
+++ b/koku/subs/test/__init__.py
@@ -19,4 +19,5 @@ class SUBSTestCase(IamTestCase):
         cls.aws_provider_type = Provider.PROVIDER_AWS_LOCAL
 
         cls.azure_provider = Provider.objects.filter(type=Provider.PROVIDER_AZURE_LOCAL).first()
+        cls.azure_tenant = cls.azure_provider.account.get("credentials").get("tenant_id")
         cls.azure_provider_type = Provider.PROVIDER_AZURE_LOCAL

--- a/koku/subs/test/test_subs_data_messenger.py
+++ b/koku/subs/test/test_subs_data_messenger.py
@@ -2,7 +2,6 @@
 # Copyright 2023 Red Hat Inc.
 # SPDX-License-Identifier: Apache-2.0
 #
-import json
 import uuid
 from collections import defaultdict
 from unittest.mock import mock_open
@@ -29,10 +28,11 @@ class TestSUBSDataMessenger(SUBSTestCase):
     @patch("subs.subs_data_messenger.os.remove")
     @patch("subs.subs_data_messenger.get_producer")
     @patch("subs.subs_data_messenger.csv.DictReader")
-    @patch("subs.subs_data_messenger.SUBSDataMessenger.build_subs_msg")
+    @patch("subs.subs_data_messenger.SUBSDataMessenger.build_subs_dict")
     def test_process_and_send_subs_message(self, mock_msg_builder, mock_reader, mock_producer, mock_remove):
         """Tests that the proper functions are called when running process_and_send_subs_message"""
         upload_keys = ["fake_key"]
+        mock_msg_builder.return_value = defaultdict(str)
         mock_reader.return_value = [
             {
                 "subs_start_time": "2023-07-01T01:00:00Z",
@@ -54,7 +54,7 @@ class TestSUBSDataMessenger(SUBSTestCase):
         mock_msg_builder.assert_called_once()
         mock_producer.assert_called_once()
 
-    def test_build_subs_msg(self):
+    def test_build_subs_dict(self):
         """
         Test building the kafka message body
         """
@@ -68,7 +68,7 @@ class TestSUBSDataMessenger(SUBSTestCase):
         sla = "Premium"
         product_ids = ["479", "70"]
         static_uuid = uuid.uuid4()
-        expected_subs_json = {
+        expected_subs_dict = {
             "event_id": str(static_uuid),
             "event_source": "cost-management",
             "event_type": "snapshot",
@@ -88,10 +88,9 @@ class TestSUBSDataMessenger(SUBSTestCase):
             "billing_provider": "aws",
             "billing_account_id": lineitem_usageaccountid,
         }
-        expected = bytes(json.dumps(expected_subs_json), "utf-8")
         with patch("subs.subs_data_messenger.uuid.uuid4") as mock_uuid:
             mock_uuid.return_value = static_uuid
-            actual = self.messenger.build_subs_msg(
+            actual = self.messenger.build_subs_dict(
                 lineitem_resourceid,
                 lineitem_usageaccountid,
                 lineitem_usagestartdate,
@@ -102,7 +101,59 @@ class TestSUBSDataMessenger(SUBSTestCase):
                 rol,
                 product_ids,
             )
-        self.assertEqual(expected, actual)
+        self.assertEqual(expected_subs_dict, actual)
+
+    def test_build_azure_subs_dict(self):
+        """
+        Test building the kafka message body
+        """
+        lineitem_resourceid = "i-55555556"
+        lineitem_usagestartdate = "2023-07-01T01:00:00Z"
+        lineitem_usageenddate = "2023-07-01T02:00:00Z"
+        lineitem_usageaccountid = "9999999999999"
+        product_vcpu = "2"
+        usage = "Production"
+        rol = "Red Hat Enterprise Linux Server"
+        sla = "Premium"
+        product_ids = ["479", "70"]
+        tenant_id = "my-fake-id"
+        static_uuid = uuid.uuid4()
+        expected_subs_dict = {
+            "event_id": str(static_uuid),
+            "event_source": "cost-management",
+            "event_type": "snapshot",
+            "account_number": self.acct,
+            "org_id": self.org_id,
+            "service_type": "RHEL System",
+            "instance_id": lineitem_resourceid,
+            "timestamp": lineitem_usagestartdate,
+            "expiration": lineitem_usageenddate,
+            "measurements": [{"value": product_vcpu, "uom": "vCPUs"}],
+            "cloud_provider": "AWS",
+            "hardware_type": "Cloud",
+            "product_ids": product_ids,
+            "role": rol,
+            "sla": sla,
+            "usage": usage,
+            "billing_provider": "aws",
+            "billing_account_id": lineitem_usageaccountid,
+            "azure_tenant_id": tenant_id,
+        }
+        with patch("subs.subs_data_messenger.uuid.uuid4") as mock_uuid:
+            mock_uuid.return_value = static_uuid
+            actual = self.messenger.build_azure_subs_dict(
+                lineitem_resourceid,
+                lineitem_usageaccountid,
+                lineitem_usagestartdate,
+                lineitem_usageenddate,
+                product_vcpu,
+                sla,
+                usage,
+                rol,
+                product_ids,
+                tenant_id,
+            )
+        self.assertEqual(expected_subs_dict, actual)
 
     @patch("subs.subs_data_messenger.get_producer")
     def test_send_kafka_message(self, mock_producer):
@@ -215,7 +266,7 @@ class TestSUBSDataMessenger(SUBSTestCase):
     @patch("subs.subs_data_messenger.os.remove")
     @patch("subs.subs_data_messenger.get_producer")
     @patch("subs.subs_data_messenger.csv.DictReader")
-    @patch("subs.subs_data_messenger.SUBSDataMessenger.build_subs_msg")
+    @patch("subs.subs_data_messenger.SUBSDataMessenger.build_subs_dict")
     def test_process_and_send_subs_message_azure_with_id(
         self, mock_msg_builder, mock_reader, mock_producer, mock_remove, mock_azure_id
     ):
@@ -223,6 +274,7 @@ class TestSUBSDataMessenger(SUBSTestCase):
         upload_keys = ["fake_key"]
         self.azure_messenger.date_map = defaultdict(list)
         mock_azure_id.return_value = ("string1", "string2")
+        mock_msg_builder.return_value = defaultdict(str)
         mock_reader.return_value = [
             {
                 "resourceid": "i-55555556",
@@ -254,7 +306,7 @@ class TestSUBSDataMessenger(SUBSTestCase):
     @patch("subs.subs_data_messenger.os.remove")
     @patch("subs.subs_data_messenger.get_producer")
     @patch("subs.subs_data_messenger.csv.DictReader")
-    @patch("subs.subs_data_messenger.SUBSDataMessenger.build_subs_msg")
+    @patch("subs.subs_data_messenger.SUBSDataMessenger.build_subs_dict")
     def test_process_and_send_subs_message_azure_time_already_processed(
         self, mock_msg_builder, mock_reader, mock_producer, mock_remove, mock_azure_id
     ):

--- a/koku/subs/test/test_subs_data_messenger.py
+++ b/koku/subs/test/test_subs_data_messenger.py
@@ -111,10 +111,10 @@ class TestSUBSDataMessenger(SUBSTestCase):
         self.messenger.send_kafka_message(kafka_msg)
         mock_producer.assert_called()
 
-    def test_determine_azure_instance_id_tag(self):
+    def test_determine_azure_instance_and_tenant_id_tag(self):
         """Test getting the azure instance id from the row provided by a tag returns as expected."""
         expected_instance = "waffle-house"
-        self.messenger.instance_map = {}
+        self.azure_messenger.instance_map = {}
         my_row = {
             "resourceid": "i-55555556",
             "subs_start_time": "2023-07-01T01:00:00Z",
@@ -129,13 +129,16 @@ class TestSUBSDataMessenger(SUBSTestCase):
             "subs_role": "Red Hat Enterprise Linux Server",
             "subs_product_ids": "479-70",
             "subs_instance": expected_instance,
+            "source": self.azure_provider.uuid,
         }
-        actual = self.messenger.determine_azure_instance_id(my_row)
-        self.assertEqual(expected_instance, actual)
+        actual_instance, actual_tenant = self.azure_messenger.determine_azure_instance_and_tenant_id(my_row)
+        self.assertEqual(expected_instance, actual_instance)
+        self.assertEqual(self.azure_tenant, actual_tenant)
 
-    def test_determine_azure_instance_id_local_prov(self):
+    def test_determine_azure_instance_and_tenant_id_local_prov(self):
         """Test that a local provider does not reach out to Azure."""
-        self.messenger.instance_map = {}
+        self.azure_messenger.instance_map = {}
+        expected_instance = ""
         my_row = {
             "resourceid": "i-55555556",
             "subs_start_time": "2023-07-01T01:00:00Z",
@@ -150,14 +153,17 @@ class TestSUBSDataMessenger(SUBSTestCase):
             "subs_role": "Red Hat Enterprise Linux Server",
             "subs_product_ids": "479-70",
             "subs_instance": "",
+            "source": self.azure_provider.uuid,
         }
-        actual = self.azure_messenger.determine_azure_instance_id(my_row)
-        self.assertEqual("", actual)
+        actual_instance, actual_tenant = self.azure_messenger.determine_azure_instance_and_tenant_id(my_row)
+        self.assertEqual(expected_instance, actual_instance)
+        self.assertEqual(self.azure_tenant, actual_tenant)
 
-    def test_determine_azure_instance_id_from_map(self):
+    def test_determine_azure_instance_and_tenant_id_from_map(self):
         """Test getting the azure instance id from the instance map returns as expected."""
-        expected = "oh-yeah"
-        self.messenger.instance_map["i-55555556"] = expected
+        expected_instance = "oh-yeah"
+        expected_tenant = "my-tenant"
+        self.azure_messenger.instance_map["i-55555556"] = (expected_instance, expected_tenant)
         my_row = {
             "resourceid": "i-55555556",
             "subs_start_time": "2023-07-01T01:00:00Z",
@@ -172,13 +178,15 @@ class TestSUBSDataMessenger(SUBSTestCase):
             "subs_role": "Red Hat Enterprise Linux Server",
             "subs_product_ids": "479-70",
             "subs_instance": "fake",
+            "source": self.azure_provider.uuid,
         }
-        actual = self.messenger.determine_azure_instance_id(my_row)
-        self.assertEqual(expected, actual)
+        actual_instance, actual_tenant = self.azure_messenger.determine_azure_instance_and_tenant_id(my_row)
+        self.assertEqual(expected_instance, actual_instance)
+        self.assertEqual(expected_tenant, actual_tenant)
 
-    def test_determine_azure_instance_id(self):
+    def test_determine_azure_instance_and_tenant_id(self):
         """Test getting the azure instance id from mock Azure Compute Client returns as expected."""
-        expected = "my-fake-id"
+        expected_instance = "my-fake-id"
         self.messenger.instance_map = {}
         my_row = {
             "resourceid": "i-55555556",
@@ -198,11 +206,12 @@ class TestSUBSDataMessenger(SUBSTestCase):
             "resourcegroup": "my-fake-rg",
         }
         with patch("subs.subs_data_messenger.AzureClientFactory") as mock_factory:
-            mock_factory.return_value.compute_client.virtual_machines.get.return_value.vm_id = expected
-            actual = self.messenger.determine_azure_instance_id(my_row)
-        self.assertEqual(expected, actual)
+            mock_factory.return_value.compute_client.virtual_machines.get.return_value.vm_id = expected_instance
+            actual_instance, actual_tenant = self.messenger.determine_azure_instance_and_tenant_id(my_row)
+        self.assertEqual(expected_instance, actual_instance)
+        self.assertEqual(self.azure_tenant, actual_tenant)
 
-    @patch("subs.subs_data_messenger.SUBSDataMessenger.determine_azure_instance_id")
+    @patch("subs.subs_data_messenger.SUBSDataMessenger.determine_azure_instance_and_tenant_id")
     @patch("subs.subs_data_messenger.os.remove")
     @patch("subs.subs_data_messenger.get_producer")
     @patch("subs.subs_data_messenger.csv.DictReader")
@@ -213,6 +222,7 @@ class TestSUBSDataMessenger(SUBSTestCase):
         """Tests that the proper functions are called when running process_and_send_subs_message with Azure provider."""
         upload_keys = ["fake_key"]
         self.azure_messenger.date_map = defaultdict(list)
+        mock_azure_id.return_value = ("string1", "string2")
         mock_reader.return_value = [
             {
                 "resourceid": "i-55555556",
@@ -240,7 +250,7 @@ class TestSUBSDataMessenger(SUBSTestCase):
         self.assertEqual(mock_msg_builder.call_count, 4)
         self.assertEqual(mock_producer.call_count, 4)
 
-    @patch("subs.subs_data_messenger.SUBSDataMessenger.determine_azure_instance_id")
+    @patch("subs.subs_data_messenger.SUBSDataMessenger.determine_azure_instance_and_tenant_id")
     @patch("subs.subs_data_messenger.os.remove")
     @patch("subs.subs_data_messenger.get_producer")
     @patch("subs.subs_data_messenger.csv.DictReader")


### PR DESCRIPTION
## Jira Ticket

[COST-4556](https://issues.redhat.com/browse/COST-4556)

## Description

This change will add the azure tenant id into the subs kafka message in the `azure_tenant_id` field.

example message:
```
b'{"event_id": "510ab535-73fa-404c-ae44-7234322e074c", "event_source": "cost-management", "event_type": "snapshot", "account_number": "10001", "org_id": "1234567", "service_type": "RHEL System", "instance_id": "<my-instance-id>", "timestamp": "2024-01-07T22:00:00+00:00", "expiration": "2024-01-07T23:00:00+00:00", "measurements": [{"value": "1", "uom": "vCPUs"}], "cloud_provider": "Azure", "hardware_type": "Cloud", "product_ids": ["69", "204"], "role": "Red Hat Enterprise Linux Server", "sla": "Premium", "usage": "Production", "billing_provider": "azure", "billing_account_id": "<my-billing-account-id>", "azure_tenant_id": "<my-tenant-id>"}'
```

## Notes

...
