### PR TITLE
handle null resource_optimization_files

### DIFF
--- a/koku/masu/util/ocp/common.py
+++ b/koku/masu/util/ocp/common.py
@@ -268,7 +268,7 @@ class Manifest(BaseModel):
     operator_version: str = ""
     date: ForceAwareDatetime
     files: list[str]
-    resource_optimization_files: list[str] = []
+    resource_optimization_files: list[str] | None = []
     start: ForceAwareDatetime | None = None
     end: ForceAwareDatetime | None = None
     certified: bool = False
@@ -281,6 +281,13 @@ class Manifest(BaseModel):
     def get_operator_version(cls, value: str, info: ValidationInfo) -> str:
         v = info.data["version"]
         return OPERATOR_VERSIONS.get(v, v)
+
+    @field_validator("resource_optimization_files", mode="after")
+    @classmethod
+    def get_resource_optimization_files(cls, value: list[str] | None) -> list:
+        if value is None:
+            value = []
+        return value
 
     @model_validator(mode="after")
     def validate_start_and_end(self) -> Self:


### PR DESCRIPTION
## Jira Ticket

[COST-####](https://issues.redhat.com/browse/COST-####)

## Description

This change will ...

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Release Notes
- [ ] proposed release note

```markdown
* [COST-####](https://issues.redhat.com/browse/COST-####) Fix some things
```

## Summary by Sourcery

Allow the `resource_optimization_files` field in the `Manifest` model to be nullable and automatically convert null values to empty lists to prevent validation errors.

Bug Fixes:
- Handle null `resource_optimization_files` by defaulting to an empty list in the Manifest model

Enhancements:
- Update `resource_optimization_files` type to `list[str] | None` and add a post-validation step to coerce null to an empty list