### PR TITLE
[COST-5565] - dont match empty resource ids

### DIFF
--- a/koku/masu/database/trino_sql/aws/openshift/managed_aws_openshift_daily.sql
+++ b/koku/masu/database/trino_sql/aws/openshift/managed_aws_openshift_daily.sql
@@ -96,6 +96,7 @@ cte_array_agg_nodes AS (
     SELECT DISTINCT resource_id
     FROM hive.{{schema | sqlsafe}}.openshift_pod_usage_line_items_daily
     WHERE source = {{ocp_source_uuid}}
+        AND resource_id != ''
         AND year = {{year}}
         AND month = {{month}}
         AND interval_start >= {{start_date}}
@@ -105,6 +106,8 @@ cte_array_agg_volumes AS (
     SELECT DISTINCT persistentvolume, csi_volume_handle
     FROM hive.{{schema | sqlsafe}}.openshift_storage_usage_line_items_daily
     WHERE source = {{ocp_source_uuid}}
+        AND persistentvolume != ''
+        AND csi_volume_handle != ''
         AND year = {{year}}
         AND month = {{month}}
         AND interval_start >= {{start_date}}


### PR DESCRIPTION
## Jira Ticket

[COST-5565](https://issues.redhat.com/browse/COST-5565)

## Description

This change will filter out OCP resources with an empty resource_id `''`

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Release Notes
- [ ] proposed release note

```markdown
* [COST-5565](https://issues.redhat.com/browse/COST-5565) Fix OCP/AWS managed table resource matching on `''`
```
