### PR TITLE
[COST-4786] Remove ast.literal_eval from view

### DIFF
--- a/koku/api/settings/tags/mapping/view.py
+++ b/koku/api/settings/tags/mapping/view.py
@@ -2,7 +2,6 @@
 # Copyright 2024 Red Hat Inc.
 # SPDX-License-Identifier: Apache-2.0
 #
-import ast
 import dataclasses
 
 import django_filters
@@ -35,6 +34,15 @@ from reporting.provider.all.models import EnabledTagKeys
 from reporting.provider.all.models import TagMapping
 
 
+def parse_list(string_to_parse):
+    """Parse a list to a string."""
+    if "[" not in string_to_parse:
+        return [string_to_parse]
+    split_values = string_to_parse.strip("[]").split(",")
+    parse_list = [value.strip().strip("'\"") for value in split_values]
+    return parse_list
+
+
 class CostModelAnnotationMixin:
     def get_annotated_queryset(self):
         when_conditions = []
@@ -55,10 +63,7 @@ class SettingsTagMappingFilter(SettingsFilter):
         default_ordering = ["parent"]
 
     def filter_by_source_type(self, queryset, name, value):
-        try:
-            value = ast.literal_eval(value)
-        except ValueError:
-            value = [value]
+        value = parse_list(value)
         return queryset.filter(Q(parent__provider_type__in=value) | Q(child__provider_type__in=value))
 
 

--- a/koku/api/settings/tags/mapping/view.py
+++ b/koku/api/settings/tags/mapping/view.py
@@ -34,12 +34,13 @@ from reporting.provider.all.models import EnabledTagKeys
 from reporting.provider.all.models import TagMapping
 
 
-def parse_list(string_to_parse):
+def parse_list(string_to_parse: str) -> list[str]:
     """Parse a list to a string."""
-    if "[" not in string_to_parse:
+    if not isinstance(string_to_parse, str):
+        raise TypeError(f"Expected str but got {type(string_to_parse)}")
         return [string_to_parse]
     split_values = string_to_parse.strip("[]").split(",")
-    parse_list = [value.strip().strip("'\"") for value in split_values]
+    parse_list = [value.strip().strip("'\" ") for value in split_values]
     return parse_list
 
 

--- a/koku/api/settings/test/tags/mappings/test_view.py
+++ b/koku/api/settings/test/tags/mappings/test_view.py
@@ -11,6 +11,7 @@ from rest_framework.test import APIClient
 
 from api.settings.tags.mapping.query_handler import Relationship
 from api.settings.tags.mapping.utils import retrieve_tag_rate_mapping
+from api.settings.tags.mapping.view import parse_list
 from api.settings.tags.mapping.view import SettingsTagMappingFilter
 from masu.test import MasuTestCase
 from reporting.provider.all.models import EnabledTagKeys
@@ -338,3 +339,8 @@ class TestSettingsTagMappingView(MasuTestCase):
         url = url + "?order_by[parent]=FAKE"
         response = self.client.get(url, **self.headers)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_parse_list(self):
+        """Test that we can parse a list."""
+        self.assertEqual(["A", "B"], parse_list("['A', 'B']"))
+        self.assertEqual(["A"], parse_list("A"))


### PR DESCRIPTION
## Jira Ticket

[COST-4786](https://issues.redhat.com/browse/COST-4786)

## Description

This change will use a separate function to convert the string of a list to list of values. 

## Testing

You should still be able to multiple filter for source_type on tag mapping.

```
http://localhost:8000/api/cost-management/v1/settings/tags/mappings/?filter[source_type]=AWS&filter[source_type]=OCP
```
Return:
```
{
    "meta": {
        "count": 1,
        "limit": 1,
        "offset": 0
    },
    "links": {
        "first": "/api/cost-management/v1/settings/tags/mappings/?filter%5Bsource_type%5D=AWS&limit=1&offset=0",
        "next": null,
        "previous": null,
        "last": "/api/cost-management/v1/settings/tags/mappings/?filter%5Bsource_type%5D=AWS&limit=1&offset=0"
    },
    "data": [
        {
            "parent": {
                "uuid": "d9374eef-0ce2-424c-84a4-0e5b94127452",
                "key": "app",
                "source_type": "OCP"
            },
            "children": [
                {
                    "uuid": "03d2bd07-1874-4109-a34c-b664f2837cd9",
                    "key": "com_redhat_rhel_usage",
                    "source_type": "AWS"
                }
            ]
        }
    ]
}
```



## Notes

...
