### PR TITLE
drop bad invoice months from ingress flow

### DIFF
--- a/koku/masu/external/downloader/gcp/gcp_report_downloader.py
+++ b/koku/masu/external/downloader/gcp/gcp_report_downloader.py
@@ -95,6 +95,9 @@ def create_daily_archives(
             days = list({day.strftime("%Y-%m-%d") for day in unique_usage_days})
             date_range = {"start": min(days), "end": max(days)}
             for invoice_month in data_frame["invoice.month"].unique():
+                # This handles bad ingress reports that have null invoice months
+                if pd.isna(invoice_month):
+                    continue
                 invoice_filter = data_frame["invoice.month"] == invoice_month
                 invoice_month_data = data_frame[invoice_filter]
                 # We may be able to completely remove invoice month in the future


### PR DESCRIPTION
## Jira Ticket

## Description

This change will skip processing null invoice months. During the ingress flow a customer sent data with some blank rows including null for the invoice month. This caused us not to process any data because of the null's. The gola here would be to skip the blank rows.

## Testing

1. Checkout Branch
2. Restart Koku
3. Create GCP storage only provider
4. Post an ingress report for the above provider that contains valid data + invalid data with null  for invoice month
5. We should successfully process the valid rows.
6. Repeat the above on main and see the following error: `Unknown downloader exception: time data '<NA>' does not match format '%Y%m'"`

Note:
Ask @lcouzens for help if your not sure how to test this.
There is a file uploaded to the dev account called bad-invoice-month.csv that can be used for testing.

## Release Notes
- [ ] proposed release note

```markdown
* [COST-####](https://issues.redhat.com/browse/COST-####) Fix some things
```
