### PR TITLE
Handle AWS iam alert

### DIFF
--- a/koku/masu/test/util/aws/test_common.py
+++ b/koku/masu/test/util/aws/test_common.py
@@ -930,8 +930,9 @@ class AwsArnTest(TestCase):
         """Assert error in account ID parsing from a badly-formed ARN."""
         mock_arn = self.fake.text()
         credentials = {"role_arn": mock_arn}
-        with self.assertRaises(SyntaxError):
+        with self.assertLogs("masu.util.aws", level="WARNING") as logger:
             utils.AwsArn(credentials)
+            self.assertTrue(any(f"Invalid ARN: {mock_arn}" in log for log in logger.output))
 
     def test_arn_and_external_id(self):
         """Assert that the AwsArn processes an ExternalId."""

--- a/koku/masu/util/aws/common.py
+++ b/koku/masu/util/aws/common.py
@@ -213,11 +213,11 @@ class AwsArn:
         if self.arn:
             match = self.arn_regex.match(self.arn)
 
-        if not match:
-            LOG.warning(f"Invalid ARN: {self.arn}")
+        if match:
+            for key, val in match.groupdict().items():
+                setattr(self, key, val)
 
-        for key, val in match.groupdict().items():
-            setattr(self, key, val)
+        LOG.warning(f"Invalid ARN: {self.arn}")
 
     def __repr__(self):
         """Return the ARN itself."""

--- a/koku/masu/util/aws/common.py
+++ b/koku/masu/util/aws/common.py
@@ -214,7 +214,7 @@ class AwsArn:
             match = self.arn_regex.match(self.arn)
 
         if not match:
-            raise SyntaxError(f"Invalid ARN: {self.arn}")
+            LOG.warning(f"Invalid ARN: {self.arn}")
 
         for key, val in match.groupdict().items():
             setattr(self, key, val)


### PR DESCRIPTION
## Jira Ticket

## Description

This change will switch from raising an alert to logging a warning message for an invalid AWS arn.

## Testing

1. Checkout Branch
2. Restart Koku
3. Create AWS provider with invalid ARN for example: `arn:aws:iam`
4. You should see the following log message `WARNING None 48 Unable to assume role with ARN arn:aws:iam.`
5. Doing this on main results in an exception raised.

## Release Notes
- [ ] proposed release note

```markdown
* Switch AWS iam roll alert to Warning
```
