### PR TITLE
[COST-6097] Add Cluster per hour cost metric

### DIFF
--- a/dev/scripts/cost_models/openshift_on_prem_cost_model.json
+++ b/dev/scripts/cost_models/openshift_on_prem_cost_model.json
@@ -241,6 +241,20 @@
                 }
             ],
             "cost_type": "Supplementary"
+        },
+        {
+            "metric": {
+                "name": "cluster_cost_per_hour"
+            },
+            "tiered_rates": [
+                {
+                    "unit": "USD",
+                    "value": 3.45,
+                    "usage_start": null,
+                    "usage_end": null
+                }
+            ],
+            "cost_type": "Infrastructure"
         }
     ]
 }

--- a/koku/api/metrics/constants.py
+++ b/koku/api/metrics/constants.py
@@ -19,6 +19,7 @@ OCP_NODE_MONTH = "node_cost_per_month"
 OCP_NODE_CORE_MONTH = "node_core_cost_per_month"
 OCP_CLUSTER_MONTH = "cluster_cost_per_month"
 OCP_CLUSTER_CORE_HOUR = "cluster_core_cost_per_hour"
+OCP_CLUSTER_HOUR = "cluster_cost_per_hour"
 OCP_PVC_MONTH = "pvc_cost_per_month"
 OCP_VM_MONTH = "vm_cost_per_month"
 OCP_VM_HOUR = "vm_cost_per_hour"
@@ -37,6 +38,7 @@ USAGE_METRIC_MAP = {
     OCP_METRIC_STORAGE_GB_USAGE_MONTH: STORAGE,
     OCP_METRIC_STORAGE_GB_REQUEST_MONTH: STORAGE,
     OCP_CLUSTER_CORE_HOUR: CPU,
+    OCP_CLUSTER_HOUR: CPU,
 }
 
 PVC_DISTRIBUTION = "pvc"
@@ -58,6 +60,7 @@ METRIC_CHOICES = (
     (OCP_NODE_CORE_MONTH, OCP_NODE_CORE_MONTH),
     (OCP_CLUSTER_MONTH, OCP_CLUSTER_MONTH),
     (OCP_CLUSTER_CORE_HOUR, OCP_CLUSTER_CORE_HOUR),
+    (OCP_CLUSTER_HOUR, OCP_CLUSTER_HOUR),
     (OCP_PVC_MONTH, OCP_PVC_MONTH),
     (OCP_VM_MONTH, OCP_VM_MONTH),
     (OCP_VM_HOUR, OCP_VM_HOUR),
@@ -80,6 +83,7 @@ COST_MODEL_USAGE_RATES = (
     OCP_NODE_CORE_HOUR,
     OCP_VM_HOUR,
     OCP_CLUSTER_CORE_HOUR,
+    OCP_CLUSTER_HOUR,
 )
 
 COST_MODEL_NODE_RATES = {
@@ -199,6 +203,14 @@ COST_MODEL_METRIC_MAP = [
         "label_metric": "Cluster",
         "label_measurement": "Count",
         "label_measurement_unit": "cluster-month",
+        "default_cost_type": "Infrastructure",
+    },
+    {
+        "source_type": "OCP",
+        "metric": "cluster_cost_per_hour",
+        "label_metric": "Cluster",
+        "label_measurement": "Count",
+        "label_measurement_unit": "cluster-hour",
         "default_cost_type": "Infrastructure",
     },
     {

--- a/koku/masu/database/ocp_report_db_accessor.py
+++ b/koku/masu/database/ocp_report_db_accessor.py
@@ -663,6 +663,7 @@ GROUP BY partitions.year, partitions.month, partitions.source
             "cpu_effective_rate": rates.get(metric_constants.OCP_METRIC_CPU_CORE_EFFECTIVE_USAGE_HOUR, 0),
             "node_core_hour_rate": rates.get(metric_constants.OCP_NODE_CORE_HOUR, 0),
             "cluster_core_hour_rate": rates.get(metric_constants.OCP_CLUSTER_CORE_HOUR, 0),
+            "cluster_hour_rate": rates.get(metric_constants.OCP_CLUSTER_HOUR, 0),
             "memory_usage_rate": rates.get(metric_constants.OCP_METRIC_MEM_GB_USAGE_HOUR, 0),
             "memory_request_rate": rates.get(metric_constants.OCP_METRIC_MEM_GB_REQUEST_HOUR, 0),
             "memory_effective_rate": rates.get(metric_constants.OCP_METRIC_MEM_GB_EFFECTIVE_USAGE_HOUR, 0),

--- a/koku/masu/database/ocp_report_db_accessor.py
+++ b/koku/masu/database/ocp_report_db_accessor.py
@@ -728,30 +728,6 @@ GROUP BY partitions.year, partitions.month, partitions.source
             "report_period": report_period_id,
         }
 
-        table_name = OCP_REPORT_TABLE_MAP["line_item_daily_summary"]
-        LOG.info(log_json(msg=f"removing cluster cost model {rate_type} hourly costs from daily summary", context=ctx))
-
-        tmp_sql = """
-            DELETE FROM {{schema | sqlsafe}}.{{table | sqlsafe}}
-                WHERE usage_start >= {{start_date}}
-                AND usage_start <= {{end_date}}
-                AND report_period_id = {{report_period_id}}
-                AND cost_model_rate_type = {{rate_type}}
-                AND source_uuid = {{source_uuid}}::uuid
-                AND monthly_cost_type IS NULL
-        """
-        tmp_sql_params = {
-            "schema": self.schema,
-            "table": table_name,
-            "start_date": start_date,
-            "end_date": end_date,
-            "report_period_id": report_period_id,
-            "rate_type": rate_type,
-            "source_uuid": str(provider_uuid),
-        }
-
-        self._prepare_and_execute_raw_sql_query(table_name, tmp_sql, tmp_sql_params, operation="DELETE")
-
         sql = pkgutil.get_data("masu.database", "trino_sql/openshift/cost_model/hourly_cost_cluster.sql")
         sql = sql.decode("utf-8")
         sql_params = {

--- a/koku/masu/database/sql/openshift/cost_model/usage_costs.sql
+++ b/koku/masu/database/sql/openshift/cost_model/usage_costs.sql
@@ -89,6 +89,7 @@ SELECT uuid_generate_v4(),
         + sum(coalesce(pod_effective_usage_cpu_core_hours, 0)) * {{cpu_effective_rate}}
         + sum(coalesce(pod_effective_usage_cpu_core_hours, 0)) * {{node_core_hour_rate}}
         + sum(coalesce(pod_effective_usage_cpu_core_hours, 0)) * {{cluster_core_hour_rate}}
+        + sum(coalesce(pod_effective_usage_cpu_core_hours, 0)) / max(cluster_capacity_cpu_core_hours) * 24 * {{cluster_hour_rate}}
         as cost_model_cpu_cost,
     sum(coalesce(pod_usage_memory_gigabyte_hours, 0)) * {{memory_usage_rate}}
         + sum(coalesce(pod_request_memory_gigabyte_hours, 0)) * {{memory_request_rate}}

--- a/koku/masu/database/sql/openshift/cost_model/usage_costs.sql
+++ b/koku/masu/database/sql/openshift/cost_model/usage_costs.sql
@@ -89,7 +89,6 @@ SELECT uuid_generate_v4(),
         + sum(coalesce(pod_effective_usage_cpu_core_hours, 0)) * {{cpu_effective_rate}}
         + sum(coalesce(pod_effective_usage_cpu_core_hours, 0)) * {{node_core_hour_rate}}
         + sum(coalesce(pod_effective_usage_cpu_core_hours, 0)) * {{cluster_core_hour_rate}}
---        + sum(coalesce(pod_effective_usage_cpu_core_hours, 0)) / max(cluster_capacity_cpu_core_hours) * pod_usage.distinct_hours_used * {{cluster_hour_rate}}
         as cost_model_cpu_cost,
     sum(coalesce(pod_usage_memory_gigabyte_hours, 0)) * {{memory_usage_rate}}
         + sum(coalesce(pod_request_memory_gigabyte_hours, 0)) * {{memory_request_rate}}

--- a/koku/masu/database/sql/openshift/cost_model/usage_costs.sql
+++ b/koku/masu/database/sql/openshift/cost_model/usage_costs.sql
@@ -89,7 +89,7 @@ SELECT uuid_generate_v4(),
         + sum(coalesce(pod_effective_usage_cpu_core_hours, 0)) * {{cpu_effective_rate}}
         + sum(coalesce(pod_effective_usage_cpu_core_hours, 0)) * {{node_core_hour_rate}}
         + sum(coalesce(pod_effective_usage_cpu_core_hours, 0)) * {{cluster_core_hour_rate}}
-        + sum(coalesce(pod_effective_usage_cpu_core_hours, 0)) / max(cluster_capacity_cpu_core_hours) * 24 * {{cluster_hour_rate}}
+--        + sum(coalesce(pod_effective_usage_cpu_core_hours, 0)) / max(cluster_capacity_cpu_core_hours) * pod_usage.distinct_hours_used * {{cluster_hour_rate}}
         as cost_model_cpu_cost,
     sum(coalesce(pod_usage_memory_gigabyte_hours, 0)) * {{memory_usage_rate}}
         + sum(coalesce(pod_request_memory_gigabyte_hours, 0)) * {{memory_request_rate}}

--- a/koku/masu/database/trino_sql/openshift/cost_model/hourly_cost_cluster.sql
+++ b/koku/masu/database/trino_sql/openshift/cost_model/hourly_cost_cluster.sql
@@ -51,41 +51,33 @@ SELECT uuid(),
     max(report_period_id) AS report_period_id,
     lids.cluster_id,
     max(clusterhrs.cluster_alias) AS cluster_alias,
-    data_source,
+    'Pod' AS data_source,
     usage_start,
     max(usage_end) AS usage_end,
-    lids.namespace,
-    node,
-    max(resource_id) AS resource_id,
-    pod_labels,
-    all_labels,
+    NULL AS namespace,
+    NULL AS node,
+    NULL AS resource_id,
+    NULL AS pod_labels,
+    NULL AS all_labels,
     source_uuid,
     {{rate_type}} AS cost_model_rate_type,
     max(clusterhrs.cluster_interval_hours) * CAST({{cluster_cost_per_hour}} AS DECIMAL(33, 15)) AS cost_model_cpu_cost,
     0 AS cost_model_memory_cost,
     0 AS cost_model_volume_cost,
-    cost_category_id
+    NULL AS cost_category_id
 FROM postgres.{{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary AS lids
 JOIN cte_cluster_usage_hours AS clusterhrs
     ON lids.cluster_id = clusterhrs.cluster_id
     AND clusterhrs.interval_day = lids.usage_start
-WHERE usage_start >= DATE({{start_date}})
-    AND usage_start <= DATE({{end_date}})
+WHERE usage_start BETWEEN DATE({{start_date}}) AND DATE({{end_date}})
     AND report_period_id = {{report_period_id}}
     AND data_source = 'Pod'
     AND lids.monthly_cost_type IS NULL
     AND pod_usage_cpu_core_hours IS NOT NULL
     AND pod_request_cpu_core_hours IS NOT NULL
     AND pod_request_cpu_core_hours != 0
-GROUP BY usage_start,
-         usage_end,
-         source_uuid,
-         lids.cluster_id,
-         clusterhrs.cluster_alias,
-         node,
-         lids.namespace,
-         data_source,
-         cost_category_id,
-         pod_labels,
-         all_labels
+GROUP BY
+    lids.cluster_id,
+    usage_start,
+    source_uuid
 ;

--- a/koku/masu/database/trino_sql/openshift/cost_model/hourly_cost_cluster.sql
+++ b/koku/masu/database/trino_sql/openshift/cost_model/hourly_cost_cluster.sql
@@ -45,39 +45,66 @@ cte_cluster_usage_hours AS (
         ON pod_usage.namespace = cte_clusters.namespace
     WHERE source = {{source_uuid}}
     GROUP BY cte_clusters.cluster_id, cte_clusters.cluster_alias, DATE(interval_start)
+),
+
+-- Get the number of occurrences per cluster per day.
+cluster_usage_count AS (
+    SELECT
+        cluster_id,
+        usage_start,
+        COUNT(*) AS usage_line_count
+    FROM postgres.{{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary
+    WHERE usage_start BETWEEN DATE({{start_date}}) AND DATE({{end_date}})
+        AND report_period_id = {{report_period_id}}
+        AND data_source = 'Pod'
+        AND monthly_cost_type IS NULL
+        AND pod_usage_cpu_core_hours IS NOT NULL
+        AND pod_request_cpu_core_hours IS NOT NULL
+        AND pod_request_cpu_core_hours != 0
+    GROUP BY cluster_id, usage_start
 )
 
 SELECT uuid(),
     max(report_period_id) AS report_period_id,
     lids.cluster_id,
     max(clusterhrs.cluster_alias) AS cluster_alias,
-    'Pod' AS data_source,
-    usage_start,
+    data_source,
+    lids.usage_start,
     max(usage_end) AS usage_end,
-    NULL AS namespace,
-    NULL AS node,
-    NULL AS resource_id,
-    NULL AS pod_labels,
-    NULL AS all_labels,
+    lids.namespace,
+    node,
+    max(resource_id) AS resource_id,
+    pod_labels,
+    all_labels,
     source_uuid,
     {{rate_type}} AS cost_model_rate_type,
-    max(clusterhrs.cluster_interval_hours) * CAST({{cluster_cost_per_hour}} AS DECIMAL(33, 15)) AS cost_model_cpu_cost,
+    (max(clusterhrs.cluster_interval_hours) * CAST({{cluster_cost_per_hour}} AS DECIMAL(33, 15))) / max(usage_count.usage_line_count) AS cost_model_cpu_cost,
     0 AS cost_model_memory_cost,
     0 AS cost_model_volume_cost,
-    NULL AS cost_category_id
+    cost_category_id
 FROM postgres.{{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary AS lids
 JOIN cte_cluster_usage_hours AS clusterhrs
     ON lids.cluster_id = clusterhrs.cluster_id
     AND clusterhrs.interval_day = lids.usage_start
-WHERE usage_start BETWEEN DATE({{start_date}}) AND DATE({{end_date}})
+JOIN cluster_usage_count AS usage_count
+    ON lids.cluster_id = usage_count.cluster_id
+    AND lids.usage_start = usage_count.usage_start
+WHERE lids.usage_start BETWEEN DATE({{start_date}}) AND DATE({{end_date}})
     AND report_period_id = {{report_period_id}}
     AND data_source = 'Pod'
     AND lids.monthly_cost_type IS NULL
     AND pod_usage_cpu_core_hours IS NOT NULL
     AND pod_request_cpu_core_hours IS NOT NULL
     AND pod_request_cpu_core_hours != 0
-GROUP BY
-    lids.cluster_id,
-    usage_start,
-    source_uuid
+GROUP BY lids.usage_start,
+         usage_end,
+         source_uuid,
+         lids.cluster_id,
+         clusterhrs.cluster_alias,
+         node,
+         lids.namespace,
+         data_source,
+         cost_category_id,
+         pod_labels,
+         all_labels
 ;

--- a/koku/masu/database/trino_sql/openshift/cost_model/hourly_cost_cluster.sql
+++ b/koku/masu/database/trino_sql/openshift/cost_model/hourly_cost_cluster.sql
@@ -76,14 +76,14 @@ SELECT uuid(),
         ELSE 0
     END as cost_model_cpu_cost,
     CASE WHEN cte_distribution_type.dt = 'memory'
-    THEN ( max(cte_cluster.cluster_hours)/max(cte_cluster.node_count) * cast({{cluster_cost_per_hour}} as decimal(24, 9)) * sum(lids.pod_effective_usage_memory_gigabyte_hours)/sum(cte_node_usage.mem_usage) )
+        THEN ( max(cte_cluster.cluster_hours)/max(cte_cluster.node_count) * cast({{cluster_cost_per_hour}} as decimal(24, 9)) * sum(lids.pod_effective_usage_memory_gigabyte_hours)/sum(cte_node_usage.mem_usage) )
         ELSE 0
     END as cost_model_memory_cost,
     0 as cost_model_volume_cost,
     lids.cost_category_id
 FROM postgres.{{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary as lids
 JOIN cte_distribution_type
-        ON cte_distribution_type.source_uuid = lids.source_uuid
+    ON cte_distribution_type.source_uuid = lids.source_uuid
 JOIN cte_node_usage
     ON lids.source_uuid = cast({{source_uuid}} as uuid)
     AND lids.usage_start = cte_node_usage.usage_start

--- a/koku/masu/database/trino_sql/openshift/cost_model/hourly_cost_cluster.sql
+++ b/koku/masu/database/trino_sql/openshift/cost_model/hourly_cost_cluster.sql
@@ -1,0 +1,93 @@
+INSERT INTO postgres.{{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary (
+    uuid,
+    report_period_id,
+    cluster_id,
+    cluster_alias,
+    data_source,
+    usage_start,
+    usage_end,
+    namespace,
+    node,
+    resource_id,
+    pod_labels,
+    all_labels,
+    source_uuid,
+    cost_model_rate_type,
+    cost_model_cpu_cost,
+    cost_model_memory_cost,
+    cost_model_volume_cost,
+    cost_category_id
+)
+
+-- Get clusters from daily summary
+WITH cte_clusters AS (
+    SELECT
+        DISTINCT cluster_id,
+        cluster_alias,
+        namespace
+    FROM postgres.{{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary AS ocp
+    WHERE usage_start >= DATE({{start_date}})
+        AND usage_start <= DATE({{end_date}})
+        AND source_uuid = CAST({{source_uuid}} AS uuid)
+        AND pod_request_cpu_core_hours IS NOT NULL
+        AND pod_request_cpu_core_hours != 0
+),
+
+-- Get number of hours for each cluster
+cte_cluster_usage_hours AS (
+    SELECT
+        cte_clusters.cluster_id,
+        cte_clusters.cluster_alias,
+        DATE(interval_start) AS interval_day,
+        COUNT(pod_usage.interval_start) AS cluster_interval_hours
+    FROM hive.{{schema | sqlsafe}}.openshift_pod_usage_line_items pod_usage
+    INNER JOIN cte_clusters
+        ON pod_usage.namespace = cte_clusters.namespace
+    WHERE source = {{source_uuid}}
+        AND pod_usage.interval_start >= DATE({{start_date}})
+        AND pod_usage.interval_start <= DATE({{end_date}})
+    GROUP BY cte_clusters.cluster_id, cte_clusters.cluster_alias, DATE(interval_start)
+)
+
+SELECT uuid(),
+    max(report_period_id) AS report_period_id,
+    cluster_id,
+    max(cluster_alias) AS cluster_alias,
+    data_source,
+    usage_start,
+    max(usage_end) AS usage_end,
+    lids.namespace,
+    node,
+    max(resource_id) AS resource_id,
+    pod_labels,
+    all_labels,
+    source_uuid,
+    {{rate_type}} AS cost_model_rate_type,
+    max(clusterhrs.cluster_interval_hours) * CAST({{cluster_hour_rate}} AS DECIMAL(33, 15)) AS cost_model_cpu_cost,
+    0 AS cost_model_memory_cost,
+    0 AS cost_model_volume_cost,
+    cost_category_id
+FROM postgres.{{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary AS lids
+JOIN cte_cluster_usage_hours AS clusterhrs
+    ON lids.cluster_id = clusterhrs.cluster_id
+    AND clusterhrs.interval_day = lids.usage_start
+WHERE usage_start >= DATE({{start_date}})
+    AND usage_start <= DATE({{end_date}})
+    AND report_period_id = {{report_period_id}}
+    AND data_source = 'Pod'
+    AND lids.monthly_cost_type IS NULL
+    AND pod_usage_cpu_core_hours IS NOT NULL
+    AND pod_request_cpu_core_hours IS NOT NULL
+    AND pod_request_cpu_core_hours != 0
+GROUP BY usage_start,
+         usage_end,
+         source_uuid,
+         cluster_id,
+         cluster_alias,
+         node,
+         lids.namespace,
+         data_source,
+         cost_category_id,
+         pod_labels,
+         all_labels
+;

--- a/koku/masu/database/trino_sql/openshift/cost_model/hourly_cost_cluster.sql
+++ b/koku/masu/database/trino_sql/openshift/cost_model/hourly_cost_cluster.sql
@@ -21,55 +21,53 @@ INSERT INTO postgres.{{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summa
 
 WITH cte_cluster_usage_hours AS (
     SELECT
-        CAST(source AS VARCHAR) AS source,
         DATE(interval_start) AS interval_day,
         COUNT(DISTINCT interval_start) AS cluster_hours
     FROM hive.{{schema | sqlsafe}}.openshift_pod_usage_line_items
-    WHERE source = {{source_uuid}} AND
-          YEAR(cast(interval_start as date)) = YEAR(cast({{start_date}} as date)) AND
-          MONTH(cast(interval_start as date)) = MONTH(cast({{start_date}} as date))
-    GROUP BY source, DATE(interval_start)
+    WHERE source = {{source_uuid}}
+        AND year = {{year}}
+        AND month = {{month}}
+    GROUP BY DATE(interval_start)
 )
 
 SELECT uuid(),
-    max(report_period_id) AS report_period_id,
+    {{report_period_id}} as report_period_id,
     lids.cluster_id,
     lids.cluster_alias,
-    data_source,
+    lids.data_source,
     lids.usage_start,
-    max(usage_end) AS usage_end,
+    max(lids.usage_end) AS usage_end,
     lids.namespace,
-    node,
-    max(resource_id) AS resource_id,
-    pod_labels,
-    all_labels,
-    source_uuid,
+    lids.node,
+    max(lids.resource_id) AS resource_id,
+    lids.pod_labels,
+    lids.all_labels,
+    lids.source_uuid,
     {{rate_type}} AS cost_model_rate_type,
     (max(clusterhrs.cluster_hours) * CAST({{cluster_cost_per_hour}} AS DECIMAL(33, 15))) AS cost_model_cpu_cost,
     0 AS cost_model_memory_cost,
     0 AS cost_model_volume_cost,
-    cost_category_id
+    lids.cost_category_id
 FROM postgres.{{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary AS lids
 JOIN cte_cluster_usage_hours AS clusterhrs
-    ON CAST(lids.source_uuid AS VARCHAR) = clusterhrs.source
+    ON cast({{source_uuid}} as uuid) = lids.source_uuid
     AND clusterhrs.interval_day = lids.usage_start
-WHERE lids.usage_start BETWEEN DATE({{start_date}}) AND DATE({{end_date}})
-    AND report_period_id = {{report_period_id}}
-    AND data_source = 'Pod'
+WHERE lids.usage_start >= date({{start_date}}) AND lids.usage_start <= date({{end_date}})
+    AND lids.report_period_id = {{report_period_id}}
+    AND lids.data_source = 'Pod'
     AND lids.monthly_cost_type IS NULL
-    AND pod_usage_cpu_core_hours IS NOT NULL
-    AND pod_request_cpu_core_hours IS NOT NULL
-    AND pod_request_cpu_core_hours != 0
+    AND lids.pod_usage_cpu_core_hours IS NOT NULL
+    AND lids.pod_request_cpu_core_hours IS NOT NULL
+    AND lids.pod_request_cpu_core_hours != 0
 GROUP BY lids.usage_start,
-         usage_end,
-         source_uuid,
+         lids.usage_end,
+         lids.source_uuid,
          lids.cluster_id,
          lids.cluster_alias,
-         node,
+         lids.node,
          lids.namespace,
-         data_source,
-         cost_category_id,
-         pod_labels,
-         all_labels
- LIMIT 1
+         lids.data_source,
+         lids.cost_category_id,
+         lids.pod_labels,
+         lids.all_labels
 ;

--- a/koku/masu/database/trino_sql/openshift/cost_model/hourly_cost_cluster.sql
+++ b/koku/masu/database/trino_sql/openshift/cost_model/hourly_cost_cluster.sql
@@ -83,7 +83,7 @@ SELECT uuid(),
     lids.cost_category_id
 FROM postgres.{{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary as lids
 JOIN cte_distribution_type
-    ON cte_distribution_type.source_uuid = lids.source_uuid
+    ON cast(cte_distribution_type.source_uuid as uuid) = lids.source_uuid
 JOIN cte_node_usage
     ON lids.source_uuid = cast({{source_uuid}} as uuid)
     AND lids.usage_start = cte_node_usage.usage_start
@@ -100,10 +100,12 @@ WHERE lids.usage_start >= date({{start_date}})
     AND lids.pod_effective_usage_cpu_core_hours > 0
 GROUP BY lids.usage_start,
          lids.cluster_id,
+         lids.source_uuid,
          lids.namespace,
          lids.node,
          lids.resource_id,
          lids.data_source,
          lids.cost_category_id,
-         lids.pod_labels
+         lids.pod_labels,
+         cte_distribution_type.dt
 ;

--- a/koku/masu/database/trino_sql/openshift/cost_model/hourly_cost_cluster.sql
+++ b/koku/masu/database/trino_sql/openshift/cost_model/hourly_cost_cluster.sql
@@ -19,55 +19,22 @@ INSERT INTO postgres.{{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summa
     cost_category_id
 )
 
--- Get clusters from daily summary
-WITH cte_clusters AS (
+WITH cte_cluster_usage_hours AS (
     SELECT
-        DISTINCT cluster_id,
-        cluster_alias,
-        namespace
-    FROM postgres.{{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary AS ocp
-    WHERE usage_start >= DATE({{start_date}})
-        AND usage_start <= DATE({{end_date}})
-        AND source_uuid = CAST({{source_uuid}} AS uuid)
-        AND pod_request_cpu_core_hours IS NOT NULL
-        AND pod_request_cpu_core_hours != 0
-),
-
--- Get number of hours for each cluster
-cte_cluster_usage_hours AS (
-    SELECT
-        cte_clusters.cluster_id AS cluster_id,
-        cte_clusters.cluster_alias AS cluster_alias,
+        CAST(source AS VARCHAR) AS source,
         DATE(interval_start) AS interval_day,
-        COUNT(DISTINCT EXTRACT(hour FROM pod_usage.interval_start)) AS cluster_interval_hours
-    FROM hive.{{schema | sqlsafe}}.openshift_pod_usage_line_items pod_usage
-    INNER JOIN cte_clusters
-        ON pod_usage.namespace = cte_clusters.namespace
-    WHERE source = {{source_uuid}}
-    GROUP BY cte_clusters.cluster_id, cte_clusters.cluster_alias, DATE(interval_start)
-),
-
--- Get the number of occurrences per cluster per day.
-cluster_usage_count AS (
-    SELECT
-        cluster_id,
-        usage_start,
-        COUNT(*) AS usage_line_count
-    FROM postgres.{{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary
-    WHERE usage_start BETWEEN DATE({{start_date}}) AND DATE({{end_date}})
-        AND report_period_id = {{report_period_id}}
-        AND data_source = 'Pod'
-        AND monthly_cost_type IS NULL
-        AND pod_usage_cpu_core_hours IS NOT NULL
-        AND pod_request_cpu_core_hours IS NOT NULL
-        AND pod_request_cpu_core_hours != 0
-    GROUP BY cluster_id, usage_start
+        COUNT(DISTINCT interval_start) AS cluster_hours
+    FROM hive.{{schema | sqlsafe}}.openshift_pod_usage_line_items
+    WHERE source = {{source_uuid}} AND
+          YEAR(cast(interval_start as date)) = YEAR(cast({{start_date}} as date)) AND
+          MONTH(cast(interval_start as date)) = MONTH(cast({{start_date}} as date))
+    GROUP BY source, DATE(interval_start)
 )
 
 SELECT uuid(),
     max(report_period_id) AS report_period_id,
     lids.cluster_id,
-    max(clusterhrs.cluster_alias) AS cluster_alias,
+    lids.cluster_alias,
     data_source,
     lids.usage_start,
     max(usage_end) AS usage_end,
@@ -78,17 +45,14 @@ SELECT uuid(),
     all_labels,
     source_uuid,
     {{rate_type}} AS cost_model_rate_type,
-    (max(clusterhrs.cluster_interval_hours) * CAST({{cluster_cost_per_hour}} AS DECIMAL(33, 15))) / max(usage_count.usage_line_count) AS cost_model_cpu_cost,
+    (max(clusterhrs.cluster_hours) * CAST({{cluster_cost_per_hour}} AS DECIMAL(33, 15))) AS cost_model_cpu_cost,
     0 AS cost_model_memory_cost,
     0 AS cost_model_volume_cost,
     cost_category_id
 FROM postgres.{{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary AS lids
 JOIN cte_cluster_usage_hours AS clusterhrs
-    ON lids.cluster_id = clusterhrs.cluster_id
+    ON CAST(lids.source_uuid AS VARCHAR) = clusterhrs.source
     AND clusterhrs.interval_day = lids.usage_start
-JOIN cluster_usage_count AS usage_count
-    ON lids.cluster_id = usage_count.cluster_id
-    AND lids.usage_start = usage_count.usage_start
 WHERE lids.usage_start BETWEEN DATE({{start_date}}) AND DATE({{end_date}})
     AND report_period_id = {{report_period_id}}
     AND data_source = 'Pod'
@@ -100,7 +64,7 @@ GROUP BY lids.usage_start,
          usage_end,
          source_uuid,
          lids.cluster_id,
-         clusterhrs.cluster_alias,
+         lids.cluster_alias,
          node,
          lids.namespace,
          data_source,

--- a/koku/masu/database/trino_sql/openshift/cost_model/hourly_cost_cluster.sql
+++ b/koku/masu/database/trino_sql/openshift/cost_model/hourly_cost_cluster.sql
@@ -71,4 +71,5 @@ GROUP BY lids.usage_start,
          cost_category_id,
          pod_labels,
          all_labels
+ LIMIT 1
 ;

--- a/koku/masu/database/trino_sql/openshift/cost_model/hourly_cost_cluster.sql
+++ b/koku/masu/database/trino_sql/openshift/cost_model/hourly_cost_cluster.sql
@@ -36,8 +36,8 @@ WITH cte_clusters AS (
 -- Get number of hours for each cluster
 cte_cluster_usage_hours AS (
     SELECT
-        cte_clusters.cluster_id,
-        cte_clusters.cluster_alias,
+        cte_clusters.cluster_id AS cluster_id,
+        cte_clusters.cluster_alias AS cluster_alias,
         DATE(interval_start) AS interval_day,
         COUNT(pod_usage.interval_start) AS cluster_interval_hours
     FROM hive.{{schema | sqlsafe}}.openshift_pod_usage_line_items pod_usage
@@ -51,8 +51,8 @@ cte_cluster_usage_hours AS (
 
 SELECT uuid(),
     max(report_period_id) AS report_period_id,
-    cluster_id,
-    max(cluster_alias) AS cluster_alias,
+    lids.cluster_id,
+    max(clusterhrs.cluster_alias) AS cluster_alias,
     data_source,
     usage_start,
     max(usage_end) AS usage_end,
@@ -63,7 +63,7 @@ SELECT uuid(),
     all_labels,
     source_uuid,
     {{rate_type}} AS cost_model_rate_type,
-    max(clusterhrs.cluster_interval_hours) * CAST({{cluster_hour_rate}} AS DECIMAL(33, 15)) AS cost_model_cpu_cost,
+    max(clusterhrs.cluster_interval_hours) * CAST({{cluster_cost_per_hour}} AS DECIMAL(33, 15)) AS cost_model_cpu_cost,
     0 AS cost_model_memory_cost,
     0 AS cost_model_volume_cost,
     cost_category_id
@@ -82,8 +82,8 @@ WHERE usage_start >= DATE({{start_date}})
 GROUP BY usage_start,
          usage_end,
          source_uuid,
-         cluster_id,
-         cluster_alias,
+         lids.cluster_id,
+         clusterhrs.cluster_alias,
          node,
          lids.namespace,
          data_source,

--- a/koku/masu/database/trino_sql/openshift/cost_model/hourly_cost_cluster.sql
+++ b/koku/masu/database/trino_sql/openshift/cost_model/hourly_cost_cluster.sql
@@ -39,13 +39,11 @@ cte_cluster_usage_hours AS (
         cte_clusters.cluster_id AS cluster_id,
         cte_clusters.cluster_alias AS cluster_alias,
         DATE(interval_start) AS interval_day,
-        COUNT(pod_usage.interval_start) AS cluster_interval_hours
+        COUNT(DISTINCT EXTRACT(hour FROM pod_usage.interval_start)) AS cluster_interval_hours
     FROM hive.{{schema | sqlsafe}}.openshift_pod_usage_line_items pod_usage
     INNER JOIN cte_clusters
         ON pod_usage.namespace = cte_clusters.namespace
     WHERE source = {{source_uuid}}
-        AND pod_usage.interval_start >= DATE({{start_date}})
-        AND pod_usage.interval_start <= DATE({{end_date}})
     GROUP BY cte_clusters.cluster_id, cte_clusters.cluster_alias, DATE(interval_start)
 )
 

--- a/koku/masu/test/database/test_ocp_report_db_accessor.py
+++ b/koku/masu/test/database/test_ocp_report_db_accessor.py
@@ -1213,9 +1213,8 @@ class OCPReportDBAccessorTest(MasuTestCase):
         self.assertTrue(result)
         mock_postgresql.assert_called_once_with("reporting_ocp_vm_summary_p", ANY, sql_params, operation="INSERT")
 
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
     @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query")
-    def test_populate_cluster_hourly_usage_costs(self, mock_trino, mock_postgres):
+    def test_populate_cluster_hourly_usage_costs(self, mock_postgres):
         """Test the populate cluster hourly usage costs"""
 
         with self.accessor as acc:
@@ -1227,7 +1226,6 @@ class OCPReportDBAccessorTest(MasuTestCase):
                 self.ocp_provider_uuid,
                 1,
             )
-            mock_trino.assert_called()
             mock_postgres.assert_called()
 
     @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")

--- a/koku/masu/test/database/test_ocp_report_db_accessor.py
+++ b/koku/masu/test/database/test_ocp_report_db_accessor.py
@@ -1214,3 +1214,36 @@ class OCPReportDBAccessorTest(MasuTestCase):
         result = self.accessor._populate_virtualization_storage_costs(sql_params)
         self.assertTrue(result)
         mock_postgresql.assert_called_once_with("reporting_ocp_vm_summary_p", ANY, sql_params, operation="INSERT")
+
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query")
+    def test_populate_cluster_hourly_usage_costs(self, mock_trino, mock_postgres):
+        """Test the populate cluster hourly usage costs"""
+
+        with self.accessor as acc:
+            acc.populate_cluster_hourly_usage_costs(
+                metric_constants.SUPPLEMENTARY_COST_TYPE,
+                1,
+                self.dh.this_month_start,
+                self.dh.this_month_end,
+                self.ocp_provider_uuid,
+                1,
+            )
+            mock_trino.assert_called()
+            mock_postgres.assert_called()
+
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query")
+    def test_populate_usage_costs_cluster_rate(self, mock_trino, mock_postgres):
+        """Test the populate cluster hourly usage costs"""
+
+        with self.accessor as acc:
+            acc.populate_usage_costs(
+                metric_constants.SUPPLEMENTARY_COST_TYPE,
+                {metric_constants.OCP_CLUSTER_HOUR: 1},
+                self.dh.this_month_start,
+                self.dh.this_month_end,
+                self.ocp_provider_uuid,
+            )
+            mock_postgres.assert_called()
+            mock_trino.assert_called()


### PR DESCRIPTION
## Jira Ticket

[COST-6097](https://issues.redhat.com/browse/COST-6097)

## Description

This change will add a new Cost Model metric: `cluster_cost_per_hour`.

Basically, the value is calculated by counting how many distinct hour occurrences there were on the same day in the cluster, using `COUNT(DISTINCT interval_start) AS cluster_hours` in the Trino table `openshift_pod_usage_line_items`.

Testing and validation instructions are below.

## Testing

1. Checkout Branch
2. Restart Koku
3. Ingest OCP data
4. Create a new Cost Model with the new `cluster_cost_per_hour` metric
5. Check Trino to see how many hours the cluster ran:
```
select 
    date(interval_start) as interval_start_date, 
    count(distinct interval_start) as cluster_hours 
from 
    openshift_pod_usage_line_items 
where
    year='2025' and month='04' -- replace with your local data
group by 
    DATE(interval_start) 
limit 1;
```

6. Multiply `cluster_hours` by the `cluster_cost_per_hour` rate you created in step 4 above
7. Check if the values match the result of this Postgres query:
```
SELECT 
    cluster_id, SUM(cost_model_cpu_cost)
FROM 
    org1234567.reporting_ocpusagelineitem_daily_summary 
GROUP BY 
    cluster_id ;
```


### Example
I created a cost model with a `cluster_cost_per_hour` rate of 1.8 USD
```
"rates": [
                {
                    "metric": {
                        "name": "cluster_cost_per_hour",
                        "label_metric": "Cluster",
                        "label_measurement": "Count",
                        "label_measurement_unit": "cluster-hour"
                    },
                    "description": "",
                    "tiered_rates": [
                        {
                            "unit": "USD",
                            "usage": {
                                "usage_end": null,
                                "usage_start": null
                            },
                            "value": 1.8
                        }
                    ],
                    "cost_type": "Supplementary"
                }
```

My cluster run for 14 hours
| cluster_id                     | cluster_alias                    | interval_day | cluster_interval_hours |
|-------------------------------|----------------------------------|---------------|-------------------------|
| test_cost_x_ocp_static_cluster_3 | test_cost_x_ocp_static_cluster_3 | 2025-04-02    | 14                      |

Postgres query result (14 * 1.8 = 25.2)
| cluster_id                     | sum   |
|-------------------------------|--------|
| test_cost_x_ocp_static_cluster_3 | 25.2  |

You can also check through `/v1/reports/openshift/costs/?group_by[cluster]=*`

## Release Notes
- [ ] Add cluster per hour cost metric to the Cost Model

```markdown
* [COST-6097](https://issues.redhat.com/browse/COST-6097) Add cluster per hour cost metric to the Cost Model
```
