### PR TITLE
[COST-4643] use cascade_delete to remove expired CostUsageReportManifest

### DIFF
--- a/koku/masu/database/report_manifest_db_accessor.py
+++ b/koku/masu/database/report_manifest_db_accessor.py
@@ -19,6 +19,7 @@ from django.db.models.functions import RowNumber
 from django.utils import timezone
 
 from api.common import log_json
+from koku.database import cascade_delete
 from reporting_common.models import CostUsageReportManifest
 from reporting_common.models import CostUsageReportStatus
 from reporting_common.states import ManifestState
@@ -160,12 +161,14 @@ class ReportManifestDBAccessor:
             provider_type   (String) the provider type to delete associated manifests
             expired_date (datetime.datetime) delete all manifests older than this date, exclusive.
         """
-        delete_count = CostUsageReportManifest.objects.filter(
+        manifests_to_delete = CostUsageReportManifest.objects.filter(
             provider__type=provider_type, billing_period_start_datetime__lt=expired_date
-        ).delete()[0]
+        )
+        count = manifests_to_delete.count()
+        cascade_delete(manifests_to_delete.query.model, manifests_to_delete)
         LOG.info(
             "Removed %s CostUsageReportManifest(s) for provider type %s that had a billing period start date before %s",
-            delete_count,
+            count,
             provider_type,
             expired_date,
         )
@@ -178,12 +181,14 @@ class ReportManifestDBAccessor:
             provider_uuid (uuid) The provider uuid to use to delete associated manifests
             expired_date (datetime.datetime) delete all manifests older than this date, exclusive.
         """
-        delete_count = CostUsageReportManifest.objects.filter(
+        manifests_to_delete = CostUsageReportManifest.objects.filter(
             provider_id=provider_uuid, billing_period_start_datetime__lt=expired_date
-        ).delete()
+        )
+        count = manifests_to_delete.count()
+        cascade_delete(manifests_to_delete.query.model, manifests_to_delete)
         LOG.info(
             "Removed %s CostUsageReportManifest(s) for provider_uuid %s that had a billing period start date before %s",
-            delete_count,
+            count,
             provider_uuid,
             expired_date,
         )
@@ -321,11 +326,13 @@ class ReportManifestDBAccessor:
            manifest_count: {len(manifest_id_list)}
         """
         LOG.info(msg)
-        delete_count = CostUsageReportManifest.objects.filter(
+        manifests_to_delete = CostUsageReportManifest.objects.filter(
             provider_id=provider_uuid, id__in=manifest_id_list
-        ).delete()
+        )
+        count = manifests_to_delete.count()
+        cascade_delete(manifests_to_delete.query.model, manifests_to_delete)
         LOG.info(
             "Removed %s manifests for provider_uuid %s",
-            delete_count,
+            count,
             provider_uuid,
         )


### PR DESCRIPTION
## Jira Ticket

[COST-4643](https://issues.redhat.com/browse/COST-4643)

## Description

This change will delete manifests via cascade_delete

## Testing

1. with some OCP data loaded
2. `make shell`
3. delete manifests through the ReportManifestDBAccessor methods and see success.
```
>>> from masu.database.report_manifest_db_accessor import ReportManifestDBAccessor
>>> with ReportManifestDBAccessor() as acc:
...   acc.purge_expired_report_manifest('OCP', '2024-03-10')
[2024-03-13 16:09:19,206] INFO None 83486 Removed 8 CostUsageReportManifest(s) for provider type OCP that had a billing period start date before 2024-03-10
```
4. my db only had these 8 OCP manifests. Since I deleted everything, I expect both these tables to be empty:
```
postgres=# select * from reporting_common_costusagereportstatus;
(0 rows)

postgres=# select * from reporting_common_costusagereportmanifest;
(0 rows)

```
## Notes

...
