### PR TITLE
Increase gunicorn workers for sources client

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -843,6 +843,8 @@ objects:
           value: ${DEVELOPMENT}
         - name: GUNICORN_LOG_LEVEL
           value: ${GUNICORN_LOG_LEVEL}
+        - name: GUNICORN_WORKERS
+          value: ${GUNICORN_WORKERS}
         - name: KOKU_LOG_LEVEL
           value: ${SOURCES_CLIENT_KOKU_LOG_LEVEL}
         - name: UNLEASH_LOG_LEVEL

--- a/deploy/kustomize/patches/sources-client.yaml
+++ b/deploy/kustomize/patches/sources-client.yaml
@@ -61,6 +61,8 @@
           value: ${DEVELOPMENT}
         - name: GUNICORN_LOG_LEVEL
           value: ${GUNICORN_LOG_LEVEL}
+        - name: GUNICORN_WORKERS
+          value: ${GUNICORN_WORKERS}
         - name: KOKU_LOG_LEVEL
           value: ${SOURCES_CLIENT_KOKU_LOG_LEVEL}
         - name: UNLEASH_LOG_LEVEL

--- a/koku/gunicorn_conf.py
+++ b/koku/gunicorn_conf.py
@@ -36,8 +36,7 @@ bind = f"0.0.0.0:{CLOWDER_PORT}"
 
 # Worker Processes (https://docs.gunicorn.org/en/stable/settings.html#worker-processes)
 cpu_resources = ENVIRONMENT.int("POD_CPU_LIMIT", default=multiprocessing.cpu_count())
-gunicorn_workers = ENVIRONMENT.int("GUNICORN_WORKERS", default=(cpu_resources * 2 + 1))
-workers = 1 if SOURCES else gunicorn_workers
+workers = ENVIRONMENT.int("GUNICORN_WORKERS", default=(cpu_resources * 2 + 1))
 gunicorn_threads = ENVIRONMENT.bool("GUNICORN_THREADS", default=False)
 if gunicorn_threads:
     threads = cpu_resources * 2 + 1


### PR DESCRIPTION
## Description

Currently the sources client uses a single gunicorn worker process. The liveness and readiness probes fail when the single worker process is busy, causing the pod to be restarted.

Set the number of gunicorn workers for the sources client in the same way as other processes by using the value in `GUNICORN_WORKERS`.