### PR TITLE
[COST-5097] Format OCP data transfer fields like other usage fileds

### DIFF
--- a/koku/api/report/ocp/provider_map.py
+++ b/koku/api/report/ocp/provider_map.py
@@ -762,6 +762,7 @@ class OCPProviderMap(ProviderMap):
                             },
                         },
                         "cost_units_key": "raw_currency",
+                        "usage_units_key": "GB",
                         "sum_columns": [
                             "usage",
                             "data_transfer_in",

--- a/koku/api/report/ocp/query_handler.py
+++ b/koku/api/report/ocp/query_handler.py
@@ -92,6 +92,7 @@ class OCPReportQueryHandler(ReportQueryHandler):
             },
             "units": "usage_units",
         }
+        ocp_pack_definitions["usage"]["keys"].extend(["data_transfer_in", "data_transfer_out"])
 
         # super() needs to be called after _mapper and _limit is set
         super().__init__(parameters)

--- a/koku/api/report/test/ocp/view/test_ocp_network_view.py
+++ b/koku/api/report/test/ocp/view/test_ocp_network_view.py
@@ -56,9 +56,9 @@ class OCPReportViewNetworkTest(IamTestCase):
         meta = data.get("meta")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(meta["total"]["data_transfer_in"], self.total_usage_in)
-        self.assertEqual(meta["total"]["data_transfer_out"], self.total_usage_out)
-        self.assertEqual(meta["total"]["usage"], self.total_usage)
+        self.assertEqual(meta["total"]["data_transfer_in"]["value"], self.total_usage_in)
+        self.assertEqual(meta["total"]["data_transfer_out"]["value"], self.total_usage_out)
+        self.assertEqual(meta["total"]["usage"]["value"], self.total_usage)
 
     def test_get_node_network_costs_group_by_project(self):
         with schema_context(self.schema_name):


### PR DESCRIPTION
## Jira Ticket

[COST-3761](https://issues.redhat.com/browse/COST-3761)
[COST-5097](https://issues.redhat.com/browse/COST-5097)

## Description

Change the `data_transfer_in` and `data_transfer_out` fields on the `reports/openshift/network/` API to a dictionary containing `value` and `units`. This is the format the UI code is expecting in order to display the correct unit.



## Testing

1. Checkout Branch
2. Restart Koku
3. Load OCP on cloud data
4. Query `api/cost-management/v1/reports/openshift/network/`
5. The `data_transfer_in` and `data_transfer_out` fields should contain `value` and `units`
```
                    "data_transfer_in": {
                        "value": 5.130763036371731,
                        "units": "GB"
                    },
                    "data_transfer_out": {
                        "value": 8.17570363879331,
                        "units": "GB"
                    }
```
6. The values in `meta['total']` have `value` and `units`
```
        "total": {
            "usage": {
                "value": 92.89183179519655,
                "units": "GBeeebob"
            },
            "data_transfer_in": {
                "value": 37.49290500960895,
                "units": "GBeeebob"
            },
            "data_transfer_out": {
                "value": 55.3989267855876,
                "units": "GBeeebob"
            },
```

## Release Notes
- [x] proposed release note

```markdown
* [COST-5097](https://issues.redhat.com/browse/COST-5097) Change OCP on cloud network data transfer fields to contain value and units instead of just the value
```
