### PR TITLE
[COST-4570] Order bill queryset by ID before list conversion

### DIFF
--- a/koku/masu/util/aws/common.py
+++ b/koku/masu/util/aws/common.py
@@ -498,7 +498,8 @@ def get_bills_from_provider(
                 bills = bills.filter(billing_period_start__gte=start_date)
             if end_date:
                 bills = bills.filter(billing_period_start__lte=end_date)
-
+            # ordering by id (PK) so the first bill is the same as .first() would return
+            bills = bills.order_by("id")
             bills = list(bills.all())
 
     return bills

--- a/koku/masu/util/azure/common.py
+++ b/koku/masu/util/azure/common.py
@@ -166,7 +166,8 @@ def get_bills_from_provider(provider_uuid, schema, start_date=None, end_date=Non
                 bills = bills.filter(billing_period_start__gte=start_date)
             if end_date:
                 bills = bills.filter(billing_period_start__lte=end_date)
-
+            # ordering by id (PK) so the first bill is the same as .first() would return
+            bills = bills.order_by("id")
             bills = list(bills.all())
 
     return bills

--- a/koku/masu/util/gcp/common.py
+++ b/koku/masu/util/gcp/common.py
@@ -57,7 +57,8 @@ def get_bills_from_provider(provider_uuid, schema, start_date=None, end_date=Non
             bills = bills.filter(billing_period_start__gte=start_date)
         if end_date:
             bills = bills.filter(billing_period_start__lte=end_date)
-
+        # ordering by id (PK) so the first bill is the same as .first() would return
+        bills = bills.order_by("id")
         bills = list(bills.all())
 
     return bills


### PR DESCRIPTION
## Jira Ticket

[COST-4570](https://issues.redhat.com/browse/COST-4570)

## Description

This change will order the queryset results by ID (primary key) before returning them so that when we select the 0th element it is the same bill as would be chosen by `.first()`.

## Testing

1. Checkout Branch
2. Restart Koku
3. Create and load test customer data
4. Get in a python shell in the schema: `make shell-schema`
5. Run some python to check bills and order and verify the first bill in the list matches the same bill `.first()` would return.
```
>>> from reporting.models import AWSCostEntryBill
>>> 
>>> bills = AWSCostEntryBill.objects.all()
>>> bills
<QuerySet [<AWSCostEntryBill: AWSCostEntryBill object (5)>, <AWSCostEntryBill: AWSCostEntryBill object (6)>, <AWSCostEntryBill: AWSCostEntryBill object (3)>, <AWSCostEntryBill: AWSCostEntryBill object (7)>, <AWSCostEntryBill: AWSCostEntryBill object (4)>, <AWSCostEntryBill: AWSCostEntryBill object (8)>]>
>>> bills.first()
<AWSCostEntryBill: AWSCostEntryBill object (3)>
>>> bills = bills.order_by("id")
>>> bill_list = list(bills)
>>> bill_list[0]
<AWSCostEntryBill: AWSCostEntryBill object (3)>

```

## Notes

...
