### PR TITLE
Update nise and AWS DataTransferGenerator resource IDs

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -3,4 +3,5 @@ paths = [
     '''grafana\/grafana.db.sql''',
     '''.env.example''',
     '''docs\/devtools.md''',
+    '''dev\/scripts\/nise_ymls\/ocp_on_aws\/aws_static_data.yml''',
 ]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -2781,11 +2781,11 @@
         },
         "koku-nise": {
             "hashes": [
-                "sha256:5675274050e7fd9242329a0c40035e60abdec988e95bd91316596636bb388fea",
-                "sha256:f09fbf9b795371fd3d1f93c641f6f64de8f146488399631eb507d59db372b052"
+                "sha256:4678257aac57c53b879f30ce5f518c227c492e33234660613c1f330bd8631ea7",
+                "sha256:cf6e3ec02398127979e942a573da7b6b798866ef44651a803012c77031c894e2"
             ],
             "index": "pypi",
-            "version": "==4.5.7"
+            "version": "==4.6.1"
         },
         "kombu": {
             "hashes": [

--- a/dev/scripts/nise_ymls/ocp_on_aws/aws_static_data.yml
+++ b/dev/scripts/nise_ymls/ocp_on_aws/aws_static_data.yml
@@ -329,7 +329,7 @@ generators:
         costCategory/env: ephemeral
   - DataTransferGenerator:
       product_sku: VEAJHRNKTJZQ
-      resource_id: i-55555555
+      resource_id: 55555555
       tags:
         resourceTags/user:app: analytics
         resourceTags/user:Mapping: d1
@@ -340,7 +340,7 @@ generators:
       start_date: {{start_date}}
       end_date: {{end_date}}
       product_sku: VEAJHRNKTJAA
-      resource_id: i-55555556
+      resource_id: 55555556
       tags:
         resourceTags/user:app: cost
         resourceTags/user:Mapping: d1
@@ -351,7 +351,7 @@ generators:
       start_date: {{start_date}}
       end_date: {{end_date}}
       product_sku: VEAJHRNKTJAB
-      resource_id: i-55555557
+      resource_id: 55555557
       tags:
         resourceTags/user:app: catalog
         resourceTags/user:Mapping: d1
@@ -362,7 +362,7 @@ generators:
       start_date: {{start_date}}
       end_date: {{end_date}}
       product_sku: VEAJHRNKTJAC
-      resource_id: i-55555558
+      resource_id: 55555558
       tags:
         resourceTags/user:app: catalog
         resourceTags/user:Mapping: d1
@@ -374,7 +374,7 @@ generators:
       start_date: {{start_date}}
       end_date: {{end_date}}
       product_sku: VEAJHRNAAAAA
-      resource_id: i-55555559
+      resource_id: 55555559
       tags:
         resourceTags/user:app: cost
         resourceTags/user:Mapping: d1
@@ -420,7 +420,7 @@ generators:
   - DataTransferGenerator:
       start_date: {{start_date}}
       end_date: {{end_date}}
-      resource_id: i-55555554
+      resource_id: 55555554
       product_sku: AERJHRNCCCCC
       product_code: AmazonRDS
       product_name: Amazon Relational Database Service


### PR DESCRIPTION
## Jira Ticket

[COST-3761](https://issues.redhat.com/browse/COST-3761)

## Description

Update `nise` to make the AWS DataTransferGenerator resource_id field behave the same as th EC2 Generator resource_id field. Update the `nise` YAML file to match the new behavior.

Related `nise` change: https://github.com/project-koku/nise/pull/518

## Testing

1. Checkout Branch
2. Restart Koku
3. Create a customer and load AWS data

```
make create-test-customer
make load-test-customer-data test_source=aws
```
4. Verify the Data Transfer resource IDs look correct

```
trino:org1234567> SELECT distinct lineitem_resourceid, product_sku, product_productfamily FROM aws_line_items WHERE lineitem_productcode = 'AmazonEC2';
```

## Release Notes
- [x] proposed release note

```markdown
* Update `nise` and YAML file to use correct resource_id format for AWS Data Transfer Generators
```
