### PR TITLE
add additional info to INSERT operation

### DIFF
--- a/koku/masu/database/ocp_report_db_accessor.py
+++ b/koku/masu/database/ocp_report_db_accessor.py
@@ -441,7 +441,7 @@ class OCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
             sql = pkgutil.get_data("masu.database", f"sql/openshift/cost_model/distribute_cost/{sql_file}")
             sql = sql.decode("utf-8")
             LOG.info(log_json(msg=log_msg, context=sql_params))
-            self._prepare_and_execute_raw_sql_query(table_name, sql, sql_params, operation="INSERT")
+            self._prepare_and_execute_raw_sql_query(table_name, sql, sql_params, operation=f"INSERT: {log_msg}")
 
     def populate_monthly_cost_sql(self, cost_type, rate_type, rate, start_date, end_date, distribution, provider_uuid):
         """


### PR DESCRIPTION
## Description

This change will add context for INSERT logs.

## Testing

1. make load-test-customer-data test_source=ONPREM
2. peruse logs and see something similar to:
```
koku-worker-1  | [2024-07-19 20:10:49,649] INFO 526a1406-7181-4940-af1b-789da5fa6776 35 {'message': 'finished INSERT: distributing platform_cost', 'tracing_id': '', 'row_count': 323, 'table': 'reporting_ocpusagelineitem_daily_summary', 'running_time': 0.48398900032043457}
```
this gives us something better to search in Kibana to see how long these insertions take to complete.

## Release Notes
- [x] proposed release note

```markdown
* logging improvements
```
