### PR TITLE
[COST-4807] fix CWE-547 false positive

### DIFF
--- a/koku/providers/provider_errors.py
+++ b/koku/providers/provider_errors.py
@@ -103,7 +103,7 @@ class ProviderErrors:
         "The provided client secret keys for this source are expired. "
         "In Azure, refresh your client secret and try again."
     )
-    AZURE_INCORRECT_CLIENT_SECRET_MESSAGE = (
+    AZURE_CLIENT_SECRET_INCORRECT_MESSAGE = (
         "A problem has been detected with the Azure client secret for this source. "
         "Refer to the Microsoft Azure troubleshooting guide in the cost management documentation for details."
     )

--- a/koku/sources/sources_error_message.py
+++ b/koku/sources/sources_error_message.py
@@ -23,7 +23,7 @@ class SourcesErrorMessage:
         """Azure client error messages."""
         scrubbed_message = ProviderErrors.AZURE_GENERAL_CLIENT_ERROR_MESSAGE
         if any(test in message for test in ["http error: 401", "Authentication failed", "(401) Unauthorized"]):
-            scrubbed_message = ProviderErrors.AZURE_INCORRECT_CLIENT_SECRET_MESSAGE
+            scrubbed_message = ProviderErrors.AZURE_CLIENT_SECRET_INCORRECT_MESSAGE
         if "AADSTS700016" in message:
             scrubbed_message = ProviderErrors.AZURE_INCORRECT_CLIENT_ID_MESSAGE
         if "AADSTS90002" in message:

--- a/koku/sources/test/test_sources_error_message.py
+++ b/koku/sources/test/test_sources_error_message.py
@@ -52,12 +52,12 @@ class SourcesErrorMessageTest(TestCase):
             {
                 "key": ProviderErrors.AZURE_CLIENT_ERROR,
                 "internal_message": ", AdalError: Get Token request returned http error: 401 and server response:",
-                "expected_message": ProviderErrors.AZURE_INCORRECT_CLIENT_SECRET_MESSAGE,
+                "expected_message": ProviderErrors.AZURE_CLIENT_SECRET_INCORRECT_MESSAGE,
             },
             {
                 "key": ProviderErrors.AZURE_CLIENT_ERROR,
                 "internal_message": "Authentication failed",
-                "expected_message": ProviderErrors.AZURE_INCORRECT_CLIENT_SECRET_MESSAGE,
+                "expected_message": ProviderErrors.AZURE_CLIENT_SECRET_INCORRECT_MESSAGE,
             },
             {
                 "key": ProviderErrors.AZURE_CLIENT_ERROR,
@@ -65,7 +65,7 @@ class SourcesErrorMessageTest(TestCase):
                     "(401) Unauthorized. Request ID: cca1a5a4-4107-4e7a-b3b4-b88f31e6a674\n"
                     "Code: 401\nMessage: Unauthorized. Request ID: cca1a5a4-4107-4e7a-b3b4-b88f31e6a674"
                 ),
-                "expected_message": ProviderErrors.AZURE_INCORRECT_CLIENT_SECRET_MESSAGE,
+                "expected_message": ProviderErrors.AZURE_CLIENT_SECRET_INCORRECT_MESSAGE,
             },
             {
                 "key": ProviderErrors.AZURE_CLIENT_ERROR,


### PR DESCRIPTION
## Jira Ticket

[COST-4807](https://issues.redhat.com/browse/COST-4807)

## Description

`AZURE_INCORRECT_CLIENT_SECRET_MESSAGE` is incorrectly identified as a hard-coded secret. This PR changes this constant's name which Snyk does not identify as a hard-coded secret.

## Testing

1. azure smokes

## Release Notes
- [x] proposed release note

```markdown
* [COST-4807](https://issues.redhat.com/browse/COST-4807) rename constant to prevent CWE-547 false-positive
```
