### PR TITLE
[COST-4947] Remove account and region fields from ProviderInfrastructureMap

### DIFF
--- a/koku/api/provider/models.py
+++ b/koku/api/provider/models.py
@@ -573,5 +573,3 @@ class ProviderInfrastructureMap(models.Model):
 
     infrastructure_type = models.CharField(max_length=50, choices=Provider.CLOUD_PROVIDER_CHOICES, blank=False)
     infrastructure_provider = models.ForeignKey("Provider", on_delete=models.CASCADE)
-    infrastructure_account = models.CharField(max_length=50, null=True)
-    infrastructure_region = models.CharField(max_length=50, null=True)


### PR DESCRIPTION
## Jira Ticket

[COST-4947](https://issues.redhat.com/browse/COST-4947)

## Description

This change will remove account and region from the ProviderInfrastructureMap prior to the migration on the DB. 

This follows the suggested flow from the following gist: https://gist.github.com/majackson/493c3d6d4476914ca9da63f84247407b#removing-fields-or-tables 

## Testing

1. Smokes should pass

## Release Notes
- [ ] proposed release note

```markdown
* [COST-4947](https://issues.redhat.com/browse/COST-####) Remove account and region from the ProviderInfrastructureMap model
```
