### PR TITLE
[COST-4947] Remove account and region from ProviderInfrastructureMap filter

### DIFF
--- a/koku/masu/processor/ocp/ocp_cloud_updater_base.py
+++ b/koku/masu/processor/ocp/ocp_cloud_updater_base.py
@@ -143,8 +143,6 @@ class OCPCloudUpdaterBase:
                 infra = ProviderInfrastructureMap.objects.filter(
                     infrastructure_provider_id=infra_tuple[0],
                     infrastructure_type=infra_tuple[1],
-                    infrastructure_account=infra_tuple[2],
-                    infrastructure_region=infra_tuple[3],
                 ).first()
             if not infra:
                 continue


### PR DESCRIPTION
## Jira Ticket

[COST-4947](https://issues.redhat.com/browse/COST-4947)

## Description

This change will remove account and region from the filter for ProviderInfrastructureMap objects when setting infrastructure on a provider object.

## Testing

1. Checkout Main
2. Restart Koku
3. Create test customer data: `make create-test-customer`
4. Create a ProviderInfrastructureMap record for your cloud provider source (i chose AWS) replacing your UUID.
```
INSERT INTO api_providerinfrastructuremap (infrastructure_provider_id, infrastructure_type, infrastructure_account, infrastructure_region) VALUES ('90d1a57d-74f0-4818-9d0a-5e4a5855ee03', 'AWS', '', '');
```
5. Load the test customer data that goes with your cloud source.
6. Check the logs for the messages about a cluster running on infrastructure like below:
```
koku-worker-1  | [2024-04-17 13:48:16,800] INFO a3c1b718-51b8-42ba-baae-f483c1c91a24 42 {'message': 'checking if OCP cluster is running on cloud infrastructure', 'tracing_id': '', 'schema': 'org1234567', 'provider_uuid': 'd03a9693-106d-43f5-a9d5-0540a33c11a6', 'cluster_id': 'my-ocp-cluster-1', 'cluster_alias': 'Test OCP on AWS'}
...
koku-worker-1  | [2024-04-17 13:48:17,060] INFO a3c1b718-51b8-42ba-baae-f483c1c91a24 42 {'message': 'executing trino sql', 'tracing_id': '', 'schema': 'org1234567', 'start_date': datetime.date(2024, 4, 1), 'end_date': datetime.date(2024, 4, 17), 'log_ref': 'reporting_ocpinfrastructure_provider_map.sql'}
...
koku-worker-1  | [2024-04-17 13:48:17,628] INFO a3c1b718-51b8-42ba-baae-f483c1c91a24 42 {'message': 'OCP cluster is running on cloud infrastructure', 'tracing_id': '', 'schema': 'org1234567', 'provider_uuid': 'd03a9693-106d-43f5-a9d5-0540a33c11a6', 'cluster_id': 'my-ocp-cluster-1', 'cluster_alias': 'Test OCP on AWS', 'ocp_provider_uuid': 'd03a9693-106d-43f5-a9d5-0540a33c11a6', 'infra_provider_uuid': '90d1a57d-74f0-4818-9d0a-5e4a5855ee03', 'infra_provider_type': 'AWS-local'}
```
7. Go to the sources endpoint and view your cluster and verify it DOES NOT show an infrastructure for the cluster.
8. Checkout this branch
9. Repeat steps 5 and 6, this time when you go to the sources endpoint you will notice the cluster HAS been updated with the correct infrastructure.

## Release Notes
- [x] proposed release note

```markdown
* [COST-4947](https://issues.redhat.com/browse/COST-4947) Remove account and region from ProviderInfrastructureMap filter so an OCP provider can correctly be correlated to its infrastructure if region and account don't match.
```
