### PR TITLE
[COST-4967] Update Azure Openshift Correlation to be contains.

### DIFF
--- a/dev/scripts/nise_ymls/ocp_on_azure/azure_static_data.yml
+++ b/dev/scripts/nise_ymls/ocp_on_azure/azure_static_data.yml
@@ -55,6 +55,7 @@ generators:
       end_date: {{end_date}}
       meter_id: 55555555-4444-3333-2222-111111111123
       resource_location: "US North Central"
+      instance_id: '/subscriptions/99999999-9999-9999-9999-999999999999/resourceGroups/koku-99hqd-rg/providers/Microsoft.Compute/disks/azure-cloud-prefix-pvc-volume_2'
       amount: 10
       rate: 0.01
       tags:
@@ -64,6 +65,7 @@ generators:
       end_date: {{end_date}}
       meter_id: 55555555-4444-3333-2222-111111111122
       resource_location: "US North Central"
+      instance_id: '/subscriptions/99999999-9999-9999-9999-999999999999/resourceGroups/koku-99hqd-rg/providers/Microsoft.Compute/disks/pvc-volume_1-azure_cloud_suffix'
       amount: 10
       rate: 0.01
       tags:
@@ -73,6 +75,7 @@ generators:
       end_date: {{end_date}}
       meter_id: 55555555-4444-3333-2222-111111111121
       resource_location: "US North Central"
+      instance_id: '/subscriptions/99999999-9999-9999-9999-999999999999/resourceGroups/koku-99hqd-rg/providers/Microsoft.Compute/disks/pvc-1234567-33333333-3333-3333-3333'
       amount: 10
       rate: 0.01
       tags:

--- a/koku/masu/database/trino_sql/reporting_ocpazurecostlineitem_daily_summary.sql
+++ b/koku/masu/database/trino_sql/reporting_ocpazurecostlineitem_daily_summary.sql
@@ -366,10 +366,11 @@ SELECT azure.uuid as azure_uuid,
     max(azure.month) as month
     FROM hive.{{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary as ocp
     JOIN hive.{{schema | sqlsafe}}.azure_openshift_daily_resource_matched_temp as azure
-        ON azure.usage_start = ocp.usage_start
+        ON (azure.usage_start = ocp.usage_start)
         AND (
-                (azure.resource_id = ocp.node AND ocp.data_source = 'Pod')
-                    OR (azure.resource_id = ocp.persistentvolume AND ocp.data_source = 'Storage')
+                (strpos(azure.resource_id, ocp.node) > 0 AND ocp.data_source = 'Pod')
+            OR
+                (strpos(azure.resource_id, ocp.persistentvolume) > 0 AND ocp.data_source = 'Storage')
             )
     WHERE ocp.source = {{ocp_source_uuid}}
         AND ocp.year = {{year}}


### PR DESCRIPTION
## Jira Ticket

[COST-4967](https://issues.redhat.com/browse/COST-4967)

## Description

This change will update the Azure filtered by OpenShift logic to do a contains using `strpos` instead of doing an exact matching.

The bug is that their are prefixes and suffixes on the Azure instance-ids that are not not part of OCP's persistent volume names for the customer.

Example:
Azure Instance Id: `azure-cloud-prefix-pvc-volume_2`
OpenShift PVC name: `pvc-volume_2`


## Testing

1. Checkout Branch
2. Upload data
3. Run this trino query:
```
select distinct resource_id from reporting_ocpazurecostlineitem_project_daily_summary where service_name='Storage';
```
See the instance_ids that we added that are partial matches:
```
 azure-cloud-prefix-pvc-volume_2
 pvc-volume_1-azure_cloud_suffix
 ```

## Release Notes
- [ ] proposed release note

```markdown
* [COST-####](https://issues.redhat.com/browse/COST-####) Fix some things
```
