### PR TITLE
[COST-4974] Trino Migration to Drop Azure Line Items

### DIFF
--- a/scripts/cji_scripts/migrate_trino.py
+++ b/scripts/cji_scripts/migrate_trino.py
@@ -163,7 +163,7 @@ def main():
     logging.info(schemas)
 
     tables_to_drop = [
-        "azure_openshift_daily",
+        "azure_line_items",
     ]
     # columns_to_drop = ["ocp_matched"]
     # columns_to_add = {


### PR DESCRIPTION
## Jira Ticket

[COST-4974](https://issues.redhat.com/browse/COST-4974)

## Description

This change will drop the azure line items table to address an issue where an agreement switch could cause columns to be missing.

## Testing

1. Checkout Branch
2. Restart Koku
3. Load azure data
4. Run the trino migration and see the table get dropped

## Release Notes
- [ ] proposed release note

```markdown
* [COST-4974](https://issues.redhat.com/browse/COST-4974) Drop the azure_line_items table so it can be recreated next download.
```
