### PR TITLE
[COST-5132] Fix duplication in managed ocp on aws flow

### DIFF
--- a/koku/masu/database/trino_sql/aws/openshift/managed_aws_openshift_daily.sql
+++ b/koku/masu/database/trino_sql/aws/openshift/managed_aws_openshift_daily.sql
@@ -111,10 +111,11 @@ cte_array_agg_volumes AS (
         AND interval_start < date_add('day', 1, {{end_date}})
 ),
 cte_matchable_resource_names AS (
+    -- this matches the endswith method done with resource id matching python
     SELECT resource_names.lineitem_resourceid
     FROM cte_aws_resource_names AS resource_names
     JOIN cte_array_agg_nodes AS nodes
-        ON strpos(resource_names.lineitem_resourceid, nodes.resource_id) != 0
+        ON substr(resource_names.lineitem_resourceid, -length(nodes.resource_id)) = nodes.resource_id
 
     UNION
 
@@ -122,8 +123,8 @@ cte_matchable_resource_names AS (
     FROM cte_aws_resource_names AS resource_names
     JOIN cte_array_agg_volumes AS volumes
         ON (
-            strpos(resource_names.lineitem_resourceid, volumes.persistentvolume) != 0
-            OR strpos(resource_names.lineitem_resourceid, volumes.csi_volume_handle) != 0
+            substr(resource_names.lineitem_resourceid, -length(volumes.persistentvolume)) = volumes.persistentvolume
+            OR substr(resource_names.lineitem_resourceid, -length(volumes.csi_volume_handle)) = volumes.csi_volume_handle
         )
 
 ),
@@ -178,8 +179,7 @@ SELECT aws.lineitem_resourceid,
     cast(day(aws.lineitem_usagestartdate) as varchar) as day
 FROM hive.{{schema | sqlsafe}}.aws_line_items_daily AS aws
 LEFT JOIN cte_matchable_resource_names AS resource_names
-    -- this matches the endswith method this matching was done with in python
-    ON substr(aws.lineitem_resourceid, -length(resource_names.lineitem_resourceid)) = resource_names.lineitem_resourceid
+    ON resource_names.lineitem_resourceid = aws.lineitem_resourceid
 LEFT JOIN cte_agg_tags AS tag_matches
     ON any_match(tag_matches.matched_tags, x->strpos(resourcetags, x) != 0)
 WHERE aws.source = {{aws_source_uuid}}


### PR DESCRIPTION
## Jira Ticket

[COST-5132](https://issues.redhat.com/browse/COST-5132)

## Description

This change will fix a duplication bug introduced in [COST-5132](https://issues.redhat.com/browse/COST-5132)

## Bug Description
While working on  [COST-5480](https://issues.redhat.com/browse/COST-5480) I discovered a bug with how we were doing resource matching for the new managed tables. There is an issue with the sql we are used to replicate the ends with logic in our parquet file creation workflow. The ends with logic is currently matching with more than one resource due to abnormalities in resource id creation across different product families. This behavior is resulting in cost duplication in the final result for the managed tables. 

```
SELECT DISTINCT lineitem_resourceid, product_productfamily FROM hive.org1234567.aws_line_items_daily WHERE source = '87db5f9d-3a57-4fae-82fe-958f03a91286' AND year = '2024' AND month = '08' AND lineitem_usagestartdate >= DATE('2024-08-01') AND lineitem_usagestartdate < date_add('day', 1, DATE('2024-09-01')) AND lineitem_resourceid like '%i-7655681621'
```
Results:
```
                 lineitem_resourceid                  | product_productfamily
-----------------------------------------------------+----------------------
 i-i-7655681621                                       | Data Transfer
 i-7655681621                                         | Compute Instance
 arn:aws:rds:us-west-1a:9999999999999:db:i-7655681621 | Database Instance
 ```


The  *i-7655681621* was matching with  arn:aws:rds:us-west-1a:9999999999999:db:*i-7655681621*and i-*i-7655681621* causing the cost duplication. At first we believed the issue to be Nise specific; however, after investigating some real cost reports we were able to replicate the problem. Therefore, we will need to ensure that cost duplication can not happen due to a resource ending with like values.

## Testing

1. Check out main
2. Enable the managed table data processing:
```
 def is_managed_ocp_cloud_processing_enabled(account):
     account = convert_account(account)
     context = {"schema": account}
-    return UNLEASH_CLIENT.is_enabled("cost-management.backend.feature-cost-5129-ocp-cloud-processing", context)
+    return True
+    # return UNLEASH_CLIENT.is_enabled("cost-management.backend.feature-cost-5129-ocp-cloud-processing", context)
```
3. Run the following smoke test locally:
```
ENV_FOR_DYNACONF=local DYNACONF_IQE_VAULT_LOADER_ENABLED=false DYNACONF_IQE_VAULT_IGNORE_PATH_ERRORS=True iqe tests plugin cost_management -k "ocp_on_aws_source_raw_calc" -raA --pdb
```

Make sure to add a breakpoint in the test.

4. Run the following Query:
#### Managed Table:
```
select product_productfamily, sum(lineitem_unblendedcost) from managed_aws_openshift_daily group by product_productfamily order by product_productfamily;
```
```
 product_productfamily |       _col1
-----------------------+--------------------
 Storage               |  89595.66666666779
 Compute Instance      |            90180.0
 Data Transfer         |          1030056.0
 DNS Zone              |            26052.0
 Database Instance     |            20040.0
 Cloud Connectivity    |            28056.0
 Storage Snapshot      | 2204.3999999999996
```

#### Parquet Table:
```
select product_productfamily, sum(lineitem_unblendedcost) from aws_openshift_daily group by product_productfamily order by product_productfamily;
```

```
 product_productfamily |       _col1
-----------------------+--------------------
 Storage               |   89595.6666666677
 Compute Instance      |            90180.0
 Data Transfer         |           629256.0
 DNS Zone              |            26052.0
 Database Instance     |            10020.0
 Cloud Connectivity    |            28056.0
 Storage Snapshot      | 2204.3999999999996
```

Note: Notice how the Data Transfer and Database Instance cost is higher.

 
 5. Switch to this branch and complete steps 3 & 4 again:
 
 ```
 product_productfamily |       _col1
-----------------------+-------------------
 Cloud Connectivity    |           28084.0
 Compute Instance      |           90270.0
 DNS Zone              |           26078.0
 Data Transfer         |          629884.0
 Database Instance     |           10030.0
 Storage               | 67496.61111107956
 Storage Snapshot      |            2206.6
```

```
 product_productfamily |       _col1
-----------------------+-------------------
 Cloud Connectivity    |           28084.0
 Compute Instance      |           90270.0
 DNS Zone              |           26078.0
 Data Transfer         |          629884.0
 Database Instance     |           10030.0
 Storage               | 67496.61111107956
 Storage Snapshot      |            2206.6
 ```
 
 ## Solution Description
 I moved the endswith logic to the cte_matchable_resource_names. The union there automatically provides a deduplication of resource ids, and it allows us to do exact matching on the left join for resource matching preventing the duplicate rows from being created.

## Release Notes
- [ ] proposed release note

```markdown
* [COST-5132](https://issues.redhat.com/browse/COST-5132) Fix a bug with the hidden managed ocp on aws flow 
```
