### PR TITLE
[COST-5020] Use org_id for kafka message key in subs processing

### DIFF
--- a/koku/subs/subs_data_messenger.py
+++ b/koku/subs/subs_data_messenger.py
@@ -127,7 +127,7 @@ class SUBSDataMessenger:
     def send_kafka_message(self, msg):
         """Sends a kafka message to the SUBS topic with the S3 keys for the uploaded reports."""
         producer = get_producer()
-        producer.produce(SUBS_TOPIC, value=msg, callback=delivery_callback)
+        producer.produce(SUBS_TOPIC, key=self.org_id, value=msg, callback=delivery_callback)
         producer.poll(0)
 
     def build_base_subs_dict(self, instance_id, tstamp, expiration, cpu_count, sla, usage, role, product_ids):


### PR DESCRIPTION
## Jira Ticket

[COST-5020](https://issues.redhat.com/browse/COST-5020)

## Description

This change will use the org_id for the message key when producing kafka messages for subs consumption.

## Testing

1. Smokes should pass

## Release Notes
- [x] proposed release note

```markdown
* [COST-5020](https://issues.redhat.com/browse/COST-5020) Use org_id as message key when producing swatch kafka messages.
```
