### PR TITLE
[COST-4394] Fixing OCI GB and TB calculations

### DIFF
--- a/koku/masu/database/trino_sql/reporting_ocicostentrylineitem_daily_summary.sql
+++ b/koku/masu/database/trino_sql/reporting_ocicostentrylineitem_daily_summary.sql
@@ -41,17 +41,17 @@ SELECT uuid() as uuid,
         WHEN 'BYTES' THEN usage_amount / (
                 cast(day(last_day_of_month(date(usage_start))) as integer)
             ) *
-            power(2, -30)
+            power(10, -9)
         WHEN 'BYTE_MS' THEN usage_amount / 1000.0 / (
             86400.0 *
             cast(extract(day from last_day_of_month(date(usage_start))) as integer)
             ) *
-            power(2, -30)
+            power(10, -9)
         WHEN 'GB_MS' THEN usage_amount / 1000.0 / (
             86400.0 *
             cast(extract(day from last_day_of_month(date(usage_start))) as integer)
             )
-        WHEN 'TB_MS' THEN (usage_amount * 1024) / 1000.0 / (
+        WHEN 'TB_MS' THEN (usage_amount * 1000) / 1000.0 / (
             86400.0 *
             CAST(EXTRACT(day FROM last_day_of_month(date(usage_start))) AS INTEGER)
             )


### PR DESCRIPTION
## Jira Ticket

[COST-4394](https://issues.redhat.com/browse/COST-4394)

## Description

This change will fix the calculations regarding the OCI conversion from `bytes` to `Gigabytes` and from `Terabytes/millisecond` to `Gigabytes/Month`, **considering that we are using the Decimal Standard, and we have stated that we should use the GB unit**.

In the former code, `power(2, -30)` is used, which is equivalent to `dividing by 2^30`. This is the conversion factor for `bytes` to `Gibibytes (GiB)`, where `1 GiB = 2^30 bytes`.

This change will fix it, replacing by `* power(10, -9)`, which is equivalent to dividing by 10^9. This is the conversion factor for `bytes` to `Gigabytes (GB)`, where `1 GB = 10^9 bytes`.

When it comes to the `TB_MS` side, according to the **Decimal Standard**, we have to `multiply by 1000` instead of `1024` (which would convert to `GiB`).

