### PR TITLE
[COST-6268] add in managed table log msgs

### DIFF
--- a/koku/masu/database/aws_report_db_accessor.py
+++ b/koku/masu/database/aws_report_db_accessor.py
@@ -291,8 +291,10 @@ class AWSReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
         unattributed_storage = is_feature_unattributed_storage_enabled_aws(self.schema)
 
         sql_file = "trino_sql/reporting_ocpawscostlineitem_daily_summary.sql"
+        msg = "running OCP on AWS SQL"
         if is_managed_ocp_cloud_summary_enabled(self.schema, Provider.PROVIDER_AWS):
             # We have to populate the ocp on cloud managed tables prior to executing this file
+            msg = "running OCP on AWS Manged table SQL"
             sql_metadata = SummarySqlMetadata(
                 self.schema,
                 openshift_provider_uuid,
@@ -324,7 +326,7 @@ class AWSReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
             "unattributed_storage": unattributed_storage,
         }
         ctx = self.extract_context_from_sql_params(sql_params)
-        LOG.info(log_json(msg="running OCP on AWS SQL", context=ctx))
+        LOG.info(log_json(msg=msg, context=ctx))
         self._execute_trino_multipart_sql_query(sql, bind_params=sql_params)
 
     def back_populate_ocp_infrastructure_costs(self, start_date, end_date, report_period_id):

--- a/koku/masu/database/aws_report_db_accessor.py
+++ b/koku/masu/database/aws_report_db_accessor.py
@@ -294,7 +294,7 @@ class AWSReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
         msg = "running OCP on AWS SQL"
         if is_managed_ocp_cloud_summary_enabled(self.schema, Provider.PROVIDER_AWS):
             # We have to populate the ocp on cloud managed tables prior to executing this file
-            msg = "running OCP on AWS Manged table SQL"
+            msg = "running OCP on AWS Managed table SQL"
             sql_metadata = SummarySqlMetadata(
                 self.schema,
                 openshift_provider_uuid,

--- a/koku/masu/database/azure_report_db_accessor.py
+++ b/koku/masu/database/azure_report_db_accessor.py
@@ -300,7 +300,9 @@ class AzureReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
             pod_column = "pod_effective_usage_memory_gigabyte_hours"
             node_column = "node_capacity_memory_gigabyte_hours"
         sql_file = "trino_sql/reporting_ocpazurecostlineitem_daily_summary.sql"
+        msg = "running OCP on Azure SQL"
         if is_managed_ocp_cloud_summary_enabled(self.schema, Provider.PROVIDER_AZURE):
+            msg = "running OCP on Azure Manged table SQL"
             # We have to populate the ocp on cloud managed tables prior to executing this file
             sql_metadata = SummarySqlMetadata(
                 self.schema,
@@ -334,7 +336,7 @@ class AzureReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
             "unattributed_storage": is_feature_unattributed_storage_enabled_azure(self.schema),
         }
         ctx = self.extract_context_from_sql_params(sql_params)
-        LOG.info(log_json(msg="running OCP on Azure SQL", context=ctx))
+        LOG.info(log_json(msg=msg, context=ctx))
         self._execute_trino_multipart_sql_query(sql, bind_params=sql_params)
 
     def update_line_item_daily_summary_with_tag_mapping(self, start_date, end_date, bill_ids=None):

--- a/koku/masu/database/azure_report_db_accessor.py
+++ b/koku/masu/database/azure_report_db_accessor.py
@@ -302,7 +302,7 @@ class AzureReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
         sql_file = "trino_sql/reporting_ocpazurecostlineitem_daily_summary.sql"
         msg = "running OCP on Azure SQL"
         if is_managed_ocp_cloud_summary_enabled(self.schema, Provider.PROVIDER_AZURE):
-            msg = "running OCP on Azure Manged table SQL"
+            msg = "running OCP on Azure Managed table SQL"
             # We have to populate the ocp on cloud managed tables prior to executing this file
             sql_metadata = SummarySqlMetadata(
                 self.schema,


### PR DESCRIPTION
## Jira Ticket
Just a couple of log messages I missed. (Already did GCP)

## Summary by Sourcery

Use dynamic log messages to indicate whether OCP cost summary queries are running in managed-table mode or standard SQL for AWS and Azure.

Enhancements:
- Enhance AWS report accessor to log “running OCP on AWS Managed table SQL” when managed OCP cloud summary is enabled
- Enhance Azure report accessor to log “running OCP on Azure Managed table SQL” when managed OCP cloud summary is enabled