### PR TITLE
Revert "Add labels to vm storage rows (#5544)"

### DIFF
--- a/koku/masu/database/trino_sql/openshift/reporting_ocp_vm_summary_p_storage.sql
+++ b/koku/masu/database/trino_sql/openshift/reporting_ocp_vm_summary_p_storage.sql
@@ -19,7 +19,6 @@ INSERT INTO postgres.{{schema | sqlsafe}}.reporting_ocp_vm_summary_p (
     resource_ids,
     usage_start,
     usage_end,
-    pod_labels,
     cost_category_id,
     source_uuid,
     persistentvolumeclaim,
@@ -74,7 +73,6 @@ SELECT uuid() as id,
     array_agg(DISTINCT resource_id) as resource_ids,
     min(usage_start) as usage_start,
     max(usage_start) as usage_end,
-    all_labels as pod_labels,
     max(cost_category_id) as cost_category_id,
     CAST({{source_uuid}} as uuid) as source_uuid,
     max(ocp.persistentvolumeclaim) as persistentvolumeclaim,
@@ -92,4 +90,4 @@ WHERE usage_start >= DATE({{start_date}})
     AND namespace IS DISTINCT FROM 'Platform unallocated'
     AND namespace IS DISTINCT FROM 'Network unattributed'
     AND namespace IS DISTINCT FROM 'Storage unattributed'
-GROUP BY all_labels, cluster_alias, cluster_id, namespace, vm_name, cost_model_rate_type, ocp.persistentvolumeclaim
+GROUP BY cluster_alias, cluster_id, namespace, vm_name, cost_model_rate_type, ocp.persistentvolumeclaim


### PR DESCRIPTION
This reverts commit 3979c9c9b704484c6867677f7de4310d1a2a1c86.

## Jira Ticket

## Description

This change will revert add the labels to the vm storage rows:
1. We need to combine the labels with what is available for the virtual machines, so if they filter by a virtual machine label
2. we need to grab the latest pod labels

## Testing

## Release Notes
- [ ] proposed release note

```markdown
* [COST-####](https://issues.redhat.com/browse/COST-####) Fix some things
```
