### PR TITLE
[COST-6319] update nginx image

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -371,7 +371,7 @@ objects:
               fieldPath: metadata.name
         - name: ROS_OCP_API
           value: ${ROS_OCP_API}
-        image: quay.io/cloudservices/ubi8-nginx-124
+        image: registry.access.redhat.com/ubi9/nginx-124
         livenessProbe:
           failureThreshold: 5
           httpGet:

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -371,7 +371,7 @@ objects:
               fieldPath: metadata.name
         - name: ROS_OCP_API
           value: ${ROS_OCP_API}
-        image: registry.access.redhat.com/ubi9/nginx-124
+        image: ${NGINX_IMAGE}:${NGINX_IMAGE_TAG}
         livenessProbe:
           failureThreshold: 5
           httpGet:
@@ -5667,6 +5667,14 @@ parameters:
   name: ROS_OCP_API
   required: true
   value: koku-api-writes
+- description: Image tag
+  name: NGINX_IMAGE_TAG
+  required: true
+  value: latest
+- description: Image
+  name: NGINX_IMAGE
+  required: true
+  value: registry.access.redhat.com/ubi9/nginx-124
 - displayName: Minimum replicas
   name: LISTENER_REPLICAS
   required: true

--- a/deploy/kustomize/patches/nginx.yaml
+++ b/deploy/kustomize/patches/nginx.yaml
@@ -10,7 +10,7 @@
       private:
         enabled: false
     podSpec:
-      image: quay.io/cloudservices/ubi8-nginx-124
+      image: registry.access.redhat.com/ubi9/nginx-124
       command:
         - nginx
         - "-g"

--- a/deploy/kustomize/patches/nginx.yaml
+++ b/deploy/kustomize/patches/nginx.yaml
@@ -10,7 +10,7 @@
       private:
         enabled: false
     podSpec:
-      image: registry.access.redhat.com/ubi9/nginx-124
+      image: ${NGINX_IMAGE}:${NGINX_IMAGE_TAG}
       command:
         - nginx
         - "-g"
@@ -105,3 +105,18 @@
     name: ROS_OCP_API
     required: true
     value: 'koku-api-writes'  # Defaults to the Koku API for standalone deployments where ROS isn't deployed -- https://stackoverflow.com/q/32845674
+
+- op: add
+  path: /parameters/-
+  value:
+    description: Image tag
+    name: NGINX_IMAGE_TAG
+    required: true
+    value: latest
+- op: add
+  path: /parameters/-
+  value:
+    description: Image
+    name: NGINX_IMAGE
+    required: true
+    value: registry.access.redhat.com/ubi9/nginx-124


### PR DESCRIPTION
## Jira Ticket

[COST-6319](https://issues.redhat.com/browse/COST-6319)

## Description

This change will switch to the registry.redhat nginx image rather than the cloudservices mirror. This PR will also enable us to modify these values thru app-interface.

## Testing

1. regression testing

## Release Notes
- [x] proposed release note

```markdown
* [COST-6319](https://issues.redhat.com/browse/COST-6319) Switch to rhel9 nginx image built via konflux
```

## Summary by Sourcery

Enhancements:
- Update nginx image references from quay.io/cloudservices/ubi8-nginx-124 to registry.access.redhat.com/ubi9/nginx-124 in clowdapp.yaml and kustomize patch

## Summary by Sourcery

Switch nginx deployment to use the RHEL9-based registry.access.redhat.com/ubi9/nginx-124 image

Enhancements:
- Update nginx image reference in deploy/clowdapp.yaml to registry.access.redhat.com/ubi9/nginx-124
- Update nginx image reference in deploy/kustomize/patches/nginx.yaml to registry.access.redhat.com/ubi9/nginx-124