### PR TITLE
Update clamav-scan task image

### DIFF
--- a/.tekton/koku-pull-request.yaml
+++ b/.tekton/koku-pull-request.yaml
@@ -377,7 +377,7 @@ spec:
             - name: name
               value: clamav-scan
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.1@sha256:1981b5aa330a4d59f59d760e54a36ebd596948abf6a36e45e103d4fd82ecbcf3
+              value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.1@sha256:59a538a9c8affbfc584ddbe57468d8ce59c4830b37a472bc98ab8f46df82afce
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/koku-push.yaml
+++ b/.tekton/koku-push.yaml
@@ -374,7 +374,7 @@ spec:
             - name: name
               value: clamav-scan
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.1@sha256:1981b5aa330a4d59f59d760e54a36ebd596948abf6a36e45e103d4fd82ecbcf3
+              value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.1@sha256:59a538a9c8affbfc584ddbe57468d8ce59c4830b37a472bc98ab8f46df82afce
             - name: kind
               value: task
           resolver: bundles


### PR DESCRIPTION
## Description

Update the image used by the clamav task. This may fix the timeout issue we were seeing.

## Release Notes
- [x] proposed release note

```markdown
* Update clamav image
```
