### PR TITLE
OCP VM Order by vm_name

### DIFF
--- a/koku/api/report/ocp/provider_map.py
+++ b/koku/api/report/ocp/provider_map.py
@@ -821,7 +821,7 @@ class OCPProviderMap(ProviderMap):
                             "request_memory_units": Value("GiB", output_field=CharField()),
                             "cluster": Max(Coalesce("cluster_alias", "cluster_id")),
                             "node": Max(F("node")),
-                            "namespace": Max("namespace"),
+                            "project": Max("namespace"),
                             "source_uuid": ArrayAgg(
                                 F("source_uuid"), filter=Q(source_uuid__isnull=False), distinct=True
                             ),

--- a/koku/api/report/ocp/serializers.py
+++ b/koku/api/report/ocp/serializers.py
@@ -297,6 +297,7 @@ class OCPVirtualMachinesOrderBySerializer(OCPOrderBySerializer):
     project = serializers.ChoiceField(choices=OrderSerializer.ORDER_CHOICES, required=False)
     cluster = serializers.ChoiceField(choices=OrderSerializer.ORDER_CHOICES, required=False)
     node = serializers.ChoiceField(choices=OrderSerializer.ORDER_CHOICES, required=False)
+    vm_name = serializers.ChoiceField(choices=OrderSerializer.ORDER_CHOICES, required=False)
     request_cpu = serializers.ChoiceField(choices=OrderSerializer.ORDER_CHOICES, required=False)
     request_memory = serializers.ChoiceField(choices=OrderSerializer.ORDER_CHOICES, required=False)
 


### PR DESCRIPTION
## Jira Ticket

[COST-5637](https://issues.redhat.com/browse/COST-5637)

## Description

This change will fix order_by vm_name, also changed the provider map to return `project` instead of `namespace` to be consistent with other API's

## Testing

1. Checkout Branch
2. Restart Koku
3. load OCP data with vm's
4. Test http://localhost:8000/api/cost-management/v1/reports/openshift/resources/virtual-machines/?order_by[vm_name]=asc # with asc and desc
5. Also check that the returned data now says project instead of namespace

## Release Notes
- [ ] proposed release note

```markdown
* [COST-5637](https://issues.redhat.com/browse/COST-5637) - Fix OCP VM order by vm name and project returned data field
```
