### PR TITLE
Switch to using podman in build_deploy

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -30,13 +30,9 @@ function job_cleanup() {
 
 trap job_cleanup EXIT ERR SIGINT SIGTERM
 
-DOCKER_CONF="$TMP_JOB_DIR/.docker"
-mkdir -p "$DOCKER_CONF"
-docker --config="$DOCKER_CONF" login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
-docker --config="$DOCKER_CONF" build --build-arg GIT_COMMIT="$GIT_COMMIT" -t "${IMAGE}:${IMAGE_TAG}" .
-docker --config="$DOCKER_CONF" push "${IMAGE}:${IMAGE_TAG}"
+podman login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
+podman build --build-arg GIT_COMMIT="$GIT_COMMIT" -t "${IMAGE}:${IMAGE_TAG}" .
+podman push "${IMAGE}:${IMAGE_TAG}"
 
-docker --config="$DOCKER_CONF" tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:latest"
-docker --config="$DOCKER_CONF" push "${IMAGE}:latest"
-
-docker --config="$DOCKER_CONF" logout
+podman tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:latest"
+podman push "${IMAGE}:latest"


### PR DESCRIPTION
## Jira Ticket

[COST-5078](https://issues.redhat.com/browse/COST-5078)

## Description

The VM used in CI is now RHEL 8

## Testing

Look at the output of [koku build-main](https://ci.ext.devshift.net/job/project-koku-koku-gh-build-main/), [koku smoke-test](https://ci.ext.devshift.net/job/project-koku-koku-smoke-test-main/), and [koku pipeline](https://ci.ext.devshift.net/job/koku-pipeline-pr-check-main/) after merging this

## Release Notes
- [x] proposed release note

```markdown
* [COST-5078](https://issues.redhat.com/browse/COST-5078) Switch to RHEL 8 VMs for CI jobs
```
