### PR TITLE
[COST-5198] Only store user object on write requests

### DIFF
--- a/koku/api/provider/provider_builder.py
+++ b/koku/api/provider/provider_builder.py
@@ -101,7 +101,7 @@ class ProviderBuilder:
             try:
                 customer = Customer.objects.filter(org_id=self.org_id).get()
             except Customer.DoesNotExist:
-                customer = IdentityHeaderMiddleware.create_customer(self.account_number, self.org_id)
+                customer = IdentityHeaderMiddleware.create_customer(self.account_number, self.org_id, "POST")
             try:
                 user = User.objects.get(username=username)
             except User.DoesNotExist:

--- a/koku/koku/test_middleware.py
+++ b/koku/koku/test_middleware.py
@@ -242,8 +242,8 @@ class IdentityHeaderMiddlewareTest(IamTestCase):
         customer = self._create_customer_data()
         account_id = customer["account_id"]
         org_id = customer["org_id"]
-        orig_cust = IdentityHeaderMiddleware.create_customer(account_id, org_id)
-        dup_cust = IdentityHeaderMiddleware.create_customer(account_id, org_id)
+        orig_cust = IdentityHeaderMiddleware.create_customer(account_id, org_id, "POST")
+        dup_cust = IdentityHeaderMiddleware.create_customer(account_id, org_id, "POST")
         self.assertEqual(orig_cust, dup_cust)
 
     def test_race_condition_user(self):

--- a/koku/sources/test/api/test_view.py
+++ b/koku/sources/test/api/test_view.py
@@ -173,7 +173,7 @@ class SourcesViewTests(IamTestCase):
         other_account = "10002"
         other_org_id = "2222222"
         customer = self._create_customer_data(account=other_account, org_id=other_org_id)
-        IdentityHeaderMiddleware.create_customer(other_account, other_org_id)
+        IdentityHeaderMiddleware.create_customer(other_account, other_org_id, "POST")
         request_context = self._create_request_context(customer, user_data, create_customer=True, is_admin=True)
 
         with requests_mock.mock() as m:
@@ -210,7 +210,7 @@ class SourcesViewTests(IamTestCase):
         other_account = "10002"
         other_org_id = "2222222"
         customer = self._create_customer_data(account=other_account, org_id=other_org_id)
-        IdentityHeaderMiddleware.create_customer(other_account, other_org_id)
+        IdentityHeaderMiddleware.create_customer(other_account, other_org_id, "POST")
 
         request_context = self._create_request_context(customer, user_data, create_customer=True, is_admin=True)
         with requests_mock.mock() as m:

--- a/koku/sources/test/test_kafka_listener.py
+++ b/koku/sources/test/test_kafka_listener.py
@@ -126,7 +126,7 @@ class SourcesKafkaMsgHandlerTest(IamTestCase):
         post_save.disconnect(storage_callback, sender=Sources)
         account = "10001"
         org_id = "1234567"
-        IdentityHeaderMiddleware.create_customer(account, org_id)
+        IdentityHeaderMiddleware.create_customer(account, org_id, "POST")
 
     def setUp(self):
         """Setup the test method."""

--- a/koku/sources/test/test_kafka_message_processor.py
+++ b/koku/sources/test/test_kafka_message_processor.py
@@ -144,7 +144,7 @@ class KafkaMessageProcessorTest(IamTestCase):
         post_save.disconnect(storage_callback, sender=Sources)
         account = "10001"
         org_id = "1234567"
-        IdentityHeaderMiddleware.create_customer(account, org_id)
+        IdentityHeaderMiddleware.create_customer(account, org_id, "POST")
 
     def setUp(self):
         self.valid_creds = {

--- a/koku/sources/test/test_kafka_source_manager.py
+++ b/koku/sources/test/test_kafka_source_manager.py
@@ -42,7 +42,7 @@ class ProviderBuilderTest(IamTestCase):
         super().setUpClass()
         cls.account = "12345"
         cls.org_id = "3333333"
-        IdentityHeaderMiddleware.create_customer(cls.account, cls.org_id)
+        IdentityHeaderMiddleware.create_customer(cls.account, cls.org_id, "POST")
 
     def setUp(self):
         """Test case setup."""

--- a/koku/sources/test/test_tasks.py
+++ b/koku/sources/test/test_tasks.py
@@ -30,7 +30,7 @@ class SourcesTasksTest(TestCase):
         post_save.disconnect(storage_callback, sender=Sources)
         account = "12345"
         org_id = "3333333"
-        IdentityHeaderMiddleware.create_customer(account, org_id)
+        IdentityHeaderMiddleware.create_customer(account, org_id, "POST")
 
     def setUp(self):
         """Setup the test method."""


### PR DESCRIPTION
* Update the middleware to only store the user object on write requests

## Jira Ticket

[COST-5198](https://issues.redhat.com/browse/COST-5198)

## Description

This change will only store user object on write requests

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint get endpoint
    1. You should see no user created but method functions
4. Hit post endpoint
    1. You should see a user created and method functions
