### PR TITLE
[COST-5738] Exclude usage rows from virtualization table

### DIFF
--- a/koku/masu/database/sql/openshift/reporting_ocp_vm_summary_p.sql
+++ b/koku/masu/database/sql/openshift/reporting_ocp_vm_summary_p.sql
@@ -91,6 +91,6 @@ WHERE usage_start >= {{start_date}}::date
         + COALESCE(cost_model_volume_cost, 0)
         + COALESCE(distributed_cost, 0)
         + COALESCE(infrastructure_raw_cost, 0)
-        + COALESCE(infrastructure_markup_cost, 0)) <> 0
+        + COALESCE(infrastructure_markup_cost, 0)) != 0
 GROUP BY cluster_alias, cluster_id, namespace, latest.node_name, vm_name, cost_model_rate_type, latest.labels
 ;

--- a/koku/masu/database/sql/openshift/reporting_ocp_vm_summary_p.sql
+++ b/koku/masu/database/sql/openshift/reporting_ocp_vm_summary_p.sql
@@ -85,5 +85,12 @@ WHERE usage_start >= {{start_date}}::date
     AND namespace IS DISTINCT FROM 'Platform unallocated'
     AND namespace IS DISTINCT FROM 'Network unattributed'
     AND namespace IS DISTINCT FROM 'Storage unattributed'
+    AND (
+        COALESCE(cost_model_cpu_cost, 0)
+        + COALESCE(cost_model_memory_cost, 0)
+        + COALESCE(cost_model_volume_cost, 0)
+        + COALESCE(distributed_cost, 0)
+        + COALESCE(infrastructure_raw_cost, 0)
+        + COALESCE(infrastructure_markup_cost, 0)) <> 0
 GROUP BY cluster_alias, cluster_id, namespace, latest.node_name, vm_name, cost_model_rate_type, latest.labels
 ;


### PR DESCRIPTION
## Jira Ticket

[COST-5738](https://issues.redhat.com/browse/COST-5738)

## Description

This change will exclude the usage only rows from the virtualization table. 

## Testing

```
ENV_FOR_DYNACONF=local DYNACONF_IQE_VAULT_LOADER_ENABLED=false DYNACONF_IQE_VAULT_IGNORE_PATH_ERRORS=True iqe tests plugin cost_management -k "test_api_ocp_virtual_machines_report_content" -raA --pdb
```
Result:
```
PASSED iqe_cost_management/tests/rest_api/v1/test__ocp_virtual_machines_reports.py::test_api_ocp_virtual_machines_report_content[current_month]
PASSED iqe_cost_management/tests/rest_api/v1/test__ocp_virtual_machines_reports.py::test_api_ocp_virtual_machines_report_content[previous_month]
============================================================================================================== 2 passed, 12888 deselected, 36 warnings in 40.06s ===============================================================================================================
```

## Release Notes
- [ ] proposed release note

```markdown
* [COST-5738](https://issues.redhat.com/browse/COST-5738) Exclude usage rows from virtualization table
```
