### PR TITLE
[COST-5029] - Override start date for OCP infra mapping

### DIFF
--- a/koku/masu/processor/ocp/ocp_report_parquet_summary_updater.py
+++ b/koku/masu/processor/ocp/ocp_report_parquet_summary_updater.py
@@ -12,6 +12,7 @@ from django.utils import timezone
 from django_tenants.utils import schema_context
 
 from api.common import log_json
+from api.utils import DateHelper
 from koku.pg_partition import PartitionHandlerMixin
 from masu.database.ocp_report_db_accessor import OCPReportDBAccessor
 from masu.processor.ocp.ocp_cloud_updater_base import OCPCloudUpdaterBase
@@ -167,7 +168,8 @@ class OCPReportParquetSummaryUpdater(PartitionHandlerMixin):
         return start_date, end_date
 
     def check_cluster_infrastructure(self, start_date, end_date):
-
+        # Override start date so we map with a more complete dataset
+        start_date = DateHelper().month_start(start_date)
         LOG.info(
             log_json(
                 msg="checking if OCP cluster is running on cloud infrastructure",


### PR DESCRIPTION
## Jira Ticket

[COST-5029](https://issues.redhat.com/browse/COST-5029)

## Description

This change will override the start date being passed into the `check_cluster_infrastructure` function so daily operator payload processing attempts to match clusters to cloud providers over a wider dataset.

## Testing

1. Checkout Branch
2. Restart Koku
3. load your fav OCP on Cloud data
4. See everything correlate correctly
5. Hit the resummary endpoint for you OCP provider with a date != to start of the month
 `localhost:5042/api/cost-management/v1/report_data/?schema=org1234567&provider_uuid=1db0352d-e4df-4772-b4a0-90bac1e51b15&start_date=2024-05-10`
6. Check logs for passed in date being changed to start of month

Example log:
[2024-05-15 18:54:44,394] INFO 9fc8cd8e-d453-4764-b678-89587fbecafb 1818 {'message': 'checking if OCP cluster is running on cloud infrastructure', 'tracing_id': '', 'schema': 'org1234567', 'provider_uuid': '1db0352d-e4df-4772-b4a0-90bac1e51b15', 'cluster_id': 'test_cost_ocp_on_gcp_cluster_pom', 'cluster_alias': 'OCP source for cluster test_cost_ocp_on_gcp_cluster_pom', 'start_date': datetime.date(2024, 5, 1), 'end_date': datetime.date(2024, 5, 15)}


## Release Notes
- [ ] proposed release note

```markdown
* [COST-####](https://issues.redhat.com/browse/COST-####) Fix daily OCP on Cloud provider matching
```
