### PR TITLE
[COST-5317] Support order by account_alias

### DIFF
--- a/koku/api/report/aws/serializers.py
+++ b/koku/api/report/aws/serializers.py
@@ -251,19 +251,13 @@ class AWSEC2ComputeOrderBySerializer(AWSOrderBySerializer):
 
     _opfields = (
         "resource_id",
-        "account",
-        "usage_amount",
         "instance_type",
-        "region",
         "operating_system",
         "instance_name",
     )
 
     resource_id = serializers.ChoiceField(choices=OrderSerializer.ORDER_CHOICES, required=False)
-    account = serializers.ChoiceField(choices=OrderSerializer.ORDER_CHOICES, required=False)
-    usage_amount = serializers.ChoiceField(choices=OrderSerializer.ORDER_CHOICES, required=False)
     instance_type = serializers.ChoiceField(choices=OrderSerializer.ORDER_CHOICES, required=False)
-    region = serializers.ChoiceField(choices=OrderSerializer.ORDER_CHOICES, required=False)
     operating_system = serializers.ChoiceField(choices=OrderSerializer.ORDER_CHOICES, required=False)
     instance_name = serializers.ChoiceField(choices=OrderSerializer.ORDER_CHOICES, required=False)
 
@@ -280,12 +274,12 @@ class AWSEC2ComputeQueryParamSerializer(AWSQueryParamSerializer):
 
     order_by_allowlist = (
         "resource_id",
-        "account",
-        "usage_amount",
-        "instance_type",
-        "region",
-        "operating_system",
         "instance_name",
+        "instance_type",
+        "operating_system",
+        "account_alias",
+        "account",
+        "region",
         "cost",
         "usage",
     )


### PR DESCRIPTION
## Jira Ticket

[COST-5317](https://issues.redhat.com/browse/COST-5317)

## Description

This change will add support for order by `account_alias`.

## Testing

1. Checkout Branch
2. Restart Koku
3. Load test data for AWS
    ```
    make create-test-customer
    make load-test-customer-data test_source=aws
    ```
4. Hit endpoint 
    
    ```
    http://127.0.0.1:8000/api/cost-management/v1/reports/aws/resources/ec2-compute/?order_by[account_alias]=desc
    ```

    - You should see a list of EC2 instances in the response data ordered by `account_alias`,  similar to this:

        <Details>

        ```
        {
            "meta": {
                "count": 8,
                "limit": 100,
                "offset": 0,
                "currency": "USD",
                "cost_type": "unblended_cost",
                "order_by": {
                    "account_alias": "desc"
                },
                "filter": {
                    "time_scope_value": "-1",
                    "time_scope_units": "month",
                    "resolution": "monthly"
                },
                "group_by": {},
                "exclude": {},
                "total": {
                    "usage": {
                        "value": 3584.0,
                        "units": "Hrs"
                    },
                    "infrastructure": {
                        "raw": {
                            "value": 344.064,
                            "units": "USD"
                        },
                        "markup": {
                            "value": 34.4064,
                            "units": "USD"
                        },
                        "usage": {
                            "value": 0.0,
                            "units": "USD"
                        },
                        "total": {
                            "value": 378.4704,
                            "units": "USD"
                        }
                    },
                    "supplementary": {
                        "raw": {
                            "value": 0.0,
                            "units": "USD"
                        },
                        "markup": {
                            "value": 0.0,
                            "units": "USD"
                        },
                        "usage": {
                            "value": 0.0,
                            "units": "USD"
                        },
                        "total": {
                            "value": 0.0,
                            "units": "USD"
                        }
                    },
                    "cost": {
                        "raw": {
                            "value": 344.064,
                            "units": "USD"
                        },
                        "markup": {
                            "value": 34.4064,
                            "units": "USD"
                        },
                        "usage": {
                            "value": 0.0,
                            "units": "USD"
                        },
                        "total": {
                            "value": 378.4704,
                            "units": "USD"
                        }
                    }
                }
            },
            "links": {
                "first": "/api/cost-management/v1/reports/aws/resources/ec2-compute/?limit=100&offset=0&order_by%5Baccount_alias%5D=desc",
                "next": null,
                "previous": null,
                "last": "/api/cost-management/v1/reports/aws/resources/ec2-compute/?limit=100&offset=0&order_by%5Baccount_alias%5D=desc"
            },
            "data": [
                {
                    "date": "2024-07",
                    "resource_ids": [
                        {
                            "resource_id": "i-444444442",
                            "values": [
                                {
                                    "resource_id": "i-444444442",
                                    "date": "2024-07",
                                    "usage": {
                                        "value": 448.0,
                                        "units": "Hrs"
                                    },
                                    "source_uuid": [
                                        "569f280f-7ef3-4c03-a650-91725eb3aabf"
                                    ],
                                    "account_alias": "null",
                                    "account": "9999999999998",
                                    "instance_name": null,
                                    "instance_type": "m5.large",
                                    "operating_system": "Debian",
                                    "region": "us-east-1",
                                    "vcpu": 2,
                                    "memory": "8 GiB",
                                    "tags": [
                                        {
                                            "key": "version",
                                            "values": [
                                                "beta"
                                            ]
                                        },
                                        {
                                            "key": "environment",
                                            "values": [
                                                "dev"
                                            ]
                                        },
                                        {
                                            "key": "com_REDHAT_rhel",
                                            "values": [
                                                "RHEL 7 ELS"
                                            ]
                                        },
                                        {
                                            "key": "dashed-key-on-aws",
                                            "values": [
                                                "dashed-value"
                                            ]
                                        },
                                        {
                                            "key": "com_redhat_rhel_sla",
                                            "values": [
                                                "self-support"
                                            ]
                                        },
                                        {
                                            "key": "com_redhat_rhel_usage",
                                            "values": [
                                                "disaster Recovery"
                                            ]
                                        },
                                        {
                                            "key": "CoM_RedHat_Rhel_varianT",
                                            "values": [
                                                "SAP"
                                            ]
                                        }
                                    ],
                                    "infrastructure": {
                                        "raw": {
                                            "value": 43.008,
                                            "units": "USD"
                                        },
                                        "markup": {
                                            "value": 4.3008,
                                            "units": "USD"
                                        },
                                        "usage": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "total": {
                                            "value": 47.3088,
                                            "units": "USD"
                                        }
                                    },
                                    "supplementary": {
                                        "raw": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "markup": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "usage": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "total": {
                                            "value": 0.0,
                                            "units": "USD"
                                        }
                                    },
                                    "cost": {
                                        "raw": {
                                            "value": 43.008,
                                            "units": "USD"
                                        },
                                        "markup": {
                                            "value": 4.3008,
                                            "units": "USD"
                                        },
                                        "usage": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "total": {
                                            "value": 47.3088,
                                            "units": "USD"
                                        }
                                    }
                                }
                            ]
                        },
                        {
                            "resource_id": "i-444444443",
                            "values": [
                                {
                                    "resource_id": "i-444444443",
                                    "date": "2024-07",
                                    "usage": {
                                        "value": 448.0,
                                        "units": "Hrs"
                                    },
                                    "source_uuid": [
                                        "569f280f-7ef3-4c03-a650-91725eb3aabf"
                                    ],
                                    "account_alias": "null",
                                    "account": "9999999999998",
                                    "instance_name": "instance-name-5",
                                    "instance_type": "m5.large",
                                    "operating_system": "Gentoo Linux",
                                    "region": "us-east-1",
                                    "vcpu": 2,
                                    "memory": "8 GiB",
                                    "tags": [
                                        {
                                            "key": "Name",
                                            "values": [
                                                "instance-name-5"
                                            ]
                                        },
                                        {
                                            "key": "version",
                                            "values": [
                                                "beta"
                                            ]
                                        },
                                        {
                                            "key": "environment",
                                            "values": [
                                                "dev"
                                            ]
                                        },
                                        {
                                            "key": "com_REDHAT_rhel",
                                            "values": [
                                                "7"
                                            ]
                                        },
                                        {
                                            "key": "dashed-key-on-aws",
                                            "values": [
                                                "dashed-value"
                                            ]
                                        },
                                        {
                                            "key": "com_redhat_rhel_sla",
                                            "values": [
                                                "self-support"
                                            ]
                                        },
                                        {
                                            "key": "com_redhat_rhel_usage",
                                            "values": [
                                                "disaster Recovery"
                                            ]
                                        },
                                        {
                                            "key": "CoM_RedHat_Rhel_varianT",
                                            "values": [
                                                "hPC"
                                            ]
                                        }
                                    ],
                                    "infrastructure": {
                                        "raw": {
                                            "value": 43.008,
                                            "units": "USD"
                                        },
                                        "markup": {
                                            "value": 4.3008,
                                            "units": "USD"
                                        },
                                        "usage": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "total": {
                                            "value": 47.3088,
                                            "units": "USD"
                                        }
                                    },
                                    "supplementary": {
                                        "raw": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "markup": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "usage": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "total": {
                                            "value": 0.0,
                                            "units": "USD"
                                        }
                                    },
                                    "cost": {
                                        "raw": {
                                            "value": 43.008,
                                            "units": "USD"
                                        },
                                        "markup": {
                                            "value": 4.3008,
                                            "units": "USD"
                                        },
                                        "usage": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "total": {
                                            "value": 47.3088,
                                            "units": "USD"
                                        }
                                    }
                                }
                            ]
                        },
                        {
                            "resource_id": "i-444444445",
                            "values": [
                                {
                                    "resource_id": "i-444444445",
                                    "date": "2024-07",
                                    "usage": {
                                        "value": 448.0,
                                        "units": "Hrs"
                                    },
                                    "source_uuid": [
                                        "569f280f-7ef3-4c03-a650-91725eb3aabf"
                                    ],
                                    "account_alias": "null",
                                    "account": "9999999999998",
                                    "instance_name": null,
                                    "instance_type": "m5.large",
                                    "operating_system": "SUSE Linux Enterprise Server",
                                    "region": "us-east-1",
                                    "vcpu": 2,
                                    "memory": "8 GiB",
                                    "tags": [
                                        {
                                            "key": "version",
                                            "values": [
                                                "beta"
                                            ]
                                        },
                                        {
                                            "key": "environment",
                                            "values": [
                                                "dev"
                                            ]
                                        },
                                        {
                                            "key": "com_REDHAT_rhel",
                                            "values": [
                                                "RHEL 8 ELS"
                                            ]
                                        },
                                        {
                                            "key": "dashed-key-on-aws",
                                            "values": [
                                                "dashed-value"
                                            ]
                                        },
                                        {
                                            "key": "com_redhat_rhel_sla",
                                            "values": [
                                                "self-support"
                                            ]
                                        },
                                        {
                                            "key": "com_redhat_rhel_usage",
                                            "values": [
                                                "disaster Recovery"
                                            ]
                                        },
                                        {
                                            "key": "CoM_RedHat_Rhel_varianT",
                                            "values": [
                                                "SAP"
                                            ]
                                        }
                                    ],
                                    "infrastructure": {
                                        "raw": {
                                            "value": 43.008,
                                            "units": "USD"
                                        },
                                        "markup": {
                                            "value": 4.3008,
                                            "units": "USD"
                                        },
                                        "usage": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "total": {
                                            "value": 47.3088,
                                            "units": "USD"
                                        }
                                    },
                                    "supplementary": {
                                        "raw": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "markup": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "usage": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "total": {
                                            "value": 0.0,
                                            "units": "USD"
                                        }
                                    },
                                    "cost": {
                                        "raw": {
                                            "value": 43.008,
                                            "units": "USD"
                                        },
                                        "markup": {
                                            "value": 4.3008,
                                            "units": "USD"
                                        },
                                        "usage": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "total": {
                                            "value": 47.3088,
                                            "units": "USD"
                                        }
                                    }
                                }
                            ]
                        },
                        {
                            "resource_id": "i-444444446",
                            "values": [
                                {
                                    "resource_id": "i-444444446",
                                    "date": "2024-07",
                                    "usage": {
                                        "value": 448.0,
                                        "units": "Hrs"
                                    },
                                    "source_uuid": [
                                        "569f280f-7ef3-4c03-a650-91725eb3aabf"
                                    ],
                                    "account_alias": "null",
                                    "account": "9999999999998",
                                    "instance_name": "instance name 4",
                                    "instance_type": "m5.large",
                                    "operating_system": "Gentoo Linux",
                                    "region": "us-east-1",
                                    "vcpu": 2,
                                    "memory": "8 GiB",
                                    "tags": [
                                        {
                                            "key": "Name",
                                            "values": [
                                                "instance name 4"
                                            ]
                                        },
                                        {
                                            "key": "version",
                                            "values": [
                                                "beta"
                                            ]
                                        },
                                        {
                                            "key": "environment",
                                            "values": [
                                                "dev"
                                            ]
                                        },
                                        {
                                            "key": "com_REDHAT_rhel",
                                            "values": [
                                                "8"
                                            ]
                                        },
                                        {
                                            "key": "dashed-key-on-aws",
                                            "values": [
                                                "dashed-value"
                                            ]
                                        },
                                        {
                                            "key": "com_redhat_rhel_sla",
                                            "values": [
                                                "self-support"
                                            ]
                                        },
                                        {
                                            "key": "com_REDHAT_rhel_addon",
                                            "values": [
                                                "ELS"
                                            ]
                                        },
                                        {
                                            "key": "com_redhat_rhel_usage",
                                            "values": [
                                                "disaster Recovery"
                                            ]
                                        },
                                        {
                                            "key": "CoM_RedHat_Rhel_varianT",
                                            "values": [
                                                "hPC"
                                            ]
                                        },
                                        {
                                            "key": "com_REDHAT_rhel_conversion",
                                            "values": [
                                                "True"
                                            ]
                                        }
                                    ],
                                    "infrastructure": {
                                        "raw": {
                                            "value": 43.008,
                                            "units": "USD"
                                        },
                                        "markup": {
                                            "value": 4.3008,
                                            "units": "USD"
                                        },
                                        "usage": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "total": {
                                            "value": 47.3088,
                                            "units": "USD"
                                        }
                                    },
                                    "supplementary": {
                                        "raw": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "markup": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "usage": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "total": {
                                            "value": 0.0,
                                            "units": "USD"
                                        }
                                    },
                                    "cost": {
                                        "raw": {
                                            "value": 43.008,
                                            "units": "USD"
                                        },
                                        "markup": {
                                            "value": 4.3008,
                                            "units": "USD"
                                        },
                                        "usage": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "total": {
                                            "value": 47.3088,
                                            "units": "USD"
                                        }
                                    }
                                }
                            ]
                        },
                        {
                            "resource_id": "i-55555555",
                            "values": [
                                {
                                    "resource_id": "i-55555555",
                                    "date": "2024-07",
                                    "usage": {
                                        "value": 448.0,
                                        "units": "Hrs"
                                    },
                                    "source_uuid": [
                                        "569f280f-7ef3-4c03-a650-91725eb3aabf"
                                    ],
                                    "account_alias": "null",
                                    "account": "9999999999998",
                                    "instance_name": "instance-name-1",
                                    "instance_type": "m5.large",
                                    "operating_system": "Amazon Linux",
                                    "region": "us-east-1",
                                    "vcpu": 2,
                                    "memory": "8 GiB",
                                    "tags": [
                                        {
                                            "key": "Map",
                                            "values": [
                                                "a2"
                                            ]
                                        },
                                        {
                                            "key": "Name",
                                            "values": [
                                                "instance-name-1"
                                            ]
                                        },
                                        {
                                            "key": "Mapping",
                                            "values": [
                                                "a1"
                                            ]
                                        },
                                        {
                                            "key": "version",
                                            "values": [
                                                "prod"
                                            ]
                                        },
                                        {
                                            "key": "dashed-key-on-aws",
                                            "values": [
                                                "dashed-value"
                                            ]
                                        }
                                    ],
                                    "infrastructure": {
                                        "raw": {
                                            "value": 43.008,
                                            "units": "USD"
                                        },
                                        "markup": {
                                            "value": 4.3008,
                                            "units": "USD"
                                        },
                                        "usage": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "total": {
                                            "value": 47.3088,
                                            "units": "USD"
                                        }
                                    },
                                    "supplementary": {
                                        "raw": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "markup": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "usage": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "total": {
                                            "value": 0.0,
                                            "units": "USD"
                                        }
                                    },
                                    "cost": {
                                        "raw": {
                                            "value": 43.008,
                                            "units": "USD"
                                        },
                                        "markup": {
                                            "value": 4.3008,
                                            "units": "USD"
                                        },
                                        "usage": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "total": {
                                            "value": 47.3088,
                                            "units": "USD"
                                        }
                                    }
                                }
                            ]
                        },
                        {
                            "resource_id": "i-55555556",
                            "values": [
                                {
                                    "resource_id": "i-55555556",
                                    "date": "2024-07",
                                    "usage": {
                                        "value": 448.0,
                                        "units": "Hrs"
                                    },
                                    "source_uuid": [
                                        "569f280f-7ef3-4c03-a650-91725eb3aabf"
                                    ],
                                    "account_alias": "null",
                                    "account": "9999999999998",
                                    "instance_name": "instance-name-2",
                                    "instance_type": "m5.large",
                                    "operating_system": "Amazon Linux",
                                    "region": "us-east-1",
                                    "vcpu": 2,
                                    "memory": "8 GiB",
                                    "tags": [
                                        {
                                            "key": "Map",
                                            "values": [
                                                "b2"
                                            ]
                                        },
                                        {
                                            "key": "Name",
                                            "values": [
                                                "instance-name-2"
                                            ]
                                        },
                                        {
                                            "key": "Mapping",
                                            "values": [
                                                "b1"
                                            ]
                                        },
                                        {
                                            "key": "version",
                                            "values": [
                                                "beta"
                                            ]
                                        },
                                        {
                                            "key": "environment",
                                            "values": [
                                                "dev"
                                            ]
                                        },
                                        {
                                            "key": "com_REDHAT_rhel",
                                            "values": [
                                                "8"
                                            ]
                                        },
                                        {
                                            "key": "dashed-key-on-aws",
                                            "values": [
                                                "dashed-value"
                                            ]
                                        },
                                        {
                                            "key": "com_redhat_rhel_sla",
                                            "values": [
                                                "self-support"
                                            ]
                                        },
                                        {
                                            "key": "com_REDHAT_rhel_addon",
                                            "values": [
                                                "ELS"
                                            ]
                                        },
                                        {
                                            "key": "com_redhat_rhel_usage",
                                            "values": [
                                                "disaster Recovery"
                                            ]
                                        },
                                        {
                                            "key": "CoM_RedHat_Rhel_varianT",
                                            "values": [
                                                "Workstation"
                                            ]
                                        },
                                        {
                                            "key": "com_redhat_rhel_conversion",
                                            "values": [
                                                "True"
                                            ]
                                        }
                                    ],
                                    "infrastructure": {
                                        "raw": {
                                            "value": 43.008,
                                            "units": "USD"
                                        },
                                        "markup": {
                                            "value": 4.3008,
                                            "units": "USD"
                                        },
                                        "usage": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "total": {
                                            "value": 47.3088,
                                            "units": "USD"
                                        }
                                    },
                                    "supplementary": {
                                        "raw": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "markup": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "usage": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "total": {
                                            "value": 0.0,
                                            "units": "USD"
                                        }
                                    },
                                    "cost": {
                                        "raw": {
                                            "value": 43.008,
                                            "units": "USD"
                                        },
                                        "markup": {
                                            "value": 4.3008,
                                            "units": "USD"
                                        },
                                        "usage": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "total": {
                                            "value": 47.3088,
                                            "units": "USD"
                                        }
                                    }
                                }
                            ]
                        },
                        {
                            "resource_id": "i-55555557",
                            "values": [
                                {
                                    "resource_id": "i-55555557",
                                    "date": "2024-07",
                                    "usage": {
                                        "value": 448.0,
                                        "units": "Hrs"
                                    },
                                    "source_uuid": [
                                        "569f280f-7ef3-4c03-a650-91725eb3aabf"
                                    ],
                                    "account_alias": "null",
                                    "account": "9999999999998",
                                    "instance_name": "instance_name_3",
                                    "instance_type": "m5.large",
                                    "operating_system": "FreeBSD",
                                    "region": "us-east-1",
                                    "vcpu": 2,
                                    "memory": "8 GiB",
                                    "tags": [
                                        {
                                            "key": "Map",
                                            "values": [
                                                "c2"
                                            ]
                                        },
                                        {
                                            "key": "Name",
                                            "values": [
                                                "instance_name_3"
                                            ]
                                        },
                                        {
                                            "key": "Mapping",
                                            "values": [
                                                "c1"
                                            ]
                                        },
                                        {
                                            "key": "version",
                                            "values": [
                                                "gamma"
                                            ]
                                        },
                                        {
                                            "key": "environment",
                                            "values": [
                                                "dev"
                                            ]
                                        },
                                        {
                                            "key": "com_REDHAT_rhel",
                                            "values": [
                                                "7"
                                            ]
                                        },
                                        {
                                            "key": "com_REDHAT_addon",
                                            "values": [
                                                "ELS"
                                            ]
                                        },
                                        {
                                            "key": "dashed-key-on-aws",
                                            "values": [
                                                "dashed-value"
                                            ]
                                        },
                                        {
                                            "key": "com_redhat_rhel_sla",
                                            "values": [
                                                "Standard"
                                            ]
                                        },
                                        {
                                            "key": "com_REDHAT_conversion",
                                            "values": [
                                                "True"
                                            ]
                                        },
                                        {
                                            "key": "CoM_RedHat_Rhel_varianT",
                                            "values": [
                                                "Workstation"
                                            ]
                                        }
                                    ],
                                    "infrastructure": {
                                        "raw": {
                                            "value": 43.008,
                                            "units": "USD"
                                        },
                                        "markup": {
                                            "value": 4.3008,
                                            "units": "USD"
                                        },
                                        "usage": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "total": {
                                            "value": 47.3088,
                                            "units": "USD"
                                        }
                                    },
                                    "supplementary": {
                                        "raw": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "markup": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "usage": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "total": {
                                            "value": 0.0,
                                            "units": "USD"
                                        }
                                    },
                                    "cost": {
                                        "raw": {
                                            "value": 43.008,
                                            "units": "USD"
                                        },
                                        "markup": {
                                            "value": 4.3008,
                                            "units": "USD"
                                        },
                                        "usage": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "total": {
                                            "value": 47.3088,
                                            "units": "USD"
                                        }
                                    }
                                }
                            ]
                        },
                        {
                            "resource_id": "i-55555558",
                            "values": [
                                {
                                    "resource_id": "i-55555558",
                                    "date": "2024-07",
                                    "usage": {
                                        "value": 448.0,
                                        "units": "Hrs"
                                    },
                                    "source_uuid": [
                                        "569f280f-7ef3-4c03-a650-91725eb3aabf"
                                    ],
                                    "account_alias": "null",
                                    "account": "9999999999998",
                                    "instance_name": null,
                                    "instance_type": "m5.large",
                                    "operating_system": "Debian",
                                    "region": "us-east-1",
                                    "vcpu": 2,
                                    "memory": "8 GiB",
                                    "tags": [
                                        {
                                            "key": "Map",
                                            "values": [
                                                "d2"
                                            ]
                                        },
                                        {
                                            "key": "Mapping",
                                            "values": [
                                                "d1"
                                            ]
                                        },
                                        {
                                            "key": "version",
                                            "values": [
                                                "master"
                                            ]
                                        },
                                        {
                                            "key": "dashed-key-on-aws",
                                            "values": [
                                                "dashed-value"
                                            ]
                                        }
                                    ],
                                    "infrastructure": {
                                        "raw": {
                                            "value": 43.008,
                                            "units": "USD"
                                        },
                                        "markup": {
                                            "value": 4.3008,
                                            "units": "USD"
                                        },
                                        "usage": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "total": {
                                            "value": 47.3088,
                                            "units": "USD"
                                        }
                                    },
                                    "supplementary": {
                                        "raw": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "markup": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "usage": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "total": {
                                            "value": 0.0,
                                            "units": "USD"
                                        }
                                    },
                                    "cost": {
                                        "raw": {
                                            "value": 43.008,
                                            "units": "USD"
                                        },
                                        "markup": {
                                            "value": 4.3008,
                                            "units": "USD"
                                        },
                                        "usage": {
                                            "value": 0.0,
                                            "units": "USD"
                                        },
                                        "total": {
                                            "value": 47.3088,
                                            "units": "USD"
                                        }
                                    }
                                }
                            ]
                        }
                    ]
                }
            ]
        }
        ```

        </Details>

## Release Notes
- [x] proposed release note

```markdown
* [COST-5317](https://issues.redhat.com/browse/COST-5317) Support order by account_alias
```