### PR TITLE
fix provider type bug for manged tables task

### DIFF
--- a/koku/masu/api/report_data.py
+++ b/koku/masu/api/report_data.py
@@ -58,6 +58,9 @@ def report_data(request):
         if queue_name not in QUEUE_LIST:
             errmsg = f"'queue' must be one of {QUEUE_LIST}."
             return Response({"Error": errmsg}, status=status.HTTP_400_BAD_REQUEST)
+        if start_date is None:
+            errmsg = "start_date is a required parameter."
+            return Response({"Error": errmsg}, status=status.HTTP_400_BAD_REQUEST)
 
         try:
             provider = Provider.objects.get(uuid=provider_uuid)
@@ -68,10 +71,6 @@ def report_data(request):
             return Response({"Error": errmsg}, status=status.HTTP_400_BAD_REQUEST)
         if provider_schema != schema_name:
             errmsg = f"provider_uuid {provider_uuid} is not associated with schema {schema_name}."
-            return Response({"Error": errmsg}, status=status.HTTP_400_BAD_REQUEST)
-
-        if start_date is None:
-            errmsg = "start_date is a required parameter."
             return Response({"Error": errmsg}, status=status.HTTP_400_BAD_REQUEST)
 
         # For GCP invoice month summary periods

--- a/koku/masu/api/report_data.py
+++ b/koku/masu/api/report_data.py
@@ -6,7 +6,6 @@
 # flake8: noqa
 import logging
 
-from django.conf import settings
 from django.views.decorators.cache import never_cache
 from rest_framework import status
 from rest_framework.decorators import api_view
@@ -23,8 +22,6 @@ from common.queues import PriorityQueue
 from common.queues import QUEUE_LIST
 from masu.processor import is_managed_ocp_cloud_summary_enabled
 from masu.processor.tasks import process_openshift_on_cloud_trino
-from masu.processor.tasks import remove_expired_data
-from masu.processor.tasks import update_all_summary_tables
 from masu.processor.tasks import update_summary_tables
 
 LOG = logging.getLogger(__name__)
@@ -32,7 +29,7 @@ REPORT_DATA_KEY = "Report Data Task IDs"
 
 
 @never_cache
-@api_view(http_method_names=["GET", "DELETE"])
+@api_view(http_method_names=["GET"])
 @permission_classes((AllowAny,))
 @renderer_classes(tuple(api_settings.DEFAULT_RENDERER_CLASSES))
 def report_data(request):
@@ -41,41 +38,37 @@ def report_data(request):
         async_results = []
         params = request.query_params
         async_result = None
-        all_providers = False
         provider_uuid = params.get("provider_uuid")
-        provider_type = params.get("provider_type")
         schema_name = params.get("schema")
         start_date = params.get("start_date")
         end_date = params.get("end_date")
         invoice_month = params.get("invoice_month")
-        provider = None
-        fallback_queue = get_customer_queue(schema_name, PriorityQueue)
+        # Set boolean for ocp_on_cloud based on param string
+        ocp_on_cloud = params.get("ocp_on_cloud", "true").lower() == "true"
 
-        ocp_on_cloud = params.get("ocp_on_cloud", "true").lower()
-        ocp_on_cloud = ocp_on_cloud == "true"
+        fallback_queue = get_customer_queue(schema_name, PriorityQueue)
         queue_name = params.get("queue") or fallback_queue
-        if provider_uuid is None and provider_type is None:
-            errmsg = "provider_uuid or provider_type must be supplied as a parameter."
+
+        if provider_uuid is None:
+            errmsg = "provider_uuid must be supplied as a parameter."
+            return Response({"Error": errmsg}, status=status.HTTP_400_BAD_REQUEST)
+        if schema_name is None:
+            errmsg = "schema is a required parameter."
             return Response({"Error": errmsg}, status=status.HTTP_400_BAD_REQUEST)
         if queue_name not in QUEUE_LIST:
             errmsg = f"'queue' must be one of {QUEUE_LIST}."
             return Response({"Error": errmsg}, status=status.HTTP_400_BAD_REQUEST)
 
-        if provider_uuid == "*":
-            all_providers = True
-        elif provider_uuid:
-            try:
-                p = Provider.objects.get(uuid=provider_uuid)
-                provider = p.type
-                provider_schema = p.account.get("schema_name")
-            except Provider.DoesNotExist:
-                errmsg = f"provider_uuid {provider_uuid} does not exist"
-                return Response({"Error": errmsg}, status=status.HTTP_400_BAD_REQUEST)
-            if provider_schema != schema_name:
-                errmsg = f"provider_uuid {provider_uuid} is not associated with schema {schema_name}."
-                return Response({"Error": errmsg}, status=status.HTTP_400_BAD_REQUEST)
-        else:
-            provider = provider_type
+        try:
+            provider = Provider.objects.get(uuid=provider_uuid)
+            provider_schema = provider.account.get("schema_name")
+            provider_type = provider.type
+        except Provider.DoesNotExist:
+            errmsg = f"provider_uuid {provider_uuid} does not exist"
+            return Response({"Error": errmsg}, status=status.HTTP_400_BAD_REQUEST)
+        if provider_schema != schema_name:
+            errmsg = f"provider_uuid {provider_uuid} is not associated with schema {schema_name}."
+            return Response({"Error": errmsg}, status=status.HTTP_400_BAD_REQUEST)
 
         if start_date is None:
             errmsg = "start_date is a required parameter."
@@ -83,10 +76,7 @@ def report_data(request):
 
         # For GCP invoice month summary periods
         if not invoice_month:
-            if provider in [Provider.PROVIDER_GCP, Provider.PROVIDER_GCP_LOCAL] or provider_type in [
-                Provider.PROVIDER_GCP,
-                Provider.PROVIDER_GCP_LOCAL,
-            ]:
+            if provider_type in [Provider.PROVIDER_GCP, Provider.PROVIDER_GCP_LOCAL]:
                 if end_date:
                     invoice_month = end_date[0:4] + end_date[5:7]
                 else:
@@ -94,84 +84,32 @@ def report_data(request):
 
         months = get_months_in_date_range(start=start_date, end=end_date, invoice_month=invoice_month)
 
-        if not all_providers:
-            if schema_name is None:
-                errmsg = "schema is a required parameter."
-                return Response({"Error": errmsg}, status=status.HTTP_400_BAD_REQUEST)
-
-            if provider is None:
-                errmsg = "Unable to determine provider type."
-                return Response({"Error": errmsg}, status=status.HTTP_400_BAD_REQUEST)
-
-            if provider_type and provider_type != provider:
-                errmsg = "provider_uuid and provider_type have mismatched provider types."
-                return Response({"Error": errmsg}, status=status.HTTP_400_BAD_REQUEST)
-
-            for month in months:
-                async_result = update_summary_tables.s(
-                    schema_name,
-                    provider,
-                    provider_uuid,
-                    month[0],
-                    month[1],
-                    invoice_month=month[2],
-                    queue_name=queue_name,
-                    ocp_on_cloud=ocp_on_cloud,
+        for month in months:
+            async_result = update_summary_tables.s(
+                schema_name,
+                provider_type,
+                provider_uuid,
+                month[0],
+                month[1],
+                invoice_month=month[2],
+                queue_name=queue_name,
+                ocp_on_cloud=ocp_on_cloud,
+            ).apply_async(queue=queue_name or fallback_queue)
+            async_results.append({str(month): str(async_result)})
+            # If managed flow is enabled trigger trino managed processing
+            if is_managed_ocp_cloud_summary_enabled(schema_name, provider_type):
+                tracing_id = str(async_result)
+                report = {
+                    "schema_name": schema_name,
+                    "provider_type": provider_type,
+                    "provider_uuid": provider_uuid,
+                    "tracing_id": tracing_id,
+                    "start": month[0],
+                    "end": month[1],
+                    "invoice_month": month[2],
+                }
+                ocp_async = process_openshift_on_cloud_trino.s(
+                    [report], provider_type, schema_name, provider_uuid, tracing_id, masu_api_trigger=True
                 ).apply_async(queue=queue_name or fallback_queue)
-                async_results.append({str(month): str(async_result)})
-                if is_managed_ocp_cloud_summary_enabled(schema_name, provider_type):
-                    tracing_id = str(async_result)
-                    report = {
-                        "schema_name": schema_name,
-                        "provider_type": provider,
-                        "provider_uuid": provider_uuid,
-                        "tracing_id": tracing_id,
-                        "start": month[0],
-                        "end": month[1],
-                        "invoice_month": month[2],
-                    }
-                    ocp_async = process_openshift_on_cloud_trino.s(
-                        [report], provider, schema_name, provider_uuid, tracing_id, masu_api_trigger=True
-                    ).apply_async(queue=queue_name or fallback_queue)
-                    async_results.append({f"Managed OCP on Cloud {str(month)}": str(ocp_async)})
-        else:
-            # TODO: when DEVELOPMENT=False, disable resummarization for all providers to prevent burning the db.
-            # this query could be re-enabled if we need it, but we should consider limiting its use to a schema.
-            if not settings.DEVELOPMENT:
-                errmsg = "?provider_uuid=* is invalid query."
-                return Response({"Error": errmsg}, status=status.HTTP_400_BAD_REQUEST)
-            for month in months:
-                async_result = update_all_summary_tables.delay(month[0], month[1], invoice_month=month[2])
-                async_results.append({str(month): str(async_result)})
+                async_results.append({f"Managed OCP on Cloud {str(month)}": str(ocp_async)})
         return Response({REPORT_DATA_KEY: async_results})
-
-    if request.method == "DELETE":
-        params = request.query_params
-
-        schema_name = params.get("schema")
-        provider = params.get("provider")
-        provider_uuid = params.get("provider_uuid")
-        simulate = params.get("simulate")
-
-        if schema_name is None:
-            errmsg = "schema is a required parameter."
-            return Response({"Error": errmsg}, status=status.HTTP_400_BAD_REQUEST)
-
-        if provider is None:
-            errmsg = "provider is a required parameter."
-            return Response({"Error": errmsg}, status=status.HTTP_400_BAD_REQUEST)
-
-        if provider_uuid is None:
-            errmsg = "provider_uuid is a required parameter."
-            return Response({"Error": errmsg}, status=status.HTTP_400_BAD_REQUEST)
-
-        if simulate is not None and simulate.lower() not in ("true", "false"):
-            errmsg = "simulate must be a boolean."
-            return Response({"Error": errmsg}, status=status.HTTP_400_BAD_REQUEST)
-
-        simulate = simulate is not None and simulate.lower() == "true"
-        LOG.info("Calling remove_expired_data async task.")
-
-        async_result = remove_expired_data.delay(schema_name, provider, simulate, provider_uuid)
-
-        return Response({"Report Data Task ID": str(async_result)})

--- a/koku/masu/test/api/test_report_data.py
+++ b/koku/masu/test/api/test_report_data.py
@@ -6,7 +6,6 @@
 import datetime
 from unittest.mock import call
 from unittest.mock import patch
-from urllib.parse import urlencode
 
 from django.test import TestCase
 from django.test.utils import override_settings
@@ -147,7 +146,7 @@ class ReportDataTests(TestCase):
     @patch("masu.api.report_data.update_summary_tables")
     def test_get_report_data_schema_missing(self, mock_update, _):
         """Test GET report_data endpoint returns a 400 for missing schema."""
-        params = {"start_date": self.start_date, "provider_type": self.provider_type}
+        params = {"start_date": self.start_date, "provider_uuid": self.provider_uuid}
         expected_key = "Error"
         expected_message = "schema is a required parameter."
 
@@ -165,7 +164,7 @@ class ReportDataTests(TestCase):
         params = {"start_date": self.start_date, "schema": self.schema_name}
 
         expected_key = "Error"
-        expected_message = "provider_uuid or provider_type must be supplied as a parameter."
+        expected_message = "provider_uuid must be supplied as a parameter."
 
         response = self.client.get(reverse("report_data"), params)
         body = response.json()
@@ -249,26 +248,6 @@ class ReportDataTests(TestCase):
 
     @patch("koku.middleware.MASU", return_value=True)
     @patch("masu.api.report_data.update_summary_tables")
-    def test_get_report_data_mismatch_types_uuid(self, mock_update, _):
-        """Test GET report_data endpoint returns a 400 for mismatched type and uuid."""
-        params = {
-            "schema": self.schema_name,
-            "provider_uuid": self.provider_uuid,
-            "provider_type": Provider.PROVIDER_OCP,
-            "start_date": self.start_date,
-        }
-        expected_key = "Error"
-        expected_message = "provider_uuid and provider_type have mismatched provider types."
-
-        response = self.client.get(reverse("report_data"), params)
-        body = response.json()
-
-        self.assertEqual(response.status_code, 400)
-        self.assertIn(expected_key, body)
-        self.assertEqual(body[expected_key], expected_message)
-
-    @patch("koku.middleware.MASU", return_value=True)
-    @patch("masu.api.report_data.update_summary_tables")
     def test_get_report_data_with_end_date(self, mock_update, _):
         """Test GET report_data endpoint with end date."""
         start_date = DateHelper().today
@@ -325,211 +304,6 @@ class ReportDataTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn(expected_key, body)
         mock_update.s.assert_has_calls(expected_calls, any_order=True)
-
-    @patch("koku.middleware.MASU", return_value=True)
-    @patch("masu.api.report_data.update_summary_tables")
-    def test_get_report_data_with_only_provider_type(self, mock_update, _):
-        """Test GET report_data endpoint with only provider_type."""
-        end_date = self.start_date_time + datetime.timedelta(days=1)
-        multiple_calls = self.start_date_time.month != end_date.month
-
-        params = {
-            "schema": self.schema_name,
-            "provider_type": self.provider_type,
-            "start_date": self.start_date,
-            "end_date": end_date.strftime("%Y-%m-%d"),
-        }
-        expected_key = "Report Data Task IDs"
-        expected_calls = [
-            call(
-                params["schema"],
-                params["provider_type"],
-                None,
-                params["start_date"],
-                params["end_date"],
-                queue_name=PriorityQueue.DEFAULT,
-                ocp_on_cloud=True,
-                invoice_month=None,
-            )
-        ]
-
-        if multiple_calls:
-            expected_calls = [
-                call(
-                    params["schema"],
-                    params["provider_type"],
-                    None,
-                    params["start_date"],
-                    params["start_date"],
-                    queue_name=PriorityQueue.DEFAULT,
-                    ocp_on_cloud=True,
-                    invoice_month=None,
-                ),
-                call(
-                    params["schema"],
-                    params["provider_type"],
-                    None,
-                    params["end_date"],
-                    params["end_date"],
-                    queue_name=PriorityQueue.DEFAULT,
-                    ocp_on_cloud=True,
-                    invoice_month=None,
-                ),
-            ]
-
-        response = self.client.get(reverse("report_data"), params)
-        body = response.json()
-
-        self.assertEqual(response.status_code, 200)
-        self.assertIn(expected_key, body)
-        mock_update.s.assert_has_calls(expected_calls, any_order=True)
-
-    @override_settings(DEVELOPMENT=True)
-    @patch("koku.middleware.MASU", return_value=True)
-    @patch("masu.api.report_data.update_all_summary_tables")
-    def test_get_report_data_for_all_providers_dev_true(self, mock_update, _):
-        """Test GET report_data endpoint with provider_uuid=*."""
-        params = {"provider_uuid": "*", "start_date": self.start_date}
-        expected_key = "Report Data Task IDs"
-
-        response = self.client.get(reverse("report_data"), params)
-        body = response.json()
-
-        self.assertEqual(response.status_code, 200)
-        self.assertIn(expected_key, body)
-        mock_update.delay.assert_called_with(
-            params["start_date"], DateHelper().today.date().strftime("%Y-%m-%d"), invoice_month=None
-        )
-
-    @override_settings(DEVELOPMENT=False)
-    @patch("koku.middleware.MASU", return_value=True)
-    @patch("masu.api.report_data.update_all_summary_tables")
-    def test_get_report_data_for_all_providers_dev_false(self, mock_update, _):
-        """Test GET report_data endpoint with provider_uuid=*."""
-        params = {"provider_uuid": "*", "start_date": self.start_date}
-        response = self.client.get(reverse("report_data"), params)
-        self.assertEqual(response.status_code, 400)
-
-    @patch("koku.middleware.MASU", return_value=True)
-    @patch("masu.api.report_data.remove_expired_data")
-    def test_remove_report_data(self, mock_remove, _):
-        """Test that the DELETE call to report_data works."""
-        params = {
-            "schema": self.schema_name,
-            "provider": self.provider_type,
-            "provider_uuid": self.provider_uuid,
-            "simulate": False,
-        }
-        query_string = urlencode(params)
-        expected_key = "Report Data Task ID"
-
-        url = reverse("report_data") + "?" + query_string
-        response = self.client.delete(url)
-        body = response.json()
-
-        self.assertEqual(response.status_code, 200)
-        self.assertIn(expected_key, body)
-        mock_remove.delay.assert_called_with(
-            params["schema"], params["provider"], params["simulate"], str(params["provider_uuid"])
-        )
-
-    @patch("koku.middleware.MASU", return_value=True)
-    @patch("masu.api.report_data.remove_expired_data")
-    def test_remove_report_data_simulate(self, mock_remove, _):
-        """Test that the DELETE call to report_data works."""
-        params = {
-            "schema": self.schema_name,
-            "provider": self.provider_type,
-            "provider_uuid": self.provider_uuid,
-            "simulate": True,
-        }
-        query_string = urlencode(params)
-        expected_key = "Report Data Task ID"
-
-        url = reverse("report_data") + "?" + query_string
-        response = self.client.delete(url)
-        body = response.json()
-
-        self.assertEqual(response.status_code, 200)
-        self.assertIn(expected_key, body)
-        mock_remove.delay.assert_called_with(
-            params["schema"], params["provider"], params["simulate"], str(params["provider_uuid"])
-        )
-
-    @patch("koku.middleware.MASU", return_value=True)
-    @patch("masu.api.report_data.remove_expired_data")
-    def test_remove_report_data_simulate_missing(self, mock_remove, _):
-        """Test that the DELETE call to report_data works."""
-        params = {
-            "schema": self.schema_name,
-            "provider": self.provider_type,
-            "provider_uuid": self.provider_uuid,
-        }
-        query_string = urlencode(params)
-        expected_key = "Report Data Task ID"
-
-        url = reverse("report_data") + "?" + query_string
-        response = self.client.delete(url)
-        body = response.json()
-
-        self.assertEqual(response.status_code, 200)
-        self.assertIn(expected_key, body)
-        mock_remove.delay.assert_called_with(params["schema"], params["provider"], False, str(params["provider_uuid"]))
-
-    @patch("koku.middleware.MASU", return_value=True)
-    @patch("masu.api.report_data.remove_expired_data")
-    def test_remove_report_data_schema_missing(self, mock_remove, _):
-        """Test that the DELETE call to report_data works."""
-        params = {
-            "provider": self.provider_type,
-            "provider_uuid": self.provider_uuid,
-            "simulate": True,
-        }
-        query_string = urlencode(params)
-        expected_key = "Error"
-        expected_message = "schema is a required parameter."
-
-        url = reverse("report_data") + "?" + query_string
-        response = self.client.delete(url)
-        body = response.json()
-
-        self.assertEqual(response.status_code, 400)
-        self.assertIn(expected_key, body)
-        self.assertEqual(body[expected_key], expected_message)
-
-    @patch("koku.middleware.MASU", return_value=True)
-    @patch("masu.api.report_data.remove_expired_data")
-    def test_remove_report_data_provider_missing(self, mock_remove, _):
-        """Test that the DELETE call to report_data works."""
-        params = {"schema": self.schema_name, "provider_uuid": self.provider_uuid, "simulate": True}
-        query_string = urlencode(params)
-        expected_key = "Error"
-        expected_message = "provider is a required parameter."
-
-        url = reverse("report_data") + "?" + query_string
-        response = self.client.delete(url)
-        body = response.json()
-
-        self.assertEqual(response.status_code, 400)
-        self.assertIn(expected_key, body)
-        self.assertEqual(body[expected_key], expected_message)
-
-    @patch("koku.middleware.MASU", return_value=True)
-    @patch("masu.api.report_data.remove_expired_data")
-    def test_remove_report_data_provider_uuid_missing(self, mock_remove, _):
-        """Test that the DELETE call to report_data works."""
-        params = {"schema": self.schema_name, "provider": self.provider_type, "simulate": True}
-        query_string = urlencode(params)
-        expected_key = "Error"
-        expected_message = "provider_uuid is a required parameter."
-
-        url = reverse("report_data") + "?" + query_string
-        response = self.client.delete(url)
-        body = response.json()
-
-        self.assertEqual(response.status_code, 400)
-        self.assertIn(expected_key, body)
-        self.assertEqual(body[expected_key], expected_message)
 
     @patch("koku.middleware.MASU", return_value=True)
     @patch("masu.api.report_data.update_summary_tables")


### PR DESCRIPTION
## Jira Ticket

[COST-####](https://issues.redhat.com/browse/COST-####)

## Description

This change was to fix the provider_type being passed to `if is_managed_ocp_cloud_summary_enabled(schema_name, provider_type):`, originally this was passing a `None` instead of the correct provider type.

This change also removes the old delete and summary by * provider logic which was never used. Additionally this also simplifies the remaining code. 

## Testing

1. Checkout Branch
2. Restart Koku
3. Load data
4. Trigger a resummary via the masu endpoint
5. Summary tasks should be triggered correctly for the schema/provider specified.
6. Additionally if you enabled the managed tables flags that take should also be triggered correctly too.

## Release Notes
- [ ] proposed release note

```markdown
* [COST-####](https://issues.redhat.com/browse/COST-####) Fix some things
```
