### PR TITLE
[COST-4626] bump parquet converter version

### DIFF
--- a/koku/masu/api/upgrade_trino/util/constants.py
+++ b/koku/masu/api/upgrade_trino/util/constants.py
@@ -2,7 +2,7 @@ from common.enum import StrEnum
 
 # Update this to trigger the converter to run again
 # even if marked as successful
-CONVERTER_VERSION = "1"
+CONVERTER_VERSION = "2"
 
 
 class ConversionContextKeys(StrEnum):


### PR DESCRIPTION
## Jira Ticket

[COST-4626](https://issues.redhat.com/browse/COST-4626)

## Description

This change will bump the converter version so that files can be re-converted after #5039 was merged.

## Release Notes
- [x] proposed release note

```markdown
* [[COST-4626](https://issues.redhat.com/browse/COST-4626)] bump parquet converter version
```
