### PR TITLE
use `no_account` for account id if missing

### DIFF
--- a/koku/masu/external/kafka_msg_handler.py
+++ b/koku/masu/external/kafka_msg_handler.py
@@ -139,7 +139,7 @@ def create_daily_archives(payload_info: utils.PayloadInfo, filepath: Path, conte
     for daily_file in daily_files:
         # Push to S3
         s3_csv_path = get_path_prefix(
-            payload_info.account,
+            payload_info.trino_schema,
             payload_info.provider_type,
             payload_info.provider_uuid,
             daily_file.get("date"),
@@ -346,7 +346,7 @@ def extract_payload(url, request_id, b64_identity, context):  # noqa: C901
         shutil.rmtree(payload_path.parent)
         return None, manifest.uuid
     provider: Provider = source.provider
-    schema_name = provider.account.get("schema_name")
+    schema_name: str = provider.account.get("schema_name")
     context["provider_type"] = provider.type
     context["schema"] = schema_name
 
@@ -364,7 +364,8 @@ def extract_payload(url, request_id, b64_identity, context):  # noqa: C901
         cluster_alias=provider.name,
         account=context["account"],
         org_id=context["org_id"],
-        schema_name=provider.account.get("schema_name"),
+        schema_name=schema_name,
+        trino_schema=schema_name.lstrip("acct"),
     )
 
     # Create directory tree for report.

--- a/koku/masu/external/kafka_msg_handler.py
+++ b/koku/masu/external/kafka_msg_handler.py
@@ -351,8 +351,9 @@ def extract_payload(url, request_id, b64_identity, context):  # noqa: C901
     context["schema"] = schema_name
 
     # set the account and org_id based on the provider if the kafka msg don't contain them
-    context["account"] = context["account"] or provider.account.get("account_id")
     context["org_id"] = context["org_id"] or provider.account.get("org_id")
+    # for anemic accounts, use `no_acount`
+    context["account"] = context["account"] or provider.account.get("account_id") or "no_account"
 
     payload = utils.PayloadInfo(
         request_id=request_id,

--- a/koku/masu/external/kafka_msg_handler.py
+++ b/koku/masu/external/kafka_msg_handler.py
@@ -362,10 +362,10 @@ def extract_payload(url, request_id, b64_identity, context):  # noqa: C901
         provider_uuid=provider.uuid,
         provider_type=provider.type,
         cluster_alias=provider.name,
-        account=context["account"],
+        account_id=context["account"],
         org_id=context["org_id"],
         schema_name=schema_name,
-        trino_schema=schema_name.lstrip("acct"),
+        trino_schema=schema_name,
     )
 
     # Create directory tree for report.

--- a/koku/masu/external/kafka_msg_handler.py
+++ b/koku/masu/external/kafka_msg_handler.py
@@ -352,7 +352,7 @@ def extract_payload(url, request_id, b64_identity, context):  # noqa: C901
 
     # set the account and org_id based on the provider if the kafka msg don't contain them
     context["org_id"] = context["org_id"] or provider.account.get("org_id")
-    # for anemic accounts, use `no_acount`
+    # for anemic accounts, use `no_account`
     context["account"] = context["account"] or provider.account.get("account_id") or "no_account"
 
     payload = utils.PayloadInfo(

--- a/koku/masu/external/ros_report_shipper.py
+++ b/koku/masu/external/ros_report_shipper.py
@@ -64,7 +64,7 @@ class ROSReportShipper:
         self.schema_name = payload_info.schema_name
 
         self.metadata = {
-            "account": payload_info.account,
+            "account": payload_info.account_id,
             "org_id": payload_info.org_id,
             "source_id": self.source_id,
             "provider_uuid": self.provider_uuid,

--- a/koku/masu/test/external/test_kafka_msg_handler.py
+++ b/koku/masu/test/external/test_kafka_msg_handler.py
@@ -172,9 +172,10 @@ class KafkaMsgHandlerTest(MasuTestCase):
             provider_uuid=self.ocp_provider_uuid,
             provider_type="OCP",
             cluster_alias=self.cluster_id,
-            account="10001",
+            account_id="10001",
             org_id="10001",
             schema_name=self.schema_name,
+            trino_schema=self.schema_name,
         )
 
     @patch("masu.external.kafka_msg_handler.listen_for_messages")

--- a/koku/masu/test/external/test_ros_report_shipper.py
+++ b/koku/masu/test/external/test_ros_report_shipper.py
@@ -37,9 +37,10 @@ class TestROSReportShipper(TestCase):
             provider_uuid=cls.provider_uuid,
             provider_type="OCP",
             cluster_alias=cls.cluster_alias,
-            account=cls.account_id,
+            account_id=cls.account_id,
             org_id=cls.org_id,
             schema_name=cls.schema_name,
+            trino_schema=cls.schema_name,
         )
         test_context = {
             "account": cls.account_id,

--- a/koku/masu/util/ocp/common.py
+++ b/koku/masu/util/ocp/common.py
@@ -316,9 +316,10 @@ class PayloadInfo(BaseModel):
     provider_uuid: UUID4
     provider_type: str
     cluster_alias: str
-    account: str
+    account_id: str
     org_id: str
     schema_name: str
+    trino_schema: str
 
 
 def parse_manifest(report_directory) -> Manifest:

--- a/koku/masu/util/ocp/common.py
+++ b/koku/masu/util/ocp/common.py
@@ -321,6 +321,11 @@ class PayloadInfo(BaseModel):
     schema_name: str
     trino_schema: str
 
+    @field_validator("trino_schema", mode="after")
+    @classmethod
+    def get_trino_schema(cls, value: str) -> str:
+        return value.lstrip("acct")
+
 
 def parse_manifest(report_directory) -> Manifest:
     """


### PR DESCRIPTION
## Jira Ticket

[COST-####](https://issues.redhat.com/browse/COST-####)

## Description

This change will handle anemic accounts by passing `no_accounts` to ROS. Also, add `trino_schema` to `Payload` info which is used when grabbing the S3 path.

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Release Notes
- [ ] proposed release note

```markdown
* [COST-####](https://issues.redhat.com/browse/COST-####) Fix some things
```

## Summary by Sourcery

Bug Fixes:
- Default to 'no_account' when account ID is missing in Kafka message context