### PR TITLE
Skip Jenkins tests and run tests in Konflux if label is set on PR

### DIFF
--- a/ci/functions.sh
+++ b/ci/functions.sh
@@ -26,13 +26,16 @@ function set_label_flags() {
         return 1
     fi
 
-    if ! grep -E 'lgtm|pr-check-build|.*smoke-tests|ok-to-skip-smokes' <<< "$PR_LABELS"; then
+    if ! grep -E 'lgtm|pr-check-build|.*smoke-tests|ok-to-skip-smokes|run-konflux-tests' <<< "$PR_LABELS"; then
         SKIP_PR_CHECK='true'
         EXIT_CODE=1
         echo "PR check skipped"
     elif grep -E 'ok-to-skip-smokes' <<< "$PR_LABELS"; then
         SKIP_PR_CHECK='true'
         echo "smokes not required"
+    elif grep -E 'run-konflux-tests' <<< "$PR_LABELS"; then
+        SKIP_PR_CHECK='true'
+        echo "Skipping test run since PR is labled to run tests in Konflux."
     elif ! grep -E '.*smoke-tests' <<< "$PR_LABELS"; then
         echo "WARNING! No smoke-tests labels found!, PR smoke tests will be skipped"
         SKIP_SMOKE_TESTS='true'


### PR DESCRIPTION
## Jira Ticket

[COST-5502](https://issues.redhat.com/browse/COST-5502)

## Description

Skip PR checks if `run-konflux-tests` is set on the PR

## Testing

1. Run test with `run-konflux-tests` label on the PR
2. Run tests without `run-konflux-tests` label on the PR

## Release Notes
- [x] proposed release note

```markdown
* [COST-5502](https://issues.redhat.com/browse/COST-5502) Control where CI tests are run based on PR label
```
