### PR TITLE
[COST-5011] Limit OS disk correlation to pod data source rows

### DIFF
--- a/koku/masu/database/trino_sql/reporting_ocpazurecostlineitem_daily_summary.sql
+++ b/koku/masu/database/trino_sql/reporting_ocpazurecostlineitem_daily_summary.sql
@@ -372,7 +372,7 @@ SELECT azure.uuid as azure_uuid,
             OR
                 (strpos(azure.resource_id, ocp.persistentvolume) > 0 AND ocp.data_source = 'Storage')
             OR
-                (LOWER(CONCAT(ocp.node, '_OSDisk')) = LOWER(azure.resource_id)) AND ocp.data_source = 'Pod'
+                (LOWER(CONCAT(ocp.node, '_OSDisk')) = LOWER(azure.resource_id) AND ocp.data_source = 'Pod')
             )
     WHERE ocp.source = {{ocp_source_uuid}}
         AND ocp.year = {{year}}

--- a/koku/masu/database/trino_sql/reporting_ocpazurecostlineitem_daily_summary.sql
+++ b/koku/masu/database/trino_sql/reporting_ocpazurecostlineitem_daily_summary.sql
@@ -368,7 +368,7 @@ SELECT azure.uuid as azure_uuid,
     JOIN hive.{{schema | sqlsafe}}.azure_openshift_daily_resource_matched_temp as azure
         ON (azure.usage_start = ocp.usage_start)
         AND (
-                (replace(lower(azure.resource_id), "_osdisk", "") = lower(ocp.node) AND ocp.data_source = 'Pod')
+                (replace(lower(azure.resource_id), '_osdisk', '') = lower(ocp.node) AND ocp.data_source = 'Pod')
             OR
                 (strpos(azure.resource_id, ocp.persistentvolume) > 0 AND ocp.data_source = 'Storage')
             )

--- a/koku/masu/database/trino_sql/reporting_ocpazurecostlineitem_daily_summary.sql
+++ b/koku/masu/database/trino_sql/reporting_ocpazurecostlineitem_daily_summary.sql
@@ -372,7 +372,7 @@ SELECT azure.uuid as azure_uuid,
             OR
                 (strpos(azure.resource_id, ocp.persistentvolume) > 0 AND ocp.data_source = 'Storage')
             OR
-                (LOWER(CONCAT(ocp.node, '_OSDisk')) = LOWER(azure.resource_id))
+                (LOWER(CONCAT(ocp.node, '_OSDisk')) = LOWER(azure.resource_id)) AND ocp.data_source = 'Pod'
             )
     WHERE ocp.source = {{ocp_source_uuid}}
         AND ocp.year = {{year}}

--- a/koku/masu/database/trino_sql/reporting_ocpazurecostlineitem_daily_summary.sql
+++ b/koku/masu/database/trino_sql/reporting_ocpazurecostlineitem_daily_summary.sql
@@ -368,11 +368,9 @@ SELECT azure.uuid as azure_uuid,
     JOIN hive.{{schema | sqlsafe}}.azure_openshift_daily_resource_matched_temp as azure
         ON (azure.usage_start = ocp.usage_start)
         AND (
-                (azure.resource_id = ocp.node AND ocp.data_source = 'Pod')
+                (replace(lower(azure.resource_id), "_osdisk", "") = lower(ocp.node) AND ocp.data_source = 'Pod')
             OR
                 (strpos(azure.resource_id, ocp.persistentvolume) > 0 AND ocp.data_source = 'Storage')
-            OR
-                (LOWER(CONCAT(ocp.node, '_OSDisk')) = LOWER(azure.resource_id) AND ocp.data_source = 'Pod')
             )
     WHERE ocp.source = {{ocp_source_uuid}}
         AND ocp.year = {{year}}


### PR DESCRIPTION
## Jira Ticket

[COST-5011](https://issues.redhat.com/browse/COST-5011)

## Description

This change will limit OS disk correlation to the POD data source rows. 

## Testing
- https://gitlab.cee.redhat.com/insights-qe/iqe-cost-management-plugin/-/merge_requests/1970/diffs

## Release Notes
- [ ] proposed release note

```markdown
* [COST-5011](https://issues.redhat.com/browse/COST-5011) Limit OS disk correlation to pod data source rows
```
