### PR TITLE
[COST=4569] Send azure_subscription_id in kafka message

### DIFF
--- a/koku/subs/subs_data_messenger.py
+++ b/koku/subs/subs_data_messenger.py
@@ -159,11 +159,27 @@ class SUBSDataMessenger:
         self, instance_id, billing_account_id, tstamp, expiration, cpu_count, sla, usage, role, product_ids, tenant_id
     ):
         """Adds azure_tenant_id to the base subs dict."""
-        subs_dict = self.build_subs_dict(
-            instance_id, billing_account_id, tstamp, expiration, cpu_count, sla, usage, role, product_ids
-        )
-        subs_dict["azure_tenant_id"] = tenant_id
-        return subs_dict
+        return {
+            "event_id": str(uuid.uuid4()),
+            "event_source": "cost-management",
+            "event_type": "snapshot",
+            "account_number": self.account_id,
+            "org_id": self.org_id,
+            "service_type": "RHEL System",
+            "instance_id": instance_id,
+            "timestamp": tstamp,
+            "expiration": expiration,
+            "measurements": [{"value": cpu_count, "uom": "vCPUs"}],
+            "cloud_provider": self.provider_type,
+            "hardware_type": "Cloud",
+            "product_ids": product_ids,
+            "role": role,
+            "sla": sla,
+            "usage": usage,
+            "billing_provider": self.provider_type.lower(),
+            "azure_subscription_id": billing_account_id,
+            "azure_tenant_id": tenant_id,
+        }
 
     def process_azure_row(self, row):
         """Process an Azure row into subs kafka messages."""

--- a/koku/subs/test/test_subs_data_messenger.py
+++ b/koku/subs/test/test_subs_data_messenger.py
@@ -136,7 +136,7 @@ class TestSUBSDataMessenger(SUBSTestCase):
             "sla": sla,
             "usage": usage,
             "billing_provider": "aws",
-            "billing_account_id": lineitem_usageaccountid,
+            "azure_subscription_id": lineitem_usageaccountid,
             "azure_tenant_id": tenant_id,
         }
         with patch("subs.subs_data_messenger.uuid.uuid4") as mock_uuid:
@@ -266,15 +266,11 @@ class TestSUBSDataMessenger(SUBSTestCase):
     @patch("subs.subs_data_messenger.os.remove")
     @patch("subs.subs_data_messenger.get_producer")
     @patch("subs.subs_data_messenger.csv.DictReader")
-    @patch("subs.subs_data_messenger.SUBSDataMessenger.build_subs_dict")
-    def test_process_and_send_subs_message_azure_with_id(
-        self, mock_msg_builder, mock_reader, mock_producer, mock_remove, mock_azure_id
-    ):
+    def test_process_and_send_subs_message_azure_with_id(self, mock_reader, mock_producer, mock_remove, mock_azure_id):
         """Tests that the proper functions are called when running process_and_send_subs_message with Azure provider."""
         upload_keys = ["fake_key"]
         self.azure_messenger.date_map = defaultdict(list)
         mock_azure_id.return_value = ("string1", "string2")
-        mock_msg_builder.return_value = defaultdict(str)
         mock_reader.return_value = [
             {
                 "resourceid": "i-55555556",
@@ -299,7 +295,6 @@ class TestSUBSDataMessenger(SUBSTestCase):
         with patch("builtins.open", mock_op):
             self.azure_messenger.process_and_send_subs_message(upload_keys)
         mock_azure_id.assert_called_once()
-        self.assertEqual(mock_msg_builder.call_count, 4)
         self.assertEqual(mock_producer.call_count, 4)
 
     @patch("subs.subs_data_messenger.SUBSDataMessenger.determine_azure_instance_and_tenant_id")


### PR DESCRIPTION
## Jira Ticket

[COST-4569](https://issues.redhat.com/browse/COST-4569)

## Description

This change will send the azure subscription id in the `azure_subscription_id` field instead of `billing_account_id` for a subs message. The `billing_account_id` field should be omitted since it is not being filled for Azure.

sample message:
```
b'{"event_id": "510ab535-73fa-404c-ae44-7234322e074c", "event_source": "cost-management", "event_type": "snapshot", "account_number": "10001", "org_id": "1234567", "service_type": "RHEL System", "instance_id": "<my-instance-id>", "timestamp": "2024-01-07T22:00:00+00:00", "expiration": "2024-01-07T23:00:00+00:00", "measurements": [{"value": "1", "uom": "vCPUs"}], "cloud_provider": "Azure", "hardware_type": "Cloud", "product_ids": ["69", "204"], "role": "Red Hat Enterprise Linux Server", "sla": "Premium", "usage": "Production", "billing_provider": "azure", "azure_subscription_id": "<my-subscription-id>", "azure_tenant_id": "<my-tenant-id>"}'

```
## Notes

...
