### PR TITLE
[COST-4626] strip `acct` from schema in parquet converter

### DIFF
--- a/koku/masu/api/upgrade_trino/util/verify_parquet_files.py
+++ b/koku/masu/api/upgrade_trino/util/verify_parquet_files.py
@@ -8,7 +8,6 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 from botocore.exceptions import ClientError
 from django.conf import settings
-from django_tenants.utils import schema_context
 
 from api.common import log_json
 from api.provider.models import Provider
@@ -114,10 +113,9 @@ class VerifyParquetFiles:
         """
         generates the s3 path prefixes.
         """
-        with schema_context(self.schema_name):
-            ocp_on_cloud_check = Provider.objects.filter(
-                infrastructure__infrastructure_provider__uuid=self.provider_uuid
-            ).exists()
+        ocp_on_cloud_check = Provider.objects.filter(
+            infrastructure__infrastructure_provider__uuid=self.provider_uuid
+        ).exists()
         path_prefixes = set()
         for report_type in self.report_types:
             path_prefixes.add(self._parquet_path_s3(bill_date, report_type))

--- a/koku/masu/api/upgrade_trino/util/verify_parquet_files.py
+++ b/koku/masu/api/upgrade_trino/util/verify_parquet_files.py
@@ -29,7 +29,7 @@ class VerifyParquetFiles:
     S3_PREFIX_LOG_KEY = "s3_prefix"
 
     def __init__(self, schema_name, provider_uuid, provider_type, simulate, bill_date, cleaned_column_mapping):
-        self.schema_name = schema_name
+        self.schema_name = schema_name.replace("acct", "")
         self.provider_uuid = uuid.UUID(provider_uuid)
         self.provider_type = provider_type.replace("-local", "")
         self.simulate = simulate


### PR DESCRIPTION
## Jira Ticket

[COST-4626](https://issues.redhat.com/browse/COST-4626)

## Description

For schema that start with `acct`, the `acct` is not part of the s3 path. This needs to be stripped for the parquet conversion to succeed for these schema.

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Release Notes
- [x] proposed release note

```markdown
* [COST-4626](https://issues.redhat.com/browse/COST-4626) remove `acct` from schema when converting parquet files
```
