### PR TITLE
[COST-5820] Return Azure errors to UI

### DIFF
--- a/koku/providers/provider_errors.py
+++ b/koku/providers/provider_errors.py
@@ -101,11 +101,7 @@ class ProviderErrors:
     )
     AZURE_EXPIRED_CLIENT_SECRET_KEYS_MESSAGE = (
         "The provided client secret keys for this source are expired. "
-        "In Azure, refresh your client secret and try again."
-    )
-    AZURE_CLIENT_SECRET_INCORRECT_MESSAGE = (
-        "A problem has been detected with the Azure client secret for this source. "
-        "Refer to the Microsoft Azure troubleshooting guide in the cost management documentation for details."
+        "Visit the Azure portal to refresh the client secret keys for your application."
     )
     AZURE_INCORRECT_CLIENT_ID_MESSAGE = (
         "The client ID was entered incorrectly for this source. Edit your Azure source and verify the client ID."
@@ -125,11 +121,6 @@ class ProviderErrors:
         "The subscription ID was entered incorrectly for this source. "
         "Edit your Azure source and verify the subscription ID."
     )
-    AZURE_UNAUTHORIZED_MESSAGE = (
-        "Azure reported an authorization error. "
-        "In Azure, check the resource group, storage account, cost export scope, and service principal."
-    )
-    AZURE_GENERAL_CLIENT_ERROR_MESSAGE = "Azure client configuration error."
     OCI_BUCKET_MISSING_MESSAGE = (
         "Cost management requires an OCI bucket to store cost and usage reports. "
         "Edit your OCI source to include the name of your OCI bucket."

--- a/koku/sources/sources_error_message.py
+++ b/koku/sources/sources_error_message.py
@@ -21,7 +21,7 @@ class SourcesErrorMessage:
 
     def azure_client_errors(self, message):
         """Azure client error messages."""
-        scrubbed_message = str(message)
+        scrubbed_message = message
         if "AADSTS700016" in message:
             scrubbed_message = ProviderErrors.AZURE_INCORRECT_CLIENT_ID_MESSAGE
         if "AADSTS90002" in message:

--- a/koku/sources/sources_error_message.py
+++ b/koku/sources/sources_error_message.py
@@ -21,9 +21,7 @@ class SourcesErrorMessage:
 
     def azure_client_errors(self, message):
         """Azure client error messages."""
-        scrubbed_message = ProviderErrors.AZURE_GENERAL_CLIENT_ERROR_MESSAGE
-        if any(test in message for test in ["http error: 401", "Authentication failed", "(401) Unauthorized"]):
-            scrubbed_message = ProviderErrors.AZURE_CLIENT_SECRET_INCORRECT_MESSAGE
+        scrubbed_message = str(message)
         if "AADSTS700016" in message:
             scrubbed_message = ProviderErrors.AZURE_INCORRECT_CLIENT_ID_MESSAGE
         if "AADSTS90002" in message:
@@ -36,8 +34,6 @@ class SourcesErrorMessage:
             scrubbed_message = ProviderErrors.AZURE_INCORRECT_STORAGE_ACCOUNT_MESSAGE
         if any(test in message for test in ["SubscriptionNotFound", "InvalidSubscriptionId"]):
             scrubbed_message = ProviderErrors.AZURE_INCORRECT_SUBSCRIPTION_ID_MESSAGE
-        if any(test in message for test in ["RBACAccessDenied", "does not have authorization", "scope is invalid"]):
-            scrubbed_message = ProviderErrors.AZURE_UNAUTHORIZED_MESSAGE
         return scrubbed_message
 
     def aws_client_errors(self, message):

--- a/koku/sources/test/test_sources_error_message.py
+++ b/koku/sources/test/test_sources_error_message.py
@@ -51,24 +51,6 @@ class SourcesErrorMessageTest(TestCase):
         test_matrix = [
             {
                 "key": ProviderErrors.AZURE_CLIENT_ERROR,
-                "internal_message": ", AdalError: Get Token request returned http error: 401 and server response:",
-                "expected_message": ProviderErrors.AZURE_CLIENT_SECRET_INCORRECT_MESSAGE,
-            },
-            {
-                "key": ProviderErrors.AZURE_CLIENT_ERROR,
-                "internal_message": "Authentication failed",
-                "expected_message": ProviderErrors.AZURE_CLIENT_SECRET_INCORRECT_MESSAGE,
-            },
-            {
-                "key": ProviderErrors.AZURE_CLIENT_ERROR,
-                "internal_message": (
-                    "(401) Unauthorized. Request ID: cca1a5a4-4107-4e7a-b3b4-b88f31e6a674\n"
-                    "Code: 401\nMessage: Unauthorized. Request ID: cca1a5a4-4107-4e7a-b3b4-b88f31e6a674"
-                ),
-                "expected_message": ProviderErrors.AZURE_CLIENT_SECRET_INCORRECT_MESSAGE,
-            },
-            {
-                "key": ProviderErrors.AZURE_CLIENT_ERROR,
                 "internal_message": (
                     ", AdalError: Get Token request returned http error: 400 and server response:"
                     ' {"error":"invalid_request","error_description":"AADSTS90002: Tenant'
@@ -115,26 +97,6 @@ class SourcesErrorMessageTest(TestCase):
                     " could not be found."
                 ),
                 "expected_message": ProviderErrors.AZURE_INCORRECT_SUBSCRIPTION_ID_MESSAGE,
-            },
-            {
-                "key": ProviderErrors.AZURE_CLIENT_ERROR,
-                "internal_message": "Random azure error",
-                "expected_message": ProviderErrors.AZURE_GENERAL_CLIENT_ERROR_MESSAGE,
-            },
-            {
-                "key": ProviderErrors.AZURE_CLIENT_ERROR,
-                "internal_message": (
-                    "The client 'xxxxx' with object id 'xxxxx' does not have authorization to perform action "
-                    "'Microsoft.Storage/storageAccounts/listKeys/action' over scope "
-                    "'/subscriptions/xxxxx/resourceGroups/xxxxx/providers/Microsoft.Storage/storageAccounts/xxxxx' "
-                    "or the scope is invalid. If access was recently granted, please refresh your credentials."
-                ),
-                "expected_message": ProviderErrors.AZURE_UNAUTHORIZED_MESSAGE,
-            },
-            {
-                "key": ProviderErrors.AZURE_CLIENT_ERROR,
-                "internal_message": "'(RBACAccessDenied) The client does not have authorization to perform action.",
-                "expected_message": ProviderErrors.AZURE_UNAUTHORIZED_MESSAGE,
             },
         ]
         for test in test_matrix:


### PR DESCRIPTION
## Jira Ticket

[COST-5820](https://issues.redhat.com/browse/COST-5820)

## Description

This change allows returning some of the Azure client errors in their raw format to UI where necessary.

## Testing

1. smokes and unit tests should pass

## Release Notes
- [ ] Return raw Azure client errors to UI.

```markdown
* [COST-5820](https://issues.redhat.com/browse/COST-5820) Return raw Azure client errors to UI.
```
