### PR TITLE
Add unleash flag to skip trino tag matched get logic

### DIFF
--- a/koku/masu/processor/__init__.py
+++ b/koku/masu/processor/__init__.py
@@ -70,13 +70,6 @@ def is_ocp_on_cloud_summary_disabled(account):  # pragma: no cover
     return res
 
 
-def is_tag_processing_disabled(account):  # pragma: no cover
-    """Flag the customer as tag processing disabled."""
-    account = convert_account(account)
-    context = {"schema": account}
-    return UNLEASH_CLIENT.is_enabled("cost-management.backend.is_tag_processing_disabled", context)
-
-
 def is_rate_limit_customer_large(account):  # pragma: no cover
     """Flag the customer as large and to be rate limited."""
     account = convert_account(account)
@@ -188,3 +181,10 @@ def is_customer_cost_model_large(account):  # pragma: no cover
     account = convert_account(account)
     context = {"schema": account}
     return UNLEASH_CLIENT.is_enabled("cost-management.backend.large-customer-cost-model", context)
+
+
+def is_tag_processing_disabled(account):  # pragma: no cover
+    """Flag the customer as tag processing disabled."""
+    account = convert_account(account)
+    context = {"schema": account}
+    return UNLEASH_CLIENT.is_enabled("cost-management.backend.is_tag_processing_disabled", context)

--- a/koku/masu/processor/__init__.py
+++ b/koku/masu/processor/__init__.py
@@ -70,11 +70,11 @@ def is_ocp_on_cloud_summary_disabled(account):  # pragma: no cover
     return res
 
 
-def is_rate_limit_customer_large(account):  # pragma: no cover
-    """Flag the customer as large and to be rate limited."""
+def is_customer_large(account):  # pragma: no cover
+    """Flag the customer as large."""
     account = convert_account(account)
     context = {"schema": account}
-    return UNLEASH_CLIENT.is_enabled("cost-management.backend.large-customer.rate-limit", context)
+    return UNLEASH_CLIENT.is_enabled("cost-management.backend.large-customer", context)
 
 
 def is_customer_penalty(account):  # pragma: no cover
@@ -84,7 +84,7 @@ def is_customer_penalty(account):  # pragma: no cover
     return UNLEASH_CLIENT.is_enabled("cost-management.backend.penalty-customer", context)
 
 
-def is_customer_large(account):  # pragma: no cover
+def is_rate_limit_customer_large(account):  # pragma: no cover
     """Flag the customer as large and to be rate limited."""
     account = convert_account(account)
     context = {"schema": account}

--- a/koku/masu/processor/__init__.py
+++ b/koku/masu/processor/__init__.py
@@ -70,11 +70,11 @@ def is_ocp_on_cloud_summary_disabled(account):  # pragma: no cover
     return res
 
 
-def is_customer_large(account):  # pragma: no cover
-    """Flag the customer as large."""
+def is_tag_processing_disabled(account):  # pragma: no cover
+    """Flag the customer as tag processing disabled."""
     account = convert_account(account)
     context = {"schema": account}
-    return UNLEASH_CLIENT.is_enabled("cost-management.backend.large-customer", context)
+    return UNLEASH_CLIENT.is_enabled("cost-management.backend.is_tag_processing_disabled", context)
 
 
 def is_customer_penalty(account):  # pragma: no cover
@@ -85,6 +85,13 @@ def is_customer_penalty(account):  # pragma: no cover
 
 
 def is_rate_limit_customer_large(account):  # pragma: no cover
+    """Flag the customer as large and to be rate limited."""
+    account = convert_account(account)
+    context = {"schema": account}
+    return UNLEASH_CLIENT.is_enabled("cost-management.backend.large-customer.rate-limit", context)
+
+
+def is_customer_large(account):  # pragma: no cover
     """Flag the customer as large and to be rate limited."""
     account = convert_account(account)
     context = {"schema": account}

--- a/koku/masu/processor/__init__.py
+++ b/koku/masu/processor/__init__.py
@@ -77,18 +77,18 @@ def is_tag_processing_disabled(account):  # pragma: no cover
     return UNLEASH_CLIENT.is_enabled("cost-management.backend.is_tag_processing_disabled", context)
 
 
-def is_customer_penalty(account):  # pragma: no cover
-    """Flag the customer as penalised."""
-    account = convert_account(account)
-    context = {"schema": account}
-    return UNLEASH_CLIENT.is_enabled("cost-management.backend.penalty-customer", context)
-
-
 def is_rate_limit_customer_large(account):  # pragma: no cover
     """Flag the customer as large and to be rate limited."""
     account = convert_account(account)
     context = {"schema": account}
     return UNLEASH_CLIENT.is_enabled("cost-management.backend.large-customer.rate-limit", context)
+
+
+def is_customer_penalty(account):  # pragma: no cover
+    """Flag the customer as penalised."""
+    account = convert_account(account)
+    context = {"schema": account}
+    return UNLEASH_CLIENT.is_enabled("cost-management.backend.penalty-customer", context)
 
 
 def is_customer_large(account):  # pragma: no cover

--- a/koku/masu/processor/parquet/ocp_cloud_parquet_report_processor.py
+++ b/koku/masu/processor/parquet/ocp_cloud_parquet_report_processor.py
@@ -26,6 +26,7 @@ from masu.database.azure_report_db_accessor import AzureReportDBAccessor
 from masu.database.gcp_report_db_accessor import GCPReportDBAccessor
 from masu.database.ocp_report_db_accessor import OCPReportDBAccessor
 from masu.database.report_manifest_db_accessor import ReportManifestDBAccessor
+from masu.processor import is_tag_processing_disabled
 from masu.processor.ocp.ocp_cloud_updater_base import OCPCloudUpdaterBase
 from masu.processor.parquet.parquet_report_processor import OPENSHIFT_REPORT_TYPE
 from masu.processor.parquet.parquet_report_processor import PARQUET_EXT
@@ -172,6 +173,10 @@ class OCPCloudParquetReportProcessor(ParquetReportProcessor):
                 matched_tags = self.db_accessor.get_openshift_on_cloud_matched_tags(self.bill_id)
             if not matched_tags and enabled_tags:
                 LOG.info(log_json(msg="matched tags not available via Postgres", context=ctx))
+                # This flag is specifically for disabling trino tag matching for specific customers.
+                if is_tag_processing_disabled(self.schema_name):
+                    LOG.info(log_json(msg="trino tag matching disabled for customer", context=ctx))
+                    return []
                 LOG.info(log_json(msg="getting matching tags from Trino", context=ctx))
                 matched_tags = self.db_accessor.get_openshift_on_cloud_matched_tags_trino(
                     self.provider_uuid,

--- a/koku/masu/test/processor/parquet/test_ocp_cloud_parquet_report_processor.py
+++ b/koku/masu/test/processor/parquet/test_ocp_cloud_parquet_report_processor.py
@@ -448,6 +448,17 @@ class TestOCPCloudParquetReportProcessor(MasuTestCase):
             self.report_processor.get_matched_tags([])
             mock_get_tags.assert_not_called()
 
+    @patch.object(AWSReportDBAccessor, "check_for_matching_enabled_keys", return_value=True)
+    @patch.object(OCPCloudParquetReportProcessor, "has_enabled_ocp_labels", return_value=True)
+    @patch.object(AWSReportDBAccessor, "get_openshift_on_cloud_matched_tags", return_value=None)
+    @patch("masu.processor.parquet.ocp_cloud_parquet_report_processor.is_tag_processing_disabled", return_value=True)
+    def test_get_matched_tags_trino_disabled(
+        self, mock_unleash, mock_pg_tags, mock_has_enabled, mock_matching_enabled
+    ):
+        """Test that we skip trino matched tag queries if disabled in unleash."""
+        result = self.report_processor.get_matched_tags([])
+        self.assertEqual(result, [])
+
     def test_instantiating_processor_without_manifest_id(self):
         """Assert that report_status exists and is None."""
         report_processor = OCPCloudParquetReportProcessor(


### PR DESCRIPTION
## Jira Ticket

## Description

This change will add an unleash flag to skip trino matched tag querying.

## Testing

1. Checkout Branch
2. Restart Koku
3. enable unleash flag to skip trino tag processing
4. Ingest OCP on Cloud data with tag matching
5. should see logs saying matched tag fetching was skipped

