### PR TITLE
[COST-5128] Process new subs tag to identify non-converted instances

### DIFF
--- a/dev/scripts/nise_ymls/ocp_on_aws/aws_static_data.yml
+++ b/dev/scripts/nise_ymls/ocp_on_aws/aws_static_data.yml
@@ -35,11 +35,12 @@ generators:
         resourceTags/user:environment: dev
         resourceTags/user:version: beta
         resourceTags/user:dashed-key-on-aws: dashed-value
-        resourceTags/user:com_REDHAT_rhel: RHEL 8 ELS
+        resourceTags/user:com_REDHAT_rhel: 8
+        resourceTags/user:com_REDHAT_rhel_addon: ELS
         resourceTags/user:com_redhat_rhel_sla: self-support
         resourceTags/user:CoM_RedHat_Rhel_varianT: Workstation
         resourceTags/user:com_redhat_rhel_usage: disaster Recovery
-        resourceTags/user:com_redhat_rhel_addon: True
+        resourceTags/user:com_redhat_rhel_conversion: True
         resourceTags/user:Mapping: b1
         resourceTags/user:Map: b2
         resourceTags/user:Name: instance-name-2
@@ -65,7 +66,9 @@ generators:
         resourceTags/user:environment: dev
         resourceTags/user:version: gamma
         resourceTags/user:dashed-key-on-aws: dashed-value
-        resourceTags/user:com_REDHAT_rhel: RHEL 7 ELS
+        resourceTags/user:com_REDHAT_rhel: 7
+        resourceTags/user:com_REDHAT_addon: ELS
+        resourceTags/user:com_REDHAT_conversion: True
         resourceTags/user:com_redhat_rhel_sla: Standard
         resourceTags/user:CoM_RedHat_Rhel_varianT: Workstation
         resourceTags/user:Mapping: c1
@@ -94,7 +97,9 @@ generators:
         resourceTags/user:environment: dev
         resourceTags/user:version: beta
         resourceTags/user:dashed-key-on-aws: dashed-value
-        resourceTags/user:com_REDHAT_rhel: RHEL 8 ELS
+        resourceTags/user:com_REDHAT_rhel: 8
+        resourceTags/user:com_REDHAT_rhel_addon: ELS
+        resourceTags/user:com_REDHAT_rhel_conversion: True
         resourceTags/user:com_redhat_rhel_sla: self-support
         resourceTags/user:CoM_RedHat_Rhel_varianT: hPC
         resourceTags/user:com_redhat_rhel_usage: disaster Recovery
@@ -121,7 +126,7 @@ generators:
         resourceTags/user:environment: dev
         resourceTags/user:version: beta
         resourceTags/user:dashed-key-on-aws: dashed-value
-        resourceTags/user:com_REDHAT_rhel: RHEL 7 els
+        resourceTags/user:com_REDHAT_rhel: 7
         resourceTags/user:com_redhat_rhel_sla: self-support
         resourceTags/user:CoM_RedHat_Rhel_varianT: hPC
         resourceTags/user:com_redhat_rhel_usage: disaster Recovery

--- a/dev/scripts/nise_ymls/ocp_on_aws/aws_static_data.yml
+++ b/dev/scripts/nise_ymls/ocp_on_aws/aws_static_data.yml
@@ -39,6 +39,7 @@ generators:
         resourceTags/user:com_redhat_rhel_sla: self-support
         resourceTags/user:CoM_RedHat_Rhel_varianT: Workstation
         resourceTags/user:com_redhat_rhel_usage: disaster Recovery
+        resourceTags/user:com_redhat_rhel_addon: True
         resourceTags/user:Mapping: b1
         resourceTags/user:Map: b2
         resourceTags/user:Name: instance-name-2

--- a/koku/subs/subs_data_messenger.py
+++ b/koku/subs/subs_data_messenger.py
@@ -27,6 +27,16 @@ from providers.azure.client import AzureClientFactory
 
 LOG = logging.getLogger(__name__)
 
+HPC_ROLE = "Red Hat Enterprise Linux Compute Node"
+SAP_ROLE = "SAP"
+RHEL_7 = "69"
+RHEL_8 = "479"
+ELS = "204"
+RHEL_7_HPC_ID = "76"
+RHEL_7_SAP_ID = "146"
+RHEL_8_HPC_ID = "479"
+RHEL_8_SAP_ID = "241"
+
 
 class SUBSDataMessenger:
     def __init__(self, context, schema_name, tracing_id):
@@ -106,11 +116,12 @@ class SUBSDataMessenger:
                             row["subs_start_time"],
                             row["subs_end_time"],
                             row["subs_vcpu"],
+                            row["subs_rhel_version"],
                             row["subs_sla"],
                             row["subs_usage"],
                             row["subs_role"],
-                            row["subs_product_ids"].split("-"),
-                            row["subs_addon"],
+                            row["subs_conversion"],
+                            row["subs_addon_id"],
                         )
                         msg = bytes(json.dumps(subs_dict), "utf-8")
                         self.send_kafka_message(msg)
@@ -131,8 +142,11 @@ class SUBSDataMessenger:
         producer.produce(SUBS_TOPIC, key=self.org_id, value=msg, callback=delivery_callback)
         producer.poll(0)
 
-    def build_base_subs_dict(self, instance_id, tstamp, expiration, cpu_count, sla, usage, role, product_ids, addon):
+    def build_base_subs_dict(
+        self, instance_id, tstamp, expiration, cpu_count, version, sla, usage, role, conversion, addon
+    ):
         """Gathers the relevant information for the kafka message and returns a filled dictionary of information."""
+        product_ids = self.determine_product_ids(version, addon, role)
         subs_dict = {
             "event_id": str(uuid.uuid4()),
             "event_source": "cost-management",
@@ -151,12 +165,12 @@ class SUBSDataMessenger:
             "usage": usage,
             "billing_provider": self.provider_type.lower(),
         }
-        if addon == "true":
-            subs_dict["conversion"] = False
-        else:
+        if conversion == "true":
             subs_dict["conversion"] = True
+        else:
+            subs_dict["conversion"] = False
         # SAP is identified only through product ids and does not have an associated Role
-        if role != "SAP":
+        if role != SAP_ROLE:
             subs_dict["role"] = role
         return subs_dict
 
@@ -167,15 +181,16 @@ class SUBSDataMessenger:
         tstamp,
         expiration,
         cpu_count,
+        version,
         sla,
         usage,
         role,
-        product_ids,
+        conversion,
         addon,
     ):
         """Adds AWS specific fields to the base subs dict."""
         subs_dict = self.build_base_subs_dict(
-            instance_id, tstamp, expiration, cpu_count, sla, usage, role, product_ids, addon
+            instance_id, tstamp, expiration, cpu_count, version, sla, usage, role, conversion, addon
         )
         subs_dict["billing_account_id"] = billing_account_id
         return subs_dict
@@ -187,16 +202,17 @@ class SUBSDataMessenger:
         tstamp,
         expiration,
         cpu_count,
+        version,
         sla,
         usage,
         role,
-        product_ids,
-        tenant_id,
+        conversion,
         addon,
+        tenant_id,
     ):
         """Adds Azure specific fields to the base subs dict."""
         subs_dict = self.build_base_subs_dict(
-            instance_id, tstamp, expiration, cpu_count, sla, usage, role, product_ids, addon
+            instance_id, tstamp, expiration, cpu_count, version, sla, usage, role, conversion, addon
         )
         subs_dict["azure_subscription_id"] = billing_account_id
         subs_dict["azure_tenant_id"] = tenant_id
@@ -225,12 +241,13 @@ class SUBSDataMessenger:
                 start.isoformat(),
                 end.isoformat(),
                 row["subs_vcpu"],
+                row["subs_rhel_version"],
                 row["subs_sla"],
                 row["subs_usage"],
                 row["subs_role"],
-                row["subs_product_ids"].split("-"),
+                row["subs_conversion"],
+                row["subs_addon_id"],
                 tenant_id,
-                row["subs_addon"],
             )
             msg = bytes(json.dumps(subs_dict), "utf-8")
             # move to the next hour in the range
@@ -238,3 +255,28 @@ class SUBSDataMessenger:
             self.send_kafka_message(msg)
             msg_count += 1
         return msg_count
+
+    def determine_product_ids(self, rhel_version, addon, role):
+        """Determine the appropriate product id's based on the RHEL version, addon and role.
+
+        HPC variants overwrite the product id's and are handled via ROLE.
+        SAP variants are additional product id's.
+        """
+        product_ids = []
+        if rhel_version == RHEL_7:
+            if role == HPC_ROLE:
+                return [RHEL_7_HPC_ID]
+            elif role == SAP_ROLE:
+                product_ids.append(RHEL_7_SAP_ID)
+            product_ids.append(RHEL_7)
+        elif rhel_version == RHEL_8:
+            if role == HPC_ROLE:
+                return [RHEL_8_HPC_ID]
+            elif role == SAP_ROLE:
+                product_ids.append(RHEL_8_SAP_ID)
+            product_ids.append(RHEL_8)
+
+        if addon == ELS:
+            product_ids.append(ELS)
+
+        return product_ids

--- a/koku/subs/test/test_subs_data_messenger.py
+++ b/koku/subs/test/test_subs_data_messenger.py
@@ -565,3 +565,20 @@ class TestSUBSDataMessenger(SUBSTestCase):
         mock_azure_id.assert_not_called()
         mock_msg_builder.assert_not_called()
         mock_producer.assert_not_called()
+
+    def test_determine_product_ids(self):
+        """Test that different combinations of inputs result in expected product IDs"""
+        mapping_to_expected = {
+            ("69", "204", "Red Hat Enterprise Linux Compute Node"): ["76"],  # RHEL 7 HPC
+            ("69", "204", "SAP"): ["146", "69", "204"],  # RHEL 7 ELS SAP
+            ("69", "", "Workstation"): ["69"],  # RHEL 7 workstation
+            ("479", "204", "Red Hat Enterprise Linux Compute Node"): ["479"],  # RHEL 8 HPC
+            ("479", "204", "SAP"): ["241", "479", "204"],  # RHEL 8 ELS SAP
+            ("479", "204", "Workstation"): ["479", "204"],  # RHEL 8 ELS
+            ("479", "", "Workstation"): ["479"],  # RHEL 8 Workstation
+        }
+        for tup, expected in mapping_to_expected.items():
+            with self.subTest(inputs=tup):
+                version, addon, role = tup
+                actual = self.messenger.determine_product_ids(version, addon, role)
+                self.assertEqual(expected, actual)

--- a/koku/subs/test/test_subs_data_messenger.py
+++ b/koku/subs/test/test_subs_data_messenger.py
@@ -45,8 +45,9 @@ class TestSUBSDataMessenger(SUBSTestCase):
                 "subs_usage": "Production",
                 "subs_sla": "Premium",
                 "subs_role": "Red Hat Enterprise Linux Server",
-                "subs_product_ids": "479-70",
-                "subs_addon": "true",
+                "subs_rhel_version": "479",
+                "subs_addon_id": "204",
+                "subs_conversion": "true",
             }
         ]
         mock_op = mock_open(read_data="x,y,z")
@@ -63,11 +64,13 @@ class TestSUBSDataMessenger(SUBSTestCase):
         lineitem_usagestartdate = "2023-07-01T01:00:00Z"
         lineitem_usageenddate = "2023-07-01T02:00:00Z"
         product_vcpu = "2"
+        version = "479"
+        converted = "true"
         usage = "Production"
         rol = "Red Hat Enterprise Linux Server"
         sla = "Premium"
-        product_ids = ["479", "70"]
-        addon = "false"
+        product_ids = ["479", "204"]
+        addon = "204"
         static_uuid = uuid.uuid4()
         expected_subs_dict = {
             "event_id": str(static_uuid),
@@ -96,10 +99,11 @@ class TestSUBSDataMessenger(SUBSTestCase):
                 lineitem_usagestartdate,
                 lineitem_usageenddate,
                 product_vcpu,
+                version,
                 sla,
                 usage,
                 rol,
-                product_ids,
+                converted,
                 addon,
             )
         self.assertEqual(expected_subs_dict, actual)
@@ -116,8 +120,10 @@ class TestSUBSDataMessenger(SUBSTestCase):
         usage = "Production"
         rol = "Red Hat Enterprise Linux Server"
         sla = "Premium"
-        addon = "false"
-        product_ids = ["479", "70"]
+        addon = "204"
+        version = "479"
+        product_ids = ["479", "204"]
+        converted = "true"
         static_uuid = uuid.uuid4()
         expected_subs_dict = {
             "event_id": str(static_uuid),
@@ -148,10 +154,11 @@ class TestSUBSDataMessenger(SUBSTestCase):
                 lineitem_usagestartdate,
                 lineitem_usageenddate,
                 product_vcpu,
+                version,
                 sla,
                 usage,
                 rol,
-                product_ids,
+                converted,
                 addon,
             )
         self.assertEqual(expected_subs_dict, actual)
@@ -167,8 +174,10 @@ class TestSUBSDataMessenger(SUBSTestCase):
         usage = "Production"
         rol = "SAP"
         sla = "Premium"
-        product_ids = ["479", "70"]
-        addon = "false"
+        product_ids = ["241", "479", "204"]
+        version = "479"
+        addon = "204"
+        converted = "true"
         static_uuid = uuid.uuid4()
         expected_subs_dict = {
             "event_id": str(static_uuid),
@@ -196,15 +205,16 @@ class TestSUBSDataMessenger(SUBSTestCase):
                 lineitem_usagestartdate,
                 lineitem_usageenddate,
                 product_vcpu,
+                version,
                 sla,
                 usage,
                 rol,
-                product_ids,
+                converted,
                 addon,
             )
         self.assertEqual(expected_subs_dict, actual)
 
-    def test_build_base_subs_dict_addon_true(self):
+    def test_build_base_subs_dict_addon_els(self):
         """
         Test building the kafka message body
         """
@@ -212,11 +222,13 @@ class TestSUBSDataMessenger(SUBSTestCase):
         lineitem_usagestartdate = "2023-07-01T01:00:00Z"
         lineitem_usageenddate = "2023-07-01T02:00:00Z"
         product_vcpu = "2"
+        version = "479"
+        converted = "false"
         usage = "Production"
         rol = "SAP"
         sla = "Premium"
-        product_ids = ["479", "70"]
-        addon = "true"
+        product_ids = ["241", "479", "204"]
+        addon = "204"
         static_uuid = uuid.uuid4()
         expected_subs_dict = {
             "event_id": str(static_uuid),
@@ -244,10 +256,11 @@ class TestSUBSDataMessenger(SUBSTestCase):
                 lineitem_usagestartdate,
                 lineitem_usageenddate,
                 product_vcpu,
+                version,
                 sla,
                 usage,
                 rol,
-                product_ids,
+                converted,
                 addon,
             )
         self.assertEqual(expected_subs_dict, actual)
@@ -261,11 +274,13 @@ class TestSUBSDataMessenger(SUBSTestCase):
         lineitem_usageenddate = "2023-07-01T02:00:00Z"
         lineitem_usageaccountid = "9999999999999"
         product_vcpu = "2"
+        version = "479"
+        converted = "true"
         usage = "Production"
         rol = "Red Hat Enterprise Linux Server"
         sla = "Premium"
-        product_ids = ["479", "70"]
-        addon = "false"
+        product_ids = ["479", "204"]
+        addon = "204"
         tenant_id = "my-fake-id"
         static_uuid = uuid.uuid4()
         expected_subs_dict = {
@@ -298,12 +313,13 @@ class TestSUBSDataMessenger(SUBSTestCase):
                 lineitem_usagestartdate,
                 lineitem_usageenddate,
                 product_vcpu,
+                version,
                 sla,
                 usage,
                 rol,
-                product_ids,
-                tenant_id,
+                converted,
                 addon,
+                tenant_id,
             )
         self.assertEqual(expected_subs_dict, actual)
 
@@ -316,11 +332,13 @@ class TestSUBSDataMessenger(SUBSTestCase):
         lineitem_usageenddate = "2023-07-01T02:00:00Z"
         lineitem_usageaccountid = "9999999999999"
         product_vcpu = "2"
+        version = "479"
+        converted = "true"
         usage = "Production"
         rol = "SAP"
         sla = "Premium"
-        addon = "False"
-        product_ids = ["479", "70"]
+        addon = "204"
+        product_ids = ["241", "479", "204"]
         tenant_id = "my-fake-id"
         static_uuid = uuid.uuid4()
         expected_subs_dict = {
@@ -352,12 +370,13 @@ class TestSUBSDataMessenger(SUBSTestCase):
                 lineitem_usagestartdate,
                 lineitem_usageenddate,
                 product_vcpu,
+                version,
                 sla,
                 usage,
                 rol,
-                product_ids,
-                tenant_id,
+                converted,
                 addon,
+                tenant_id,
             )
         self.assertEqual(expected_subs_dict, actual)
 
@@ -495,8 +514,9 @@ class TestSUBSDataMessenger(SUBSTestCase):
                 "subs_sla": "Premium",
                 "subs_role": "Red Hat Enterprise Linux Server",
                 "subs_usage_quantity": "4",
-                "subs_product_ids": "479-70",
-                "subs_addon": "false",
+                "subs_rhel_version": "479",
+                "subs_addon_id": "204",
+                "subs_conversion": "true",
                 "subs_instance": "",
                 "source": self.azure_provider.uuid,
                 "resourcegroup": "my-fake-rg",

--- a/koku/subs/test/test_subs_data_messenger.py
+++ b/koku/subs/test/test_subs_data_messenger.py
@@ -46,6 +46,7 @@ class TestSUBSDataMessenger(SUBSTestCase):
                 "subs_sla": "Premium",
                 "subs_role": "Red Hat Enterprise Linux Server",
                 "subs_product_ids": "479-70",
+                "subs_addon": "true",
             }
         ]
         mock_op = mock_open(read_data="x,y,z")
@@ -66,6 +67,7 @@ class TestSUBSDataMessenger(SUBSTestCase):
         rol = "Red Hat Enterprise Linux Server"
         sla = "Premium"
         product_ids = ["479", "70"]
+        addon = "false"
         static_uuid = uuid.uuid4()
         expected_subs_dict = {
             "event_id": str(static_uuid),
@@ -98,6 +100,7 @@ class TestSUBSDataMessenger(SUBSTestCase):
                 usage,
                 rol,
                 product_ids,
+                addon,
             )
         self.assertEqual(expected_subs_dict, actual)
 
@@ -113,6 +116,7 @@ class TestSUBSDataMessenger(SUBSTestCase):
         usage = "Production"
         rol = "Red Hat Enterprise Linux Server"
         sla = "Premium"
+        addon = "false"
         product_ids = ["479", "70"]
         static_uuid = uuid.uuid4()
         expected_subs_dict = {
@@ -148,6 +152,7 @@ class TestSUBSDataMessenger(SUBSTestCase):
                 usage,
                 rol,
                 product_ids,
+                addon,
             )
         self.assertEqual(expected_subs_dict, actual)
 
@@ -163,6 +168,7 @@ class TestSUBSDataMessenger(SUBSTestCase):
         rol = "SAP"
         sla = "Premium"
         product_ids = ["479", "70"]
+        addon = "false"
         static_uuid = uuid.uuid4()
         expected_subs_dict = {
             "event_id": str(static_uuid),
@@ -194,6 +200,55 @@ class TestSUBSDataMessenger(SUBSTestCase):
                 usage,
                 rol,
                 product_ids,
+                addon,
+            )
+        self.assertEqual(expected_subs_dict, actual)
+
+    def test_build_base_subs_dict_addon_true(self):
+        """
+        Test building the kafka message body
+        """
+        lineitem_resourceid = "i-55555556"
+        lineitem_usagestartdate = "2023-07-01T01:00:00Z"
+        lineitem_usageenddate = "2023-07-01T02:00:00Z"
+        product_vcpu = "2"
+        usage = "Production"
+        rol = "SAP"
+        sla = "Premium"
+        product_ids = ["479", "70"]
+        addon = "true"
+        static_uuid = uuid.uuid4()
+        expected_subs_dict = {
+            "event_id": str(static_uuid),
+            "event_source": "cost-management",
+            "event_type": "snapshot",
+            "account_number": self.acct,
+            "org_id": self.org_id,
+            "service_type": "RHEL System",
+            "instance_id": lineitem_resourceid,
+            "timestamp": lineitem_usagestartdate,
+            "expiration": lineitem_usageenddate,
+            "measurements": [{"value": product_vcpu, "uom": "vCPUs"}],
+            "cloud_provider": "AWS",
+            "hardware_type": "Cloud",
+            "product_ids": product_ids,
+            "sla": sla,
+            "usage": usage,
+            "billing_provider": "aws",
+            "conversion": False,
+        }
+        with patch("subs.subs_data_messenger.uuid.uuid4") as mock_uuid:
+            mock_uuid.return_value = static_uuid
+            actual = self.messenger.build_base_subs_dict(
+                lineitem_resourceid,
+                lineitem_usagestartdate,
+                lineitem_usageenddate,
+                product_vcpu,
+                sla,
+                usage,
+                rol,
+                product_ids,
+                addon,
             )
         self.assertEqual(expected_subs_dict, actual)
 
@@ -210,6 +265,7 @@ class TestSUBSDataMessenger(SUBSTestCase):
         rol = "Red Hat Enterprise Linux Server"
         sla = "Premium"
         product_ids = ["479", "70"]
+        addon = "false"
         tenant_id = "my-fake-id"
         static_uuid = uuid.uuid4()
         expected_subs_dict = {
@@ -247,6 +303,7 @@ class TestSUBSDataMessenger(SUBSTestCase):
                 rol,
                 product_ids,
                 tenant_id,
+                addon,
             )
         self.assertEqual(expected_subs_dict, actual)
 
@@ -262,6 +319,7 @@ class TestSUBSDataMessenger(SUBSTestCase):
         usage = "Production"
         rol = "SAP"
         sla = "Premium"
+        addon = "False"
         product_ids = ["479", "70"]
         tenant_id = "my-fake-id"
         static_uuid = uuid.uuid4()
@@ -299,6 +357,7 @@ class TestSUBSDataMessenger(SUBSTestCase):
                 rol,
                 product_ids,
                 tenant_id,
+                addon,
             )
         self.assertEqual(expected_subs_dict, actual)
 
@@ -326,6 +385,7 @@ class TestSUBSDataMessenger(SUBSTestCase):
             "subs_sla": "Premium",
             "subs_role": "Red Hat Enterprise Linux Server",
             "subs_product_ids": "479-70",
+            "subs_addon": "false",
             "subs_instance": expected_instance,
             "source": self.azure_provider.uuid,
         }
@@ -350,6 +410,7 @@ class TestSUBSDataMessenger(SUBSTestCase):
             "subs_sla": "Premium",
             "subs_role": "Red Hat Enterprise Linux Server",
             "subs_product_ids": "479-70",
+            "subs_addon": "false",
             "subs_instance": "",
             "source": self.azure_provider.uuid,
         }
@@ -375,6 +436,7 @@ class TestSUBSDataMessenger(SUBSTestCase):
             "subs_sla": "Premium",
             "subs_role": "Red Hat Enterprise Linux Server",
             "subs_product_ids": "479-70",
+            "subs_addon": "false",
             "subs_instance": "fake",
             "source": self.azure_provider.uuid,
         }
@@ -399,6 +461,7 @@ class TestSUBSDataMessenger(SUBSTestCase):
             "subs_sla": "Premium",
             "subs_role": "Red Hat Enterprise Linux Server",
             "subs_product_ids": "479-70",
+            "subs_addon": "false",
             "subs_instance": "",
             "source": self.azure_provider.uuid,
             "resourcegroup": "my-fake-rg",
@@ -433,6 +496,7 @@ class TestSUBSDataMessenger(SUBSTestCase):
                 "subs_role": "Red Hat Enterprise Linux Server",
                 "subs_usage_quantity": "4",
                 "subs_product_ids": "479-70",
+                "subs_addon": "false",
                 "subs_instance": "",
                 "source": self.azure_provider.uuid,
                 "resourcegroup": "my-fake-rg",
@@ -469,6 +533,7 @@ class TestSUBSDataMessenger(SUBSTestCase):
                 "subs_sla": "Premium",
                 "subs_role": "Red Hat Enterprise Linux Server",
                 "subs_product_ids": "479-70",
+                "subs_addon": "false",
                 "subs_instance": "",
                 "source": self.azure_provider.uuid,
                 "resourcegroup": "my-fake-rg",

--- a/koku/subs/trino_sql/aws/determine_resource_ids_for_usage_account.sql
+++ b/koku/subs/trino_sql/aws/determine_resource_ids_for_usage_account.sql
@@ -7,6 +7,6 @@ AND lineitem_productcode = 'AmazonEC2'
 AND strpos(lower(resourcetags), 'com_redhat_rhel') > 0
 AND lineitem_usageaccountid = {{usage_account}}
     {% if excluded_ids %}
-        AND lineitem_usageaccountid NOT IN {{excluded_ids | inclause}}
+        AND lineitem_resourceid NOT IN {{excluded_ids | inclause}}
     {% endif %}
 GROUP BY lineitem_resourceid

--- a/koku/subs/trino_sql/aws/subs_summary.sql
+++ b/koku/subs/trino_sql/aws/subs_summary.sql
@@ -49,7 +49,8 @@ FROM
               'com_redhat_rhel_variant',
               'com_redhat_rhel_usage',
               'com_redhat_rhel_sla',
-              'com_redhat_rhel_addon' ],
+              'com_redhat_rhel_addon',
+              'com_redhat_rhel_conversion'],
               lower(k)
             )
           ),

--- a/koku/subs/trino_sql/aws/subs_summary.sql
+++ b/koku/subs/trino_sql/aws/subs_summary.sql
@@ -39,7 +39,11 @@ SELECT
         WHEN 'sap' THEN '479-241'
         ELSE '479'
       END
-  END as subs_product_ids
+  END as subs_product_ids,
+  CASE lower(json_extract_scalar(tags, '$.com_redhat_rhel_addon'))
+    WHEN 'true' THEN 'true'
+    ELSE 'false'
+  END as subs_addon
 FROM
   (
     SELECT *,
@@ -54,7 +58,8 @@ FROM
               ARRAY[ 'com_redhat_rhel',
               'com_redhat_rhel_variant',
               'com_redhat_rhel_usage',
-              'com_redhat_rhel_sla' ],
+              'com_redhat_rhel_sla',
+              'com_redhat_rhel_addon' ],
               lower(k)
             )
           ),

--- a/koku/subs/trino_sql/aws/subs_summary.sql
+++ b/koku/subs/trino_sql/aws/subs_summary.sql
@@ -22,28 +22,18 @@ SELECT
     ELSE 'Premium'
   END as subs_sla,
   CASE lower(json_extract_scalar(tags, '$.com_redhat_rhel'))
-    WHEN 'rhel 7 els' THEN
-      CASE lower(json_extract_scalar(tags, '$.com_redhat_rhel_variant'))
-        WHEN 'sap' THEN '69-204-146'
-        WHEN 'hpc' THEN '76'
-        ELSE '69-204'
-      END
-    WHEN 'rhel 8 els' THEN
-      CASE lower(json_extract_scalar(tags, '$.com_redhat_rhel_variant'))
-        WHEN 'sap' THEN '479-204-241'
-        WHEN 'hpc' THEN '479'
-        ELSE '479-204'
-      END
-    ELSE
-      CASE lower(json_extract_scalar(tags, '$.com_redhat_rhel_variant'))
-        WHEN 'sap' THEN '479-241'
-        ELSE '479'
-      END
-  END as subs_product_ids,
+    WHEN '7' THEN '69'
+    WHEN '8' THEN '479'
+    ELSE '479'
+  END as subs_rhel_version,
   CASE lower(json_extract_scalar(tags, '$.com_redhat_rhel_addon'))
+    WHEN 'els' THEN '204'
+    ELSE NULL
+  END as subs_addon_id,
+  CASE lower(json_extract_scalar(tags, '$.com_redhat_rhel_conversion'))
     WHEN 'true' THEN 'true'
     ELSE 'false'
-  END as subs_addon
+  END as subs_conversion
 FROM
   (
     SELECT *,

--- a/koku/subs/trino_sql/azure/subs_summary.sql
+++ b/koku/subs/trino_sql/azure/subs_summary.sql
@@ -23,29 +23,19 @@ SELECT
     ELSE 'Premium'
   END as subs_sla,
   CASE lower(json_extract_scalar(tags, '$.com_redhat_rhel'))
-    WHEN 'rhel 7 els' THEN
-      CASE lower(json_extract_scalar(tags, '$.com_redhat_rhel_variant'))
-        WHEN 'sap' THEN '69-204-146'
-        WHEN 'hpc' THEN '76'
-        ELSE '69-204'
-      END
-    WHEN 'rhel 8 els' THEN
-      CASE lower(json_extract_scalar(tags, '$.com_redhat_rhel_variant'))
-        WHEN 'sap' THEN '479-204-241'
-        WHEN 'hpc' THEN '479'
-        ELSE '479-204'
-      END
-    ELSE
-      CASE lower(json_extract_scalar(tags, '$.com_redhat_rhel_variant'))
-        WHEN 'sap' THEN '479-241'
-        ELSE '479'
-      END
-  END as subs_product_ids,
-  COALESCE(lower(json_extract_scalar(lower(tags), '$.com_redhat_rhel_instance')), '') as subs_instance,
+    WHEN '7' THEN '69'
+    WHEN '8' THEN '479'
+    ELSE '479'
+  END as subs_rhel_version,
   CASE lower(json_extract_scalar(tags, '$.com_redhat_rhel_addon'))
+    WHEN 'els' THEN '204'
+    ELSE NULL
+  END as subs_addon_id,
+  CASE lower(json_extract_scalar(tags, '$.com_redhat_rhel_conversion'))
     WHEN 'true' THEN 'true'
     ELSE 'false'
-  END as subs_addon
+  END as subs_conversion,
+  COALESCE(lower(json_extract_scalar(lower(tags), '$.com_redhat_rhel_instance')), '') as subs_instance
 FROM
     hive.{{schema | sqlsafe}}.azure_line_items
 WHERE

--- a/koku/subs/trino_sql/azure/subs_summary.sql
+++ b/koku/subs/trino_sql/azure/subs_summary.sql
@@ -41,7 +41,11 @@ SELECT
         ELSE '479'
       END
   END as subs_product_ids,
-  COALESCE(lower(json_extract_scalar(lower(tags), '$.com_redhat_rhel_instance')), '') as subs_instance
+  COALESCE(lower(json_extract_scalar(lower(tags), '$.com_redhat_rhel_instance')), '') as subs_instance,
+  CASE lower(json_extract_scalar(tags, '$.com_redhat_rhel_addon'))
+    WHEN 'true' THEN 'true'
+    ELSE 'false'
+  END as subs_addon
 FROM
     hive.{{schema | sqlsafe}}.azure_line_items
 WHERE


### PR DESCRIPTION
## Jira Ticket

[COST-5128](https://issues.redhat.com/browse/COST-5128)

## Description

This change will process a new tag to identify whether this is a converted instance or not.

## Testing

1. Checkout Branch
2. Restart Koku
3. if you'd like, comment out the kafka message send in `subs_data_messenger` and change it to a log message so you can see the message.
4. Create and load AWS test customer data
5. Check minio for the subs file and verify the fields for `subs_rhel_version`, `subs_addon_id` and `subs_conversion` all match the expected values based on the tags in `com_redhat_rhel`, `com_redhat_rhel_addon` and `com_redhat_rhel_conversion`.
6. sample path: `koku-bucket/org1234567/AWS/source=d0b04109-dff9-4807-b56a-5369722e1ad9/date=2024-06-12/subs_f72ffb41-9c12-48d2-afd0-c81e32783cbf_d0b04109-dff9-4807-b56a-5369722e1ad9_0_0.csv`
7. Check out a message from the logs and see something like: 
```
subs_worker  | b'{"event_id": "600cdc1f-9843-449c-9a8d-2d9053510c3f", "event_source": "cost-management", "event_type": "snapshot", "account_number": "10001", "org_id": "1234567", "service_type": "RHEL System", "instance_id": "i-55555556", "timestamp": "2024-06-13T00:00:00Z", "expiration": "2024-06-13T01:00:00Z", "measurements": [{"value": "2", "uom": "vCPUs"}], "cloud_provider": "AWS", "hardware_type": "Cloud", "product_ids": ["479", "204"], "sla": "Self-Support", "usage": "Disaster Recovery", "billing_provider": "aws", "conversion": false, "role": "Red Hat Enterprise Linux Workstation", "billing_account_id": "9999999999998"}'


```


## Release Notes
- [ ] proposed release note

```markdown
* [COST-5128](https://issues.redhat.com/browse/COST-5128) Set conversion to false for subs message if new tag is present
```
