### PR TITLE
Skip tag SQL if key is present in cache but value is None

### DIFF
--- a/koku/koku/cache.py
+++ b/koku/koku/cache.py
@@ -123,6 +123,26 @@ def invalidate_view_cache_for_tenant_and_all_source_types(schema_name):
         invalidate_view_cache_for_tenant_and_source_type(schema_name, source_type)
 
 
+def get_value_from_cache(cache_key, cache_choice="default"):
+    cache = caches[cache_choice]
+    return cache.get(cache_key)
+
+
+def set_value_in_cache(cache_key, cache_value, cache_choice="default"):
+    cache = caches[cache_choice]
+    cache.set(cache_key, cache_value)
+
+
+def is_key_in_cache(cache_key, cache_choice="default"):
+    cache = caches[cache_choice]
+    return cache.has_key(cache_key)
+
+
+def build_matching_tags_key(schema_name, provider_type):
+    """Return the key for matching tags"""
+    return f"OCP-on-{provider_type}:{schema_name}:matching-tags"
+
+
 def get_cached_matching_tags(schema_name, provider_type):
     """Return cached OCP on Cloud matched tags if exists."""
     cache = caches["default"]

--- a/koku/masu/test/processor/parquet/test_ocp_cloud_parquet_report_processor.py
+++ b/koku/masu/test/processor/parquet/test_ocp_cloud_parquet_report_processor.py
@@ -415,7 +415,7 @@ class TestOCPCloudParquetReportProcessor(MasuTestCase):
         matched_tags = [{"tag_one": "value_one"}, {"tag_two": "value_bananas"}]
         mock_get_tags.reset_mock()
         with patch(
-            "masu.processor.parquet.ocp_cloud_parquet_report_processor.get_cached_matching_tags",
+            "masu.processor.parquet.ocp_cloud_parquet_report_processor.get_value_from_cache",
             return_value=matched_tags,
         ):
             self.report_processor.get_matched_tags([])
@@ -439,7 +439,7 @@ class TestOCPCloudParquetReportProcessor(MasuTestCase):
         matched_tags = [{"tag_one": "value_one"}, {"tag_two": "value_bananas"}]
         mock_get_tags.reset_mock()
         with patch(
-            "masu.processor.parquet.ocp_cloud_parquet_report_processor.get_cached_matching_tags",
+            "masu.processor.parquet.ocp_cloud_parquet_report_processor.get_value_from_cache",
             return_value=matched_tags,
         ):
             self.report_processor.get_matched_tags([])


### PR DESCRIPTION
## Jira Ticket

[COST-####](https://issues.redhat.com/browse/COST-####)

## Description

This change will skip running OCP on Cloud matching tag SQL if the key exists in the cache but there is no value. We don't need to run this for every data frame if we already established there are no matching tags.

## Testing

1. Checkout main
2. Create test customer but don't load any data
3. Go into the worker `docker exec -it koku-koku-worker-1 /bin/bash` and `python manage.py shell`
4. Create an `OCPCloudParquetReportProcessor` for a provider type that has no data
```
>>> from masu.processor.parquet.ocp_cloud_parquet_report_processor import OCPCloudParquetReportProcessor

>>> my_processor = OCPCloudParquetReportProcessor(
    schema_name="org1234567", 
    report_path="/fake/", 
    provider_uuid="89464311-7be9-4d95-8db9-5271873b0564", 
    provider_type="Azure", 
    manifest_id=1,
    context={"start_date": "2024-06-01", "tracing_id": "1"},
)
```
5. Attempt to get the matched tags twice and see that both times there were no matching enabled keys.
6. See a message similar to the following: 
```
>>> my_processor.get_matched_tags(['fake'])
[2024-06-24 19:50:50,048] INFO None 143 {'message': 'no matching enabled keys for OCP on Azure', 'tracing_id': '', 'schema': 'org1234567'}
>>> my_processor.get_matched_tags(['fake'])
[2024-06-24 19:50:53,252] INFO None 143 {'message': 'no matching enabled keys for OCP on Azure', 'tracing_id': '', 'schema': 'org1234567'}
```
7. Verify the key exists in the cache:
```
>>> from django.core.cache import caches
>>> my_cache.has_key('OCP-on-Azure:org1234567:matching-tags')
True
```
8. Crush your cache: `make delete-redis-cache`
9. Checkout this branch
10. Go back into the worker `docker exec -it koku-koku-worker-1 /bin/bash` and `python manage.py shell`
11. Repeat step 4
12. Attempt to get the matched tags twice but this time, see it pull from cache for the second attempt:
```
>>> my_processor.get_matched_tags(['fake'])
[2024-06-24 19:58:26,049] INFO None 229 {'message': 'no matching enabled keys for OCP on Azure', 'tracing_id': '', 'schema': 'org1234567'}
>>> my_processor.get_matched_tags(['fake'])
[2024-06-24 19:58:28,358] INFO None 229 {'message': 'retreived matching tags from cache', 'tracing_id': '', 'schema': 'org1234567', 'provider_uuid': '89464311-7be9-4d95-8db9-5271873b0564', 'provider_type': 'Azure'}
```
## Release Notes
- [ ] proposed release note

```markdown
* [COST-####](https://issues.redhat.com/browse/COST-####) Skip the OCP on Cloud matched tags check if the key is already in the cache but has no value.
```
