### PR TITLE
[COST-4176, COST-5651] currency: fix capitalization

### DIFF
--- a/koku/api/currency/currencies.py
+++ b/koku/api/currency/currencies.py
@@ -16,7 +16,7 @@ CURRENCIES = [
         "code": "BRL",
         "name": "Brazilian Real",
         "symbol": "R$",
-        "description": "BRL (R$) - Brazilian real",
+        "description": "BRL (R$) - Brazilian Real",
     },
     {
         "code": "CAD",
@@ -64,7 +64,7 @@ CURRENCIES = [
         "code": "INR",
         "name": "Indian Rupee",
         "symbol": "\u20b9",
-        "description": "INR (\u20b9) - Indian rupee",
+        "description": "INR (\u20b9) - Indian Rupee",
     },
     {
         "code": "JPY",


### PR DESCRIPTION
## Jira Ticket

[COST-4176](https://issues.redhat.com/browse/COST-4176)
[COST-5651](https://issues.redhat.com/browse/COST-5651)

## Description

This change will fix the capitalization in the description of BRL and INR.

## Testing

1. Checkout Branch
2. Restart Koku
3. http://localhost:8000/api/cost-management/v1/currency/?limit=20
see:
```
...
{
  code: "BRL",
  name: "Brazilian Real",
  symbol: "R$",
  description: "BRL (R$) - Brazilian Real" <<<<<< this is all caps
},
...

{
  code: "INR",
  name: "Indian Rupee",
  symbol: "₹",
  description: "INR (₹) - Indian Rupee" <<<<<< this is all caps
},
...
```

## Release Notes
- [x] proposed release note

```markdown
* [COST-4176, COST-5651] currency: fix capitalization of BRL and INR descriptions
```
