### PR TITLE
[COST-5315] Return network_unattributed_distributed costs in the OCP costs API

### DIFF
--- a/koku/api/report/ocp/provider_map.py
+++ b/koku/api/report/ocp/provider_map.py
@@ -245,6 +245,7 @@ class OCPProviderMap(ProviderMap):
                             + self.distributed_unattributed_storage_cost,
                             "cost_platform_distributed": self.distributed_platform_cost,
                             "cost_worker_unallocated_distributed": self.distributed_worker_cost,
+                            "cost_network_unattributed_distributed": self.distributed_unattributed_network_cost,
                             "cost_storage_unattributed_distributed": self.distributed_unattributed_storage_cost,
                         },
                         "default_ordering": {"cost_total": "desc"},
@@ -274,6 +275,7 @@ class OCPProviderMap(ProviderMap):
                             + self.distributed_unattributed_network_cost,
                             "cost_platform_distributed": self.distributed_platform_cost,
                             "cost_worker_unallocated_distributed": self.distributed_worker_cost,
+                            "cost_network_unattributed_distributed": self.distributed_unattributed_network_cost,
                             "cost_storage_unattributed_distributed": self.distributed_unattributed_storage_cost,
                             # the `currency_annotation` is inserted by the `annotations` property of the query-handler
                             "cost_units": Coalesce("currency_annotation", Value("USD", output_field=CharField())),

--- a/koku/api/report/ocp/query_handler.py
+++ b/koku/api/report/ocp/query_handler.py
@@ -75,6 +75,7 @@ class OCPReportQueryHandler(ReportQueryHandler):
             "cost_usage": {"key": "usage", "group": "cost"},
             "cost_platform_distributed": {"key": "platform_distributed", "group": "cost"},
             "cost_worker_unallocated_distributed": {"key": "worker_unallocated_distributed", "group": "cost"},
+            "cost_network_unattributed_distributed": {"key": "network_unattributed_distributed", "group": "cost"},
             "cost_storage_unattributed_distributed": {"key": "storage_unattributed_distributed", "group": "cost"},
             "cost_total_distributed": {"key": "distributed", "group": "cost"},
             "cost_total": {"key": "total", "group": "cost"},

--- a/koku/api/report/test/ocp/view/test_views.py
+++ b/koku/api/report/test/ocp/view/test_views.py
@@ -593,8 +593,19 @@ class OCPReportViewTest(IamTestCase):
                 .get("total")
             )
             expected_total = cost if cost is not None else 0
-        total = data.get("meta", {}).get("total", {}).get("cost", {}).get("total", {}).get("value", 0)
+        meta_total_cost = data.get("meta", {}).get("total", {}).get("cost", {})
+        total = meta_total_cost.get("total", {}).get("value", 0)
         distributed_cost = data.get("meta", {}).get("total", {}).get("cost", {}).get("distributed", {}).get("value", 0)
+        expected_dist_cost_keys = {
+            "platform_distributed",
+            "worker_unallocated_distributed",
+            "network_unattributed_distributed",
+            "storage_unattributed_distributed",
+        }
+        self.assertTrue(
+            expected_dist_cost_keys.issubset(meta_total_cost),
+            f"Missing {expected_dist_cost_keys.difference(meta_total_cost)}",
+        )
         self.assertNotEqual(total, Decimal(0))
         self.assertNotEqual(distributed_cost, Decimal(0))
         self.assertAlmostEqual(distributed_cost, expected_total, 6)


### PR DESCRIPTION
## Jira Ticket

[COST-3761](https://issues.redhat.com/browse/COST-3761)
[COST-5315](https://issues.redhat.com/browse/COST-5315)

## Description

Add `network_unattributed_distributed` to the cost values returned by the `reports/openshift/costs/` API.

## Testing

1. Checkout Branch
2. Restart Koku
3. Load OCP on cloud data
4. `curl http://localhost:8000/api/cost-management/v1/reports/openshift/costs/`
5.  See that the expected valuse are in `meta['total']['cost']`

<details>
  <summary>Example output</summary>

```json
{
"meta": {
    ...
    "total": {
        ...
        "cost": {
            "raw": {
                "value": 6.650151911232001,
                "units": "USD"
            },
            "markup": {
                "value": 0.0,
                "units": "USD"
            },
            "usage": {
                "value": 0.0,
                "units": "USD"
            },
            "platform_distributed": {
                "value": 0.0,
                "units": "USD"
            },
            "worker_unallocated_distributed": {
                "value": 0.0,
                "units": "USD"
            },
            "network_unattributed_distributed": {
                "value": 0.0,
                "units": "USD"
            },
            "storage_unattributed_distributed": {
                "value": 0.0,
                "units": "USD"
            },
            "distributed": {
                "value": 6.650151911232001,
                "units": "USD"
            },
            "total": {
                "value": 6.650151911232001,
                "units": "USD"
            }
        }
    }
},

```  
</details>


## Release Notes
- [x] proposed release note

```markdown
* [COST-5315](https://issues.redhat.com/browse/COST-5315) Add `network_unattributed_distributed` to the OCP costs API
```
