### PR TITLE
set max retry for trino connection

### DIFF
--- a/koku/koku/trino_database.py
+++ b/koku/koku/trino_database.py
@@ -106,6 +106,7 @@ def connect(**connect_args):
         ),
         "schema": connect_args["schema"],
         "legacy_primitive_types": connect_args.get("legacy_primitive_types", False),
+        "max_attempts": 9,  # based on exponential backoff used in the trino lib, max retries with take ~100 seconds
     }
     return trino.dbapi.connect(**trino_connect_args)
 

--- a/koku/koku/trino_database.py
+++ b/koku/koku/trino_database.py
@@ -106,7 +106,7 @@ def connect(**connect_args):
         ),
         "schema": connect_args["schema"],
         "legacy_primitive_types": connect_args.get("legacy_primitive_types", False),
-        "max_attempts": 9,  # based on exponential backoff used in the trino lib, max retries with take ~100 seconds
+        "max_attempts": 9,  # based on exponential backoff used in the trino lib, 9 max retries with take ~100 seconds
     }
     return trino.dbapi.connect(**trino_connect_args)
 


### PR DESCRIPTION
## Description

The default max-attempts in the trino library is 3. This gives the connection approx 1.4 seconds to re-establish a connection to the trino-coordinator. During a cluster upgrade, the cutover to the new coordinator likely takes longer than 1.4 seconds.

This PR sets the max-attempts count to 9 which will give the workers approx 100 seconds to re-establish the connection to the coordinator.

