### PR TITLE
Include provider in OCP/cloud tag sql params

### DIFF
--- a/koku/api/report/test/util/model_bakery_loader.py
+++ b/koku/api/report/test/util/model_bakery_loader.py
@@ -528,7 +528,7 @@ class ModelBakeryDataLoader(DataLoader):
         with dbaccessor(self.schema) as accessor:
             # update tags
             cls_method = getattr(accessor, tags_update_method)
-            cls_method([bill.id for bill in bills], self.first_start_date, self.last_end_date)
+            cls_method([bill.id for bill in bills], self.first_start_date, self.last_end_date, cluster_id)
 
             # update ui tables
             sql_params = {

--- a/koku/api/report/test/util/model_bakery_loader.py
+++ b/koku/api/report/test/util/model_bakery_loader.py
@@ -528,7 +528,8 @@ class ModelBakeryDataLoader(DataLoader):
         with dbaccessor(self.schema) as accessor:
             # update tags
             cls_method = getattr(accessor, tags_update_method)
-            cls_method([bill.id for bill in bills], self.first_start_date, self.last_end_date, report_period)
+            for report_period in report_periods:
+                cls_method([bill.id for bill in bills], self.first_start_date, self.last_end_date, report_period.id)
 
             # update ui tables
             sql_params = {

--- a/koku/api/report/test/util/model_bakery_loader.py
+++ b/koku/api/report/test/util/model_bakery_loader.py
@@ -528,7 +528,7 @@ class ModelBakeryDataLoader(DataLoader):
         with dbaccessor(self.schema) as accessor:
             # update tags
             cls_method = getattr(accessor, tags_update_method)
-            cls_method([bill.id for bill in bills], self.first_start_date, self.last_end_date, cluster_id)
+            cls_method([bill.id for bill in bills], self.first_start_date, self.last_end_date)
 
             # update ui tables
             sql_params = {

--- a/koku/masu/database/aws_report_db_accessor.py
+++ b/koku/masu/database/aws_report_db_accessor.py
@@ -275,14 +275,14 @@ class AWSReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
         }
         self._prepare_and_execute_raw_sql_query(table_name, sql, sql_params)
 
-    def populate_ocp_on_aws_tag_information(self, bill_ids, start_date, end_date, cluster_id):
+    def populate_ocp_on_aws_tag_information(self, bill_ids, start_date, end_date, current_ocp_report_period_id):
         """Populate the line item aggregated totals data table."""
         sql_params = {
             "schema": self.schema,
             "bill_ids": bill_ids,
             "start_date": start_date,
             "end_date": end_date,
-            "cluster_id": cluster_id,
+            "report_period_id": current_ocp_report_period_id,
         }
         # Tag Summary
         sql = pkgutil.get_data("masu.database", "sql/reporting_ocpawstags_summary.sql")

--- a/koku/masu/database/aws_report_db_accessor.py
+++ b/koku/masu/database/aws_report_db_accessor.py
@@ -275,14 +275,14 @@ class AWSReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
         }
         self._prepare_and_execute_raw_sql_query(table_name, sql, sql_params)
 
-    def populate_ocp_on_aws_tag_information(self, bill_ids, start_date, end_date, current_ocp_report_period_id):
+    def populate_ocp_on_aws_tag_information(self, bill_ids, start_date, end_date, report_period_id):
         """Populate the line item aggregated totals data table."""
         sql_params = {
             "schema": self.schema,
             "bill_ids": bill_ids,
             "start_date": start_date,
             "end_date": end_date,
-            "report_period_id": current_ocp_report_period_id,
+            "report_period_id": report_period_id,
         }
         # Tag Summary
         sql = pkgutil.get_data("masu.database", "sql/reporting_ocpawstags_summary.sql")

--- a/koku/masu/database/aws_report_db_accessor.py
+++ b/koku/masu/database/aws_report_db_accessor.py
@@ -275,9 +275,15 @@ class AWSReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
         }
         self._prepare_and_execute_raw_sql_query(table_name, sql, sql_params)
 
-    def populate_ocp_on_aws_tag_information(self, bill_ids, start_date, end_date):
+    def populate_ocp_on_aws_tag_information(self, bill_ids, start_date, end_date, cluster_id):
         """Populate the line item aggregated totals data table."""
-        sql_params = {"schema": self.schema, "bill_ids": bill_ids, "start_date": start_date, "end_date": end_date}
+        sql_params = {
+            "schema": self.schema,
+            "bill_ids": bill_ids,
+            "start_date": start_date,
+            "end_date": end_date,
+            "cluster_id": cluster_id,
+        }
         # Tag Summary
         sql = pkgutil.get_data("masu.database", "sql/reporting_ocpawstags_summary.sql")
         sql = sql.decode("utf-8")

--- a/koku/masu/database/azure_report_db_accessor.py
+++ b/koku/masu/database/azure_report_db_accessor.py
@@ -152,9 +152,15 @@ class AzureReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
         """Get the cost entry bill objects with billing period before provided date."""
         return AzureCostEntryBill.objects.filter(billing_period_start__lte=date)
 
-    def populate_ocp_on_azure_tag_information(self, bill_ids, start_date, end_date):
+    def populate_ocp_on_azure_tag_information(self, bill_ids, start_date, end_date, cluster_id):
         """Populate the line item aggregated totals data table."""
-        sql_params = {"schema": self.schema, "bill_ids": bill_ids, "start_date": start_date, "end_date": end_date}
+        sql_params = {
+            "schema": self.schema,
+            "bill_ids": bill_ids,
+            "start_date": start_date,
+            "end_date": end_date,
+            "cluster_id": cluster_id,
+        }
         # Tag summary
         sql = pkgutil.get_data("masu.database", "sql/reporting_ocpazuretags_summary.sql")
         sql = sql.decode("utf-8")

--- a/koku/masu/database/azure_report_db_accessor.py
+++ b/koku/masu/database/azure_report_db_accessor.py
@@ -152,14 +152,14 @@ class AzureReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
         """Get the cost entry bill objects with billing period before provided date."""
         return AzureCostEntryBill.objects.filter(billing_period_start__lte=date)
 
-    def populate_ocp_on_azure_tag_information(self, bill_ids, start_date, end_date, cluster_id):
+    def populate_ocp_on_azure_tag_information(self, bill_ids, start_date, end_date, report_period_id):
         """Populate the line item aggregated totals data table."""
         sql_params = {
             "schema": self.schema,
             "bill_ids": bill_ids,
             "start_date": start_date,
             "end_date": end_date,
-            "cluster_id": cluster_id,
+            "report_period_id": report_period_id,
         }
         # Tag summary
         sql = pkgutil.get_data("masu.database", "sql/reporting_ocpazuretags_summary.sql")

--- a/koku/masu/database/gcp_report_db_accessor.py
+++ b/koku/masu/database/gcp_report_db_accessor.py
@@ -475,14 +475,14 @@ class GCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
         )
         return [json.loads(result[0]) for result in results]
 
-    def populate_ocp_on_gcp_tag_information(self, gcp_bill_ids, start_date, end_date, ocp_uuid):
+    def populate_ocp_on_gcp_tag_information(self, gcp_bill_ids, start_date, end_date, cluster_id):
         """Populate the line item aggregated totals data table."""
         sql_params = {
             "schema": self.schema,
             "gcp_bill_ids": gcp_bill_ids,
             "start_date": start_date,
             "end_date": end_date,
-            "source_uuid": ocp_uuid,
+            "cluster_id": cluster_id,
         }
         # Tag Summary
         sql = pkgutil.get_data("masu.database", "sql/gcp/openshift/reporting_ocpgcptags_summary.sql")

--- a/koku/masu/database/gcp_report_db_accessor.py
+++ b/koku/masu/database/gcp_report_db_accessor.py
@@ -475,13 +475,14 @@ class GCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
         )
         return [json.loads(result[0]) for result in results]
 
-    def populate_ocp_on_gcp_tag_information(self, gcp_bill_ids, start_date, end_date):
+    def populate_ocp_on_gcp_tag_information(self, gcp_bill_ids, start_date, end_date, ocp_uuid):
         """Populate the line item aggregated totals data table."""
         sql_params = {
             "schema": self.schema,
             "gcp_bill_ids": gcp_bill_ids,
             "start_date": start_date,
             "end_date": end_date,
+            "source_uuid": ocp_uuid,
         }
         # Tag Summary
         sql = pkgutil.get_data("masu.database", "sql/gcp/openshift/reporting_ocpgcptags_summary.sql")

--- a/koku/masu/database/gcp_report_db_accessor.py
+++ b/koku/masu/database/gcp_report_db_accessor.py
@@ -475,14 +475,14 @@ class GCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
         )
         return [json.loads(result[0]) for result in results]
 
-    def populate_ocp_on_gcp_tag_information(self, gcp_bill_ids, start_date, end_date, cluster_id):
+    def populate_ocp_on_gcp_tag_information(self, gcp_bill_ids, start_date, end_date, report_period_id):
         """Populate the line item aggregated totals data table."""
         sql_params = {
             "schema": self.schema,
             "gcp_bill_ids": gcp_bill_ids,
             "start_date": start_date,
             "end_date": end_date,
-            "cluster_id": cluster_id,
+            "report_period_id": report_period_id,
         }
         # Tag Summary
         sql = pkgutil.get_data("masu.database", "sql/gcp/openshift/reporting_ocpgcptags_summary.sql")

--- a/koku/masu/database/sql/gcp/openshift/reporting_ocpgcptags_summary.sql
+++ b/koku/masu/database/sql/gcp/openshift/reporting_ocpgcptags_summary.sql
@@ -12,7 +12,7 @@ WITH cte_tag_value AS (
         jsonb_each_text(li.tags) labels
     WHERE li.usage_start >= {{start_date}}
         AND li.usage_start <= {{end_date}}
-        AND li.source_uuid = {{source_uuid}}
+        AND li.cluster_id = {{cluster_id}}
         AND value IS NOT NULL
         AND li.tags ?| (SELECT array_agg(DISTINCT key) FROM {{schema | sqlsafe}}.reporting_enabledtagkeys WHERE enabled=true AND provider_type = 'GCP')
     {% if bill_ids %}

--- a/koku/masu/database/sql/gcp/openshift/reporting_ocpgcptags_summary.sql
+++ b/koku/masu/database/sql/gcp/openshift/reporting_ocpgcptags_summary.sql
@@ -12,7 +12,7 @@ WITH cte_tag_value AS (
         jsonb_each_text(li.tags) labels
     WHERE li.usage_start >= {{start_date}}
         AND li.usage_start <= {{end_date}}
-        AND li.cluster_id = {{cluster_id}}
+        AND li.report_period_id = {{report_period_id}}
         AND value IS NOT NULL
         AND li.tags ?| (SELECT array_agg(DISTINCT key) FROM {{schema | sqlsafe}}.reporting_enabledtagkeys WHERE enabled=true AND provider_type = 'GCP')
     {% if bill_ids %}

--- a/koku/masu/database/sql/gcp/openshift/reporting_ocpgcptags_summary.sql
+++ b/koku/masu/database/sql/gcp/openshift/reporting_ocpgcptags_summary.sql
@@ -12,6 +12,7 @@ WITH cte_tag_value AS (
         jsonb_each_text(li.tags) labels
     WHERE li.usage_start >= {{start_date}}
         AND li.usage_start <= {{end_date}}
+        AND li.source_uuid = {{source_uuid}}
         AND value IS NOT NULL
         AND li.tags ?| (SELECT array_agg(DISTINCT key) FROM {{schema | sqlsafe}}.reporting_enabledtagkeys WHERE enabled=true AND provider_type = 'GCP')
     {% if bill_ids %}

--- a/koku/masu/database/sql/reporting_ocpawstags_summary.sql
+++ b/koku/masu/database/sql/reporting_ocpawstags_summary.sql
@@ -11,6 +11,7 @@ WITH cte_tag_value AS (
         jsonb_each_text(li.tags) labels
     WHERE li.usage_start >= {{start_date}}
         AND li.usage_start <= {{end_date}}
+        AND li.cluster_id = {{cluster_id}}
         AND li.tags ?| (SELECT array_agg(DISTINCT key) FROM {{schema | sqlsafe}}.reporting_enabledtagkeys WHERE enabled=true AND provider_type='AWS')
     {% if bill_ids %}
         AND li.cost_entry_bill_id IN {{ bill_ids | inclause }}

--- a/koku/masu/database/sql/reporting_ocpawstags_summary.sql
+++ b/koku/masu/database/sql/reporting_ocpawstags_summary.sql
@@ -11,7 +11,7 @@ WITH cte_tag_value AS (
         jsonb_each_text(li.tags) labels
     WHERE li.usage_start >= {{start_date}}
         AND li.usage_start <= {{end_date}}
-        AND li.cluster_id = {{cluster_id}}
+        AND li.report_period_id = {{report_period_id}}
         AND li.tags ?| (SELECT array_agg(DISTINCT key) FROM {{schema | sqlsafe}}.reporting_enabledtagkeys WHERE enabled=true AND provider_type='AWS')
     {% if bill_ids %}
         AND li.cost_entry_bill_id IN {{ bill_ids | inclause }}

--- a/koku/masu/database/sql/reporting_ocpazuretags_summary.sql
+++ b/koku/masu/database/sql/reporting_ocpazuretags_summary.sql
@@ -10,7 +10,7 @@ WITH cte_tag_value AS (
         jsonb_each_text(li.tags) labels
     WHERE li.usage_start >= {{start_date}}
         AND li.usage_start <= {{end_date}}
-        AND li.cluster_id = {{cluster_id}}
+        AND li.report_period_id = {{report_period_id}}
         AND li.tags ?| (SELECT array_agg(DISTINCT key) FROM {{schema | sqlsafe}}.reporting_enabledtagkeys WHERE enabled=true AND provider_type='Azure')
     {% if bill_ids %}
         AND li.cost_entry_bill_id IN {{ bill_ids | inclause }}

--- a/koku/masu/database/sql/reporting_ocpazuretags_summary.sql
+++ b/koku/masu/database/sql/reporting_ocpazuretags_summary.sql
@@ -10,6 +10,7 @@ WITH cte_tag_value AS (
         jsonb_each_text(li.tags) labels
     WHERE li.usage_start >= {{start_date}}
         AND li.usage_start <= {{end_date}}
+        AND li.cluster_id = {{cluster_id}}
         AND li.tags ?| (SELECT array_agg(DISTINCT key) FROM {{schema | sqlsafe}}.reporting_enabledtagkeys WHERE enabled=true AND provider_type='Azure')
     {% if bill_ids %}
         AND li.cost_entry_bill_id IN {{ bill_ids | inclause }}

--- a/koku/masu/processor/ocp/ocp_cloud_parquet_summary_updater.py
+++ b/koku/masu/processor/ocp/ocp_cloud_parquet_summary_updater.py
@@ -299,7 +299,7 @@ class OCPCloudParquetReportSummaryUpdater(PartitionHandlerMixin, OCPCloudUpdater
                 sql_params["start_date"] = start
                 sql_params["end_date"] = end
                 accessor.back_populate_ocp_infrastructure_costs(start, end, current_ocp_report_period_id)
-                accessor.populate_ocp_on_aws_tag_information(aws_bill_ids, start, end, cluster_id)
+                accessor.populate_ocp_on_aws_tag_information(aws_bill_ids, start, end, current_ocp_report_period_id)
                 accessor.populate_ocp_on_aws_ui_summary_tables_trino(
                     start, end, openshift_provider_uuid, aws_provider_uuid
                 )
@@ -434,7 +434,9 @@ class OCPCloudParquetReportSummaryUpdater(PartitionHandlerMixin, OCPCloudUpdater
                 sql_params["start_date"] = start
                 sql_params["end_date"] = end
                 accessor.back_populate_ocp_infrastructure_costs(start, end, current_ocp_report_period_id)
-                accessor.populate_ocp_on_azure_tag_information(azure_bill_ids, start, end, cluster_id)
+                accessor.populate_ocp_on_azure_tag_information(
+                    azure_bill_ids, start, end, current_ocp_report_period_id
+                )
                 accessor.populate_ocp_on_azure_ui_summary_tables_trino(
                     start, end, openshift_provider_uuid, azure_provider_uuid
                 )
@@ -555,7 +557,7 @@ class OCPCloudParquetReportSummaryUpdater(PartitionHandlerMixin, OCPCloudUpdater
                 accessor.populate_ocp_on_gcp_ui_summary_tables_trino(
                     start, end, openshift_provider_uuid, gcp_provider_uuid
                 )
-                accessor.populate_ocp_on_gcp_tag_information(gcp_bill_ids, start, end, cluster_id)
+                accessor.populate_ocp_on_gcp_tag_information(gcp_bill_ids, start, end, current_ocp_report_period_id)
 
             with OCPReportDBAccessor(self._schema) as ocp_accessor:
                 sql_params["source_type"] = "GCP"

--- a/koku/masu/processor/ocp/ocp_cloud_parquet_summary_updater.py
+++ b/koku/masu/processor/ocp/ocp_cloud_parquet_summary_updater.py
@@ -555,7 +555,7 @@ class OCPCloudParquetReportSummaryUpdater(PartitionHandlerMixin, OCPCloudUpdater
                 accessor.populate_ocp_on_gcp_ui_summary_tables_trino(
                     start, end, openshift_provider_uuid, gcp_provider_uuid
                 )
-                accessor.populate_ocp_on_gcp_tag_information(gcp_bill_ids, start, end)
+                accessor.populate_ocp_on_gcp_tag_information(gcp_bill_ids, start, end, openshift_provider_uuid)
 
             with OCPReportDBAccessor(self._schema) as ocp_accessor:
                 sql_params["source_type"] = "GCP"

--- a/koku/masu/processor/ocp/ocp_cloud_parquet_summary_updater.py
+++ b/koku/masu/processor/ocp/ocp_cloud_parquet_summary_updater.py
@@ -299,7 +299,7 @@ class OCPCloudParquetReportSummaryUpdater(PartitionHandlerMixin, OCPCloudUpdater
                 sql_params["start_date"] = start
                 sql_params["end_date"] = end
                 accessor.back_populate_ocp_infrastructure_costs(start, end, current_ocp_report_period_id)
-                accessor.populate_ocp_on_aws_tag_information(aws_bill_ids, start, end)
+                accessor.populate_ocp_on_aws_tag_information(aws_bill_ids, start, end, cluster_id)
                 accessor.populate_ocp_on_aws_ui_summary_tables_trino(
                     start, end, openshift_provider_uuid, aws_provider_uuid
                 )
@@ -434,7 +434,7 @@ class OCPCloudParquetReportSummaryUpdater(PartitionHandlerMixin, OCPCloudUpdater
                 sql_params["start_date"] = start
                 sql_params["end_date"] = end
                 accessor.back_populate_ocp_infrastructure_costs(start, end, current_ocp_report_period_id)
-                accessor.populate_ocp_on_azure_tag_information(azure_bill_ids, start, end)
+                accessor.populate_ocp_on_azure_tag_information(azure_bill_ids, start, end, cluster_id)
                 accessor.populate_ocp_on_azure_ui_summary_tables_trino(
                     start, end, openshift_provider_uuid, azure_provider_uuid
                 )

--- a/koku/masu/processor/ocp/ocp_cloud_parquet_summary_updater.py
+++ b/koku/masu/processor/ocp/ocp_cloud_parquet_summary_updater.py
@@ -555,7 +555,7 @@ class OCPCloudParquetReportSummaryUpdater(PartitionHandlerMixin, OCPCloudUpdater
                 accessor.populate_ocp_on_gcp_ui_summary_tables_trino(
                     start, end, openshift_provider_uuid, gcp_provider_uuid
                 )
-                accessor.populate_ocp_on_gcp_tag_information(gcp_bill_ids, start, end, openshift_provider_uuid)
+                accessor.populate_ocp_on_gcp_tag_information(gcp_bill_ids, start, end, cluster_id)
 
             with OCPReportDBAccessor(self._schema) as ocp_accessor:
                 sql_params["source_type"] = "GCP"

--- a/koku/masu/processor/tasks.py
+++ b/koku/masu/processor/tasks.py
@@ -513,7 +513,7 @@ def update_summary_tables(  # noqa: C901
             msg = f"Task {task_name} already running for {cache_args}. Requeuing."
             if rate_limited:
                 msg = f"Schema {schema} is currently rate limited. Requeuing."
-            LOG.debug(log_json(tracing_id, msg=msg))
+            LOG.info(log_json(tracing_id, msg=msg))
             update_summary_tables.s(
                 schema,
                 provider_type,
@@ -723,8 +723,6 @@ def update_openshift_on_cloud(  # noqa: C901
     """Update OpenShift on Cloud for a specific OpenShift and cloud source."""
     # Get latest manifest id for running OCP provider
     ocp_manifest_id = get_latest_openshift_on_cloud_manifest(start_date, openshift_provider_uuid)
-    # Set OpenShift summary started time
-    set_summary_timestamp(ManifestState.START, ocp_manifest_id)
     task_name = "masu.processor.tasks.update_openshift_on_cloud"
     if is_ocp_on_cloud_summary_disabled(schema_name):
         msg = f"OCP on Cloud summary disabled for {schema_name}."
@@ -748,7 +746,7 @@ def update_openshift_on_cloud(  # noqa: C901
             msg = f"Task {task_name} already running for {cache_args}. Requeuing."
             if rate_limited:
                 msg = f"Schema {schema_name} is currently rate limited. Requeuing."
-            LOG.debug(log_json(tracing_id, msg=msg))
+            LOG.info(log_json(tracing_id, msg=msg))
             update_openshift_on_cloud.s(
                 schema_name,
                 openshift_provider_uuid,
@@ -764,6 +762,8 @@ def update_openshift_on_cloud(  # noqa: C901
             return
         worker_cache.lock_single_task(task_name, cache_args, timeout=timeout)
 
+    # Set OpenShift summary started time
+    set_summary_timestamp(ManifestState.START, ocp_manifest_id)
     ctx = {
         "schema": schema_name,
         "ocp_provider_uuid": openshift_provider_uuid,

--- a/koku/masu/test/database/test_aws_report_db_accessor.py
+++ b/koku/masu/test/database/test_aws_report_db_accessor.py
@@ -425,6 +425,7 @@ class AWSReportDBAccessorTest(MasuTestCase):
         """
         mock_unleash.return_value = True
         populated_keys = []
+        report_period_id = 1
         with schema_context(self.schema):
             enabled_tags = EnabledTagKeys.objects.filter(provider_type=Provider.PROVIDER_AWS, enabled=True)
             for enabled_tag in enabled_tags:
@@ -447,7 +448,7 @@ class AWSReportDBAccessorTest(MasuTestCase):
             child_key, child_obj, child_count = populated_keys[1]
             TagMapping.objects.create(parent=parent_obj, child=child_obj)
             self.accessor.populate_ocp_on_aws_tag_information(
-                bill_ids, self.dh.this_month_start, self.dh.today, self.cluster_id
+                bill_ids, self.dh.this_month_start, self.dh.today, report_period_id
             )
             expected_parent_count = parent_count + child_count
             actual_parent_count = OCPAWSCostLineItemProjectDailySummaryP.objects.filter(

--- a/koku/masu/test/database/test_aws_report_db_accessor.py
+++ b/koku/masu/test/database/test_aws_report_db_accessor.py
@@ -446,7 +446,9 @@ class AWSReportDBAccessorTest(MasuTestCase):
             parent_key, parent_obj, parent_count = populated_keys[0]
             child_key, child_obj, child_count = populated_keys[1]
             TagMapping.objects.create(parent=parent_obj, child=child_obj)
-            self.accessor.populate_ocp_on_aws_tag_information(bill_ids, self.dh.this_month_start, self.dh.today)
+            self.accessor.populate_ocp_on_aws_tag_information(
+                bill_ids, self.dh.this_month_start, self.dh.today, self.cluster_id
+            )
             expected_parent_count = parent_count + child_count
             actual_parent_count = OCPAWSCostLineItemProjectDailySummaryP.objects.filter(
                 tags__has_key=parent_key, usage_start__gte=self.dh.this_month_start, usage_start__lte=self.dh.today

--- a/koku/masu/test/database/test_azure_report_db_accessor.py
+++ b/koku/masu/test/database/test_azure_report_db_accessor.py
@@ -369,7 +369,9 @@ class AzureReportDBAccessorTest(MasuTestCase):
             parent_key, parent_obj, parent_count = populated_keys[0]
             child_key, child_obj, child_count = populated_keys[1]
             TagMapping.objects.create(parent=parent_obj, child=child_obj)
-            self.accessor.populate_ocp_on_azure_tag_information(bill_ids, self.dh.this_month_start, self.dh.today)
+            self.accessor.populate_ocp_on_azure_tag_information(
+                bill_ids, self.dh.this_month_start, self.dh.today, self.ocp_cluster_id
+            )
             expected_parent_count = parent_count + child_count
             actual_parent_count = OCPAzureCostLineItemProjectDailySummaryP.objects.filter(
                 tags__has_key=parent_key, usage_start__gte=self.dh.this_month_start, usage_start__lte=self.dh.today

--- a/koku/masu/test/database/test_azure_report_db_accessor.py
+++ b/koku/masu/test/database/test_azure_report_db_accessor.py
@@ -348,6 +348,7 @@ class AzureReportDBAccessorTest(MasuTestCase):
         """
         mock_unleash.return_value = True
         populated_keys = []
+        report_period_id = 1
         with schema_context(self.schema):
             enabled_tags = EnabledTagKeys.objects.filter(provider_type=Provider.PROVIDER_AZURE, enabled=True)
             for enabled_tag in enabled_tags:
@@ -370,7 +371,7 @@ class AzureReportDBAccessorTest(MasuTestCase):
             child_key, child_obj, child_count = populated_keys[1]
             TagMapping.objects.create(parent=parent_obj, child=child_obj)
             self.accessor.populate_ocp_on_azure_tag_information(
-                bill_ids, self.dh.this_month_start, self.dh.today, self.ocp_cluster_id
+                bill_ids, self.dh.this_month_start, self.dh.today, report_period_id
             )
             expected_parent_count = parent_count + child_count
             actual_parent_count = OCPAzureCostLineItemProjectDailySummaryP.objects.filter(

--- a/koku/masu/test/database/test_gcp_report_db_accessor.py
+++ b/koku/masu/test/database/test_gcp_report_db_accessor.py
@@ -395,7 +395,7 @@ class GCPReportDBAccessorTest(MasuTestCase):
         end_date = self.dh.this_month_end.date()
 
         mock_gcp_bills = [Mock(), Mock()]
-        self.accessor.populate_ocp_on_gcp_tag_information(mock_gcp_bills, start_date, end_date)
+        self.accessor.populate_ocp_on_gcp_tag_information(mock_gcp_bills, start_date, end_date, self.ocp_cluster_id)
         mock_trino.assert_called()
 
     @patch("masu.database.gcp_report_db_accessor.GCPReportDBAccessor.schema_exists_trino")
@@ -514,7 +514,9 @@ class GCPReportDBAccessorTest(MasuTestCase):
             parent_key, parent_obj, parent_count = populated_keys[0]
             child_key, child_obj, child_count = populated_keys[1]
             TagMapping.objects.create(parent=parent_obj, child=child_obj)
-            self.accessor.populate_ocp_on_gcp_tag_information(bill_ids, self.dh.this_month_start, self.dh.today)
+            self.accessor.populate_ocp_on_gcp_tag_information(
+                bill_ids, self.dh.this_month_start, self.dh.today, self.ocp_cluster_id
+            )
             expected_parent_count = parent_count + child_count
             actual_parent_count = OCPGCPCostLineItemProjectDailySummaryP.objects.filter(
                 tags__has_key=parent_key, usage_start__gte=self.dh.this_month_start, usage_start__lte=self.dh.today

--- a/koku/masu/test/database/test_gcp_report_db_accessor.py
+++ b/koku/masu/test/database/test_gcp_report_db_accessor.py
@@ -391,11 +391,12 @@ class GCPReportDBAccessorTest(MasuTestCase):
     @patch("masu.database.gcp_report_db_accessor.GCPReportDBAccessor._execute_raw_sql_query")
     def test_populate_ocp_on_gcp_tag_information_assert_call(self, mock_trino):
         """Test that we construst our SQL and execute our query."""
+        report_period_id = 1
         start_date = self.dh.this_month_start.date()
         end_date = self.dh.this_month_end.date()
 
         mock_gcp_bills = [Mock(), Mock()]
-        self.accessor.populate_ocp_on_gcp_tag_information(mock_gcp_bills, start_date, end_date, self.ocp_cluster_id)
+        self.accessor.populate_ocp_on_gcp_tag_information(mock_gcp_bills, start_date, end_date, report_period_id)
         mock_trino.assert_called()
 
     @patch("masu.database.gcp_report_db_accessor.GCPReportDBAccessor.schema_exists_trino")
@@ -493,6 +494,7 @@ class GCPReportDBAccessorTest(MasuTestCase):
         """
         mock_unleash.return_value = True
         populated_keys = []
+        report_period_id = 1
         with schema_context(self.schema):
             enabled_tags = EnabledTagKeys.objects.filter(provider_type=Provider.PROVIDER_GCP, enabled=True)
             for enabled_tag in enabled_tags:
@@ -515,7 +517,7 @@ class GCPReportDBAccessorTest(MasuTestCase):
             child_key, child_obj, child_count = populated_keys[1]
             TagMapping.objects.create(parent=parent_obj, child=child_obj)
             self.accessor.populate_ocp_on_gcp_tag_information(
-                bill_ids, self.dh.this_month_start, self.dh.today, self.ocp_cluster_id
+                bill_ids, self.dh.this_month_start, self.dh.today, report_period_id
             )
             expected_parent_count = parent_count + child_count
             actual_parent_count = OCPGCPCostLineItemProjectDailySummaryP.objects.filter(

--- a/koku/masu/test/processor/ocp/test_ocp_cloud_parquet_report_summary_updater.py
+++ b/koku/masu/test/processor/ocp/test_ocp_cloud_parquet_report_summary_updater.py
@@ -307,7 +307,7 @@ class OCPCloudParquetReportSummaryUpdaterTest(MasuTestCase):
         mock_ui_summary.assert_called_with(
             start_date, end_date, self.ocpgcp_provider_uuid, self.gcp_test_provider_uuid
         )
-        mock_tag_summary.assert_called_with([1, 2], start_date, end_date)
+        mock_tag_summary.assert_called_with([1, 2], start_date, end_date, cluster_id)
 
     @patch(
         "masu.processor.ocp.ocp_cloud_parquet_summary_updater.OCPReportDBAccessor.populate_ocp_on_all_ui_summary_tables"  # noqa: E501
@@ -379,7 +379,7 @@ class OCPCloudParquetReportSummaryUpdaterTest(MasuTestCase):
             start_date, end_date, self.ocpgcp_provider_uuid, self.gcp_test_provider_uuid
         )
 
-        mock_tag_summary.assert_called_with([1, 2], start_date, end_date)
+        mock_tag_summary.assert_called_with([1, 2], start_date, end_date, cluster_id)
 
     @patch("masu.processor.ocp.ocp_cloud_parquet_summary_updater.OCPReportDBAccessor.get_cluster_for_provider")
     @patch(

--- a/koku/masu/test/processor/ocp/test_ocp_cloud_parquet_report_summary_updater.py
+++ b/koku/masu/test/processor/ocp/test_ocp_cloud_parquet_report_summary_updater.py
@@ -307,7 +307,7 @@ class OCPCloudParquetReportSummaryUpdaterTest(MasuTestCase):
         mock_ui_summary.assert_called_with(
             start_date, end_date, self.ocpgcp_provider_uuid, self.gcp_test_provider_uuid
         )
-        mock_tag_summary.assert_called_with([1, 2], start_date, end_date, cluster_id)
+        mock_tag_summary.assert_called_with([1, 2], start_date, end_date, current_ocp_report_period_id)
 
     @patch(
         "masu.processor.ocp.ocp_cloud_parquet_summary_updater.OCPReportDBAccessor.populate_ocp_on_all_ui_summary_tables"  # noqa: E501
@@ -379,7 +379,7 @@ class OCPCloudParquetReportSummaryUpdaterTest(MasuTestCase):
             start_date, end_date, self.ocpgcp_provider_uuid, self.gcp_test_provider_uuid
         )
 
-        mock_tag_summary.assert_called_with([1, 2], start_date, end_date, cluster_id)
+        mock_tag_summary.assert_called_with([1, 2], start_date, end_date, current_ocp_report_period_id)
 
     @patch("masu.processor.ocp.ocp_cloud_parquet_summary_updater.OCPReportDBAccessor.get_cluster_for_provider")
     @patch(


### PR DESCRIPTION
## Jira Ticket

[COST-####](https://issues.redhat.com/browse/COST-####)

## Description

This change will add source_uuid to reporting_ocp{cloud}tags_summary.sql in order to reduce the select scale set. The more clusters/providers a customer has the slower this query is going to become.

Additionally fixed up some logging. 

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Release Notes
- [ ] proposed release note

```markdown
* [COST-####](https://issues.redhat.com/browse/COST-####) Fix some things
```
