### PR TITLE
[COST-5769] add v3.3.2 commits to operator versions

### DIFF
--- a/koku/masu/util/ocp/common.py
+++ b/koku/masu/util/ocp/common.py
@@ -36,6 +36,7 @@ class OCPReportTypes(Enum):
 
 
 OPERATOR_VERSIONS = {
+    "8e957a5b174639642809df0317b39593532d6fb7": "costmanagement-metrics-operator:3.3.2",
     "6b4d72a4a629527c1de086b416faf6d226fe587a": "costmanagement-metrics-operator:3.3.1",
     "8c10aa090b2be3d2aea7553ce2cb62e78844ce6f": "costmanagement-metrics-operator:3.3.0",
     "212f944b3b1d7cfbf6e48a63c4ed74bfe942bbe1": "costmanagement-metrics-operator:3.2.1",
@@ -54,6 +55,7 @@ OPERATOR_VERSIONS = {
     "084bca2e1c48caab18c237453c17ceef61747fe2": "costmanagement-metrics-operator:1.1.3",
     "6f10d07e3af3ea4f073d4ffda9019d8855f52e7f": "costmanagement-metrics-operator:1.1.0",
     "fd764dcd7e9b993025f3e05f7cd674bb32fad3be": "costmanagement-metrics-operator:1.0.0",
+    "1dd2f05c51daa7487ea53b1f3f4894316b1759e1": "koku-metrics-operator:v3.3.2",
     "b0731873d0c54aa1d016b8b3463b29c23c9e852c": "koku-metrics-operator:v3.3.1",
     "1650a9fa9f353efee534dde6030ece40e6a9a1ee": "koku-metrics-operator:v3.3.0",
     "631434d278be57cfedaa5ad0000cb3a3dfb69a76": "koku-metrics-operator:v3.2.1",


### PR DESCRIPTION
## Jira Ticket

[COST-5769](https://issues.redhat.com/browse/COST-5769)

## Description

This change will add version 3.3.2 operator commits to the OPERATOR_VERSIONS map.

## Release Notes
- [ ] proposed release note

```markdown
* [COST-5769](https://issues.redhat.com/browse/COST-5769) add v3.3.2 operator commits
```
