### PR TITLE
[COST-4713] Azure OpenShift daily trino migration

### DIFF
--- a/scripts/cji_scripts/migrate_trino.py
+++ b/scripts/cji_scripts/migrate_trino.py
@@ -162,26 +162,24 @@ def main():
     logging.info("Running against the following schemas")
     logging.info(schemas)
 
-    # tables_to_drop = [
-    #     "azure_openshift_daily_resource_matched_temp",
-    #     "azure_openshift_daily_tag_matched_temp",
-    #     "reporting_ocpazurecostlineitem_project_daily_summary_temp",
-    # ]
+    tables_to_drop = [
+        "azure_openshift_daily",
+    ]
     # columns_to_drop = ["ocp_matched"]
-    columns_to_add = {
-        "subscription_name": "varchar",
-    }
+    # columns_to_add = {
+    #     "subscription_name": "varchar",
+    # }
     for schema in schemas:
         CONNECT_PARAMS["schema"] = schema
-        logging.info(f"*** Adding column to tables for schema {schema} ***")
-        add_columns_to_table(columns_to_add, "reporting_ocpazurecostlineitem_project_daily_summary", CONNECT_PARAMS)
-        add_columns_to_table(columns_to_add, "azure_openshift_daily_resource_matched_temp", CONNECT_PARAMS)
-        add_columns_to_table(columns_to_add, "azure_openshift_daily_tag_matched_temp", CONNECT_PARAMS)
-        add_columns_to_table(
-            columns_to_add, "reporting_ocpazurecostlineitem_project_daily_summary_temp", CONNECT_PARAMS
-        )
-        # logging.info(f"*** Dropping tables {tables_to_drop} for schema {schema} ***")
-        # drop_tables(tables_to_drop, CONNECT_PARAMS)
+        # logging.info(f"*** Adding column to tables for schema {schema} ***")
+        # add_columns_to_table(columns_to_add, "reporting_ocpazurecostlineitem_project_daily_summary", CONNECT_PARAMS)
+        # add_columns_to_table(columns_to_add, "azure_openshift_daily_resource_matched_temp", CONNECT_PARAMS)
+        # add_columns_to_table(columns_to_add, "azure_openshift_daily_tag_matched_temp", CONNECT_PARAMS)
+        # add_columns_to_table(
+        #     columns_to_add, "reporting_ocpazurecostlineitem_project_daily_summary_temp", CONNECT_PARAMS
+        # )
+        logging.info(f"*** Dropping tables {tables_to_drop} for schema {schema} ***")
+        drop_tables(tables_to_drop, CONNECT_PARAMS)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Jira Ticket

[COST-4713](https://issues.redhat.com/browse/COST-4713)

## Description

This change will drop the `azure_openshift_daily` table so it can be recreated. This table can be missing the `billingcurrency` column if a source is old enough.

## Testing

1. Checkout Branch
2. Restart Koku
3. Create and Load OCP on Azure data
4. `make create-test-customer` followed by `make load-test-customer-data`
5. After data is loaded, run the trino migration: `python scripts/cji_scripts/migrate_trino.py`
6. Verify the `azure_openshift_daily` table is gone from trino
7. Load more test data
8. After it completes loading, verify that the `azure_openshift_daily` table is now present again

## Notes

...
