### PR TITLE
[COST-5637] Fix provider map infra calcuations for virtualization

### DIFF
--- a/koku/api/report/ocp/provider_map.py
+++ b/koku/api/report/ocp/provider_map.py
@@ -783,11 +783,11 @@ class OCPProviderMap(ProviderMap):
                             "sup_markup": Sum(Value(0, output_field=DecimalField())),
                             "sup_total": self.cost_model_supplementary_cost,
                             "infra_raw": self.cloud_infrastructure_cost,
-                            "infra_usage": self.cost_model_cost,
+                            "infra_usage": self.cost_model_infrastructure_cost,
                             "infra_markup": self.markup_cost,
                             "infra_total": self.cloud_infrastructure_cost
                             + self.markup_cost
-                            + self.cost_model_cpu_infrastructure_cost,
+                            + self.cost_model_infrastructure_cost,
                             "cost_raw": self.cloud_infrastructure_cost,
                             "cost_usage": self.cost_model_cost,
                             "cost_markup": self.markup_cost,
@@ -804,11 +804,11 @@ class OCPProviderMap(ProviderMap):
                             "sup_markup": Sum(Value(0, output_field=DecimalField())),
                             "sup_total": self.cost_model_supplementary_cost,
                             "infra_raw": self.cloud_infrastructure_cost,
-                            "infra_usage": self.cost_model_cost,
+                            "infra_usage": self.cost_model_infrastructure_cost,
                             "infra_markup": self.markup_cost,
                             "infra_total": self.cloud_infrastructure_cost
                             + self.markup_cost
-                            + self.cost_model_cpu_infrastructure_cost,
+                            + self.cost_model_infrastructure_cost,
                             "cost_raw": self.cloud_infrastructure_cost,
                             "cost_usage": self.cost_model_cost,
                             "cost_markup": self.markup_cost,


### PR DESCRIPTION
## Jira Ticket

[COST-5637](https://issues.redhat.com/browse/COST-5367)

## Description

This change will adjust the VM provider map to use the same calculates as the cost endpoint

## Testing

Visually check the vm provider map section matches the cost provider map section & integrations tests.

## Release Notes
- [ ] proposed release note

```markdown
* [COST-5637](https://issues.redhat.com/browse/COST-5637) Fix provider map infra calcuations for virtualization
```
