### PR TITLE
[COST-5905] add masu endpoint to invalidate cache

### DIFF
--- a/koku/api/forecast/test/test_views.py
+++ b/koku/api/forecast/test/test_views.py
@@ -10,7 +10,7 @@ from rest_framework.test import APIClient
 
 from api.iam.test.iam_test_case import IamTestCase
 from api.iam.test.iam_test_case import RbacPermissions
-from koku.settings import CacheEnum
+from koku.cache import CacheEnum
 
 # from api.forecast.views import AWSCostForecastView
 # from api.forecast.views import AzureCostForecastView

--- a/koku/api/forecast/test/test_views.py
+++ b/koku/api/forecast/test/test_views.py
@@ -10,6 +10,7 @@ from rest_framework.test import APIClient
 
 from api.iam.test.iam_test_case import IamTestCase
 from api.iam.test.iam_test_case import RbacPermissions
+from koku.settings import CacheEnum
 
 # from api.forecast.views import AWSCostForecastView
 # from api.forecast.views import AzureCostForecastView
@@ -25,7 +26,7 @@ class AWSCostForecastViewTest(IamTestCase):
     def setUp(self):
         """Set up the rate view tests."""
         super().setUp()
-        caches["rbac"].clear()
+        caches[CacheEnum.rbac].clear()
 
     @RbacPermissions({"aws.account": {"read": ["*"]}, "aws.organizational_unit": {"read": ["*"]}})
     def test_get_forecast(self):
@@ -73,7 +74,7 @@ class AzureCostForecastViewTest(IamTestCase):
     def setUp(self):
         """Set up the rate view tests."""
         super().setUp()
-        caches["rbac"].clear()
+        caches[CacheEnum.rbac].clear()
 
     @RbacPermissions({"azure.subscription_guid": {"read": ["*"]}})
     def test_get_forecast(self):
@@ -90,7 +91,7 @@ class OCICostForecastViewTest(IamTestCase):
     def setUp(self):
         """Set up the rate view tests."""
         super().setUp()
-        caches["rbac"].clear()
+        caches[CacheEnum.rbac].clear()
 
     @RbacPermissions({"oci.payer_tenant_id": {"read": ["*"]}})
     def test_get_forecast(self):
@@ -107,7 +108,7 @@ class OCPCostForecastViewTest(IamTestCase):
     def setUp(self):
         """Set up the rate view tests."""
         super().setUp()
-        caches["rbac"].clear()
+        caches[CacheEnum.rbac].clear()
 
     @RbacPermissions({"openshift.cluster": {"read": ["*"]}, "openshift.node": {"read": ["*"]}})
     def test_get_forecast(self):
@@ -124,7 +125,7 @@ class OCPAWSCostForecastViewTest(IamTestCase):
     def setUp(self):
         """Set up the rate view tests."""
         super().setUp()
-        caches["rbac"].clear()
+        caches[CacheEnum.rbac].clear()
 
     @RbacPermissions(
         {
@@ -148,7 +149,7 @@ class OCPAzureCostForecastViewTest(IamTestCase):
     def setUp(self):
         """Set up the rate view tests."""
         super().setUp()
-        caches["rbac"].clear()
+        caches[CacheEnum.rbac].clear()
 
     @RbacPermissions(
         {
@@ -171,7 +172,7 @@ class OCPAllCostForecastViewTest(IamTestCase):
     def setUp(self):
         """Set up the rate view tests."""
         super().setUp()
-        caches["rbac"].clear()
+        caches[CacheEnum.rbac].clear()
 
     @RbacPermissions({"openshift.cluster": {"read": ["*"]}, "openshift.node": {"read": ["*"]}})
     def test_get_forecast(self):

--- a/koku/api/provider/provider_builder.py
+++ b/koku/api/provider/provider_builder.py
@@ -19,7 +19,7 @@ from api.provider.provider_manager import ProviderManager
 from api.provider.provider_manager import ProviderManagerAuthorizationError
 from api.provider.provider_manager import ProviderManagerError
 from api.provider.serializers import ProviderSerializer
-from koku.cache import invalidate_view_cache_for_tenant_and_cache_key
+from koku.cache import invalidate_cache_for_tenant_and_cache_key
 from koku.cache import SOURCES_CACHE_PREFIX
 from koku.middleware import IdentityHeaderMiddleware
 
@@ -137,7 +137,7 @@ class ProviderBuilder:
             if serializer.is_valid(raise_exception=True):
                 instance = serializer.save()
         finally:
-            invalidate_view_cache_for_tenant_and_cache_key(customer.schema_name, SOURCES_CACHE_PREFIX)
+            invalidate_cache_for_tenant_and_cache_key(customer.schema_name, SOURCES_CACHE_PREFIX)
             connection.set_schema_to_public()
         return instance
 
@@ -160,7 +160,7 @@ class ProviderBuilder:
         serializer.is_valid(raise_exception=True)
         serializer.save()
         connection.set_schema_to_public()
-        invalidate_view_cache_for_tenant_and_cache_key(customer.schema_name, SOURCES_CACHE_PREFIX)
+        invalidate_cache_for_tenant_and_cache_key(customer.schema_name, SOURCES_CACHE_PREFIX)
         return instance
 
     def destroy_provider(self, provider_uuid, retry_count=None):
@@ -180,5 +180,5 @@ class ProviderBuilder:
             except ProviderManagerAuthorizationError as err:
                 LOG.warning(str(err), exc_info=err)
 
-        invalidate_view_cache_for_tenant_and_cache_key(customer.schema_name, SOURCES_CACHE_PREFIX)
+        invalidate_cache_for_tenant_and_cache_key(customer.schema_name, SOURCES_CACHE_PREFIX)
         connection.set_schema_to_public()

--- a/koku/api/provider/provider_manager.py
+++ b/koku/api/provider/provider_manager.py
@@ -22,7 +22,7 @@ from api.provider.models import ProviderBillingSource
 from api.provider.models import Sources
 from api.utils import DateHelper
 from cost_models.models import CostModelMap
-from koku.cache import invalidate_view_cache_for_tenant_and_cache_key
+from koku.cache import invalidate_cache_for_tenant_and_cache_key
 from koku.cache import SOURCES_CACHE_PREFIX
 from koku.database import execute_delete_sql
 from masu.util.ocp import common as utils
@@ -386,7 +386,7 @@ def provider_post_save_refresh_cache(*args, **kwargs):
     """Invalidate sources view cache after provider save."""
     provider: Provider = kwargs["instance"]
     if customer := provider.customer:
-        invalidate_view_cache_for_tenant_and_cache_key(customer.schema_name, SOURCES_CACHE_PREFIX)
+        invalidate_cache_for_tenant_and_cache_key(customer.schema_name, SOURCES_CACHE_PREFIX)
 
 
 @receiver(post_delete, sender=Provider)

--- a/koku/api/urls.py
+++ b/koku/api/urls.py
@@ -110,6 +110,7 @@ from api.views import UserAccessView
 from api.views import UserCostTypeSettings
 from koku.cache import AWS_CACHE_PREFIX
 from koku.cache import AZURE_CACHE_PREFIX
+from koku.cache import CacheEnum
 from koku.cache import GCP_CACHE_PREFIX
 from koku.cache import OCI_CACHE_PREFIX
 from koku.cache import OPENSHIFT_ALL_CACHE_PREFIX
@@ -133,247 +134,275 @@ urlpatterns = [
     path("metrics/", metrics, name="metrics"),
     path(
         "tags/aws/",
-        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=AWS_CACHE_PREFIX)(AWSTagView.as_view()),
+        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=AWS_CACHE_PREFIX)(
+            AWSTagView.as_view()
+        ),
         name="aws-tags",
     ),
     path(
         "tags/azure/",
-        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=AZURE_CACHE_PREFIX)(AzureTagView.as_view()),
+        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=AZURE_CACHE_PREFIX)(
+            AzureTagView.as_view()
+        ),
         name="azure-tags",
     ),
     path(
         "tags/gcp/",
-        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=GCP_CACHE_PREFIX)(GCPTagView.as_view()),
+        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=GCP_CACHE_PREFIX)(
+            GCPTagView.as_view()
+        ),
         name="gcp-tags",
     ),
     path(
         "tags/oci/",
-        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=OCI_CACHE_PREFIX)(OCITagView.as_view()),
+        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=OCI_CACHE_PREFIX)(
+            OCITagView.as_view()
+        ),
         name="oci-tags",
     ),
     path(
         "tags/openshift/",
-        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=OPENSHIFT_CACHE_PREFIX)(OCPTagView.as_view()),
+        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=OPENSHIFT_CACHE_PREFIX)(
+            OCPTagView.as_view()
+        ),
         name="openshift-tags",
     ),
     path(
         "tags/openshift/infrastructures/all/",
-        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=OPENSHIFT_ALL_CACHE_PREFIX)(
-            OCPAllTagView.as_view()
-        ),
+        cache_page(
+            timeout=settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=OPENSHIFT_ALL_CACHE_PREFIX
+        )(OCPAllTagView.as_view()),
         name="openshift-all-tags",
     ),
     path(
         "tags/openshift/infrastructures/aws/",
-        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=OPENSHIFT_AWS_CACHE_PREFIX)(
-            OCPAWSTagView.as_view()
-        ),
+        cache_page(
+            timeout=settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=OPENSHIFT_AWS_CACHE_PREFIX
+        )(OCPAWSTagView.as_view()),
         name="openshift-aws-tags",
     ),
     path(
         "tags/openshift/infrastructures/azure/",
-        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=OPENSHIFT_AZURE_CACHE_PREFIX)(
-            OCPAzureTagView.as_view()
-        ),
+        cache_page(
+            timeout=settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=OPENSHIFT_AZURE_CACHE_PREFIX
+        )(OCPAzureTagView.as_view()),
         name="openshift-azure-tags",
     ),
     path(
         "tags/openshift/infrastructures/gcp/",
-        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=OPENSHIFT_GCP_CACHE_PREFIX)(
-            OCPGCPTagView.as_view()
-        ),
+        cache_page(
+            timeout=settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=OPENSHIFT_GCP_CACHE_PREFIX
+        )(OCPGCPTagView.as_view()),
         name="openshift-gcp-tags",
     ),
     path(
         "tags/aws/<key>/",
-        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=AWS_CACHE_PREFIX)(AWSTagView.as_view()),
+        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=AWS_CACHE_PREFIX)(
+            AWSTagView.as_view()
+        ),
         name="aws-tags-key",
     ),
     path(
         "tags/azure/<key>/",
-        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=AZURE_CACHE_PREFIX)(AzureTagView.as_view()),
+        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=AZURE_CACHE_PREFIX)(
+            AzureTagView.as_view()
+        ),
         name="azure-tags-key",
     ),
     path(
         "tags/openshift/<key>/",
-        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=OPENSHIFT_CACHE_PREFIX)(OCPTagView.as_view()),
+        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=OPENSHIFT_CACHE_PREFIX)(
+            OCPTagView.as_view()
+        ),
         name="openshift-tags-key",
     ),
     path(
         "tags/gcp/<key>/",
-        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=GCP_CACHE_PREFIX)(GCPTagView.as_view()),
+        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=GCP_CACHE_PREFIX)(
+            GCPTagView.as_view()
+        ),
         name="gcp-tags-key",
     ),
     path(
         "tags/oci/<key>/",
-        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=OCI_CACHE_PREFIX)(OCITagView.as_view()),
+        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=OCI_CACHE_PREFIX)(
+            OCITagView.as_view()
+        ),
         name="oci-tags-key",
     ),
     path(
         "tags/openshift/infrastructures/all/<key>/",
-        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=OPENSHIFT_ALL_CACHE_PREFIX)(
-            OCPAllTagView.as_view()
-        ),
+        cache_page(
+            timeout=settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=OPENSHIFT_ALL_CACHE_PREFIX
+        )(OCPAllTagView.as_view()),
         name="openshift-all-tags-key",
     ),
     path(
         "tags/openshift/infrastructures/aws/<key>/",
-        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=OPENSHIFT_AWS_CACHE_PREFIX)(
-            OCPAWSTagView.as_view()
-        ),
+        cache_page(
+            timeout=settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=OPENSHIFT_AWS_CACHE_PREFIX
+        )(OCPAWSTagView.as_view()),
         name="openshift-aws-tags-key",
     ),
     path(
         "tags/openshift/infrastructures/azure/<key>/",
-        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=OPENSHIFT_AZURE_CACHE_PREFIX)(
-            OCPAzureTagView.as_view()
-        ),
+        cache_page(
+            timeout=settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=OPENSHIFT_AZURE_CACHE_PREFIX
+        )(OCPAzureTagView.as_view()),
         name="openshift-azure-tags-key",
     ),
     path(
         "reports/aws/costs/",
-        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=AWS_CACHE_PREFIX)(AWSCostView.as_view()),
+        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=AWS_CACHE_PREFIX)(
+            AWSCostView.as_view()
+        ),
         name="reports-aws-costs",
     ),
     path(
         "reports/aws/instance-types/",
-        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=AWS_CACHE_PREFIX)(
+        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=AWS_CACHE_PREFIX)(
             AWSInstanceTypeView.as_view()
         ),
         name="reports-aws-instance-type",
     ),
     path(
         "reports/aws/resources/ec2-compute/",
-        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=AWS_CACHE_PREFIX)(
+        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=AWS_CACHE_PREFIX)(
             AWSEC2ComputeView.as_view()
         ),
         name="reports-aws-ec2-compute",
     ),
     path(
         "reports/aws/storage/",
-        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=AWS_CACHE_PREFIX)(AWSStorageView.as_view()),
+        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=AWS_CACHE_PREFIX)(
+            AWSStorageView.as_view()
+        ),
         name="reports-aws-storage",
     ),
     path(
         "reports/azure/costs/",
-        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=AZURE_CACHE_PREFIX)(AzureCostView.as_view()),
+        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=AZURE_CACHE_PREFIX)(
+            AzureCostView.as_view()
+        ),
         name="reports-azure-costs",
     ),
     path(
         "reports/azure/instance-types/",
-        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=AZURE_CACHE_PREFIX)(
+        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=AZURE_CACHE_PREFIX)(
             AzureInstanceTypeView.as_view()
         ),
         name="reports-azure-instance-type",
     ),
     path(
         "reports/azure/storage/",
-        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=AZURE_CACHE_PREFIX)(
+        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=AZURE_CACHE_PREFIX)(
             AzureStorageView.as_view()
         ),
         name="reports-azure-storage",
     ),
     path(
         "reports/openshift/resources/virtual-machines/",
-        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=OPENSHIFT_CACHE_PREFIX)(
+        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=OPENSHIFT_CACHE_PREFIX)(
             OCPReportVirtualMachinesView.as_view()
         ),
         name="reports-openshift-virtual-machines",
     ),
     path(
         "reports/openshift/costs/",
-        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=OPENSHIFT_CACHE_PREFIX)(
+        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=OPENSHIFT_CACHE_PREFIX)(
             OCPCostView.as_view()
         ),
         name="reports-openshift-costs",
     ),
     path(
         "reports/openshift/memory/",
-        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=OPENSHIFT_CACHE_PREFIX)(
+        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=OPENSHIFT_CACHE_PREFIX)(
             OCPMemoryView.as_view()
         ),
         name="reports-openshift-memory",
     ),
     path(
         "reports/openshift/compute/",
-        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=OPENSHIFT_CACHE_PREFIX)(OCPCpuView.as_view()),
+        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=OPENSHIFT_CACHE_PREFIX)(
+            OCPCpuView.as_view()
+        ),
         name="reports-openshift-cpu",
     ),
     path(
         "reports/openshift/volumes/",
-        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=OPENSHIFT_CACHE_PREFIX)(
+        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=OPENSHIFT_CACHE_PREFIX)(
             OCPVolumeView.as_view()
         ),
         name="reports-openshift-volume",
     ),
     path(
         "reports/openshift/network/",
-        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=OPENSHIFT_CACHE_PREFIX)(
+        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=OPENSHIFT_CACHE_PREFIX)(
             OCPNetworkView.as_view()
         ),
         name="reports-openshift-network",
     ),
     path(
         "reports/openshift/infrastructures/all/costs/",
-        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=OPENSHIFT_ALL_CACHE_PREFIX)(
-            OCPAllCostView.as_view()
-        ),
+        cache_page(
+            timeout=settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=OPENSHIFT_ALL_CACHE_PREFIX
+        )(OCPAllCostView.as_view()),
         name="reports-openshift-all-costs",
     ),
     path(
         "reports/openshift/infrastructures/all/storage/",
-        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=OPENSHIFT_ALL_CACHE_PREFIX)(
-            OCPAllStorageView.as_view()
-        ),
+        cache_page(
+            timeout=settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=OPENSHIFT_ALL_CACHE_PREFIX
+        )(OCPAllStorageView.as_view()),
         name="reports-openshift-all-storage",
     ),
     path(
         "reports/openshift/infrastructures/all/instance-types/",
-        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=OPENSHIFT_ALL_CACHE_PREFIX)(
-            OCPAllInstanceTypeView.as_view()
-        ),
+        cache_page(
+            timeout=settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=OPENSHIFT_ALL_CACHE_PREFIX
+        )(OCPAllInstanceTypeView.as_view()),
         name="reports-openshift-all-instance-type",
     ),
     path(
         "reports/openshift/infrastructures/aws/costs/",
-        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=OPENSHIFT_AWS_CACHE_PREFIX)(
-            OCPAWSCostView.as_view()
-        ),
+        cache_page(
+            timeout=settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=OPENSHIFT_AWS_CACHE_PREFIX
+        )(OCPAWSCostView.as_view()),
         name="reports-openshift-aws-costs",
     ),
     path(
         "reports/openshift/infrastructures/aws/storage/",
-        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=OPENSHIFT_AWS_CACHE_PREFIX)(
-            OCPAWSStorageView.as_view()
-        ),
+        cache_page(
+            timeout=settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=OPENSHIFT_AWS_CACHE_PREFIX
+        )(OCPAWSStorageView.as_view()),
         name="reports-openshift-aws-storage",
     ),
     path(
         "reports/openshift/infrastructures/aws/instance-types/",
-        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=OPENSHIFT_AWS_CACHE_PREFIX)(
-            OCPAWSInstanceTypeView.as_view()
-        ),
+        cache_page(
+            timeout=settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=OPENSHIFT_AWS_CACHE_PREFIX
+        )(OCPAWSInstanceTypeView.as_view()),
         name="reports-openshift-aws-instance-type",
     ),
     path(
         "reports/openshift/infrastructures/azure/costs/",
-        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=OPENSHIFT_AZURE_CACHE_PREFIX)(
-            OCPAzureCostView.as_view()
-        ),
+        cache_page(
+            timeout=settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=OPENSHIFT_AZURE_CACHE_PREFIX
+        )(OCPAzureCostView.as_view()),
         name="reports-openshift-azure-costs",
     ),
     path(
         "reports/openshift/infrastructures/azure/storage/",
-        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=OPENSHIFT_AZURE_CACHE_PREFIX)(
-            OCPAzureStorageView.as_view()
-        ),
+        cache_page(
+            timeout=settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=OPENSHIFT_AZURE_CACHE_PREFIX
+        )(OCPAzureStorageView.as_view()),
         name="reports-openshift-azure-storage",
     ),
     path(
         "reports/openshift/infrastructures/azure/instance-types/",
-        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=OPENSHIFT_AZURE_CACHE_PREFIX)(
-            OCPAzureInstanceTypeView.as_view()
-        ),
+        cache_page(
+            timeout=settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=OPENSHIFT_AZURE_CACHE_PREFIX
+        )(OCPAzureInstanceTypeView.as_view()),
         name="reports-openshift-azure-instance-type",
     ),
     path("ingress/reports/", IngressReportsView.as_view(), name="reports"),
@@ -425,7 +454,9 @@ urlpatterns = [
     ),
     path(
         "resource-types/aws-categories/",
-        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=AWS_CACHE_PREFIX)(AWSCategoryView.as_view()),
+        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=AWS_CACHE_PREFIX)(
+            AWSCategoryView.as_view()
+        ),
         name="aws-categories",
     ),
     path("resource-types/gcp-accounts/", GCPAccountView.as_view(), name="gcp-accounts"),
@@ -487,57 +518,65 @@ urlpatterns = [
     ),
     path(
         "reports/gcp/costs/",
-        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=GCP_CACHE_PREFIX)(GCPCostView.as_view()),
+        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=GCP_CACHE_PREFIX)(
+            GCPCostView.as_view()
+        ),
         name="reports-gcp-costs",
     ),
     path(
         "reports/gcp/instance-types/",
-        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=GCP_CACHE_PREFIX)(
+        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=GCP_CACHE_PREFIX)(
             GCPInstanceTypeView.as_view()
         ),
         name="reports-gcp-instance-type",
     ),
     path(
         "reports/gcp/storage/",
-        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=GCP_CACHE_PREFIX)(GCPStorageView.as_view()),
+        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=GCP_CACHE_PREFIX)(
+            GCPStorageView.as_view()
+        ),
         name="reports-gcp-storage",
     ),
     path(
         "reports/oci/costs/",
-        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=OCI_CACHE_PREFIX)(OCICostView.as_view()),
+        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=OCI_CACHE_PREFIX)(
+            OCICostView.as_view()
+        ),
         name="reports-oci-costs",
     ),
     path(
         "reports/oci/instance-types/",
-        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=OCI_CACHE_PREFIX)(
+        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=OCI_CACHE_PREFIX)(
             OCIInstanceTypeView.as_view()
         ),
         name="reports-oci-instance-type",
     ),
     path(
         "reports/oci/storage/",
-        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=OCI_CACHE_PREFIX)(OCIStorageView.as_view()),
+        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=OCI_CACHE_PREFIX)(
+            OCIStorageView.as_view()
+        ),
         name="reports-oci-storage",
     ),
     path(
         "reports/openshift/infrastructures/gcp/costs/",
-        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=OPENSHIFT_GCP_CACHE_PREFIX)(
-            OCPGCPCostView.as_view()
-        ),
+        cache_page(
+            timeout=settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=OPENSHIFT_GCP_CACHE_PREFIX
+        )(OCPGCPCostView.as_view()),
         name="reports-openshift-gcp-costs",
     ),
     path(
         "reports/openshift/infrastructures/gcp/instance-types/",
-        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=OPENSHIFT_GCP_CACHE_PREFIX)(
-            OCPGCPInstanceTypeView.as_view()
-        ),
+        cache_page(
+            timeout=settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=OPENSHIFT_GCP_CACHE_PREFIX
+        )(OCPGCPInstanceTypeView.as_view()),
         name="reports-openshift-gcp-instance-type",
     ),
     path(
         "reports/openshift/infrastructures/gcp/storage/",
-        cache_page(timeout=settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=OPENSHIFT_GCP_CACHE_PREFIX)(
-            OCPGCPStorageView.as_view()
-        ),
+        cache_page(
+            timeout=settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=OPENSHIFT_GCP_CACHE_PREFIX
+        )(OCPGCPStorageView.as_view()),
         name="reports-openshift-gcp-storage",
     ),
     # Sunset paths

--- a/koku/api/views.py
+++ b/koku/api/views.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 """API views for import organization"""
-# flake8: noqa
 from api.cloud_accounts.views import cloud_accounts
 from api.currency.view import get_currency
 from api.currency.view import get_exchange_rates

--- a/koku/cost_models/test/test_view.py
+++ b/koku/cost_models/test/test_view.py
@@ -22,8 +22,8 @@ from api.provider.serializers import ProviderSerializer
 from cost_models.models import CostModelAudit
 from cost_models.models import CostModelMap
 from cost_models.serializers import CostModelSerializer
+from koku.cache import CacheEnum
 from koku.rbac import RbacService
-from koku.settings import CacheEnum
 
 
 class CostModelViewTests(IamTestCase):

--- a/koku/cost_models/test/test_view.py
+++ b/koku/cost_models/test/test_view.py
@@ -23,6 +23,7 @@ from cost_models.models import CostModelAudit
 from cost_models.models import CostModelMap
 from cost_models.serializers import CostModelSerializer
 from koku.rbac import RbacService
+from koku.settings import CacheEnum
 
 
 class CostModelViewTests(IamTestCase):
@@ -89,7 +90,7 @@ class CostModelViewTests(IamTestCase):
     def setUp(self):
         """Set up the rate view tests."""
         super().setUp()
-        caches["rbac"].clear()
+        caches[CacheEnum.rbac].clear()
         self.initialize_request()
 
     def test_create_cost_model_success(self):
@@ -421,7 +422,7 @@ class CostModelViewTests(IamTestCase):
         for test_case in test_matrix:
             with patch.object(RbacService, "get_access_for_user", return_value=test_case.get("access")):
                 url = reverse("cost-models-list")
-                caches["rbac"].clear()
+                caches[CacheEnum.rbac].clear()
                 response = client.get(url, **request_context["request"].META)
                 self.assertEqual(response.status_code, test_case.get("expected_response"))
 
@@ -462,7 +463,7 @@ class CostModelViewTests(IamTestCase):
         for test_case in test_matrix:
             with patch.object(RbacService, "get_access_for_user", return_value=test_case.get("access")):
                 url = reverse("cost-models-detail", kwargs={"uuid": cost_model_uuid})
-                caches["rbac"].clear()
+                caches[CacheEnum.rbac].clear()
                 response = client.get(url, **request_context["request"].META)
                 self.assertEqual(response.status_code, test_case.get("expected_response"))
 
@@ -520,7 +521,7 @@ class CostModelViewTests(IamTestCase):
                 rate_data = copy.deepcopy(self.fake_data)
                 rate_data["source_uuids"] = []
                 rate_data["rates"][0]["metric"] = test_case.get("metric")
-                caches["rbac"].clear()
+                caches[CacheEnum.rbac].clear()
                 with patch("cost_models.cost_model_manager.update_cost_model_costs"):
                     response = client.post(url, data=rate_data, format="json", **request_context["request"].META)
 
@@ -555,7 +556,7 @@ class CostModelViewTests(IamTestCase):
                 rate_data["rates"][0].get("tiered_rates")[0]["value"] = test_case.get("value")
                 rate_data["source_uuids"] = []
                 url = reverse("cost-models-detail", kwargs={"uuid": cost_model_uuid})
-                caches["rbac"].clear()
+                caches[CacheEnum.rbac].clear()
                 with patch("cost_models.cost_model_manager.update_cost_model_costs"):
                     response = client.put(url, data=rate_data, format="json", **request_context["request"].META)
 
@@ -588,7 +589,7 @@ class CostModelViewTests(IamTestCase):
         for test_case in test_matrix:
             with patch.object(RbacService, "get_access_for_user", return_value=test_case.get("access")):
                 url = reverse("cost-models-detail", kwargs={"uuid": test_case.get("cost_model_uuid")})
-                caches["rbac"].clear()
+                caches[CacheEnum.rbac].clear()
                 with patch("cost_models.cost_model_manager.update_cost_model_costs"):
                     response = client.delete(url, **request_context["request"].META)
                 self.assertEqual(response.status_code, test_case.get("expected_response"))

--- a/koku/cost_models/views.py
+++ b/koku/cost_models/views.py
@@ -3,5 +3,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 """API views for import organization"""
-# flake8: noqa
 from cost_models.view import CostModelViewSet

--- a/koku/koku/cache.py
+++ b/koku/koku/cache.py
@@ -4,7 +4,6 @@
 #
 """Cache functions."""
 import logging
-from enum import StrEnum
 
 from django.conf import settings
 from django.core.cache import caches
@@ -15,12 +14,7 @@ from redis import Redis
 
 from api.common import log_json
 from api.provider.models import Provider
-
-
-class CacheEnum(StrEnum):
-    default = "default"
-    rbac = "rbac"
-    worker = "worker"
+from koku.settings import CacheEnum  # noqa: F401
 
 
 class KokuCacheError(Exception):

--- a/koku/koku/cache.py
+++ b/koku/koku/cache.py
@@ -4,6 +4,7 @@
 #
 """Cache functions."""
 import logging
+from enum import StrEnum
 
 from django.conf import settings
 from django.core.cache import caches
@@ -14,6 +15,12 @@ from redis import Redis
 
 from api.common import log_json
 from api.provider.models import Provider
+
+
+class CacheEnum(StrEnum):
+    default = "default"
+    rbac = "rbac"
+    worker = "worker"
 
 
 class KokuCacheError(Exception):
@@ -37,7 +44,7 @@ SOURCES_CACHE_PREFIX = "sources"
 TAG_MAPPING_PREFIX = "tag-mapping"
 
 
-def invalidate_cache_for_tenant_and_cache_key(schema_name, cache_key_prefix=None, *, cache_name="default"):
+def invalidate_cache_for_tenant_and_cache_key(schema_name, cache_key_prefix=None, *, cache_name=CacheEnum.default):
     """Invalidate our view cache for a specific tenant and source type.
 
     If cache_key_prefix is None, all views will be invalidated.
@@ -125,22 +132,22 @@ def invalidate_view_cache_for_tenant_and_all_source_types(schema_name):
         invalidate_view_cache_for_tenant_and_source_type(schema_name, source_type)
 
 
-def get_value_from_cache(cache_key, cache_choice="default"):
+def get_value_from_cache(cache_key, cache_choice=CacheEnum.default):
     cache = caches[cache_choice]
     return cache.get(cache_key)
 
 
-def delete_value_from_cache(cache_key, cache_choice="default"):
+def delete_value_from_cache(cache_key, cache_choice=CacheEnum.default):
     cache = caches[cache_choice]
     return cache.delete(cache_key)
 
 
-def set_value_in_cache(cache_key, cache_value, cache_choice="default"):
+def set_value_in_cache(cache_key, cache_value, cache_choice=CacheEnum.default):
     cache = caches[cache_choice]
     cache.set(cache_key, cache_value)
 
 
-def is_key_in_cache(cache_key, cache_choice="default"):
+def is_key_in_cache(cache_key, cache_choice=CacheEnum.default):
     cache = caches[cache_choice]
     return cache.has_key(cache_key)
 
@@ -160,41 +167,41 @@ def build_trino_table_exists_key(schema_name, table_name):
 
 def get_cached_matching_tags(schema_name, provider_type):
     """Return cached OCP on Cloud matched tags if exists."""
-    cache = caches["default"]
+    cache = caches[CacheEnum.default]
     cache_key = f"OCP-on-{provider_type}:{schema_name}:matching-tags"
     return cache.get(cache_key)
 
 
 def set_cached_matching_tags(schema_name, provider_type, matched_tags):
     """Return cached OCP on Cloud matched tags if exists."""
-    cache = caches["default"]
+    cache = caches[CacheEnum.default]
     cache_key = f"OCP-on-{provider_type}:{schema_name}:matching-tags"
     cache.set(cache_key, matched_tags)
 
 
 def get_cached_infra_map(schema_name, provider_type, provider_uuid):
     """Return cached OCP on Cloud infra-map if exists."""
-    cache = caches["default"]
+    cache = caches[CacheEnum.default]
     cache_key = f"OCP-on-{provider_type}:{schema_name}:{provider_uuid}:infra-map"
     return cache.get(cache_key)
 
 
 def set_cached_infra_map(schema_name, provider_type, provider_uuid, infra_map):
     """Return cached OCP on Cloud infra-map if exists."""
-    cache = caches["default"]
+    cache = caches[CacheEnum.default]
     cache_key = f"OCP-on-{provider_type}:{schema_name}:{provider_uuid}:infra-map"
     cache.set(cache_key, infra_map)
 
 
 def get_cached_tag_rate_map(schema_name):
     """Return cached tag rate map for tag mapping."""
-    cache = caches["default"]
+    cache = caches[CacheEnum.default]
     cache_key = f"{TAG_MAPPING_PREFIX}:{schema_name}:tag-rate-map"
     return cache.get(cache_key)
 
 
 def set_cached_tag_rate_map(schema_name, tag_rate_map):
     """Return cached OCP on Cloud infra-map if exists."""
-    cache = caches["default"]
+    cache = caches[CacheEnum.default]
     cache_key = f"{TAG_MAPPING_PREFIX}:{schema_name}:tag-rate-map"
     cache.set(cache_key, tag_rate_map)

--- a/koku/koku/cache.py
+++ b/koku/koku/cache.py
@@ -14,7 +14,7 @@ from redis import Redis
 
 from api.common import log_json
 from api.provider.models import Provider
-from koku.settings import CacheEnum  # noqa: F401
+from koku.settings import CacheEnum
 
 
 class KokuCacheError(Exception):

--- a/koku/koku/cache.py
+++ b/koku/koku/cache.py
@@ -38,7 +38,7 @@ SOURCES_CACHE_PREFIX = "sources"
 TAG_MAPPING_PREFIX = "tag-mapping"
 
 
-def invalidate_cache_for_tenant_and_cache_key(schema_name, cache_key_prefix=None, *, cache_name=CacheEnum.default):
+def invalidate_cache_for_tenant_and_cache_key(schema_name, cache_key_prefix=None, *, cache_name=CacheEnum.api):
     """Invalidate our view cache for a specific tenant and source type.
 
     If cache_key_prefix is None, all views will be invalidated.

--- a/koku/koku/middleware.py
+++ b/koku/koku/middleware.py
@@ -41,6 +41,7 @@ from api.utils import DateHelper
 from koku.metrics import DB_CONNECTION_ERRORS_COUNTER
 from koku.rbac import RbacConnectionError
 from koku.rbac import RbacService
+from koku.settings import CacheEnum
 
 MAX_CACHE_SIZE = 10000
 USER_CACHE = TTLCache(maxsize=MAX_CACHE_SIZE, ttl=settings.MIDDLEWARE_TIME_TO_LIVE)
@@ -98,7 +99,7 @@ class HttpResponseFailedDependency(JsonResponse):
         data = {
             "errors": [
                 {
-                    "detail": f'{dikt.get("source")} unavailable. Error: {dikt.get("exception")}',
+                    "detail": f"{dikt.get('source')} unavailable. Error: {dikt.get('exception')}",
                     "status": self.status_code,
                     "title": "Failed Dependency",
                 }
@@ -375,7 +376,7 @@ class IdentityHeaderMiddleware(MiddlewareMixin):
             user.admin = is_admin
             user.req_id = req_id
 
-            cache = caches["rbac"]
+            cache = caches[CacheEnum.rbac]
             user_access = cache.get(f"{user.uuid}_{org_id}")
 
             if not user_access:

--- a/koku/koku/middleware.py
+++ b/koku/koku/middleware.py
@@ -38,10 +38,10 @@ from api.iam.models import User
 from api.iam.serializers import create_schema_name
 from api.iam.serializers import extract_header
 from api.utils import DateHelper
+from koku.cache import CacheEnum
 from koku.metrics import DB_CONNECTION_ERRORS_COUNTER
 from koku.rbac import RbacConnectionError
 from koku.rbac import RbacService
-from koku.settings import CacheEnum
 
 MAX_CACHE_SIZE = 10000
 USER_CACHE = TTLCache(maxsize=MAX_CACHE_SIZE, ttl=settings.MIDDLEWARE_TIME_TO_LIVE)

--- a/koku/koku/settings.py
+++ b/koku/koku/settings.py
@@ -17,7 +17,6 @@ import logging
 import os
 import re
 import sys
-from enum import StrEnum
 from json import JSONDecodeError
 from zoneinfo import ZoneInfo
 
@@ -28,6 +27,7 @@ from oci.exceptions import ConfigFileNotFound
 
 from . import database
 from . import sentry  # noqa: F401
+from .cache import CacheEnum
 from .configurator import CONFIGURATOR
 from .env import ENVIRONMENT
 
@@ -228,12 +228,6 @@ REDIS_CONNECTION_POOL_KWARGS = {
     "health_check_interval": REDIS_HEALTH_CHECK_INTERVAL,
     "retry_on_timeout": REDIS_RETRY_ON_TIMEOUT,
 }
-
-
-class CacheEnum(StrEnum):
-    default = "default"
-    rbac = "rbac"
-    worker = "worker"
 
 
 KEEPDB = ENVIRONMENT.bool("KEEPDB", default=True)

--- a/koku/koku/settings.py
+++ b/koku/koku/settings.py
@@ -253,7 +253,7 @@ if "test" in sys.argv:
         CacheEnum.api: {
             "BACKEND": "django.core.cache.backends.dummy.DummyCache",
             "LOCATION": TEST_CACHE_LOCATION,
-            "KEY_PREFIX": "default",
+            "KEY_PREFIX": "api",
             "KEY_FUNCTION": "django_tenants.cache.make_key",
             "REVERSE_KEY_FUNCTION": "django_tenants.cache.reverse_key",
         },
@@ -271,7 +271,7 @@ else:
     CACHES = {
         CacheEnum.default: {
             "BACKEND": "django_redis.cache.RedisCache",
-            "LOCATION": f"redis://{REDIS_HOST}:{REDIS_PORT}/{REDIS_DB}",
+            "LOCATION": REDIS_URL,
             "KEY_PREFIX": "default",
             "KEY_FUNCTION": "django_tenants.cache.make_key",
             "REVERSE_KEY_FUNCTION": "django_tenants.cache.reverse_key",
@@ -285,7 +285,7 @@ else:
         },
         CacheEnum.api: {
             "BACKEND": "django_redis.cache.RedisCache",
-            "LOCATION": f"redis://{REDIS_HOST}:{REDIS_PORT}/{REDIS_DB}",
+            "LOCATION": REDIS_URL,
             "KEY_PREFIX": "api",
             "KEY_FUNCTION": "django_tenants.cache.make_key",
             "REVERSE_KEY_FUNCTION": "django_tenants.cache.reverse_key",
@@ -300,7 +300,7 @@ else:
         CacheEnum.rbac: {
             "BACKEND": "django_redis.cache.RedisCache",
             "KEY_PREFIX": "rbac",
-            "LOCATION": f"redis://{REDIS_HOST}:{REDIS_PORT}/1",
+            "LOCATION": REDIS_URL,
             "TIMEOUT": ENVIRONMENT.get_value("RBAC_CACHE_TIMEOUT", default=300),
             "OPTIONS": {
                 "CLIENT_CLASS": "django_redis.client.DefaultClient",

--- a/koku/koku/settings.py
+++ b/koku/koku/settings.py
@@ -17,6 +17,7 @@ import logging
 import os
 import re
 import sys
+from enum import StrEnum
 from json import JSONDecodeError
 from zoneinfo import ZoneInfo
 
@@ -27,7 +28,6 @@ from oci.exceptions import ConfigFileNotFound
 
 from . import database
 from . import sentry  # noqa: F401
-from .cache import CacheEnum
 from .configurator import CONFIGURATOR
 from .env import ENVIRONMENT
 
@@ -229,8 +229,15 @@ REDIS_CONNECTION_POOL_KWARGS = {
     "retry_on_timeout": REDIS_RETRY_ON_TIMEOUT,
 }
 
-
 KEEPDB = ENVIRONMENT.bool("KEEPDB", default=True)
+
+
+class CacheEnum(StrEnum):
+    default = "default"
+    rbac = "rbac"
+    worker = "worker"
+
+
 TEST_CACHE_LOCATION = "unique-snowflake"
 if "test" in sys.argv:
     TEST_RUNNER = "koku.koku_test_runner.KokuTestRunner"

--- a/koku/koku/test_cache.py
+++ b/koku/koku/test_cache.py
@@ -46,10 +46,16 @@ CACHE_PREFIXES = (
     CACHES={
         CacheEnum.default: {
             "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
-            "LOCATION": "unique-snowflake",
+            "LOCATION": "unique-snowflake-default",
             "KEY_FUNCTION": "django_tenants.cache.make_key",
             "REVERSE_KEY_FUNCTION": "django_tenants.cache.reverse_key",
-        }
+        },
+        CacheEnum.api: {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "unique-snowflake-api",
+            "KEY_FUNCTION": "django_tenants.cache.make_key",
+            "REVERSE_KEY_FUNCTION": "django_tenants.cache.reverse_key",
+        },
     }
 )
 class KokuCacheTest(IamTestCase):
@@ -59,7 +65,7 @@ class KokuCacheTest(IamTestCase):
         """Set up cache tests."""
         super().setUp()
 
-        self.cache = caches[CacheEnum.default]
+        self.cache = caches[CacheEnum.api]
         self.cache_key_prefix = random.choice(CACHE_PREFIXES)
 
     def tearDown(self):
@@ -86,13 +92,13 @@ class KokuCacheTest(IamTestCase):
         CACHES={
             CacheEnum.default: {
                 "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
-                "LOCATION": "unique-snowflake1",
+                "LOCATION": "unique-snowflake-default",
                 "KEY_FUNCTION": "django_tenants.cache.make_key",
                 "REVERSE_KEY_FUNCTION": "django_tenants.cache.reverse_key",
             },
             "non-default": {
                 "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
-                "LOCATION": "unique-snowflake2",
+                "LOCATION": "unique-snowflake-non-default",
                 "KEY_FUNCTION": "django_tenants.cache.make_key",
                 "REVERSE_KEY_FUNCTION": "django_tenants.cache.reverse_key",
             },
@@ -114,7 +120,7 @@ class KokuCacheTest(IamTestCase):
         self.assertIsNone(cache.get(key_to_clear))
         self.assertIsNotNone(cache.get(remaining_key))
 
-    @override_settings(CACHES={CacheEnum.default: {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}})
+    @override_settings(CACHES={CacheEnum.api: {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}})
     def test_invalidate_cache_for_tenant_and_cache_key_dummy_cache(self):
         """Test that using DummyCache logs correctly."""
         with self.assertLogs(logger="koku.cache", level="INFO"):
@@ -122,7 +128,7 @@ class KokuCacheTest(IamTestCase):
 
     @override_settings(
         CACHES={
-            CacheEnum.default: {
+            CacheEnum.api: {
                 "BACKEND": "django.core.cache.backends.db.DatabaseCache",
                 "LOCATION": "worker_cache_table",
             }

--- a/koku/koku/test_cache.py
+++ b/koku/koku/test_cache.py
@@ -13,6 +13,7 @@ from api.provider.models import Provider
 from koku.cache import AWS_CACHE_PREFIX
 from koku.cache import AZURE_CACHE_PREFIX
 from koku.cache import build_matching_tags_key
+from koku.cache import CacheEnum
 from koku.cache import delete_value_from_cache
 from koku.cache import get_cached_infra_map
 from koku.cache import get_cached_tag_rate_map
@@ -43,7 +44,7 @@ CACHE_PREFIXES = (
 
 @override_settings(
     CACHES={
-        "default": {
+        CacheEnum.default: {
             "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
             "LOCATION": "unique-snowflake",
             "KEY_FUNCTION": "django_tenants.cache.make_key",
@@ -58,7 +59,7 @@ class KokuCacheTest(IamTestCase):
         """Set up cache tests."""
         super().setUp()
 
-        self.cache = caches["default"]
+        self.cache = caches[CacheEnum.default]
         self.cache_key_prefix = random.choice(CACHE_PREFIXES)
 
     def tearDown(self):
@@ -83,7 +84,7 @@ class KokuCacheTest(IamTestCase):
 
     @override_settings(
         CACHES={
-            "default": {
+            CacheEnum.default: {
                 "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
                 "LOCATION": "unique-snowflake1",
                 "KEY_FUNCTION": "django_tenants.cache.make_key",
@@ -113,7 +114,7 @@ class KokuCacheTest(IamTestCase):
         self.assertIsNone(cache.get(key_to_clear))
         self.assertIsNotNone(cache.get(remaining_key))
 
-    @override_settings(CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}})
+    @override_settings(CACHES={CacheEnum.default: {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}})
     def test_invalidate_cache_for_tenant_and_cache_key_dummy_cache(self):
         """Test that using DummyCache logs correctly."""
         with self.assertLogs(logger="koku.cache", level="INFO"):
@@ -121,7 +122,10 @@ class KokuCacheTest(IamTestCase):
 
     @override_settings(
         CACHES={
-            "default": {"BACKEND": "django.core.cache.backends.db.DatabaseCache", "LOCATION": "worker_cache_table"}
+            CacheEnum.default: {
+                "BACKEND": "django.core.cache.backends.db.DatabaseCache",
+                "LOCATION": "worker_cache_table",
+            }
         }
     )
     def test_invalidate_cache_for_tenant_and_cache_key_unsupported_backend(self):

--- a/koku/koku/test_cache.py
+++ b/koku/koku/test_cache.py
@@ -17,8 +17,8 @@ from koku.cache import delete_value_from_cache
 from koku.cache import get_cached_infra_map
 from koku.cache import get_cached_tag_rate_map
 from koku.cache import get_value_from_cache
+from koku.cache import invalidate_cache_for_tenant_and_cache_key
 from koku.cache import invalidate_view_cache_for_tenant_and_all_source_types
-from koku.cache import invalidate_view_cache_for_tenant_and_cache_key
 from koku.cache import invalidate_view_cache_for_tenant_and_source_type
 from koku.cache import invalidate_view_cache_for_tenant_and_source_types
 from koku.cache import is_key_in_cache
@@ -30,7 +30,6 @@ from koku.cache import OPENSHIFT_CACHE_PREFIX
 from koku.cache import set_cached_infra_map
 from koku.cache import set_cached_tag_rate_map
 from koku.cache import set_value_in_cache
-
 
 CACHE_PREFIXES = (
     AWS_CACHE_PREFIX,
@@ -67,7 +66,7 @@ class KokuCacheTest(IamTestCase):
         super().tearDown()
         self.cache.clear()
 
-    def test_invalidate_view_cache_for_tenant_and_cache_key(self):
+    def test_invalidate_cache_for_tenant_and_cache_key(self):
         """Test that specific cache data is deleted."""
         key_to_clear = f"{self.schema_name}:{self.cache_key_prefix}"
         remaining_key = f"keeper:{self.cache_key_prefix}"
@@ -77,26 +76,58 @@ class KokuCacheTest(IamTestCase):
         self.assertIsNotNone(self.cache.get(key_to_clear))
         self.assertIsNotNone(self.cache.get(remaining_key))
 
-        invalidate_view_cache_for_tenant_and_cache_key(self.schema_name, self.cache_key_prefix)
+        invalidate_cache_for_tenant_and_cache_key(self.schema_name, self.cache_key_prefix)
 
         self.assertIsNone(self.cache.get(key_to_clear))
         self.assertIsNotNone(self.cache.get(remaining_key))
 
+    @override_settings(
+        CACHES={
+            "default": {
+                "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+                "LOCATION": "unique-snowflake1",
+                "KEY_FUNCTION": "django_tenants.cache.make_key",
+                "REVERSE_KEY_FUNCTION": "django_tenants.cache.reverse_key",
+            },
+            "non-default": {
+                "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+                "LOCATION": "unique-snowflake2",
+                "KEY_FUNCTION": "django_tenants.cache.make_key",
+                "REVERSE_KEY_FUNCTION": "django_tenants.cache.reverse_key",
+            },
+        }
+    )
+    def test_invalidate_cache_for_tenant_and_cache_key_non_default(self):
+        """Test that specific cache data is deleted."""
+        cache = caches["non-default"]
+        key_to_clear = f"{self.schema_name}:{self.cache_key_prefix}"
+        remaining_key = f"keeper:{self.cache_key_prefix}"
+        cache_data = {key_to_clear: "value", remaining_key: "value"}
+        cache.set_many(cache_data)
+
+        self.assertIsNotNone(cache.get(key_to_clear))
+        self.assertIsNotNone(cache.get(remaining_key))
+
+        invalidate_cache_for_tenant_and_cache_key(self.schema_name, self.cache_key_prefix, cache_name="non-default")
+
+        self.assertIsNone(cache.get(key_to_clear))
+        self.assertIsNotNone(cache.get(remaining_key))
+
     @override_settings(CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}})
-    def test_invalidate_view_cache_for_tenant_and_cache_key_dummy_cache(self):
+    def test_invalidate_cache_for_tenant_and_cache_key_dummy_cache(self):
         """Test that using DummyCache logs correctly."""
         with self.assertLogs(logger="koku.cache", level="INFO"):
-            invalidate_view_cache_for_tenant_and_cache_key(self.schema_name, self.cache_key_prefix)
+            invalidate_cache_for_tenant_and_cache_key(self.schema_name, self.cache_key_prefix)
 
     @override_settings(
         CACHES={
             "default": {"BACKEND": "django.core.cache.backends.db.DatabaseCache", "LOCATION": "worker_cache_table"}
         }
     )
-    def test_invalidate_view_cache_for_tenant_and_cache_key_unsupported_backend(self):
+    def test_invalidate_cache_for_tenant_and_cache_key_unsupported_backend(self):
         """Test that an unsupported cache backend raises an error."""
         with self.assertRaises(KokuCacheError):
-            invalidate_view_cache_for_tenant_and_cache_key(self.schema_name, self.cache_key_prefix)
+            invalidate_cache_for_tenant_and_cache_key(self.schema_name, self.cache_key_prefix)
 
     def test_invalidate_view_cache_for_tenant_and_source_type(self):
         """Test that all views for a source type and tenant are invalidated."""

--- a/koku/koku/test_middleware.py
+++ b/koku/koku/test_middleware.py
@@ -39,6 +39,7 @@ from koku.middleware import IdentityHeaderMiddleware
 from koku.middleware import KokuTenantMiddleware
 from koku.middleware import KokuTenantSchemaExistsMiddleware
 from koku.middleware import RequestTimingMiddleware
+from koku.settings import CacheEnum
 from koku.test_rbac import mocked_requests_get_500_text
 
 
@@ -247,7 +248,7 @@ class IdentityHeaderMiddlewareTest(IamTestCase):
         dup_cust = IdentityHeaderMiddleware.create_customer(account_id, org_id, "POST")
         self.assertEqual(orig_cust, dup_cust)
 
-    @override_settings(CACHES={"rbac": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}})
+    @override_settings(CACHES={CacheEnum.rbac: {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}})
     @patch("koku.rbac.RbacService.get_access_for_user")
     def test_process_non_admin(self, get_access_mock):
         """Test case for process_request as a non-admin user."""
@@ -277,12 +278,12 @@ class IdentityHeaderMiddlewareTest(IamTestCase):
 
         user_uuid = mock_request.user.uuid
         org_id = customer.get("org_id")
-        cache = caches["rbac"]
+        cache = caches[CacheEnum.rbac]
         cache_key = f"{user_uuid}_{org_id}"
         self.assertEqual(cache.get(cache_key), mock_access)
 
         middleware.process_request(mock_request)
-        cache = caches["rbac"]
+        cache = caches[CacheEnum.rbac]
         self.assertEqual(cache.get(cache_key), mock_access)
 
     def test_process_not_entitled(self):

--- a/koku/koku/test_middleware.py
+++ b/koku/koku/test_middleware.py
@@ -33,13 +33,13 @@ from api.iam.models import Tenant
 from api.iam.models import User
 from api.iam.test.iam_test_case import IamTestCase
 from koku import middleware as MD
+from koku.cache import CacheEnum
 from koku.middleware import EXTENDED_METRICS
 from koku.middleware import HttpResponseUnauthorizedRequest
 from koku.middleware import IdentityHeaderMiddleware
 from koku.middleware import KokuTenantMiddleware
 from koku.middleware import KokuTenantSchemaExistsMiddleware
 from koku.middleware import RequestTimingMiddleware
-from koku.settings import CacheEnum
 from koku.test_rbac import mocked_requests_get_500_text
 
 

--- a/koku/masu/api/invalidate_cache.py
+++ b/koku/masu/api/invalidate_cache.py
@@ -4,7 +4,6 @@
 #
 """Endpoint for cache invalidation."""
 import logging
-from enum import StrEnum
 
 from pydantic import BaseModel
 from pydantic import ValidationError
@@ -23,14 +22,9 @@ from koku.cache import invalidate_cache_for_tenant_and_cache_key
 LOG = logging.getLogger("__name__")
 
 
-class CacheType(StrEnum):
-    api = "api"
-    rbac = "rbac"
-
-
 class CacheInvalidationEvent(BaseModel):
     schema_name: str
-    cache_type: CacheType
+    cache_name: CacheEnum
 
 
 class CacheInvalidationEvents(BaseModel):
@@ -51,9 +45,9 @@ def invalidate_cache(request: Request):
         return Response(e.errors(), status=status.HTTP_400_BAD_REQUEST)
 
     for event in events.events:
-        if event.cache_type == CacheType.api:
+        if event.cache_name == CacheEnum.default:
             invalidate_cache_for_tenant_and_cache_key(event.schema_name, cache_name=CacheEnum.default)
-        elif event.cache_type == CacheType.rbac:
+        elif event.cache_name == CacheEnum.rbac:
             invalidate_cache_for_tenant_and_cache_key(event.schema_name, cache_name=CacheEnum.rbac)
 
     return Response({"msg": "invalidated cache"} | events.model_dump(), status=status.HTTP_200_OK)

--- a/koku/masu/api/invalidate_cache.py
+++ b/koku/masu/api/invalidate_cache.py
@@ -4,6 +4,7 @@
 #
 """Endpoint for cache invalidation."""
 import logging
+from typing import Literal
 
 from pydantic import BaseModel
 from pydantic import ValidationError
@@ -24,7 +25,7 @@ LOG = logging.getLogger("__name__")
 
 class CacheInvalidationEvent(BaseModel):
     schema_name: str
-    cache_name: CacheEnum
+    cache_name: Literal[CacheEnum.default, CacheEnum.rbac]  # we don't support invalidating the CacheEnum.worker cache
 
 
 class CacheInvalidationEvents(BaseModel):

--- a/koku/masu/api/invalidate_cache.py
+++ b/koku/masu/api/invalidate_cache.py
@@ -1,0 +1,59 @@
+#
+# Copyright 2025 Red Hat Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Endpoint for cache invalidation."""
+import logging
+from enum import StrEnum
+
+from pydantic import BaseModel
+from pydantic import ValidationError
+from rest_framework import status
+from rest_framework.decorators import api_view
+from rest_framework.decorators import permission_classes
+from rest_framework.decorators import renderer_classes
+from rest_framework.permissions import AllowAny
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.settings import api_settings
+
+from koku.cache import invalidate_cache_for_tenant_and_cache_key
+from koku.settings import CacheEnum
+
+LOG = logging.getLogger("__name__")
+
+
+class CacheType(StrEnum):
+    api = "api"
+    rbac = "rbac"
+
+
+class CacheInvalidationEvent(BaseModel):
+    schema_name: str
+    cache_type: CacheType
+
+
+class CacheInvalidationEvents(BaseModel):
+    events: list[CacheInvalidationEvent]
+
+
+@api_view(http_method_names=["POST"])
+@permission_classes((AllowAny,))
+@renderer_classes(tuple(api_settings.DEFAULT_RENDERER_CLASSES))
+def invalidate_cache(request: Request):
+    data = request.data
+    if isinstance(data, dict):
+        data = [data]
+    try:
+        events = CacheInvalidationEvents(events=data)
+    except ValidationError as e:
+        LOG.warning(f"validation error: {str(e)}")
+        return Response(e.errors(), status=status.HTTP_400_BAD_REQUEST)
+
+    for event in events.events:
+        if event.cache_type == CacheType.api:
+            invalidate_cache_for_tenant_and_cache_key(event.schema_name, cache_name=CacheEnum.default)
+        elif event.cache_type == CacheType.rbac:
+            invalidate_cache_for_tenant_and_cache_key(event.schema_name, cache_name=CacheEnum.rbac)
+
+    return Response({"msg": "invalidated cache"} | events.model_dump(), status=status.HTTP_200_OK)

--- a/koku/masu/api/invalidate_cache.py
+++ b/koku/masu/api/invalidate_cache.py
@@ -25,7 +25,7 @@ LOG = logging.getLogger("__name__")
 
 class CacheInvalidationEvent(BaseModel):
     schema_name: str
-    cache_name: Literal[CacheEnum.api, CacheEnum.rbac]  # we don't support invalidating the CacheEnum.worker cache
+    cache_name: Literal[CacheEnum.api, CacheEnum.rbac]
 
 
 class CacheInvalidationEvents(BaseModel):

--- a/koku/masu/api/invalidate_cache.py
+++ b/koku/masu/api/invalidate_cache.py
@@ -17,8 +17,8 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.settings import api_settings
 
+from koku.cache import CacheEnum
 from koku.cache import invalidate_cache_for_tenant_and_cache_key
-from koku.settings import CacheEnum
 
 LOG = logging.getLogger("__name__")
 

--- a/koku/masu/api/urls.py
+++ b/koku/masu/api/urls.py
@@ -28,6 +28,7 @@ from masu.api.views import hcs_report_data
 from masu.api.views import hcs_report_finalization
 from masu.api.views import ingest_ocp_payload
 from masu.api.views import ingress_reports
+from masu.api.views import invalidate_cache
 from masu.api.views import lockinfo
 from masu.api.views import ManifestStatusViewSet
 from masu.api.views import notification
@@ -91,6 +92,7 @@ urlpatterns = [
     path("db-performance/explain-query/", explain_query, name="explain_query"),
     path("db-performance/db-version/", pg_engine_version, name="db_version"),
     path("db-performance/schema-sizes/", schema_sizes, name="schema_sizes"),
+    path("invalidate_cache", invalidate_cache, name="invalidate_cache"),
 ]
 
 if settings.DEBUG:

--- a/koku/masu/api/views.py
+++ b/koku/masu/api/views.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 """API views for import organization"""
-# noqa: F401
 from masu.api.additional_context import additional_context
 from masu.api.bigquery_cost import bigquery_cost
 from masu.api.crawl_account_hierarchy import crawl_account_hierarchy

--- a/koku/masu/api/views.py
+++ b/koku/masu/api/views.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 """API views for import organization"""
-# flake8: noqa
+# noqa: F401
 from masu.api.additional_context import additional_context
 from masu.api.bigquery_cost import bigquery_cost
 from masu.api.crawl_account_hierarchy import crawl_account_hierarchy
@@ -23,6 +23,7 @@ from masu.api.hcs_report_data import hcs_report_data
 from masu.api.hcs_report_finalization import hcs_report_finalization
 from masu.api.ingest_ocp_payload import ingest_ocp_payload
 from masu.api.ingress_reports import ingress_reports
+from masu.api.invalidate_cache import invalidate_cache
 from masu.api.manifest.views import ManifestStatusViewSet
 from masu.api.notifications import notification
 from masu.api.process_openshift_on_cloud import process_openshift_on_cloud

--- a/koku/masu/openapi.json
+++ b/koku/masu/openapi.json
@@ -2211,6 +2211,55 @@
                     }
                 }
             ]
+        },
+        "/invalidate_cache/": {
+            "post": {
+                "summary": "trigger cache invalidation",
+                "operationId": "postInvalidateCache",
+                "parameters": [],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "oneOf": [
+                                    {
+                                        "$ref": "#/components/schemas/InvalidateCachePostList"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/InvalidateCachePostDict"
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "notification that cache was invalidated",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/InvalidateCacheOKResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "invalid payload",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/InvalidateCacheBadRequestResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "tags": [
+                    "Invalidate Cache"
+                ]
+            }
         }
     },
     "components": {
@@ -3269,6 +3318,122 @@
                     "aws_list_account_aliases": {
                         "type": "boolean",
                         "example": true
+                    }
+                }
+            },
+            "InvalidateCachePostDict": {
+                "properties": {
+                    "schema_name": {
+                        "title": "Schema Name",
+                        "type": "string"
+                    },
+                    "cache_name": {
+                        "enum": [
+                            "api",
+                            "rbac"
+                        ],
+                        "title": "Cache Name",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "schema_name",
+                    "cache_name"
+                ],
+                "type": "object"
+            },
+            "InvalidateCachePostList": {
+                "type": "array",
+                "items": {
+                    "$ref": "#/components/schemas/InvalidateCachePostDict"
+                },
+                "example": [
+                    {
+                        "schema_name": "org1234567",
+                        "cache_name": "api"
+                    },
+                    {
+                        "schema_name": "org1234567",
+                        "cache_name": "rbac"
+                    }
+                ]
+            },
+            "InvalidateCacheOKResponse": {
+                "type": "object",
+                "properties": {
+                    "msg": {
+                        "type": "string",
+                        "example": "invalidated cache"
+                    },
+                    "events": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/InvalidateCachePostDict"
+                        }
+                    }
+                },
+                "example": {
+                    "msg": "invalidated cache",
+                    "events": [
+                        {
+                            "schema_name": "org1234567",
+                            "cache_name": "rbac"
+                        },
+                        {
+                            "schema_name": "org1234567",
+                            "cache_name": "api"
+                        }
+                    ]
+                }
+            },
+            "InvalidateCacheBadRequestResponse": {
+                "type": "array",
+                "items": {
+                    "$ref": "#/components/schemas/PydanticErrorObject"
+                },
+                "example": [
+                    {
+                        "type": "literal_error",
+                        "loc": [
+                            "events",
+                            0,
+                            "cache_name"
+                        ],
+                        "msg": "Input should be <CacheEnum.api: 'api'> or <CacheEnum.rbac: 'rbac'>",
+                        "input": "asdfasdf",
+                        "ctx": {
+                            "expected": "<CacheEnum.api: 'api'> or <CacheEnum.rbac: 'rbac'>"
+                        },
+                        "url": "https://errors.pydantic.dev/2.10/v/literal_error"
+                    }
+                ]
+            },
+            "PydanticErrorObject": {
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "A computer-readable identifier of the error type."
+                    },
+                    "loc": {
+                        "type": "object",
+                        "description": "The error's location as a list."
+                    },
+                    "msg": {
+                        "type": "string",
+                        "description": "A human-readable explanation of the error."
+                    },
+                    "input": {
+                        "type": "object",
+                        "description": "The input provided for validation."
+                    },
+                    "ctx": {
+                        "type": "string",
+                        "description": "An optional object which contains values required to render the error message."
+                    },
+                    "url": {
+                        "type": "string",
+                        "description": "The URL to further information about the error."
                     }
                 }
             }

--- a/koku/masu/processor/cost_model_cost_updater.py
+++ b/koku/masu/processor/cost_model_cost_updater.py
@@ -9,7 +9,7 @@ import ciso8601
 
 from api.models import Provider
 from api.utils import DateHelper
-from koku.cache import invalidate_view_cache_for_tenant_and_cache_key
+from koku.cache import invalidate_cache_for_tenant_and_cache_key
 from koku.cache import invalidate_view_cache_for_tenant_and_source_type
 from koku.cache import TAG_MAPPING_PREFIX
 from masu.processor import is_customer_cost_model_large
@@ -108,4 +108,4 @@ class CostModelCostUpdater:
                 self._updater.update_summary_cost_model_costs(start_date, end_date)
             invalidate_view_cache_for_tenant_and_source_type(self._schema, self._provider.type)
             # Invalidate the tag_rate_map for tag mapping
-            invalidate_view_cache_for_tenant_and_cache_key(self._schema, TAG_MAPPING_PREFIX)
+            invalidate_cache_for_tenant_and_cache_key(self._schema, TAG_MAPPING_PREFIX)

--- a/koku/masu/processor/worker_cache.py
+++ b/koku/masu/processor/worker_cache.py
@@ -10,6 +10,7 @@ from django.core.cache import caches
 from django.db import connection
 
 from koku import CELERY_INSPECT
+from koku.cache import CacheEnum
 
 TASK_CACHE_EXPIRE = 30
 LOG = logging.getLogger(__name__)
@@ -60,7 +61,7 @@ class WorkerCache:
 
     """
 
-    cache = caches["worker"]
+    cache = caches[CacheEnum.worker]
 
     def __init__(self):
         self._hostname = settings.HOSTNAME

--- a/koku/masu/test/api/test_invalidate_cache.py
+++ b/koku/masu/test/api/test_invalidate_cache.py
@@ -52,7 +52,9 @@ class CacheInvalidationAPIViewTest(MasuTestCase):
         response = self.client.post(url, data=test_payload, content_type="application/json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        self.mock_invalidate.assert_called_once_with(self.schema_name, cache_name=CacheEnum.rbac)
+        self.mock_invalidate.assert_called_once_with(
+            self.schema_name.removeprefix("org"), cache_key_prefix=CacheEnum.rbac, cache_name=CacheEnum.rbac
+        )
 
     def test_cache_invalidation_default_success(self, _):
         """Test the cache invalidation endpoint."""
@@ -61,7 +63,9 @@ class CacheInvalidationAPIViewTest(MasuTestCase):
         response = self.client.post(url, data=test_payload, content_type="application/json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        self.mock_invalidate.assert_called_once_with(self.schema_name, cache_name=CacheEnum.api)
+        self.mock_invalidate.assert_called_once_with(
+            self.schema_name, cache_key_prefix=CacheEnum.api, cache_name=CacheEnum.api
+        )
 
     def test_cache_invalidation_api_not_valid_type(self, _):
         """Test the cache invalidation endpoint."""

--- a/koku/masu/test/api/test_invalidate_cache.py
+++ b/koku/masu/test/api/test_invalidate_cache.py
@@ -10,7 +10,7 @@ from django.test.utils import override_settings
 from django.urls import reverse
 from rest_framework import status
 
-from koku.settings import CacheEnum
+from koku.cache import CacheEnum
 from masu.test import MasuTestCase
 
 LOG = logging.getLogger(__name__)

--- a/koku/masu/test/api/test_invalidate_cache.py
+++ b/koku/masu/test/api/test_invalidate_cache.py
@@ -31,13 +31,13 @@ class CacheInvalidationAPIViewTest(MasuTestCase):
         """Test the cache invalidation endpoint."""
         tests = [
             [
-                {"schema_name": self.schema_name, "cache_type": "api"},
-                {"schema_name": self.schema_name, "cache_type": "rbac"},
+                {"schema_name": self.schema_name, "cache_name": "default"},
+                {"schema_name": self.schema_name, "cache_name": "rbac"},
             ],
-            [{"schema_name": self.schema_name, "cache_type": "api"}],
-            [{"schema_name": self.schema_name, "cache_type": "rbac"}],
-            {"schema_name": self.schema_name, "cache_type": "api"},
-            {"schema_name": self.schema_name, "cache_type": "rbac"},
+            [{"schema_name": self.schema_name, "cache_name": "default"}],
+            [{"schema_name": self.schema_name, "cache_name": "rbac"}],
+            {"schema_name": self.schema_name, "cache_name": "default"},
+            {"schema_name": self.schema_name, "cache_name": "rbac"},
         ]
         url = reverse("invalidate_cache")
         for test in tests:
@@ -47,16 +47,16 @@ class CacheInvalidationAPIViewTest(MasuTestCase):
 
     def test_cache_invalidation_rbac_success(self, _):
         """Test the cache invalidation endpoint."""
-        test_payload = {"schema_name": self.schema_name, "cache_type": "rbac"}
+        test_payload = {"schema_name": self.schema_name, "cache_name": "rbac"}
         url = reverse("invalidate_cache")
         response = self.client.post(url, data=test_payload, content_type="application/json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         self.mock_invalidate.assert_called_once_with(self.schema_name, cache_name=CacheEnum.rbac)
 
-    def test_cache_invalidation_api_success(self, _):
+    def test_cache_invalidation_default_success(self, _):
         """Test the cache invalidation endpoint."""
-        test_payload = {"schema_name": self.schema_name, "cache_type": "api"}
+        test_payload = {"schema_name": self.schema_name, "cache_name": "default"}
         url = reverse("invalidate_cache")
         response = self.client.post(url, data=test_payload, content_type="application/json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -67,13 +67,13 @@ class CacheInvalidationAPIViewTest(MasuTestCase):
         """Test the cache invalidation endpoint."""
         tests = [
             [
-                {"schema_name": self.schema_name, "cache_type": "api1"},
-                {"schema_name": self.schema_name, "cache_type": "rbac1"},
+                {"schema_name": self.schema_name, "cache_name": "default1"},
+                {"schema_name": self.schema_name, "cache_name": "rbac1"},
             ],
-            [{"schema_name": self.schema_name, "cache_type": "api1"}],
-            [{"schema_name": self.schema_name, "cache_type": "rbac1"}],
-            {"schema_name": self.schema_name, "cache_type": "api1"},
-            {"schema_name": self.schema_name, "cache_type": "rbac1"},
+            [{"schema_name": self.schema_name, "cache_name": "default1"}],
+            [{"schema_name": self.schema_name, "cache_name": "rbac1"}],
+            {"schema_name": self.schema_name, "cache_name": "default1"},
+            {"schema_name": self.schema_name, "cache_name": "rbac1"},
         ]
         url = reverse("invalidate_cache")
         for test in tests:
@@ -86,12 +86,12 @@ class CacheInvalidationAPIViewTest(MasuTestCase):
     def test_cache_invalidation_api_missing_params(self, _):
         tests = [
             [
-                {"cache_type": "api1"},
+                {"cache_name": "default1"},
                 {"schema_name": self.schema_name},
             ],
-            [{"cache_type": "api1"}],
+            [{"cache_name": "default1"}],
             [{"schema_name": self.schema_name}],
-            {"cache_type": "api1"},
+            {"cache_name": "default1"},
             {"schema_name": self.schema_name},
         ]
         url = reverse("invalidate_cache")
@@ -105,8 +105,8 @@ class CacheInvalidationAPIViewTest(MasuTestCase):
     def test_cache_invalidation_api_invalid_payloads(self, _):
         tests = [
             [
-                "cache_type",
-                "api1",
+                "cache_name",
+                "default1",
                 {"schema_name": self.schema_name},
             ],
             "this is an invalid payload",

--- a/koku/masu/test/api/test_invalidate_cache.py
+++ b/koku/masu/test/api/test_invalidate_cache.py
@@ -1,0 +1,121 @@
+#
+# Copyright 2025 Red Hat Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Test the cache invalidation endpoint."""
+import logging
+from unittest.mock import patch
+
+from django.test.utils import override_settings
+from django.urls import reverse
+from rest_framework import status
+
+from koku.settings import CacheEnum
+from masu.test import MasuTestCase
+
+LOG = logging.getLogger(__name__)
+
+
+@override_settings(ROOT_URLCONF="masu.urls")
+@patch("koku.middleware.MASU", return_value=True)
+class CacheInvalidationAPIViewTest(MasuTestCase):
+    """Test Cases for the Cache Invalidation API."""
+
+    def setUp(self):
+        patcher = patch("masu.api.invalidate_cache.invalidate_cache_for_tenant_and_cache_key")
+        self.mock_invalidate = patcher.start()
+        self.addCleanup(patcher.stop)
+        super().setUp()
+
+    def test_cache_invalidation_success(self, _):
+        """Test the cache invalidation endpoint."""
+        tests = [
+            [
+                {"schema_name": self.schema_name, "cache_type": "api"},
+                {"schema_name": self.schema_name, "cache_type": "rbac"},
+            ],
+            [{"schema_name": self.schema_name, "cache_type": "api"}],
+            [{"schema_name": self.schema_name, "cache_type": "rbac"}],
+            {"schema_name": self.schema_name, "cache_type": "api"},
+            {"schema_name": self.schema_name, "cache_type": "rbac"},
+        ]
+        url = reverse("invalidate_cache")
+        for test in tests:
+            with self.subTest(test=test):
+                response = self.client.post(url, data=test, content_type="application/json")
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_cache_invalidation_rbac_success(self, _):
+        """Test the cache invalidation endpoint."""
+        test_payload = {"schema_name": self.schema_name, "cache_type": "rbac"}
+        url = reverse("invalidate_cache")
+        response = self.client.post(url, data=test_payload, content_type="application/json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.mock_invalidate.assert_called_once_with(self.schema_name, cache_name=CacheEnum.rbac)
+
+    def test_cache_invalidation_api_success(self, _):
+        """Test the cache invalidation endpoint."""
+        test_payload = {"schema_name": self.schema_name, "cache_type": "api"}
+        url = reverse("invalidate_cache")
+        response = self.client.post(url, data=test_payload, content_type="application/json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.mock_invalidate.assert_called_once_with(self.schema_name, cache_name=CacheEnum.default)
+
+    def test_cache_invalidation_api_not_valid_type(self, _):
+        """Test the cache invalidation endpoint."""
+        tests = [
+            [
+                {"schema_name": self.schema_name, "cache_type": "api1"},
+                {"schema_name": self.schema_name, "cache_type": "rbac1"},
+            ],
+            [{"schema_name": self.schema_name, "cache_type": "api1"}],
+            [{"schema_name": self.schema_name, "cache_type": "rbac1"}],
+            {"schema_name": self.schema_name, "cache_type": "api1"},
+            {"schema_name": self.schema_name, "cache_type": "rbac1"},
+        ]
+        url = reverse("invalidate_cache")
+        for test in tests:
+            with self.subTest(test=test):
+                response = self.client.post(url, data=test, content_type="application/json")
+                self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        self.mock_invalidate.assert_not_called()
+
+    def test_cache_invalidation_api_missing_params(self, _):
+        tests = [
+            [
+                {"cache_type": "api1"},
+                {"schema_name": self.schema_name},
+            ],
+            [{"cache_type": "api1"}],
+            [{"schema_name": self.schema_name}],
+            {"cache_type": "api1"},
+            {"schema_name": self.schema_name},
+        ]
+        url = reverse("invalidate_cache")
+        for test in tests:
+            with self.subTest(test=test):
+                response = self.client.post(url, data=test, content_type="application/json")
+                self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        self.mock_invalidate.assert_not_called()
+
+    def test_cache_invalidation_api_invalid_payloads(self, _):
+        tests = [
+            [
+                "cache_type",
+                "api1",
+                {"schema_name": self.schema_name},
+            ],
+            "this is an invalid payload",
+            {"hello", "invalid", "paylaods"},
+        ]
+        url = reverse("invalidate_cache")
+        for test in tests:
+            with self.subTest(test=test):
+                response = self.client.post(url, data=test, content_type="application/json")
+                self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        self.mock_invalidate.assert_not_called()

--- a/koku/masu/test/api/test_invalidate_cache.py
+++ b/koku/masu/test/api/test_invalidate_cache.py
@@ -31,12 +31,12 @@ class CacheInvalidationAPIViewTest(MasuTestCase):
         """Test the cache invalidation endpoint."""
         tests = [
             [
-                {"schema_name": self.schema_name, "cache_name": "default"},
+                {"schema_name": self.schema_name, "cache_name": "api"},
                 {"schema_name": self.schema_name, "cache_name": "rbac"},
             ],
-            [{"schema_name": self.schema_name, "cache_name": "default"}],
+            [{"schema_name": self.schema_name, "cache_name": "api"}],
             [{"schema_name": self.schema_name, "cache_name": "rbac"}],
-            {"schema_name": self.schema_name, "cache_name": "default"},
+            {"schema_name": self.schema_name, "cache_name": "api"},
             {"schema_name": self.schema_name, "cache_name": "rbac"},
         ]
         url = reverse("invalidate_cache")
@@ -56,23 +56,23 @@ class CacheInvalidationAPIViewTest(MasuTestCase):
 
     def test_cache_invalidation_default_success(self, _):
         """Test the cache invalidation endpoint."""
-        test_payload = {"schema_name": self.schema_name, "cache_name": "default"}
+        test_payload = {"schema_name": self.schema_name, "cache_name": "api"}
         url = reverse("invalidate_cache")
         response = self.client.post(url, data=test_payload, content_type="application/json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        self.mock_invalidate.assert_called_once_with(self.schema_name, cache_name=CacheEnum.default)
+        self.mock_invalidate.assert_called_once_with(self.schema_name, cache_name=CacheEnum.api)
 
     def test_cache_invalidation_api_not_valid_type(self, _):
         """Test the cache invalidation endpoint."""
         tests = [
             [
-                {"schema_name": self.schema_name, "cache_name": "default1"},
+                {"schema_name": self.schema_name, "cache_name": "api1"},
                 {"schema_name": self.schema_name, "cache_name": "rbac1"},
             ],
-            [{"schema_name": self.schema_name, "cache_name": "default1"}],
+            [{"schema_name": self.schema_name, "cache_name": "api1"}],
             [{"schema_name": self.schema_name, "cache_name": "rbac1"}],
-            {"schema_name": self.schema_name, "cache_name": "default1"},
+            {"schema_name": self.schema_name, "cache_name": "api1"},
             {"schema_name": self.schema_name, "cache_name": "rbac1"},
         ]
         url = reverse("invalidate_cache")
@@ -86,12 +86,12 @@ class CacheInvalidationAPIViewTest(MasuTestCase):
     def test_cache_invalidation_api_missing_params(self, _):
         tests = [
             [
-                {"cache_name": "default1"},
+                {"cache_name": "api1"},
                 {"schema_name": self.schema_name},
             ],
-            [{"cache_name": "default1"}],
+            [{"cache_name": "api1"}],
             [{"schema_name": self.schema_name}],
-            {"cache_name": "default1"},
+            {"cache_name": "api1"},
             {"schema_name": self.schema_name},
         ]
         url = reverse("invalidate_cache")
@@ -106,7 +106,7 @@ class CacheInvalidationAPIViewTest(MasuTestCase):
         tests = [
             [
                 "cache_name",
-                "default1",
+                "api1",
                 {"schema_name": self.schema_name},
             ],
             "this is an invalid payload",

--- a/koku/masu/test/processor/test_tasks.py
+++ b/koku/masu/test/processor/test_tasks.py
@@ -32,6 +32,7 @@ from django_tenants.utils import schema_context
 from api.iam.models import Tenant
 from api.models import Provider
 from common.queues import SummaryQueue
+from koku.cache import CacheEnum
 from koku.middleware import KokuTenantMiddleware
 from masu.config import Config
 from masu.database import AWS_CUR_TABLE_MAP
@@ -1430,13 +1431,13 @@ class TestWorkerCacheThrottling(MasuTestCase):
 
     def single_task_is_running(self, task_name, task_args=None):
         """Check for a single task key in the cache."""
-        cache = caches["worker"]
+        cache = caches[CacheEnum.worker]
         cache_str = create_single_task_cache_key(task_name, task_args)
         return bool(cache.get(cache_str))
 
     def lock_single_task(self, task_name, task_args=None, timeout=None):
         """Add a cache entry for a single task to lock a specific task."""
-        cache = caches["worker"]
+        cache = caches[CacheEnum.worker]
         cache_str = create_single_task_cache_key(task_name, task_args)
         cache.add(cache_str, "kokuworker", 3)
 

--- a/koku/sources/api/view.py
+++ b/koku/sources/api/view.py
@@ -34,7 +34,7 @@ from api.provider.models import Sources
 from api.provider.provider_builder import ProviderBuilder
 from api.provider.provider_manager import ProviderManager
 from api.provider.provider_manager import ProviderManagerError
-from koku.cache import invalidate_view_cache_for_tenant_and_cache_key
+from koku.cache import invalidate_cache_for_tenant_and_cache_key
 from koku.cache import SOURCES_CACHE_PREFIX
 from masu.util.aws.common import get_available_regions
 from sources.api.serializers import AdminSourcesSerializer
@@ -65,7 +65,7 @@ class DestroySourceMixin(mixins.DestroyModelMixin):
                 return Response(msg, status=500)
             else:
                 result = super().destroy(request, *args, **kwargs)
-                invalidate_view_cache_for_tenant_and_cache_key(schema_name, SOURCES_CACHE_PREFIX)
+                invalidate_cache_for_tenant_and_cache_key(schema_name, SOURCES_CACHE_PREFIX)
                 return result
         LOG.error("Failed to remove Source")
         return Response("Failed to remove Source", status=500)
@@ -219,7 +219,7 @@ class SourcesViewSet(*MIXIN_LIST):
         schema_name = request.user.customer.schema_name
         try:
             result = super().update(request=request, args=args, kwargs=kwargs)
-            invalidate_view_cache_for_tenant_and_cache_key(schema_name, SOURCES_CACHE_PREFIX)
+            invalidate_cache_for_tenant_and_cache_key(schema_name, SOURCES_CACHE_PREFIX)
             return result
         except (SourcesStorageError, ParseError) as error:
             raise SourcesException(str(error))

--- a/koku/sources/api/view.py
+++ b/koku/sources/api/view.py
@@ -34,6 +34,7 @@ from api.provider.models import Sources
 from api.provider.provider_builder import ProviderBuilder
 from api.provider.provider_manager import ProviderManager
 from api.provider.provider_manager import ProviderManagerError
+from koku.cache import CacheEnum
 from koku.cache import invalidate_cache_for_tenant_and_cache_key
 from koku.cache import SOURCES_CACHE_PREFIX
 from masu.util.aws.common import get_available_regions
@@ -226,7 +227,9 @@ class SourcesViewSet(*MIXIN_LIST):
         except SourcesDependencyError as error:
             raise SourcesDependencyException(str(error))
 
-    @method_decorator(cache_page(settings.CACHE_MIDDLEWARE_SECONDS, key_prefix=SOURCES_CACHE_PREFIX))
+    @method_decorator(
+        cache_page(settings.CACHE_MIDDLEWARE_SECONDS, cache=CacheEnum.api, key_prefix=SOURCES_CACHE_PREFIX)
+    )
     def list(self, request, *args, **kwargs):
         """Obtain the list of sources."""
 

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ exclude =
   **/.unleash/
 per-file-ignores =
   koku/reporting/models.py: F401
+  **/views.py: F401
 
 import-order-style = pycharm
 application-import-names = koku, api, providers, reporting, reporting_common, cost_models, masu


### PR DESCRIPTION
## Jira Ticket

[COST-5905](https://issues.redhat.com/browse/COST-5905)

## Description
* add api specific cache and update `cache_page` to use this cache
  * also, add KEY_PREFIX for `default`, `api`, and `rbac` caches
* create new masu endpoint `/api/cost-management/v1/invalidate_cache` which accepts `POST` requests
  * the `POST` body accepts either a list (of dicts) or a dict
  * the dict must contain the `schema_name` and the `cache_name`
* create `CacheEnum` and use throughout the code base. This represents the names of the caches we use

Example usage:
1. clear single cache:
```
curl --location 'http://localhost:5042/api/cost-management/v1/invalidate_cache' \
--header 'Content-Type: application/json' \
--data '{"schema_name": "org1234567_mskarbek", "cache_name": "rbac"}'

200 OK
{
    "msg": "invalidated cache",
    "events": [
        {
            "schema_name": "org1234567_mskarbek",
            "cache_name": "rbac"
        }
    ]
}
```

2. clear more than 1 cache:
```
curl --location 'http://localhost:5042/api/cost-management/v1/invalidate_cache' \
--header 'Content-Type: application/json' \
--data '[{"schema_name": "org1234567_mskarbek", "cache_name": "rbac"}, {"schema_name": "org1234567_mskarbek", "cache_name": "default"}]'

200 OK
{
    "msg": "invalidated cache",
    "events": [
        {
            "schema_name": "org1234567_mskarbek",
            "cache_name": "rbac"
        },
        {
            "schema_name": "org1234567_mskarbek",
            "cache_name": "default"
        }
    ]
}
```

3. the endpoint also provides validation:
(we cannot clear the `worker` cache)
```
curl --location 'http://localhost:5042/api/cost-management/v1/invalidate_cache' \
--header 'Content-Type: application/json' \
--data '[{"schema_name": "org1234567_mskarbek", "cache_name": "rbac"}, {"schema_name": "org1234567_mskarbek", "cache_name": "worker"}]'

400 Bad Request
[
    {
        "type": "literal_error",
        "loc": [
            "events",
            1,
            "cache_name"
        ],
        "msg": "Input should be <CacheEnum.default: 'default'> or <CacheEnum.rbac: 'rbac'>",
        "input": "worker",
        "ctx": {
            "expected": "<CacheEnum.default: 'default'> or <CacheEnum.rbac: 'rbac'>"
        },
        "url": "https://errors.pydantic.dev/2.10/v/literal_error"
    }
]

also logged in masu-server logs:
masu_server  | [2025-03-13 19:49:29,867] INFO None None None 22 Identity: {"identity": {"account_number": "10001", "org_id": "1234567", "type": "User", "user": {"username": "user_dev", "email": "user_dev@foo.com", "is_org_admin": "True", "access": {}}}, "entitlements": {"cost_management": {"is_entitled": "True"}}}
masu_server  | validation error: 1 validation error for CacheInvalidationEvents
masu_server  | events.1.cache_name
masu_server  |   Input should be <CacheEnum.default: 'default'> or <CacheEnum.rbac: 'rbac'> [type=literal_error, input_value='worker', input_type=str]
masu_server  |     For further information visit https://errors.pydantic.dev/2.10/v/literal_error
masu_server  | [2025-03-13 19:49:29,895] INFO None None None 22 {'method': 'POST', 'path': '/api/cost-management/v1/invalidate_cache', 'status': 400, 'request_id': None, 'account': None, 'org_id': None, 'username': None, 'is_admin': False, 'response_time': 28}
masu_server  | [2025-03-13 19:49:29,895] WARNING None None None 22 Bad Request: /api/cost-management/v1/invalidate_cache
masu_server  | [2025-03-13 19:49:29,895] WARNING None None None 22 "POST /api/cost-management/v1/invalidate_cache HTTP/1.1" 400 295
```

## Testing

1. create sources and ingest data.
2. create a shell to examine cache

```
$ make shell
>>> from django.conf import settings
>>> from redis import Redis
>>> cache = Redis(host='localhost',port=settings.REDIS_PORT,db=settings.REDIS_DB,**settings.REDIS_CONNECTION_POOL_KWARGS)
```
3. Delete whatever keys are present:
```
>>> all_keys = cache.keys("*")
>>> all_keys = [key.decode("utf-8") for key in all_keys]
>>> for key in all_keys:
...   cache.delete(key)
1
1
...
```
(even with all of these deleted, the `kombu.binding...` keys will return. Try to look past them)
4. Hit any endpoint. I used:
http://localhost:8000/api/cost-management/v1/reports/openshift/resources/virtual-machines/
http://localhost:8000/api/cost-management/v1/sources/
5. examine the cache and see keys for these endpoints and an RBAC entry:
(the api pages are prefixed with `{schema}:api:`, rbac is prefixed with `rbac:` and ends with the schema with `acct` or `org` stripped)
```
>>> cache.keys("*")
[b'_kombu.binding.download', b'_kombu.binding.subs_extraction', b'_kombu.binding.ocp', b'_kombu.binding.celery.pidbox', b'_kombu.binding.subs_transmission', b'_kombu.binding.priority', b'_kombu.binding.celery', b'_kombu.binding.refresh', b'_kombu.binding.summary', b'org1234567_mskarbek:api:1:views.decorators.cache.cache_page.openshift-view.GET.6988ffc390fed00938d9090c6be8f3fb.93484dd78fce74e570936af6047e8d9a.en-us.UTC', b'rbac:1:b36cb4b2-84ce-4806-9ca1-a7c2cddb37ab_1234567_mskarbek', b'_kombu.binding.cost_model', b'org1234567_mskarbek:api:1:views.decorators.cache.cache_header.openshift-view.6988ffc390fed00938d9090c6be8f3fb.en-us.UTC', b'org1234567_mskarbek:api:1:views.decorators.cache.cache_page.sources.GET.731f477e1aca51c26bd23649e88dcde4.52498d91dc09f347723aa735b400b2c8.en-us.UTC', b'org1234567_mskarbek:api:1:views.decorators.cache.cache_header.sources.731f477e1aca51c26bd23649e88dcde4.en-us.UTC', b'_kombu.binding.hcs']
```
6. Clear cache for the API:
```
curl --location 'http://localhost:5042/api/cost-management/v1/invalidate_cache' \
--header 'Content-Type: application/json' \
--data '[{"schema_name": "org1234567_mskarbek", "cache_name": "api"}]'
```
7. Re-examine the cache and see that the API keys are gone:
```
[b'_kombu.binding.download', b'_kombu.binding.subs_extraction', b'_kombu.binding.ocp', b'_kombu.binding.celery.pidbox', b'_kombu.binding.subs_transmission', b'_kombu.binding.priority', b'_kombu.binding.celery', b'_kombu.binding.refresh', b'_kombu.binding.summary', b'rbac:1:b36cb4b2-84ce-4806-9ca1-a7c2cddb37ab_1234567_mskarbek', b'_kombu.binding.cost_model', b'_kombu.binding.hcs']
```
8. Clear the cache for RBAC:
```
curl --location 'http://localhost:5042/api/cost-management/v1/invalidate_cache' \
--header 'Content-Type: application/json' \
--data '[{"schema_name": "org1234567_mskarbek", "cache_name": "rbac"}]'
```
9. Again, examine the cache, and see only the `_kombu` keys:
```
>>> cache.keys("*")
[b'_kombu.binding.download', b'_kombu.binding.subs_extraction', b'_kombu.binding.ocp', b'_kombu.binding.celery.pidbox', b'_kombu.binding.subs_transmission', b'_kombu.binding.priority', b'_kombu.binding.celery', b'_kombu.binding.refresh', b'_kombu.binding.summary', b'_kombu.binding.cost_model', b'_kombu.binding.hcs']
```

10. Now do it all again, except this time, do not clear cache in the beginning. We should not see any of the `trino` keys removed when using the masu endpoint.
```
$ make delete-test-customer-data; make delete-testing; make delete-trino-data; make delete-redis-cache
$ make create-test-customer; make load-test-customer-data test_source=ONPREM
```
for example, when running this to delete api/rbac:
```
curl --location 'http://localhost:5042/api/cost-management/v1/invalidate_cache' \
--header 'Content-Type: application/json' \
--data '[{"schema_name": "org1234567_mskarbek", "cache_name": "rbac"}, {"schema_name": "org1234567_mskarbek", "cache_name": "api"}]'
```
you should still see these keys:
```
b'public:default:1:schema-exists-trino-org1234567_mskarbek',
b'org1234567_mskarbek:default:1:schema-exists-trino-org1234567_mskarbek'
```


## Release Notes
- [ ] proposed release note

```markdown
* [COST-####](https://issues.redhat.com/browse/COST-####) Fix some things
```
