### PR TITLE
[COST-6308] - handle new or unknown Operator reports

### DIFF
--- a/koku/masu/processor/parquet/parquet_report_processor.py
+++ b/koku/masu/processor/parquet/parquet_report_processor.py
@@ -453,7 +453,7 @@ class ParquetReportProcessor:
 
             self.prepare_parquet_s3(Path(csv_filename))
             if self.provider_type == Provider.PROVIDER_OCP and self.report_type is None:
-                msg = "could not establish report type"
+                msg = "Unknown report type, skipping file processing"
                 LOG.warning(
                     log_json(
                         self.tracing_id,
@@ -462,7 +462,7 @@ class ParquetReportProcessor:
                         filename=csv_filename,
                     )
                 )
-                raise ParquetReportProcessorError(msg)
+                return parquet_base_filename, daily_data_frames
 
             parquet_base_filename, daily_frame, success = self.convert_csv_to_parquet(csv_filename)
             daily_data_frames.extend(daily_frame)

--- a/koku/masu/test/processor/parquet/test_parquet_report_processor.py
+++ b/koku/masu/test/processor/parquet/test_parquet_report_processor.py
@@ -291,6 +291,14 @@ class TestParquetReportProcessor(MasuTestCase):
             self.report_processor.convert_to_parquet()
             self.assertIn(expected, " ".join(logger.output))
 
+        exp_msg = "Unknown report type, skipping file processing"
+        with patch("masu.processor.parquet.parquet_report_processor.get_path_prefix", return_value=""), patch(
+            "masu.processor.parquet.parquet_report_processor.ParquetReportProcessor.report_type", new=None
+        ), patch("masu.processor.parquet.parquet_report_processor.ParquetReportProcessor.prepare_parquet_s3"):
+            with self.assertLogs("masu.processor.parquet.parquet_report_processor", level="WARNING") as logger:
+                self.report_processor_ocp.convert_to_parquet()
+                self.assertIn(exp_msg, " ".join(logger.output))
+
         with patch("masu.processor.parquet.parquet_report_processor.get_path_prefix", return_value=""), patch.object(
             ParquetReportProcessor,
             "convert_csv_to_parquet",


### PR DESCRIPTION
## Jira Ticket

[COST-6308](https://issues.redhat.com/browse/COST-6308)

## Description

This change will skip processing Operator reports that are unknown report types.

## Testing

1. Checkout Branch
2. Restart Koku
3. regression testing
4. Create operator payload with extra report not matching current report types
5. Ingest payload
6. You should see koku skip the unknown report and finish processing all other files.

## Release Notes
- [ ] proposed release note

```markdown
* [COST-6308](https://issues.redhat.com/browse/COST-6308) Skip processing new reports that are unknown by koku
```

## Summary by Sourcery

Bug Fixes:
- Skip processing unknown Operator report types in parquet processor instead of raising an error.

## Summary by Sourcery

Handle new or unknown Operator report types by logging a warning and skipping their processing instead of raising an error

Bug Fixes:
- Skip raising an error for unknown Operator report types and return gracefully

Tests:
- Add test case to verify unknown report types are skipped with a warning logged