### PR TITLE
Improve our logging readability

### DIFF
--- a/koku/api/common/__init__.py
+++ b/koku/api/common/__init__.py
@@ -21,6 +21,8 @@ def log_json(tracing_id="", *, msg, context=None, **kwargs):
         stmt |= context
     stmt |= kwargs
     for key, value in stmt.items():
+        if key == "split_files":
+            stmt[key] = len(value)
         if isinstance(value, UUID):
             stmt[key] = str(value)
     return stmt


### PR DESCRIPTION
## Jira Ticket

[COST-5168](https://issues.redhat.com/browse/COST-5168)

## Description

This change will redefine the split_files statement in our context logging. So we dont have a sea of file names filling the logs.

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Release Notes
- [ ] proposed release note

```markdown
* [COST-5168](https://issues.redhat.com/browse/COST-5168) Logging improvements
```
