### PR TITLE
[COST-4423] - fix manifest updates for cluster info

### DIFF
--- a/koku/masu/test/util/test_common.py
+++ b/koku/masu/test/util/test_common.py
@@ -543,28 +543,34 @@ class CommonUtilTests(MasuTestCase):
 
     def test_set_summary_timestamp(self):
         """Test setting summary times for manifests."""
-        self.assertIsNone(common_utils.set_summary_timestamp("test", "2023-01-01"))
-
-        this_month_str = str(DateHelper().this_month_start.date())
-        self.assertIsNone(common_utils.set_summary_timestamp("test", this_month_str))
-
         provider_uuid = self.aws_provider_uuid
         manifest = CostUsageReportManifest.objects.filter(
             provider=provider_uuid,
             billing_period_start_datetime=DateHelper().this_month_start,
             creation_datetime__isnull=False,
         ).latest("creation_datetime")
-        common_utils.set_summary_timestamp(ManifestState.START, this_month_str, manifest_id=manifest.id)
+        common_utils.set_summary_timestamp(ManifestState.START, manifest_id=manifest.id)
         manifest = CostUsageReportManifest.objects.filter(id=manifest.id).first()
         self.assertIn("start", manifest.state.get("summary"))
 
-        common_utils.set_summary_timestamp(ManifestState.START, this_month_str, provider_uuid=provider_uuid)
-        manifest = CostUsageReportManifest.objects.filter(
-            provider=provider_uuid,
-            billing_period_start_datetime=DateHelper().this_month_start,
-            creation_datetime__isnull=False,
-        ).latest("creation_datetime")
-        self.assertIn("start", manifest.state.get("summary"))
+
+def test_get_latest_openshift_on_cloud_manifest(self):
+    """test fetching latest manifest for ocp on cloud provider"""
+    provider_uuid = self.aws_provider_uuid
+    self.assertIsNone(common_utils.get_latest_openshift_on_cloud_manifest("test", "2023-01-01"))
+
+    this_month_str = str(DateHelper().this_month_start.date())
+    self.assertIsNone(common_utils.get_latest_openshift_on_cloud_manifest("test", this_month_str))
+
+    manifest_expected_id = common_utils.get_latest_openshift_on_cloud_manifest(
+        this_month_str, provider_uuid=provider_uuid
+    )
+    manifest = CostUsageReportManifest.objects.filter(
+        provider=provider_uuid,
+        billing_period_start_datetime=DateHelper().this_month_start,
+        creation_datetime__isnull=False,
+    ).latest("creation_datetime")
+    self.assertEqual(manifest.manifest_id, manifest_expected_id)
 
 
 class NamedTemporaryGZipTests(TestCase):

--- a/koku/masu/util/common.py
+++ b/koku/masu/util/common.py
@@ -477,9 +477,17 @@ def chunk_columns(col_list, chunk_count):
         yield list(col_list[i : i + chunk_count])
 
 
-def set_summary_timestamp(state, start_date, manifest_id=None, provider_uuid=None):
-    """Function for setting last summary for given provider"""
+def set_summary_timestamp(state, manifest_id):
+    """Function for setting last summary for given manifest"""
+    if manifest_id:
+        LOG.info(f"setting summary {state} for manifest: {manifest_id}")
+        ReportManifestDBAccessor().update_manifest_state(ManifestStep.SUMMARY, state, manifest_id)
+
+
+def get_latest_openshift_on_cloud_manifest(start_date, provider_uuid):
+    """Function for getting latest manifest for given openshift provider (ocp on cloud)"""
     start_date = parser.parse(str(start_date))
+    manifest_id = None
     # We need to update previous manifests for customer filtered flows
     billing_period = DateHelper().month_start_utc(start_date)
     if provider_uuid:
@@ -492,6 +500,4 @@ def set_summary_timestamp(state, start_date, manifest_id=None, provider_uuid=Non
             manifest_id = manifest.id
         except CostUsageReportManifest.DoesNotExist:
             pass
-    if manifest_id:
-        LOG.info(f"setting summary {state} for manifest: {manifest_id}, provider: {provider_uuid}")
-        ReportManifestDBAccessor().update_manifest_state(ManifestStep.SUMMARY, state, manifest_id)
+    return manifest_id


### PR DESCRIPTION
## Jira Ticket

[COST-4423](https://issues.redhat.com/browse/COST-4423)

## Description

This change will fix which manifest is getting updated during summary flows, we wanted to add provider_uuid as part of OCP on Cloud summary tasks so we could update the latest OCP manifest for the cluster info pages.

The only downside of switching back some of this is the report_data (re-summary) endpoint would update the latest manifest for whichever provider was triggered. This endpoint in a future update we could consider adopting this manifest lookup in order to pass in the correct manifest for these summary tasks.

## Testing

1. Checkout Branch
2. Restart Koku with multiple workers
3. Ingest OCP data and send a second payload mid summary
4. We should continue to update the correct manifest mid processing 

## Release Notes
- [ ] proposed release note

```markdown
* [COST-4423](https://issues.redhat.com/browse/COST-4423) Fix which manifest is getting updated during summary flows specifically for OCP on Cloud tasks.
```
