### PR TITLE
Cluster info - grab latest manifest accross month boundries.

### DIFF
--- a/koku/api/provider/provider_manager.py
+++ b/koku/api/provider/provider_manager.py
@@ -85,7 +85,10 @@ class ProviderManager:
         self.manifest = (
             CostUsageReportManifest.objects.filter(
                 provider=self._uuid,
-                billing_period_start_datetime=self.date_helper.this_month_start,
+                billing_period_start_datetime__in=[
+                    self.date_helper.this_month_start,
+                    self.date_helper.last_month_start,
+                ],
                 creation_datetime__isnull=False,
             )
             .order_by("-creation_datetime")
@@ -188,7 +191,10 @@ class ProviderManager:
                 manifest = (
                     CostUsageReportManifest.objects.filter(
                         provider=self.model.infrastructure.infrastructure_provider_id,
-                        billing_period_start_datetime=self.date_helper.this_month_start,
+                        billing_period_start_datetime__in=[
+                            self.date_helper.this_month_start,
+                            self.date_helper.last_month_start,
+                        ],
                         creation_datetime__isnull=False,
                     )
                     .order_by("-creation_datetime")


### PR DESCRIPTION
## Jira Ticket

[COST-5009](https://issues.redhat.com/browse/COST-5009)

## Description

This change will change our manifest lookup logic to filter for current and previous month. This means we should always have a latest timestamp for statuses even when we enter a new month boundary.

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Release Notes
- [ ] proposed release note

```markdown
* [COST-####](https://issues.redhat.com/browse/COST-####) Fix data details (cluster info) timestamps for start of new month 
```
