### PR TITLE
[COST-5195] - Prevent duplicate OCP cost model tasks

### DIFF
--- a/koku/masu/processor/worker_cache.py
+++ b/koku/masu/processor/worker_cache.py
@@ -5,6 +5,7 @@
 """Cache of worker tasks currently running."""
 import logging
 
+from celery.result import AsyncResult
 from django.conf import settings
 from django.core.cache import caches
 from django.db import connection
@@ -152,6 +153,19 @@ class WorkerCache:
         """Check if a task is in the cache."""
         task_list = self.get_all_running_tasks()
         return task_key in task_list
+
+    def get_task_from_cache_key(self, cache_key):
+        """Return the currently queued task"""
+        task = None
+        for i in self.get_all_running_tasks():
+            if cache_key in i:
+                task_id = i.split(":")[-1]
+                task = AsyncResult(task_id)
+        return task
+
+    def set_cache_task_id(self, cache_key, task_id):
+        """Set task id for cached key"""
+        return
 
     def single_task_is_running(self, task_name, task_args=None):
         """Check for a single task key in the cache."""


### PR DESCRIPTION
## Jira Ticket

[COST-5195](https://issues.redhat.com/browse/COST-5195)

## Description

This change will add a new worker cached args check to add and validate that no current cost model tasks have been queued matching the same args before queuing a new task. 

## Testing

1. Checkout Branch
2. Restart Koku with multiple workers
3. Load OCP data with a cost model 
4. Add the following wait and log message to the `update_cost_model_costs` task. 
    
        LOG.info(f"\n\n WAITING ON COST MODEL TASK \n\n")
        import time; time.sleep(100)

6. Generate new OCP data and post it via masu
7. Worker 1 should process the data then hang in the sleep (Simulating a task in-progress)
8. Generate/post new data again
9. See the second worker downloads/processes the report but this time logs the following.  `cost model update for range already queued, skipping new task.`

## Release Notes
- [ ] proposed release note

```markdown
* [COST-5195](https://issues.redhat.com/browse/COST-5195) Prevent duplicate cost model update task being queued
```
