### PR TITLE
[COST-4873] update ephemeral placeholder credentials

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -4098,9 +4098,6 @@ objects:
   kind: Secret
   metadata:
     name: koku-aws
-  stringData:
-    aws-access-key-id: ${AWS_ACCESS_KEY_ID_EPH}
-    aws-secret-access-key: ${AWS_SECRET_ACCESS_KEY_EPH}
 - apiVersion: v1
   data:
     gcp-credentials: ${GCP_CREDENTIALS_EPH}
@@ -4499,15 +4496,7 @@ parameters:
 - displayName: AWS credentials file
   name: AWS_CREDENTIALS_EPH
   required: true
-  value: aW5zZXJ0LWJhc2U2NC1lbmNvZGVkLXZhbHVl
-- displayName: AWS Access Key ID (Ephemeral)
-  name: AWS_ACCESS_KEY_ID_EPH
-  required: true
-  value: insert-string-value
-- displayName: AWS Secret Access Key (Ephemeral)
-  name: AWS_SECRET_ACCESS_KEY_EPH
-  required: true
-  value: insert-string-value
+  value: W2RlZmF1bHRdCmF3c19hY2Nlc3Nfa2V5X2lkPUFXU19BQ0NFU1NfS0VZX0lECmF3c19zZWNyZXRfYWNjZXNzX2tleT1BV1NfU0VDUkVUX0FDQ0VTU19LRVkK
 - displayName: GCP Credentials (Ephemeral)
   name: GCP_CREDENTIALS_EPH
   required: true
@@ -4519,7 +4508,7 @@ parameters:
 - displayName: OCI Config (Ephemeral)
   name: OCI_CONFIG_EPH
   required: true
-  value: aW5zZXJ0LWJhc2U2NC1lbmNvZGVkLXZhbHVl
+  value: W0RFRkFVTFRdCnVzZXI9b2NpZDEudXNlci5pZApmaW5nZXJwcmludD0wMDAwMDAwMDAwMDAwMDAwMAp0ZW5hbmN5PW9jaWQxLnRlbmFuY3kuaWQK
 - description: Enhanced Org Admin
   displayName: Enhanced Org Admin
   name: ENHANCED_ORG_ADMIN

--- a/deploy/kustomize/base/base.yaml
+++ b/deploy/kustomize/base/base.yaml
@@ -153,9 +153,6 @@ objects:
   kind: Secret # For ephemeral/local environment only
   metadata:
     name: koku-aws
-  stringData:
-    aws-access-key-id: "${AWS_ACCESS_KEY_ID_EPH}"
-    aws-secret-access-key: "${AWS_SECRET_ACCESS_KEY_EPH}"
   data:
     aws-credentials: "${AWS_CREDENTIALS_EPH}"
 - apiVersion: v1
@@ -577,15 +574,7 @@ parameters:
 - displayName: AWS credentials file
   name: AWS_CREDENTIALS_EPH
   required: true
-  value: aW5zZXJ0LWJhc2U2NC1lbmNvZGVkLXZhbHVl
-- name: AWS_ACCESS_KEY_ID_EPH
-  displayName: AWS Access Key ID (Ephemeral)
-  required: true
-  value: insert-string-value
-- name: AWS_SECRET_ACCESS_KEY_EPH
-  displayName: AWS Secret Access Key (Ephemeral)
-  required: true
-  value: insert-string-value
+  value: W2RlZmF1bHRdCmF3c19hY2Nlc3Nfa2V5X2lkPUFXU19BQ0NFU1NfS0VZX0lECmF3c19zZWNyZXRfYWNjZXNzX2tleT1BV1NfU0VDUkVUX0FDQ0VTU19LRVkK
 - name: GCP_CREDENTIALS_EPH
   displayName: GCP Credentials (Ephemeral)
   required: true
@@ -597,7 +586,7 @@ parameters:
 - name: OCI_CONFIG_EPH
   displayName: OCI Config (Ephemeral)
   required: true
-  value: aW5zZXJ0LWJhc2U2NC1lbmNvZGVkLXZhbHVl
+  value: W0RFRkFVTFRdCnVzZXI9b2NpZDEudXNlci5pZApmaW5nZXJwcmludD0wMDAwMDAwMDAwMDAwMDAwMAp0ZW5hbmN5PW9jaWQxLnRlbmFuY3kuaWQK
 - description: Enhanced Org Admin
   displayName: Enhanced Org Admin
   name: ENHANCED_ORG_ADMIN


### PR DESCRIPTION
## Jira Ticket

[COST-4873](https://issues.redhat.com/browse/COST-4873)

## Description

This change replaces the blank ephemeral secret values with values that represent the real credentials files. the previous OCI_CONFIG_EPH value was preventing the pods from starting because the config file was invalid.

```
OCI_CONFIG_EPH:
---
W0RFRkFVTFRdCnVzZXI9b2NpZDEudXNlci5pZApmaW5nZXJwcmludD0wMDAwMDAwMDAwMDAwMDAwMAp0ZW5hbmN5PW9jaWQxLnRlbmFuY3kuaWQK
---
[DEFAULT]
user=ocid1.user.id
fingerprint=00000000000000000
tenancy=ocid1.tenancy.id

---
AWS_CREDENTIALS_EPH:
---
W2RlZmF1bHRdCmF3c19hY2Nlc3Nfa2V5X2lkPUFXU19BQ0NFU1NfS0VZX0lECmF3c19zZWNyZXRfYWNjZXNzX2tleT1BV1NfU0VDUkVUX0FDQ0VTU19LRVkK
---
[default]
aws_access_key_id=AWS_ACCESS_KEY_ID
aws_secret_access_key=AWS_SECRET_ACCESS_KEY
```

## Testing

1. manually deploy to ephemeral and see the pods spin up

## Release Notes
- [x] proposed release note

```markdown
* [COST-4873](https://issues.redhat.com/browse/COST-4873) update ephemeral placeholder credentials
```
