### PR TITLE
[COST-4121] OpenAPI spec. update: new unit (GiB) used on OCP

### DIFF
--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -10281,19 +10281,19 @@
                                                 ],
                                                 "usage": {
                                                     "value": 4.62038,
-                                                    "units": "GB-Hours"
+                                                    "units": "GiB-Hours"
                                                 },
                                                 "request": {
                                                     "value": 6.158921,
-                                                    "units": "GB-Hours"
+                                                    "units": "GiB-Hours"
                                                 },
                                                 "limit": {
                                                     "value": 405.835939,
-                                                    "units": "GB-Hours"
+                                                    "units": "GiB-Hours"
                                                 },
                                                 "capacity": {
                                                     "value": 17893.948761,
-                                                    "units": "GB-Hours"
+                                                    "units": "GiB-Hours"
                                                 },
                                                 "infrastructure": {
                                                     "raw": {
@@ -10381,15 +10381,15 @@
                                             ],
                                             "usage": {
                                                 "value": 283.455815,
-                                                "units": "GB-Mo"
+                                                "units": "GiB-Mo"
                                             },
                                             "request": {
                                                 "value": 14058.333334,
-                                                "units": "GB-Mo"
+                                                "units": "GiB-Mo"
                                             },
                                             "capacity": {
                                                 "value": 13732.252982,
-                                                "units": "GB-Mo"
+                                                "units": "GiB-Mo"
                                             },
                                             "infrastructure": {
                                                 "raw": {


### PR DESCRIPTION
## Jira Ticket

[COST-4121](https://issues.redhat.com/browse/COST-4121)

## Description

This change will make the units changes below in the OpenAPI `ReportOpenshiftMemory` and `ReportOpenshiftVolume` sections:

- From `GB-Hours` to `GiB-Hours` and 
- From `GB-Mo` to `GiB-Mo` 
