### PR TITLE
[COST-5132] update Managed OCP on AWS tag matching

### DIFF
--- a/koku/masu/database/trino_sql/aws/openshift/managed_aws_openshift_daily.sql
+++ b/koku/masu/database/trino_sql/aws/openshift/managed_aws_openshift_daily.sql
@@ -182,6 +182,7 @@ LEFT JOIN cte_matchable_resource_names AS resource_names
     ON resource_names.lineitem_resourceid = aws.lineitem_resourceid
 LEFT JOIN cte_agg_tags AS tag_matches
     ON any_match(tag_matches.matched_tags, x->strpos(resourcetags, x) != 0)
+    AND resource_names.lineitem_resourceid IS NULL
 WHERE aws.source = {{aws_source_uuid}}
     AND aws.year = {{year}}
     AND aws.month= {{month}}


### PR DESCRIPTION
## Jira Ticket

[COST-5132](https://issues.redhat.com/browse/COST-5132)

## Description

This change will update managed OCP on AWS tag matching to only run on rows that have not be resource id matched.

## Release Notes
- [ ] proposed release note

```markdown
* [COST-5132](https://issues.redhat.com/browse/COST-5132) Update managed ocp on aws tag matching
```
