### PR TITLE
[COST-5443] Creating a common filter for filtering by resource_id and instance_name.

### DIFF
--- a/koku/api/report/aws/provider_map.py
+++ b/koku/api/report/aws/provider_map.py
@@ -74,8 +74,6 @@ class AWSProviderMap(ProviderMap):
                         {"field": "instance_name", "operation": "icontains", "composition_key": "instance_filter"},
                         {"field": "resource_id", "operation": "icontains", "composition_key": "instance_filter"},
                     ],
-                    "instance_name": {"field": "instance_name", "operation": "icontains"},
-                    "resource_id": {"field": "resource_id", "operation": "icontains"},
                 },
                 "group_by_options": ["service", "account", "region", "az", "product_family", "org_unit_id"],
                 "tag_column": "tags",

--- a/koku/api/report/aws/provider_map.py
+++ b/koku/api/report/aws/provider_map.py
@@ -70,6 +70,10 @@ class AWSProviderMap(ProviderMap):
                     "org_unit_single_level": {"field": "organizational_unit__org_unit_id", "operation": "icontains"},
                     "instance_type": {"field": "instance_type", "operation": "icontains"},
                     "operating_system": {"field": "operating_system", "operation": "icontains"},
+                    "instance": [
+                        {"field": "instance_name", "operation": "icontains", "composition_key": "instance_filter"},
+                        {"field": "resource_id", "operation": "icontains", "composition_key": "instance_filter"},
+                    ],
                     "instance_name": {"field": "instance_name", "operation": "icontains"},
                     "resource_id": {"field": "resource_id", "operation": "icontains"},
                 },

--- a/koku/api/report/aws/serializers.py
+++ b/koku/api/report/aws/serializers.py
@@ -206,7 +206,7 @@ class AWSEC2ComputeFilterSerializer(BaseFilterSerializer):
     TIME_CHOICES = (("-1", "-1"), ("-2", "-2"), ("-3", "-3"))
     TIME_UNIT_CHOICES = (("month", "month"),)
 
-    _opfields = ("resource_id", "instance_name", "account", "operating_system", "region")
+    _opfields = ("instance", "account", "operating_system", "region")
 
     _aws_category = True
 
@@ -215,8 +215,12 @@ class AWSEC2ComputeFilterSerializer(BaseFilterSerializer):
     limit = None
     offset = None
 
-    resource_id = StringOrListField(child=serializers.CharField(), required=False)
-    instance_name = StringOrListField(child=serializers.CharField(), required=False)
+    # Not valid for this endpoint.
+    # instance_name and resource_id is filtered by instance field.
+    instance_name = None
+    resource_id = None
+
+    instance = StringOrListField(child=serializers.CharField(), required=False)
     operating_system = StringOrListField(child=serializers.CharField(), required=False)
     account = StringOrListField(child=serializers.CharField(), required=False)
     region = StringOrListField(child=serializers.CharField(), required=False)
@@ -243,12 +247,16 @@ class AWSEC2ComputeFilterSerializer(BaseFilterSerializer):
 class AWSEC2ExcludeSerializer(BaseExcludeSerializer):
     """Serializer for handling query parameter exclude."""
 
-    _opfields = ("account", "region", "resource_id", "instance_name", "operating_system")
+    _opfields = ("account", "region", "instance", "operating_system")
+
+    # Not valid for this endpoint.
+    # instance_name and resource_id is filtered by instance field.
+    instance_name = None
+    resource_id = None
 
     account = StringOrListField(child=serializers.CharField(), required=False)
     region = StringOrListField(child=serializers.CharField(), required=False)
-    resource_id = StringOrListField(child=serializers.CharField(), required=False)
-    instance_name = StringOrListField(child=serializers.CharField(), required=False)
+    instance = StringOrListField(child=serializers.CharField(), required=False)
     operating_system = StringOrListField(child=serializers.CharField(), required=False)
 
 

--- a/koku/api/report/aws/serializers.py
+++ b/koku/api/report/aws/serializers.py
@@ -215,11 +215,6 @@ class AWSEC2ComputeFilterSerializer(BaseFilterSerializer):
     limit = None
     offset = None
 
-    # Not valid for this endpoint.
-    # instance_name and resource_id is filtered by instance field.
-    instance_name = None
-    resource_id = None
-
     instance = StringOrListField(child=serializers.CharField(), required=False)
     operating_system = StringOrListField(child=serializers.CharField(), required=False)
     account = StringOrListField(child=serializers.CharField(), required=False)
@@ -248,11 +243,6 @@ class AWSEC2ExcludeSerializer(BaseExcludeSerializer):
     """Serializer for handling query parameter exclude."""
 
     _opfields = ("account", "region", "instance", "operating_system")
-
-    # Not valid for this endpoint.
-    # instance_name and resource_id is filtered by instance field.
-    instance_name = None
-    resource_id = None
 
     account = StringOrListField(child=serializers.CharField(), required=False)
     region = StringOrListField(child=serializers.CharField(), required=False)

--- a/koku/api/report/test/aws/test_views.py
+++ b/koku/api/report/test/aws/test_views.py
@@ -661,3 +661,39 @@ class AWSReportViewTest(IamTestCase):
                 url = base_url + param
                 response = self.client.get(url, **self.headers)
                 self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_ec2_compute_instance_filter(self):
+        """Test EC2 compute instance filter."""
+
+        # Assert that instance filter is working
+        base_url = reverse("reports-aws-ec2-compute")
+        url = base_url + "?filter[instance]=example_instance_name"
+        response = self.client.get(url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Assert that instance filter is not working with invalid filter
+        url = base_url + "?filter[instance_name]=example_instance_name"
+        response = self.client.get(url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        url = base_url + "?filter[resource_id]=example_instance_name"
+        response = self.client.get(url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_ec2_compute_instance_exclude_filter(self):
+        """Test EC2 compute instance filter."""
+
+        # Assert that instance filter is working
+        base_url = reverse("reports-aws-ec2-compute")
+        url = base_url + "?exclude[instance]=example_instance_name"
+        response = self.client.get(url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Assert that instance filter is not working with invalid filter
+        url = base_url + "?exclude[instance_name]=example_instance_name"
+        response = self.client.get(url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        url = base_url + "?exclude[resource_id]=example_instance_name"
+        response = self.client.get(url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
## Jira Ticket

[COST-5443](https://issues.redhat.com/browse/COST-5443)

## Description

This change will drop `instance_name` and `resource_id` filter options for EC2 Compute and insert a new filter named `instance`, which refers to instance_name and resource_id fields.

Additionally, this change will drop `instance_name` and `resource_id` exclude options for EC2 Compute and insert a new exclude named `instance`, which refers to instance_name and resource_id fields.

## Testing

1. Checkout Branch
2. Restart Koku
3. Run tests with `tox -e py311 -- api.report.test.aws.test_views.AWSReportViewTest.test_ec2_compute_instance_exclude_filter` and `tox -e py311 -- api.report.test.aws.test_views.AWSReportViewTest.test_ec2_compute_instance_filter`

## Release Notes
- [ ] Add a common filter for filtering by resource_id and instance_name

```markdown
* [COST-5443](https://issues.redhat.com/browse/COST-5443) Add a common filter for filtering by resource_id and instance_name
```
