### PR TITLE
masu - Account for intermediate `None` values when getting cost model

### DIFF
--- a/koku/masu/api/sources/test/test_views.py
+++ b/koku/masu/api/sources/test/test_views.py
@@ -52,6 +52,17 @@ class SourcesViewSetTests(MasuTestCase):
 
         self.assertEqual(result, [])
 
+    def test_get_cost_models_none_in_the_middle(self, mock_masu):
+        viewset = SourcesViewSet()
+        data = {
+            "provider": {
+                "customer": None,
+            }
+        }
+        result = viewset.get_cost_models(data)
+
+        self.assertEqual(result, [])
+
     def test_sources_detail(self, mock_masu):
         """Test the sources GET detail call."""
 

--- a/koku/masu/api/sources/views.py
+++ b/koku/masu/api/sources/views.py
@@ -115,8 +115,14 @@ class SourcesViewSet(*MIXIN_LIST):
 
     def get_cost_models(self, obj):
         """Get the cost models associated with this provider."""
-        if not obj or not (schema := obj.get("provider", {}).get("customer", {}).get("schema_name")):
+        try:
+            # The key value may be None, so 'or' is used instead of a default value for get()
+            provider = obj.get("provider") or {}
+            customer = provider.get("customer") or {}
+            schema = customer["schema_name"]
+        except (AttributeError, KeyError):
             return []
+
         with schema_context(schema):
             cost_models_map = CostModelMap.objects.filter(provider_uuid=obj["source_uuid"])
             return [{"name": m.cost_model.name, "uuid": m.cost_model.uuid} for m in cost_models_map]


### PR DESCRIPTION
## Description

Handle intermediate values of `None` in additon to a missing key.

## Release Notes
- [x] proposed release note

```markdown
* masu - Account for intermediate values of `None` when getting the cost model information for a source
```
