### PR TITLE
[COST-5007] add trino host/port to mgmt cji

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -4048,6 +4048,10 @@ objects:
           value: ${MGMT_IMAGE}
         - name: MGMT_IMAGE_TAG
           value: ${MGMT_IMAGE_TAG}
+        - name: TRINO_HOST
+          value: ${TRINO_HOST}
+        - name: TRINO_PORT
+          value: ${TRINO_PORT}
         image: ${MGMT_IMAGE}:${MGMT_IMAGE_TAG}
         resources:
           limits:

--- a/deploy/kustomize/base/base.yaml
+++ b/deploy/kustomize/base/base.yaml
@@ -115,6 +115,10 @@ objects:
           value: ${MGMT_IMAGE}
         - name: MGMT_IMAGE_TAG
           value: ${MGMT_IMAGE_TAG}
+        - name: TRINO_HOST
+          value: ${TRINO_HOST}
+        - name: TRINO_PORT
+          value: ${TRINO_PORT}
     # The bulk of your App. This is where your running apps will live
     deployments:
     -


### PR DESCRIPTION
## Jira Ticket

[COST-5007](https://issues.redhat.com/browse/COST-5007)

## Description

This change will add the trino host and port to the mgmt cmd pod spec.

## Release Notes
- [x] proposed release note

```markdown
* [COST-5007](https://issues.redhat.com/browse/COST-5007) Add TRINO_PORT/TRINO_HOST to mgmt-cji pod spec
```
