### PR TITLE
Improve accuracy of our current delete/insert log messaging

### DIFF
--- a/koku/masu/database/aws_report_db_accessor.py
+++ b/koku/masu/database/aws_report_db_accessor.py
@@ -94,7 +94,7 @@ class AWSReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
                 table_name,
                 sql,
                 sql_params,
-                operation="DELETE/INSERT",
+                operation="INSERT",
             )
 
     def populate_line_item_daily_summary_table_trino(self, start_date, end_date, source_uuid, bill_id, markup_value):

--- a/koku/masu/database/azure_report_db_accessor.py
+++ b/koku/masu/database/azure_report_db_accessor.py
@@ -195,7 +195,7 @@ class AzureReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
                 "schema": self.schema,
                 "source_uuid": source_uuid,
             }
-            self._prepare_and_execute_raw_sql_query(table_name, sql, sql_params, operation="DELETE/INSERT")
+            self._prepare_and_execute_raw_sql_query(table_name, sql, sql_params, operation="INSERT")
 
     def populate_ocp_on_azure_ui_summary_tables(self, sql_params, tables=OCPAZURE_UI_SUMMARY_TABLES):
         """Populate our UI summary tables (formerly materialized views)."""

--- a/koku/masu/database/gcp_report_db_accessor.py
+++ b/koku/masu/database/gcp_report_db_accessor.py
@@ -70,7 +70,7 @@ class GCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
                     "invoice_month": invoice_month,
                 }
 
-                self._prepare_and_execute_raw_sql_query(table_name, sql, sql_params, operation="DELETE/INSERT")
+                self._prepare_and_execute_raw_sql_query(table_name, sql, sql_params, operation="INSERT")
 
     def get_cost_entry_bills_query_by_provider(self, provider_uuid):
         """Return all cost entry bills for the specified provider."""
@@ -406,7 +406,7 @@ class GCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
                 sql_params["invoice_month"] = invoice_month
                 sql = pkgutil.get_data("masu.database", f"sql/gcp/openshift/{table_name}.sql")
                 sql = sql.decode("utf-8")
-                self._prepare_and_execute_raw_sql_query(table_name, sql, sql_params, operation="DELETE/INSERT")
+                self._prepare_and_execute_raw_sql_query(table_name, sql, sql_params, operation="INSERT")
 
     def populate_ocp_on_gcp_ui_summary_tables_trino(
         self, start_date, end_date, openshift_provider_uuid, gcp_provider_uuid, tables=OCPGCP_UI_SUMMARY_TABLES

--- a/koku/masu/database/oci_report_db_accessor.py
+++ b/koku/masu/database/oci_report_db_accessor.py
@@ -66,7 +66,7 @@ class OCIReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
                 "schema": self.schema,
                 "source_uuid": source_uuid,
             }
-            self._prepare_and_execute_raw_sql_query(table_name, sql, sql_params, operation="DELETE/INSERT")
+            self._prepare_and_execute_raw_sql_query(table_name, sql, sql_params, operation="INSERT")
 
     def populate_line_item_daily_summary_table_trino(self, start_date, end_date, source_uuid, bill_id, markup_value):
         """Populate the daily aggregated summary of line items table.

--- a/koku/masu/database/ocp_report_db_accessor.py
+++ b/koku/masu/database/ocp_report_db_accessor.py
@@ -93,7 +93,7 @@ class OCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
                 "schema": self.schema,
                 "source_uuid": source_uuid,
             }
-            self._prepare_and_execute_raw_sql_query(table_name, sql, sql_params, operation="DELETE/INSERT")
+            self._prepare_and_execute_raw_sql_query(table_name, sql, sql_params, operation="INSERT")
 
     def update_line_item_daily_summary_with_enabled_tags(self, start_date, end_date, report_period_ids):
         """Populate the enabled tag key table.


### PR DESCRIPTION
## Jira Ticket

[COST-####](https://issues.redhat.com/browse/COST-####)

## Description

This change will fix our log messages regarding deletes and inserts to make them slightly more accurate and hopefully easier to understand. 

Before this change we did the following:

[2024-01-10 15:13:04,632] INFO c4e7e7a4-6b5b-481a-9d69-08f8d5e83cda 2389 Deleting records from reporting_ocpawscostlineitem_project_daily_summary_p for source 2dfc5380-7aed-4047-a62b-cdfb60af7f02 from 2024-01-01T00:00:00 to 2024-01-10T00:00:00
koku-worker_1       | [2024-01-10 15:13:04,632] INFO c4e7e7a4-6b5b-481a-9d69-08f8d5e83cda 2389 {'message': 'triggering DELETE', 'tracing_id': '', 'table': 'reporting_ocpawscostlineitem_project_daily_summary_p'}
koku-worker_1       | [2024-01-10 15:13:04,642] INFO c4e7e7a4-6b5b-481a-9d69-08f8d5e83cda 2389 {'message': 'finished DELETE', 'tracing_id': '', 'table': 'reporting_ocpawscostlineitem_project_daily_summary_p', 'running_time': 0.00930166244506836}

followed by:

koku-worker_1       | [2024-01-10 15:13:52,224] INFO c4e7e7a4-6b5b-481a-9d69-08f8d5e83cda 2389 {'message': 'triggering DELETE/INSERT', 'tracing_id': '', 'schema': 'org1234567', 'start_date': '2024-01-01', 'end_date': '2024-01-10', 'provider_uuid': '0bc53884-512d-4682-990f-d5ae0162b664', 'table': 'reporting_ocpawscostlineitem_project_daily_summary_p'}
koku-worker_1       | [2024-01-10 15:13:52,229] INFO c4e7e7a4-6b5b-481a-9d69-08f8d5e83cda 2389 {'message': 'triggering DELETE/INSERT', 'tracing_id': '', 'table': 'reporting_ocpawscostlineitem_project_daily_summary_p'}
koku-worker_1       | [2024-01-10 15:13:52,240] INFO c4e7e7a4-6b5b-481a-9d69-08f8d5e83cda 2389 {'message': 'finished DELETE/INSERT', 'tracing_id': '', 'table': 'reporting_ocpawscostlineitem_project_daily_summary_p', 'running_time': 0.009747505187988281}

But in reality those second set of log messages are only doing an INSERT.


## Testing

1. Checkout Branch
2. Restart Koku
3. Make load data
4. Watch the logs

## Notes

...
