### PR TITLE
[COST-4310] Get correct bill ID during summary

### DIFF
--- a/koku/masu/util/gcp/common.py
+++ b/koku/masu/util/gcp/common.py
@@ -18,7 +18,6 @@ from reporting.provider.gcp.models import GCPCostEntryBill
 LOG = logging.getLogger(__name__)
 pd.options.mode.chained_assignment = None
 
-
 def get_bills_from_provider(provider_uuid, schema, start_date=None, end_date=None):
     """
     Return the GCP bill IDs given a provider UUID.
@@ -53,10 +52,14 @@ def get_bills_from_provider(provider_uuid, schema, start_date=None, end_date=Non
 
     with schema_context(schema):
         bills = GCPCostEntryBill.objects.filter(provider_id=provider.uuid)
+        kwargs = {}
         if start_date:
-            bills = bills.filter(billing_period_start__gte=start_date)
+            kwargs["billing_period_start__gte"] = start_date
+
         if end_date:
-            bills = bills.filter(billing_period_start__lte=end_date)
+            kwargs["billing_period_start__lte"] = end_date
+
+        bills = bills.filter(**kwargs)
         # postgres doesn't always return this query in the same order, ordering by ID (PK) will
         # ensure that any list iteration or indexing is always done in the same order
         bills = list(bills.order_by("id").all())


### PR DESCRIPTION
## Jira Ticket

[COST-4310](https://issues.redhat.com/browse/COST-4310)

## Description

Rough WIP, but the idea is to get the bill_id that corresponds to the start and end date of the date pair, falling back to the latest bill ID.

Using the first item in the list of bills results in the incorrect bill ID if when running summary for months besides the current month.

This is a bit klunky and could use some refinement.

Also, we'll need to do the same thing for other providers as well. The code getting the bill ID will probably need to move to a separate function.

## Testing

1. Checkout Branch
2. Restart Koku
3. Load GCP data
4. Runn summary

## Release Notes
- [ ] proposed release note

```markdown
* [COST-4310](https://issues.redhat.com/browse/COST-4310) Get correct bill ID when running summary
```
