### PR TITLE
[COST-5513] Specify registry when pushing metrics

### DIFF
--- a/koku/koku/metrics.py
+++ b/koku/koku/metrics.py
@@ -130,7 +130,7 @@ def collect_metrics(self):
     db_status.collect()
     LOG.debug("Pushing stats to gateway: %s", settings.PROMETHEUS_PUSHGATEWAY)
     try:
-        push_to_gateway(settings.PROMETHEUS_PUSHGATEWAY, job="koku.metrics.collect_metrics")
+        push_to_gateway(gateway=settings.PROMETHEUS_PUSHGATEWAY, job="koku.metrics.collect_metrics", registry=REGISTRY)
     except OSError as exc:
         LOG.error("Problem reaching pushgateway: %s", exc)
         self.update_state(state="FAILURE", meta={"result": str(exc), "traceback": str(exc.__traceback__)})


### PR DESCRIPTION
## Jira Ticket

[COST-5213](https://issues.redhat.com/browse/COST-5213)

## Description

This is a simple fix to add a missing parameter. More work may need to be done if the way we are using multiprocess mode is incorrect.

The [docs state](https://prometheus.github.io/client_python/multiprocess/) that a pushgateway may not be used with multiprocess mode, yet that is what we are doing.

The `CollectorRegistry` is instantiated on import since it is a global in `koku.metrics`. That registy is then registered with a `MultiProcessCollector``, also on import. This may work, but it seems like it may be problematic.

## Testing

1. Checkout Branch
2. Restart Koku

## Release Notes
- [x] proposed release note

```markdown
* [COST-5213](https://issues.redhat.com/browse/COST-5213) Add missing registry parameter when pushing metrics
```
