### PR TITLE
[COST-5125] Trino migration command improvements

### DIFF
--- a/koku/masu/management/commands/migrate_trino_tables.py
+++ b/koku/masu/management/commands/migrate_trino_tables.py
@@ -316,7 +316,7 @@ def get_all_schemas() -> list[str]:
     return schemas
 
 
-def run_trino_sql(sql, schema=None) -> t.Optional[str]:
+def run_trino_sql(sql, schema=None) -> list[t.Optional[list[int]]]:
     retries = 5
     for n in range(1, retries + 1):
         attempt = n
@@ -341,7 +341,7 @@ def run_trino_sql(sql, schema=None) -> t.Optional[str]:
                 raise err
         except TrinoUserError as err:
             LOG.error(err.message)
-            return schema
+            return []
 
 
 def log_start(schemas: list[str]) -> str:

--- a/koku/masu/management/commands/migrate_trino_tables.py
+++ b/koku/masu/management/commands/migrate_trino_tables.py
@@ -142,7 +142,7 @@ class Action(BaseModel):
         return self.schemas
 
     def get_schemas(self) -> set[str]:
-        LOG.info("Finding all schemas for migration...")
+        LOG.info("Finding schemas...")
         result = set()
         for col in self.list_of_cols.list:
             schemas = run_trino_sql(textwrap.dedent(self.find_query.format(col=col)))
@@ -345,7 +345,7 @@ def run_trino_sql(sql, schema=None) -> list[t.Optional[list[int]]]:
 
 
 def log_start(schemas: list[str]) -> str:
-    message = f"Running against the following schemas: {schemas}"
+    message = f"Running against the following schemas: {', '.join(schemas)}"
     if (schema_count := len(schemas)) > 10:
         message = f"Running against {schema_count} schemas"
 

--- a/koku/masu/management/commands/migrate_trino_tables.py
+++ b/koku/masu/management/commands/migrate_trino_tables.py
@@ -304,16 +304,16 @@ class Command(BaseCommand):
 def get_all_schemas() -> list[str]:
     sql = "SELECT schema_name FROM information_schema.schemata"
     schemas = run_trino_sql(sql)
-    schemas = [
+    schemas = {
         schema
         for listed_schema in schemas
         for schema in listed_schema
         if schema not in ["default", "information_schema"]
-    ]
+    }
     if not schemas:
         LOG.info("No schema in DB to update")
 
-    return schemas
+    return sorted(schemas)
 
 
 def run_trino_sql(sql, schema=None) -> list[t.Optional[list[int]]]:

--- a/koku/masu/management/commands/migrate_trino_tables.py
+++ b/koku/masu/management/commands/migrate_trino_tables.py
@@ -358,7 +358,8 @@ def drop_tables(tables, schemas) -> None:
         schemas = get_all_schemas()
 
     if not set(tables).issubset(EXTERNAL_TABLES):
-        raise ValueError("Attempting to drop non-external table, revise the list of tables to drop.", tables)
+        LOG.error(f"Attempting to drop non-external table, revise the list of tables to drop. {tables}")
+        sys.exit()
 
     log_start(schemas)
     schema_count = len(schemas)

--- a/koku/masu/management/commands/migrate_trino_tables.py
+++ b/koku/masu/management/commands/migrate_trino_tables.py
@@ -448,7 +448,7 @@ def find_expired_partitions(schema, months, table, source_column_param):
     WHERE partitions.partition_date < DATE '{expiration_date.date()!s}'
     GROUP BY partitions.year, partitions.month, partitions.source
         """
-    LOG.info(f"{prefix}Finding expired partitions for {schema} {table}")
+    LOG.info(f"{prefix}Finding expired partitions for {table}")
     return run_trino_sql(textwrap.dedent(expired_partitions_query), schema)
 
 
@@ -471,12 +471,12 @@ def drop_expired_partitions(tables, schemas):
 
             source_column_param = manage_table_mapping[table]
             if not check_table_exists(schema, table):
-                LOG.info(f"{prefix}{table} does not exist for {schema}")
+                LOG.info(f"{prefix}{table} does not exist")
                 continue
 
             expired_partitions = find_expired_partitions(schema, months, table, source_column_param)
             if not expired_partitions:
-                LOG.info(f"{prefix}No expired partitions found for {table} {schema}")
+                LOG.info(f"{prefix}No expired partitions found for {table}")
                 continue
 
             LOG.info(f"{prefix}Found {len(expired_partitions)}")

--- a/koku/masu/management/commands/migrate_trino_tables.py
+++ b/koku/masu/management/commands/migrate_trino_tables.py
@@ -317,13 +317,13 @@ def get_all_schemas() -> list[str]:
 
 
 def run_trino_sql(sql, schema=None) -> list[t.Optional[list[int]]]:
-    retries = 5
+    retries = 8
     for n in range(1, retries + 1):
         attempt = n
         remaining_retries = retries - n
         # Exponential backoff with a little bit of randomness and a
         # minimum wait of 0.5 and max wait of 7
-        wait = (min(2**n, 7) + secrets.randbelow(1000) / 1000) or 0.5
+        wait = (min(2**n, 12) + secrets.randbelow(1000) / 1000) or 0.5
         try:
             with trino_db.connect(schema=schema) as conn:
                 cur = conn.cursor()

--- a/koku/masu/management/commands/migrate_trino_tables.py
+++ b/koku/masu/management/commands/migrate_trino_tables.py
@@ -376,7 +376,7 @@ def drop_tables(tables, schemas) -> None:
                 LOG.error(e)
 
 
-def drop_partitions_from_tables(list_of_partitions: ListDropPartitions, schemas: list) -> None:
+def drop_partitions_from_tables(list_of_partitions: ListDropPartitions, schemas: list) -> None:  # noqa: C901
     """drop specified partitions from tables"""
     if not schemas:
         schemas = get_all_schemas()

--- a/koku/masu/management/commands/migrate_trino_tables.py
+++ b/koku/masu/management/commands/migrate_trino_tables.py
@@ -390,7 +390,11 @@ def drop_partitions_from_tables(list_of_partitions: ListDropPartitions, schemas:
             sql = f"SELECT count(DISTINCT {part.partition_column}) FROM {part.table}"
             try:
                 result = run_trino_sql(sql, schema)
-                partition_count = result[0][0]
+                try:
+                    partition_count = result[0][0]
+                except IndexError:
+                    LOG.warning(f"{prefix}Unable to get partition count")
+                    continue
 
                 if not partition_count:
                     LOG.info(f"{prefix}No partitions to delete")


### PR DESCRIPTION
## Jira Ticket

[COST-5125](https://issues.redhat.com/browse/COST-5125)

## Description

Add better logging and fine tune the retry behavior.

The overall progess is reported during exeuction as well as indenting log messages for operations on each schema.

```
[2024-06-26 18:50:33,174] INFO None 57531 Finding all schemas for migration...
[2024-06-26 18:50:33,338] INFO None 57531 Running against the following schemas: {'org1234567', 'test_ocp_table_has_column'}
[2024-06-26 18:50:33,338] INFO None 57531 Modifying tables for schema org1234567 (1 / 2)
[2024-06-26 18:50:33,338] INFO None 57531     org1234567: Altering table reporting_ocpusagelineitem_daily_summary...
[2024-06-26 18:50:33,650] INFO None 57531     org1234567: Altered table reporting_ocpusagelineitem_daily_summary []
[2024-06-26 18:50:33,651] INFO None 57531 Modifying tables for schema test_ocp_table_has_column (2 / 2)
[2024-06-26 18:50:33,651] INFO None 57531     test_ocp_table_has_column: Altering table reporting_ocpusagelineitem_daily_summary...
[2024-06-26 18:50:33,723] INFO None 57531     test_ocp_table_has_column: Altered table reporting_ocpusagelineitem_daily_summary []
[2024-06-26 18:50:33,723] INFO None 57531 Validating...
[2024-06-26 18:50:33,723] INFO None 57531 Finding all schemas for migration...
[2024-06-26 18:50:33,829] INFO None 57531 Migration successful
```

If the migration will run against more than ten schemas, it lists the count in the log message instead of all the schemas.

## Testing

1. Checkout Branch
2. Load some data
3. Run the following command twice. On the second run, it should not make changes.

```
python koku/manage.py migrate_trino_tables --add-columns '[ {"table": "reporting_ocpusagelineitem_daily_summary", "column": "some_new_column", "datatype": "varchar"} ]'
```

4. Run the following command twice
```
python koku/manage.py migrate_trino_tables --drop-columns '[ {"table": "reporting_ocpusagelineitem_daily_summary", "column": "some_new_column", "datatype": "varchar"} ]'
```

5. Run the follow command to drop an external table
```
python koku/manage.py migrate_trino_tables --drop-tables aws_line_items
```

6. Run the following command to attempt to drop a managed table
```
python koku/manage.py migrate_trino_tables --drop-tables aws_openshift_daily_resource_matched_temp
```

## Release Notes
- [x] proposed release note

```markdown
* [COST-5125](https://issues.redhat.com/browse/COST-5125) Improve logging and fine tune behavior of Trino migration management command
```
