### PR TITLE
[COST-4835] validate tag uuids

### DIFF
--- a/koku/api/settings/tags/mapping/view.py
+++ b/koku/api/settings/tags/mapping/view.py
@@ -26,6 +26,7 @@ from api.settings.tags.mapping.serializers import ViewOptionsSerializer
 from api.settings.tags.mapping.utils import resummarize_current_month_by_tag_keys
 from api.settings.tags.mapping.utils import retrieve_tag_rate_mapping
 from api.settings.tags.mapping.utils import TagMappingFilters
+from api.settings.tags.serializers import SettingsTagIDSerializer
 from api.settings.utils import NonValidatedMultipleChoiceFilter
 from reporting.provider.all.models import EnabledTagKeys
 from reporting.provider.all.models import TagMapping
@@ -136,6 +137,8 @@ class SettingsTagMappingChildRemoveView(APIView):
 
     def put(self, request: Request):
         children_uuids = request.data.get("ids", [])
+        serializer = SettingsTagIDSerializer(data={"id_list": children_uuids})
+        serializer.is_valid(raise_exception=True)
         if not TagMapping.objects.filter(child__uuid__in=children_uuids).exists():
             return Response({"detail": "Invalid children UUIDs."}, status=status.HTTP_400_BAD_REQUEST)
         TagMapping.objects.filter(child__in=children_uuids).delete()
@@ -148,6 +151,8 @@ class SettingsTagMappingParentRemoveView(APIView):
 
     def put(self, request: Request):
         parents_uuid = request.data.get("ids", [])
+        serializer = SettingsTagIDSerializer(data={"id_list": parents_uuid})
+        serializer.is_valid(raise_exception=True)
         if not TagMapping.objects.filter(parent__uuid__in=parents_uuid).exists():
             return Response({"detail": "Invalid parents UUIDs."}, status=status.HTTP_400_BAD_REQUEST)
         # We should resummarize based on the child uuids since they were the ones replaced.

--- a/koku/api/settings/test/tags/mappings/test_view.py
+++ b/koku/api/settings/test/tags/mappings/test_view.py
@@ -146,6 +146,13 @@ class TestSettingsTagMappingView(MasuTestCase):
         response = self.client.put(url, data, format="json", **self.headers)
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
+    def test_put_method_remove_children_invalid_uuid(self):
+        """Test removing children invalid uuids."""
+        url = reverse("tags-mapping-child-remove")
+        data = {"ids": ["gibberish"]}
+        response = self.client.put(url, data, format="json", **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
     def test_put_method_remove_parent(self):
         """Test removing parent."""
         url = reverse("tags-mapping-child-add")
@@ -160,6 +167,13 @@ class TestSettingsTagMappingView(MasuTestCase):
         data = {"ids": [self.enabled_uuid_list[0]]}
         response = self.client.put(url, data, format="json", **self.headers)
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_put_method_remove_parent_invalid_uuid(self):
+        """Test removing parents invalid uuid."""
+        url = reverse("tags-mapping-parent-remove")
+        data = {"ids": ["gibberish"]}
+        response = self.client.put(url, data, format="json", **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_filter_by_source_type(self):
         """Test the filter by source_type."""


### PR DESCRIPTION
## Jira Ticket

[COST-4835](https://issues.redhat.com/browse/COST-4835)

## Description

This change will validate UUIDs in PUT requests to 
```
settings/tags/mappings/parent/remove/
settings/tags/mappings/child/remove/
```

- [x] add unit tests

## Testing

1. PUT request to:
```
$ curl --location --request PUT 'http://localhost:8000/api/cost-management/v1/settings/tags/mappings/parent/remove/' \
--header 'Content-Type: application/json' \
--data '{
   "ids": ["insert-nonsense"]
}
'
{"errors":[{"detail":"invalid uuid supplied.","source":"id_list.0","status":400}]}
```
See the 400 status (this is a 500 on main)
2. PUT request to remove child:
```
$ curl --location --request PUT 'http://localhost:8000/api/cost-management/v1/settings/tags/mappings/child/remove/' \
--header 'Content-Type: application/json' \
--data '{
   "ids": ["insert-nonsense"]
}
'

{"errors":[{"detail":"invalid uuid supplied.","source":"id_list.0","status":400}]}
```
See 400 status (this is a 500 on main)

## Release Notes
- [x] proposed release note

```markdown
* [[COST-4835](https://issues.redhat.com/browse/COST-4835)] Validate UUIDs when removing parent/child tags in tag-mapping
```
