### PR TITLE
[COST-6158] - Handle upfront/recurring fees for amortised costs

### DIFF
--- a/koku/masu/database/trino_sql/reporting_awscostentrylineitem_daily_summary.sql
+++ b/koku/masu/database/trino_sql/reporting_awscostentrylineitem_daily_summary.sql
@@ -114,6 +114,8 @@ FROM (
             CASE
                 WHEN lineitem_lineitemtype='SavingsPlanCoveredUsage'
                 OR lineitem_lineitemtype='SavingsPlanNegation'
+                OR lineitem_lineitemtype='SavingsPlanUpfrontFee'
+                OR lineitem_lineitemtype='SavingsPlanRecurringFee'
                 THEN savingsplan_savingsplaneffectivecost
                 ELSE lineitem_unblendedcost
             END

--- a/koku/masu/database/trino_sql/reporting_awscostentrylineitem_summary_by_ec2_compute_p.sql
+++ b/koku/masu/database/trino_sql/reporting_awscostentrylineitem_summary_by_ec2_compute_p.sql
@@ -158,6 +158,8 @@ FROM (
             CASE
                 WHEN lineitem_lineitemtype='SavingsPlanCoveredUsage'
                 OR lineitem_lineitemtype='SavingsPlanNegation'
+                OR lineitem_lineitemtype='SavingsPlanUpfrontFee'
+                OR lineitem_lineitemtype='SavingsPlanRecurringFee'
                 THEN savingsplan_savingsplaneffectivecost
                 ELSE lineitem_unblendedcost
             END


### PR DESCRIPTION
## Jira Ticket

[COST-6158](https://issues.redhat.com/browse/COST-6158)

## Description

This change will add the correct handling for upfront and recurring fees with regards to amortised costs. Not handling these today means we have duplicate costs since `SavingsPlanEffectiveCost` makes up the amortised amount for this.

## Testing
Not really a way to test these upfront/recurring fees with test data so this is more regression testing. Unless you want to look into PNT data and run some trino queries for the 8th of March (where we saw this anomaly to double check it)

1. Checkout Branch
2. Restart Koku
3. Load AWS data
4. All processing should continue to work as expected.


## Release Notes
- [ ] proposed release note

```markdown
* [COST-6158](https://issues.redhat.com/browse/COST-6158) Fix amortised cost upfront and recurring fees
```

## Summary by Sourcery

Update AWS cost calculation to correctly handle Savings Plan upfront and recurring fees by including these line item types in the cost calculation

Bug Fixes:
- Resolve duplicate cost reporting by correctly processing SavingsPlanUpfrontFee and SavingsPlanRecurringFee line item types

Enhancements:
- Modify SQL queries to use SavingsPlan effective cost for upfront and recurring fee line items