### PR TITLE
Upgrade Codecov action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,6 +276,7 @@ jobs:
           flags: unittests
           name: Python-${{ matrix.python-version}}
           fail_ci_if_error: true
+          plugin: pycoverage  # Only run one plugin even though we don't want any to run.
 
       - name: Set Codecov job status on skipped tests
         if: needs.changed-files.outputs.run_tests != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,11 +269,12 @@ jobs:
       - name: Upload coverage to Codecov
         if: needs.changed-files.outputs.run_tests == 'true'
         uses: codecov/codecov-action@v3.1.1
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           file: ./coverage.xml
           flags: unittests
           name: Python-${{ matrix.python-version}}
-          # token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
 
       - name: Set Codecov job status on skipped tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,7 +268,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: needs.changed-files.outputs.run_tests == 'true'
-        uses: codecov/codecov-action@v3.1.1
+        uses: codecov/codecov-action@v4.2.0
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:


### PR DESCRIPTION
## Description

This is more direct than relying on option parsing in the Codecov action.

Unfortunately, Codecov has moved to requiring a token for uploads. In practice, this breaks coverage uploads from PRs from forks since they do not have access to secrets even though they have stated this should work for public repos.

We don't have OIDC setup so that's not feasible for us at the moment.

Related to 
https://github.com/codecov/feedback/issues/112
https://github.com/codecov/feedback/issues/315

## Release Notes
- [ ] proposed release note

```markdown
* [COST-####](https://issues.redhat.com/browse/COST-####) Fix some things
```
