### PR TITLE
[COST-5609] Allow smokes-labeler job to write to pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,11 @@ jobs:
     name: Smoke Test Label
     runs-on: ubuntu-20.04
 
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
             echo "RUN_TESTS=true" >> $GITHUB_ENV
           fi
 
-      - name: Setting smokes-required label
+      - name: Set smokes-required label
         if: env.RUN_TESTS == 'true'
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         continue-on-error: true
@@ -99,14 +99,25 @@ jobs:
               repo: context.repo.repo,
               labels: [ 'smokes-required' ]
             })
-            github.rest.issues.removeLabel({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              name: 'ok-to-skip-smokes'
-            })
 
-      - name: Remove smokes-required label
+            const response = await github.rest.issues.listLabelsOnIssue({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              })
+
+            const labels = response.data.map(({name}) => name)
+
+            if (labels.includes('ok-to-skip-smokes')) {
+              github.rest.issues.removeLabel({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'ok-to-skip-smokes'
+              })
+            }
+
+      - name: Set ok-to-skip-smokes label
         if: env.RUN_TESTS != 'true'
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         continue-on-error: true
@@ -118,12 +129,23 @@ jobs:
               repo: context.repo.repo,
               labels: [ 'ok-to-skip-smokes' ]
             })
-            github.rest.issues.removeLabel({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              name: 'smokes-required'
-            })
+
+            const response = await github.rest.issues.listLabelsOnIssue({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              })
+
+            const labels = response.data.map(({name}) => name)
+
+            if (labels.includes('smokes-required')) {
+              github.rest.issues.removeLabel({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'smokes-required'
+              })
+            }
 
   changed-files:
     name: Detect changed files


### PR DESCRIPTION
## Jira Ticket

[COST-5609](https://issues.redhat.com/browse/COST-5609)

## Description

Allow the smokes-labeler job to write to PRs.

Only remove a label if it is set on the PR. This prevents 404 errors if a DELETE request is sent to a label that is not set on a PR.

## Testing

Case 1
1. Add `smokes-required` label to this PR
2. Re-run checks
3. Observe the `smokes-required` label is removed without error

Case 2
1. Remove the `ok-to-skip-smokes` label
2. Re-run checks
3. Observe the `ok-to-skip-smokes` label is added

## Release Notes
- [x] proposed release note

```markdown
* [COST-5609](https://issues.redhat.com/browse/COST-5609) Allow smokes-labeler job to write to pull requests
```
