### PR TITLE
[COST-5371] Ensure we do not use NULL values when summing

### DIFF
--- a/koku/masu/database/sql/openshift/all/reporting_ocpallcostlineitem_project_daily_summary_gcp.sql
+++ b/koku/masu/database/sql/openshift/all/reporting_ocpallcostlineitem_project_daily_summary_gcp.sql
@@ -58,7 +58,10 @@ SELECT 'GCP' as source_type,
        max(unit) as unit,
        sum(unblended_cost + credit_amount) as unblended_cost,
        sum(project_markup_cost) as project_markup_cost,
-       sum(pod_cost + pod_credit) as pod_cost,
+       sum(
+           coalesce(pod_cost, 0)
+           + coalesce(pod_credit, 0)
+       ) as pod_cost,
        max(currency) as currency_code,
        max(cost_category_id) as cost_category_id,
        {{source_uuid}}::uuid as source_uuid

--- a/koku/masu/database/sql/reporting_ocpazure_ocp_infrastructure_back_populate.sql
+++ b/koku/masu/database/sql/reporting_ocpazure_ocp_infrastructure_back_populate.sql
@@ -65,7 +65,10 @@ INSERT INTO {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary (
         ocp_azure.pod_labels as all_labels,
         rp.provider_id as source_uuid,
         sum(ocp_azure.pretax_cost + ocp_azure.markup_cost) AS infrastructure_raw_cost,
-        sum(ocp_azure.pod_cost + ocp_azure.project_markup_cost) AS infrastructure_project_raw_cost,
+        sum(
+            coalesce(ocp_azure.pod_cost, 0)
+            + coalesce(ocp_azure.project_markup_cost, 0)
+        ) AS infrastructure_project_raw_cost,
         CASE
             WHEN data_transfer_direction = 'IN' THEN sum(infrastructure_data_in_gigabytes)
             ELSE NULL

--- a/koku/masu/database/sql/reporting_ocpgcp_ocp_infrastructure_back_populate.sql
+++ b/koku/masu/database/sql/reporting_ocpgcp_ocp_infrastructure_back_populate.sql
@@ -65,8 +65,16 @@ INSERT INTO {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary (
         ocp_gcp.pod_labels as all_labels,
         max(ocp_gcp.cost_category_id) as cost_category_id,
         rp.provider_id as source_uuid,
-        sum(ocp_gcp.unblended_cost + ocp_gcp.markup_cost + ocp_gcp.credit_amount) AS infrastructure_raw_cost,
-        sum(ocp_gcp.unblended_cost + ocp_gcp.project_markup_cost + ocp_gcp.pod_credit) AS infrastructure_project_raw_cost,
+        sum(
+            coalesce(ocp_gcp.unblended_cost, 0)
+            + coalesce(ocp_gcp.markup_cost, 0)
+            + coalesce(ocp_gcp.credit_amount, 0)
+        ) AS infrastructure_raw_cost,
+        sum(
+            coalesce(ocp_gcp.unblended_cost ,0)
+            + coalesce(ocp_gcp.project_markup_cost, 0)
+            + coalesce(ocp_gcp.pod_credit, 0)
+        ) AS infrastructure_project_raw_cost,
         CASE
             WHEN upper(data_transfer_direction) = 'IN' THEN sum(infrastructure_data_in_gigabytes)
             ELSE NULL


### PR DESCRIPTION
## Jira Ticket

[COST-5371](https://issues.redhat.com/browse/COST-5371)

## Description

Use `coalesce()` on fields that could potentially be `NULL`. If any value in a `sum()` statement is `NULL`, the result will be `NULL`.

## Testing

1. Checkout Branch
2. Restart Koku
3. Checkout IQE branch `dchorvat/network_test_branch`
4. Run `iqe tests plugin cost_management -k "test_api_ocp_on_gcp_ingest_single_source" -s`
5. Query the following APIs and ensure costs for `Network unattributed` match

```
http://localhost:8000/api/cost-management/v1/reports/openshift/costs/?filter%5Btime_scope_units%5D=month&group_by%5Bproject%5D=network
http://localhost:8000/api/cost-management/v1/reports/openshift/infrastructures/all/costs/?filter%5Bresolution%5D=monthly&group_by%5Bproject%5D=network
http://localhost:8000/api/cost-management/v1/reports/openshift/infrastructures/gcp/costs/?filter%5Bresolution%5D=monthly&group_by%5Bproject%5D=network
http://localhost:8000/api/cost-management/v1/reports/openshift/network/?group_by%5Bproject%5D=network&filter%5Btime_scope_units%5D=month
```
  

## Release Notes
- [x] proposed release note 
```markdown
* [COST-5371](https://issues.redhat.com/browse/COST-5371) Do not use NULL values when adding costs
```
