### PR TITLE
catch non-existent manifest for ocp-on-cloud infra provider

### DIFF
--- a/koku/api/provider/provider_manager.py
+++ b/koku/api/provider/provider_manager.py
@@ -137,6 +137,7 @@ class ProviderManager:
         """Get statuses for given manifest."""
         if not manifest:
             return None
+        manifest = manifest.latest("creation_datetime")
         states = {
             ManifestStep.DOWNLOAD: {"state": ManifestState.PENDING},
             ManifestStep.PROCESSING: {"state": ManifestState.PENDING},
@@ -189,7 +190,7 @@ class ProviderManager:
                     provider=self.model.infrastructure.infrastructure_provider_id,
                     billing_period_start_datetime=self.date_helper.this_month_start,
                     creation_datetime__isnull=False,
-                ).latest("creation_datetime")
+                )
                 return {
                     "type": self.model.infrastructure.infrastructure_type,
                     "uuid": self.model.infrastructure.infrastructure_provider_id,


### PR DESCRIPTION
## Jira Ticket

[COST-####](https://issues.redhat.com/browse/COST-####)

## Description
If a cloud provider, on which an OCP cluster is running, does not have a manifest for the current month, the sources endpoint will fail to load.

This PR fixes that.

## Testing

1. on main
2. ingest data:
```
$ make create-test-customer; make load-test-customer-data test_source=AWS
```
3. visit http://localhost:8000/api/cost-management/v1/sources/
4. look at the `"name": "Test OCP on AWS",` source, and under infrastructure, see that `cloud_provider_state` is populated:
```
           "cloud_provider_state": {
                    "download": { ....
```
5. Delete the manifest for AWS for *this* month:
```
postgres=# select id from reporting_common_costusagereportmanifest rcc JOIN api_provider ap ON rcc.provider_id = ap.uuid WHERE billing_period_start_datetime>='2024-03-01' and type='AWS-local';
-[ RECORD 1 ]
id | 3 <<<<<<<< this is what we use to delete below

postgres=# delete from reporting_common_costusagereportstatus where manifest_id=3;
DELETE 1
postgres=# delete from reporting_common_costusagereportmanifest where id=3;
DELETE 1
```
6. delete redis cache (`make delete-redis-cache`) and visit http://localhost:8000/api/cost-management/v1/sources/
7. see 500 status on the sources endpoint
8. Checkout this branch
9. let things reload and delete redis cache (`make delete-redis-cache`)
10. hit source endpoint again, and see success:
http://localhost:8000/api/cost-management/v1/sources/
11. for the `"name": "Test OCP on AWS",` source, see this under the infrastructure:
```
"cloud_provider_state": null

```

## Notes

...
