### PR TITLE
[COST-3617] Fixing GCP date_range bug

### DIFF
--- a/koku/masu/external/downloader/gcp/gcp_report_downloader.py
+++ b/koku/masu/external/downloader/gcp/gcp_report_downloader.py
@@ -101,12 +101,7 @@ def create_daily_archives(
                 days = list({day.strftime("%Y-%m-%d") for day in unique_usage_days})
 
                 # getting the lowest and highest date from the invoice.month's
-                if min_day is None or min(days) < min_day:
-                    min_day = min(days)
-
-                if max_day is None or max(days) > max_day:
-                    max_day = max(days)
-
+                min_day, max_day = get_min_max_days(days, min_day, max_day)
                 partition_dates = invoice_month_data.partition_date.unique()
                 for partition_date in partition_dates:
                     partition_date_filter = invoice_month_data["partition_date"] == partition_date
@@ -147,6 +142,16 @@ def create_daily_archives(
         LOG.info(log_json(tracing_id, msg=msg, context=context))
         raise CreateDailyArchivesError(msg)
     return daily_file_names, date_range
+
+
+def get_min_max_days(days, min_day, max_day):
+    if min_day is None or min(days) < min_day:
+        min_day = min(days)
+
+    if max_day is None or max(days) > max_day:
+        max_day = max(days)
+
+    return min_day, max_day
 
 
 class GCPReportDownloader(ReportDownloaderBase, DownloaderInterface):

--- a/koku/masu/test/external/downloader/gcp/test_gcp_report_downloader.py
+++ b/koku/masu/test/external/downloader/gcp/test_gcp_report_downloader.py
@@ -20,6 +20,7 @@ from masu.external.downloader.gcp.gcp_report_downloader import create_daily_arch
 from masu.external.downloader.gcp.gcp_report_downloader import DATA_DIR
 from masu.external.downloader.gcp.gcp_report_downloader import GCPReportDownloader
 from masu.external.downloader.gcp.gcp_report_downloader import GCPReportDownloaderError
+from masu.external.downloader.gcp.gcp_report_downloader import get_min_max_days
 from masu.test import MasuTestCase
 from masu.util.common import CreateDailyArchivesError
 from masu.util.common import date_range_pair
@@ -462,3 +463,17 @@ class GCPReportDownloaderTest(MasuTestCase):
                 self.assertTrue(os.path.exists(daily_file))
                 os.remove(daily_file)
             os.remove(temp_path)
+
+    def test_get_min_max_dates(self):
+        """Test if we are getting the lowest and highest days."""
+        min_day = None
+        max_day = None
+        min_day, max_day = get_min_max_days(["2022-08-01"], min_day, max_day)
+        min_day, max_day = get_min_max_days(["2022-09-01"], min_day, max_day)
+        min_day, max_day = get_min_max_days(["2022-10-01"], min_day, max_day)
+        min_day, max_day = get_min_max_days(["2022-11-01"], min_day, max_day)
+
+        self.assertEqual(min_day, "2022-08-01")
+        self.assertEqual(max_day, "2022-11-01")
+        self.assertIsNotNone(min_day)
+        self.assertIsNotNone(max_day)


### PR DESCRIPTION
## Jira Ticket

[COST-3617](https://issues.redhat.com/browse/COST-3617)

## Description

This update will configure the `date_range` data after iterating through multiple instances of `invoice.month`, utilizing the lowest and highest days of **all** occurrences for the start and end keys, respectively. It's important to mention that the `invoice.month` key retains the most recent month throughout the iteration.

This approach ensures that the date range isn't overwritten by the start and end dates from only the last iteration.

## Testing

1. Checkout Branch
2. Restart Koku
3. Run local tests `tox -e py39 -- masu.test.external.downloader.gcp.test_gcp_report_downloader.GCPReportDownloaderTest`
4. It is worth manually changing the `usage_start_time`, `usage_end_time` and `invoice.month` etc. columns in the local `koku/koku/masu/test/data/gcp/2022-08-01_5.csv` file to verify the accurate generation of the `date_range` data.

