### PR TITLE
[COST-5635] Remove bad distinct on from virt sql

### DIFF
--- a/koku/masu/database/sql/openshift/reporting_ocp_vm_summary_p.sql
+++ b/koku/masu/database/sql/openshift/reporting_ocp_vm_summary_p.sql
@@ -51,8 +51,7 @@ INSERT INTO {{schema | sqlsafe}}.reporting_ocp_vm_summary_p (
     cost_category_id,
     source_uuid
 )
-SELECT DISTINCT ON (vm_name)
-    uuid_generate_v4() as id,
+SELECT uuid_generate_v4() as id,
     cluster_alias,
     cluster_id,
     namespace,


### PR DESCRIPTION
## Jira Ticket

[COST-5635](https://issues.redhat.com/browse/COST-5635)

## Description

This change will remove the bad secondary distinct on from the virtualization sql.

## Testing

ON Main:

`plopezpe-OCPVirt_ui_automatio`n   and 
run
`ENV_FOR_DYNACONF=local DYNACONF_IQE_VAULT_LOADER_ENABLED=false DYNACONF_IQE_VAULT_IGNORE_PATH_ERRORS=True iqe tests plugin cost_management -k "test_ui_ocp_details_vms_ingest" -raA --pdb`
It will place a breakpoint for you after the OCP data is ingested
The file used is ocp_static_report_0_template

Hit: 
http://localhost:8000/api/cost-management/v1/reports/openshift/resources/virtual-machines/?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[project]=test_echo&order_by[cost]=desc&limit=100


You'll get # of virtual machines with total cost 0.0

Do the same on this branch.

## Release Notes
- [ ] proposed release note

```markdown
* [COST-5635](https://issues.redhat.com/browse/COST-5635) Remove bad distinct on from virtualization sql
```
