### PR TITLE
Remove unleash flag for disabling gcp resource matching

### DIFF
--- a/koku/masu/processor/__init__.py
+++ b/koku/masu/processor/__init__.py
@@ -69,17 +69,6 @@ def is_ocp_on_cloud_summary_disabled(account):  # pragma: no cover
     return res
 
 
-def is_gcp_resource_matching_disabled(account):  # pragma: no cover
-    """Disable GCP resource matching for OCP on GCP."""
-    account = convert_account(account)
-    context = {"schema": account}
-    res = UNLEASH_CLIENT.is_enabled("cost-management.backend.disable-gcp-resource-matching", context)
-    if res:
-        LOG.info(log_json(msg="GCP resource matching is disabled", context=context))
-
-    return res
-
-
 def is_customer_large(account):  # pragma: no cover
     """Flag the customer as large."""
     account = convert_account(account)

--- a/koku/masu/test/database/test_ocp_report_db_accessor.py
+++ b/koku/masu/test/database/test_ocp_report_db_accessor.py
@@ -517,20 +517,6 @@ class OCPReportDBAccessorTest(MasuTestCase):
             mock_trino.assert_called()
             self.assertIn(expected_log, logger.output)
 
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query")
-    def test_get_ocp_infrastructure_map_trino_gcp_with_disabled_resource_matching(self, mock_trino):
-        """Test that Trino is used to find matched resource names."""
-        start_date = self.dh.this_month_start.date()
-        end_date = self.dh.this_month_end.date()
-        expected_log = f"INFO:masu.util.gcp.common:GCP resource matching disabled for {self.schema}"
-        with patch("masu.util.gcp.common.is_gcp_resource_matching_disabled", return_value=True):
-            with self.assertLogs("masu", level="INFO") as logger:
-                self.accessor.get_ocp_infrastructure_map_trino(
-                    start_date, end_date, gcp_provider_uuid=self.gcp_provider_uuid
-                )
-                mock_trino.assert_called()
-                self.assertIn(expected_log, logger.output)
-
     @patch("masu.database.ocp_report_db_accessor.trino_table_exists")
     @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.get_projects_trino")
     @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query")

--- a/koku/masu/test/util/gcp/test_common.py
+++ b/koku/masu/test/util/gcp/test_common.py
@@ -284,4 +284,8 @@ class TestGCPUtils(MasuTestCase):
         with self.assertLogs("masu.util.gcp.common", level="INFO") as logger:
             result = utils.check_resource_level(uuid4())
             self.assertFalse(result)
-            self.assertIn(expected_log, logger.output[1])
+            log_seen = False
+            for log_message in logger.output:
+                if expected_log in log_message:
+                    log_seen = True
+            self.assertTrue(log_seen)


### PR DESCRIPTION
## Jira Ticket

## Description

This change will remove an unused unleash flag for disabling gcp resource matching. 

Notes:
- I was unable to find this flag in the unleash UI

## Release Notes
- [ ] proposed release note

```markdown
* Remove unleash flag for disabling gcp resource matching
```
