### PR TITLE
[COST-5216] Delete filtering optimization

### DIFF
--- a/koku/masu/util/aws/common.py
+++ b/koku/masu/util/aws/common.py
@@ -715,12 +715,18 @@ def get_s3_objects_matching_metadata(
     if context is None:
         context = {}
     try:
+        s3_client = boto3.client(
+            "s3",
+            aws_access_key_id=settings.S3_ACCESS_KEY,
+            aws_secret_access_key=settings.S3_SECRET,
+            region_name=settings.S3_REGION,
+        )
         keys = []
         for obj_summary in _get_s3_objects(s3_path):
-            existing_object = obj_summary.Object()
-            metadata_value = existing_object.metadata.get(metadata_key)
+            response = s3_client.head_object(Bucket=obj_summary.bucket_name, Key=obj_summary.key)
+            metadata_value = response["Metadata"].get(metadata_key)
             if metadata_value == metadata_value_check:
-                keys.append(existing_object.key)
+                keys.append(obj_summary.key)
         return keys
     except (EndpointConnectionError, ClientError) as err:
         LOG.warning(
@@ -743,12 +749,18 @@ def get_s3_objects_not_matching_metadata(
     if context is None:
         context = {}
     try:
+        s3_client = boto3.client(
+            "s3",
+            aws_access_key_id=settings.S3_ACCESS_KEY,
+            aws_secret_access_key=settings.S3_SECRET,
+            region_name=settings.S3_REGION,
+        )
         keys = []
         for obj_summary in _get_s3_objects(s3_path):
-            existing_object = obj_summary.Object()
-            metadata_value = existing_object.metadata.get(metadata_key)
+            response = s3_client.head_object(Bucket=obj_summary.bucket_name, Key=obj_summary.key)
+            metadata_value = response["Metadata"].get(metadata_key)
             if metadata_value != metadata_value_check:
-                keys.append(existing_object.key)
+                keys.append(obj_summary.key)
         return keys
     except (EndpointConnectionError, ClientError) as err:
         LOG.warning(


### PR DESCRIPTION
## Jira Ticket

[COST-5216](https://issues.redhat.com/browse/COST-5216)

## Description

This change will switch us to using head_object to download only the metadata during the delete filtering instead of the s3 object. This will save us some time since we will no longer need to spend cycles retrieving the additional attributes available to the object from s3 such as the ACL, owner, storage type, etc.

## Testing

I wrote a little test script we can use for this:
https://gist.github.com/myersCody/0c57dc2132a7a712c035ae1210c30d20

Output:

```
TEST NOT MATCHING
------
2023/04/30/a678b047-f78e-4ad8-9fbe-1e3b73bd5a24/
Metadata: {}


------
2023/04/30/a678b047-f78e-4ad8-9fbe-1e3b73bd5a24/0d34ec6a-1cab-4c89-a03e-cb471c0ba067.csv
Metadata: {'test-key': '1'}


------
2023/04/30/a678b047-f78e-4ad8-9fbe-1e3b73bd5a24/0d34ec6a-1cab-4c89-a03e-cb471c0ba067.csv.metadata
Metadata: {}


['2023/04/30/a678b047-f78e-4ad8-9fbe-1e3b73bd5a24/', '2023/04/30/a678b047-f78e-4ad8-9fbe-1e3b73bd5a24/0d34ec6a-1cab-4c89-a03e-cb471c0ba067.csv.metadata']
TEST MATCHING
------
2023/04/30/a678b047-f78e-4ad8-9fbe-1e3b73bd5a24/
Metadata: {}


------
2023/04/30/a678b047-f78e-4ad8-9fbe-1e3b73bd5a24/0d34ec6a-1cab-4c89-a03e-cb471c0ba067.csv
Metadata: {'test-key': '1'}


------
2023/04/30/a678b047-f78e-4ad8-9fbe-1e3b73bd5a24/0d34ec6a-1cab-4c89-a03e-cb471c0ba067.csv.metadata
Metadata: {}


['2023/04/30/a678b047-f78e-4ad8-9fbe-1e3b73bd5a24/0d34ec6a-1cab-4c89-a03e-cb471c0ba067.csv']
```

## Release Notes
- [ ] proposed release note

```markdown
* [COST-5216](https://issues.redhat.com/browse/COST-5216) Optimize delete filtering logic to only collect necessary metadata
```
