### PR TITLE
update sqlparse and gunicorn

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -34,7 +34,7 @@ google-api-python-client = ">=1.12.4"
 google-auth = ">=1.22.1"
 google-cloud-bigquery = ">=2.2.0"
 google-cloud-storage = "*"
-gunicorn = ">=20.0"
+gunicorn = "*"
 ibm-cloud-sdk-core = ">=3.5.2"
 ibm-platform-services = ">=0.17.8"
 jinjasql2 = "*"
@@ -58,6 +58,7 @@ trino = "*"
 unleashclient = "<5"  # new version breaks for unknown reason
 watchtower = "==1.0.6"  # new version breaks for unknown reason
 whitenoise = ">=5.0"
+sqlparse = "*"
 
 [dev-packages]
 argh = ">=0.26.2"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "5f83cd3699d9f37dd9ca68412c10e51782efe4ec41768720290d2e3bebec9cbe"
+            "sha256": "1a7bf61a88ed7060abb550ed657c1eedaf361a2660515f9c042a5056f03a7a41"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -859,12 +859,12 @@
         },
         "gunicorn": {
             "hashes": [
-                "sha256:3213aa5e8c24949e792bcacfc176fef362e7aac80b76c56f6b5122bf350722f0",
-                "sha256:88ec8bff1d634f98e61b9f65bc4bf3cd918a90806c6f5c48bc5603849ec81033"
+                "sha256:350679f91b24062c86e386e198a15438d53a7a8207235a78ba1b53df4c4378d9",
+                "sha256:4a0b436239ff76fb33f11c07a16482c521a7e09c1ce3cc293c2330afe01bec63"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.5'",
-            "version": "==21.2.0"
+            "markers": "python_version >= '3.7'",
+            "version": "==22.0.0"
         },
         "httplib2": {
             "hashes": [
@@ -3330,11 +3330,12 @@
         },
         "sqlparse": {
             "hashes": [
-                "sha256:5430a4fe2ac7d0f93e66f1efc6e1338a41884b7ddf2a350cedd20ccc4d9d28f3",
-                "sha256:d446183e84b8349fa3061f0fe7f06ca94ba65b426946ffebe6e3e8295332420c"
+                "sha256:714d0a4932c059d16189f58ef5411ec2287a4360f17cdd0edd2d09d4c5087c93",
+                "sha256:c204494cd97479d0e39f28c93d46c0b2d5959c7b9ab904762ea6c7af211c8663"
             ],
-            "markers": "python_version >= '3.5'",
-            "version": "==0.4.4"
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==0.5.0"
         },
         "tabulate": {
             "hashes": [


### PR DESCRIPTION
## Jira Ticket

[COST-4937](https://issues.redhat.com/browse/COST-4937)

## Description

For some reason #5043 only updated the non-dev sqlparse (so it did not address the dependabot alert...). This PR updates the dev sqlparse as well as gunicorn.

## Testing

1. smokes

## Release Notes
- [x] proposed release note

```markdown
* [COST-4937](https://issues.redhat.com/browse/COST-4937) upgrade gunicorn
```
