### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/check-image.yml
+++ b/.github/workflows/check-image.yml
@@ -9,22 +9,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.7
+
       - name: Install skopeo
         run: sudo apt-get install -y skopeo
+
       - name: Check change
         run: |
           skopeo inspect "docker://registry.access.redhat.com/ubi8/ubi-minimal:latest" | grep -Po '(?<="Digest": ")([^"]+)' > .baseimagedigest
           docker run --rm --entrypoint sh -u 0 quay.io/cloudservices/koku:latest -c \
             'yum upgrade -y --security > /dev/null; rpm -qa | sort | sha256sum' \
             >> .baseimagedigest
+
       - name: Do change if the digest changed
         run: |
           git config user.name 'Update-a-Bot'
           git config user.email 'insights@redhat.com'
           git add .baseimagedigest
           git commit -m "chore(image): update and rebuild image" || echo "No new changes"
+
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v6.0.5
         with:
           title: 'chore(image): update base image'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,15 +15,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v4.1.7
 
       - name: Install Python
-        uses: actions/setup-python@v4.3.0
+        uses: actions/setup-python@v5.1.0
         with:
           python-version: '3.9'
 
       - name: Run pre-commit checks
-        uses: pre-commit/action@v3.0.0
+        uses: pre-commit/action@v3.0.1
         env:
           SETUPTOOLS_USE_DISTUTILS: stdlib
 
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v4.1.7
         with:
           fetch-depth: 0
 
@@ -57,7 +57,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v41.0.0
+        uses: tj-actions/changed-files@v44.5.2
         with:
           files_from_source_file: docker-files.txt
 
@@ -70,7 +70,7 @@ jobs:
 
       - name: Setting smokes-required label
         if: env.RUN_TESTS == 'true'
-        uses: actions/github-script@v6.3.3
+        uses: actions/github-script@v7.0.1
         continue-on-error: true
         with:
           script: |
@@ -89,7 +89,7 @@ jobs:
 
       - name: Remove smokes-required label
         if: env.RUN_TESTS != 'true'
-        uses: actions/github-script@v6.3.3
+        uses: actions/github-script@v7.0.1
         continue-on-error: true
         with:
           script: |
@@ -114,13 +114,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v4.1.7
         with:
           fetch-depth: 0
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v41.0.0
+        uses: tj-actions/changed-files@v44.5.2
         with:
           files: |
             db_functions/**
@@ -160,7 +160,7 @@ jobs:
     steps:
       - name: Checkout
         if: needs.changed-files.outputs.run_tests == 'true'
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v4.1.7
         with:
           fetch-depth: 0
 
@@ -174,7 +174,7 @@ jobs:
 
       - name: Set up Python ${{ matrix.python-version }}
         if: needs.changed-files.outputs.run_tests == 'true'
-        uses: actions/setup-python@v4.3.0
+        uses: actions/setup-python@v5.1.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -185,7 +185,7 @@ jobs:
       - name: Cache dependencies
         if: needs.changed-files.outputs.run_tests == 'true'
         id: cache-dependencies
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v4.0.2
         with:
           path: |
             ~/.cache/pipenv
@@ -243,10 +243,11 @@ jobs:
 
       - name: Upload test coverage file
         if: steps.unit_tests_run.outcome == 'success'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.3
         with:
           name: coverage
           path: coverage.xml
+          overwrite: true
 
   coverage:
     name: Coverage
@@ -258,19 +259,19 @@ jobs:
         # this checkout is required for the coverage report. If we don't do this, then
         # the uploaded report is invalid and codecov doesn't know how to process it.
         if: needs.changed-files.outputs.run_tests == 'true'
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v4.1.7
         with:
           fetch-depth: 0
 
       - name: Download coverage result from units
         if: needs.changed-files.outputs.run_tests == 'true'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4.1.7
         with:
           name: coverage
 
       - name: Upload coverage to Codecov
         if: needs.changed-files.outputs.run_tests == 'true'
-        uses: codecov/codecov-action@v4.2.0
+        uses: codecov/codecov-action@v4.4.1
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v4.1.7
         with:
           fetch-depth: 0
 
@@ -43,7 +43,7 @@ jobs:
         run: bash .github/scripts/get_description.sh
 
       - name: Set release body
-        uses: ncipollo/release-action@v1.11.1
+        uses: ncipollo/release-action@v1.14.0
         with:
           bodyFile: release_body.md
           commit: ${{ github.event.inputs.commit }}


### PR DESCRIPTION
## Description

Node.js 16 actions are deprecated. Update the actions before things start breaking.

## Release Notes
- [x] proposed release note

```markdown
* Update GitHub actions due to the deprecation of Node.js 16
```
