### PR TITLE
Update Masu tooling to recheck infra map

### DIFF
--- a/koku/masu/api/recheck_infra_map.py
+++ b/koku/masu/api/recheck_infra_map.py
@@ -32,18 +32,18 @@ def recheck_infra_map(request):
     """
     params = request.query_params
     if not params:
-        errmsg = "Parameter missing. Required: cloud_provider, start_date, end_date"
+        errmsg = "Parameter missing. Required: provider_uuid, start_date, end_date"
         return Response({"Error": errmsg}, status=status.HTTP_400_BAD_REQUEST)
 
-    cloud_provider = params.get("cloud_provider")
+    provider_uuid = params.get("provider_uuid")
     start_date = params.get("start_date")
     end_date = params.get("end_date")
 
     try:
-        provider = Provider.objects.get(uuid=cloud_provider)
+        provider = Provider.objects.get(uuid=provider_uuid)
         provider_schema = provider.account.get("schema_name")
     except Provider.DoesNotExist:
-        errmsg = f"cloud_provider {cloud_provider} does not exist"
+        errmsg = f"provider_uuid {provider_uuid} does not exist"
         return Response({"Error": errmsg}, status=status.HTTP_400_BAD_REQUEST)
 
     ocp_updater = OCPCloudUpdaterBase(provider_schema, provider, None)

--- a/koku/masu/api/recheck_infra_map.py
+++ b/koku/masu/api/recheck_infra_map.py
@@ -1,0 +1,52 @@
+#
+# Copyright 2024 Red Hat Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+"""View for temporary force check of infra map."""
+import logging
+
+from django.views.decorators.cache import never_cache
+from rest_framework import status
+from rest_framework.decorators import api_view
+from rest_framework.decorators import permission_classes
+from rest_framework.decorators import renderer_classes
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from rest_framework.settings import api_settings
+
+from api.models import Provider
+from masu.processor.ocp.ocp_cloud_updater_base import OCPCloudUpdaterBase
+
+LOG = logging.getLogger(__name__)
+
+
+@never_cache
+@api_view(http_method_names=["GET"])
+@permission_classes((AllowAny,))
+@renderer_classes(tuple(api_settings.DEFAULT_RENDERER_CLASSES))
+def recheck_infra_map(request):
+    """Checks to see if a cloud provider should be mapped to an Openshift Source.
+
+    The start and end date used here is for the inframap sql and be a small range of days
+    you know have correlation.
+    """
+    params = request.query_params
+    if not params:
+        errmsg = "Parameter missing. Required: cloud_provider, start_date, end_date"
+        return Response({"Error": errmsg}, status=status.HTTP_400_BAD_REQUEST)
+
+    cloud_provider = params.get("cloud_provider")
+    start_date = params.get("start_date")
+    end_date = params.get("end_date")
+
+    try:
+        provider = Provider.objects.get(uuid=cloud_provider)
+        provider_schema = provider.account.get("schema_name")
+    except Provider.DoesNotExist:
+        errmsg = f"cloud_provider {cloud_provider} does not exist"
+        return Response({"Error": errmsg}, status=status.HTTP_400_BAD_REQUEST)
+
+    ocp_updater = OCPCloudUpdaterBase(provider_schema, provider, None)
+    # a manifest is not needed to recheck the infra map
+    infra_map = ocp_updater._generate_ocp_infra_map_from_sql_trino(start_date, end_date, False)
+    return Response({"Infrastructure map": str(infra_map)})

--- a/koku/masu/api/recheck_infra_map.py
+++ b/koku/masu/api/recheck_infra_map.py
@@ -31,13 +31,13 @@ def recheck_infra_map(request):
     you know have correlation.
     """
     params = request.query_params
-    if not params:
-        errmsg = "Parameter missing. Required: provider_uuid, start_date, end_date"
-        return Response({"Error": errmsg}, status=status.HTTP_400_BAD_REQUEST)
-
     provider_uuid = params.get("provider_uuid")
     start_date = params.get("start_date")
     end_date = params.get("end_date")
+
+    if not params or not (provider_uuid and start_date and end_date):
+        errmsg = "Parameter missing. Required: provider_uuid, start_date, end_date"
+        return Response({"Error": errmsg}, status=status.HTTP_400_BAD_REQUEST)
 
     try:
         provider = Provider.objects.get(uuid=provider_uuid)

--- a/koku/masu/api/urls.py
+++ b/koku/masu/api/urls.py
@@ -34,6 +34,7 @@ from masu.api.views import notification
 from masu.api.views import pg_engine_version
 from masu.api.views import process_openshift_on_cloud
 from masu.api.views import purge_trino_files
+from masu.api.views import recheck_infra_map
 from masu.api.views import report_data
 from masu.api.views import running_celery_tasks
 from masu.api.views import schema_sizes
@@ -67,6 +68,7 @@ urlpatterns = [
     path("trino/query/", trino_query, name="trino_query"),
     path("trino/api/", trino_ui, name="trino_ui"),
     path("notification/", notification, name="notification"),
+    path("recheck_infra_map/", recheck_infra_map, name="recheck_infra_map"),
     path("update_cost_model_costs/", update_cost_model_costs, name="update_cost_model_costs"),
     path("report/process/openshift_on_cloud/", process_openshift_on_cloud, name="process_openshift_on_cloud"),
     path("report/summarize/openshift_on_cloud/", update_openshift_on_cloud, name="update_openshift_on_cloud"),

--- a/koku/masu/api/views.py
+++ b/koku/masu/api/views.py
@@ -27,6 +27,7 @@ from masu.api.manifest.views import ManifestStatusViewSet
 from masu.api.notifications import notification
 from masu.api.process_openshift_on_cloud import process_openshift_on_cloud
 from masu.api.purge_trino_files import purge_trino_files
+from masu.api.recheck_infra_map import recheck_infra_map
 from masu.api.report_data import report_data
 from masu.api.running_celery_tasks import celery_queue_lengths
 from masu.api.running_celery_tasks import celery_queue_tasks

--- a/koku/masu/processor/ocp/ocp_cloud_updater_base.py
+++ b/koku/masu/processor/ocp/ocp_cloud_updater_base.py
@@ -66,7 +66,7 @@ class OCPCloudUpdaterBase:
                 infra_map[str(provider.uuid)] = (self._provider_uuid, self._provider.type)
         return infra_map
 
-    def _generate_ocp_infra_map_from_sql_trino(self, start_date, end_date):
+    def _generate_ocp_infra_map_from_sql_trino(self, start_date, end_date, check_cache=True):
         """Get the OCP on X infrastructure map.
 
         Args:
@@ -77,16 +77,17 @@ class OCPCloudUpdaterBase:
             infra_map (dict) The OCP infrastructure map.
 
         """
-        cache_infra_map = get_cached_infra_map(self._schema, self._provider.type, self._provider_uuid)
-        if cache_infra_map:
-            LOG.info(
-                log_json(
-                    msg="retrieved matching infra map from cache",
-                    provider_uuid=self._provider_uuid,
-                    schema=self._schema,
+        if check_cache:
+            cache_infra_map = get_cached_infra_map(self._schema, self._provider.type, self._provider_uuid)
+            if cache_infra_map:
+                LOG.info(
+                    log_json(
+                        msg="retrieved matching infra map from cache",
+                        provider_uuid=self._provider_uuid,
+                        schema=self._schema,
+                    )
                 )
-            )
-            return cache_infra_map
+                return cache_infra_map
         infra_map = {}
         if self._provider.type == Provider.PROVIDER_OCP:
             with OCPReportDBAccessor(self._schema) as accessor:

--- a/koku/masu/test/api/test_recheck_infra_map.py
+++ b/koku/masu/test/api/test_recheck_infra_map.py
@@ -32,7 +32,7 @@ class RecheckInfraMapViewTest(TestCase):
         """Test response when provider does not exist."""
         mock_get.side_effect = Provider.DoesNotExist
         response = self.client.get(
-            self.url, {"cloud_provider": "nonexistent-uuid", "start_date": "2023-01-01", "end_date": "2023-01-02"}
+            self.url, {"provider_uuid": "nonexistent-uuid", "start_date": "2023-01-01", "end_date": "2023-01-02"}
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("does not exist", response.data["Error"])
@@ -50,7 +50,7 @@ class RecheckInfraMapViewTest(TestCase):
         mock_generate_map.return_value = {"node1": "clusterA"}
 
         response = self.client.get(
-            self.url, {"cloud_provider": "test-uuid", "start_date": "2023-01-01", "end_date": "2023-01-02"}
+            self.url, {"provider_uuid": "test-uuid", "start_date": "2023-01-01", "end_date": "2023-01-02"}
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["Infrastructure map"], str(mock_generate_map.return_value))

--- a/koku/masu/test/api/test_recheck_infra_map.py
+++ b/koku/masu/test/api/test_recheck_infra_map.py
@@ -1,0 +1,56 @@
+#
+# Copyright 2024 Red Hat Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+from unittest.mock import Mock
+from unittest.mock import patch
+
+from django.test import TestCase
+from django.test.utils import override_settings
+from django.urls import reverse
+from rest_framework import status
+
+from api.models import Provider
+
+
+@override_settings(ROOT_URLCONF="masu.urls")
+class RecheckInfraMapViewTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.url = reverse("recheck_infra_map")
+
+    @patch("koku.middleware.MASU", return_value=True)
+    def test_missing_parameters(self, _):
+        """Test response when parameters are missing."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("Parameter missing", response.data["Error"])
+
+    @patch("koku.middleware.MASU", return_value=True)
+    @patch("api.models.Provider.objects.get")
+    def test_provider_does_not_exist(self, mock_get, _):
+        """Test response when provider does not exist."""
+        mock_get.side_effect = Provider.DoesNotExist
+        response = self.client.get(
+            self.url, {"cloud_provider": "nonexistent-uuid", "start_date": "2023-01-01", "end_date": "2023-01-02"}
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("does not exist", response.data["Error"])
+
+    @patch("koku.middleware.MASU", return_value=True)
+    @patch("api.models.Provider.objects.get")
+    @patch("masu.processor.ocp.ocp_cloud_updater_base.OCPCloudUpdaterBase._generate_ocp_infra_map_from_sql_trino")
+    def test_successful_infra_map_generation(self, mock_generate_map, mock_get, _):
+        """Test successful infra map generation."""
+        # Mock the Provider object
+        provider_mock = Mock()
+        provider_mock.account = {"schema_name": "test_schema"}
+        mock_get.return_value = provider_mock
+        # Mock the infra map generation
+        mock_generate_map.return_value = {"node1": "clusterA"}
+
+        response = self.client.get(
+            self.url, {"cloud_provider": "test-uuid", "start_date": "2023-01-01", "end_date": "2023-01-02"}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["Infrastructure map"], str(mock_generate_map.return_value))


### PR DESCRIPTION
## Jira Ticket

## Description

This change will allow us to manually recheck if a cloud provider should be correlated to an OpenShift source.

## Testing

1. Load test customer data
2. Check infra map:
```
select * from api_providerinfrastructuremap;
```
Result:
```
 id | infrastructure_type |      infrastructure_provider_id
----+---------------------+--------------------------------------
  4 | AWS-local           | 98b89c57-877c-488d-a491-6dbfe263b85c
  5 | GCP-local           | c001307a-d5f0-4d47-81a3-4e441970edc8
  6 | Azure-local         | 33e97dcf-8f24-4675-aae2-af36588f9d29
(3 rows)
```
3. Remove correlation:
```
UPDATE api_provider set infrastructure_id = NULL where 1 = 1 AND infrastructure_id is not null;
```
`UPDATE 3`
```
DELETE FROM api_providerinfrastructuremap where 1 = 1;
```
`DELETE 3`
4. double check to make sure no correlation:
```
select * from api_provider where infrastructure_id is not null;
select * from api_providerinfrastructuremap;
```
5. Use the new endpoint providing the cloud provider uuid for each source that we manually removed:
```
http://127.0.0.1:5042/api/cost-management/v1/recheck_infra_map/?start_date=2024-10-01&cloud_provider=33e97dcf-8f24-4675-aae2-af36588f9d29&end_date=2024-10-28
```
6. Run queries from step 4 and see that they are recorrelated.



## Release Notes
- [ ] proposed release note

```markdown
*  Update tooling to recheck infrastructure mappings for a cloud provider
```
