### PR TITLE
[COST-5176] correctly pass context dictionary within log_json function call

### DIFF
--- a/koku/hcs/daily_report.py
+++ b/koku/hcs/daily_report.py
@@ -51,9 +51,9 @@ class ReportHCS:
                     )
 
             except HCSTableNotFoundError as tnfe:
-                LOG.info(log_json(self._tracing_id, msg=f"{tnfe}, skipping..."), context=self._ctx)
+                LOG.info(log_json(self._tracing_id, msg=f"{tnfe}, skipping...", context=self._ctx))
 
             except Exception as e:
                 LOG.warning(
-                    log_json(self._tracing_id, msg="get_hcs_daily_summary exception"), context=self._ctx, exc_info=e
+                    log_json(self._tracing_id, msg="get_hcs_daily_summary exception", context=self._ctx), exc_info=e
                 )


### PR DESCRIPTION
## Jira Ticket

[COST-5176](https://issues.redhat.com/browse/COST-5176)

## Description

This change will correctly pass context dict within log_json function call and not the LOG call.

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Release Notes
- [x] proposed release note

```markdown
* [COST-5176](https://issues.redhat.com/browse/COST-5176) Correctly pass context dictionary within log_json function call
```
