### PR TITLE
[COST-4993] gate ec2 endpoint with unleash

### DIFF
--- a/koku/api/report/aws/view.py
+++ b/koku/api/report/aws/view.py
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 """AWS views."""
+from rest_framework.exceptions import NotFound
+
 from api.common.permissions.aws_access import AwsAccessPermission
 from api.common.permissions.aws_access import AWSOUAccessPermission
 from api.models import Provider
@@ -10,6 +12,7 @@ from api.report.aws.query_handler import AWSReportQueryHandler
 from api.report.aws.serializers import AWSEC2ComputeQueryParamSerializer
 from api.report.aws.serializers import AWSQueryParamSerializer
 from api.report.view import ReportView
+from masu.processor import is_feature_cost_4403_ec2_compute_cost_enabled
 
 
 class AWSView(ReportView):
@@ -45,3 +48,8 @@ class AWSEC2ComputeView(AWSView):
 
     report = "ec2_compute"
     serializer = AWSEC2ComputeQueryParamSerializer
+
+    def get(self, request, **kwargs):
+        if not is_feature_cost_4403_ec2_compute_cost_enabled(request.user.customer.schema_name):
+            raise NotFound()
+        return super().get(request, **kwargs)

--- a/koku/api/report/test/aws/test_views.py
+++ b/koku/api/report/test/aws/test_views.py
@@ -4,6 +4,7 @@
 #
 """Test the AWS Report views."""
 import copy
+from unittest.mock import patch
 
 from django.urls import reverse
 from rest_framework import status
@@ -600,6 +601,23 @@ class AWSReportViewTest(IamTestCase):
         url = reverse("reports-aws-costs") + "?group_by[aws_categroy:invalid]=value"
         response = self.client.get(url, **self.headers)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_ec2_compute_view_unleashed(self):
+        """Test EC2 compute view returns correct repsonses depending on unleash."""
+        url = reverse("reports-aws-ec2-compute")
+        with patch(
+            "api.report.aws.view.is_feature_cost_4403_ec2_compute_cost_enabled",
+            return_value=False,
+        ):
+            response = self.client.get(url, **self.headers)
+            self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+        with patch(
+            "api.report.aws.view.is_feature_cost_4403_ec2_compute_cost_enabled",
+            return_value=True,
+        ):
+            response = self.client.get(url, **self.headers)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_ec2_compute_view_returns_default_time_period_params(self):
         """Test EC2 compute view returns HTTP 200 and valid default meta filter."""

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39
+envlist = py311
 skipsdist = True
 
 [flake8]


### PR DESCRIPTION
## Jira Ticket

[COST-4993](https://issues.redhat.com/browse/COST-4993)

## Description

This change will use the `is_feature_cost_4403_ec2_compute_cost_enabled` feature flag to gate the API response.

## Testing

1. start koku with gunicorn:
```
$ RUN_GUNICORN=True docker compose up koku-server
```
2. in unleash, clone the `cost-management.backend.schema-flag-template` -> `cost-management.backend.feature-4403-enable-ec2-compute-processing`
3. delete redis cache:
```
$ make delete-redis-cache
```
4. visit http://localhost:8000/api/cost-management/v1/reports/aws/resources/ec2-compute/?filter[operating_system]=10 and see a response
5. in unleash, set the rollout % to 0%. Wait a few minutes
6. delete redis-cache:
```
$ make delete-redis-cache
```
7. visit http://localhost:8000/api/cost-management/v1/reports/aws/resources/ec2-compute/?filter[operating_system]=10 again and this time see a 404 Not Found response:
```
{
    "errors": [
        {
            "detail": "Not found.",
            "source": "detail",
            "status": 404
        }
    ]
}
```

## Release Notes
- [x] proposed release note

```markdown
* [COST-4993](https://issues.redhat.com/browse/COST-4993) gate EC2 endpoint with unleash flag
```
