### PR TITLE
test docker compose

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
 
       - name: Start the postgres DB
         if: needs.changed-files.outputs.run_tests == 'true'
-        run: docker-compose up -d db
+        run: docker compose up -d db
 
       - name: Set up Python ${{ matrix.python-version }}
         if: needs.changed-files.outputs.run_tests == 'true'


### PR DESCRIPTION
## Jira Ticket

[COST-####](https://issues.redhat.com/browse/COST-####)

## Description

Tweak our docker commands for CI unit tests since compose v1 has been deprecated. This essentially means we need to change `docker-compose` commands to `docker compose` (Remove the dash)

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Release Notes
- [ ] proposed release note

```markdown
* [COST-####](https://issues.redhat.com/browse/COST-####) Fix some things
```
