### PR TITLE
Use local settings in ephemeral daily job to disable Ibutsu

### DIFF
--- a/smoke_test.sh
+++ b/smoke_test.sh
@@ -10,7 +10,7 @@ IQE_MARKER_EXPRESSION="cost_smoke"
 IQE_FILTER_EXPRESSION=""
 IQE_CJI_TIMEOUT="5h"
 IQE_PARALLEL_ENABLED="false"
-IQE_ENV_VARS="JOB_NAME=${JOB_NAME},BUILD_NUMBER=${BUILD_NUMBER}"
+IQE_ENV_VARS="JOB_NAME=${JOB_NAME},BUILD_NUMBER=${BUILD_NUMBER},IQE_TESTS_LOCAL_CONF_PATH=/iqe_venv/lib/python3.12/site-packages/iqe_cost_management/conf_ephemeral_daily_job"
 
 # Get bonfire helper scripts
 CICD_URL="https://raw.githubusercontent.com/RedHatInsights/cicd-tools/main"


### PR DESCRIPTION
## Jira Ticket

[COST-4724](https://issues.redhat.com/browse/COST-4724)

## Description

This change will temporarily disable Ibutsu in ephemeral daily job by overwriting the default iqe setting by settings.local.yaml -> thus hopefully prevent OOMkills of iqe pod

