### PR TITLE
[COST-6264] Handle multiple usage accounts in subs extractor

### DIFF
--- a/koku/subs/subs_data_extractor.py
+++ b/koku/subs/subs_data_extractor.py
@@ -2,7 +2,6 @@
 # Copyright 2023 Red Hat Inc.
 # SPDX-License-Identifier: Apache-2.0
 #
-import hashlib
 import logging
 import math
 import os
@@ -51,11 +50,6 @@ class SUBSDataExtractor(ReportDBAccessorBase):
     def subs_s3_path(self):
         """The S3 path to be used for a SUBS report upload."""
         return f"{self.schema}/{self.provider_type}/source={self.provider_uuid}/date={self.date_helper.today.date()}"
-
-    def obfuscate_usage_account_id(self, usage_account_id):
-        """Generate a short deterministic hash from the usage account"""
-        full_hash = hashlib.sha256(usage_account_id.encode()).hexdigest()
-        return full_hash[:12]
 
     def get_latest_processed_dict_for_provider(self, year, month):
         """Get a dictionary of resourceid, last processed time for all resources for this source."""
@@ -216,8 +210,7 @@ class SUBSDataExtractor(ReportDBAccessorBase):
             return []
         last_processed_dict = self.get_latest_processed_dict_for_provider(year, month)
         for usage_account in usage_accounts:
-            usage_account_hash = self.obfuscate_usage_account_id(usage_account)
-            base_filename = f"subs_{self.tracing_id}_{self.provider_uuid}_{usage_account_hash}"
+            base_filename = f"subs_{self.tracing_id}_{self.provider_uuid}_{usage_account}"
 
             resource_ids = self.get_resource_ids_for_usage_account(usage_account, year, month)
             if not resource_ids:

--- a/koku/subs/subs_data_extractor.py
+++ b/koku/subs/subs_data_extractor.py
@@ -53,7 +53,7 @@ class SUBSDataExtractor(ReportDBAccessorBase):
         return f"{self.schema}/{self.provider_type}/source={self.provider_uuid}/date={self.date_helper.today.date()}"
 
     def obfuscate_usage_account_id(self, usage_account_id):
-        """Generate a short deterministic has from the usage account"""
+        """Generate a short deterministic hash from the usage account"""
         full_hash = hashlib.sha256(usage_account_id.encode()).hexdigest()
         return full_hash[:12]
 

--- a/koku/subs/test/test_subs_data_extractor.py
+++ b/koku/subs/test/test_subs_data_extractor.py
@@ -201,7 +201,9 @@ class TestSUBSDataExtractor(SUBSTestCase):
         base_filename = "fake_filename"
         mock_copy.return_value = expected_key
         mock_trino.return_value = (MagicMock(), MagicMock())
-        upload_keys = self.extractor.gather_and_upload_for_resource_batch(year, month, batch, base_filename)
+        upload_keys = self.extractor.gather_and_upload_for_resource_batch(
+            year, month, batch, base_filename, "fake_usage_account"
+        )
         mock_row_count.assert_called_once()
         mock_trino.assert_called_once()
         mock_copy.assert_called_once()
@@ -229,7 +231,9 @@ class TestSUBSDataExtractor(SUBSTestCase):
         base_filename = "fake_filename"
         mock_copy.return_value = expected_key
         mock_trino.return_value = ([], [("fake_col1",), ("fake_col2",)])
-        upload_keys = self.extractor.gather_and_upload_for_resource_batch(year, month, batch, base_filename)
+        upload_keys = self.extractor.gather_and_upload_for_resource_batch(
+            year, month, batch, base_filename, "fake_usage_account"
+        )
         mock_row_count.assert_called_once()
         mock_trino.assert_called_once()
         mock_copy.assert_not_called()

--- a/koku/subs/trino_sql/aws/subs_row_count.sql
+++ b/koku/subs/trino_sql/aws/subs_row_count.sql
@@ -9,6 +9,7 @@ SELECT count(*)
       AND lineitem_lineitemtype IN ('Usage', 'SavingsPlanCoveredUsage', 'DiscountedUsage')
       AND product_vcpu != ''
       AND strpos(lower(resourcetags), 'com_redhat_rhel') > 0
+      AND lineitem_usageaccountid = {{usage_account}}
       AND (
         {% for item in resources %}
             (

--- a/koku/subs/trino_sql/aws/subs_summary.sql
+++ b/koku/subs/trino_sql/aws/subs_summary.sql
@@ -67,6 +67,7 @@ FROM
       AND lineitem_lineitemtype IN ('Usage', 'SavingsPlanCoveredUsage', 'DiscountedUsage')
       AND product_vcpu != ''
       AND strpos(lower(resourcetags), 'com_redhat_rhel') > 0
+      AND lineitem_usageaccountid = {{usage_account}}
       AND (
         {% for item in resources %}
             (

--- a/koku/subs/trino_sql/azure/subs_row_count.sql
+++ b/koku/subs/trino_sql/azure/subs_row_count.sql
@@ -9,6 +9,7 @@ WHERE
     AND metercategory = 'Virtual Machines'
     AND json_extract_scalar(lower(additionalinfo), '$.vcpus') IS NOT NULL
     AND json_extract_scalar(lower(lower(tags)), '$.com_redhat_rhel') IS NOT NULL
+    AND (subscriptionid = {{usage_account}} or subscriptionguid = {{usage_account}})
     -- ensure there is usage
     AND ceil(quantity) > 0
     AND (

--- a/koku/subs/trino_sql/azure/subs_summary.sql
+++ b/koku/subs/trino_sql/azure/subs_summary.sql
@@ -47,6 +47,7 @@ WHERE
     AND metercategory = 'Virtual Machines'
     AND json_extract_scalar(lower(additionalinfo), '$.vcpus') IS NOT NULL
     AND json_extract_scalar(lower(lower(tags)), '$.com_redhat_rhel') IS NOT NULL
+    AND (subscriptionid = {{usage_account}} or subscriptionguid = {{usage_account}})
     -- ensure there is usage
     AND ceil(quantity) > 0
     AND (


### PR DESCRIPTION
## Jira Ticket

[COST-6264](https://issues.redhat.com/browse/COST-6264)

## Description

This change will add a snip it of a hash of usage account to the filename. As of right now when we loop through the usage accounts our file naming convention is not unique enough causing us to overwrite csv files in the subs bucket. 

## Reproducer

Run this on main to reproduce the issue.

**Step One: Setup Koku**
1. Find the following methods and have them return True
- `enable_subs_extraction`
- `enable_subs_messaging`
2. Comment out the `provider type not valid for subs processing` check
```
# if provider_type.rstrip("-local") not in settings.ENABLE_SUBS_PROVIDER_TYPES:
        #     LOG.info(log_json(tracing_id, msg="provider type not valid for subs processing", context=context))
        #     continue
```
The `['AWS']` is suppose to be the default here; however, I just commented out the check to keep things moving.
3. Comment out where we try to send the msg to kafka: `self.send_kafka_message(msg)` and add `LOG.info(f"subs_resource_id: {row['subs_resource_id']}")`
^ This will help you see which resources are being sent in the event.
4. If you don't have debug logs turned on, you will want to turn this log into an info:
```
LOG.debug(
            log_json(
                self.tracing_id,
                msg=f"identified {total_count} matching records for metered rhel",
                context=self.context | {"resource_ids": [row["rid"] for row in batch]},
            )
        )
```
5. `make docker-down`
6. `make docker-up-min-with-subs`

**Step Two Setup IQE:**
1. Pull & checkout my reproducer branch from the iqe cost management plugin: `cmyers-cost-6264-reproducer`
2. Now go to Nise and checkout my branch there `cost-COST-6270-user-acct-assign`
3. Inside of your iqe venv, go to your nise file path and run this command while on my branch:
```
uv pip install -e .
```

4. Run the test:
```
ENV_FOR_DYNACONF=local iqe tests plugin cost_management -k test_api_aws_rhel_report_creation -raA --pdb
```

**Step Three: Confirm the bug**
Checking the subs-worker log, you wills see that 3 resources were supposed to be included in the report during the extraction phase.
1. `i-9999999999999`
```
subs_worker  | [2025-04-28 20:15:29,517] DEBUG 204a4baa-6f2b-4d84-b8fe-ebf662e6a51d b81e07f1-9ff5-4aff-9808-3b60457a34d1 6a18eace-94a1-4c51-bc4c-b74ffef247ae 28 {'message': 'identified 44 matching records for metered rhel', 'tracing_id': '34f7cc66-1493-42a1-8064-542eec3b9e15', 'schema': 'org1234567', 'provider_type': 'AWS-local', 'provider_uuid': 'e485ba63-9039-4dd1-bcaf-6537f05af981', 'resource_ids': ['i-9999999999999']}
```
2. `i-9999999999998`
```
subs_worker  | [2025-04-28 20:15:30,793] DEBUG 204a4baa-6f2b-4d84-b8fe-ebf662e6a51d b81e07f1-9ff5-4aff-9808-3b60457a34d1 6a18eace-94a1-4c51-bc4c-b74ffef247ae 28 {'message': 'identified 44 matching records for metered rhel', 'tracing_id': '34f7cc66-1493-42a1-8064-542eec3b9e15', 'schema': 'org1234567', 'provider_type': 'AWS-local', 'provider_uuid': 'e485ba63-9039-4dd1-bcaf-6537f05af981', 'resource_ids': ['i-9999999999998']}
```
3. `i-9999999999997`
```
subs_worker  | [2025-04-28 20:15:32,174] DEBUG 204a4baa-6f2b-4d84-b8fe-ebf662e6a51d b81e07f1-9ff5-4aff-9808-3b60457a34d1 6a18eace-94a1-4c51-bc4c-b74ffef247ae 28 {'message': 'identified 44 matching records for metered rhel', 'tracing_id': '34f7cc66-1493-42a1-8064-542eec3b9e15', 'schema': 'org1234567', 'provider_type': 'AWS-local', 'provider_uuid': 'e485ba63-9039-4dd1-bcaf-6537f05af981', 'resource_ids': ['i-9999999999997']}
```

However, if you search for the log I had you add for when we sent the kafka message you will notice that only the last resource logged in the exractor will be present:
```
subs_resource_id
```

If you go to minio and download the subs file, you will notice that we only have one file and that file contains only one resource_id.
```
koku-bucket/org1234567/AWS/source=<p_uuid>/date=<today>
```

## Testing

1. Check out this branch and rerun the iqe test from the reproducer.
2. Watch the subs-worker logs and see that now all 3 resources show up during data the messenger phase
```
subs_resource_id: i-9999999999999
subs_resource_id: i-9999999999998
subs_resource_id: i-9999999999997
```
3. Look inside of minio and see that we now have 3 files where previously we just had one.

## Release Notes
- [ ] proposed release note

```markdown
* [COST-6264](https://issues.redhat.com/browse/COST-6264) Handle multiple usage accounts in subs extractor
```

## Summary by Sourcery

Bug Fixes:
- Fix data overwriting issue in S3 by including a hash of the usage account ID in the filename when multiple usage accounts are processed for a single provider.

## Summary by Sourcery

Add unique filename generation for subscription extraction to prevent file overwriting when processing multiple usage accounts

New Features:
- Introduced a method to generate a unique hash for usage account IDs

Bug Fixes:
- Prevent overwriting of CSV files in S3 when processing multiple usage accounts
- Ensure unique file naming for each usage account during subscription extraction

Enhancements:
- Modified SQL queries to filter by specific usage account
- Updated resource batch processing to include usage account context