### PR TITLE
fix ephemeral bucket names

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -5692,11 +5692,11 @@ parameters:
   required: true
   value: quay.io/redhat-services-prod/cost-mgmt-dev-tenant/koku
 - name: S3_BUCKET_NAME
-  value: koku-eph-s3
+  value: hccm-eph-s3
 - name: S3_ROS_BUCKET_NAME
-  value: ros-eph-s3
+  value: hccm-ros-eph-s3
 - name: S3_SUBS_BUCKET_NAME
-  value: subs-eph-s3
+  value: hccm-subs-eph-s3
 - name: AWS_SHARED_CREDENTIALS_FILE
   value: /etc/aws/aws-credentials
 - description: GCP Credentials Location

--- a/deploy/kustomize/base/base.yaml
+++ b/deploy/kustomize/base/base.yaml
@@ -276,11 +276,11 @@ parameters:
   required: true
   value: quay.io/redhat-services-prod/cost-mgmt-dev-tenant/koku
 - name: S3_BUCKET_NAME
-  value: koku-eph-s3
+  value: hccm-eph-s3
 - name: S3_ROS_BUCKET_NAME
-  value: ros-eph-s3
+  value: hccm-ros-eph-s3
 - name: S3_SUBS_BUCKET_NAME
-  value: subs-eph-s3
+  value: hccm-subs-eph-s3
 - name: AWS_SHARED_CREDENTIALS_FILE
   value: "/etc/aws/aws-credentials"
 - name: GOOGLE_APPLICATION_CREDENTIALS


### PR DESCRIPTION
## Description

In stage and prod, our bucket names follow the convention `hccm{-subs|-ros}-{env}-s3` whereas ephemeral does not. This PR aligns the ephemeral env with stage and prod.
