### PR TITLE
[cost-4945] Fix lowercase instance_name on EC2 report

### DIFF
--- a/koku/masu/database/trino_sql/reporting_awscostentrylineitem_summary_by_ec2_compute.sql
+++ b/koku/masu/database/trino_sql/reporting_awscostentrylineitem_summary_by_ec2_compute.sql
@@ -82,7 +82,7 @@ FROM (
         max(date(lineitem_usagestartdate)) as usage_end,
         lineitem_usageaccountid as usage_account_id,
         lineitem_resourceid as resource_id,
-        json_extract_scalar(json_parse(lower(resourcetags)), '$.name') AS instance_name,
+        json_extract_scalar(json_parse(resourcetags), '$.Name') AS instance_name,
         nullif(product_instancetype, '') as instance_type,
         nullif(product_operatingsystem, '') as operating_system,
         nullif(product_region, '') as region,


### PR DESCRIPTION
## Jira Ticket

[COST-4945](https://issues.redhat.com/browse/COST-4945)

## Description

This change will remove the `lower()` function when converting tags to instance_name field.

## Testing

1. Checkout Branch
2. Restart Koku
3. Insert some uppercase characters in the tags field on the aws_static_data.yml file. E. g: `resourceTags/user:Name: inStanCe_nAmE_3` 
4. Access `v1/reports/aws/resources/ec2-compute/`
5. Check if instance_name has the uppercase letters. It should be identical to the tag.

## Release Notes
- [ ] Fix lowercase instance_name on EC2 report

```markdown
* [COST-4945](https://issues.redhat.com/browse/COST-4945) Fix lowercase instance_name on EC2 report
```
