### PR TITLE
[COST-4741] - Separate AWS node network costs into a Network unattributed namespace

### DIFF
--- a/koku/masu/database/sql/reporting_ocpaws_ocp_infrastructure_back_populate.sql
+++ b/koku/masu/database/sql/reporting_ocpaws_ocp_infrastructure_back_populate.sql
@@ -21,6 +21,8 @@ INSERT INTO {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary (
     infrastructure_project_raw_cost,
     infrastructure_usage_cost,
     supplementary_usage_cost,
+    infrastructure_data_in_gigabytes,
+    infrastructure_data_out_gigabytes,
     pod_usage_cpu_core_hours,
     pod_request_cpu_core_hours,
     pod_limit_cpu_core_hours,
@@ -67,6 +69,14 @@ INSERT INTO {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary (
         sum(coalesce(nullif(ocp_aws.savingsplan_effective_cost, 0), ocp_aws.unblended_cost) + coalesce(nullif(ocp_aws.markup_cost_savingsplan, 0), ocp_aws.markup_cost)) AS infrastructure_project_raw_cost,
         '{"cpu": 0.000000000, "memory": 0.000000000, "storage": 0.000000000}'::jsonb as infrastructure_usage_cost,
         '{"cpu": 0.000000000, "memory": 0.000000000, "storage": 0.000000000}'::jsonb as supplementary_usage_cost,
+        CASE
+            WHEN upper(data_transfer_direction) = 'IN' THEN sum(infrastructure_data_in_gigabytes)
+            ELSE 0
+        END as infrastructure_data_in_gigabytes,
+        CASE
+            WHEN upper(data_transfer_direction) = 'OUT' THEN sum(infrastructure_data_out_gigabytes)
+            ELSE 0
+        END as infrastructure_data_out_gigabytes,
         0 as pod_usage_cpu_core_hours,
         0 as pod_request_cpu_core_hours,
         0 as pod_limit_cpu_core_hours,
@@ -102,5 +112,6 @@ INSERT INTO {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary (
         ocp_aws.persistentvolumeclaim,
         ocp_aws.resource_id,
         ocp_aws.pod_labels,
+        ocp_aws.data_transfer_direction,
         rp.provider_id
 ;

--- a/koku/masu/database/sql/reporting_ocpaws_ocp_infrastructure_back_populate.sql
+++ b/koku/masu/database/sql/reporting_ocpaws_ocp_infrastructure_back_populate.sql
@@ -71,11 +71,11 @@ INSERT INTO {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary (
         '{"cpu": 0.000000000, "memory": 0.000000000, "storage": 0.000000000}'::jsonb as supplementary_usage_cost,
         CASE
             WHEN upper(data_transfer_direction) = 'IN' THEN sum(infrastructure_data_in_gigabytes)
-            ELSE 0
+            ELSE NULL
         END as infrastructure_data_in_gigabytes,
         CASE
             WHEN upper(data_transfer_direction) = 'OUT' THEN sum(infrastructure_data_out_gigabytes)
-            ELSE 0
+            ELSE NULL
         END as infrastructure_data_out_gigabytes,
         0 as pod_usage_cpu_core_hours,
         0 as pod_request_cpu_core_hours,

--- a/koku/masu/database/trino_sql/reporting_ocpawscostlineitem_daily_summary.sql
+++ b/koku/masu/database/trino_sql/reporting_ocpawscostlineitem_daily_summary.sql
@@ -207,10 +207,10 @@ SELECT cast(uuid() as varchar) as uuid,
         WHEN max(aws.lineitem_productcode) = 'AmazonEC2' AND max(aws.product_productfamily) = 'Data Transfer' THEN
             -- Yes, it's a network record. What's the direction?
             CASE
-                WHEN position(lower(max(aws.lineitem_usagetype)) IN 'in-bytes') > 0 THEN 'IN'
-                WHEN position(lower(max(aws.lineitem_usagetype)) IN 'out-bytes') > 0 THEN 'OUT'
-                WHEN (position(lower(max(aws.lineitem_usagetype)) IN 'regional-bytes') > 0 AND position(max(lineitem_operation) IN '-In') > 0) THEN 'IN'
-                WHEN (position(lower(max(aws.lineitem_usagetype)) IN 'regional-bytes') > 0 AND position(max(lineitem_operation) IN '-Out') > 0) THEN 'OUT'
+                WHEN position('in-bytes' IN lower(max(aws.lineitem_usagetype))) > 0 THEN 'IN'
+                WHEN position('out-bytes' IN lower(max(aws.lineitem_usagetype))) > 0 THEN 'OUT'
+                WHEN (position('regional-bytes' IN lower(max(aws.lineitem_usagetype))) > 0 AND position('-in' IN lower(max(lineitem_operation))) > 0) THEN 'IN'
+                WHEN (position('regional-bytes' IN lower(max(aws.lineitem_usagetype))) > 0 AND position('-out' IN lower(max(lineitem_operation))) > 0) THEN 'OUT'
                 ELSE NULL
             END
     END AS data_transfer_direction,
@@ -869,6 +869,7 @@ INSERT INTO postgres.{{schema | sqlsafe}}.reporting_ocpawscostlineitem_project_d
     region,
     unit,
     usage_amount,
+    data_transfer_direction,
     currency_code,
     unblended_cost,
     markup_cost,
@@ -909,6 +910,7 @@ SELECT uuid(),
     region,
     unit,
     usage_amount,
+    data_transfer_direction,
     currency_code,
     unblended_cost,
     markup_cost,

--- a/koku/masu/database/trino_sql/reporting_ocpawscostlineitem_daily_summary.sql
+++ b/koku/masu/database/trino_sql/reporting_ocpawscostlineitem_daily_summary.sql
@@ -844,6 +844,8 @@ WHERE ocp.source = {{ocp_source_uuid}}
     AND aws.month = {{month}}
     -- Network related costs
     AND aws.data_transfer_direction IS NOT NULL
+    -- Storage and Pod can have the same resource_id and we want the Pod
+    AND ocp.data_source = 'Pod'
 GROUP BY
     aws.uuid,
     ocp.node,

--- a/koku/masu/database/trino_sql/reporting_ocpawscostlineitem_daily_summary.sql
+++ b/koku/masu/database/trino_sql/reporting_ocpawscostlineitem_daily_summary.sql
@@ -207,10 +207,10 @@ SELECT cast(uuid() as varchar) as uuid,
         WHEN max(aws.lineitem_productcode) = 'AmazonEC2' AND max(aws.product_productfamily) = 'Data Transfer' THEN
             -- Yes, it's a network record. What's the direction?
             CASE
-                WHEN position('in-bytes' IN lower(max(aws.lineitem_usagetype))) > 0 THEN 'IN'
-                WHEN position('out-bytes' IN lower(max(aws.lineitem_usagetype))) > 0 THEN 'OUT'
-                WHEN (position('regional-bytes' IN lower(max(aws.lineitem_usagetype))) > 0 AND position('-in' IN lower(max(lineitem_operation))) > 0) THEN 'IN'
-                WHEN (position('regional-bytes' IN lower(max(aws.lineitem_usagetype))) > 0 AND position('-out' IN lower(max(lineitem_operation))) > 0) THEN 'OUT'
+                WHEN strpos(lower(max(aws.lineitem_usagetype)), 'in-bytes') > 0 THEN 'IN'
+                WHEN strpos(lower(max(aws.lineitem_usagetype)), 'out-bytes') > 0 THEN 'OUT'
+                WHEN (strpos(lower(max(aws.lineitem_usagetype)), 'regional-bytes') > 0 AND strpos(lower(max(lineitem_operation)), '-in') > 0) THEN 'IN'
+                WHEN (strpos(lower(max(aws.lineitem_usagetype)), 'regional-bytes') > 0 AND strpos(lower(max(lineitem_operation)), '-out') > 0) THEN 'OUT'
                 ELSE NULL
             END
     END AS data_transfer_direction,
@@ -830,7 +830,7 @@ SELECT
 FROM hive.{{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary AS ocp
 JOIN hive.{{schema | sqlsafe}}.aws_openshift_daily_resource_matched_temp AS aws
     ON aws.usage_start = ocp.usage_start
-    AND position(ocp.resource_id IN aws.resource_id) != 0
+    AND strpos(aws.resource_id, ocp.resource_id) != 0
 LEFT JOIN postgres.{{schema | sqlsafe}}.reporting_awsaccountalias AS aa
     ON aws.usage_account_id = aa.account_id
 WHERE ocp.source = {{ocp_source_uuid}}

--- a/koku/masu/database/trino_sql/reporting_ocpawscostlineitem_daily_summary.sql
+++ b/koku/masu/database/trino_sql/reporting_ocpawscostlineitem_daily_summary.sql
@@ -207,10 +207,10 @@ SELECT cast(uuid() as varchar) as uuid,
         WHEN max(aws.lineitem_productcode) = 'AmazonEC2' AND max(aws.product_productfamily) = 'Data Transfer' THEN
             -- Yes, it's a network record. What's the direction?
             CASE
-                WHEN position(max(aws.lineitem_usagetype) IN 'In-Bytes') > 0 THEN 'IN'
-                WHEN position(max(aws.lineitem_usagetype) IN 'Out-Bytes') > 0 THEN 'OUT'
-                WHEN (position(max(aws.lineitem_usagetype) IN 'Regional-Bytes') > 0 AND position(max(lineitem_operation) IN '-In') > 0) THEN 'IN'
-                WHEN (position(max(aws.lineitem_usagetype) IN 'Regional-Bytes') > 0 AND position(max(lineitem_operation) IN '-Out') > 0) THEN 'OUT'
+                WHEN position(lower(max(aws.lineitem_usagetype)) IN 'in-bytes') > 0 THEN 'IN'
+                WHEN position(lower(max(aws.lineitem_usagetype)) IN 'out-bytes') > 0 THEN 'OUT'
+                WHEN (position(lower(max(aws.lineitem_usagetype)) IN 'regional-bytes') > 0 AND position(max(lineitem_operation) IN '-In') > 0) THEN 'IN'
+                WHEN (position(lower(max(aws.lineitem_usagetype)) IN 'regional-bytes') > 0 AND position(max(lineitem_operation) IN '-Out') > 0) THEN 'OUT'
                 ELSE NULL
             END
     END AS data_transfer_direction,

--- a/koku/masu/database/trino_sql/reporting_ocpawscostlineitem_daily_summary.sql
+++ b/koku/masu/database/trino_sql/reporting_ocpawscostlineitem_daily_summary.sql
@@ -249,7 +249,8 @@ GROUP BY aws.lineitem_usagestartdate,
     aws.product_region,
     aws.lineitem_usagetype,
     aws.resourcetags,
-    aws.costcategory
+    aws.costcategory,
+    lineitem_operation
 ;
 
 INSERT INTO hive.{{schema | sqlsafe}}.aws_openshift_daily_tag_matched_temp (

--- a/koku/masu/database/trino_sql/reporting_ocpawscostlineitem_daily_summary.sql
+++ b/koku/masu/database/trino_sql/reporting_ocpawscostlineitem_daily_summary.sql
@@ -242,11 +242,12 @@ WHERE aws.source = {{aws_source_uuid}}
     AND aws.resource_id_matched = TRUE
 GROUP BY aws.lineitem_usagestartdate,
     aws.lineitem_resourceid,
-    4, -- CASE satement
+    4, -- product_code
     aws.product_productfamily,
     aws.product_instancetype,
     aws.lineitem_availabilityzone,
     aws.product_region,
+    aws.lineitem_usagetype,
     aws.resourcetags,
     aws.costcategory
 ;
@@ -335,7 +336,7 @@ WHERE aws.source = {{aws_source_uuid}}
     AND (aws.resource_id_matched = FALSE OR aws.resource_id_matched IS NULL)
 GROUP BY aws.lineitem_usagestartdate,
     aws.lineitem_resourceid,
-    4, -- CASE satement
+    4, -- product_code
     aws.product_productfamily,
     aws.product_instancetype,
     aws.lineitem_availabilityzone,

--- a/koku/masu/database/trino_sql/reporting_ocpawscostlineitem_daily_summary.sql
+++ b/koku/masu/database/trino_sql/reporting_ocpawscostlineitem_daily_summary.sql
@@ -790,7 +790,7 @@ SELECT
     max(cluster_alias),
     max(data_source),
     'Network unattributed' AS namespace,
-    max(node),
+    ocp.node AS node,
     max(persistentvolumeclaim),
     max(persistentvolume),
     max(storageclass),


### PR DESCRIPTION
## Jira Ticket

[COST-4741](https://issues.redhat.com/browse/COST-4741)

## Description

Separates out AWS node network costs into a separate project for later distribution.

## Testing

1. Load OCP on AWS test data.
    This is currently broken. You will need to run the second command twice.

    ```
    make create-test-customer
    make load-test-customer-data test_source=aws
    ```
    
1. Inspect data in Trino. Where product_family is `Data Transfer` and `product_code` is `AmazonEC2`, there should be a data transfer direction

    ```
    SELECT namespace,product_code,product_family,data_transfer_direction,usage_amount FROM reporting_ocpawscostlineitem_project_daily_summary;
    ```
    
    ```
    namespace                 |  product_code  |   product_family   | data_transfer_direction |     usage_amount
    --------------------------+----------------+--------------------+-------------------------+-----------------------
     cost-management          | AmazonEC2      | Compute Instance   | NULL                    |                   8.0
     Network unattributed     | AmazonEC2      | Data Transfer      | IN                      |   0.05788159130273985
     Network unattributed     | AmazonEC2      | Data Transfer      | IN                      |   0.08385133566183305
     Network unattributed     | AmazonEC2      | Data Transfer      | OUT                     | 4.0166646410467517E-4
     Network unattributed     | AmazonEC2      | Data Transfer      | IN                      |  0.013915647933780239
     Platform unallocated     | AmazonEC2      | Data Transfer      | NULL                    |   0.04199137044014825
     Network unattributed     | AmazonEC2      | Data Transfer      | OUT                     |  0.050977435375557656
    ...
    ```

1. Verify there are records for Network unattributed in PostgreSQL AWS daily summary table

    ```
    SELECT * FROM reporting_ocpawscostlineitem_project_daily_summary_p WHERE namespace = 'Network unattributed';
    ```
    
1. Verify OpenShift costs are correct

    ```
    curl http://localhost:8000/api/cost-management/v1/reports/openshift/costs/
    ```
    
1. Verify AWS filtered by OpenShift costs are correct

    ```
    http://localhost:8000/api/cost-management/v1/reports/openshift/infrastructures/aws/costs/
    ```
    
1. Compare Trino and PostgreSQL data to make sure costs add up:

    ```
    postgres=# SELECT sum(unblended_cost) from reporting_aws_cost_summary_p
    sum
    -----------------
     23785.362736418
    
    trino:org1234567> SELECT sum(lineitem_unblendedcost) from aws_line_items;
    _col0
    --------------------
     23785.362736451105
    (1 row)
    ```
    



## Release Notes
- [x] proposed release note

```markdown
* [COST-3761](https://issues.redhat.com/browse/COST-3761) Separate AWS EC2 instance network costs into a `Network unattributed` project
  Network costs were previously combined with the AWS EC2 instance costs. Now those costs presented in a new `Network unattributed` project.
```
