### PR TITLE
[COST-4947] Remove references to region and account in ProviderInfrastructureMap

### DIFF
--- a/koku/api/provider/provider_manager.py
+++ b/koku/api/provider/provider_manager.py
@@ -198,8 +198,6 @@ class ProviderManager:
                     "type": self.model.infrastructure.infrastructure_type,
                     "uuid": self.model.infrastructure.infrastructure_provider_id,
                     "id": source.source_id,
-                    "account": self.model.infrastructure.infrastructure_account,
-                    "region": self.model.infrastructure.infrastructure_region,
                     "last_polling_time": self.get_last_polling_time(
                         self.model.infrastructure.infrastructure_provider_id
                     ),

--- a/koku/api/provider/test/test_provider_manager.py
+++ b/koku/api/provider/test/test_provider_manager.py
@@ -707,13 +707,8 @@ class ProviderManagerTest(IamTestCase):
         credentials = {"cluster_id": "cluster_id_1001"}
         provider_authentication = ProviderAuthentication.objects.create(credentials=credentials)
         aws_provider = Provider.objects.filter(type="AWS-local").first()
-        account = "account"
-        region = "west"
         infrastructure = ProviderInfrastructureMap.objects.create(
-            infrastructure_type=Provider.PROVIDER_AWS,
-            infrastructure_provider=aws_provider,
-            infrastructure_account=account,
-            infrastructure_region=region,
+            infrastructure_type=Provider.PROVIDER_AWS, infrastructure_provider=aws_provider
         )
         with patch("masu.celery.tasks.check_report_updates"):
             provider = Provider.objects.create(
@@ -731,21 +726,16 @@ class ProviderManagerTest(IamTestCase):
             infrastructure_info = manager.get_infrastructure_info()
             self.assertEqual(infrastructure_info.get("type", ""), Provider.PROVIDER_AWS)
             self.assertEqual(infrastructure_info.get("uuid", ""), aws_provider.uuid)
-            self.assertEqual(infrastructure_info.get("account", ""), account)
-            self.assertEqual(infrastructure_info.get("region", ""), region)
 
     def test_ocp_on_azure_infrastructure_type(self):
         """Test that the provider infrastructure returns Azure when running on Azure."""
         credentials = {"cluster_id": "cluster_id_1002"}
         provider_authentication = ProviderAuthentication.objects.create(credentials=credentials)
         azure_provider = Provider.objects.filter(type="Azure-local").first()
-        account = "account"
-        region = "west"
+
         infrastructure = ProviderInfrastructureMap.objects.create(
             infrastructure_type=Provider.PROVIDER_AZURE,
             infrastructure_provider=azure_provider,
-            infrastructure_account=account,
-            infrastructure_region=region,
         )
         with patch("masu.celery.tasks.check_report_updates"):
             provider = Provider.objects.create(
@@ -762,8 +752,6 @@ class ProviderManagerTest(IamTestCase):
             infrastructure_info = manager.get_infrastructure_info()
             self.assertEqual(infrastructure_info.get("type", ""), Provider.PROVIDER_AZURE)
             self.assertEqual(infrastructure_info.get("uuid", ""), azure_provider.uuid)
-            self.assertEqual(infrastructure_info.get("account", ""), account)
-            self.assertEqual(infrastructure_info.get("region", ""), region)
 
     def test_ocp_infrastructure_type(self):
         """Test that the provider infrastructure returns Unknown when running stand alone."""

--- a/koku/api/report/test/util/model_bakery_loader.py
+++ b/koku/api/report/test/util/model_bakery_loader.py
@@ -154,8 +154,6 @@ class ModelBakeryDataLoader(DataLoader):
                     "ProviderInfrastructureMap",
                     infrastructure_type=provider_type,
                     infrastructure_provider=provider,
-                    infrastructure_account="account",
-                    infrastructure_region="east",
                 )
                 linked_openshift_provider.infrastructure = infra_map
                 linked_openshift_provider.save()

--- a/koku/masu/api/sources/serializers.py
+++ b/koku/masu/api/sources/serializers.py
@@ -33,8 +33,6 @@ class ProviderInfrastructureSerializer(serializers.Serializer):
     id = serializers.IntegerField()
     infrastructure_type = serializers.CharField()
     infrastructure_provider_id = serializers.UUIDField()
-    infrastructure_account = serializers.CharField()
-    infrastructure_region = serializers.CharField()
 
 
 class ProviderAuthenticationSerializer(serializers.ModelSerializer):

--- a/koku/masu/api/sources/test/test_serializers.py
+++ b/koku/masu/api/sources/test/test_serializers.py
@@ -70,8 +70,6 @@ class SourceSerializerTest(MasuTestCase):
                     "id": infrastructure.id,
                     "infrastructure_type": infrastructure.infrastructure_type,
                     "infrastructure_provider_id": infrastructure.infrastructure_provider_id,
-                    "infrastructure_account": infrastructure.infrastructure_account,
-                    "infrastructure_region": infrastructure.infrastructure_region,
                 }
                 infrastructure_serializer = ProviderInfrastructureSerializer(
                     data=infrastructure_data, context=self.request_context

--- a/koku/masu/database/ocp_report_db_accessor.py
+++ b/koku/masu/database/ocp_report_db_accessor.py
@@ -205,8 +205,8 @@ class OCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
                 for entry in results:
                     # This dictionary is keyed on an OpenShift provider UUID
                     # and the tuple contains
-                    # (Infra Provider UUID, Infra Provider Type, Infra account number, Infra region)
-                    db_results[entry[0]] = (entry[1], entry[2], entry[3], entry[4])
+                    # (Infra Provider UUID, Infra Provider Type)
+                    db_results[entry[0]] = (entry[1], entry[2])
                 if db_results:
                     # An OCP cluster can only run on a single source, so stop here if we found a match
                     return db_results

--- a/koku/masu/database/trino_sql/aws/reporting_ocpinfrastructure_provider_map.sql
+++ b/koku/masu/database/trino_sql/aws/reporting_ocpinfrastructure_provider_map.sql
@@ -1,9 +1,7 @@
 
 WITH cte_aws_resource_ids AS (
     SELECT DISTINCT lineitem_resourceid,
-        aws.source,
-        aws.bill_payeraccountid,
-        aws.product_region
+        aws.source
     FROM hive.{{schema | sqlsafe}}.aws_line_items_daily AS aws
     WHERE aws.lineitem_usagestartdate >= {{start_date}}
         AND aws.lineitem_usagestartdate < date_add('day', 1, {{end_date}})
@@ -31,9 +29,7 @@ cte_ocp_resource_ids AS (
 )
 SELECT DISTINCT ocp.source as ocp_uuid,
     aws.source as infra_uuid,
-    api_provider.type as type,
-    aws.bill_payeraccountid as account,
-    aws.product_region as region
+    api_provider.type as type
 FROM cte_aws_resource_ids AS aws
 JOIN cte_ocp_resource_ids AS ocp
     ON strpos(aws.lineitem_resourceid, ocp.resource_id) != 0

--- a/koku/masu/database/trino_sql/azure/reporting_ocpinfrastructure_provider_map.sql
+++ b/koku/masu/database/trino_sql/azure/reporting_ocpinfrastructure_provider_map.sql
@@ -1,9 +1,7 @@
 
 WITH cte_azure_instances AS (
     SELECT DISTINCT split_part(coalesce(nullif(azure.resourceid, ''), azure.instanceid), '/', 9) as instance,
-        azure.source,
-        coalesce(nullif(azure.subscriptionid, ''), azure.subscriptionguid) as subscription,
-        azure.resourcelocation
+        azure.source
     FROM hive.{{schema | sqlsafe}}.azure_line_items AS azure
     WHERE coalesce(azure.date, azure.usagedatetime) >= {{start_date}}
         AND coalesce(azure.date, azure.usagedatetime) < date_add('day', 1, {{end_date}})
@@ -29,9 +27,7 @@ cte_ocp_nodes AS (
 )
 SELECT DISTINCT ocp.source as ocp_uuid,
     azure.source as infra_uuid,
-    api_provider.type as type,
-    azure.subscription as subscription,
-    azure.resourcelocation as region
+    api_provider.type as type
 FROM cte_azure_instances AS azure
 JOIN cte_ocp_nodes AS ocp
     ON ocp.node = azure.instance

--- a/koku/masu/processor/ocp/ocp_cloud_updater_base.py
+++ b/koku/masu/processor/ocp/ocp_cloud_updater_base.py
@@ -136,8 +136,6 @@ class OCPCloudUpdaterBase:
                 infra, _ = ProviderInfrastructureMap.objects.get_or_create(
                     infrastructure_provider_id=infra_tuple[0],
                     infrastructure_type=infra_tuple[1],
-                    infrastructure_account=infra_tuple[2],
-                    infrastructure_region=infra_tuple[3],
                 )
             except IntegrityError:
                 infra = ProviderInfrastructureMap.objects.filter(

--- a/koku/masu/test/processor/ocp/test_ocp_cloud_parquet_report_summary_updater.py
+++ b/koku/masu/test/processor/ocp/test_ocp_cloud_parquet_report_summary_updater.py
@@ -513,11 +513,9 @@ class OCPCloudParquetReportSummaryUpdaterTest(MasuTestCase):
         """Test set_provider_infra_map."""
         infra_uuid = self.aws_provider_uuid
         infra_type = self.aws_provider.type
-        infra_account = "account"
-        infra_region = "east"
         p: Provider = self.baker.make("Provider", type=Provider.PROVIDER_OCP)
 
-        infra_map = {str(p.uuid): (infra_uuid, infra_type, infra_account, infra_region)}
+        infra_map = {str(p.uuid): (infra_uuid, infra_type)}
         expected_infra = ProviderInfrastructureMap.objects.get(infrastructure_provider_id=infra_uuid)
 
         updater = OCPCloudParquetReportSummaryUpdater(schema=self.schema, provider=p, manifest=None)
@@ -542,14 +540,12 @@ class OCPCloudParquetReportSummaryUpdaterTest(MasuTestCase):
         """Test set_provider_infra_map does not raise exception when providermap is not found."""
         infra_uuid = self.aws_provider_uuid
         infra_type = self.aws_provider.type
-        infra_account = "account"
-        infra_region = "east"
         p: Provider = self.baker.make("Provider", type=Provider.PROVIDER_OCP)
 
         mock_map.get_or_create.side_effect = IntegrityError()
         mock_map.filter.return_value.first.return_value = None
 
-        infra_map = {str(p.uuid): (infra_uuid, infra_type, infra_account, infra_region)}
+        infra_map = {str(p.uuid): (infra_uuid, infra_type)}
 
         updater = OCPCloudParquetReportSummaryUpdater(schema=self.schema, provider=p, manifest=None)
         try:
@@ -561,12 +557,10 @@ class OCPCloudParquetReportSummaryUpdaterTest(MasuTestCase):
         """Test set_provider_infra_map during race condition creating map."""
         infra_uuid = self.aws_provider_uuid
         infra_type = self.aws_provider.type
-        infra_account = "account"
-        infra_region = "east"
         p: Provider = self.baker.make("Provider", type=Provider.PROVIDER_OCP)
         expected_infra = ProviderInfrastructureMap.objects.get(infrastructure_provider_id=infra_uuid)
 
-        infra_map = {str(p.uuid): (infra_uuid, infra_type, infra_account, infra_region)}
+        infra_map = {str(p.uuid): (infra_uuid, infra_type)}
         updater = OCPCloudParquetReportSummaryUpdater(schema=self.schema, provider=p, manifest=None)
         with patch("masu.processor.ocp.ocp_cloud_updater_base.ProviderInfrastructureMap.objects") as mock_map:
             mock_map.get_or_create.side_effect = IntegrityError()


### PR DESCRIPTION
## Jira Ticket

[COST-4947](https://issues.redhat.com/browse/COST-4947)

## Description

This change will remove references to account and region for ProviderInfrastructureMap objects.

## Testing

Units and Smokes should be fine here.

## Release Notes
- [x] proposed release note

```markdown
* [COST-4947](https://issues.redhat.com/browse/COST-4947) Remove references to ProviderInfrastructureMap in preparation for deleting it.
```
