### PR TITLE
[COST-5570] Fix AWS vcpu metric amount calculation

### DIFF
--- a/koku/subs/subs_data_messenger.py
+++ b/koku/subs/subs_data_messenger.py
@@ -116,20 +116,13 @@ class SUBSDataMessenger:
                         RHEL_ELS_SYSTEMS_PROCESSED.labels(provider_type=Provider.PROVIDER_AWS).inc()
                         try:
                             RHEL_ELS_VCPU_HOURS.labels(provider_type=Provider.PROVIDER_AWS).inc(
-                                amount=(float(row["subs_vcpu"]) * int(row["subs_usage"]))
+                                amount=float(row["subs_vcpu"])
                             )
                         except ValueError:
                             LOG.info(
                                 log_json(
                                     self.tracing_id,
                                     msg=f"vCPU amount could not be cast to a float {row['subs_vcpu']}",
-                                    context=self.context,
-                                )
-                            )
-                            LOG.info(
-                                log_json(
-                                    self.tracing_id,
-                                    msg=f"usage amount could not be cast to a int {row['subs_usage']}",
                                     context=self.context,
                                 )
                             )


### PR DESCRIPTION
## Jira Ticket

[COST-5570](https://issues.redhat.com/browse/COST-5570)

## Description

* usage is always 1 for the hour interval

## Testing

1. Checkout Branch
2. Restart Koku
3. Load data with AWS rhel metering info
4. Validate endpoint

## Release Notes
- [ ] Fix prometheus metric for RHEL ELS vcpu counting

```markdown
* [COST-5570](https://issues.redhat.com/browse/COST-5570) Fix prometheus metric for RHEL ELS vcpu counting
```
