### PR TITLE
[COST-5502] Update image used by smoke test

### DIFF
--- a/smoke_test.sh
+++ b/smoke_test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-IMAGE="quay.io/cloudservices/koku"
+IMAGE="quay.io/redhat-services-prod/cost-mgmt-dev-tenant/koku"
 APP_NAME="hccm"  # name of app-sre "application" folder this component lives in
 COMPONENT_NAME="koku"  # name of app-sre "resourceTemplate" in deploy.yaml for this component
 COMPONENTS="hive-metastore koku trino"  # specific components to deploy (optional, default: all)


### PR DESCRIPTION
## Jira Issue

[COST-5502](https://issues.redhat.com/browse/COST-5520)

## Description

Use the Konflux release image for nightly smoke tests. Since this test is running against `main`, it doesn't need to wait for an image build since the image should already exist.

By default, the image tag is the 7 character SHA of HEAD, which lines up with how the Konflux release images are tagged.

## Release Notes
- [x] proposed release note

```markdown
* [COST-5502](https://issues.redhat.com/browse/COST-5520) Use Konflux image for nightly smoke tests
```
