### PR TITLE
Ignore `dev/containers` for updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,8 @@
     ],
     "schedule": [
         "on Tuesday after 3am and before 10am"
+    ],
+    "ignorePaths": [
+      "dev/containers/**"
     ]
 }


### PR DESCRIPTION
## Jira Ticket

[COST-5364](https://issues.redhat.com/browse/COST-5364)

## Description

Prevent Renovate Bot from updating our dev containers
## Release Notes
- [x] proposed release note

```markdown
* [COST-5364](https://issues.redhat.com/browse/COST-5364) Prevent Renovate Bot from updating dev containers
```
