### PR TITLE
[COST-5299] clear cache when table is dropped by migration

### DIFF
--- a/koku/koku/cache.py
+++ b/koku/koku/cache.py
@@ -128,6 +128,11 @@ def get_value_from_cache(cache_key, cache_choice="default"):
     return cache.get(cache_key)
 
 
+def delete_value_from_cache(cache_key, cache_choice="default"):
+    cache = caches[cache_choice]
+    return cache.delete(cache_key)
+
+
 def set_value_in_cache(cache_key, cache_value, cache_choice="default"):
     cache = caches[cache_choice]
     cache.set(cache_key, cache_value)

--- a/koku/koku/test_cache.py
+++ b/koku/koku/test_cache.py
@@ -13,6 +13,7 @@ from api.provider.models import Provider
 from koku.cache import AWS_CACHE_PREFIX
 from koku.cache import AZURE_CACHE_PREFIX
 from koku.cache import build_matching_tags_key
+from koku.cache import delete_value_from_cache
 from koku.cache import get_cached_infra_map
 from koku.cache import get_cached_tag_rate_map
 from koku.cache import get_value_from_cache
@@ -280,3 +281,15 @@ class KokuCacheTest(IamTestCase):
 
         set_value_in_cache(cache_key, "fake-value")
         self.assertTrue(is_key_in_cache(cache_key))
+
+    def test_delete_value_from_cache(self):
+        """Test that getting a value from the cache and setting a value in the cache works as intended."""
+        cache_key = "my-fake-key-get-test"
+        expected_value = "my-fake-value"
+
+        self.assertFalse(is_key_in_cache(cache_key))
+        # basically, test that this does not cause an issue when the key does not exist
+        self.assertFalse(delete_value_from_cache(cache_key))
+
+        set_value_in_cache(cache_key, expected_value)
+        self.assertTrue(delete_value_from_cache(cache_key))

--- a/koku/masu/management/commands/migrate_trino_tables.py
+++ b/koku/masu/management/commands/migrate_trino_tables.py
@@ -376,7 +376,9 @@ def drop_tables(tables, schemas) -> None:
             try:
                 result = run_trino_sql(sql, schema)
                 LOG.info(f"{prefix}DROP TABLE result: {result}")
-                delete_value_from_cache(build_trino_table_exists_key(schema, table_name))
+                key = build_trino_table_exists_key(schema, table_name)
+                result = delete_value_from_cache(key)
+                LOG.info(f"{prefix}delete cache key {key}: {result}")
             except Exception as e:
                 LOG.error(e)
 

--- a/koku/masu/management/commands/migrate_trino_tables.py
+++ b/koku/masu/management/commands/migrate_trino_tables.py
@@ -23,6 +23,8 @@ from trino.exceptions import TrinoUserError
 
 import koku.trino_database as trino_db
 from api.utils import DateHelper
+from koku.cache import build_trino_table_exists_key
+from koku.cache import delete_value_from_cache
 
 LOG = logging.getLogger(__name__)
 # External tables can be dropped as the data in S3 will persist
@@ -374,6 +376,7 @@ def drop_tables(tables, schemas) -> None:
             try:
                 result = run_trino_sql(sql, schema)
                 LOG.info(f"{prefix}DROP TABLE result: {result}")
+                delete_value_from_cache(build_trino_table_exists_key(schema, table_name))
             except Exception as e:
                 LOG.error(e)
 


### PR DESCRIPTION
## Jira Ticket

[COST-5299](https://issues.redhat.com/browse/COST-5299)

## Description

This change will delete cache values when we drop tables via trino migration.

## Testing

1. clear db:
```
$ make delete-test-customer-data; make delete-testing; make delete-trino-data; make delete-redis-cache
```
2. check redis cache for key:
```
(key this shell open)
$ docker exec -it masu_server sh
$ python koku/manage.py shell
>>> from koku.cache import build_trino_table_exists_key
>>> from koku.cache import is_key_in_cache
>>> key = build_trino_table_exists_key('org1234567', 'openshift_namespace_labels_line_items')
>>> is_key_in_cache(key)
False
```
3. create customer; ingest OCP on prem:
```
$ make create-test-customer; make load-test-customer-data test_source=ONPREM 
```
4. check redis cache for key:
```
>>> is_key_in_cache(key)
True
```
5. run trino migration:
```
(in another shell)
$ docker exec -it masu_server sh
$ python koku/manage.py migrate_trino_tables --drop-tables openshift_namespace_labels_line_items
...
[2024-07-18 16:19:03,370] INFO None 40583 Running against the following schemas: org1234567
[2024-07-18 16:19:03,370] INFO None 40583 Dropping tables ['openshift_namespace_labels_line_items'] for org1234567 (1 / 1)
[2024-07-18 16:19:03,370] INFO None 40583     org1234567: Dropping table openshift_namespace_labels_line_items
[2024-07-18 16:19:03,394] INFO None 40583     org1234567: DROP TABLE result: []
[2024-07-18 16:19:03,401] INFO None 40583     org1234567: delete cache key table-exists-trino-org1234567-openshift_namespace_labels_line_items: True
```
if the key does not exist in cache, we log `False`:
```
[2024-07-18 16:38:04,322] INFO None 1764     org1234567: delete cache key table-exists-trino-org1234567-openshift_namespace_labels_line_items: False
```

6. check cache for key:
```
>>> is_key_in_cache(key)
False
```

## Release Notes
- [x] proposed release note

```markdown
* [[COST-5299](https://issues.redhat.com/browse/COST-5299)] clear cache when table is dropped by migration
```
