### PR TITLE
[COST-5318] Support exclude instance_name and operating_system params

### DIFF
--- a/koku/api/report/aws/serializers.py
+++ b/koku/api/report/aws/serializers.py
@@ -240,10 +240,16 @@ class AWSEC2ComputeFilterSerializer(BaseFilterSerializer):
     )
 
 
-class AWSEC2ExcludeSerializer(AWSExcludeSerializer):
+class AWSEC2ExcludeSerializer(BaseExcludeSerializer):
     """Serializer for handling query parameter exclude."""
 
-    _opfields = ("account", "region")
+    _opfields = ("account", "region", "resource_id", "instance_name", "operating_system")
+
+    account = StringOrListField(child=serializers.CharField(), required=False)
+    region = StringOrListField(child=serializers.CharField(), required=False)
+    resource_id = StringOrListField(child=serializers.CharField(), required=False)
+    instance_name = StringOrListField(child=serializers.CharField(), required=False)
+    operating_system = StringOrListField(child=serializers.CharField(), required=False)
 
 
 class AWSEC2ComputeOrderBySerializer(AWSOrderBySerializer):


### PR DESCRIPTION
## Jira Ticket

[COST-5318](https://issues.redhat.com/browse/COST-5318)

## Description

This change will add support for `exclude[instance_name]` and `exclude[operating_system]` params and raise validation error for `exclude[service]`


## Testing

1. Checkout Branch
2. Restart Koku
3. Load test data for AWS
    ```
    make create-test-customer
    make load-test-customer-data test_source=aws
    ```
4. Hit endpoint 
    
    ```
    http://127.0.0.1:8000/api/cost-management/v1/reports/aws/resources/ec2-compute/?exclude[operating_system]=Linux
    ```

    - You should not see EC2 instances with `operating_system` like `Linux` in the response data,  similar to this:

        <Details>

        ```
        {
            "meta": {
                "count": 3,
                "limit": 100,
                "offset": 0,
                "currency": "USD",
                "cost_type": "unblended_cost",
                "exclude": {
                    "operating_system": [
                        "Linux"
                    ]
                },
                "filter": {
                    "time_scope_value": "-1",
                    "time_scope_units": "month",
                    "resolution": "monthly"
                },
                "group_by": {},
                "order_by": {},
                "total": {
                    "usage": {
                        "value": 1344.0,
                        "units": "Hrs"
                    },
                    "infrastructure": {
                        "raw": {
                            "value": 129.024,
                            "units": "USD"
                        },
                        "markup": {
                            "value": 12.9024,
                            "units": "USD"
                        },
                        "usage": {
                            "value": 0.0,
                            "units": "USD"
                        },
                        "total": {
                            "value": 141.9264,
                            "units": "USD"
                        }
                    },
                    "supplementary": {
                        "raw": {
                            "value": 0.0,
                            "units": "USD"
                        },
                        "markup": {
                            "value": 0.0,
                            "units": "USD"
                        },
                        "usage": {
                            "value": 0.0,
                            "units": "USD"
                        },
                        "total": {
                            "value": 0.0,
                            "units": "USD"
                        }
                    },
                    "cost": {
                        "raw": {
                            "value": 129.024,
                            "units": "USD"
                        },
                        "markup": {
                            "value": 12.9024,
                            "units": "USD"
                        },
                        "usage": {
                            "value": 0.0,
                            "units": "USD"
                        },
                        "total": {
                            "value": 141.9264,
                            "units": "USD"
                        }
                    }
                }
            },
            "links": {
                "first": "/api/cost-management/v1/reports/aws/resources/ec2-compute/?exclude%5Boperating_system%5D=Linux&limit=100&offset=0",
                "next": null,
                "previous": null,
                "last": "/api/cost-management/v1/reports/aws/resources/ec2-compute/?exclude%5Boperating_system%5D=Linux&limit=100&offset=0"
            },
            "data": [
                {
                    "date": "2024-07",
                    "resource_ids": [
                        {
                            "resource_id": "i-55555558",
                            "values": [
                                {
                                    "resource_id": "i-55555558",
                                    "date": "2024-07",
                                    "usage": {
                                        "value": 448.0,
                                        "units": "Hrs"
                                    },
                                    "source_uuid": [
                                        "569f280f-7ef3-4c03-a650-91725eb3aabf"
                                    ],
                                    "account_alias": null,
                                    "account": "9999999999998",
                                    "instance_name": null,
                                    "instance_type": "m5.large",
                                    "operating_system": "Debian",
                                    "region": "us-east-1",
                                    "vcpu": 2,
                                    "memory": "8 GiB",
                                    "tags": [
                                        {
                                            "key": "Map",
                                            "values": [
                                                "d2"
                                            ]
                                        },
                                        {
                                            "key": "Mapping",
                                            "values": [
                                                "d1"
                                            ]
                                        },
                                        {
                                            "key": "version",
                                            "values": [
                                                "master"
                                            ]
                                        },
                                        {
                                            "key": "dashed-key-on-aws",
                                            "values": [
                                                "dashed-value"
                                            ]
                                        }
                                    ],
                                    "infrastructure": {
                                        "raw": {
                                            "value": 43.008,
                                            "units": "USD"
                                        },
                                        "markup": {
                                            "value": 4.3008,
                                            "units": "USD"
                                        },
                                        "usage": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "total": {
                                            "value": 47.3088,
                                            "units": "USD"
                                        }
                                    },
                                    "supplementary": {
                                        "raw": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "markup": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "usage": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "total": {
                                            "value": 0.0,
                                            "units": "USD"
                                        }
                                    },
                                    "cost": {
                                        "raw": {
                                            "value": 43.008,
                                            "units": "USD"
                                        },
                                        "markup": {
                                            "value": 4.3008,
                                            "units": "USD"
                                        },
                                        "usage": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "total": {
                                            "value": 47.3088,
                                            "units": "USD"
                                        }
                                    }
                                }
                            ]
                        },
                        {
                            "resource_id": "i-55555557",
                            "values": [
                                {
                                    "resource_id": "i-55555557",
                                    "date": "2024-07",
                                    "usage": {
                                        "value": 448.0,
                                        "units": "Hrs"
                                    },
                                    "source_uuid": [
                                        "569f280f-7ef3-4c03-a650-91725eb3aabf"
                                    ],
                                    "account_alias": null,
                                    "account": "9999999999998",
                                    "instance_name": "instance_name_3",
                                    "instance_type": "m5.large",
                                    "operating_system": "FreeBSD",
                                    "region": "us-east-1",
                                    "vcpu": 2,
                                    "memory": "8 GiB",
                                    "tags": [
                                        {
                                            "key": "Map",
                                            "values": [
                                                "c2"
                                            ]
                                        },
                                        {
                                            "key": "Name",
                                            "values": [
                                                "instance_name_3"
                                            ]
                                        },
                                        {
                                            "key": "Mapping",
                                            "values": [
                                                "c1"
                                            ]
                                        },
                                        {
                                            "key": "version",
                                            "values": [
                                                "gamma"
                                            ]
                                        },
                                        {
                                            "key": "environment",
                                            "values": [
                                                "dev"
                                            ]
                                        },
                                        {
                                            "key": "com_REDHAT_rhel",
                                            "values": [
                                                "7"
                                            ]
                                        },
                                        {
                                            "key": "com_REDHAT_addon",
                                            "values": [
                                                "ELS"
                                            ]
                                        },
                                        {
                                            "key": "dashed-key-on-aws",
                                            "values": [
                                                "dashed-value"
                                            ]
                                        },
                                        {
                                            "key": "com_redhat_rhel_sla",
                                            "values": [
                                                "Standard"
                                            ]
                                        },
                                        {
                                            "key": "com_REDHAT_conversion",
                                            "values": [
                                                "True"
                                            ]
                                        },
                                        {
                                            "key": "CoM_RedHat_Rhel_varianT",
                                            "values": [
                                                "Workstation"
                                            ]
                                        }
                                    ],
                                    "infrastructure": {
                                        "raw": {
                                            "value": 43.008,
                                            "units": "USD"
                                        },
                                        "markup": {
                                            "value": 4.3008,
                                            "units": "USD"
                                        },
                                        "usage": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "total": {
                                            "value": 47.3088,
                                            "units": "USD"
                                        }
                                    },
                                    "supplementary": {
                                        "raw": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "markup": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "usage": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "total": {
                                            "value": 0.0,
                                            "units": "USD"
                                        }
                                    },
                                    "cost": {
                                        "raw": {
                                            "value": 43.008,
                                            "units": "USD"
                                        },
                                        "markup": {
                                            "value": 4.3008,
                                            "units": "USD"
                                        },
                                        "usage": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "total": {
                                            "value": 47.3088,
                                            "units": "USD"
                                        }
                                    }
                                }
                            ]
                        },
                        {
                            "resource_id": "i-444444442",
                            "values": [
                                {
                                    "resource_id": "i-444444442",
                                    "date": "2024-07",
                                    "usage": {
                                        "value": 448.0,
                                        "units": "Hrs"
                                    },
                                    "source_uuid": [
                                        "569f280f-7ef3-4c03-a650-91725eb3aabf"
                                    ],
                                    "account_alias": null,
                                    "account": "9999999999998",
                                    "instance_name": null,
                                    "instance_type": "m5.large",
                                    "operating_system": "Debian",
                                    "region": "us-east-1",
                                    "vcpu": 2,
                                    "memory": "8 GiB",
                                    "tags": [
                                        {
                                            "key": "version",
                                            "values": [
                                                "beta"
                                            ]
                                        },
                                        {
                                            "key": "environment",
                                            "values": [
                                                "dev"
                                            ]
                                        },
                                        {
                                            "key": "com_REDHAT_rhel",
                                            "values": [
                                                "RHEL 7 ELS"
                                            ]
                                        },
                                        {
                                            "key": "dashed-key-on-aws",
                                            "values": [
                                                "dashed-value"
                                            ]
                                        },
                                        {
                                            "key": "com_redhat_rhel_sla",
                                            "values": [
                                                "self-support"
                                            ]
                                        },
                                        {
                                            "key": "com_redhat_rhel_usage",
                                            "values": [
                                                "disaster Recovery"
                                            ]
                                        },
                                        {
                                            "key": "CoM_RedHat_Rhel_varianT",
                                            "values": [
                                                "SAP"
                                            ]
                                        }
                                    ],
                                    "infrastructure": {
                                        "raw": {
                                            "value": 43.008,
                                            "units": "USD"
                                        },
                                        "markup": {
                                            "value": 4.3008,
                                            "units": "USD"
                                        },
                                        "usage": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "total": {
                                            "value": 47.3088,
                                            "units": "USD"
                                        }
                                    },
                                    "supplementary": {
                                        "raw": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "markup": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "usage": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "total": {
                                            "value": 0.0,
                                            "units": "USD"
                                        }
                                    },
                                    "cost": {
                                        "raw": {
                                            "value": 43.008,
                                            "units": "USD"
                                        },
                                        "markup": {
                                            "value": 4.3008,
                                            "units": "USD"
                                        },
                                        "usage": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "total": {
                                            "value": 47.3088,
                                            "units": "USD"
                                        }
                                    }
                                }
                            ]
                        }
                    ]
                }
            ]
        }
        ```

        </Details>

    
    - Similar behavior is expected when `exclude[instance_name]=instance_name_3` is applied

## Release Notes
- [x] proposed release note

```markdown
* [COST-5318](https://issues.redhat.com/browse/COST-5318) Support exclude instance_name and operating_system
```
