### PR TITLE
[COST-4752] Azure scrub disabled tags in trino.

### DIFF
--- a/koku/masu/database/azure_report_db_accessor.py
+++ b/koku/masu/database/azure_report_db_accessor.py
@@ -388,28 +388,6 @@ class AzureReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
         }
         self._prepare_and_execute_raw_sql_query(table_name, sql, sql_params)
 
-    def update_line_item_daily_summary_with_enabled_tags(self, start_date, end_date, bill_ids):
-        """Populate the enabled tag key table.
-        Args:
-            start_date (datetime.date) The date to start populating the table.
-            end_date (datetime.date) The date to end on.
-            bill_ids (list) A list of bill IDs.
-        Returns
-            (None)
-        """
-        table_name = self._table_map["line_item_daily_summary"]
-        sql = pkgutil.get_data(
-            "masu.database", "sql/reporting_azurecostentryline_item_daily_summary_update_enabled_tags.sql"
-        )
-        sql = sql.decode("utf-8")
-        sql_params = {
-            "start_date": start_date,
-            "end_date": end_date,
-            "bill_ids": bill_ids,
-            "schema": self.schema,
-        }
-        self._prepare_and_execute_raw_sql_query(table_name, sql, sql_params)
-
     def get_openshift_on_cloud_matched_tags(self, azure_bill_id):
         """Return a list of matched tags."""
         sql = pkgutil.get_data("masu.database", "sql/reporting_ocpazure_matched_tags.sql")

--- a/koku/masu/database/trino_sql/reporting_azurecostentrylineitem_daily_summary.sql
+++ b/koku/masu/database/trino_sql/reporting_azurecostentrylineitem_daily_summary.sql
@@ -75,7 +75,7 @@ SELECT uuid() as uuid,
     max(li.currency) as currency,
     cast(
         map_filter(
-            cast(json_parse(li.tags) as map(varchar, varchar)),
+            cast(li.tags as map(varchar, varchar)),
             (k,v) -> contains(pek.keys, k)
         ) as json
      ) as tags,
@@ -85,6 +85,8 @@ SELECT uuid() as uuid,
     sum(cast(li.pretax_cost * {{markup | sqlsafe}} AS decimal(24,9))) as markup_cost,
     li.subscription_name -- account name
 FROM cte_line_items AS li
+CROSS JOIN
+    cte_pg_enabled_keys as pek
 GROUP BY li.usage_date,
     li.cost_entry_bill_id,
     13, -- matches column num for tags map_filter

--- a/koku/masu/processor/azure/azure_report_parquet_summary_updater.py
+++ b/koku/masu/processor/azure/azure_report_parquet_summary_updater.py
@@ -95,7 +95,6 @@ class AzureReportParquetSummaryUpdater(PartitionHandlerMixin):
                 accessor.populate_enabled_tag_keys(start, end, bill_ids)
                 accessor.populate_ui_summary_tables(start, end, self._provider.uuid)
             accessor.populate_tags_summary_table(bill_ids, start_date, end_date)
-            accessor.update_line_item_daily_summary_with_enabled_tags(start_date, end_date, bill_ids)
             accessor.update_line_item_daily_summary_with_tag_mapping(start_date, end_date, bill_ids)
             for bill in bills:
                 if bill.summary_data_creation_datetime is None:

--- a/koku/masu/test/database/test_azure_report_db_accessor.py
+++ b/koku/masu/test/database/test_azure_report_db_accessor.py
@@ -278,38 +278,6 @@ class AzureReportDBAccessorTest(MasuTestCase):
             self.accessor.populate_enabled_tag_keys(start_date, end_date, bill_ids)
             self.assertNotEqual(EnabledTagKeys.objects.filter(provider_type=Provider.PROVIDER_AZURE).count(), 0)
 
-    def test_update_line_item_daily_summary_with_enabled_tags(self):
-        """Test that we filter the daily summary table's tags with only enabled tags."""
-        dh = DateHelper()
-        start_date = dh.this_month_start.date()
-        end_date = dh.this_month_end.date()
-
-        bills = self.accessor.bills_for_provider_uuid(self.azure_provider_uuid, start_date)
-        with schema_context(self.schema):
-            AzureTagsSummary.objects.all().delete()
-            key_to_keep = (
-                EnabledTagKeys.objects.filter(provider_type=Provider.PROVIDER_AZURE).filter(key="app").first()
-            )
-            EnabledTagKeys.objects.filter(provider_type=Provider.PROVIDER_AZURE).update(enabled=False)
-            EnabledTagKeys.objects.filter(provider_type=Provider.PROVIDER_AZURE).filter(key="app").update(enabled=True)
-            bill_ids = [bill.id for bill in bills]
-            self.accessor.update_line_item_daily_summary_with_enabled_tags(start_date, end_date, bill_ids)
-            tags = (
-                AzureCostEntryLineItemDailySummary.objects.filter(
-                    usage_start__gte=start_date, cost_entry_bill_id__in=bill_ids
-                )
-                .values_list("tags")
-                .distinct()
-            )
-
-            for tag in tags:
-                tag_dict = tag[0]
-                tag_keys = list(tag_dict.keys())
-                if tag_keys:
-                    self.assertEqual([key_to_keep.key], tag_keys)
-                else:
-                    self.assertEqual([], tag_keys)
-
     def test_table_properties(self):
         self.assertEqual(self.accessor.line_item_daily_summary_table, AzureCostEntryLineItemDailySummary)
 


### PR DESCRIPTION
## Jira Ticket

[COST-4752](https://issues.redhat.com/browse/COST-4752)

## Description

This change will move disabled tag key logic to trino.

## Testing
1. Checkout Branch
2. Check on the Azure tags:
```
http://localhost:8000/api/cost-management/v1/settings/tags/?provider_type=Azure
```
4. Resummarize the source
```
http://127.0.0.1:5042/api/cost-management/v1/report_data/?start_date=2024-03-01&schema=org1234567&provider_uuid=b895aaaa-ddd8-4550-8b81-76a218d8c43d
```
5. Check Postgresql to make sure only enable tags appear. 
```
 SELECT distinct(tags) from reporting_azurecostentrylineitem_daily_summary;
 ```
 ```
                                           tags
-------------------------------------------------------------------------------------------
 {"app": "banking"}
 {"storageclass": "Loki"}
 {"app": "mobile"}
 {"version": "MilkyWay", "environment": "Jupiter", "dashed-key-on-azure": "dashed-value"}
 {"version": "Andromeda", "environment": "Jupiter", "dashed-key-on-azure": "dashed-value"}
 {"storageclass": "Odin"}
 {"app": "weather"}
 {"storageclass": "Thor"}
 {"storageclass": "Tyr"}
 {"version": "Sombrero"}
 {"version": "Mars", "dashed-key-on-azure": "dashed-value"}
 {"storageclass": "Baldur"}
(12 rows)
```


## Notes

...
