### PR TITLE
[COST-5627] Fix Azure default extension issue

### DIFF
--- a/koku/masu/external/downloader/azure/azure_report_downloader.py
+++ b/koku/masu/external/downloader/azure/azure_report_downloader.py
@@ -42,7 +42,7 @@ class AzureReportDownloaderNoFileError(Exception):
 
 
 def get_processing_date(
-    s3_csv_path, manifest_id, provider_uuid, start_date, end_date, context, tracing_id, ingress_reports=None
+        s3_csv_path, manifest_id, provider_uuid, start_date, end_date, context, tracing_id, ingress_reports=None
 ):
     """
     Fetch initial dataframe from CSV plus start_delta and time_inteval.
@@ -60,12 +60,12 @@ def get_processing_date(
     # Azure does not have an invoice column so we have to do some guessing here
     # Ingres reports should always clear and process everything
     if (
-        start_date.year < dh.today.year
-        and dh.today.day > 1
-        or start_date.month < dh.today.month
-        and dh.today.day > 1
-        or not check_provider_setup_complete(provider_uuid)
-        or ingress_reports
+            start_date.year < dh.today.year
+            and dh.today.day > 1
+            or start_date.month < dh.today.month
+            and dh.today.day > 1
+            or not check_provider_setup_complete(provider_uuid)
+            or ingress_reports
     ):
         process_date = start_date
         process_date = ReportManifestDBAccessor().set_manifest_daily_start_date(manifest_id, process_date)
@@ -77,15 +77,15 @@ def get_processing_date(
 
 
 def create_daily_archives(
-    tracing_id,
-    account,
-    provider_uuid,
-    local_file,
-    base_filename,
-    manifest_id,
-    start_date,
-    context,
-    ingress_reports=None,
+        tracing_id,
+        account,
+        provider_uuid,
+        local_file,
+        base_filename,
+        manifest_id,
+        start_date,
+        context,
+        ingress_reports=None,
 ):
     """
     Create daily CSVs from incoming report and archive to S3.
@@ -117,10 +117,10 @@ def create_daily_archives(
         return [], {}
     try:
         with pd.read_csv(
-            local_file,
-            chunksize=settings.PARQUET_PROCESSING_BATCH_SIZE,
-            parse_dates=[time_interval],
-            dtype=pd.StringDtype(storage="pyarrow"),
+                local_file,
+                chunksize=settings.PARQUET_PROCESSING_BATCH_SIZE,
+                parse_dates=[time_interval],
+                dtype=pd.StringDtype(storage="pyarrow"),
         ) as reader:
             for i, data_frame in enumerate(reader):
                 if data_frame.empty:
@@ -333,7 +333,7 @@ class AzureReportDownloader(ReportDownloaderBase, DownloaderInterface):
             else:
                 try:
                     blob = self._azure_client.get_latest_cost_export_for_path(
-                        report_path, self.container_name, compression_mode
+                        report_path, self.container_name
                     )
                 except AzureCostReportNotFound as ex:
                     msg = f"Unable to find manifest. Error: {ex}"

--- a/koku/masu/external/downloader/azure/azure_report_downloader.py
+++ b/koku/masu/external/downloader/azure/azure_report_downloader.py
@@ -332,9 +332,7 @@ class AzureReportDownloader(ReportDownloaderBase, DownloaderInterface):
                 manifest["reportKeys"] = [blob["blobName"] for blob in manifest_json["blobs"]]
             else:
                 try:
-                    blob = self._azure_client.get_latest_cost_export_for_path(
-                        report_path, self.container_name, compression_mode
-                    )
+                    blob = self._azure_client.get_latest_cost_export_for_path(report_path, self.container_name)
                 except AzureCostReportNotFound as ex:
                     msg = f"Unable to find manifest. Error: {ex}"
                     LOG.info(log_json(self.tracing_id, msg=msg, context=self.context))

--- a/koku/masu/external/downloader/azure/azure_report_downloader.py
+++ b/koku/masu/external/downloader/azure/azure_report_downloader.py
@@ -304,7 +304,7 @@ class AzureReportDownloader(ReportDownloaderBase, DownloaderInterface):
             except AzureCostReportNotFound as ex:
                 json_manifest = None
                 msg = f"No JSON manifest exists. {ex}"
-                LOG.debug(msg)
+                LOG.info(msg)
             if json_manifest:
                 report_name = json_manifest.name
                 last_modified = json_manifest.last_modified

--- a/koku/masu/external/downloader/azure/azure_report_downloader.py
+++ b/koku/masu/external/downloader/azure/azure_report_downloader.py
@@ -42,7 +42,7 @@ class AzureReportDownloaderNoFileError(Exception):
 
 
 def get_processing_date(
-        s3_csv_path, manifest_id, provider_uuid, start_date, end_date, context, tracing_id, ingress_reports=None
+    s3_csv_path, manifest_id, provider_uuid, start_date, end_date, context, tracing_id, ingress_reports=None
 ):
     """
     Fetch initial dataframe from CSV plus start_delta and time_inteval.
@@ -60,12 +60,12 @@ def get_processing_date(
     # Azure does not have an invoice column so we have to do some guessing here
     # Ingres reports should always clear and process everything
     if (
-            start_date.year < dh.today.year
-            and dh.today.day > 1
-            or start_date.month < dh.today.month
-            and dh.today.day > 1
-            or not check_provider_setup_complete(provider_uuid)
-            or ingress_reports
+        start_date.year < dh.today.year
+        and dh.today.day > 1
+        or start_date.month < dh.today.month
+        and dh.today.day > 1
+        or not check_provider_setup_complete(provider_uuid)
+        or ingress_reports
     ):
         process_date = start_date
         process_date = ReportManifestDBAccessor().set_manifest_daily_start_date(manifest_id, process_date)
@@ -77,15 +77,15 @@ def get_processing_date(
 
 
 def create_daily_archives(
-        tracing_id,
-        account,
-        provider_uuid,
-        local_file,
-        base_filename,
-        manifest_id,
-        start_date,
-        context,
-        ingress_reports=None,
+    tracing_id,
+    account,
+    provider_uuid,
+    local_file,
+    base_filename,
+    manifest_id,
+    start_date,
+    context,
+    ingress_reports=None,
 ):
     """
     Create daily CSVs from incoming report and archive to S3.
@@ -117,10 +117,10 @@ def create_daily_archives(
         return [], {}
     try:
         with pd.read_csv(
-                local_file,
-                chunksize=settings.PARQUET_PROCESSING_BATCH_SIZE,
-                parse_dates=[time_interval],
-                dtype=pd.StringDtype(storage="pyarrow"),
+            local_file,
+            chunksize=settings.PARQUET_PROCESSING_BATCH_SIZE,
+            parse_dates=[time_interval],
+            dtype=pd.StringDtype(storage="pyarrow"),
         ) as reader:
             for i, data_frame in enumerate(reader):
                 if data_frame.empty:
@@ -333,7 +333,7 @@ class AzureReportDownloader(ReportDownloaderBase, DownloaderInterface):
             else:
                 try:
                     blob = self._azure_client.get_latest_cost_export_for_path(
-                        report_path, self.container_name
+                        report_path, self.container_name, compression_mode
                     )
                 except AzureCostReportNotFound as ex:
                     msg = f"Unable to find manifest. Error: {ex}"

--- a/koku/masu/external/downloader/azure/azure_report_downloader.py
+++ b/koku/masu/external/downloader/azure/azure_report_downloader.py
@@ -26,7 +26,6 @@ from masu.util import common as com_utils
 from masu.util.aws.common import copy_local_report_file_to_s3_bucket
 from masu.util.aws.common import get_or_clear_daily_s3_by_date
 from masu.util.azure import common as utils
-from masu.util.azure.common import AzureBlobExtension
 
 DATA_DIR = Config.TMP_DIR
 LOG = logging.getLogger(__name__)
@@ -272,7 +271,7 @@ class AzureReportDownloader(ReportDownloaderBase, DownloaderInterface):
 
         """
         manifest = {}
-        compression_mode = AzureBlobExtension.csv.value  # Default value
+        compression_mode = None
         if self.ingress_reports:
             reports = [report.split(f"{self.container_name}/")[1] for report in self.ingress_reports]
             year = date_time.strftime("%Y")

--- a/koku/masu/external/downloader/azure/azure_service.py
+++ b/koku/masu/external/downloader/azure/azure_service.py
@@ -68,6 +68,8 @@ class AzureService:
     ) -> t.Optional[BlobProperties]:
         latest_blob = None
         for blob in blobs:
+            if extension and not blob.name.endswith(extension):
+                continue
             if report_path in blob.name:
                 if not latest_blob or blob.last_modified > latest_blob.last_modified:
                     latest_blob = blob

--- a/koku/masu/external/downloader/azure/azure_service.py
+++ b/koku/masu/external/downloader/azure/azure_service.py
@@ -71,17 +71,13 @@ class AzureService:
             AzureBlobExtension.gzip.value,
             AzureBlobExtension.manifest.value,
         ]
-        if extension and extension not in valid_extensions:
-            raise ValueError(f"Invalid compression type: {extension}")
-
         latest_blob = None
         for blob in blobs:
             if extension:
                 if not blob.name.endswith(extension):
                     continue
-            else:
-                if not any(blob.name.endswith(ext) for ext in valid_extensions):
-                    continue
+            elif not any(blob.name.endswith(ext) for ext in valid_extensions):
+                continue
 
             if report_path in blob.name:
                 if not latest_blob or blob.last_modified > latest_blob.last_modified:
@@ -166,9 +162,7 @@ class AzureService:
 
         return report
 
-    def get_latest_cost_export_for_path(
-        self, report_path: str, container_name: str, compression: t.Optional[str] = None
-    ) -> BlobProperties:
+    def get_latest_cost_export_for_path(self, report_path: str, container_name: str) -> BlobProperties:
         """
         Get the latest cost export for a given path and container based on the compression type.
 
@@ -184,7 +178,7 @@ class AzureService:
             ValueError: If the compression type is not 'gzip' or 'csv'.
             AzureCostReportNotFound: If no blob is found for the given path and container.
         """
-        return self._get_latest_blob_for_path(report_path, container_name, compression)
+        return self._get_latest_blob_for_path(report_path, container_name)
 
     def get_latest_manifest_for_path(self, report_path: str, container_name: str) -> BlobProperties:
         return self._get_latest_blob_for_path(report_path, container_name, AzureBlobExtension.manifest.value)

--- a/koku/masu/external/downloader/azure/azure_service.py
+++ b/koku/masu/external/downloader/azure/azure_service.py
@@ -92,7 +92,7 @@ class AzureService:
     ) -> BlobProperties:
         """Get the latest file with the specified extension from given storage account container."""
 
-        latest_report = None
+        latest_file = None
         if not container_name:
             message = "Unable to gather latest file as container name is not provided."
             LOG.warning(message)
@@ -125,12 +125,12 @@ class AzureService:
             LOG.warning(error_msg)
             raise AzureCostReportNotFound(message)
 
-        latest_report = self._get_latest_blob(report_path, blobs, extension)
-        if not latest_report:
+        latest_file = self._get_latest_blob(report_path, blobs, extension)
+        if not latest_file:
             message = f"No file found in container " f"'{container_name}' for path '{report_path}'."
             raise AzureCostReportNotFound(message)
 
-        return latest_report
+        return latest_file
 
     def _list_blobs(self, starts_with: str, container_name: str) -> list[BlobProperties]:
         try:

--- a/koku/masu/external/downloader/azure/azure_service.py
+++ b/koku/masu/external/downloader/azure/azure_service.py
@@ -69,7 +69,7 @@ class AzureService:
         valid_extensions = [
             AzureBlobExtension.csv.value,
             AzureBlobExtension.gzip.value,
-            AzureBlobExtension.manifest.value,
+            AzureBlobExtension.json.value,
         ]
         latest_blob = None
         for blob in blobs:

--- a/koku/masu/external/downloader/azure/azure_service.py
+++ b/koku/masu/external/downloader/azure/azure_service.py
@@ -66,19 +66,8 @@ class AzureService:
     def _get_latest_blob(
         self, report_path: str, blobs: list[BlobProperties], extension: t.Optional[str] = None
     ) -> t.Optional[BlobProperties]:
-        valid_extensions = [
-            AzureBlobExtension.csv.value,
-            AzureBlobExtension.gzip.value,
-            AzureBlobExtension.json.value,
-        ]
         latest_blob = None
         for blob in blobs:
-            if extension:
-                if not blob.name.endswith(extension):
-                    continue
-            elif not any(blob.name.endswith(ext) for ext in valid_extensions):
-                continue
-
             if report_path in blob.name:
                 if not latest_blob or blob.last_modified > latest_blob.last_modified:
                     latest_blob = blob

--- a/koku/masu/external/downloader/azure/azure_service.py
+++ b/koku/masu/external/downloader/azure/azure_service.py
@@ -181,7 +181,7 @@ class AzureService:
         return self._get_latest_blob_for_path(report_path, container_name)
 
     def get_latest_manifest_for_path(self, report_path: str, container_name: str) -> BlobProperties:
-        return self._get_latest_blob_for_path(report_path, container_name, AzureBlobExtension.manifest.value)
+        return self._get_latest_blob_for_path(report_path, container_name, AzureBlobExtension.json.value)
 
     def download_file(
         self,

--- a/koku/masu/external/downloader/azure/azure_service.py
+++ b/koku/masu/external/downloader/azure/azure_service.py
@@ -37,16 +37,16 @@ class AzureService:
     """A class to handle interactions with the Azure services."""
 
     def __init__(
-        self,
-        tenant_id,
-        client_id,
-        client_secret,
-        resource_group_name,
-        storage_account_name,
-        subscription_id=None,
-        cloud="public",
-        scope=None,
-        export_name=None,
+            self,
+            tenant_id,
+            client_id,
+            client_secret,
+            resource_group_name,
+            storage_account_name,
+            subscription_id=None,
+            cloud="public",
+            scope=None,
+            export_name=None,
     ):
         """Establish connection information."""
         self._resource_group_name = resource_group_name
@@ -64,24 +64,28 @@ class AzureService:
             raise AzureServiceError("Azure Service credentials are not configured.")
 
     def _get_latest_blob(
-        self, report_path: str, blobs: list[BlobProperties], extension: str
+            self, report_path: str, blobs: list[BlobProperties], extension: t.Optional[str] = None
     ) -> t.Optional[BlobProperties]:
+        default_extensions = [AzureBlobExtension.csv.value, AzureBlobExtension.gzip.value]
         latest_blob = None
         for blob in blobs:
-            if not blob.name.endswith(extension):
-                continue
+            if extension:
+                if not blob.name.endswith(extension):
+                    continue
+            else:
+                if not any(blob.name.endswith(ext) for ext in default_extensions):
+                    continue
 
-            if report_path in blob.name and not latest_blob:
-                latest_blob = blob
-            elif report_path in blob.name and blob.last_modified > latest_blob.last_modified:
-                latest_blob = blob
+            if report_path in blob.name:
+                if not latest_blob or blob.last_modified > latest_blob.last_modified:
+                    latest_blob = blob
         return latest_blob
 
     def _get_latest_blob_for_path(
-        self,
-        report_path: str,
-        container_name: str,
-        extension: str,
+            self,
+            report_path: str,
+            container_name: str,
+            extension: t.Optional[str] = None,
     ) -> BlobProperties:
         """Get the latest file with the specified extension from given storage account container."""
 
@@ -120,10 +124,7 @@ class AzureService:
 
         latest_report = self._get_latest_blob(report_path, blobs, extension)
         if not latest_report:
-            message = (
-                f"No file with extension '{extension}' found in container "
-                f"'{container_name}' for path '{report_path}'."
-            )
+            message = f"No file found in container " f"'{container_name}' for path '{report_path}'."
             raise AzureCostReportNotFound(message)
 
         return latest_report
@@ -158,9 +159,7 @@ class AzureService:
 
         return report
 
-    def get_latest_cost_export_for_path(
-        self, report_path: str, container_name: str, compression: str
-    ) -> BlobProperties:
+    def get_latest_cost_export_for_path(self, report_path: str, container_name: str) -> BlobProperties:
         """
         Get the latest cost export for a given path and container based on the compression type.
 
@@ -176,22 +175,18 @@ class AzureService:
             ValueError: If the compression type is not 'gzip' or 'csv'.
             AzureCostReportNotFound: If no blob is found for the given path and container.
         """
-        valid_compressions = [AzureBlobExtension.gzip.value, AzureBlobExtension.csv.value]
-        if compression not in valid_compressions:
-            raise ValueError(f"Invalid compression type: {compression}. Expected one of: {valid_compressions}.")
-
-        return self._get_latest_blob_for_path(report_path, container_name, compression)
+        return self._get_latest_blob_for_path(report_path, container_name)
 
     def get_latest_manifest_for_path(self, report_path: str, container_name: str) -> BlobProperties:
         return self._get_latest_blob_for_path(report_path, container_name, AzureBlobExtension.manifest.value)
 
     def download_file(
-        self,
-        key: str,
-        container_name: str,
-        destination: str = None,
-        suffix: str = AzureBlobExtension.csv.value,
-        ingress_reports: list[str] = None,
+            self,
+            key: str,
+            container_name: str,
+            destination: str = None,
+            suffix: str = AzureBlobExtension.csv.value,
+            ingress_reports: list[str] = None,
     ) -> str:
         """
         Download the file from a given storage container. Supports both CSV and GZIP formats.

--- a/koku/masu/test/external/downloader/azure/test_azure_report_downloader.py
+++ b/koku/masu/test/external/downloader/azure/test_azure_report_downloader.py
@@ -226,7 +226,7 @@ class AzureReportDownloaderTest(MasuTestCase):
         manifest, _ = self.ingress_downloader._get_manifest(self.mock_data.test_date)
 
         self.assertEqual(manifest.get("reportKeys"), [self.mock_data.ingress_report])
-        self.assertEqual(manifest.get("Compression"), AzureBlobExtension.csv.value)
+        self.assertEqual(manifest.get("Compression"), None)
         self.assertEqual(manifest.get("billingPeriod").get("start"), expected_start)
         self.assertEqual(manifest.get("billingPeriod").get("end"), expected_end)
 
@@ -249,7 +249,7 @@ class AzureReportDownloaderTest(MasuTestCase):
 
         self.assertEqual(manifest.get("assemblyId"), self.mock_data.export_uuid)
         self.assertEqual(manifest.get("reportKeys"), [self.mock_data.export_file])
-        self.assertEqual(manifest.get("Compression"), AzureBlobExtension.csv.value)
+        self.assertEqual(manifest.get("Compression"), None)
         self.assertEqual(manifest.get("billingPeriod").get("start"), expected_start)
         self.assertEqual(manifest.get("billingPeriod").get("end"), expected_end)
 

--- a/koku/masu/test/external/downloader/azure/test_azure_services.py
+++ b/koku/masu/test/external/downloader/azure/test_azure_services.py
@@ -675,3 +675,18 @@ class AzureServiceTest(MasuTestCase):
         self.assertTrue(result.endswith(".gz"))
         mock_cloud_storage_account.get_blob_client.assert_called_with("fake_container", "fake_key.csv.gz")
         mock_blob_client.download_blob.assert_called_once()
+
+    def test_get_latest_blob_no_extension_invalid_files(self):
+        """Test that blobs with invalid extensions are ignored when no extension is specified."""
+        report_path = "/container/report/path"
+        blobs = (
+            FakeBlob(f"{report_path}/file01.csv", datetime(2022, 12, 16)),
+            FakeBlob(f"{report_path}/file02.txt", datetime(2022, 12, 17)),  # Invalid extension
+            FakeBlob(f"{report_path}/file03.log", datetime(2022, 12, 18)),  # Invalid extension
+            FakeBlob(f"{report_path}/file04.csv.gz", datetime(2022, 12, 19)),  # Valid extension
+        )
+        azure_service = self.get_mock_client()
+        latest_blob = azure_service._get_latest_blob(f"{report_path}", blobs, None)
+
+        # The latest valid blob is file04.csv.gz
+        self.assertEqual(latest_blob.name, f"{report_path}/file04.csv.gz")

--- a/koku/masu/test/external/downloader/azure/test_azure_services.py
+++ b/koku/masu/test/external/downloader/azure/test_azure_services.py
@@ -508,10 +508,8 @@ class AzureServiceTest(MasuTestCase):
         self.assertIn("Azure Service credentials are not configured.", str(context.exception))
 
     @patch("masu.external.downloader.azure.azure_service.AzureClientFactory")
-    @patch.object(AzureService, "_get_latest_blob_for_path")
-    def test_get_latest_cost_export_for_path_invalid_compression(self, mock_get_latest_blob, mock_factory):
+    def test_get_latest_cost_export_for_path_invalid_compression(self, mock_factory):
         """Test when an invalid compression type is provided and ValueError is raised."""
-        mock_get_latest_blob.return_value = None
         mock_factory.return_value.credentials = Mock()
 
         service = AzureService(

--- a/koku/masu/test/external/downloader/azure/test_azure_services.py
+++ b/koku/masu/test/external/downloader/azure/test_azure_services.py
@@ -463,7 +463,6 @@ class AzureServiceTest(MasuTestCase):
         """
         report_path = "/container/report/path"
         blobs = (
-            FakeBlob(f"{report_path}/_manifest.json", datetime(2022, 12, 18)),
             FakeBlob(f"{report_path}/file01.csv", datetime(2022, 12, 16)),
             FakeBlob(f"{report_path}/file02.csv", datetime(2022, 12, 15)),
             FakeBlob("some/other/path/file01.csv", datetime(2022, 12, 1)),
@@ -636,18 +635,3 @@ class AzureServiceTest(MasuTestCase):
         self.assertTrue(result.endswith(".gz"))
         mock_cloud_storage_account.get_blob_client.assert_called_with("fake_container", "fake_key.csv.gz")
         mock_blob_client.download_blob.assert_called_once()
-
-    def test_get_latest_blob_no_extension_invalid_files(self):
-        """Test that blobs with invalid extensions are ignored when no extension is specified."""
-        report_path = "/container/report/path"
-        blobs = (
-            FakeBlob(f"{report_path}/file01.csv", datetime(2022, 12, 16)),
-            FakeBlob(f"{report_path}/file02.txt", datetime(2022, 12, 17)),  # Invalid extension
-            FakeBlob(f"{report_path}/file03.log", datetime(2022, 12, 18)),  # Invalid extension
-            FakeBlob(f"{report_path}/file04.csv.gz", datetime(2022, 12, 19)),  # Valid extension
-        )
-        azure_service = self.get_mock_client()
-        latest_blob = azure_service._get_latest_blob(f"{report_path}", blobs, None)
-
-        # The latest valid blob is file04.csv.gz
-        self.assertEqual(latest_blob.name, f"{report_path}/file04.csv.gz")

--- a/koku/masu/test/external/downloader/azure/test_azure_services.py
+++ b/koku/masu/test/external/downloader/azure/test_azure_services.py
@@ -210,7 +210,7 @@ class AzureServiceTest(MasuTestCase):
         type(mock_blob).name = name_attr  # kludge to set name attribute on Mock
 
         svc = self.get_mock_client(blob_list=[mock_blob])
-        cost_export = svc.get_latest_cost_export_for_path(report_path, self.container_name, ".csv.gz")
+        cost_export = svc.get_latest_cost_export_for_path(report_path, self.container_name)
         self.assertEqual(cost_export.last_modified.date(), self.current_date_time.date())
 
     def test_get_latest_cost_export_for_path_missing(self):
@@ -218,7 +218,7 @@ class AzureServiceTest(MasuTestCase):
         report_path = FAKE.word()
         svc = self.get_mock_client()
         with self.assertRaises(AzureCostReportNotFound):
-            svc.get_latest_cost_export_for_path(report_path, self.container_name, ".csv.gz")
+            svc.get_latest_cost_export_for_path(report_path, self.container_name)
 
     def test_describe_cost_management_exports(self):
         """Test that cost management exports are returned for the account."""
@@ -259,7 +259,7 @@ class AzureServiceTest(MasuTestCase):
         svc = self.get_mock_client(blob_list=[mock_blob])
         svc._cloud_storage_account.get_container_client.side_effect = throw_azure_http_error
         with self.assertRaises(AzureCostReportNotFound):
-            svc.get_latest_cost_export_for_path(report_path, self.container_name, ".csv.gz")
+            svc.get_latest_cost_export_for_path(report_path, self.container_name)
 
     def test_get_latest_cost_export_http_error_403(self):
         """Test that the latest cost export catches the error for Azure HttpError 403."""
@@ -272,7 +272,7 @@ class AzureServiceTest(MasuTestCase):
         svc = self.get_mock_client(blob_list=[mock_blob])
         svc._cloud_storage_account.get_container_client.side_effect = throw_azure_http_error_403
         with self.assertRaises(AzureCostReportNotFound):
-            svc.get_latest_cost_export_for_path(report_path, self.container_name, ".csv.gz")
+            svc.get_latest_cost_export_for_path(report_path, self.container_name)
 
     def test_get_latest_cost_export_no_container(self):
         """Test that the latest cost export catches the error for no container."""
@@ -285,7 +285,7 @@ class AzureServiceTest(MasuTestCase):
 
         svc = self.get_mock_client(blob_list=[mock_blob])
         with self.assertRaises(AzureCostReportNotFound):
-            svc.get_latest_cost_export_for_path(report_path, container_name, ".csv.gz")
+            svc.get_latest_cost_export_for_path(report_path, container_name)
 
     def test_get_latest_manifest_for_path(self):
         """Given a list of blobs with multiple manifests, ensure the latest one is returned"""
@@ -422,9 +422,7 @@ class AzureServiceTest(MasuTestCase):
             service = AzureService(
                 self.tenant_id, self.client_id, self.client_secret, self.resource_group_name, self.storage_account_name
             )
-            service.get_latest_cost_export_for_path(
-                report_path=FAKE.word(), container_name=FAKE.word(), compression=".csv.gz"
-            )
+            service.get_latest_cost_export_for_path(report_path=FAKE.word(), container_name=FAKE.word())
 
     def test_describe_cost_management_exports_with_scope_and_name(self):
         """Test that cost management exports using scope and name are returned for the account."""
@@ -487,7 +485,7 @@ class AzureServiceTest(MasuTestCase):
         svc = self.get_mock_client(blob_list=[mock_blob])
         svc._cloud_storage_account.get_container_client.side_effect = ResourceNotFoundError("Oops!")
         with self.assertRaises(AzureCostReportNotFound):
-            svc.get_latest_cost_export_for_path(report_path, self.container_name, ".csv.gz")
+            svc.get_latest_cost_export_for_path(report_path, self.container_name)
 
     @patch("masu.external.downloader.azure.azure_service.AzureClientFactory")
     def test_azure_service_missing_credentials(self, mock_factory):
@@ -506,25 +504,6 @@ class AzureServiceTest(MasuTestCase):
             )
 
         self.assertIn("Azure Service credentials are not configured.", str(context.exception))
-
-    @patch("masu.external.downloader.azure.azure_service.AzureClientFactory")
-    def test_get_latest_cost_export_for_path_invalid_compression(self, mock_factory):
-        """Test when an invalid compression type is provided and ValueError is raised."""
-        mock_factory.return_value.credentials = Mock()
-
-        service = AzureService(
-            tenant_id="fake_tenant_id",
-            client_id="fake_client_id",
-            client_secret="fake_client_secret",
-            resource_group_name="fake_resource_group",
-            storage_account_name="fake_storage_account",
-            subscription_id="fake_subscription_id",
-        )
-
-        with self.assertRaises(ValueError) as context:
-            service.get_latest_cost_export_for_path("fake_report_path", "fake_container_name", "invalid_compression")
-
-        self.assertIn("Invalid compression type", str(context.exception))
 
     @patch("masu.external.downloader.azure.azure_service.AzureService._list_blobs")
     @patch("masu.external.downloader.azure.azure_service.AzureClientFactory")
@@ -624,24 +603,6 @@ class AzureServiceTest(MasuTestCase):
             service.download_file("fake_key.csv", "fake_container")
 
         self.assertIn("Failed to download cost export", str(context.exception))
-
-    @patch("masu.external.downloader.azure.azure_service.AzureClientFactory")
-    def test_invalid_compression_type(self, mock_factory):
-        """Test that an invalid compression type raises an exception."""
-
-        service = AzureService(
-            tenant_id="fake_tenant_id",
-            client_id="fake_client_id",
-            client_secret="fake_client_secret",
-            resource_group_name="fake_resource_group",
-            storage_account_name="fake_storage_account",
-            subscription_id="fake_subscription_id",
-        )
-
-        with self.assertRaises(ValueError) as context:
-            service.get_latest_cost_export_for_path("fake_report_path", "fake_container_name", "invalid_compression")
-
-        self.assertIn("Invalid compression type", str(context.exception))
 
     @patch("masu.external.downloader.azure.azure_service.AzureService._list_blobs")
     @patch("masu.external.downloader.azure.azure_service.AzureClientFactory")


### PR DESCRIPTION
## Jira Ticket

[COST-5627](https://issues.redhat.com/browse/COST-5627)

## Description

This change fixes the issue of a hardcoded file extension (csv) when no manifest is present. Now, the program dynamically identifies and selects the latest file with supported extensions, such as `.csv` or `.gz`.

## Testing

1. Checkout Branch
2. Restart Koku
3. Ingest `csv` and `csv.gz` data with and without a `mainfest.json` file
4. Run some Azure unit tests, like `tox -e py311 -- masu.test.external.downloader.azure`

## Release Notes
- [ ] Fix Azure default extension issue

```markdown
* [COST-5627](https://issues.redhat.com/browse/COST-5627) Fix Azure default extension issue
```
