### PR TITLE
Add flower as a dev dependency

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -64,6 +64,7 @@ sqlparse = "*"
 [dev-packages]
 argh = ">=0.26.2"
 astroid = ">=2.3"
+flower = "*"
 coverage = ">=5.0"
 crc-bonfire = "*"
 debugpy = ">=1.3.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "420c125a8ecfaebc012aab840f5461a14e57c51ae3e5213ea2341b46ace1d86b"
+            "sha256": "b67b765f3e4de6c57aed4affb209e2fef66468fcded4fa762d5147bb829dc685"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -1737,6 +1737,14 @@
         }
     },
     "develop": {
+        "amqp": {
+            "hashes": [
+                "sha256:827cb12fb0baa892aad844fd95258143bce4027fdac4fccddbc43330fd281637",
+                "sha256:a1ecff425ad063ad42a486c902807d1482311481c8ad95a72694b2975e75f7fd"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==5.2.0"
+        },
         "anytree": {
             "hashes": [
                 "sha256:244def434ccf31b668ed282954e5d315b4e066c4940b94aff4a7962d85947830",
@@ -1793,6 +1801,13 @@
             "index": "pypi",
             "version": "==12.20.0"
         },
+        "billiard": {
+            "hashes": [
+                "sha256:299de5a8da28a783d51b197d496bef4f1595dd023a93a4f59dde1886ae905547",
+                "sha256:87103ea78fa6ab4d5c751c4909bcff74617d985de7fa8b672cf8618afd5a875b"
+            ],
+            "version": "==3.6.4.0"
+        },
         "boto3": {
             "hashes": [
                 "sha256:4460958d2b0c53bd2195b23ed5d45db2350e514486fe8caeb38b285b30742280",
@@ -1823,6 +1838,15 @@
             ],
             "index": "pypi",
             "version": "==5.3.3"
+        },
+        "celery": {
+            "hashes": [
+                "sha256:138420c020cd58d6707e6257b6beda91fd39af7afde5d36c6334d175302c0e14",
+                "sha256:fafbd82934d30f8a004f81e8f7a062e31413a23d444be8ee3326553915958c6d"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.7'",
+            "version": "==5.2.7"
         },
         "certifi": {
             "hashes": [
@@ -2014,6 +2038,29 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==8.1.7"
+        },
+        "click-didyoumean": {
+            "hashes": [
+                "sha256:4f82fdff0dbe64ef8ab2279bd6aa3f6a99c3b28c05aa09cbfc07c9d7fbb5a463",
+                "sha256:5c4bb6007cfea5f2fd6583a2fb6701a22a41eb98957e63d0fac41c10e7c3117c"
+            ],
+            "markers": "python_full_version >= '3.6.2'",
+            "version": "==0.3.1"
+        },
+        "click-plugins": {
+            "hashes": [
+                "sha256:46ab999744a9d831159c3411bb0c79346d94a444df9a3a3742e9ed63645f264b",
+                "sha256:5d262006d3222f5057fd81e1623d4443e41dcda5dc815c06b442aa3c02889fc8"
+            ],
+            "version": "==1.1.1"
+        },
+        "click-repl": {
+            "hashes": [
+                "sha256:17849c23dba3d667247dc4defe1757fff98694e90fe37474f3feebb69ced26a9",
+                "sha256:fb7e06deb8da8de86180a33a9da97ac316751c094c6899382da7feeeeb51b812"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==0.3.0"
         },
         "contourpy": {
             "hashes": [
@@ -2250,6 +2297,15 @@
             ],
             "index": "pypi",
             "version": "==7.0.0"
+        },
+        "flower": {
+            "hashes": [
+                "sha256:5ab717b979530770c16afb48b50d2a98d23c3e9fe39851dcf6bc4d01845a02a0",
+                "sha256:9db2c621eeefbc844c8dd88be64aef61e84e2deb29b271e02ab2b5b9f01068e2"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.1"
         },
         "fonttools": {
             "hashes": [
@@ -2501,6 +2557,14 @@
             ],
             "version": "==1.62.2"
         },
+        "humanize": {
+            "hashes": [
+                "sha256:582a265c931c683a7e9b8ed9559089dea7edcf6cc95be39a3cbc2c5d5ac2bcfa",
+                "sha256:ce284a76d5b1377fd8836733b983bfb0b76f1aa1c090de2566fcf008d7f6ab16"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==4.9.0"
+        },
         "identify": {
             "hashes": [
                 "sha256:37d93f380f4de590500d9dba7db359d0d3da95ffe7f9de1753faa159e71e7dfa",
@@ -2672,6 +2736,15 @@
             ],
             "index": "pypi",
             "version": "==4.5.2"
+        },
+        "kombu": {
+            "hashes": [
+                "sha256:37cee3ee725f94ea8bb173eaab7c1760203ea53bbebae226328600f9d2799610",
+                "sha256:8b213b24293d3417bcf0d2f5537b7f756079e3ea232a8386dcc89a59fd2361a4"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.7'",
+            "version": "==5.2.4"
         },
         "kubernetes": {
             "hashes": [
@@ -3083,6 +3156,23 @@
             "index": "pypi",
             "version": "==3.7.1"
         },
+        "prometheus-client": {
+            "hashes": [
+                "sha256:287629d00b147a32dcb2be0b9df905da599b2d82f80377083ec8463309a4bb89",
+                "sha256:cde524a85bce83ca359cc837f28b8c0db5cac7aa653a588fd7e84ba061c329e7"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==0.20.0"
+        },
+        "prompt-toolkit": {
+            "hashes": [
+                "sha256:0d7bfa67001d5e39d02c224b663abc33687405033a8c422d0d675a5a13361d10",
+                "sha256:1e1b29cb58080b1e69f207c893a1a7bf16d127a5c30c9d17a25a5d77792e5360"
+            ],
+            "markers": "python_full_version >= '3.7.0'",
+            "version": "==3.0.47"
+        },
         "proto-plus": {
             "hashes": [
                 "sha256:89075171ef11988b3fa157f5dbd8b9cf09d65fffee97e29ce403cd8defba19d2",
@@ -3466,6 +3556,13 @@
             ],
             "index": "pypi",
             "version": "==4.0.1"
+        },
+        "wcwidth": {
+            "hashes": [
+                "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859",
+                "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5"
+            ],
+            "version": "==0.2.13"
         },
         "websocket-client": {
             "hashes": [

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -313,3 +313,21 @@ Examples commands and results:
 'schema1': {'PG': {'reporting_awscostentrylineitem_daily_summary': 'All data complete for table: reporting_awscostentrylineitem_daily_summary'}, 'TRINO': 'PG data complete so skipping trino query'}},
 'schema3': {'PG': {'reporting_awscostentrylineitem_daily_summary': 'All data complete for table: reporting_awscostentrylineitem_daily_summary'}, 'TRINO': 'PG data complete so skipping trino query'}}
 ```
+
+## Monitoring Celery ##
+
+[Flower] is a tool for monitoring Celery clusters. It provides detailed information about the status of workers and tasks.
+
+Flower is installed with the dev dependencies but it is not run by default. To start Flower, run
+
+```
+celery -A koku flower
+```
+
+Open http://localhost:5555 to see Celery details.
+
+See the [Flower documentation][flower] for detailed usage information.
+
+
+
+[flower]: https://flower.readthedocs.io/en/latest/index.html


### PR DESCRIPTION
## Description

Add [flower](https://flower.readthedocs.io/en/latest/index.html) as a dev dependency to provide bette visibly into celery tasks during development.

## Testing

1. Checkout Branch
2. Run `pipenv install --dev`
3. Run `celery -A koku flower`
4. Open http://localhost:5555

## Release Notes
- [x] proposed release note

```markdown
* Add [flower](https://flower.readthedocs.io/en/latest/index.html) as a development dependency
```
