### PR TITLE
[COST-4814] Tag mapping inconsistent ordering.

### DIFF
--- a/koku/api/settings/tags/mapping/query_handler.py
+++ b/koku/api/settings/tags/mapping/query_handler.py
@@ -5,6 +5,7 @@
 """Query handler for Tag Mappings."""
 import dataclasses
 import uuid
+from collections import OrderedDict
 from typing import Union
 
 
@@ -24,7 +25,8 @@ class Relationship:
     def create_list_of_relationships(
         cls, data: list[dict[str : dict[str, Union[uuid.UUID, str]]]]
     ) -> list["Relationship"]:
-        result = {}
+        result = OrderedDict()
+
         for item in data:
             parent = TagKey(**item["parent"])
             child = TagKey(**item["child"])


### PR DESCRIPTION
## Jira Ticket

[COST-4814](https://issues.redhat.com/browse/COST-4814)

## Description

Switch to an ordered dictionary to maintain the orders applied to the query.

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Release Notes
- [ ] proposed release note

```markdown
* [COST-4814](https://issues.redhat.com/browse/COST-4814) Fix inconsistent ordering
```
