### PR TITLE
[COST-6083] Handle null requests during vm tag exclusion

### DIFF
--- a/koku/api/report/ocp/provider_map.py
+++ b/koku/api/report/ocp/provider_map.py
@@ -828,8 +828,13 @@ class OCPProviderMap(ProviderMap):
                             "cost_usage": self.cost_model_cost,
                             "cost_markup": self.markup_cost,
                             "cost_total": self.cloud_infrastructure_cost + self.markup_cost + self.cost_model_cost,
-                            "request_cpu": Sum("pod_request_cpu_core_hours") / 24,
-                            "request_memory": Sum("pod_request_memory_gigabyte_hours") / 24,
+                            "request_cpu": Coalesce(
+                                Sum("pod_request_cpu_core_hours") / 24, Sum(Value(0, output_field=DecimalField()))
+                            ),
+                            "request_memory": Coalesce(
+                                Sum("pod_request_memory_gigabyte_hours") / 24,
+                                Sum(Value(0, output_field=DecimalField())),
+                            ),
                             "request_cpu_units": Max(Value("Core", output_field=CharField())),
                             "request_memory_units": Max(Value("GiB", output_field=CharField())),
                             "cost_total_distributed": self.cloud_infrastructure_cost
@@ -862,8 +867,13 @@ class OCPProviderMap(ProviderMap):
                             "cost_total": self.cloud_infrastructure_cost + self.markup_cost + self.cost_model_cost,
                             # the `currency_annotation` is inserted by the `annotations` property of the query-handler
                             "cost_units": Max(Coalesce("currency_annotation", Value("USD", output_field=CharField()))),
-                            "request_cpu": Max("pod_request_cpu_core_hours") / 24,
-                            "request_memory": Max("pod_request_memory_gigabyte_hours") / 24,
+                            "request_cpu": Coalesce(
+                                Sum("pod_request_cpu_core_hours") / 24, Sum(Value(0, output_field=DecimalField()))
+                            ),
+                            "request_memory": Coalesce(
+                                Sum("pod_request_memory_gigabyte_hours") / 24,
+                                Sum(Value(0, output_field=DecimalField())),
+                            ),
                             "request_cpu_units": Value("Core", output_field=CharField()),
                             "request_memory_units": Value("GiB", output_field=CharField()),
                             "cost_total_distributed": self.cloud_infrastructure_cost


### PR DESCRIPTION
## Jira Ticket

[COST-6083](https://issues.redhat.com/browse/COST-6083)

## Description

This change will handle null results during tag exclusion logic for the VM report endpoint. 

## Testing

There is a reproducer for this issue:
- branch: `dchorvat/ocp_vm_tag_filtering_updates`
- test: `test_api_ocp_virtual_machines_order_by_pagination_filtering`

Run the reproducer on Main and see that it fails. Run the reproducer on this branch and see the test passes.

Background:
When we exclude a tag value, the distributed cost will still appear on the endpoint since we don't populated tags for those rows which is the expected behavior. However, those rows also do not populate cpu and memory request data, so a null is being returned:

*Example:*
```
{
                    "vm_name": "echovm",
                    "values": [
                        {
                            "vm_name": "echovm",
                            "date": "2025-03",
                            "cluster": "test_cost_ocp_static_cluster_0",
                            "request_cpu": null,
                            "request_memory": null,
                            "node": "tests-echo",
                            "project": "test_echo",
                            "source_uuid": [
                                "db3fb121-d882-4e5e-a532-2b5988c87fe7"
                            ],
                            "storage": [],
                            "tags": [],
                            "infrastructure": {
                                "raw": {
                                    "value": 0.0,
                                    "units": "USD"
                                },
                                "markup": {
                                    "value": 0.0,
                                    "units": "USD"
                                },
                                "usage": {
                                    "value": 0.0,
                                    "units": "USD"
                                },
                                "total": {
                                    "value": 0.0,
                                    "units": "USD"
                                }
                            },
                            "supplementary": {
                                "raw": {
                                    "value": 0.0,
                                    "units": "USD"
                                },
                                "markup": {
                                    "value": 0.0,
                                    "units": "USD"
                                },
                                "usage": {
                                    "value": 0.0,
                                    "units": "USD"
                                },
                                "total": {
                                    "value": 0.0,
                                    "units": "USD"
                                }
                            },
                            "cost": {
                                "raw": {
                                    "value": 0.0,
                                    "units": "USD"
                                },
                                "markup": {
                                    "value": 0.0,
                                    "units": "USD"
                                },
                                "usage": {
                                    "value": 0.0,
                                    "units": "USD"
                                },
                                "platform_distributed": {
                                    "value": 0.0,
                                    "units": "USD"
                                },
                                "worker_unallocated_distributed": {
                                    "value": 554.1647058823529,
                                    "units": "USD"
                                },
                                "network_unattributed_distributed": {
                                    "value": 0.0,
                                    "units": "USD"
                                },
                                "storage_unattributed_distributed": {
                                    "value": 0.0,
                                    "units": "USD"
                                },
                                "distributed": {
                                    "value": 554.1647058823529,
                                    "units": "USD"
                                },
                                "total": {
                                    "value": 0.0,
                                    "units": "USD"
                                }
                            }
                        }
                    ]
                },
```
Here is an example of the return on this branch:
```
{
                    "vm_name": "echovm",
                    "values": [
                        {
                            "vm_name": "echovm",
                            "date": "2025-03",
                            "cluster": "test_cost_ocp_static_cluster_0",
                            "node": "tests-echo",
                            "project": "test_echo",
                            "source_uuid": [
                                "f11869cc-52c9-4494-8ef6-72b3befeba3f"
                            ],
                            "storage": [],
                            "tags": [],
                            "infrastructure": {
                                "raw": {
                                    "value": 0.0,
                                    "units": "USD"
                                },
                                "markup": {
                                    "value": 0.0,
                                    "units": "USD"
                                },
                                "usage": {
                                    "value": 0.0,
                                    "units": "USD"
                                },
                                "total": {
                                    "value": 0.0,
                                    "units": "USD"
                                }
                            },
                            "supplementary": {
                                "raw": {
                                    "value": 0.0,
                                    "units": "USD"
                                },
                                "markup": {
                                    "value": 0.0,
                                    "units": "USD"
                                },
                                "usage": {
                                    "value": 0.0,
                                    "units": "USD"
                                },
                                "total": {
                                    "value": 0.0,
                                    "units": "USD"
                                }
                            },
                            "cost": {
                                "raw": {
                                    "value": 0.0,
                                    "units": "USD"
                                },
                                "markup": {
                                    "value": 0.0,
                                    "units": "USD"
                                },
                                "usage": {
                                    "value": 0.0,
                                    "units": "USD"
                                },
                                "platform_distributed": {
                                    "value": 0.0,
                                    "units": "USD"
                                },
                                "worker_unallocated_distributed": {
                                    "value": 554.1647058823529,
                                    "units": "USD"
                                },
                                "network_unattributed_distributed": {
                                    "value": 0.0,
                                    "units": "USD"
                                },
                                "storage_unattributed_distributed": {
                                    "value": 0.0,
                                    "units": "USD"
                                },
                                "distributed": {
                                    "value": 554.1647058823529,
                                    "units": "USD"
                                },
                                "total": {
                                    "value": 0.0,
                                    "units": "USD"
                                }
                            },
                            "request": {
                                "cpu": {
                                    "value": 0.0,
                                    "units": "Core"
                                },
                                "memory": {
                                    "value": 0.0,
                                    "units": "GiB"
                                }
                            }
                        }
                    ]
                }
```

## Release Notes
- [ ] proposed release note

```markdown
* [COST-####](https://issues.redhat.com/browse/COST-####) Fix some things
```
