### PR TITLE
[COST-4729] Fix ordering for tag mapping api.

### DIFF
--- a/koku/api/settings/test/tags/mappings/test_view.py
+++ b/koku/api/settings/test/tags/mappings/test_view.py
@@ -263,3 +263,10 @@ class TestSettingsTagMappingView(MasuTestCase):
             url = reverse("tags-mapping") + f"?child={child.key}"
             response = self.client.get(url, **self.headers)
             self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_order_by_fake_value(self):
+        """Test the get method for the tag mapping view"""
+        url = reverse("tags-mapping")
+        url = url + "?order_by[parent]=FAKE"
+        response = self.client.get(url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/koku/api/settings/utils.py
+++ b/koku/api/settings/utils.py
@@ -73,6 +73,9 @@ class SettingsFilter(FilterSet):
 
                 # Technically we accept "asc" and "desc". Only testing for "desc" to make
                 # the API more resilient.
+                if order not in ["asc", "desc"]:
+                    raise ValidationError(f"Invalid order_by parameter: {order_by_params}")
+
                 prefix = "-" if order.lower().startswith("desc") else ""
                 result.add(f"{prefix}{field}")
 


### PR DESCRIPTION
## Jira Ticket

[COST-4729](https://issues.redhat.com/browse/COST-4729)

## Description

This change will fix the source_type ordering options. Parent was fixed through the change introduced in:
https://github.com/project-koku/koku/commit/679d29d486e5a03f0fb0e7420ea6d7e6a52540eb

## Testing

* `Add order_by[source_type]=asc`

## Notes

...
