### PR TITLE
prevent running migration CI check if removal label is present

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
           pipenv install --dev --ignore-pipfile --python ${{ matrix.python-version }}
 
       - name: Check migrations
-        if: needs.changed-files.outputs.run_tests == 'true' && ${{ !(contains(github.event.pull_request.labels.*.name, 'model-removal')) }}
+        if: ${{ needs.changed-files.outputs.run_tests == 'true' && !(contains(github.event.pull_request.labels.*.name, 'model-removal')) }}
         run: bash .github/scripts/check_migrations.sh
         env:
           DATABASE_SERVICE_NAME: POSTGRES_SQL

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,9 @@ jobs:
           pipenv install --dev --ignore-pipfile --python ${{ matrix.python-version }}
 
       - name: Check migrations
-        if: ${{ needs.changed-files.outputs.run_tests == 'true' && !(contains(github.event.pull_request.labels.*.name, 'skip-migration-check')) }}
+        if: |
+          needs.changed-files.outputs.run_tests == 'true'
+          && !(contains(github.event.pull_request.labels.*.name, 'skip-migration-check'))
         run: bash .github/scripts/check_migrations.sh
         env:
           DATABASE_SERVICE_NAME: POSTGRES_SQL

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
           pipenv install --dev --ignore-pipfile --python ${{ matrix.python-version }}
 
       - name: Check migrations
-        if: needs.changed-files.outputs.run_tests == 'true' && !(contains(github.event.pull_request.labels.*.name, 'model-removal')
+        if: needs.changed-files.outputs.run_tests == 'true' && ${{ !(contains(github.event.pull_request.labels.*.name, 'model-removal') }}
         run: bash .github/scripts/check_migrations.sh
         env:
           DATABASE_SERVICE_NAME: POSTGRES_SQL

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
           pipenv install --dev --ignore-pipfile --python ${{ matrix.python-version }}
 
       - name: Check migrations
-        if: needs.changed-files.outputs.run_tests == 'true'
+        if: needs.changed-files.outputs.run_tests == 'true' && !(contains(github.event.pull_request.labels.*.name, 'model-removal')
         run: bash .github/scripts/check_migrations.sh
         env:
           DATABASE_SERVICE_NAME: POSTGRES_SQL

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
           pipenv install --dev --ignore-pipfile --python ${{ matrix.python-version }}
 
       - name: Check migrations
-        if: ${{ needs.changed-files.outputs.run_tests == 'true' && !(contains(github.event.pull_request.labels.*.name, 'model-removal')) }}
+        if: ${{ needs.changed-files.outputs.run_tests == 'true' && !(contains(github.event.pull_request.labels.*.name, 'skip-migration-check')) }}
         run: bash .github/scripts/check_migrations.sh
         env:
           DATABASE_SERVICE_NAME: POSTGRES_SQL

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
           pipenv install --dev --ignore-pipfile --python ${{ matrix.python-version }}
 
       - name: Check migrations
-        if: needs.changed-files.outputs.run_tests == 'true' && ${{ !(contains(github.event.pull_request.labels.*.name, 'model-removal') }}
+        if: needs.changed-files.outputs.run_tests == 'true' && ${{ !(contains(github.event.pull_request.labels.*.name, 'model-removal')) }}
         run: bash .github/scripts/check_migrations.sh
         env:
           DATABASE_SERVICE_NAME: POSTGRES_SQL

--- a/koku/api/provider/models.py
+++ b/koku/api/provider/models.py
@@ -573,3 +573,5 @@ class ProviderInfrastructureMap(models.Model):
 
     infrastructure_type = models.CharField(max_length=50, choices=Provider.CLOUD_PROVIDER_CHOICES, blank=False)
     infrastructure_provider = models.ForeignKey("Provider", on_delete=models.CASCADE)
+    infrastructure_account = models.CharField(max_length=50, null=True)
+    infrastructure_region = models.CharField(max_length=50, null=True)

--- a/koku/api/provider/models.py
+++ b/koku/api/provider/models.py
@@ -573,5 +573,3 @@ class ProviderInfrastructureMap(models.Model):
 
     infrastructure_type = models.CharField(max_length=50, choices=Provider.CLOUD_PROVIDER_CHOICES, blank=False)
     infrastructure_provider = models.ForeignKey("Provider", on_delete=models.CASCADE)
-    infrastructure_account = models.CharField(max_length=50, null=True)
-    infrastructure_region = models.CharField(max_length=50, null=True)


### PR DESCRIPTION
## Jira Ticket

[COST-4947](https://issues.redhat.com/browse/COST-4947)

## Description

This change will allow skipping the migration check if we are removing fields from a model since the fields should be removed prior to the migration to drop those fields running.

Adding this allows us to follow along with the flow for removing fields suggested in this gist: https://gist.github.com/majackson/493c3d6d4476914ca9da63f84247407b#removing-fields-or-tables

## Testing

1. This branch has run a few different times with and without the label with a model change. With the label the unit tests check runs smoothly and succeeds, without the label the unit tests fail similar to 
```
Migrations for 'api':
  koku/api/migrations/0063_remove_providerinfrastructuremap_infrastructure_account_and_more.py
    - Remove field infrastructure_account from providerinfrastructuremap
    - Remove field infrastructure_region from providerinfrastructuremap
Migrations are out of sync with the models. Run 'make make-migrations' to update.
```

## Release Notes
- [x] proposed release note

```markdown
* [COST-4947](https://issues.redhat.com/browse/COST-4947) Update CI check to allow removing model fields prior to migration
```
