### PR TITLE
[COST-5432] - Add RI to rhel metering sql

### DIFF
--- a/koku/subs/trino_sql/aws/subs_row_count.sql
+++ b/koku/subs/trino_sql/aws/subs_row_count.sql
@@ -6,7 +6,7 @@ SELECT count(*)
       AND year = {{ year }}
       AND month = {{ month }}
       AND lineitem_productcode = 'AmazonEC2'
-      AND lineitem_lineitemtype IN ('Usage', 'SavingsPlanCoveredUsage')
+      AND lineitem_lineitemtype IN ('Usage', 'SavingsPlanCoveredUsage', 'DiscountedUsage')
       AND product_vcpu != ''
       AND strpos(lower(resourcetags), 'com_redhat_rhel') > 0
       AND (


### PR DESCRIPTION
## Jira Ticket

[COST-5432](https://issues.redhat.com/browse/COST-5432)

## Description

This change will add Discounted Usage line items into rhel metering SQL to catch RI's 

## Testing

1. Checkout Branch
2. Restart Koku
3. Ingest rhel metering data that includes reserved instances (this can be done using nise: https://github.com/project-koku/nise/pull/538)
4. Check minio for the subs file and verify DiscountedUsage line items are present.

## Release Notes
- [ ] proposed release note

```markdown
* [COST-5432](https://issues.redhat.com/browse/COST-5432) Add RI support for rhel metering
```
