### PR TITLE
Remove obsolete version element from compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 name: koku
 
 services:


### PR DESCRIPTION
## Description

The [version property is obsolete](https://docs.docker.com/reference/compose-file/version-and-name/#version-top-level-element-obsolete) and is causing test failures.

## Release Notes
- [x] proposed release note

```markdown
* Remove obsolete `version` property from compose file
```
