### PR TITLE
[COST-5885] Add feature flag to control new source status retrieval method

### DIFF
--- a/koku/masu/processor/__init__.py
+++ b/koku/masu/processor/__init__.py
@@ -192,3 +192,10 @@ def is_tag_processing_disabled(account):  # pragma: no cover
     account = convert_account(account)
     context = {"schema": account}
     return UNLEASH_CLIENT.is_enabled("cost-management.backend.is_tag_processing_disabled", context)
+
+
+def is_status_api_update_enabled(account):  # pragma: no cover
+    """Flag to enable the new source status retrieval method."""
+    account = convert_account(account)
+    context = {"schema": account}
+    return UNLEASH_CLIENT.is_enabled("cost-management.backend.is_status_api_update_enabled", context)

--- a/koku/sources/api/source_status.py
+++ b/koku/sources/api/source_status.py
@@ -178,6 +178,6 @@ def source_status(request):
     if not is_status_api_update_enabled(source_status_obj.source.account_id):
         return Response(status=status.HTTP_204_NO_CONTENT)
 
-    status_data = source_status_obj.status()
+    source_status_obj.push_status()
 
-    return Response(data=status_data, status=status.HTTP_200_OK)
+    return Response(status=status.HTTP_204_NO_CONTENT)

--- a/koku/sources/api/source_status.py
+++ b/koku/sources/api/source_status.py
@@ -46,10 +46,6 @@ class SourceStatus:
             raise ObjectDoesNotExist(f"Source ID: {self.source_id} not ready for status")
         self.sources_client = SourcesHTTPClient(self.source.auth_header, source_id=source_id)
 
-    @property
-    def sources_response(self):
-        return self.sources_client.build_source_status(self.status())
-
     def _set_provider_active_status(self, active_status):
         """Set provider active status."""
         if self.source.koku_uuid:

--- a/koku/sources/test/api/test_source_status.py
+++ b/koku/sources/test/api/test_source_status.py
@@ -128,7 +128,7 @@ class SourcesStatusTest(IamTestCase):
     @patch("sources.api.source_status.SourcesProviderCoordinator.update_account")
     @patch("sources.api.source_status.SourcesHTTPClient.set_source_status")
     def test_push_status_first_gcp_table_discovery(
-        self, mock_set_source_status, mock_update_account, mock_create_account
+            self, mock_set_source_status, mock_update_account, mock_create_account
     ):
         """Test that push_status for initial discovery of GCP BigQuery table id."""
         mock_status = {"availability_status": "available", "availability_status_error": ""}
@@ -158,7 +158,7 @@ class SourcesStatusTest(IamTestCase):
     @patch("sources.api.source_status.SourcesProviderCoordinator.update_account")
     @patch("sources.api.source_status.SourcesHTTPClient.set_source_status")
     def test_push_status_first_gcp_table_discovery_update(
-        self, mock_set_source_status, mock_update_account, mock_create_account
+            self, mock_set_source_status, mock_update_account, mock_create_account
     ):
         """Test that push_status for initial discovery of GCP BigQuery table id after dataset was updated."""
         mock_status = {"availability_status": "available", "availability_status_error": ""}
@@ -279,7 +279,7 @@ class SourcesStatusTest(IamTestCase):
 
             status_obj = SourceStatus(test_source_id)
             with patch.object(
-                SourcesHTTPClient, "get_source_details", return_value={"name": "New Name", "source_type_id": "1"}
+                    SourcesHTTPClient, "get_source_details", return_value={"name": "New Name", "source_type_id": "1"}
             ):
                 status_obj.update_source_name()
                 mock_update_account.assert_called()
@@ -305,7 +305,7 @@ class SourcesStatusTest(IamTestCase):
 
             status_obj = SourceStatus(test_source_id)
             with patch.object(
-                SourcesHTTPClient, "get_source_details", return_value={"name": source_name, "source_type_id": "1"}
+                    SourcesHTTPClient, "get_source_details", return_value={"name": source_name, "source_type_id": "1"}
             ):
                 status_obj.update_source_name()
                 mock_update_account.assert_not_called()
@@ -668,29 +668,6 @@ class SourcesStatusTest(IamTestCase):
                 expected = f"INFO:sources.api.source_status:No provider found for Source ID: {source_id}"
                 self.assertIn(expected, logger.output)
 
-    def test_only_post_allowed(self):
-        """Test that only POST method is allowed on the source-status endpoint."""
-        url = reverse("source-status")
-        client = APIClient()
-
-        source = Sources.objects.create(
-            source_id=1,
-            name="Test Source",
-            source_type=Provider.PROVIDER_AWS,
-            authentication={"credentials": {"role_arn": "fake-iam"}},
-            billing_source={"data_source": {"bucket": "my-bucket"}},
-            offset=1,
-        )
-
-        payload = {"source_id": source.source_id}
-
-        response = client.post(url, data=payload, format="json", **self.headers)
-        self.assertIn(response.status_code, [status.HTTP_204_NO_CONTENT, status.HTTP_200_OK])
-
-        for method in ["get", "put", "patch", "delete"]:
-            response = getattr(client, method)(url, data=payload, format="json", **self.headers)
-            self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
-
     def test_source_status_push_status_called(self):
         """Test that push_status() is called when the feature flag is enabled."""
         url = reverse("source-status")
@@ -708,7 +685,7 @@ class SourcesStatusTest(IamTestCase):
         payload = {"source_id": source.source_id}
 
         with patch("sources.api.source_status.SourceStatus.push_status") as mock_push_status, patch(
-            "sources.api.source_status.is_status_api_update_enabled", return_value=True
+                "sources.api.source_status.is_status_api_update_enabled", return_value=True
         ):
             client.post(url, data=payload, format="json", **self.headers)
             mock_push_status.assert_called_once()

--- a/koku/sources/test/api/test_source_status.py
+++ b/koku/sources/test/api/test_source_status.py
@@ -636,48 +636,6 @@ class SourcesStatusTest(IamTestCase):
                 expected = f"INFO:sources.api.source_status:No provider found for Source ID: {source_id}"
                 self.assertIn(expected, logger.output)
 
-    def test_source_status_push_status_called(self):
-        """Test that push_status() is called when the feature flag is enabled."""
-        url = reverse("source-status")
-        client = APIClient()
-
-        source = Sources.objects.create(
-            source_id=1,
-            name="Test Source",
-            source_type=Provider.PROVIDER_AWS,
-            authentication={"credentials": {"role_arn": "fake-iam"}},
-            billing_source={"data_source": {"bucket": "my-bucket"}},
-            offset=1,
-        )
-
-        payload = {"source_id": source.source_id}
-
-        with patch("sources.api.source_status.SourceStatus.push_status") as mock_push_status, patch(
-            "sources.api.source_status.is_status_api_update_enabled", return_value=True
-        ):
-            client.post(url, data=payload, format="json", **self.headers)
-            mock_push_status.assert_called_once()
-
-    def test_source_status_returns_204(self):
-        """Test that source_status endpoint returns 204 No Content when the feature flag is enabled."""
-        url = reverse("source-status")
-        client = APIClient()
-
-        source = Sources.objects.create(
-            source_id=1,
-            name="Test Source",
-            source_type=Provider.PROVIDER_AWS,
-            authentication={"credentials": {"role_arn": "fake-iam"}},
-            billing_source={"data_source": {"bucket": "my-bucket"}},
-            offset=1,
-        )
-
-        payload = {"source_id": source.source_id}
-
-        with patch("sources.api.source_status.is_status_api_update_enabled", return_value=True):
-            response = client.post(url, data=payload, format="json", **self.headers)
-            self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
-
     def test_push_status_called_when_flag_enabled(self):
         """Test that push_status() is called when the feature flag is enabled."""
         url = reverse("source-status")

--- a/koku/sources/test/api/test_source_status.py
+++ b/koku/sources/test/api/test_source_status.py
@@ -128,7 +128,7 @@ class SourcesStatusTest(IamTestCase):
     @patch("sources.api.source_status.SourcesProviderCoordinator.update_account")
     @patch("sources.api.source_status.SourcesHTTPClient.set_source_status")
     def test_push_status_first_gcp_table_discovery(
-            self, mock_set_source_status, mock_update_account, mock_create_account
+        self, mock_set_source_status, mock_update_account, mock_create_account
     ):
         """Test that push_status for initial discovery of GCP BigQuery table id."""
         mock_status = {"availability_status": "available", "availability_status_error": ""}
@@ -158,7 +158,7 @@ class SourcesStatusTest(IamTestCase):
     @patch("sources.api.source_status.SourcesProviderCoordinator.update_account")
     @patch("sources.api.source_status.SourcesHTTPClient.set_source_status")
     def test_push_status_first_gcp_table_discovery_update(
-            self, mock_set_source_status, mock_update_account, mock_create_account
+        self, mock_set_source_status, mock_update_account, mock_create_account
     ):
         """Test that push_status for initial discovery of GCP BigQuery table id after dataset was updated."""
         mock_status = {"availability_status": "available", "availability_status_error": ""}
@@ -279,7 +279,7 @@ class SourcesStatusTest(IamTestCase):
 
             status_obj = SourceStatus(test_source_id)
             with patch.object(
-                    SourcesHTTPClient, "get_source_details", return_value={"name": "New Name", "source_type_id": "1"}
+                SourcesHTTPClient, "get_source_details", return_value={"name": "New Name", "source_type_id": "1"}
             ):
                 status_obj.update_source_name()
                 mock_update_account.assert_called()
@@ -305,7 +305,7 @@ class SourcesStatusTest(IamTestCase):
 
             status_obj = SourceStatus(test_source_id)
             with patch.object(
-                    SourcesHTTPClient, "get_source_details", return_value={"name": source_name, "source_type_id": "1"}
+                SourcesHTTPClient, "get_source_details", return_value={"name": source_name, "source_type_id": "1"}
             ):
                 status_obj.update_source_name()
                 mock_update_account.assert_not_called()
@@ -685,7 +685,7 @@ class SourcesStatusTest(IamTestCase):
         payload = {"source_id": source.source_id}
 
         with patch("sources.api.source_status.SourceStatus.push_status") as mock_push_status, patch(
-                "sources.api.source_status.is_status_api_update_enabled", return_value=True
+            "sources.api.source_status.is_status_api_update_enabled", return_value=True
         ):
             client.post(url, data=payload, format="json", **self.headers)
             mock_push_status.assert_called_once()


### PR DESCRIPTION
## Jira Ticket

[COST-5885](https://issues.redhat.com/browse/COST-5885)

## Description

This change will add a feature flag (is_status_api_update_enabled) to control the new source status retrieval method for source status in the `source_status` endpoint.

- If the flag is enabled: The endpoint triggers a PUT request to the Sources team using the `push_status()` method.
- If the flag is disabled: The endpoint maintains the legacy behavior and returns `204 No Content` instead.



## Release Notes
- [ ] Feature flag for source status retrieval

```markdown
* [COST-5885](https://issues.redhat.com/browse/COST-5885) Feature flag for source status retrieval
```
