### PR TITLE
[COST-4975] - Fix OCP infra state lookup

### DIFF
--- a/koku/api/provider/provider_manager.py
+++ b/koku/api/provider/provider_manager.py
@@ -191,7 +191,7 @@ class ProviderManager:
                         billing_period_start_datetime=self.date_helper.this_month_start,
                         creation_datetime__isnull=False,
                     )
-                    .order_by("creation_datetime")
+                    .order_by("-creation_datetime")
                     .first()
                 )
                 return {


### PR DESCRIPTION
## Jira Ticket

[COST-4975](https://issues.redhat.com/browse/COST-4975)

## Description

This change will switch the manifest lookup for an OCP's linked cloud provider to Desc instead of Asc so the .first() is the latest item.

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Release Notes
- [ ] proposed release note

```markdown
* [COST-4975](https://issues.redhat.com/browse/COST-4975) Fix OCP on Cloud status lookup
```
