### PR TITLE
[COST-5287] Prevent azure cost deduplication on disk-id resources

### DIFF
--- a/koku/masu/database/trino_sql/reporting_ocpazurecostlineitem_daily_summary.sql
+++ b/koku/masu/database/trino_sql/reporting_ocpazurecostlineitem_daily_summary.sql
@@ -355,6 +355,7 @@ GROUP BY ocp_filtered.azure_partial_resource_id, date(coalesce(date, usagedateti
 -- Storage disk resources:
 -- (PV’s Capacity) / Disk Capacity * Cost of Disk
 -- PV without PVCs are Unattributed Storage
+-- 2 volumes can share the same disk id
 INSERT INTO hive.{{schema | sqlsafe}}.reporting_ocpazurecostlineitem_project_daily_summary_temp (
     azure_uuid,
     cluster_id,
@@ -387,7 +388,7 @@ INSERT INTO hive.{{schema | sqlsafe}}.reporting_ocpazurecostlineitem_project_dai
     year,
     month
 )
-SELECT azure.uuid as azure_uuid,
+SELECT cast(uuid() as varchar) as azure_uuid,
     max(ocp.cluster_id) as cluster_id,
     max(ocp.cluster_alias) as cluster_alias,
     'Storage' as data_source,


### PR DESCRIPTION
## Jira Ticket

[COST-5287](https://issues.redhat.com/browse/COST-5287)

## Description

This change will generate a unique azure uuid for rows created for the azure disk id resource matching. 

Typically what happens during resource matching, more than one openshift resource can be matched to an Azure resource. We handle this scenario in a cost deduplication step [here](https://github.com/project-koku/koku/blob/bf5683a8316893360edb03a164bf66c2d985e2b3/koku/masu/database/trino_sql/reporting_ocpazurecostlineitem_daily_summary.sql#L836-L839). 

**Why is this different for disk-id storage?**
It is true that more than one volume within a cluster can be utilizing the same disk id. However, we now calculate the cost for disk-id resources with a rate based off the capacity. Which means we are distributing the original cost based off the ratio of how much of the disk's capacity has been requested by the persistent volume. Deduplicating a rate is actually just a cost reduction.

## Testing

Pedro has created a reproducer for this issue, the branch name is:
```
plopezpe-volumes_sharing_same_disk
```
I recommend going to this branch and running:
`test_api_ocp_on_azure_csi_storage_shared_disk_raw_calc`

You will notice that the test now passes on this branch, but fails on main:
```
PASSED  test_api_ocp_on_azure_csi_storage_shared_disk_raw_calc[memory]
```

## Release Notes
- [ ] proposed release note

```markdown
* [COST-5287](https://issues.redhat.com/browse/COST-5287) Prevent azure cost deduplication on disk-id resources
```
