### PR TITLE
[COST-5137] - Fix OCP-Azure-Managed sql + report_data masu endpoint

### DIFF
--- a/koku/masu/database/trino_sql/azure/openshift/populate_daily_summary/0_prepare_daily_summary_tables.sql
+++ b/koku/masu/database/trino_sql/azure/openshift/populate_daily_summary/0_prepare_daily_summary_tables.sql
@@ -114,7 +114,7 @@ CREATE TABLE IF NOT EXISTS hive.{{schema | sqlsafe}}.managed_azure_openshift_dai
 ;
 
 -- TODO: we may need a managed version of this table
-CREATE TABLE IF NOT EXISTS hive.{{schema | sqlsafe}}.azure_openshift_disk_capacities_temp
+CREATE TABLE IF NOT EXISTS hive.{{schema | sqlsafe}}.managed_azure_openshift_disk_capacities_temp
 (
     resource_id varchar,
     capacity integer,

--- a/koku/masu/management/commands/migrate_trino_tables.py
+++ b/koku/masu/management/commands/migrate_trino_tables.py
@@ -69,7 +69,11 @@ MANAGED_TABLES = {
     "azure_openshift_disk_capacities_temp",
     "aws_openshift_disk_capacities_temp",
     "managed_aws_openshift_daily",
-    "managed_azure_openshift_daily",
+    "managed_azure_openshift_daily_temp",
+    "managed_azure_openshift_disk_capacities_temp",
+    "managed_azure_uuid_temp",
+    "managed_reporting_ocpazurecostlineitem_project_daily_summary",
+    "managed_reporting_ocpazurecostlineitem_project_daily_summary_temp",
     "managed_gcp_openshift_daily",
 }
 
@@ -90,7 +94,10 @@ manage_table_mapping = {
     "azure_openshift_disk_capacities_temp": "ocp_source",
     "aws_openshift_disk_capacities_temp": "ocp_source",
     "managed_aws_openshift_daily": "ocp_source",
-    "managed_azure_openshift_daily": "ocp_source",
+    "managed_azure_openshift_daily_temp": "ocp_source",
+    "managed_azure_openshift_disk_capacities_temp": "ocp_source",
+    "managed_reporting_ocpazurecostlineitem_project_daily_summary": "ocp_source",
+    "managed_reporting_ocpazurecostlineitem_project_daily_summary_temp": "ocp_source",
     "managed_gcp_openshift_daily": "ocp_source",
 }
 

--- a/koku/masu/test/api/test_report_data.py
+++ b/koku/masu/test/api/test_report_data.py
@@ -68,6 +68,25 @@ class ReportDataTests(TestCase):
         )
 
     @patch("koku.middleware.MASU", return_value=True)
+    @patch("masu.api.report_data.process_openshift_on_cloud_trino")
+    @patch("masu.api.report_data.is_managed_ocp_cloud_summary_enabled", return_value=True)
+    def test_get_report_data_w_managed(self, mock_unleash, mock_ocp_update, _):
+        """Test the GET report_data endpoint."""
+        params = {
+            "schema": self.schema_name,
+            "start_date": self.start_date,
+            "provider_uuid": self.provider_uuid,
+        }
+        expected_key = "Report Data Task IDs"
+
+        response = self.client.get(reverse("report_data"), params)
+        body = response.json()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(expected_key, body)
+        mock_ocp_update.s.assert_called()
+
+    @patch("koku.middleware.MASU", return_value=True)
     @patch("masu.api.report_data.update_summary_tables")
     def test_get_report_data_sent_to_OCP_queue(self, mock_update, _):
         """Test the GET report_data endpoint."""

--- a/koku/masu/test/api/test_report_data.py
+++ b/koku/masu/test/api/test_report_data.py
@@ -69,8 +69,9 @@ class ReportDataTests(TestCase):
 
     @patch("koku.middleware.MASU", return_value=True)
     @patch("masu.api.report_data.process_openshift_on_cloud_trino")
+    @patch("masu.api.report_data.update_summary_tables")
     @patch("masu.api.report_data.is_managed_ocp_cloud_summary_enabled", return_value=True)
-    def test_get_report_data_w_managed(self, mock_unleash, mock_ocp_update, _):
+    def test_get_report_data_w_managed(self, mock_unleash, mock_ocp_update, mock_update, _):
         """Test the GET report_data endpoint."""
         params = {
             "schema": self.schema_name,


### PR DESCRIPTION
## Jira Ticket

[COST-5137](https://issues.redhat.com/browse/COST-5137)

## Description

This PR has the following changes:

1. Adds a new managed table for `managed_azure_openshift_disk_capacities_temp` instead of sharing `azure_openshift_disk_capacities_temp` with the non-managed flow (They squash each other a little)
2. Adds some missing SQL logic to handle correctly associating disk capacity line items in the `managed_azure_openshift_disk_capacities_temp` table
3. Adds the missing `process_openshift_on_cloud_trino` call to the report_data (summary) endpoint so this endpoint continue to function like it used too. Running both cloud and ocp on cloud managed summary tasks. 

## Testing

1. Checkout Branch
2. Enable managed table unleash flags
3. Make load/run IQE smoke tests
4. Everything should ingest correctly.

## Release Notes
- [ ] proposed release note

```markdown
* [COST-5137](https://issues.redhat.com/browse/COST-5137) Fix missing managed table improvements.
```
