### PR TITLE
log s3 batch deletes

### DIFF
--- a/koku/masu/test/util/aws/test_common.py
+++ b/koku/masu/test/util/aws/test_common.py
@@ -491,7 +491,7 @@ class TestAWSUtils(MasuTestCase):
         mock_bucket.delete_objects.assert_has_calls(
             [call(Delete={"Objects": expected_keys[:1000]}), call(Delete={"Objects": expected_keys[1000:]})]
         )
-        self.assertIn("removed files from s3 bucket", captured_logs.output[-1])
+        self.assertIn("removed batch files from s3 bucket", captured_logs.output[-1])
 
     def test_remove_s3_objects_not_matching_metadata(self):
         """Test remove_s3_objects_not_matching_metadata."""

--- a/koku/masu/util/aws/common.py
+++ b/koku/masu/util/aws/common.py
@@ -803,15 +803,15 @@ def delete_s3_objects(request_id, keys_to_delete, context) -> list[str]:
             batch_end = batch_start + batch_size
             object_keys_batch = keys_to_delete[batch_start:batch_end]
             s3_bucket.delete_objects(Delete={"Objects": object_keys_batch})
-        LOG.info(
-            log_json(
-                request_id,
-                msg="removed files from s3 bucket",
-                context=context,
-                bucket=settings.S3_BUCKET_NAME,
-                file_list=keys_to_delete,
+            LOG.info(
+                log_json(
+                    request_id,
+                    msg="removed batch files from s3 bucket",
+                    context=context,
+                    bucket=settings.S3_BUCKET_NAME,
+                    file_list=object_keys_batch,
+                )
             )
-        )
         return keys_to_delete
     except (EndpointConnectionError, ClientError) as err:
         LOG.warning(


### PR DESCRIPTION
## Jira Ticket

[COST-####](https://issues.redhat.com/browse/COST-####)

## Description

This change will tweak our logs during S3 batch deletions to log each deleted batch. Currently we log everything post delete and these logs can be large enough to not be sent to kibana.

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Release Notes
- [ ] proposed release note

```markdown
* [COST-####](https://issues.redhat.com/browse/COST-####) Fix some things
```
