### PR TITLE
[COST-4759] Restore all labels unleash flag

### DIFF
--- a/koku/api/report/ocp/provider_map.py
+++ b/koku/api/report/ocp/provider_map.py
@@ -19,6 +19,7 @@ from django.db.models.functions import Coalesce
 
 from api.models import Provider
 from api.report.provider_map import ProviderMap
+from masu.processor import is_feature_cost_3083_all_labels_enabled
 from providers.provider_access import ProviderAccessor
 from reporting.models import OCPUsageLineItemDailySummary
 from reporting.provider.ocp.models import OCPCostSummaryByNodeP
@@ -33,6 +34,12 @@ from reporting.provider.ocp.models import OCPVolumeSummaryP
 
 class OCPProviderMap(ProviderMap):
     """OCP Provider Map."""
+
+    @cached_property
+    def check_unleash_for_tag_column_cost_3038(self):
+        if is_feature_cost_3083_all_labels_enabled(self._schema_name):
+            return "all_labels"
+        return "pod_labels"
 
     def __cost_model_cost(self, cost_model_rate_type=None):
         """Return ORM term for cost model cost"""
@@ -165,7 +172,7 @@ class OCPProviderMap(ProviderMap):
                 "tag_column": "pod_labels",  # default for if a report type does not have a tag_column
                 "report_type": {
                     "costs": {
-                        "tag_column": "all_labels",
+                        "tag_column": self.check_unleash_for_tag_column_cost_3038,
                         "tables": {"query": OCPUsageLineItemDailySummary},
                         "aggregates": {
                             "sup_raw": Sum(Value(0, output_field=DecimalField())),
@@ -215,7 +222,7 @@ class OCPProviderMap(ProviderMap):
                         "sum_columns": ["cost_total", "infra_total", "sup_total"],
                     },
                     "costs_by_project": {
-                        "tag_column": "all_labels",
+                        "tag_column": self.check_unleash_for_tag_column_cost_3038,
                         "tables": {"query": OCPUsageLineItemDailySummary},
                         "aggregates": {
                             "sup_raw": Sum(Value(0, output_field=DecimalField())),

--- a/koku/api/report/test/ocp/test_views.py
+++ b/koku/api/report/test/ocp/test_views.py
@@ -1114,6 +1114,7 @@ class OCPReportViewTest(IamTestCase):
                 result = data_totals.get(key, {}).get("value")
             self.assertEqual(result, expected)
 
+    @patch("api.report.ocp.provider_map.is_feature_cost_3083_all_labels_enabled", return_value=True)
     def test_execute_costs_query_with_tag_filter(self):
         """Test that data is filtered by tag key."""
         url = "?filter[type]=pod&filter[time_scope_value]=-10&filter[enabled]=true"

--- a/koku/masu/processor/__init__.py
+++ b/koku/masu/processor/__init__.py
@@ -151,3 +151,11 @@ def is_feature_cost_3592_tag_mapping_enabled(account):
     account = convert_account(account)
     context = {"schema": account}
     return UNLEASH_CLIENT.is_enabled(unleash_flag, context, fallback_development_true)
+
+
+def is_feature_cost_3083_all_labels_enabled(account):
+    """Should all labels column be enabled."""
+    unleash_flag = "cost-management.backend.feature-cost-3083-all-labels"
+    account = convert_account(account)
+    context = {"schema": account}
+    return UNLEASH_CLIENT.is_enabled(unleash_flag, context, fallback_development_true)


### PR DESCRIPTION
## Jira Ticket

[COST-4759](https://issues.redhat.com/browse/COST-4759)

## Description

This change will add the unleash flag for the all labels field back to the ocp provider map.

## Testing

1. Checkout Branch
2. Enable unleash flag
3. Hit endpoint and see that the all labels field is used.

## Release Notes
- [ ] proposed release note

```markdown
* [COST-4759](https://issues.redhat.com/browse/COST-4759) Add unleash flag for all labels field
```
