### PR TITLE
[COST-6097] filter empty node name

### DIFF
--- a/koku/masu/database/sql/openshift/cost_model/usage_costs.sql
+++ b/koku/masu/database/sql/openshift/cost_model/usage_costs.sql
@@ -73,10 +73,10 @@ WITH cte_node_cost as (
             node,
             sum(pod_effective_usage_cpu_core_hours) as node_cpu_usage,
             sum(pod_effective_usage_memory_gigabyte_hours) as node_mem_usage,
-            max(node_capacity_cpu_core_hours) / max(node_capacity_cpu_cores) as hours_used_cpu,
-            max(node_capacity_cpu_core_hours) / max(cluster_capacity_cpu_core_hours) as node_size_cpu,
-            max(node_capacity_memory_gigabyte_hours) / max(node_capacity_memory_gigabytes) as hours_used_mem,
-            max(node_capacity_memory_gigabyte_hours) / max(cluster_capacity_memory_gigabyte_hours) as node_size_mem
+            coalesce(max(node_capacity_cpu_core_hours) / nullif(max(node_capacity_cpu_cores), 0), 0) as hours_used_cpu,
+            coalesce(max(node_capacity_cpu_core_hours) / nullif(max(cluster_capacity_cpu_core_hours), 0), 0) as node_size_cpu,
+            coalesce(max(node_capacity_memory_gigabyte_hours) / nullif(max(node_capacity_memory_gigabytes), 0), 0) as hours_used_mem,
+            coalesce(max(node_capacity_memory_gigabyte_hours) / nullif(max(cluster_capacity_memory_gigabyte_hours), 0), 0) as node_size_mem
         FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary
         WHERE usage_start >= {{start_date}}
             AND usage_start <= {{end_date}}

--- a/koku/masu/database/sql/openshift/cost_model/usage_costs.sql
+++ b/koku/masu/database/sql/openshift/cost_model/usage_costs.sql
@@ -82,6 +82,7 @@ WITH cte_node_cost as (
             AND usage_start <= {{end_date}}
             AND source_uuid = {{source_uuid}}
             AND node IS NOT NULL
+            AND node != ''
         GROUP BY usage_start, node
     )
 )


### PR DESCRIPTION
## Jira Ticket

[COST-6097](https://issues.redhat.com/browse/COST-6097)

## Description

This change will filter empty node name and use coalesce and nullif just in case the node metrics are missing.

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Release Notes
- [ ] proposed release note

```markdown
* [COST-####](https://issues.redhat.com/browse/COST-####) Fix some things
```

## Summary by Sourcery

Improve node metrics calculation by adding null and empty string handling in OpenShift cost model SQL query

Bug Fixes:
- Prevent division by zero errors by using NULLIF and COALESCE in node capacity calculations
- Filter out empty node names from cost calculations