### PR TITLE
temporarily stop using codecov token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,7 +273,7 @@ jobs:
           file: ./coverage.xml
           flags: unittests
           name: Python-${{ matrix.python-version}}
-          token: ${{ secrets.CODECOV_TOKEN }}
+          # token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
 
       - name: Set Codecov job status on skipped tests


### PR DESCRIPTION
The codecov token has stopped working. This PR removes it from our workflow since we technically don't need it for open source projects anyway.