### PR TITLE
[COST-4423] - Cluster info include timestamps

### DIFF
--- a/koku/api/provider/provider_manager.py
+++ b/koku/api/provider/provider_manager.py
@@ -135,25 +135,26 @@ class ProviderManager:
 
     def get_manifest_state(self, manifest):
         """Get statuses for given manifest."""
-        if manifest:
-            states = {
-                ManifestStep.DOWNLOAD: {"state": ManifestState.PENDING},
-                ManifestStep.PROCESSING: {"state": ManifestState.PENDING},
-                ManifestStep.SUMMARY: {"state": ManifestState.PENDING},
-            }
-            for key in states:
-                if current_state := manifest.state.get(key):
-                    manifest.state[key].pop("time_taken_seconds", None)
-                    if current_state.get(ManifestState.FAILED):
-                        states[key] = manifest.state[key]
-                        states[key]["state"] = "complete"
-                    elif current_state.get(ManifestState.END):
-                        states[key] = manifest.state[key]
-                        states[key]["state"] = "complete"
-                    elif current_state.get(ManifestState.START):
-                        states[key] = manifest.state[key]
-                        states[key]["state"] = "complete"
-            return states
+        if not manifest:
+            return None
+        states = {
+            ManifestStep.DOWNLOAD: {"state": ManifestState.PENDING},
+            ManifestStep.PROCESSING: {"state": ManifestState.PENDING},
+            ManifestStep.SUMMARY: {"state": ManifestState.PENDING},
+        }
+        for key in states:
+            if current_state := manifest.state.get(key):
+                manifest.state[key].pop("time_taken_seconds", None)
+                if current_state.get(ManifestState.FAILED):
+                    states[key] = manifest.state[key]
+                    states[key]["state"] = "failed"
+                elif current_state.get(ManifestState.END):
+                    states[key] = manifest.state[key]
+                    states[key]["state"] = "complete"
+                elif current_state.get(ManifestState.START):
+                    states[key] = manifest.state[key]
+                    states[key]["state"] = "in-progress"
+        return states
 
     def get_any_data_exists(self):
         """Get  data avaiability status."""

--- a/koku/api/provider/provider_manager.py
+++ b/koku/api/provider/provider_manager.py
@@ -199,6 +199,8 @@ class ProviderManager:
                     "last_polling_time": self.get_last_polling_time(
                         self.model.infrastructure.infrastructure_provider_id
                     ),
+                    "paused": source.paused,
+                    "source_status": source.status,
                     "cloud_provider_state": self.get_manifest_state(manifest),
                 }
         return {}

--- a/koku/api/provider/provider_manager.py
+++ b/koku/api/provider/provider_manager.py
@@ -156,6 +156,16 @@ class ProviderManager:
                     states[key]["state"] = "in-progress"
         return states
 
+    def get_last_polling_time(self, uuid=None):
+        """Get last polling timestamp for provider"""
+        if uuid:
+            provider = Provider.objects.get(uuid=uuid)
+            timestamp = provider.polling_timestamp
+        else:
+            timestamp = self.model.polling_timestamp
+        if timestamp:
+            return timestamp.strftime(DATE_TIME_FORMAT)
+
     def get_any_data_exists(self):
         """Get  data avaiability status."""
         return CostUsageReportManifest.objects.filter(provider=self._uuid, completed_datetime__isnull=False).exists()
@@ -186,6 +196,9 @@ class ProviderManager:
                     "id": source.source_id,
                     "account": self.model.infrastructure.infrastructure_account,
                     "region": self.model.infrastructure.infrastructure_region,
+                    "last_polling_time": self.get_last_polling_time(
+                        self.model.infrastructure.infrastructure_provider_id
+                    ),
                     "cloud_provider_state": self.get_manifest_state(manifest),
                 }
         return {}

--- a/koku/masu/database/report_manifest_db_accessor.py
+++ b/koku/masu/database/report_manifest_db_accessor.py
@@ -76,7 +76,8 @@ class ReportManifestDBAccessor:
                     time_now = timezone.now()
                     if not manifest.state:
                         manifest.state = {}
-                    if not manifest.state.get(step):
+                    if interval == ManifestState.START:
+                        # We need to clear END times to prevent false positives when reprocessing
                         manifest.state[step] = {}
                     manifest.state[step][interval] = time_now.isoformat()
                     if interval == ManifestState.END or interval == ManifestState.FAILED:

--- a/koku/masu/processor/parquet/parquet_report_processor.py
+++ b/koku/masu/processor/parquet/parquet_report_processor.py
@@ -459,15 +459,16 @@ class ParquetReportProcessor:
         for csv_filename in file_list:
             self.prepare_parquet_s3(Path(csv_filename))
             if self.provider_type == Provider.PROVIDER_OCP and self.report_type is None:
+                msg = "could not establish report type"
                 LOG.warning(
                     log_json(
                         self.tracing_id,
-                        msg="could not establish report type",
+                        msg=msg,
                         context=self.error_context,
                         filename=csv_filename,
                     )
                 )
-                raise ParquetReportProcessorError
+                raise ParquetReportProcessorError(msg)
             if self.provider_type == Provider.PROVIDER_OCI:
                 file_specific_start_date = str(csv_filename).split(".")[1]
                 self.start_date = file_specific_start_date
@@ -476,15 +477,16 @@ class ParquetReportProcessor:
             if self.provider_type not in (Provider.PROVIDER_AZURE):
                 self.create_daily_parquet(parquet_base_filename, daily_frame)
             if not success:
+                msg = "failed to convert files to parquet"
                 LOG.warning(
                     log_json(
                         self.tracing_id,
-                        msg="failed to convert files to parquet",
+                        msg=msg,
                         context=self.error_context,
                         file_list=failed_conversion,
                     )
                 )
-                raise ParquetReportProcessorError
+                raise ParquetReportProcessorError(msg)
         return parquet_base_filename, daily_data_frames
 
     def create_parquet_table(self, parquet_file, daily=False, partition_map=None):

--- a/koku/masu/processor/tasks.py
+++ b/koku/masu/processor/tasks.py
@@ -57,6 +57,7 @@ from masu.processor.worker_cache import WorkerCache
 from masu.util.aws.common import remove_files_not_in_set_from_s3_bucket
 from masu.util.common import execute_trino_query
 from masu.util.common import get_path_prefix
+from masu.util.common import set_summary_timestamp
 from masu.util.gcp.common import deduplicate_reports_for_gcp
 from masu.util.oci.common import deduplicate_reports_for_oci
 from reporting.ingress.models import IngressReports
@@ -421,10 +422,6 @@ def summarize_reports(  # noqa: C901
         # Updater classes for when full-month summarization is
         # required.
         with ReportManifestDBAccessor() as manifest_accesor:
-            # Set summary start time
-            manifest_accesor.update_manifest_state(
-                ManifestStep.SUMMARY, ManifestState.START, report.get("manifest_id")
-            )
             fallback_queue = UPDATE_SUMMARY_TABLES_QUEUE
             if is_customer_large(report.get("schema_name")):
                 fallback_queue = UPDATE_SUMMARY_TABLES_QUEUE_XL
@@ -483,6 +480,8 @@ def update_summary_tables(  # noqa: C901
         None
 
     """
+    # Mark summary start time
+    set_summary_timestamp(ManifestState.START, start_date, provider_uuid=provider_uuid)
     context = {
         "schema": schema,
         "provider_type": provider_type,
@@ -563,8 +562,8 @@ def update_summary_tables(  # noqa: C901
             ocp_on_cloud_infra_map = updater.get_openshift_on_cloud_infra_map(start_date, end_date, tracing_id)
     except ReportSummaryUpdaterCloudError as ex:
         LOG.info(log_json(tracing_id, msg=f"failed to correlate OpenShift metrics: error: {ex}", context=context))
-        # Set summary failed time
-        ReportManifestDBAccessor().update_manifest_state(ManifestStep.SUMMARY, ManifestState.FAILED, manifest_id)
+        # Mark summary failed time
+        set_summary_timestamp(ManifestState.FAILED, start_date, provider_uuid=provider_uuid)
 
     except ReportSummaryUpdaterProviderNotFoundError as ex:
         LOG.warning(
@@ -575,16 +574,16 @@ def update_summary_tables(  # noqa: C901
             ),
             exc_info=ex,
         )
-        # Set summary failed time
-        ReportManifestDBAccessor().update_manifest_state(ManifestStep.SUMMARY, ManifestState.FAILED, manifest_id)
+        # Mark summary failed time
+        set_summary_timestamp(ManifestState.FAILED, start_date, provider_uuid=provider_uuid)
         if not synchronous:
             worker_cache.release_single_task(task_name, cache_args)
         return
     except Exception as ex:
         if not synchronous:
             worker_cache.release_single_task(task_name, cache_args)
-        # Set summary failed time
-        ReportManifestDBAccessor().update_manifest_state(ManifestStep.SUMMARY, ManifestState.FAILED, manifest_id)
+        # Mark summary failed time
+        set_summary_timestamp(ManifestState.FAILED, start_date, provider_uuid=provider_uuid)
         raise ex
 
     if provider_type != Provider.PROVIDER_OCP:
@@ -600,8 +599,8 @@ def update_summary_tables(  # noqa: C901
         with CostModelDBAccessor(schema, provider_uuid) as cost_model_accessor:
             cost_model = cost_model_accessor.cost_model
 
-    # Mark manifest summary complete time
-    ReportManifestDBAccessor().update_manifest_state(ManifestStep.SUMMARY, ManifestState.END, manifest_id)
+    # Mark summary complete time
+    set_summary_timestamp(ManifestState.END, start_date, provider_uuid=provider_uuid)
 
     # Create queued tasks for each OpenShift on Cloud cluster
     delete_signature_list = []
@@ -721,6 +720,8 @@ def update_openshift_on_cloud(  # noqa: C901
     tracing_id=None,
 ):
     """Update OpenShift on Cloud for a specific OpenShift and cloud source."""
+    # Set OpenShift summary started time
+    set_summary_timestamp(ManifestState.START, start_date, provider_uuid=openshift_provider_uuid)
     task_name = "masu.processor.tasks.update_openshift_on_cloud"
     if is_ocp_on_cloud_summary_disabled(schema_name):
         msg = f"OCP on Cloud summary disabled for {schema_name}."
@@ -783,6 +784,8 @@ def update_openshift_on_cloud(  # noqa: C901
             infrastructure_provider_type,
             tracing_id,
         )
+        # Set OpenShift manifest summary end time
+        set_summary_timestamp(ManifestState.END, start_date, provider_uuid=openshift_provider_uuid)
     except ReportSummaryUpdaterCloudError as ex:
         LOG.info(
             log_json(
@@ -792,6 +795,8 @@ def update_openshift_on_cloud(  # noqa: C901
             ),
             exc_info=ex,
         )
+        # Set OpenShift manifest summary failed time
+        set_summary_timestamp(ManifestState.FAILED, start_date, provider_uuid=openshift_provider_uuid)
         raise ReportSummaryUpdaterCloudError from ex
     except ReportSummaryUpdaterProviderNotFoundError as ex:
         LOG.warning(
@@ -800,6 +805,8 @@ def update_openshift_on_cloud(  # noqa: C901
             ),
             exc_info=ex,
         )
+        # Set OpenShift manifest summary failed time
+        set_summary_timestamp(ManifestState.FAILED, start_date, provider_uuid=openshift_provider_uuid)
     finally:
         if not synchronous:
             worker_cache.release_single_task(task_name, cache_args)

--- a/koku/masu/test/processor/test_tasks.py
+++ b/koku/masu/test/processor/test_tasks.py
@@ -1467,10 +1467,12 @@ class TestWorkerCacheThrottling(MasuTestCase):
     @patch("masu.processor.tasks.WorkerCache.release_single_task")
     @patch("masu.processor.tasks.WorkerCache.lock_single_task")
     @patch("masu.processor.worker_cache.CELERY_INSPECT")
+    @patch("masu.util.common.CostUsageReportManifest")
     @patch("masu.database.report_manifest_db_accessor.CostUsageReportManifest.objects.select_for_update")
     def test_update_summary_tables_provider_not_found_error(
         self,
         mock_select_for_update,
+        mock_manifest,
         mock_inspect,
         mock_lock,
         mock_release,
@@ -1493,16 +1495,21 @@ class TestWorkerCacheThrottling(MasuTestCase):
             statement_found = any(expected in log for log in logger.output)
             self.assertTrue(statement_found)
 
+    @patch("masu.util.common.CostUsageReportManifest")
     @patch("masu.processor.tasks.WorkerCache.release_single_task")
     @patch("masu.processor.tasks.WorkerCache.lock_single_task")
     @patch("masu.processor.worker_cache.CELERY_INSPECT")
+    @patch("masu.database.report_manifest_db_accessor.CostUsageReportManifest.objects.select_for_update")
     def test_update_openshift_on_cloud_provider_not_found_error(
         self,
+        mock_select_for_update,
         mock_inspect,
         *args,
     ):
         """Test that the update_summary_table provider not found exception is caught."""
         mock_inspect.reserved.return_value = {"celery@kokuworker": []}
+        mock_queryset = mock_select_for_update.return_value
+        mock_queryset.get.return_value = None
         start_date = self.dh.this_month_start
         end_date = self.dh.this_month_end
         expected = "halting processing"

--- a/koku/masu/test/util/test_common.py
+++ b/koku/masu/test/util/test_common.py
@@ -26,6 +26,8 @@ from masu.config import Config
 from masu.test import MasuTestCase
 from reporting.provider.all.models import EnabledTagKeys
 from reporting.provider.aws.models import AWSCostEntryBill
+from reporting_common.models import CostUsageReportManifest
+from reporting_common.states import ManifestState
 
 
 class MockConfig:
@@ -538,6 +540,31 @@ class CommonUtilTests(MasuTestCase):
         expected = {"good_key": "good_value"}
         result = common_utils.filter_dictionary(test_dictionary, keys_to_keep)
         self.assertEqual(result, expected)
+
+    def test_set_summary_timestamp(self):
+        """Test setting summary times for manifests."""
+        self.assertIsNone(common_utils.set_summary_timestamp("test", "2023-01-01"))
+
+        this_month_str = str(DateHelper().this_month_start.date())
+        self.assertIsNone(common_utils.set_summary_timestamp("test", this_month_str))
+
+        provider_uuid = self.aws_provider_uuid
+        manifest = CostUsageReportManifest.objects.filter(
+            provider=provider_uuid,
+            billing_period_start_datetime=DateHelper().this_month_start,
+            creation_datetime__isnull=False,
+        ).latest("creation_datetime")
+        common_utils.set_summary_timestamp(ManifestState.START, this_month_str, manifest_id=manifest.id)
+        manifest = CostUsageReportManifest.objects.filter(id=manifest.id).first()
+        self.assertIn("start", manifest.state.get("summary"))
+
+        common_utils.set_summary_timestamp(ManifestState.START, this_month_str, provider_uuid=provider_uuid)
+        manifest = CostUsageReportManifest.objects.filter(
+            provider=provider_uuid,
+            billing_period_start_datetime=DateHelper().this_month_start,
+            creation_datetime__isnull=False,
+        ).latest("creation_datetime")
+        self.assertIn("start", manifest.state.get("summary"))
 
 
 class NamedTemporaryGZipTests(TestCase):

--- a/koku/sources/api/view.py
+++ b/koku/sources/api/view.py
@@ -248,6 +248,7 @@ class SourcesViewSet(*MIXIN_LIST):
                 source["current_month_data"] = False
                 source["previous_month_data"] = False
                 source["last_payload_received_at"] = False
+                source["last_polling_time"] = False
                 source["status"] = {}
                 source["has_data"] = False
                 source["infrastructure"] = {}
@@ -260,6 +261,7 @@ class SourcesViewSet(*MIXIN_LIST):
                 source["current_month_data"] = manager.get_current_month_data_exists()
                 source["previous_month_data"] = manager.get_previous_month_data_exists()
                 source["last_payload_received_at"] = manager.get_last_received_data_datetime()
+                source["last_polling_time"] = manager.get_last_polling_time()
                 source["status"] = manager.get_state()  # This holds the download/processing/summary states
                 source["has_data"] = manager.get_any_data_exists()
                 source["infrastructure"] = manager.get_infrastructure_info()
@@ -286,6 +288,7 @@ class SourcesViewSet(*MIXIN_LIST):
             response.data["current_month_data"] = False
             response.data["previous_month_data"] = False
             response.data["last_payload_received_at"] = False
+            response.data["last_polling_time"] = False
             response.data["status"] = {}
             response.data["has_data"] = False
             response.data["infrastructure"] = {}
@@ -298,6 +301,7 @@ class SourcesViewSet(*MIXIN_LIST):
             response.data["current_month_data"] = manager.get_current_month_data_exists()
             response.data["previous_month_data"] = manager.get_previous_month_data_exists()
             response.data["last_payload_received_at"] = manager.get_last_received_data_datetime()
+            response.data["last_polling_time"] = manager.get_last_polling_time()
             response.data["status"] = manager.get_state()  # This holds the download/processing/summary states
             response.data["status"] = manager.get_state()
             response.data["has_data"] = manager.get_any_data_exists()


### PR DESCRIPTION
## Jira Ticket

[COST-4423](https://issues.redhat.com/browse/COST-4423)

## Description

- Timestamps for download/processing/summary manifest states directly on the sources endpoint for a source.
- Infrastructure respective parts for the cloud provider hosting a cluster, polling time, active/paused.
- Refactor to summary timestamps! Mainly to include the addition of updating OCP provider timestamps after they have been triggered from cloud providers (OCP on CLOUD flow)
- This also includes fixes for a couple of missed raised exception msgs.


## Testing

1. Checkout Branch
2. Restart Koku
3. Load OCP on Cloud data
4. Check the sources endpoint, should see the following for an ocp provider running on a cloud.
5. Additionally hit the report_data (resummary endpoint) for an OCP on CLOUD provider either provider (ocp or cloud)
6. Check the following:

- The OCP trigger will update the OCP summary timestamps
- The CLOUD summary trigger will update Both OCP and Cloud summary timestamps

Extra things to take note of:
status section now has datetimes for download/process/summary
we also have 'last_polling_time' added for a provider and in the respective infrastructure section. This is the last time we attempted to collect reports for a cloud provider.
 We also include 'paused: T/F' in the Infra section for the cloud provider and 'source_status' this would be the active T/F flag but instead gives the UI access to the unavailable messages too if they choose to display them.


Example OCP provider response:

{
    "id": 4,
    "uuid": "6aaeae85-d66f-4041-af70-bbfd9849ec37",
    "name": "test_cost_ocp_on_aws_cluster",
    "source_type": "OCP",
    "authentication": {
        "credentials": {
            "cluster_id": "test_cost_ocp_on_aws_cluster"
        }
    },
    "billing_source": {},
    "provider_linked": true,
    "active": true,
    "paused": false,
    "current_month_data": true,
    "previous_month_data": true,
    "last_payload_received_at": "2024-03-14T12:08:03.151917Z",
    "last_polling_time": null,
    "status": {
        "download": {
            "end": "2024-03-14T12:08:05.926275+00:00",
            "start": "2024-03-14T12:08:03.161059+00:00",
            "state": "complete"
        },
        "processing": {
            "end": "2024-03-14T12:08:11.645476+00:00",
            "start": "2024-03-14T12:08:10.508165+00:00",
            "state": "complete"
        },
        "summary": {
            "end": "2024-03-14T12:10:05.642835+00:00",
            "start": "2024-03-14T12:09:58.420032+00:00",
            "state": "complete"
        }
    },
    "has_data": true,
    "infrastructure": {
        "type": "AWS-local",
        "uuid": "f53fb102-0589-4b9d-b521-45b133597a15",
        "id": 5,
        "account": "9999999999999",
        "region": "us-east-1",
        "last_polling_time": "2024-03-14 12:08:39",
        "paused": false,
        "source_status": {"availability_status": "available", "availability_status_error": ""}, locally this is probably empty
        "cloud_provider_state": {
            "download": {
                "end": "2024-03-14T12:08:43.659019+00:00",
                "start": "2024-03-14T12:08:41.271080+00:00",
                "state": "complete"
            },
            "processing": {
                "end": "2024-03-14T12:08:54.948450+00:00",
                "start": "2024-03-14T12:08:43.666051+00:00",
                "state": "complete"
            },
            "summary": {
                "end": "2024-03-14T12:09:36.109387+00:00",
                "start": "2024-03-14T12:09:34.369197+00:00",
                "state": "complete"
            }
        }
    },
    "cost_models": [
        {
            "name": "test_cost_model_test_cost_ocp_on_aws_cluster",
            "uuid": "219f04bf-65a1-4538-855f-733819ef84b2"
        }
    ],
    "additional_context": {
        "operator_version": "4.4.9",
        "operator_airgapped": false,
        "operator_certified": false,
        "operator_update_available": true
    }
}

## Notes
...
