### PR TITLE
add message for github-action ImportError

### DIFF
--- a/.github/scripts/check_migrations.sh
+++ b/.github/scripts/check_migrations.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
-set -e
-
-pipenv run make make-migrations
+OUTPUT=$(pipenv run make make-migrations 2>&1 > /dev/null)
+if echo "$OUTPUT" | grep -q "ImportError"; then
+    echo "Django is not installed or the virtual environment isn't activated. Maybe clear github-action cache?"
+    exit 2
+fi
 
 changed=`git add -N . && git diff --name-only HEAD`
 


### PR DESCRIPTION
## Description

This change will add a message to help when the migration script results in an ImportError.

## Testing

1. delete django from your pipenv
2. run the script:
```
$ .github/scripts/check_migrations.sh
Django is not installed or the virtual environment isn't activated. Maybe clear github-action cache?
```

## Release Notes
- [x] proposed release note

```markdown
* capture and log ImportError during unit-test github-action
```
