### PR TITLE
add celery task id chain

### DIFF
--- a/koku/koku/settings.py
+++ b/koku/koku/settings.py
@@ -26,10 +26,9 @@ from oci import config
 from oci.exceptions import ConfigFileNotFound
 
 from . import database
-from . import sentry
+from . import sentry  # noqa: F401
 from .configurator import CONFIGURATOR
 from .env import ENVIRONMENT
-
 
 # Database
 # https://docs.djangoproject.com/en/2.0/ref/settings/#databases
@@ -370,7 +369,9 @@ VERBOSE_FORMATTING = (
     "%(task_id)s %(task_parent_id)s %(task_root_id)s "
     "%(message)s"
 )
-SIMPLE_FORMATTING = "[%(asctime)s] %(levelname)s %(task_root_id)s %(process)d %(message)s"
+SIMPLE_FORMATTING = (
+    "[%(asctime)s] %(levelname)s %(task_root_id)s %(task_parent_id)s %(task_id)s %(process)d %(message)s"
+)
 
 LOG_DIRECTORY = ENVIRONMENT.get_value("LOG_DIRECTORY", default=BASE_DIR)
 DEFAULT_LOG_FILE = os.path.join(LOG_DIRECTORY, "app.log")


### PR DESCRIPTION
## Description

This change will add more celery-ids. 
Example:
```
koku-worker-1  | [2025-01-10 21:00:20,325] INFO 4d51dd73-847f-499e-a774-6889c781c26d None 4d51dd73-847f-499e-a774-6889c781c26d 35 {'message': 'checking for report updates' <<<< very beginning
koku-worker-1  | [2025-01-10 21:00:22,720] INFO 4d51dd73-847f-499e-a774-6889c781c26d 4d51dd73-847f-499e-a774-6889c781c26d 0ed8e696-eea4-482a-9a2e-25793ad1a099 35 {'message': 'downloading report' <<<<<< next in chain
koku-worker-1  | [2025-01-10 21:00:38,325] INFO 4d51dd73-847f-499e-a774-6889c781c26d 0ed8e696-eea4-482a-9a2e-25793ad1a099 af1e4b71-35e5-46da-8800-7c2b6cadb402 35 {'message': 'report to summarize <<<<<< next
```

## Testing

1. just look at logs 😄 

## Release Notes
- [x] proposed release note

```markdown
* add chain of celery task ids to logs
```
