### PR TITLE
Disable clamav scans since they are currently broken

### DIFF
--- a/.tekton/koku-pull-request.yaml
+++ b/.tekton/koku-pull-request.yaml
@@ -382,7 +382,7 @@ spec:
               value: task
           resolver: bundles
         when:
-          - input: "false"
+          - input: "true"
             operator: in
             values:
               - "false"

--- a/.tekton/koku-pull-request.yaml
+++ b/.tekton/koku-pull-request.yaml
@@ -382,7 +382,7 @@ spec:
               value: task
           resolver: bundles
         when:
-          - input: $(params.skip-checks)
+          - input: "false"
             operator: in
             values:
               - "false"

--- a/.tekton/koku-push.yaml
+++ b/.tekton/koku-push.yaml
@@ -379,7 +379,7 @@ spec:
               value: task
           resolver: bundles
         when:
-          - input: "false"
+          - input: "true"
             operator: in
             values:
               - "false"

--- a/.tekton/koku-push.yaml
+++ b/.tekton/koku-push.yaml
@@ -379,7 +379,7 @@ spec:
               value: task
           resolver: bundles
         when:
-          - input: $(params.skip-checks)
+          - input: "false"
             operator: in
             values:
               - "false"


### PR DESCRIPTION
## Jira Ticket

[STONEINTG-1072](https://issues.redhat.com/browse/STONEINTG-1072)

## Description

Disable clamav scans since they are currently failing. A change was made to the enterprise contract policy to waive the requirement for clamav scans for the month of November.

This will need to be reenabled next month.

## Release Notes
- [x] proposed release note

```markdown
* [STONEINTG-1072](https://issues.redhat.com/browse/STONEINTG-1072) Disable clamav scans
```
