### PR TITLE
[COST-5565] - Fix bug in old tag matching logic

### DIFF
--- a/koku/masu/util/aws/common.py
+++ b/koku/masu/util/aws/common.py
@@ -901,7 +901,6 @@ def match_openshift_resources_and_labels(data_frame, cluster_topologies, matched
     data_frame["special_case_tag_matched"] = False
     tags = data_frame["resourcetags"]
     if not tags.eq("").all():
-        tags = tags.str.lower()
         LOG.info("Matching OpenShift on AWS by tags.")
         special_case_tag_matched = tags.str.contains(
             "|".join(["openshift_cluster", "openshift_project", "openshift_node"])

--- a/koku/masu/util/azure/common.py
+++ b/koku/masu/util/azure/common.py
@@ -171,7 +171,6 @@ def match_openshift_resources_and_labels(data_frame, cluster_topologies, matched
     data_frame["special_case_tag_matched"] = False
     tags = data_frame["tags"]
     if not tags.eq("").all():
-        tags = tags.str.lower()
         LOG.info("Matching OpenShift on Azure by tags.")
         special_case_tag_matched = tags.str.contains(
             "|".join(["openshift_cluster", "openshift_project", "openshift_node"])


### PR DESCRIPTION
## Jira Ticket

[COST-5565](https://issues.redhat.com/browse/COST-5565)

## Description

This change will remove the line to lower tag key/values in the cloud dataframe before trying to match them with OCP tags. Tag matching is case sensitive and setting tags to lower inadvertently prevents us matching.

## Testing

1. Checkout Branch
2. Restart Koku
3. Load ocp on cloud data with tag matching data (make sure to use upper case tags)
4. See data is matched by tag correctly

Checkout main and do the same:
see that we fail to match on tags because `app` != `APP`

## Release Notes
- [ ] proposed release note

```markdown
* [COST-5565](https://issues.redhat.com/browse/COST-5565) Fix old tag matching logic
```
