### PR TITLE
[COST-4907] Add temp table to track aws disk capacities

### DIFF
--- a/koku/masu/database/aws_report_db_accessor.py
+++ b/koku/masu/database/aws_report_db_accessor.py
@@ -22,6 +22,7 @@ from masu.database import AWS_CUR_TABLE_MAP
 from masu.database import OCP_REPORT_TABLE_MAP
 from masu.database.report_db_accessor_base import ReportDBAccessorBase
 from masu.processor import is_feature_cost_3592_tag_mapping_enabled
+from masu.processor import is_feature_unattributed_storage_enabled_aws
 from reporting.models import OCP_ON_ALL_PERSPECTIVES
 from reporting.models import OCP_ON_AWS_PERSPECTIVES
 from reporting.models import OCP_ON_AWS_TEMP_MANAGED_TABLES
@@ -240,6 +241,8 @@ class AWSReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
             pod_column = "pod_effective_usage_memory_gigabyte_hours"
             node_column = "node_capacity_memory_gigabyte_hours"
 
+        unattributed_storage = is_feature_unattributed_storage_enabled_aws(self.schema)
+
         sql = pkgutil.get_data("masu.database", "trino_sql/reporting_ocpawscostlineitem_daily_summary.sql")
         sql = sql.decode("utf-8")
         sql_params = {
@@ -256,6 +259,7 @@ class AWSReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
             "markup": markup_value or 0,
             "pod_column": pod_column,
             "node_column": node_column,
+            "unattributed_storage": unattributed_storage,
         }
         ctx = self.extract_context_from_sql_params(sql_params)
         LOG.info(log_json(msg="running OCP on AWS SQL", context=ctx))

--- a/koku/masu/database/azure_report_db_accessor.py
+++ b/koku/masu/database/azure_report_db_accessor.py
@@ -22,7 +22,7 @@ from masu.database import AZURE_REPORT_TABLE_MAP
 from masu.database import OCP_REPORT_TABLE_MAP
 from masu.database.report_db_accessor_base import ReportDBAccessorBase
 from masu.processor import is_feature_cost_3592_tag_mapping_enabled
-from masu.processor import is_feature_unattributed_storage_enabled
+from masu.processor import is_feature_unattributed_storage_enabled_azure
 from reporting.models import OCP_ON_ALL_PERSPECTIVES
 from reporting.models import OCP_ON_AZURE_PERSPECTIVES
 from reporting.models import OCP_ON_AZURE_TEMP_MANAGED_TABLES
@@ -292,7 +292,7 @@ class AzureReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
             "markup": markup_value or 0,
             "pod_column": pod_column,
             "node_column": node_column,
-            "unattributed_storage": is_feature_unattributed_storage_enabled(self.schema),
+            "unattributed_storage": is_feature_unattributed_storage_enabled_azure(self.schema),
         }
         ctx = self.extract_context_from_sql_params(sql_params)
         LOG.info(log_json(msg="running OCP on Azure SQL", context=ctx))

--- a/koku/masu/database/trino_sql/reporting_ocpawscostlineitem_daily_summary.sql
+++ b/koku/masu/database/trino_sql/reporting_ocpawscostlineitem_daily_summary.sql
@@ -162,6 +162,19 @@ CREATE TABLE IF NOT EXISTS hive.{{schema | sqlsafe}}.reporting_ocpawscostlineite
 ) WITH(format = 'PARQUET', partitioned_by=ARRAY['aws_source', 'ocp_source', 'year', 'month', 'day'])
 ;
 
+{% if unattributed_storage %}
+CREATE TABLE IF NOT EXISTS hive.{{schema | sqlsafe}}.aws_openshift_disk_capacities_temp
+(
+    resource_id varchar,
+    capacity integer,
+    usage_start timestamp,
+    ocp_source varchar,
+    year varchar,
+    month varchar
+) WITH(format = 'PARQUET', partitioned_by=ARRAY['ocp_source', 'year', 'month'])
+{% endif %}
+;
+
 INSERT INTO hive.{{schema | sqlsafe}}.aws_openshift_daily_resource_matched_temp (
     uuid,
     usage_start,
@@ -345,6 +358,55 @@ GROUP BY aws.lineitem_usagestartdate,
     aws.costcategory,
     17, -- tags
     aws.matched_tag
+;
+
+-- Developer notes
+-- 30.44 is the average amount of days in each month between 28, 30, 31
+-- We can't use the aws_openshift_daily table to calcualte the capacity
+-- because it has already aggregated cost per each hour.
+{% if unattributed_storage %}
+INSERT INTO hive.{{schema | sqlsafe}}.aws_openshift_disk_capacities_temp (
+    resource_id,
+    capacity,
+    usage_start,
+    ocp_source,
+    year,
+    month
+)
+WITH cte_ocp_filtered_resources as (
+    select
+        distinct aws.resource_id as resource_id,
+        {{ocp_source_uuid}} as ocp_source,
+        DATE(aws.usage_start) as usage_start,
+        aws.year as year,
+        aws.month as month
+    FROM aws_openshift_daily_resource_matched_temp as aws
+    JOIN reporting_ocpusagelineitem_daily_summary as ocp
+        ON aws.usage_start = ocp.usage_start
+        AND strpos(aws.resource_id, ocp.csi_volume_handle) != 0
+    WHERE
+        ocp.source_uuid = {{ocp_source_uuid}}
+        AND ocp.year = {{year}}
+        AND lpad(ocp.month, 2, '0') = {{month}}
+        AND aws.ocp_source = {{ocp_source_uuid}}
+        AND aws.year = {{year}}
+        AND aws.month = {{month}}
+)
+SELECT
+    aws.lineitem_resourceid as resource_id,
+    CEIL(MAX(aws.lineitem_unblendedcost) / (MAX(aws.lineitem_unblendedrate) / (30.44 * 24))) AS capacity,
+    ocpaws.usage_start,
+    {{ocp_source_uuid}} as ocp_source,
+    {{year}} as year,
+    {{month}} as month
+FROM aws_line_items as aws
+INNER JOIN cte_ocp_filtered_resources as ocpaws
+    ON aws.lineitem_resourceid = ocpaws.resource_id
+    AND DATE(aws.lineitem_usagestartdate) = ocpaws.usage_start
+WHERE aws.year = {{year}}
+AND aws.month = {{month}}
+group by aws.lineitem_resourceid, ocpaws.usage_start
+{% endif %}
 ;
 
 -- Direct resource_id matching

--- a/koku/masu/management/commands/migrate_trino_tables.py
+++ b/koku/masu/management/commands/migrate_trino_tables.py
@@ -67,6 +67,7 @@ MANAGED_TABLES = {
     "reporting_ocpgcpcostlineitem_project_daily_summary_temp",
     "reporting_ocpusagelineitem_daily_summary",
     "azure_openshift_disk_capacities_temp",
+    "aws_openshift_disk_capacities_temp",
 }
 
 manage_table_mapping = {
@@ -84,6 +85,7 @@ manage_table_mapping = {
     "reporting_ocpgcpcostlineitem_project_daily_summary_temp": "ocp_source",
     "reporting_ocpusagelineitem_daily_summary": "source",
     "azure_openshift_disk_capacities_temp": "ocp_source",
+    "aws_openshift_disk_capacities_temp": "ocp_source",
 }
 
 VALID_CHARACTERS = re.compile(r"^[\w.-]+$")

--- a/koku/masu/processor/__init__.py
+++ b/koku/masu/processor/__init__.py
@@ -20,7 +20,7 @@ LOG = logging.getLogger(__name__)
 ALLOWED_COMPRESSIONS = (UNCOMPRESSED, GZIP_COMPRESSED)
 
 
-def is_feature_unattributed_storage_enabled(account):
+def is_feature_unattributed_storage_enabled_azure(account):
     """Should unattributed storage feature be enabled."""
     unleash_flag = "cost-management.backend.unattributed_storage"
     account = convert_account(account)
@@ -155,6 +155,14 @@ def check_ingress_columns(account):  # pragma: no cover
     account = convert_account(account)
     context = {"schema": account}
     return UNLEASH_CLIENT.is_enabled("cost-management.backend.check-ingress-columns", context)
+
+
+def is_feature_unattributed_storage_enabled_aws(account):
+    """Should unattributed storage feature be enabled."""
+    unleash_flag = "cost-management.backend.unattributed_storage.aws"
+    account = convert_account(account)
+    context = {"schema": account}
+    return UNLEASH_CLIENT.is_enabled(unleash_flag, context, fallback_development_true)
 
 
 def is_feature_cost_3592_tag_mapping_enabled(account):

--- a/koku/reporting/models.py
+++ b/koku/reporting/models.py
@@ -191,6 +191,7 @@ OCP_ON_AWS_TEMP_MANAGED_TABLES = {
     "reporting_ocpawscostlineitem_project_daily_summary_temp",
     "aws_openshift_daily_resource_matched_temp",
     "aws_openshift_daily_tag_matched_temp",
+    "aws_openshift_disk_capacities_temp",
 }
 
 OCP_ON_AZURE_TEMP_MANAGED_TABLES = {


### PR DESCRIPTION
## Jira Ticket

[COST-4907](https://issues.redhat.com/browse/COST-4907)

## Description

This change will add a temporary table for tracking aws disk capacities.

## Testing

1. Checkout Branch
2. load test customer data for AWS
3. select * from aws_openshift_disk_capacities_temp;
4. TRINO SQL:
```
trino:org1234567> select * from aws_openshift_disk_capacities_temp;
```
Example return:
```
    resource_id    | capacity |       usage_start       |              ocp_source              | year | month
-------------------+----------+-------------------------+--------------------------------------+------+-------
 vol-12345672      |       20 | 2024-07-29 00:00:00.000 | eea292d8-7553-4462-89a3-ed48e5a99113 | 2024 | 07
 vol-123-claimless |       30 | 2024-08-11 00:00:00.000 | eea292d8-7553-4462-89a3-ed48e5a99113 | 2024 | 08
 vol-12345671      |       20 | 2024-08-12 00:00:00.000 | eea292d8-7553-4462-89a3-ed48e5a99113 | 2024 | 08
 vol-12345674      |       20 | 2024-08-12 00:00:00.000 | eea292d8-7553-4462-89a3-ed48e5a99113 | 2024 | 08
 vol-12345671      |       20 | 2024-08-13 00:00:00.000 | eea292d8-7553-4462-89a3-ed48e5a99113 | 2024 | 08
 vol-12345672      |       20 | 2024-08-11 00:00:00.000 | eea292d8-7553-4462-89a3-ed48e5a99113 | 2024 | 08
 ```

## Release Notes
- [ ] proposed release note

```markdown
* [COST-####](https://issues.redhat.com/browse/COST-####) Fix some things
```
