### PR TITLE
Prevent Renovate bot from opening PRs outside the schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
     "extends": [
         "github>konflux-ci/mintmaker//config/renovate/renovate.json"
     ],
+    "updateNotScheduled": false,
     "schedule": [
         "on Tuesday after 3am and before 10am"
     ],


### PR DESCRIPTION
## Description

Prevent Renovate bot from opening PRs outside the schedule.

https://konflux.pages.redhat.com/docs/users/mintmaker/user.html#_how_to_stop_prsmrs_from_being_updated_outside_of_schedule

## Release Notes
- [x] proposed release note

```markdown
*Prevent Renovate bot from opening PRs outside the schedule
```
