### PR TITLE
Remove deprecated sbom-json-check

### DIFF
--- a/.tekton/koku-pull-request.yaml
+++ b/.tekton/koku-pull-request.yaml
@@ -386,28 +386,6 @@ spec:
             operator: in
             values:
               - "false"
-      - name: sbom-json-check
-        params:
-          - name: IMAGE_URL
-            value: $(tasks.build-container.results.IMAGE_URL)
-          - name: IMAGE_DIGEST
-            value: $(tasks.build-container.results.IMAGE_DIGEST)
-        runAfter:
-          - build-container
-        taskRef:
-          params:
-            - name: name
-              value: sbom-json-check
-            - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-sbom-json-check:0.1@sha256:2c5de51ec858fc8d47e41c65b20c83fdac249425d67ed6d1058f9f3e0b574500
-            - name: kind
-              value: task
-          resolver: bundles
-        when:
-          - input: $(params.skip-checks)
-            operator: in
-            values:
-              - "false"
       - name: apply-tags
         params:
           - name: IMAGE

--- a/.tekton/koku-push.yaml
+++ b/.tekton/koku-push.yaml
@@ -383,28 +383,6 @@ spec:
             operator: in
             values:
               - "false"
-      - name: sbom-json-check
-        params:
-          - name: IMAGE_URL
-            value: $(tasks.build-container.results.IMAGE_URL)
-          - name: IMAGE_DIGEST
-            value: $(tasks.build-container.results.IMAGE_DIGEST)
-        runAfter:
-          - build-container
-        taskRef:
-          params:
-            - name: name
-              value: sbom-json-check
-            - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-sbom-json-check:0.1@sha256:2c5de51ec858fc8d47e41c65b20c83fdac249425d67ed6d1058f9f3e0b574500
-            - name: kind
-              value: task
-          resolver: bundles
-        when:
-          - input: $(params.skip-checks)
-            operator: in
-            values:
-              - "false"
       - name: apply-tags
         params:
           - name: IMAGE


### PR DESCRIPTION
## Description

Remove deprecated check.

[Migration](https://raw.githubusercontent.com/konflux-ci/build-definitions/main/task/sbom-json-check/0.2/MIGRATION.md).

## Release Notes
- [x] proposed release note

```markdown
* Remove deprecated `sbom-json-check` from pipelines
```
