### PR TITLE
[COST-4520] Use multi-arch images built by Konflux for dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -629,7 +629,7 @@ services:
 
   hive-metastore:
     container_name: hive-metastore
-    image: quay.io/samdoran/ubi-hive:3.1.3-metastore-050
+    image: quay.io/redhat-services-prod/cost-mgmt-dev-tenant/ubi-hive:2f89bfb
     ports:
       - 9083:8000
     environment:
@@ -652,7 +652,7 @@ services:
 
   trino:
     container_name: trino
-    image: quay.io/samdoran/ubi-trino:453-001
+    image: quay.io/redhat-services-prod/cost-mgmt-dev-tenant/ubi-trino:04fc286
     user: root
     ports:
       - 8080:8080


### PR DESCRIPTION
## Jira Ticket

[COST-4520](https://issues.redhat.com/browse/COST-4520)

## Description

Switch the conatiner images used for local development for Hive and Trino to the multi-arch images built by Konflux.

## Testing

1. Checkout Branch
2. `make docker-trino-up`
3. Check image architecture
```
> docker inspect trino hive-metastore | jello '[item.Config.Labels.architecture for item in _]'
[
  "aarch64",
  "aarch64"
]
```

```
> docker inspect trino hive-metastore | jello '[item.Config.Labels.architecture for item in _]'
[
  "x86_64",
  "x86_64"
]
```

## Release Notes
- [x] proposed release note

```markdown
* [COST-4520](https://issues.redhat.com/browse/COST-4520) Change Hive and Trino images used for local development
```
