### PR TITLE
fix make load-test-customer-data

### DIFF
--- a/dev/scripts/load_test_customer_data.sh
+++ b/dev/scripts/load_test_customer_data.sh
@@ -353,7 +353,7 @@ build_gcp_data() {
   nise_report ocp --static-report-file "$YAML_PATH/ocp_on_gcp/rendered_ocp_static_data.yml" --ocp-cluster-id test-ocp-gcp-cluster --minio-upload http://localhost:9000 --daily-reports --payload-name "$_ocp_payload"
   # nise_report ocp --static-report-file "$YAML_PATH/ocp_on_gcp/rendered_ocp_static_data.yml" --ocp-cluster-id test-ocp-gcp-cluster --minio-upload http://localhost:9000 --payload-name "$_ocp_payload"
   nise_report gcp --static-report-file "$YAML_PATH/gcp/rendered_gcp_static_data.yml" --gcp-bucket-name "$NISE_DATA_PATH/local_providers/gcp_local"
-  nise_report gcp --static-report-file "$YAML_PATH/ocp_on_gcp/rendered_gcp_static_data.yml" --gcp-bucket-name "$NISE_DATA_PATH/local_providers/gcp_local_0 -r"
+  nise_report gcp --static-report-file "$YAML_PATH/ocp_on_gcp/rendered_gcp_static_data.yml" --gcp-bucket-name "$NISE_DATA_PATH/local_providers/gcp_local_0" -r
 
   log-info "Cleanup ${_source_name} rendered YAML files..."
   cleanup_rendered_files "${_rendered_yaml_files[@]}"


### PR DESCRIPTION
## Description

The make load-test-customer-data command is broken for OCP-on-GCP. The bucket name was defined as `".../gcp_local_0 -r"` instead of just `".../gcp_local_0"`. This PR fixes that.

## Testing

1. start with fresh DB
2. create the sources and ingest data
```
$ make create-test-customer; make load-test-customer-data test_source=GCP
```
4. check `testing/local_providers/gcp_local_0` and see data files.
5. check the sources:
http://localhost:8000/api/cost-management/v1/sources/

```
        {
            "id": 10,
            "uuid": "f232afbb-9772-49ab-af5d-9d7c7f3b93cd",
            "name": "Test OCPGCP Source",
            "source_type": "GCP-local",
            "authentication": {
                "credentials": {
                    "project_id": "example-ocpgcp-project"
                }
            },
            "billing_source": {
                "data_source": {
                    "dataset": "example-ocpgcp-dataset",
                    "table_id": "gcp_billing_export_resource_v1_table",
                    "local_dir": "/tmp/gcp_local_bucket_0"
                }
            },
            "provider_linked": true,
            "active": true,
            "paused": false,
            "current_month_data": true,
            "previous_month_data": true,
            "last_payload_received_at": "2024-05-22T19:32:05.677341Z",
            "last_polling_time": "2024-05-22 19:32:06",
            "status": {
                "download": {
                    "end": "2024-05-22T19:33:16.437574+00:00",
                    "start": "2024-05-22T19:33:11.613110+00:00",
                    "state": "complete"
                },
                "processing": {
                    "end": "2024-05-22T19:33:38.103905+00:00",
                    "start": "2024-05-22T19:33:16.449320+00:00",
                    "state": "complete"
                },
                "summary": {
                    "end": "2024-05-22T19:33:55.026394+00:00",
                    "start": "2024-05-22T19:33:53.685191+00:00",
                    "state": "complete"
                }
            },
            "has_data": true,
            "infrastructure": {},
            "cost_models": [],
            "additional_context": {}
        },
```
6. Check the ocp-on-gcp OCP source and see that it has the GCP-local infra:
```
        {
            "id": 9,
            "uuid": "2b71ed83-a5fb-4f17-bfc4-8044d53b3793",
            "name": "Test OCP on GCP",
            "source_type": "OCP",
            ...
            "infrastructure": {
                "type": "GCP-local",
                "uuid": "f232afbb-9772-49ab-af5d-9d7c7f3b93cd",
                "id": 10,
                ...
```
7. Check the GCP reports endpoint and see data for 2 GCP sources:
http://localhost:8000/api/cost-management/v1/reports/gcp/costs/
```
...
    "data": [
        {
            "date": "2024-05-13",
            "values": [
                {
                    "date": "2024-05-13",
                    "source_uuid": [
                        "6a4643d1-2deb-4c03-8225-9cea4640e4af",
                        "f232afbb-9772-49ab-af5d-9d7c7f3b93cd"
                    ],
                    "infrastructure": {
                        "raw": {
                            "value": 245760.3889969,
                            "units": "USD"
...
```
8. 


## Release Notes
- [ ] proposed release note

```markdown
* [COST-####](https://issues.redhat.com/browse/COST-####) Fix some things
```
