### PR TITLE
[COST-4713] Handle Azure billingcurrency column

### DIFF
--- a/koku/masu/database/trino_sql/reporting_ocpazurecostlineitem_daily_summary.sql
+++ b/koku/masu/database/trino_sql/reporting_ocpazurecostlineitem_daily_summary.sql
@@ -164,7 +164,7 @@ SELECT cast(uuid() as varchar) as uuid,
         ELSE unitofmeasure
     END) as unit_of_measure,
     sum(coalesce(nullif(azure.quantity, 0), azure.usagequantity)) as usage_quantity,
-    coalesce(nullif(azure.billingcurrencycode, ''), azure.currency) as currency,
+    coalesce(nullif(azure.billingcurrencycode, ''), nullif(azure.currency, ''), azure.billingcurrency) as currency,
     sum(coalesce(nullif(azure.costinbillingcurrency, 0), azure.pretaxcost)) as pretax_cost,
     azure.tags,
     max(azure.resource_id_matched) as resource_id_matched,
@@ -183,7 +183,7 @@ GROUP BY coalesce(azure.date, azure.usagedatetime),
     coalesce(nullif(servicename, ''), metercategory),
     coalesce(nullif(subscriptionid, ''), subscriptionguid),
     azure.resourcelocation,
-    coalesce(nullif(azure.billingcurrencycode, ''), azure.currency),
+    coalesce(nullif(azure.billingcurrencycode, ''), nullif(azure.currency, ''), azure.billingcurrency),
     azure.tags
 ;
 
@@ -233,7 +233,7 @@ SELECT cast(uuid() as varchar) as uuid,
         ELSE unitofmeasure
     END) as unit_of_measure,
     sum(coalesce(nullif(azure.quantity, 0), azure.usagequantity)) as usage_quantity,
-    coalesce(nullif(azure.billingcurrencycode, ''), azure.currency) as currency,
+    coalesce(nullif(azure.billingcurrencycode, ''), nullif(azure.currency, ''), azure.billingcurrency) as currency,
     sum(coalesce(nullif(azure.costinbillingcurrency, 0), azure.pretaxcost)) as pretax_cost,
     json_format(
         cast(
@@ -260,7 +260,7 @@ GROUP BY coalesce(azure.date, azure.usagedatetime),
     coalesce(nullif(servicename, ''), metercategory),
     coalesce(nullif(subscriptionid, ''), subscriptionguid),
     azure.resourcelocation,
-    coalesce(nullif(azure.billingcurrencycode, ''), azure.currency),
+    coalesce(nullif(azure.billingcurrencycode, ''), nullif(azure.currency, ''), azure.billingcurrency),
     12, -- tags
     azure.matched_tag
 ;


### PR DESCRIPTION
## Jira Ticket

[COST-4713](https://issues.redhat.com/browse/COST-4713)

## Description

This change will fix OCP on Azure infrastructure costs for users having non-USD Azure billing currency and subscription level exports

## Testing

1. Update Nise to generate v2 reports with BillingCurrency column instead of BillingCurrencyCode column
2. generate OCP on Azure data - make sure to use --version-two option for Azure and non-USD currency (you can use test_api_ocp_on_azure_source_raw_calc test)
3. wait for the data to ingest and check trino to make sure you have billingcurrency column populated
```
trino:org1234567> select DISTINCT(billingcurrency) from azure_openshift_daily;
 billingcurrency 
-----------------
 AUD             
(1 row)
```
4. check reporting_ocpazure_cost_summary_p table in koku db to see that no currency was pulled
```
postgres=# SELECT DISTINCT(currency) FROM reporting_ocpazure_cost_summary_p;
 currency 
----------
 
(1 row)
```
5. optionally run test_api_ocp_on_azure_source_raw_calc test and wait for its failure (caused by incorrect infra cost)

6. checkout the branch and repeat the step 2-3
7. check reporting_ocpazure_cost_summary_p table - you will see that currency is now present
```
postgres=# SELECT DISTINCT(currency) FROM Reporting_ocpazure_cost_summary_p;
 currency 
----------
 AUD
(1 row)
```
8. optionally run test_api_ocp_on_azure_source_raw_calc test to see that it passes
