### PR TITLE
[COST-5028] guard against report_status not existing

### DIFF
--- a/koku/masu/processor/parquet/ocp_cloud_parquet_report_processor.py
+++ b/koku/masu/processor/parquet/ocp_cloud_parquet_report_processor.py
@@ -231,7 +231,7 @@ class OCPCloudParquetReportProcessor(ParquetReportProcessor):
                 ocp_provider_uuids.append(ocp_provider_uuid)
         return tuple(ocp_provider_uuids)
 
-    def process(self, parquet_base_filename, daily_data_frames, manifest_id=None):
+    def process(self, parquet_base_filename, daily_data_frames):
         """Filter data and convert to parquet."""
         if not (ocp_provider_uuids := self.get_ocp_provider_uuids_tuple()):
             return
@@ -243,7 +243,10 @@ class OCPCloudParquetReportProcessor(ParquetReportProcessor):
             )
             return
 
-        self.report_status.update_status(CombinedChoices.OCP_CLOUD_PROCESSING)
+        if self.report_status:
+            # internal masu endpoints may result in this being None, so guard this in case there is no status to update
+            self.report_status.update_status(CombinedChoices.OCP_CLOUD_PROCESSING)
+
         # # Get OpenShift topology data
         with OCPReportDBAccessor(self.schema_name) as accessor:
             if self.provider_type == Provider.PROVIDER_GCP:

--- a/koku/masu/processor/parquet/parquet_report_processor.py
+++ b/koku/masu/processor/parquet/parquet_report_processor.py
@@ -143,13 +143,12 @@ class ParquetReportProcessor:
         """The manifest id."""
         return self._manifest_id
 
-    @property
+    @cached_property
     def report_status(self):
         if self.manifest_id:
             return CostUsageReportStatus.objects.get(
                 report_name=Path(self._report_file).name, manifest_id=self.manifest_id
             )
-        return None
 
     @property
     def report_file(self):

--- a/koku/masu/processor/report_processor.py
+++ b/koku/masu/processor/report_processor.py
@@ -118,7 +118,7 @@ class ReportProcessor:
         try:
             parquet_base_filename, daily_data_frames = self._processor.process()
             if self.ocp_on_cloud_processor:
-                self.ocp_on_cloud_processor.process(parquet_base_filename, daily_data_frames, self.manifest_id)
+                self.ocp_on_cloud_processor.process(parquet_base_filename, daily_data_frames)
             return daily_data_frames != []
         except ReportsAlreadyProcessed:
             report_status.update_status(CombinedChoices.DONE)

--- a/koku/masu/test/processor/parquet/test_ocp_cloud_parquet_report_processor.py
+++ b/koku/masu/test/processor/parquet/test_ocp_cloud_parquet_report_processor.py
@@ -22,6 +22,7 @@ from masu.test import MasuTestCase
 from masu.util.aws.common import match_openshift_resources_and_labels
 from masu.util.gcp.common import match_openshift_resources_and_labels as gcp_match_openshift_resources_and_labels
 from reporting.provider.all.models import EnabledTagKeys
+from reporting_common.models import CostUsageReportStatus
 
 
 class TestOCPCloudParquetReportProcessor(MasuTestCase):
@@ -443,3 +444,20 @@ class TestOCPCloudParquetReportProcessor(MasuTestCase):
         ):
             self.report_processor.get_matched_tags([])
             mock_get_tags.assert_not_called()
+
+    def test_instantiating_processor_without_manifest_id(self):
+        """Assert that report_status exists and is None."""
+        report_processor = OCPCloudParquetReportProcessor(
+            schema_name=self.schema,
+            report_path=self.report_path,
+            provider_uuid=self.gcp_provider_uuid,
+            provider_type=Provider.PROVIDER_GCP_LOCAL,
+            manifest_id=0,
+            context={"request_id": self.request_id, "start_date": self.start_date, "create_table": True},
+        )
+        self.assertIsNone(report_processor.report_status)
+
+    def test_instantiating_processor_with_manifest_id(self):
+        """Assert that report_status exists and is not None."""
+        self.assertIsNotNone(self.report_processor.report_status)
+        self.assertIsInstance(self.report_processor.report_status, CostUsageReportStatus)


### PR DESCRIPTION
## Jira Ticket

[COST-5028](https://issues.redhat.com/browse/COST-5028)

## Description

This change will prevent task failures when `report_status` does not exist for `OCPCloudParquetReportProcessor`.

## Testing

starting on main:
1. load test data (make load-test-customer-data)
2. trigger ocp-on-cloud resummary:
```
http://localhost:5042/api/cost-management/v1/report/process/openshift_on_cloud/?schema=org1234567&provider_uuid={any cloud source uuid}&start_date=2024-04-01
```
3. in worker logs, see task failure:
```
koku-worker-1  | [2024-05-10 17:18:40,119] ERROR 5b2f96c5-43f6-451e-8a02-29902e6bfc15 1160 Task failed: 'OCPCloudParquetReportProcessor' object has no attribute 'report_status'
```
4. checkout branch and ensure worker reloads
5. re-hit this endpoint:
```
http://localhost:5042/api/cost-management/v1/report/process/openshift_on_cloud/?schema=org1234567&provider_uuid={any cloud source uuid}&start_date=2024-04-01
```
6. see the task complete successfully.


## Release Notes
- [x] proposed release note

```markdown
* [COST-5028](https://issues.redhat.com/browse/COST-5028) guard against non-existent report_status
```
