### PR TITLE
[COST-4915] Add unattributed distribution to cost model form

### DIFF
--- a/koku/cost_models/test/test_serializers.py
+++ b/koku/cost_models/test/test_serializers.py
@@ -19,6 +19,8 @@ from api.utils import get_currency
 from cost_models.models import CostModel
 from cost_models.models import CostModelMap
 from cost_models.serializers import CostModelSerializer
+from cost_models.serializers import DEFAULT_DISTRIBUTION_INFO
+from cost_models.serializers import DistributionSerializer
 from cost_models.serializers import RateSerializer
 from cost_models.serializers import UUIDKeyRelatedField
 
@@ -844,47 +846,38 @@ class CostModelSerializerTest(IamTestCase):
             if serializer.is_valid(raise_exception=True):
                 instance = serializer.save()
             self.assertIsNotNone(instance)
+            # Add in default options
+            valid_distrib_obj["network_unattributed"] = False
+            valid_distrib_obj["storage_unattributed"] = False
             self.assertEqual(instance.distribution_info, valid_distrib_obj)
 
     def test_invalid_distribution_info_keys(self):
         """Test that source distribution_info object has invalid keys."""
-
-        invalid_distrib_info_keys = {"bad_key": "", "badder_key": True, "worker_cost": False}
-        self.ocp_data["distribution_info"] = invalid_distrib_info_keys
-        self.assertEqual(self.ocp_data["distribution_info"], invalid_distrib_info_keys)
+        bad_key1 = "bad_key"
+        bad_key2 = "worst_key"
+        invalid_distrib_info_keys = {bad_key1: "", bad_key2: True, "worker_cost": False}
         with tenant_context(self.tenant):
-            serializer = CostModelSerializer(data=self.ocp_data, context=self.request_context)
-            with self.assertRaises(serializers.ValidationError):
-                serializer.is_valid(raise_exception=True)
+            serializer = DistributionSerializer(data=invalid_distrib_info_keys)
+            self.assertTrue(serializer.is_valid(raise_exception=True))
+            self.assertNotIn(bad_key1, serializer.data)
+            self.assertNotIn(bad_key2, serializer.data)
 
     def test_none_distribution_info_returns_defaults(self):
         """Test that a none distribution_info object uses default options."""
-
-        default_distrib_info_obj = {
-            "distribution_type": metric_constants.CPU_DISTRIBUTION,
-            "platform_cost": True,
-            "worker_cost": True,
-        }
         with tenant_context(self.tenant):
             instance = None
             serializer = CostModelSerializer(data=self.ocp_data, context=self.request_context)
             if serializer.is_valid(raise_exception=True):
                 instance = serializer.save()
             self.assertIsNotNone(instance)
-            self.assertEqual(instance.distribution_info, default_distrib_info_obj)
+            self.assertEqual(instance.distribution_info, DEFAULT_DISTRIBUTION_INFO)
 
     def test_empty_distribution_info_returns_defaults(self):
         """Test that an empty distribution_info object returns default options."""
-
-        default_distrib_info_obj = {
-            "distribution_type": metric_constants.CPU_DISTRIBUTION,
-            "platform_cost": True,
-            "worker_cost": True,
-        }
         self.ocp_data["distribution_info"] = {}
         with tenant_context(self.tenant):
             instance = None
             serializer = CostModelSerializer(data=self.ocp_data, context=self.request_context)
             if serializer.is_valid(raise_exception=True):
                 instance = serializer.save()
-            self.assertEqual(instance.distribution_info, default_distrib_info_obj)
+            self.assertEqual(instance.distribution_info, DEFAULT_DISTRIBUTION_INFO)


### PR DESCRIPTION
## Jira Ticket

[COST-4915](https://issues.redhat.com/browse/COST-4915)

## Description

This change will add the unattributed distribution options to the cost model. 

## Testing

1. Checkout Branch
2. Load test customer data
3. You should see the new distribution options for our default providers
4. Delete a cost model:
DELETE method to:
`http://127.0.0.1:8000/api/cost-management/v1/cost-models/<cost-model-id>/`
5. Add a cost model:
```
{
  "name": "Cost Management OpenShift Cost Model",
  "description": "A cost model of on-premises OpenShift clusters.",
  "source_type": "OCP",
  "source_uuids": [
    "<your-source-id>"
  ],
  "rates": [
    {
      "metric": {
        "name": "node_cost_per_month",
        "label_metric": "Node",
        "label_measurement": "Currency",
        "label_measurement_unit": "node-month"
      },
      "description": "",
      "tag_rates": {
        "tag_key": "app",
        "tag_values": [
          {
            "unit": "USD",
            "usage": {
              "unit": "USD",
              "usage_end": null,
              "usage_start": null
            },
            "value": 24000,
            "default": true,
            "tag_value": "smoking",
            "description": ""
          },
          {
            "unit": "USD",
            "usage": {
              "unit": "USD",
              "usage_end": null,
              "usage_start": null
            },
            "value": 250,
            "default": false,
            "tag_value": "bigsmoke",
            "description": ""
          }
        ]
      },
      "cost_type": "Supplementary"
    },
    {
      "metric": {
        "name": "node_cost_per_month",
        "label_metric": "Node",
        "label_measurement": "Currency",
        "label_measurement_unit": "node-month"
      },
      "description": "",
      "tag_rates": {
        "tag_key": "app",
        "tag_values": [
          {
            "unit": "USD",
            "usage": {
              "unit": "USD",
              "usage_end": null,
              "usage_start": null
            },
            "value": 123,
            "default": true,
            "tag_value": "smoke",
            "description": ""
          }
        ]
      },
      "cost_type": "Infrastructure"
    },
    {
      "metric": {
        "name": "node_cost_per_month",
        "label_metric": "Node",
        "label_measurement": "Currency",
        "label_measurement_unit": "node-month"
      },
      "description": "",
      "tag_rates": {
        "tag_key": "web",
        "tag_values": [
          {
            "unit": "USD",
            "usage": {
              "unit": "USD",
              "usage_end": null,
              "usage_start": null
            },
            "value": 456,
            "default": true,
            "tag_value": "smoker",
            "description": ""
          }
        ]
      },
      "cost_type": "Infrastructure"
    },
    {
      "metric": {
        "name": "cluster_cost_per_month",
        "label_metric": "Node",
        "label_measurement": "Currency",
        "label_measurement_unit": "node-month"
      },
      "description": "",
      "tag_rates": {
        "tag_key": "app",
        "tag_values": [
          {
            "unit": "USD",
            "usage": {
              "unit": "USD",
              "usage_end": null,
              "usage_start": null
            },
            "value": 456,
            "default": true,
            "tag_value": "smoker",
            "description": ""
          }
        ]
      },
      "cost_type": "Infrastructure"
    }
  ],
  "distribution": "memory",
  "distribution_info": {
      "distribution_type": "memory",
      "platform_cost": true,
      "worker_cost": true,
      "network_unattributed": false,
      "storage_unattributed": true
  }
}
```
6. Check the db:
```
select * from cost_model;
```
Example Return:
```
uuid              | 684987ab-fb3b-4d88-8f8d-a06c29fcc56f
name              | Cost Management OpenShift Cost Model
description       | A cost model of on-premises OpenShift clusters.
source_type       | OCP
created_timestamp | 2024-04-26 20:55:33.460185+00
updated_timestamp | 2024-04-26 20:55:33.460209+00
rates             | [{"metric": {"name": "node_cost_per_month"}, "cost_type": "Supplementary", "tag_rates": {"tag_key": "app", "tag_values": [{"unit": "USD", "usage": {"unit": "USD", "usage_end": null, "usage_start": null}, "value": "24000.0000000000", "default": true, "tag_value": "smoking", "description": ""}, {"unit": "USD", "usage": {"unit": "USD", "usage_end": null, "usage_start": null}, "value": "250.0000000000", "default": false, "tag_value": "bigsmoke", "description": ""}]}, "description": ""}, {"metric": {"name": "node_cost_per_month"}, "cost_type": "Infrastructure", "tag_rates": {"tag_key": "app", "tag_values": [{"unit": "USD", "usage": {"unit": "USD", "usage_end": null, "usage_start": null}, "value": "123.0000000000", "default": true, "tag_value": "smoke", "description": ""}]}, "description": ""}, {"metric": {"name": "node_cost_per_month"}, "cost_type": "Infrastructure", "tag_rates": {"tag_key": "web", "tag_values": [{"unit": "USD", "usage": {"unit": "USD", "usage_end": null, "usage_start": null}, "value": "456.0000000000", "default": true, "tag_value": "smoker", "description": ""}]}, "description": ""}, {"metric": {"name": "cluster_cost_per_month"}, "cost_type": "Infrastructure", "tag_rates": {"tag_key": "app", "tag_values": [{"unit": "USD", "usage": {"unit": "USD", "usage_end": null, "usage_start": null}, "value": "456.0000000000", "default": true, "tag_value": "smoker", "description": ""}]}, "description": ""}]
markup            | {}
distribution      | memory
currency          | USD
distribution_info | {"worker_cost": true, "platform_cost": true, "distribution_type": "memory", "network_unattributed": false, "storage_unattributed": true}
```
The distribution_info section is what we care about here. 


## Release Notes
- [ ] proposed release note

```markdown
* [COST-####](https://issues.redhat.com/browse/COST-4915) Add unattributed distribution to cost model form
```
