### PR TITLE
[COST-5214] Remove directive to make the build work with docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -340,7 +340,14 @@ _koku-wait:
      done
 
 docker-build:
+    # HACK: Remove the ARG TARGETARCH directive to make the build work with docker
+    #       until https://github.com/containers/podman/issues/23046 is resolved.
+	@tail -n +3 Dockerfile > Dockerfile.temp
+	@mv Dockerfile.temp Dockerfile
 	$(DOCKER_COMPOSE) build koku-base
+	@echo "ARG TARGETARCH\n" | cat - Dockerfile > Dockerfile.temp
+	@mv Dockerfile.temp Dockerfile
+
 
 docker-up: docker-build
 	$(DOCKER_COMPOSE) up -d --scale koku-worker=$(scale)

--- a/Makefile
+++ b/Makefile
@@ -340,13 +340,8 @@ _koku-wait:
      done
 
 docker-build:
-    # HACK: Remove the ARG TARGETARCH directive to make the build work with docker
-    #       until https://github.com/containers/podman/issues/23046 is resolved.
-	@tail -n +3 Dockerfile > Dockerfile.temp
-	@mv Dockerfile.temp Dockerfile
-	$(DOCKER_COMPOSE) build koku-base
-	@echo "ARG TARGETARCH\n" | cat - Dockerfile > Dockerfile.temp
-	@mv Dockerfile.temp Dockerfile
+    # TARGETARCH: https://github.com/containers/podman/issues/23046 is resolved.
+	$(DOCKER_COMPOSE) build --build-arg TARGETARCH=$(shell uname -m) koku-base
 
 
 docker-up: docker-build

--- a/Makefile
+++ b/Makefile
@@ -341,7 +341,7 @@ _koku-wait:
 
 docker-build:
     # TARGETARCH: https://github.com/containers/podman/issues/23046 is resolved.
-	$(DOCKER_COMPOSE) build --build-arg TARGETARCH=$(shell uname -m) koku-base
+	$(DOCKER_COMPOSE) build --build-arg TARGETARCH=$(shell uname -m | sed s/x86_64/amd64/) koku-base
 
 
 docker-up: docker-build

--- a/Makefile
+++ b/Makefile
@@ -340,7 +340,7 @@ _koku-wait:
      done
 
 docker-build:
-    # TARGETARCH: https://github.com/containers/podman/issues/23046 is resolved.
+	# TARGETARCH: https://github.com/containers/podman/issues/23046 is resolved.
 	$(DOCKER_COMPOSE) build --build-arg TARGETARCH=$(shell uname -m | sed s/x86_64/amd64/) koku-base
 
 


### PR DESCRIPTION
## Jira Ticket

[COST-5214](https://issues.redhat.com/browse/COST-5214)

## Description

There is a podman bug that needs to be resolved which required adding this out of stage directive. Unfortunately that broke the image build for docker, which we use heavily.

This is a terrible hack until the bug in podman is resolved.

https://github.com/containers/podman/issues/23046

## Testing

1. Checkout Branch
2. `make docker-build`

## Release Notes
- [x] proposed release note

```markdown
* [COST-5214](https://issues.redhat.com/browse/COST-5214) Fix the container image for local development
```
