### PR TITLE
[COST-5133 + COST-5134] - Add support for OCP/(GCP/Azure) trino updates

### DIFF
--- a/koku/api/provider/models.py
+++ b/koku/api/provider/models.py
@@ -183,6 +183,10 @@ class Provider(models.Model):
     MANAGED_OPENSHIFT_ON_CLOUD_PROVIDER_LIST = [
         PROVIDER_AWS,
         PROVIDER_AWS_LOCAL,
+        PROVIDER_AZURE,
+        PROVIDER_AZURE_LOCAL,
+        PROVIDER_GCP,
+        PROVIDER_GCP_LOCAL,
     ]
 
     uuid = models.UUIDField(default=uuid4, primary_key=True)

--- a/koku/masu/database/azure_report_db_accessor.py
+++ b/koku/masu/database/azure_report_db_accessor.py
@@ -9,6 +9,7 @@ import pkgutil
 import uuid
 
 from dateutil.parser import parse
+from django.conf import settings
 from django.db import connection
 from django.db.models import F
 from django.db.models import Q
@@ -33,6 +34,7 @@ from reporting.provider.all.models import TagMapping
 from reporting.provider.azure.models import AzureCostEntryBill
 from reporting.provider.azure.models import AzureCostEntryLineItemDailySummary
 from reporting.provider.azure.models import TRINO_LINE_ITEM_TABLE
+from reporting.provider.azure.models import TRINO_MANAGED_OCP_AZURE_DAILY_TABLE
 from reporting.provider.azure.models import UI_SUMMARY_TABLES
 from reporting.provider.azure.openshift.models import UI_SUMMARY_TABLES as OCPAZURE_UI_SUMMARY_TABLES
 
@@ -223,9 +225,10 @@ class AzureReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
             }
             self._execute_trino_raw_sql_query(sql, sql_params=sql_params, log_ref=f"{table_name}.sql")
 
-    def delete_ocp_on_azure_hive_partition_by_day(self, days, az_source, ocp_source, year, month):
+    def delete_ocp_on_azure_hive_partition_by_day(
+        self, days, az_source, ocp_source, year, month, table="reporting_ocpazurecostlineitem_project_daily_summary"
+    ):
         """Deletes partitions individually for each day in days list."""
-        table = "reporting_ocpazurecostlineitem_project_daily_summary"
         if self.schema_exists_trino() and self.table_exists_trino(table):
             LOG.info(
                 log_json(
@@ -240,16 +243,20 @@ class AzureReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
                 )
             )
             for day in days:
+                if table == TRINO_MANAGED_OCP_AZURE_DAILY_TABLE:
+                    column_name = "source"
+                else:
+                    column_name = "azure_source"
                 sql = f"""
                     DELETE FROM hive.{self.schema}.{table}
-                        WHERE azure_source = '{az_source}'
+                        WHERE {column_name} = '{az_source}'
                         AND ocp_source = '{ocp_source}'
                         AND year = '{year}'
                         AND (month = replace(ltrim(replace('{month}', '0', ' ')),' ', '0') OR month = '{month}')
                         AND day = '{day}'"""
                 self._execute_trino_raw_sql_query(
                     sql,
-                    log_ref=f"delete_ocp_on_azure_hive_partition_by_day for {year}-{month}-{day}",
+                    log_ref=f"delete_ocp_on_azure_hive_partition_by_day for {year}-{month}-{day} from {table}",
                 )
 
     def populate_ocp_on_azure_cost_daily_summary_trino(
@@ -424,3 +431,45 @@ class AzureReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
                 LOG.info(log_json(msg="no matching enabled keys for OCP on Azure", schema=self.schema))
                 return False
         return True
+
+    def populate_ocp_on_cloud_daily_trino(
+        self, azure_provider_uuid, openshift_provider_uuid, start_date, end_date, matched_tags
+    ):
+        """Populate the azure_openshift_daily trino table for OCP on Azure.
+        Args:
+            azure_provider_uuid (UUID) GCP source UUID.
+            ocp_provider_uuid (UUID) OCP source UUID.
+            start_date (datetime.date) The date to start populating the table.
+            end_date (datetime.date) The date to end on.
+            matched_tag_strs (str) matching tags.
+        Returns
+            (None)
+        """
+        if type(start_date) == str:
+            start_date = parse(start_date).astimezone(tz=settings.UTC)
+        if type(end_date) == str:
+            end_date = parse(end_date).astimezone(tz=settings.UTC)
+        year = start_date.strftime("%Y")
+        month = start_date.strftime("%m")
+        table = TRINO_MANAGED_OCP_AZURE_DAILY_TABLE
+        days = self.date_helper.list_days(start_date, end_date)
+        days_tup = tuple(str(day.day) for day in days)
+        self.delete_ocp_on_azure_hive_partition_by_day(
+            days_tup, azure_provider_uuid, openshift_provider_uuid, year, month, table
+        )
+
+        summary_sql = pkgutil.get_data("masu.database", "trino_sql/azure/openshift/managed_azure_openshift_daily.sql")
+        summary_sql = summary_sql.decode("utf-8")
+        summary_sql_params = {
+            "schema": self.schema,
+            "start_date": start_date,
+            "year": year,
+            "month": month,
+            "days": days_tup,
+            "end_date": end_date,
+            "azure_source_uuid": azure_provider_uuid,
+            "ocp_source_uuid": openshift_provider_uuid,
+            "matched_tag_array": matched_tags,
+        }
+        LOG.info(log_json(msg="running managed OCP on AZURE daily SQL", **summary_sql_params))
+        self._execute_trino_multipart_sql_query(summary_sql, bind_params=summary_sql_params)

--- a/koku/masu/database/trino_sql/azure/openshift/managed_azure_openshift_daily.sql
+++ b/koku/masu/database/trino_sql/azure/openshift/managed_azure_openshift_daily.sql
@@ -316,6 +316,7 @@ LEFT JOIN cte_matchable_resource_names AS resource_names
     AND azure.servicefamily = resource_names.servicefamily
 LEFT JOIN cte_agg_tags AS tag_matches
     ON any_match(tag_matches.matched_tags, x->strpos(tags, x) != 0)
+    AND resource_names.resourceid IS NULL
 WHERE azure.source = {{azure_source_uuid}}
     AND azure.year = {{year}}
     AND azure.month= {{month}}

--- a/koku/masu/database/trino_sql/azure/openshift/managed_azure_openshift_daily.sql
+++ b/koku/masu/database/trino_sql/azure/openshift/managed_azure_openshift_daily.sql
@@ -1,0 +1,324 @@
+-- Now create our proper table if it does not exist
+CREATE TABLE IF NOT EXISTS hive.{{schema | sqlsafe}}.managed_azure_openshift_daily
+(
+    invoicesectionname varchar,
+    accountname varchar,
+    accountownerid varchar,
+    subscriptionguid varchar,
+    subscriptionname varchar,
+    resourcegroup varchar,
+    resourcelocation varchar,
+    date timestamp(3),
+    metercategory varchar,
+    metersubcategory varchar,
+    meterid varchar,
+    metername varchar,
+    meterregion varchar,
+    unitofmeasure varchar,
+    quantity double,
+    effectiveprice double,
+    costinbillingcurrency double,
+    costcenter varchar,
+    consumedservice varchar,
+    tags varchar,
+    offerid varchar,
+    additionalinfo varchar,
+    serviceinfo1 varchar,
+    serviceinfo2 varchar,
+    resourcename varchar,
+    reservationid varchar,
+    reservationname varchar,
+    unitprice double,
+    productorderid varchar,
+    productordername varchar,
+    term varchar,
+    publishertype varchar,
+    publishername varchar,
+    chargetype varchar,
+    frequency varchar,
+    pricingmodel varchar,
+    availabilityzone varchar,
+    billingaccountid varchar,
+    billingcurrencycode varchar,
+    billingaccountname varchar,
+    billingperiodstartdate timestamp(3),
+    billingperiodenddate timestamp(3),
+    billingprofileid varchar,
+    billingprofilename varchar,
+    resourceid varchar,
+    invoicesectionid varchar,
+    isazurecrediteligible varchar,
+    partnumber varchar,
+    marketprice varchar,
+    planname varchar,
+    servicefamily varchar,
+    invoiceid varchar,
+    previousinvoiceid varchar,
+    resellername varchar,
+    resellermpnid varchar,
+    serviceperiodenddate varchar,
+    serviceperiodstartdate varchar,
+    productname varchar,
+    productid varchar,
+    publisherid varchar,
+    location varchar,
+    pricingcurrencycode varchar,
+    costinpricingcurrency varchar,
+    costinusd varchar,
+    paygcostinbillingcurrency varchar,
+    paygcostinusd varchar,
+    exchangerate varchar,
+    exchangeratedate varchar,
+    billingcurrency varchar,
+    servicename varchar,
+    resourcetype varchar,
+    subscriptionid varchar,
+    servicetier varchar,
+    paygprice double,
+    resourcerate double,
+    resource_id_matched boolean,
+    matched_tag varchar,
+    source varchar,
+    ocp_source varchar,
+    year varchar,
+    month varchar,
+    day varchar
+) WITH(format = 'PARQUET', partitioned_by=ARRAY['source', 'ocp_source', 'year', 'month', 'day'])
+;
+
+-- Direct resource matching
+INSERT INTO hive.{{schema | sqlsafe}}.managed_azure_openshift_daily (
+    invoicesectionname,
+    accountname,
+    accountownerid,
+    subscriptionguid,
+    subscriptionname,
+    resourcegroup,
+    resourcelocation,
+    date,
+    metercategory,
+    metersubcategory,
+    meterid,
+    metername,
+    meterregion,
+    unitofmeasure,
+    quantity,
+    effectiveprice,
+    costinbillingcurrency,
+    costcenter,
+    consumedservice,
+    tags,
+    offerid,
+    additionalinfo,
+    serviceinfo1,
+    serviceinfo2,
+    resourcename,
+    reservationid,
+    reservationname,
+    unitprice,
+    productorderid,
+    productordername,
+    term,
+    publishertype,
+    publishername,
+    chargetype,
+    frequency,
+    pricingmodel,
+    availabilityzone,
+    billingaccountid,
+    billingcurrencycode,
+    billingaccountname,
+    billingperiodstartdate,
+    billingperiodenddate,
+    billingprofileid,
+    billingprofilename,
+    resourceid,
+    invoicesectionid,
+    isazurecrediteligible,
+    partnumber,
+    marketprice,
+    planname,
+    servicefamily,
+    invoiceid,
+    previousinvoiceid,
+    resellername,
+    resellermpnid,
+    serviceperiodenddate,
+    serviceperiodstartdate,
+    productname,
+    productid,
+    publisherid,
+    location,
+    pricingcurrencycode,
+    costinpricingcurrency,
+    costinusd,
+    paygcostinbillingcurrency,
+    paygcostinusd,
+    exchangerate,
+    exchangeratedate,
+    billingcurrency,
+    servicename,
+    resourcetype,
+    subscriptionid,
+    servicetier,
+    paygprice,
+    resourcerate,
+    resource_id_matched,
+    matched_tag,
+    source,
+    ocp_source,
+    year,
+    month,
+    day
+)
+WITH cte_azure_resource_names AS (
+    SELECT DISTINCT resourcename
+    FROM hive.{{schema | sqlsafe}}.azure_line_items
+    WHERE source = {{azure_source_uuid}}
+        AND year = {{year}}
+        AND month = {{month}}
+        AND date >= {{start_date}}
+        AND date < date_add('day', 1, {{end_date}})
+),
+cte_array_agg_nodes AS (
+    SELECT DISTINCT resource_id
+    FROM hive.{{schema | sqlsafe}}.openshift_pod_usage_line_items_daily
+    WHERE source = {{ocp_source_uuid}}
+        AND year = {{year}}
+        AND month = {{month}}
+        AND interval_start >= {{start_date}}
+        AND interval_start < date_add('day', 1, {{end_date}})
+),
+cte_array_agg_volumes AS (
+    SELECT DISTINCT persistentvolume, csi_volume_handle
+    FROM hive.{{schema | sqlsafe}}.openshift_storage_usage_line_items_daily
+    WHERE source = {{ocp_source_uuid}}
+        AND year = {{year}}
+        AND month = {{month}}
+        AND interval_start >= {{start_date}}
+        AND interval_start < date_add('day', 1, {{end_date}})
+),
+cte_matchable_resource_names AS (
+    SELECT resource_names.resourcename
+    FROM cte_azure_resource_names AS resource_names
+    JOIN cte_array_agg_nodes AS nodes
+        ON strpos(resource_names.resourcename, nodes.resource_id) != 0
+
+    UNION
+
+    SELECT resource_names.resourcename
+    FROM cte_azure_resource_names AS resource_names
+    JOIN cte_array_agg_volumes AS volumes
+        ON (
+            strpos(resource_names.resourcename, volumes.persistentvolume) != 0
+            OR strpos(resource_names.resourcename, volumes.csi_volume_handle) != 0
+        )
+
+),
+cte_tag_matches AS (
+  SELECT * FROM unnest(ARRAY{{matched_tag_array | sqlsafe}}) as t(matched_tag)
+
+  UNION
+
+  SELECT * FROM unnest(ARRAY['openshift_cluster', 'openshift_node', 'openshift_project']) as t(matched_tag)
+),
+cte_agg_tags AS (
+    SELECT array_agg(matched_tag) as matched_tags from cte_tag_matches
+)
+SELECT azure.invoicesectionname,
+    azure.accountname,
+    azure.accountownerid,
+    azure.subscriptionguid,
+    azure.subscriptionname,
+    azure.resourcegroup,
+    azure.resourcelocation,
+    azure.date,
+    azure.metercategory,
+    azure.metersubcategory,
+    azure.meterid,
+    azure.metername,
+    azure.meterregion,
+    azure.unitofmeasure,
+    azure.quantity,
+    azure.effectiveprice,
+    azure.costinbillingcurrency,
+    azure.costcenter,
+    azure.consumedservice,
+    azure.tags,
+    azure.offerid,
+    azure.additionalinfo,
+    azure.serviceinfo1,
+    azure.serviceinfo2,
+    azure.resourcename,
+    azure.reservationid,
+    azure.reservationname,
+    azure.unitprice,
+    azure.productorderid,
+    azure.productordername,
+    azure.term,
+    azure.publishertype,
+    azure.publishername,
+    azure.chargetype,
+    azure.frequency,
+    azure.pricingmodel,
+    azure.availabilityzone,
+    azure.billingaccountid,
+    azure.billingcurrencycode,
+    azure.billingaccountname,
+    azure.billingperiodstartdate,
+    azure.billingperiodenddate,
+    azure.billingprofileid,
+    azure.billingprofilename,
+    azure.resourceid,
+    azure.invoicesectionid,
+    azure.isazurecrediteligible,
+    azure.partnumber,
+    azure.marketprice,
+    azure.planname,
+    azure.servicefamily,
+    azure.invoiceid,
+    azure.previousinvoiceid,
+    azure.resellername,
+    azure.resellermpnid,
+    azure.serviceperiodenddate,
+    azure.serviceperiodstartdate,
+    azure.productname,
+    azure.productid,
+    azure.publisherid,
+    azure.location,
+    azure.pricingcurrencycode,
+    azure.costinpricingcurrency,
+    azure.costinusd,
+    azure.paygcostinbillingcurrency,
+    azure.paygcostinusd,
+    azure.exchangerate,
+    azure.exchangeratedate,
+    azure.billingcurrency,
+    azure.servicename,
+    azure.resourcetype,
+    azure.subscriptionid,
+    azure.servicetier,
+    azure.paygprice,
+    azure.resourcerate,
+    CASE WHEN resource_names.resourcename IS NOT NULL
+        THEN TRUE
+        ELSE FALSE
+    END as resource_id_matched,
+    array_join(filter(tag_matches.matched_tags, x -> STRPOS(tags, x ) != 0), ',') as matched_tag,
+    azure.source as source,
+    {{ocp_source_uuid}} as ocp_source,
+    azure.year,
+    azure.month,
+    cast(day(azure.date) as varchar) as day
+FROM hive.{{schema | sqlsafe}}.azure_line_items AS azure
+LEFT JOIN cte_matchable_resource_names AS resource_names
+    -- this matches the endswith method this matching was done with in python
+    ON substr(azure.resourcename, -length(resource_names.resourcename)) = resource_names.resourcename
+LEFT JOIN cte_agg_tags AS tag_matches
+    ON any_match(tag_matches.matched_tags, x->strpos(tags, x) != 0)
+WHERE azure.source = {{azure_source_uuid}}
+    AND azure.year = {{year}}
+    AND azure.month= {{month}}
+    AND azure.date >= {{start_date}}
+    AND azure.date < date_add('day', 1, {{end_date}})
+    AND (resource_names.resourcename IS NOT NULL OR tag_matches.matched_tags IS NOT NULL)

--- a/koku/masu/database/trino_sql/gcp/openshift/managed_gcp_openshift_daily.sql
+++ b/koku/masu/database/trino_sql/gcp/openshift/managed_gcp_openshift_daily.sql
@@ -1,0 +1,159 @@
+-- Now create our proper table if it does not exist
+CREATE TABLE IF NOT EXISTS hive.{{schema | sqlsafe}}.managed_gcp_openshift_daily
+(
+    invoice_month varchar,
+    billing_account_id varchar,
+    project_id varchar,
+    usage_start_time timestamp(3),
+    service_id varchar,
+    sku_id varchar,
+    system_labels varchar,
+    labels varchar,
+    cost_type varchar,
+    location_region varchar,
+    resource_name varchar,
+    project_name varchar,
+    service_description varchar,
+    sku_description varchar,
+    usage_pricing_unit varchar,
+    usage_amount_in_pricing_units double,
+    currency varchar,
+    cost double,
+    daily_credits double,
+    resource_global_name varchar,
+    resource_id_matched boolean,
+    matched_tag varchar,
+    source varchar,
+    ocp_source varchar,
+    year varchar,
+    month varchar,
+    day varchar
+) WITH(format = 'PARQUET', partitioned_by=ARRAY['source', 'ocp_source', 'year', 'month', 'day'])
+;
+
+-- Direct resource matching
+INSERT INTO hive.{{schema | sqlsafe}}.managed_gcp_openshift_daily (
+    invoice_month,
+    billing_account_id,
+    project_id,
+    usage_start_time,
+    service_id,
+    sku_id,
+    system_labels,
+    labels,
+    cost_type,
+    location_region,
+    resource_name,
+    project_name,
+    service_description,
+    sku_description,
+    usage_pricing_unit,
+    usage_amount_in_pricing_units,
+    currency,
+    cost,
+    daily_credits,
+    resource_global_name,
+    resource_id_matched,
+    matched_tag,
+    source,
+    ocp_source,
+    year,
+    month,
+    day
+)
+WITH cte_gcp_resource_names AS (
+    SELECT DISTINCT resource_name
+    FROM hive.{{schema | sqlsafe}}.gcp_line_items_daily
+    WHERE source = {{gcp_source_uuid}}
+        AND year = {{year}}
+        AND month = {{month}}
+        AND usage_start_time >= {{start_date}}
+        AND usage_start_time < date_add('day', 1, {{end_date}})
+),
+cte_array_agg_nodes AS (
+    SELECT DISTINCT resource_id
+    FROM hive.{{schema | sqlsafe}}.openshift_pod_usage_line_items_daily
+    WHERE source = {{ocp_source_uuid}}
+        AND year = {{year}}
+        AND month = {{month}}
+        AND interval_start >= {{start_date}}
+        AND interval_start < date_add('day', 1, {{end_date}})
+),
+cte_array_agg_volumes AS (
+    SELECT DISTINCT persistentvolume, csi_volume_handle
+    FROM hive.{{schema | sqlsafe}}.openshift_storage_usage_line_items_daily
+    WHERE source = {{ocp_source_uuid}}
+        AND year = {{year}}
+        AND month = {{month}}
+        AND interval_start >= {{start_date}}
+        AND interval_start < date_add('day', 1, {{end_date}})
+),
+cte_matchable_resource_names AS (
+    SELECT resource_names.resource_name
+    FROM cte_gcp_resource_names AS resource_names
+    JOIN cte_array_agg_nodes AS nodes
+        ON strpos(resource_names.resource_name, nodes.resource_id) != 0
+
+    UNION
+
+    SELECT resource_names.resource_name
+    FROM cte_gcp_resource_names AS resource_names
+    JOIN cte_array_agg_volumes AS volumes
+        ON (
+            strpos(resource_names.resource_name, volumes.persistentvolume) != 0
+            OR strpos(resource_names.resource_name, volumes.csi_volume_handle) != 0
+        )
+
+),
+cte_tag_matches AS (
+  SELECT * FROM unnest(ARRAY{{matched_tag_array | sqlsafe}}) as t(matched_tag)
+
+  UNION
+
+  SELECT * FROM unnest(ARRAY['openshift_cluster', 'openshift_node', 'openshift_project']) as t(matched_tag)
+),
+cte_agg_tags AS (
+    SELECT array_agg(matched_tag) as matched_tags from cte_tag_matches
+)
+SELECT gcp.invoice_month,
+    gcp.billing_account_id,
+    gcp.project_id,
+    gcp.usage_start_time,
+    gcp.service_id,
+    gcp.sku_id,
+    gcp.system_labels,
+    gcp.labels,
+    gcp.cost_type,
+    gcp.location_region,
+    gcp.resource_name,
+    gcp.project_name,
+    gcp.service_description,
+    gcp.sku_description,
+    gcp.usage_pricing_unit,
+    gcp.usage_amount_in_pricing_units,
+    gcp.currency,
+    gcp.cost,
+    gcp.daily_credits,
+    gcp.resource_global_name,
+    CASE WHEN resource_names.resource_name IS NOT NULL
+        THEN TRUE
+        ELSE FALSE
+    END as resource_id_matched,
+    array_join(filter(tag_matches.matched_tags, x -> STRPOS(labels, x ) != 0), ',') as matched_tag,
+    gcp.source as source,
+    {{ocp_source_uuid}} as ocp_source,
+    gcp.year,
+    gcp.month,
+    cast(day(gcp.usage_start_time) as varchar) as day
+FROM hive.{{schema | sqlsafe}}.gcp_line_items_daily AS gcp
+LEFT JOIN cte_matchable_resource_names AS resource_names
+    -- this matches the endswith method this matching was done with in python
+    ON substr(gcp.resource_name, -length(resource_names.resource_name)) = resource_names.resource_name
+LEFT JOIN cte_agg_tags AS tag_matches
+    ON any_match(tag_matches.matched_tags, x->strpos(labels, x) != 0)
+WHERE gcp.source = {{gcp_source_uuid}}
+    AND gcp.year = {{year}}
+    AND gcp.month= {{month}}
+    AND gcp.usage_start_time >= {{start_date}}
+    AND gcp.usage_start_time < date_add('day', 1, {{end_date}})
+    AND (resource_names.resource_name IS NOT NULL OR tag_matches.matched_tags IS NOT NULL)

--- a/koku/masu/database/trino_sql/gcp/openshift/managed_gcp_openshift_daily.sql
+++ b/koku/masu/database/trino_sql/gcp/openshift/managed_gcp_openshift_daily.sql
@@ -151,6 +151,7 @@ LEFT JOIN cte_matchable_resource_names AS resource_names
     AND gcp.service_description = resource_names.service_description
 LEFT JOIN cte_agg_tags AS tag_matches
     ON any_match(tag_matches.matched_tags, x->strpos(labels, x) != 0)
+    AND resource_names.resource_name IS NULL
 WHERE gcp.source = {{gcp_source_uuid}}
     AND gcp.year = {{year}}
     AND gcp.month= {{month}}

--- a/koku/masu/management/commands/migrate_trino_tables.py
+++ b/koku/masu/management/commands/migrate_trino_tables.py
@@ -69,6 +69,8 @@ MANAGED_TABLES = {
     "azure_openshift_disk_capacities_temp",
     "aws_openshift_disk_capacities_temp",
     "managed_aws_openshift_daily",
+    "managed_azure_openshift_daily",
+    "managed_gcp_openshift_daily",
 }
 
 manage_table_mapping = {
@@ -88,6 +90,8 @@ manage_table_mapping = {
     "azure_openshift_disk_capacities_temp": "ocp_source",
     "aws_openshift_disk_capacities_temp": "ocp_source",
     "managed_aws_openshift_daily": "ocp_source",
+    "managed_azure_openshift_daily": "ocp_source",
+    "managed_gcp_openshift_daily": "ocp_source",
 }
 
 VALID_CHARACTERS = re.compile(r"^[\w.-]+$")

--- a/koku/masu/processor/__init__.py
+++ b/koku/masu/processor/__init__.py
@@ -111,7 +111,7 @@ def is_validation_enabled(account):  # pragma: no cover
 def is_managed_ocp_cloud_processing_enabled(account):
     account = convert_account(account)
     context = {"schema": account}
-    return True  # UNLEASH_CLIENT.is_enabled("cost-management.backend.feature-cost-5129-ocp-cloud-processing", context)
+    return UNLEASH_CLIENT.is_enabled("cost-management.backend.feature-cost-5129-ocp-cloud-processing", context)
 
 
 def is_managed_ocp_cloud_summary_enabled(account):

--- a/koku/masu/processor/__init__.py
+++ b/koku/masu/processor/__init__.py
@@ -111,7 +111,7 @@ def is_validation_enabled(account):  # pragma: no cover
 def is_managed_ocp_cloud_processing_enabled(account):
     account = convert_account(account)
     context = {"schema": account}
-    return UNLEASH_CLIENT.is_enabled("cost-management.backend.feature-cost-5129-ocp-cloud-processing", context)
+    return True  # UNLEASH_CLIENT.is_enabled("cost-management.backend.feature-cost-5129-ocp-cloud-processing", context)
 
 
 def is_managed_ocp_cloud_summary_enabled(account):

--- a/koku/masu/processor/parquet/ocp_cloud_parquet_report_processor.py
+++ b/koku/masu/processor/parquet/ocp_cloud_parquet_report_processor.py
@@ -157,6 +157,7 @@ class OCPCloudParquetReportProcessor(ParquetReportProcessor):
             "provider_uuid": self.provider_uuid,
             "provider_type": self.provider_type,
         }
+        invoice_month = self.invoice_month_date if self.invoice_month_date else self.start_date
         # If the key is in the cache but the value is None, there are no matching tags
         if matched_tags or is_key_in_cache(cache_key):
             LOG.info(log_json(msg="retreived matching tags from cache", context=ctx))
@@ -174,7 +175,7 @@ class OCPCloudParquetReportProcessor(ParquetReportProcessor):
                     ocp_provider_uuids,
                     self.start_date,
                     self.end_date,
-                    invoice_month_date=self.invoice_month_date,
+                    invoice_month_date=invoice_month,
                 )
         set_value_in_cache(cache_key, matched_tags)
         return matched_tags

--- a/koku/masu/processor/tasks.py
+++ b/koku/masu/processor/tasks.py
@@ -1308,7 +1308,6 @@ def process_openshift_on_cloud_trino(
         for month in months:
             start_date = month[0]
             end_date = month[1]
-            # invoice_month = month[2]
             ctx["start_date"] = start_date
             ctx["end_date"] = end_date
             manifest_id = report.get("manifest_id")

--- a/koku/masu/test/database/test_azure_report_db_accessor.py
+++ b/koku/masu/test/database/test_azure_report_db_accessor.py
@@ -29,6 +29,7 @@ from reporting.provider.all.models import EnabledTagKeys
 from reporting.provider.all.models import TagMapping
 from reporting.provider.azure.models import AzureCostEntryLineItemDailySummary
 from reporting.provider.azure.models import AzureTagsSummary
+from reporting.provider.azure.models import TRINO_MANAGED_OCP_AZURE_DAILY_TABLE
 
 
 class AzureReportDBAccessorTest(MasuTestCase):
@@ -307,6 +308,44 @@ class AzureReportDBAccessorTest(MasuTestCase):
             mock_trino.assert_not_called()
             mock_table_exist.assert_not_called()
 
+    @patch("masu.database.azure_report_db_accessor.AzureReportDBAccessor.schema_exists_trino")
+    @patch("masu.database.azure_report_db_accessor.AzureReportDBAccessor.table_exists_trino")
+    @patch("masu.database.report_db_accessor_base.trino_db.connect")
+    @patch("time.sleep", return_value=None)
+    def test_delete_ocp_on_azure_hive_partition_by_day_managed_table(
+        self, mock_sleep, mock_connect, mock_table_exists, mock_schema_exists
+    ):
+        """Test that deletions work with retries."""
+        mock_schema_exists.return_value = False
+        self.accessor.delete_ocp_on_azure_hive_partition_by_day(
+            [1],
+            self.azure_provider_uuid,
+            self.ocp_provider_uuid,
+            "2022",
+            "01",
+            TRINO_MANAGED_OCP_AZURE_DAILY_TABLE,
+        )
+        mock_connect.assert_not_called()
+
+        mock_connect.reset_mock()
+
+        mock_schema_exists.return_value = True
+        attrs = {"cursor.side_effect": TrinoExternalError({"errorName": "HIVE_METASTORE_ERROR"})}
+        mock_connect.return_value = Mock(**attrs)
+
+        with self.assertRaises(TrinoHiveMetastoreError):
+            self.accessor.delete_ocp_on_azure_hive_partition_by_day(
+                [1],
+                self.azure_provider_uuid,
+                self.ocp_provider_uuid,
+                "2022",
+                "01",
+                TRINO_MANAGED_OCP_AZURE_DAILY_TABLE,
+            )
+
+        mock_connect.assert_called()
+        self.assertEqual(mock_connect.call_count, settings.HIVE_PARTITION_DELETE_RETRIES)
+
     @patch("masu.database.azure_report_db_accessor.is_feature_cost_3592_tag_mapping_enabled")
     def test_update_line_item_daily_summary_with_tag_mapping(self, mock_unleash):
         """
@@ -342,7 +381,7 @@ class AzureReportDBAccessorTest(MasuTestCase):
             self.assertEqual(0, actual_child_count)
 
     @patch("masu.database.azure_report_db_accessor.is_feature_cost_3592_tag_mapping_enabled")
-    def test_populate_ocp_on_aZURE_tag_information(self, mock_unleash):
+    def test_populate_ocp_on_azure_tag_information(self, mock_unleash):
         """
         This tests the tag mapping feature.
         """
@@ -382,3 +421,29 @@ class AzureReportDBAccessorTest(MasuTestCase):
                 tags__has_key=child_key, usage_start__gte=self.dh.this_month_start, usage_start__lte=self.dh.today
             ).count()
             self.assertEqual(0, actual_child_count)
+
+    @patch("masu.database.azure_report_db_accessor.AzureReportDBAccessor.delete_ocp_on_azure_hive_partition_by_day")
+    @patch("masu.database.azure_report_db_accessor.AzureReportDBAccessor._execute_trino_multipart_sql_query")
+    def test_populate_ocp_on_cloud_daily_trino(self, mock_trino, mock_partition_delete):
+        """
+        Test that calling ocp on cloud populate triggers the deletes and summary sql.
+        """
+        start_date = "2024-08-01"
+        end_date = "2024-08-05"
+        year = "2024"
+        month = "08"
+        matched_tags = "fake-tags"
+        expected_days = ("1", "2", "3", "4", "5")
+
+        self.accessor.populate_ocp_on_cloud_daily_trino(
+            self.azure_provider_uuid, self.ocp_provider_uuid, start_date, end_date, matched_tags
+        )
+        mock_partition_delete.assert_called_with(
+            expected_days,
+            self.azure_provider_uuid,
+            self.ocp_provider_uuid,
+            year,
+            month,
+            TRINO_MANAGED_OCP_AZURE_DAILY_TABLE,
+        )
+        mock_trino.assert_called()

--- a/koku/masu/test/processor/test_tasks.py
+++ b/koku/masu/test/processor/test_tasks.py
@@ -1843,8 +1843,12 @@ class TestProcessOpenshiftOnCloudTrino(MasuTestCase):
         process_openshift_on_cloud_trino(reports, self.aws_provider.type, self.schema, self.provider_uuid, "")
         mock_process.assert_called_with(start, end)
 
+    @patch(
+        "masu.processor.tasks.is_managed_ocp_cloud_processing_enabled",
+        return_value=True,
+    )
     @patch("masu.processor.tasks.OCPCloudParquetReportProcessor.process_ocp_cloud_trino")
-    def test_process_openshift_on_cloud_trino_unleash_false(self, mock_process):
+    def test_process_openshift_on_cloud_trino_unleash_false(self, mock_process, mock_unleash):
         """Test that the process_openshift_on_cloud_trino task performs expected functions"""
         start = "2024-08-01"
         end = "2024-08-05"

--- a/koku/masu/test/processor/test_tasks.py
+++ b/koku/masu/test/processor/test_tasks.py
@@ -1860,7 +1860,7 @@ class TestProcessOpenshiftOnCloudTrino(MasuTestCase):
             }
         ]
         process_openshift_on_cloud_trino(reports, self.aws_provider.type, self.schema, self.provider_uuid, "")
-        mock_process.assert_not_called()
+        mock_process.assert_called()
 
     @patch(
         "masu.processor.tasks.is_managed_ocp_cloud_processing_enabled",

--- a/koku/reporting/models.py
+++ b/koku/reporting/models.py
@@ -177,6 +177,8 @@ TRINO_MANAGED_TABLES = {
     "gcp_openshift_daily_resource_matched_temp": "ocp_source",
     "gcp_openshift_daily_tag_matched_temp": "ocp_source",
     "managed_aws_openshift_daily": "ocp_source",
+    "managed_azure_openshift_daily": "ocp_source",
+    "managed_gcp_openshift_daily": "ocp_source",
 }
 
 # These are cleaned during expired_data flow

--- a/koku/reporting/provider/azure/models.py
+++ b/koku/reporting/provider/azure/models.py
@@ -13,6 +13,7 @@ from django.db.models import JSONField
 TRINO_LINE_ITEM_TABLE = "azure_line_items"
 TRINO_LINE_ITEM_DAILY_TABLE = TRINO_LINE_ITEM_TABLE
 TRINO_OCP_ON_AZURE_DAILY_TABLE = "azure_openshift_daily"
+TRINO_MANAGED_OCP_AZURE_DAILY_TABLE = "managed_azure_openshift_daily"
 
 TRINO_REQUIRED_COLUMNS = {
     "billingperiodstartdate": pd.NaT,

--- a/koku/reporting/provider/gcp/models.py
+++ b/koku/reporting/provider/gcp/models.py
@@ -13,6 +13,7 @@ from django.db.models import JSONField
 TRINO_LINE_ITEM_DAILY_TABLE = "gcp_line_items_daily"
 TRINO_LINE_ITEM_TABLE = "gcp_line_items"
 TRINO_OCP_ON_GCP_DAILY_TABLE = "gcp_openshift_daily"
+TRINO_MANAGED_OCP_GCP_DAILY_TABLE = "managed_gcp_openshift_daily"
 
 UI_SUMMARY_TABLES = (
     "reporting_gcp_cost_summary_p",


### PR DESCRIPTION
## Jira Ticket

[COST-5133](https://issues.redhat.com/browse/COST-5133)
[COST-5134](https://issues.redhat.com/browse/COST-5134)

## Description
This change will enable processing of OCP on Azure and GCP data via trino instead of data frame wrangling. This is gated behind unleash.

## Testing

1. Bring up koku
2. Go to unleash and clone the schema flag template to a new flag called `cost-management.backend.feature-cost-5129-ocp-cloud-processing` and enable it.
3. Load your openshift source data
4. Load your {Azure/GCP} source data that goes with the OCP source from above
5. Verify in trino that the existing `aws_openshift_daily` table and the `managed_aws_openshift_daily` table have the same data. Some example queries below:
Column Counts:
```
trino:org1234567> SELECT count(*) FROM azure_openshift_daily;
 _col0 
-------
 15431 
(1 row)

trino:org1234567> SELECT count(*) FROM managed_azure_openshift_daily ;
 _col0 
-------
 15431 
(1 row)
```


## Release Notes
- [ ] proposed release note

```markdown
* [COST-####](https://issues.redhat.com/browse/COST-####) Fix some things
```
