### PR TITLE
Add usage units fallback for OCP on GCP storage endpoint

### DIFF
--- a/koku/api/report/gcp/openshift/provider_map.py
+++ b/koku/api/report/gcp/openshift/provider_map.py
@@ -446,6 +446,8 @@ class OCPGCPProviderMap(ProviderMap):
                         ],
                         "cost_units_key": "currency",
                         "cost_units_fallback": "USD",
+                        "usage_units_key": "unit",
+                        "usage_units_fallback": "GB-Mo",
                         "sum_columns": ["usage", "cost_total", "infra_total", "sup_total"],
                         "default_ordering": {"cost_total": "desc"},
                     },


### PR DESCRIPTION
## Jira Ticket

[COST-4392](https://issues.redhat.com/browse/COST-4392)

## Description

This PR attempts to fix missing usage units in OCP on GCP storage endpoint when we have no OCP on GCP storage data. The missing units are apparent in UI so it would be better to fix it.


## Testing

1. hit ocp on gcp storage endpoint without having any ocp on gcp storage data (make sure that the db schema is created, e.g., by creating ocp source):
http://localhost:8000/api/cost-management/v1/reports/openshift/infrastructures/gcp/storage/
2. check metadata - you will see that usage units are missing
```
"total": {
            "usage": {
                "value": 0,
                "units": 0
            }
```
4. Checkout Branch
5. hit ocp on gcp storage endpoint again - but this time add a limit to invalidate the cache:
http://localhost:8000/api/cost-management/v1/reports/openshift/infrastructures/gcp/storage/?limit=102
6. check metadata - you will see that usage units are now filled
```
"total": {
            "usage": {
                "value": 0,
                "units": "GB-Mo"
            }
```