### PR TITLE
rename components to trino in smoke_test.sh

### DIFF
--- a/smoke_test.sh
+++ b/smoke_test.sh
@@ -4,8 +4,8 @@ set -ex
 IMAGE="quay.io/cloudservices/koku"
 APP_NAME="hccm"  # name of app-sre "application" folder this component lives in
 COMPONENT_NAME="koku"  # name of app-sre "resourceTemplate" in deploy.yaml for this component
-COMPONENTS="hive-metastore koku presto"  # specific components to deploy (optional, default: all)
-COMPONENTS_W_RESOURCES="hive-metastore koku presto"  # components which should preserve resource settings (optional, default: none)
+COMPONENTS="hive-metastore koku trino"  # specific components to deploy (optional, default: all)
+COMPONENTS_W_RESOURCES="hive-metastore koku trino"  # components which should preserve resource settings (optional, default: none)
 IQE_PLUGINS="cost_management"
 IQE_MARKER_EXPRESSION="cost_smoke"
 IQE_FILTER_EXPRESSION=""


### PR DESCRIPTION
## Description

This change will rename the components from presto to trino in the `smoke_test.sh` script.

## Release Notes
- [ ] proposed release note

No release note needed.
