### PR TITLE
improve sql filtering logic on the masu trino endpoint

### DIFF
--- a/koku/masu/api/trino.py
+++ b/koku/masu/api/trino.py
@@ -43,8 +43,8 @@ def trino_query(request):
         lowered_query = set(query.lower().split(" "))
         dissallowed_keywords = {"delete", "insert", "update", "alter", "create", "drop", "grant"}
 
-        if keywords := list(dissallowed_keywords.intersection(lowered_query)):
-            errmsg = f"This endpoint does not allow a {keywords[0]} operation to be performed."
+        if keywords := dissallowed_keywords.intersection(lowered_query):
+            errmsg = f"This endpoint does not allow a {keywords.pop()} operation to be performed."
             return Response({"Error": errmsg}, status=status.HTTP_400_BAD_REQUEST)
 
         msg = f"Running Trino query: {query}"

--- a/koku/masu/api/trino.py
+++ b/koku/masu/api/trino.py
@@ -43,8 +43,8 @@ def trino_query(request):
         lowered_query = set(query.lower().split(" "))
         dissallowed_keywords = {"delete", "insert", "update", "alter", "create", "drop", "grant"}
 
-        if keywords := dissallowed_keywords.intersection(lowered_query):
-            errmsg = f"This endpoint does not allow a {keywords} operation to be performed."
+        if keywords := list(dissallowed_keywords.intersection(lowered_query)):
+            errmsg = f"This endpoint does not allow a {keywords[0]} operation to be performed."
             return Response({"Error": errmsg}, status=status.HTTP_400_BAD_REQUEST)
 
         msg = f"Running Trino query: {query}"

--- a/koku/masu/test/api/test_trino.py
+++ b/koku/masu/test/api/test_trino.py
@@ -19,15 +19,6 @@ class TrinoQueryTest(MasuTestCase):
 
     @patch("koku.middleware.MASU", return_value=True)
     @patch("masu.api.trino.trino")
-    def test_trino_query(self, mock_trino, _):
-        """Test the GET trino/query endpoint."""
-        data = {"query": "SELECT 1", "schema": "org1234567"}
-
-        response = self.client.post(reverse("trino_query"), data=data)
-        self.assertEqual(response.status_code, 200)
-
-    @patch("koku.middleware.MASU", return_value=True)
-    @patch("masu.api.trino.trino")
     def test_trino_query_no_query(self, mock_trino, _):
         """Test the GET trino/query endpoint with no query."""
         data = {"schema": "org1234567"}
@@ -71,6 +62,7 @@ class TrinoQueryTest(MasuTestCase):
             "WITH cte AS (SELECT * FROM gcp_line_items) SELECT * FROM cte",
             "SHOW TABLES",
             "DESCRIBE openshift_storage_usage_line_items",
+            "SELECT 1",
         ]
 
         for query in test_queries:

--- a/koku/masu/test/api/test_trino.py
+++ b/koku/masu/test/api/test_trino.py
@@ -9,7 +9,6 @@ from urllib.parse import urlencode
 
 from django.test.utils import override_settings
 from django.urls import reverse
-from rest_framework import status
 
 from masu.test import MasuTestCase
 
@@ -78,7 +77,6 @@ class TrinoQueryTest(MasuTestCase):
             with self.subTest(params=query):
                 data = {"query": query, "schema": "org1234567"}
                 response = self.client.post(reverse("trino_query"), data=data)
-                assert response.status_code != status.HTTP_400_BAD_REQUEST
                 self.assertEqual(response.status_code, 200)
 
 


### PR DESCRIPTION

## Description

This change uses sqlparse to improve SQL filtering logic. This should prevent false positives related disallowed keywords on queries like this one: 

`SELECT count(DISTINCT json_extract_scalar(json_parse(persistentvolumeclaim_labels), '$.kubevirt_io_created_by')) FROM openshift_storage_usage_line_items`

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit trino-query endpoint with a POST request
     ```
      http://127.0.0.1:5042/api/cost-management/v1/trino/query/
      ```
    1. You should get 400 response on operations for disallowed keywords, otherwise request should succeed with a 200 response


## Release Notes
- [ ] improve sql filtering logic on the masu trino endpoint to prevent false positives

