### PR TITLE
[COST-6134] replace tj-actions/changed-files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@531f5f7d163941f0c1c04e0ff4d8bb243ac4366f # v45.0.7
+        uses: step-security/changed-files@3dbe17c78367e7d60f00d78ae6781a35be47b4a1 # v45.0.1
         with:
           files_from_source_file: docker-files.txt
 
@@ -168,7 +168,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@531f5f7d163941f0c1c04e0ff4d8bb243ac4366f # v45.0.7
+        uses: step-security/changed-files@3dbe17c78367e7d60f00d78ae6781a35be47b4a1 # v45.0.1
         with:
           files: |
             db_functions/**
@@ -243,7 +243,7 @@ jobs:
           path: |
             ~/.cache/pipenv
             ~/.local/share/virtualenvs
-          key: ${{ runner.os }}-env-${{ matrix.python-version }}-${{ hashFiles('**/Pipfile.lock') }}-${{ secrets.ACTIONS_CACHE_KEY_UUID }}
+          key: ${{ runner.os }}-env-${{ matrix.python-version }}-${{ hashFiles('**/Pipfile.lock') }}
 
       - name: Install dependencies
         if: needs.changed-files.outputs.run_tests == 'true' && steps.cache-dependencies.outputs.cache-hit != 'true'


### PR DESCRIPTION
* replace `tj-actions/changed-files` with `step-security/changed-files`
* remove the `ACTIONS_CACHE_KEY_UUID` which is unused (previously, it was used to change the cache key when cache would become corrupted, but github has provided the ability to delete cache thru their API or in the UI)