### PR TITLE
Set locale in migration script

### DIFF
--- a/scripts/run_migrations.sh
+++ b/scripts/run_migrations.sh
@@ -33,7 +33,7 @@ bash_check()
     local -i _ver_major=0
     local -i _ver_minor=0
 
-    _ver_str=$(bash --version | grep -E "version [0-9]+\." | sed -e 's/.*version //1' -e 's/ .x86.*$//1')
+    _ver_str=$(LANG=en_US.UTF-8 bash --version | grep -E "version [0-9]+\." | sed -e 's/.*version //1' -e 's/ .x86.*$//1')
     _ver_major=${_ver_str%%.*}
     _ver_str=${_ver_str#*.}
     _ver_minor=${_ver_str%%.*}


### PR DESCRIPTION
## Description
I was getting 

> 🚨 : ERROR ::  This script uses advanced bash ops. Please upgrade bash to version >= 4.4

When trying to run migrations and/or creating local test customers. 
The cause is that my bash was in Portuguese language (?), making the `bash --version` script return blank.

This fix will hard-code the `bash --version` command to get the return in English, allowing the script to proceed with no errors.


## Testing

1. Checkout Branch
2. Restart Koku
3. Run `make run-migrations` or `make create-test-customer`
4. Make sure that the script flows properly.
