### PR TITLE
[COST-5480] Add verification SQL to check parquet to managed conversion

### DIFF
--- a/koku/masu/database/aws_report_db_accessor.py
+++ b/koku/masu/database/aws_report_db_accessor.py
@@ -534,7 +534,7 @@ class AWSReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
 
         verification_params = {
             "schema": self.schema,
-            "aws_source_uuid": aws_provider_uuid,
+            "cloud_source_uuid": aws_provider_uuid,
             "year": year,
             "month": month,
             "managed_table": TRINO_MANAGED_OCP_AWS_DAILY_TABLE,

--- a/koku/masu/database/aws_report_db_accessor.py
+++ b/koku/masu/database/aws_report_db_accessor.py
@@ -535,7 +535,6 @@ class AWSReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
         verification_params = {
             "schema": self.schema,
             "aws_source_uuid": aws_provider_uuid,
-            "ocp_source_uuid": openshift_provider_uuid,
             "year": year,
             "month": month,
             "managed_table": TRINO_MANAGED_OCP_AWS_DAILY_TABLE,

--- a/koku/masu/database/azure_report_db_accessor.py
+++ b/koku/masu/database/azure_report_db_accessor.py
@@ -35,6 +35,7 @@ from reporting.provider.azure.models import AzureCostEntryBill
 from reporting.provider.azure.models import AzureCostEntryLineItemDailySummary
 from reporting.provider.azure.models import TRINO_LINE_ITEM_TABLE
 from reporting.provider.azure.models import TRINO_MANAGED_OCP_AZURE_DAILY_TABLE
+from reporting.provider.azure.models import TRINO_OCP_ON_AZURE_DAILY_TABLE
 from reporting.provider.azure.models import UI_SUMMARY_TABLES
 from reporting.provider.azure.openshift.models import UI_SUMMARY_TABLES as OCPAZURE_UI_SUMMARY_TABLES
 
@@ -432,6 +433,19 @@ class AzureReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
                 return False
         return True
 
+    def verify_populate_ocp_on_cloud_daily_trino(self, verification_params):
+        """
+        Verify the managed trino table population went successfully.
+        """
+        verification_sql = pkgutil.get_data("masu.database", "trino_sql/verify/managed_ocp_on_cloud_tables.sql")
+        verification_sql = verification_sql.decode("utf-8")
+        LOG.info(log_json(msg="running verification for managed OCP on Azure daily SQL", **verification_params))
+        result = self._execute_trino_multipart_sql_query(verification_sql, bind_params=verification_params)
+        if False in result[0]:
+            LOG.error(log_json(msg="Verification failed", **verification_params))
+        else:
+            LOG.info(log_json(msg="Verification successful", **verification_params))
+
     def populate_ocp_on_cloud_daily_trino(
         self, azure_provider_uuid, openshift_provider_uuid, start_date, end_date, matched_tags
     ):
@@ -473,3 +487,13 @@ class AzureReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
         }
         LOG.info(log_json(msg="running managed OCP on AZURE daily SQL", **summary_sql_params))
         self._execute_trino_multipart_sql_query(summary_sql, bind_params=summary_sql_params)
+
+        verification_params = {
+            "schema": self.schema,
+            "cloud_source_uuid": azure_provider_uuid,
+            "year": year,
+            "month": month,
+            "managed_table": TRINO_MANAGED_OCP_AZURE_DAILY_TABLE,
+            "parquet_table": TRINO_OCP_ON_AZURE_DAILY_TABLE,
+        }
+        self.verify_populate_ocp_on_cloud_daily_trino(verification_params)

--- a/koku/masu/database/trino_sql/verify/managed_ocp_on_cloud_tables.sql
+++ b/koku/masu/database/trino_sql/verify/managed_ocp_on_cloud_tables.sql
@@ -5,7 +5,6 @@ FROM
         SELECT COUNT(*) AS count_1
         FROM hive.{{schema | sqlsafe}}.{{managed_table | sqlsafe}} as managed_ocpaws
         WHERE managed_ocpaws.source = {{aws_source_uuid}}
-        AND managed_ocpaws.ocp_source = {{ocp_source_uuid}}
         AND managed_ocpaws.year = {{year}}
         AND managed_ocpaws.month = {{month}}
     ) t1,

--- a/koku/masu/database/trino_sql/verify/managed_ocp_on_cloud_tables.sql
+++ b/koku/masu/database/trino_sql/verify/managed_ocp_on_cloud_tables.sql
@@ -1,0 +1,18 @@
+SELECT
+    count_1 = count_2 AS counts_match
+FROM
+    (
+        SELECT COUNT(*) AS count_1
+        FROM hive.{{schema | sqlsafe}}.{{managed_table | sqlsafe}} as managed_ocpaws
+        WHERE managed_ocpaws.source = {{aws_source_uuid}}
+        AND managed_ocpaws.ocp_source = {{ocp_source_uuid}}
+        AND managed_ocpaws.year = {{year}}
+        AND managed_ocpaws.month = {{month}}
+    ) t1,
+    (
+        SELECT COUNT(*) AS count_2
+        FROM hive.{{schema | sqlsafe}}.{{parquet_table | sqlsafe}} as parquet_table
+        WHERE parquet_table.source = {{aws_source_uuid}}
+        AND parquet_table.year = {{year}}
+        AND parquet_table.month = {{month}}
+    ) t2;

--- a/koku/masu/database/trino_sql/verify/managed_ocp_on_cloud_tables.sql
+++ b/koku/masu/database/trino_sql/verify/managed_ocp_on_cloud_tables.sql
@@ -3,15 +3,15 @@ SELECT
 FROM
     (
         SELECT COUNT(*) AS count_1
-        FROM hive.{{schema | sqlsafe}}.{{managed_table | sqlsafe}} as managed_ocpaws
-        WHERE managed_ocpaws.source = {{aws_source_uuid}}
-        AND managed_ocpaws.year = {{year}}
-        AND managed_ocpaws.month = {{month}}
+        FROM hive.{{schema | sqlsafe}}.{{managed_table | sqlsafe}} as managed_ocpcloud
+        WHERE managed_ocpcloud.source = {{cloud_source_uuid}}
+        AND managed_ocpcloud.year = {{year}}
+        AND managed_ocpcloud.month = {{month}}
     ) t1,
     (
         SELECT COUNT(*) AS count_2
         FROM hive.{{schema | sqlsafe}}.{{parquet_table | sqlsafe}} as parquet_table
-        WHERE parquet_table.source = {{aws_source_uuid}}
+        WHERE parquet_table.source = {{cloud_source_uuid}}
         AND parquet_table.year = {{year}}
         AND parquet_table.month = {{month}}
     ) t2;

--- a/koku/masu/test/database/test_aws_report_db_accessor.py
+++ b/koku/masu/test/database/test_aws_report_db_accessor.py
@@ -37,6 +37,7 @@ from reporting.provider.aws.models import AWSCostEntryBill
 from reporting.provider.aws.models import AWSCostEntryLineItemDailySummary
 from reporting.provider.aws.models import AWSCostEntryLineItemSummaryByEC2Compute
 from reporting.provider.aws.models import TRINO_MANAGED_OCP_AWS_DAILY_TABLE
+from reporting.provider.aws.models import TRINO_OCP_ON_AWS_DAILY_TABLE
 
 
 class AWSReportDBAccessorTest(MasuTestCase):
@@ -544,3 +545,27 @@ class AWSReportDBAccessorTest(MasuTestCase):
             TRINO_MANAGED_OCP_AWS_DAILY_TABLE,
         )
         mock_trino.assert_called()
+
+    @patch("masu.database.aws_report_db_accessor.AWSReportDBAccessor._execute_trino_multipart_sql_query")
+    def test_verify_populate_ocp_on_cloud_daily_trino(self, mock_trino):
+        """
+        Test validating trino tables.
+        """
+        verification_params = {
+            "schema": self.schema,
+            "cloud_source_uuid": self.aws_provider_uuid,
+            "year": "2024",
+            "month": "08",
+            "managed_table": TRINO_MANAGED_OCP_AWS_DAILY_TABLE,
+            "parquet_table": TRINO_OCP_ON_AWS_DAILY_TABLE,
+        }
+        with self.assertLogs("masu.database.aws_report_db_accessor", level="INFO") as logger:
+            self.accessor.verify_populate_ocp_on_cloud_daily_trino(verification_params)
+            assert any(
+                "Verification successful" in log for log in logger.output
+            ), "Verification successful not found in logs"
+
+        mock_trino.side_effect = [[[False]]]
+        with self.assertLogs("masu.database.aws_report_db_accessor", level="ERROR") as logger:
+            self.accessor.verify_populate_ocp_on_cloud_daily_trino(verification_params)
+            assert any("Verification failed" in log for log in logger.output), "Verification failed not found in logs"


### PR DESCRIPTION
## Jira Ticket

[COST-5480](https://issues.redhat.com/browse/COST-5480)

## Description

This change will add in some verification sql to compare counts between parquet table and the managed table.

## Testing
- run a raw calc test for ocp on aws with the conversion unleash flag enabled

```
koku-worker-1  | [2024-09-10 19:12:28,473] ERROR 4ef8c8a2-242b-4811-8c56-c17eab252ab1 4230 {'message': 'Verification failed', 'tracing_id': '', 'schema': 'org1234567', 'aws_source_uuid': '3f7f6bbc-31de-4854-b9c8-321e0aac690d', 'ocp_source_uuid': '83e965c5-c7b0-4669-a064-649c39bf49de', 'year': '2024', 'month': '08', 'managed_table': 'managed_aws_openshift_daily', 'parquet_table': 'aws_openshift_daily'}
```



## Release Notes
- [ ] proposed release note

```markdown
* [COST-####](https://issues.redhat.com/browse/COST-####) Fix some things
```
