### PR TITLE
Add missing where clause to temp table cte

### DIFF
--- a/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcpcostlineitem_daily_summary.sql
+++ b/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcpcostlineitem_daily_summary.sql
@@ -414,6 +414,7 @@ WITH cte_rankings AS (
     SELECT pds.gcp_uuid,
         count(*) as gcp_uuid_count
     FROM hive.{{schema | sqlsafe}}.reporting_ocpgcpcostlineitem_project_daily_summary_temp AS pds
+    WHERE pds.ocp_source = {{ocp_source_uuid}} AND year = {{year}} AND month = {{month}}
     GROUP BY gcp_uuid
 )
 SELECT pds.gcp_uuid,

--- a/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcpcostlineitem_daily_summary_resource_id.sql
+++ b/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcpcostlineitem_daily_summary_resource_id.sql
@@ -636,6 +636,7 @@ WITH cte_rankings AS (
     SELECT pds.gcp_uuid,
         count(*) as gcp_uuid_count
     FROM hive.{{schema | sqlsafe}}.reporting_ocpgcpcostlineitem_project_daily_summary_temp AS pds
+    WHERE pds.ocp_source = {{ocp_source_uuid}} AND year = {{year}} AND month = {{month}}
     GROUP BY gcp_uuid
 )
 SELECT pds.gcp_uuid,

--- a/koku/masu/database/trino_sql/reporting_ocpawscostlineitem_daily_summary.sql
+++ b/koku/masu/database/trino_sql/reporting_ocpawscostlineitem_daily_summary.sql
@@ -1135,6 +1135,7 @@ WITH cte_rankings AS (
     SELECT pds.aws_uuid,
         count(*) as aws_uuid_count
     FROM hive.{{schema | sqlsafe}}.reporting_ocpawscostlineitem_project_daily_summary_temp AS pds
+    WHERE pds.ocp_source = {{ocp_source_uuid}} AND year = {{year}} AND month = {{month}}
     GROUP BY aws_uuid
 )
 SELECT pds.aws_uuid,

--- a/koku/masu/database/trino_sql/reporting_ocpazurecostlineitem_daily_summary.sql
+++ b/koku/masu/database/trino_sql/reporting_ocpazurecostlineitem_daily_summary.sql
@@ -819,6 +819,7 @@ WITH cte_rankings AS (
     SELECT pds.azure_uuid,
         count(*) as azure_uuid_count
     FROM hive.{{schema | sqlsafe}}.reporting_ocpazurecostlineitem_project_daily_summary_temp AS pds
+    WHERE pds.ocp_source = {{ocp_source_uuid}} AND year = {{year}} AND month = {{month}}
     GROUP BY azure_uuid
 )
 SELECT pds.azure_uuid,


### PR DESCRIPTION
## Jira Ticket

[COST-####](https://issues.redhat.com/browse/COST-####)

## Description

This change will add a where clause to the CTE select from `reporting_ocpgcpcostlineitem_project_daily_summary_temp` since we delete from this table by ocp/year/month partitions.

Address the following error:
`TrinoExternalError(type=EXTERNAL, name=HIVE_PARTITION_DROPPED_DURING_QUERY, message="Partition no longer exists: ocp_source=000000-0000-00000-99b1-6eb9bb36fe20/year=2025/month=01"`

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Release Notes
- [ ] proposed release note

```markdown
* [COST-####](https://issues.redhat.com/browse/COST-####) Fix some things
```
