### PR TITLE
[COST-5319] Export EC2 compute response data to CSV

### DIFF
--- a/koku/api/common/pagination.py
+++ b/koku/api/common/pagination.py
@@ -323,7 +323,7 @@ class AWSEC2ComputePagination(ReportPagination):
         paginated_data = []
 
         data = (
-            queryset_data[0] if (queryset_data := queryset.get("data", [])) else []
+            queryset_data[0] if (queryset_data := queryset.get("data", [])) else {}
         )  # only single month data expected
         resource_ids = data.get("resource_ids", [])
         resource_count = len(resource_ids)

--- a/koku/api/common/pagination.py
+++ b/koku/api/common/pagination.py
@@ -327,6 +327,7 @@ class AWSEC2ComputePagination(ReportPagination):
 
         if self.offset < resource_count:
             # paginate resource IDs from current_offset to the limit
+            # limit=0 param is a special case that returns all data
             paginated_ids = resource_ids if self.limit == 0 else resource_ids[self.offset : self.offset + self.limit]
 
             if self.request.accepted_media_type and "text/csv" in self.request.accepted_media_type:

--- a/koku/api/common/pagination.py
+++ b/koku/api/common/pagination.py
@@ -331,7 +331,7 @@ class AWSEC2ComputePagination(ReportPagination):
                 paginated_data = paginated_ids
             else:
                 paginated_item = data.copy()
-                paginated_item["resource_ids"] = resource_ids[self.offset : self.offset + self.limit]
+                paginated_item["resource_ids"] = paginated_ids
                 paginated_data.append(paginated_item)
 
         return paginated_data

--- a/koku/api/common/pagination.py
+++ b/koku/api/common/pagination.py
@@ -327,10 +327,10 @@ class AWSEC2ComputePagination(ReportPagination):
 
         if self.offset < resource_count:
             # paginate resource IDs from current_offset to the limit
-            paginated_ids = resource_ids[self.offset : self.offset + self.limit] if self.limit else resource_ids
+            paginated_ids = resource_ids if self.limit == 0 else resource_ids[self.offset : self.offset + self.limit]
 
             if self.request.accepted_media_type and "text/csv" in self.request.accepted_media_type:
-                paginated_data = resource_ids if self.limit == 0 else paginated_ids
+                paginated_data = paginated_ids
             else:
                 paginated_item = data.copy()
                 paginated_item["resource_ids"] = paginated_ids

--- a/koku/api/common/pagination.py
+++ b/koku/api/common/pagination.py
@@ -327,13 +327,13 @@ class AWSEC2ComputePagination(ReportPagination):
 
         if self.offset < resource_count:
             # paginate resource IDs from current_offset to the limit
-            paginated_ids = resource_ids[self.offset : self.offset + self.limit]
 
             if self.request.accepted_media_type and "text/csv" in self.request.accepted_media_type:
-                paginated_data = paginated_ids
+                self.limit = self.default_limit if self.limit < 1 else self.limit
+                paginated_data = resource_ids[self.offset : self.offset + self.limit]
             else:
                 paginated_item = data.copy()
-                paginated_item["resource_ids"] = paginated_ids
+                paginated_item["resource_ids"] = resource_ids[self.offset : self.offset + self.limit]
                 paginated_data.append(paginated_item)
 
         return paginated_data

--- a/koku/api/common/pagination.py
+++ b/koku/api/common/pagination.py
@@ -303,7 +303,10 @@ class AWSEC2ComputePagination(ReportPagination):
 
     def get_count(self, queryset):
         """Special case count for EC2 resource IDs."""
-        return len(queryset.get("data", [])[0].get("resource_ids", []))
+        data = []
+        if queryset_data := queryset.get("data", []):
+            data = queryset_data[0].get("resource_ids", [])
+        return len(data)
 
     def get_paginated_data(self, queryset):
         """
@@ -319,7 +322,9 @@ class AWSEC2ComputePagination(ReportPagination):
 
         paginated_data = []
 
-        data = queryset.get("data", [])[0]  # only single month data expected
+        data = (
+            queryset_data[0] if (queryset_data := queryset.get("data", [])) else []
+        )  # only single month data expected
         resource_ids = data.get("resource_ids", [])
         resource_count = len(resource_ids)
 

--- a/koku/api/common/pagination.py
+++ b/koku/api/common/pagination.py
@@ -327,13 +327,13 @@ class AWSEC2ComputePagination(ReportPagination):
 
         if self.offset < resource_count:
             # paginate resource IDs from current_offset to the limit
+            paginated_ids = resource_ids[self.offset : self.offset + self.limit]
 
             if self.request.accepted_media_type and "text/csv" in self.request.accepted_media_type:
-                self.limit = self.default_limit if self.limit < 1 else self.limit
-                paginated_data = resource_ids[self.offset : self.offset + self.limit]
+                paginated_data = resource_ids if self.limit == 0 else paginated_ids
             else:
                 paginated_item = data.copy()
-                paginated_item["resource_ids"] = resource_ids[self.offset : self.offset + self.limit]
+                paginated_item["resource_ids"] = paginated_ids
                 paginated_data.append(paginated_item)
 
         return paginated_data

--- a/koku/api/common/pagination.py
+++ b/koku/api/common/pagination.py
@@ -302,15 +302,12 @@ class AWSEC2ComputePagination(ReportPagination):
     """Paginator for AWS EC2 compute instances report data."""
 
     def get_count(self, queryset):
-        """Special case count for EC2 resource IDs."""
-        data = []
-        if queryset_data := queryset.get("data", []):
-            data = queryset_data[0].get("resource_ids", [])
-        return len(data)
+        """Count EC2 compute resource IDs."""
+        return len(queryset.get("data", [{}])[0].get("resource_ids", []))
 
     def get_paginated_data(self, queryset):
         """
-        Pagination EC2 resource IDs based on the request type.
+        Paginate EC2 resource IDs based on the request type.
 
         Args:
         queryset (dict): The data containing resource IDs to be paginated.

--- a/koku/api/common/pagination.py
+++ b/koku/api/common/pagination.py
@@ -327,7 +327,7 @@ class AWSEC2ComputePagination(ReportPagination):
 
         if self.offset < resource_count:
             # paginate resource IDs from current_offset to the limit
-            paginated_ids = resource_ids[self.offset : self.offset + self.limit]
+            paginated_ids = resource_ids[self.offset : self.offset + self.limit] if self.limit else resource_ids
 
             if self.request.accepted_media_type and "text/csv" in self.request.accepted_media_type:
                 paginated_data = resource_ids if self.limit == 0 else paginated_ids

--- a/koku/api/common/test_pagination.py
+++ b/koku/api/common/test_pagination.py
@@ -229,20 +229,6 @@ class AWSEC2ComputePaginationTest(TestCase):
         self.assertEqual(len(paginated_data), 1)
         self.assertEqual(paginated_data[0]["resource_ids"], expected_data["resource_ids"])
 
-    def test_get_paginated_data_non_csv_limit_zero_or_none(self):
-        """Test paginated data for non-CSV output and limit is zero or None."""
-
-        test_limits = [0, None]
-        expected_data = self.data.get("data", [])[0].get("resource_ids", [])
-
-        for limit in test_limits:
-            with self.subTest(limit):
-                self.paginator.limit = limit
-                paginated_data = self.paginator.get_paginated_data(self.data)
-
-                self.assertEqual(len(paginated_data), 1)
-                self.assertEqual(paginated_data[0]["resource_ids"], expected_data)
-
     def test_get_paginated_data_offset_gt_resource_count(self):
         """Test pagination when offset is greater than resource counts."""
 

--- a/koku/api/common/test_pagination.py
+++ b/koku/api/common/test_pagination.py
@@ -214,8 +214,9 @@ class AWSEC2ComputePaginationTest(TestCase):
         self.paginator.request.accepted_media_type = "text/csv"
         paginated_data = self.paginator.get_paginated_data(self.data)
         expected_data = [{"resource_id": f"resource_{i}"} for i in range(0, 100)]
+        expected_count = len(self.data.get("data", [])[0].get("resource_ids", []))
 
-        self.assertEqual(self.paginator.limit, self.paginator.default_limit)
+        self.assertEqual(len(paginated_data), expected_count)
         self.assertEqual(paginated_data, expected_data)
 
     def test_get_paginated_data_non_csv(self):

--- a/koku/api/common/test_pagination.py
+++ b/koku/api/common/test_pagination.py
@@ -206,6 +206,18 @@ class AWSEC2ComputePaginationTest(TestCase):
 
         self.assertEqual(paginated_data, expected_data)
 
+    def test_get_paginated_data_csv_limit_zero(self):
+        """Test paginated data for CSV output when limit is set to zero."""
+
+        self.paginator.limit = 0
+        self.paginator.offset = 0
+        self.paginator.request.accepted_media_type = "text/csv"
+        paginated_data = self.paginator.get_paginated_data(self.data)
+        expected_data = [{"resource_id": f"resource_{i}"} for i in range(0, 100)]
+
+        self.assertEqual(self.paginator.limit, self.paginator.default_limit)
+        self.assertEqual(paginated_data, expected_data)
+
     def test_get_paginated_data_non_csv(self):
         """Test paginated data for non-CSV output."""
 

--- a/koku/api/report/aws/provider_map.py
+++ b/koku/api/report/aws/provider_map.py
@@ -358,7 +358,7 @@ class AWSProviderMap(ProviderMap):
                             "source_uuid": ArrayAgg(
                                 F("source_uuid"), filter=Q(source_uuid__isnull=False), distinct=True
                             ),
-                            "account_alias": Max("account_alias"),
+                            "account_alias": Max("account_alias__account_alias"),
                             "account": Max("usage_account_id"),
                             "instance_name": Max("instance_name"),
                             "instance_type": Max("instance_type"),


### PR DESCRIPTION
## Jira Ticket

[COST-5319](https://issues.redhat.com/browse/COST-5319)

## Description

This change will enable exporting EC2 compute response data to CSV.


## Testing

1. Checkout Branch
2. Restart Koku
3. Load test data for AWS
    ```
    make create-test-customer
    make load-test-customer-data test_source=aws
    ```
4. Launch shell and hit the EC2 endpoint with CSV output format
    
    ```
    curl --location --globoff 'http://127.0.0.1:8000/api/cost-management/v1/reports/aws/resources/ec2-compute/?filter[time_scope_value]=-2' -H 'accept: text/csv' -o output.csv
    ```
    

    - You should see EC2 response data in the `output.csv` file,  similar to this:
    
       [output.csv](https://github.com/user-attachments/files/16384378/output.csv)



## Release Notes
- [x] proposed release note

```markdown
* [COST-5319](https://issues.redhat.com/browse/COST-5319) Export EC2 compute response data to CSV
```