### PR TITLE
[COST-5434] Remove extraneous error message

### DIFF
--- a/koku/masu/database/report_db_accessor_base.py
+++ b/koku/masu/database/report_db_accessor_base.py
@@ -147,7 +147,6 @@ class ReportDBAccessorBase:
             results = trino_cur.fetchall()
             description = trino_cur.description
         except TrinoQueryError as ex:
-            LOG.error(log_json(msg="failed trino sql execution", log_ref=log_ref, context=ctx), exc_info=ex)
             if "NoSuchKey" in str(ex):
                 raise TrinoNoSuchKeyError(
                     message=ex.message,


### PR DESCRIPTION
## Jira Ticket

[COST-5434](https://issues.redhat.com/browse/COST-5434)

## Description

An equivalent error is logged in the retry decorator after all retry attempts are exhausted. This is code leftover from the previous behavior and can be removed.

Related to #5210. 

## Testing

1. Checkout Branch
2. Restart Koku
3. Load test customer data.

```
make create-test-customer
make load-test-customer-data test_source=aws
```

4. Delete test customer data
```
make delete-test-customer-data
```

5. Observe retries with no errors in the worker logs.
```
...
[2024-09-27 20:39:52,118] WARNING 82aaf11b-ac92-46d4-9855-70cd0dd711c9 44415 {'message': 'Retrying... (attempt 1)', 'tracing_id': '', 'exc_info': TrinoHiveMetastoreError()}
[2024-09-27 20:39:52,118: WARNING/MainProcess] {'message': 'Retrying... (attempt 1)', 'tracing_id': '', 'exc_info': TrinoHiveMetastoreError()}
...
```


## Release Notes
- [x] proposed release note

```markdown
* [COST-5434](https://issues.redhat.com/browse/COST-5434) Remove extraneous error logging
```
