### PR TITLE
[COST-5425] Fix regression with false unleash flag

### DIFF
--- a/koku/masu/database/trino_sql/reporting_ocpawscostlineitem_daily_summary.sql
+++ b/koku/masu/database/trino_sql/reporting_ocpawscostlineitem_daily_summary.sql
@@ -360,11 +360,11 @@ GROUP BY aws.lineitem_usagestartdate,
     aws.matched_tag
 ;
 
+{% if unattributed_storage %}
 -- Developer notes
 -- 30.44 is the average amount of days in each month between 28, 30, 31
 -- We can't use the aws_openshift_daily table to calcualte the capacity
 -- because it has already aggregated cost per each hour.
-{% if unattributed_storage %}
 INSERT INTO hive.{{schema | sqlsafe}}.aws_openshift_disk_capacities_temp (
     resource_id,
     capacity,


### PR DESCRIPTION
## Jira Ticket

[COST-4907](https://issues.redhat.com/browse/COST-4907)

## Description

This change will fix a regression for when the unleash flag is false.

## Testing

Set the `unattributed_storage` param to false in the `populate_ocp_on_aws_cost_daily_summary_trino` method and hit resummary

```
sql_params = {
            "schema": self.schema,
            "start_date": start_date,
            "year": year,
            "month": month,
            "days": days_tup,
            "end_date": end_date,
            "aws_source_uuid": aws_provider_uuid,
            "ocp_source_uuid": openshift_provider_uuid,
            "bill_id": bill_id,
            "report_period_id": report_period_id,
            "markup": markup_value or 0,
            "pod_column": pod_column,
            "node_column": node_column,
            "unattributed_storage": False,
        }
```

## Release Notes
- [ ] proposed release note

```markdown
* [COST-5425](https://issues.redhat.com/browse/COST-5425) Fix regression with false unleash flag
```
