### PR TITLE
RHCLOUD-36497 | refactor: replace "sources" with "integrations" in the error messages

### DIFF
--- a/koku/api/provider/serializers.py
+++ b/koku/api/provider/serializers.py
@@ -358,7 +358,7 @@ class ProviderSerializer(serializers.ModelSerializer):
         if dup_queryset.count() != 0:
             message = (
                 "Cost management does not allow duplicate accounts. "
-                "A source already exists with these details. Edit source settings to configure a new source."
+                "An integration already exists with these details. Edit integration settings to configure a new integration."
             )
             LOG.warning(message)
             raise serializers.ValidationError(error_obj(ProviderErrors.DUPLICATE_AUTH, message))
@@ -419,7 +419,7 @@ class ProviderSerializer(serializers.ModelSerializer):
                 if dup_queryset.count() != 0:
                     message = (
                         "Cost management does not allow duplicate accounts. "
-                        "A source already exists with these details. Edit source settings to configure a new source."
+                        "An integration already exists with these details. Edit integration settings to configure a new integration."
                     )
                     LOG.warning(message)
                     raise serializers.ValidationError(error_obj(ProviderErrors.DUPLICATE_AUTH, message))

--- a/koku/api/provider/serializers.py
+++ b/koku/api/provider/serializers.py
@@ -358,7 +358,8 @@ class ProviderSerializer(serializers.ModelSerializer):
         if dup_queryset.count() != 0:
             message = (
                 "Cost management does not allow duplicate accounts. "
-                "An integration already exists with these details. Edit integration settings to configure a new integration."
+                "An integration already exists with these details. "
+                "Edit integration settings to configure a new integration."
             )
             LOG.warning(message)
             raise serializers.ValidationError(error_obj(ProviderErrors.DUPLICATE_AUTH, message))
@@ -419,7 +420,8 @@ class ProviderSerializer(serializers.ModelSerializer):
                 if dup_queryset.count() != 0:
                     message = (
                         "Cost management does not allow duplicate accounts. "
-                        "An integration already exists with these details. Edit integration settings to configure a new integration."
+                        "An integration already exists with these details. "
+                        "Edit integration settings to configure a new integration."
                     )
                     LOG.warning(message)
                     raise serializers.ValidationError(error_obj(ProviderErrors.DUPLICATE_AUTH, message))


### PR DESCRIPTION
## Jira Ticket

[RHCLOUD-36497](https://issues.redhat.com/browse/RHCLOUD-36497)

## Description

The UI team has spotted an error message that makes a reference to "sources" instead of integrations, which would confuse users and customers.

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Release Notes
- [ ] proposed release note

```markdown
* [RHCLOUD-36497](https://issues.redhat.com/browse/RHCLOUD-36497) Replace "sources" references with "integrations" in feedback messages
```
