### PR TITLE
[COST-5214] Move TARGETARCH declaration to the top of the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+ARG TARGETARCH
+
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest AS base
 
 USER root
@@ -60,8 +62,6 @@ RUN ldconfig
 
 # No intermetiate steps for x86_64, but declare it so it can be used for the final image
 FROM --platform=amd64 base AS stage-amd64
-
-ARG TARGETARCH
 
 FROM stage-${TARGETARCH} AS final
 # PIPENV_DEV is set to true in the docker-compose allowing

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ def secrets = [
 def configuration = [vaultUrl: params.VAULT_ADDRESS, vaultCredentialId: params.VAULT_CREDS_ID, engineVersion: 1]
 
 pipeline {
-    agent { label 'insights' }
+    agent { label 'rhel8' }
     options {
         timestamps()
     }


### PR DESCRIPTION
## Jira Ticket

[COST-5214](https://issues.redhat.com/browse/COST-5214)

## Description

There is a bug in podman where this is only used correctly for the multi-stage build if it is defined as the first line.

## Testing

```
podman build --build-arg GIT_COMMIT=1f0842d71 -t koku:1f0842d -f Dockerfile .
```

## Release Notes
- [x] proposed release note

```markdown
* [COST-5214](https://issues.redhat.com/browse/COST-5214) Update containerfile to build with `podman`
```
