### PR TITLE
[COST-5657] add logging for debugging subs query

### DIFF
--- a/koku/subs/subs_data_extractor.py
+++ b/koku/subs/subs_data_extractor.py
@@ -131,6 +131,17 @@ class SUBSDataExtractor(ReportDBAccessorBase):
                 "excluded_ids": excluded_ids,
                 "usage_account": usage_account,
             }
+            LOG.info(
+                log_json(
+                    self.tracing_id,
+                    msg="get_resource_ids_for_usage_account: number of exclude_ids and text length",
+                    context=self.context
+                    | {
+                        "excluded_ids_length": len(excluded_ids),
+                        "excluded_ids_text_length": sum(len(x) for x in excluded_ids),
+                    },
+                )
+            )
             ids = self._execute_trino_raw_sql_query(
                 sql, sql_params=sql_params, context=self.context, log_ref="subs_determine_rids_for_provider"
             )


### PR DESCRIPTION
## Jira Ticket

[COST-5657](https://issues.redhat.com/browse/COST-5657)

## Description

This change will add a log statement to understand the length of the excluded_ids.

## Testing

1. run smokes. See log message in subs-extraction pod:
```
[2024-11-12 17:34:42,902] INFO c1fde00f-6591-4a30-8126-650c03d301c0 25 {'message': 'get_resource_ids_for_usage_account: number of exclude_ids and text length', 'tracing_id': '14ce4985-1c86-4529-a422-8ecbde55bbf7', 'schema': 'org3340851', 'provider_type': 'Azure', 'provider_uuid': '5f21f939-45ce-4880-bb42-331476e971cf', 'excluded_ids_length': 10, 'excluded_ids_text_length': 120}
```

## Release Notes
- [x] proposed release note

```markdown
* [[COST-5657](https://issues.redhat.com/browse/COST-5657)] add logging for debugging subs query
```
