### PR TITLE
[COST-5731] - Update OCP on AWS markup to use amortised

### DIFF
--- a/koku/masu/database/sql/openshift/all/reporting_ocpallcostlineitem_daily_summary_aws.sql
+++ b/koku/masu/database/sql/openshift/all/reporting_ocpallcostlineitem_daily_summary_aws.sql
@@ -56,7 +56,7 @@ SELECT 'AWS'::text AS source_type,
        max(aws.unit),
        --  OCP on ALL tables should use calculated_amortized_cost
        sum(calculated_amortized_cost) as unblended_cost,
-       sum(aws.markup_cost),
+       sum(aws.markup_cost_amortized),
        max(aws.currency_code),
        max(cost_category_id) as cost_category_id,
        cast(1 as decimal) as shared_projects,

--- a/koku/masu/database/sql/openshift/all/reporting_ocpallcostlineitem_project_daily_summary_aws.sql
+++ b/koku/masu/database/sql/openshift/all/reporting_ocpallcostlineitem_project_daily_summary_aws.sql
@@ -58,7 +58,7 @@ SELECT 'AWS' as source_type,
        max(unit) as unit,
       --  OCP on ALL tables should use calculated_amortized_cost
        sum(calculated_amortized_cost) as unblended_cost,
-       sum(project_markup_cost) as project_markup_cost,
+       sum(markup_cost_amortized) as project_markup_cost,
        sum(pod_cost) as pod_cost,
        max(currency_code) as currency_code,
        max(cost_category_id) as cost_category_id,

--- a/koku/masu/database/trino_sql/reporting_ocpawscostlineitem_daily_summary.sql
+++ b/koku/masu/database/trino_sql/reporting_ocpawscostlineitem_daily_summary.sql
@@ -1184,12 +1184,12 @@ SELECT pds.aws_uuid,
         ELSE calculated_amortized_cost / aws_uuid_count * cast({{markup}} as decimal(33,9))
     END as markup_cost_amortized,
     CASE WHEN resource_id_matched = TRUE AND data_source = 'Pod'
-        THEN ({{pod_column | sqlsafe}} / {{node_column | sqlsafe}}) * unblended_cost
-        ELSE unblended_cost / aws_uuid_count
+        THEN ({{pod_column | sqlsafe}} / {{node_column | sqlsafe}}) * calculated_amortized_cost
+        ELSE calculated_amortized_cost / aws_uuid_count
     END as pod_cost,
     CASE WHEN resource_id_matched = TRUE AND data_source = 'Pod'
-        THEN ({{pod_column | sqlsafe}} / {{node_column | sqlsafe}}) * unblended_cost * cast({{markup}} as decimal(24,9))
-        ELSE unblended_cost / aws_uuid_count * cast({{markup}} as decimal(24,9))
+        THEN ({{pod_column | sqlsafe}} / {{node_column | sqlsafe}}) * calculated_amortized_cost * cast({{markup}} as decimal(24,9))
+        ELSE calculated_amortized_cost / aws_uuid_count * cast({{markup}} as decimal(24,9))
     END as project_markup_cost,
     pds.pod_labels,
     CASE WHEN pds.pod_labels IS NOT NULL
@@ -1295,8 +1295,8 @@ SELECT
     max(savingsplan_effective_cost) * cast({{markup}} AS decimal(24,9)),
     max(calculated_amortized_cost),
     max(calculated_amortized_cost) * cast({{markup}} AS decimal(33,9)),
-    max(unblended_cost) AS pod_cost,
-    max(unblended_cost) * cast({{markup}} AS decimal(24,9)) AS project_markup_cost,
+    max(calculated_amortized_cost) AS pod_cost,
+    max(calculated_amortized_cost) * cast({{markup}} AS decimal(24,9)) AS project_markup_cost,
     max(ocp.pod_labels),
     cast(NULL AS varchar) AS tags,
     cast(NULL AS varchar) AS aws_cost_category,


### PR DESCRIPTION
## Jira Ticket

[COST-5731](https://issues.redhat.com/browse/COST-5731)

## Description

This change will update a few sql files for OCP on AWS to correctly use amortised cost for markup calculations

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Release Notes
- [ ] proposed release note

```markdown
* [COST-5731](https://issues.redhat.com/browse/COST-5731) Switch OCP on AWS markup to amortised
```
