### PR TITLE
[COST-5545] Ignore RIFee rows for HCS daily summary SQL

### DIFF
--- a/koku/hcs/database/sql/reporting_aws_hcs_daily_summary.sql
+++ b/koku/hcs/database/sql/reporting_aws_hcs_daily_summary.sql
@@ -76,18 +76,26 @@ WHERE
     OR (
       lineitem_legalentity LIKE '%Amazon Web Services%'
       AND lineitem_lineitemdescription LIKE '%Red Hat%'
+      -- do not include Reserved Instance Fee
+      AND lineitem_lineitemtype <> 'RIFee'
     )
     OR (
       lineitem_legalentity LIKE '%Amazon Web Services%'
       AND lineitem_lineitemdescription LIKE '%RHEL%'
+      -- do not include Reserved Instance Fee
+      AND lineitem_lineitemtype <> 'RIFee'
     )
     OR (
       lineitem_legalentity LIKE '%AWS%'
       AND lineitem_lineitemdescription LIKE '%Red Hat%'
+      -- do not include Reserved Instance Fee
+      AND lineitem_lineitemtype <> 'RIFee'
     )
     OR (
       lineitem_legalentity LIKE '%AWS%'
       AND lineitem_lineitemdescription LIKE '%RHEL%'
+      -- do not include Reserved Instance Fee
+      AND lineitem_lineitemtype <> 'RIFee'
     )
   )
   AND lineitem_usagestartdate >= {{date}}


### PR DESCRIPTION
## Jira Ticket

[COST-5545](https://issues.redhat.com/browse/COST-5545)

## Description

* Filter out rows that have 'RIFee' for the lineitemtype.

## Testing

1. Checkout Branch
2. Restart Koku
3. Process AWS data for HCS
4. Confirm that RIFee rows are not included in the extracted daily summaries.

## Release Notes
- [ ] Remove RIFee rows from the HCS processing logic

```markdown
* [COST-5545](https://issues.redhat.com/browse/COST-5545) Remove RIFee rows from the HCS processing logic
```
