### PR TITLE
[COST-5178] - batch delete S3 files

### DIFF
--- a/koku/masu/celery/tasks.py
+++ b/koku/masu/celery/tasks.py
@@ -5,7 +5,6 @@
 """Asynchronous tasks."""
 import json
 import logging
-import math
 import re
 
 import requests
@@ -45,6 +44,7 @@ from masu.processor.orchestrator import Orchestrator
 from masu.processor.tasks import autovacuum_tune_schema
 from masu.processor.tasks import DEFAULT
 from masu.prometheus_stats import QUEUES
+from masu.util.aws.common import delete_s3_objects
 from masu.util.aws.common import get_s3_resource
 from masu.util.oci.common import OCI_REPORT_TYPES
 from masu.util.ocp.common import OCP_REPORT_TYPES
@@ -119,9 +119,8 @@ def purge_s3_files(prefix, schema_name, provider_type, provider_uuid):
         LOG.info(message)
 
     LOG.info("Attempting to delete our archived data in S3 under %s", prefix)
-    remaining_objects = deleted_archived_with_prefix(settings.S3_BUCKET_NAME, prefix)
-    LOG.info(f"Deletion complete. Remaining objects: {remaining_objects}")
-    return remaining_objects
+    deleted_archived_with_prefix(settings.S3_BUCKET_NAME, prefix)
+    LOG.info("Deletion complete")
 
 
 @celery_app.task(name="masu.celery.tasks.purge_manifest_records", queue=DEFAULT)
@@ -162,23 +161,12 @@ def deleted_archived_with_prefix(s3_bucket_name, prefix):
         s3_bucket_name (str): The s3 bucket name
         prefix (str): The prefix for deletion
     """
+    context = {"service_task": "purge_old_data"}
     s3_resource = get_s3_resource(settings.S3_ACCESS_KEY, settings.S3_SECRET, settings.S3_REGION)
     s3_bucket = s3_resource.Bucket(s3_bucket_name)
-    object_keys = [{"Key": s3_object.key} for s3_object in s3_bucket.objects.filter(Prefix=prefix)]
-    LOG.info(f"Starting objects: {len(object_keys)}")
-    batch_size = 1000  # AWS S3 delete API limits to 1000 objects per request.
-    for batch_number in range(math.ceil(len(object_keys) / batch_size)):
-        batch_start = batch_size * batch_number
-        batch_end = batch_start + batch_size
-        object_keys_batch = object_keys[batch_start:batch_end]
-        s3_bucket.delete_objects(Delete={"Objects": object_keys_batch})
-
-    remaining_objects = list(s3_bucket.objects.filter(Prefix=prefix))
-    if remaining_objects:
-        LOG.warning(
-            "Found %s objects after attempting to delete all objects with prefix %s", len(remaining_objects), prefix
-        )
-    return remaining_objects
+    object_keys = [s3_object.key for s3_object in s3_bucket.objects.filter(Prefix=prefix)]
+    LOG.info(f"starting objects: {len(object_keys)}")
+    delete_s3_objects("purge masu endpoint", object_keys, context)
 
 
 @celery_app.task(  # noqa: C901


### PR DESCRIPTION
## Jira Ticket

[COST-5178](https://issues.redhat.com/browse/COST-5178)

## Description

This change will:
- improve out S3 deletions by doing batches of 1000 instead of iterating on single files
- Additionally; fix Ingress custom filter flows to always delete and reprocess full months (By original design)

## Testing

# S3 deletions #
1. Checkout Branch
2. Restart Koku
3. Load AWS data (everything should process correct)
4. Load additional AWS data and see S3 deletions complete successfully.
5. Should see the following messages `attempting to batch delete s3 files` followed by `removed files from s3 bucket`

## Release Notes
- [ ] proposed release note

```markdown
* [COST-5178](https://issues.redhat.com/browse/COST-5178) Improve processing S3 deletions 
```
