### PR TITLE
pre validator for `files` and `resource_optimization_files`

### DIFF
--- a/koku/masu/util/ocp/common.py
+++ b/koku/masu/util/ocp/common.py
@@ -23,7 +23,6 @@ from pydantic import AfterValidator
 from pydantic import BaseModel
 from pydantic import BeforeValidator
 from pydantic import ConfigDict
-from pydantic import Field
 from pydantic import field_validator
 from pydantic import model_validator
 from pydantic import UUID4
@@ -271,8 +270,8 @@ class Manifest(BaseModel):
     version: str = ""
     operator_version: str = ""
     date: ForceAwareDatetime
-    files: NoneToList = Field(default_factory=[])
-    resource_optimization_files: NoneToList = Field(default_factory=[])
+    files: NoneToList = []
+    resource_optimization_files: NoneToList = []
     start: ForceAwareDatetime | None = None
     end: ForceAwareDatetime | None = None
     certified: bool = False

--- a/koku/masu/util/ocp/common.py
+++ b/koku/masu/util/ocp/common.py
@@ -23,6 +23,7 @@ from pydantic import AfterValidator
 from pydantic import BaseModel
 from pydantic import BeforeValidator
 from pydantic import ConfigDict
+from pydantic import Field
 from pydantic import field_validator
 from pydantic import model_validator
 from pydantic import UUID4
@@ -270,8 +271,8 @@ class Manifest(BaseModel):
     version: str = ""
     operator_version: str = ""
     date: ForceAwareDatetime
-    files: NoneToList
-    resource_optimization_files: NoneToList
+    files: NoneToList = Field(default_factory=[])
+    resource_optimization_files: NoneToList = Field(default_factory=[])
     start: ForceAwareDatetime | None = None
     end: ForceAwareDatetime | None = None
     certified: bool = False


### PR DESCRIPTION
## Jira Ticket

[COST-####](https://issues.redhat.com/browse/COST-####)

## Description

This change will add a pre-validator for `files` and `resource_optimization_files`. If these values are None or missing from the payload manifest, they are converted to an empty list.

## Testing

```
>>> NoneToList = Annotated[list[str], BeforeValidator(lambda x: [] if x is None else x)]
>>> class Manifest(BaseModel):
...   files: NoneToList
... 
>>> Manifest(files=None)
Manifest(files=[])
>>> Manifest(files='not a list')
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/Users/mskarbek/projects/koku/.venv/lib/python3.11/site-packages/pydantic/main.py", line 253, in __init__
    validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pydantic_core._pydantic_core.ValidationError: 1 validation error for Manifest
files
  Input should be a valid list [type=list_type, input_value='not a list', input_type=str]
    For further information visit https://errors.pydantic.dev/2.11/v/list_type
>>> Manifest(files=['not a list'])
Manifest(files=['not a list'])
>>> Manifest(files=[1])
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/Users/mskarbek/projects/koku/.venv/lib/python3.11/site-packages/pydantic/main.py", line 253, in __init__
    validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pydantic_core._pydantic_core.ValidationError: 1 validation error for Manifest
files.0
  Input should be a valid string [type=string_type, input_value=1, input_type=int]
    For further information visit https://errors.pydantic.dev/2.11/v/string_type
```

## Release Notes
- [ ] proposed release note

```markdown
* [COST-####](https://issues.redhat.com/browse/COST-####) Fix some things
```

## Summary by Sourcery

Simplify Pydantic validation by introducing a NoneToList pre-validator to convert None to empty lists and apply it to the Manifest’s `files` and `resource_optimization_files` fields, removing the redundant manual validator.

Enhancements:
- Add a NoneToList Annotated type with a BeforeValidator to default None to an empty list.
- Replace the `files` and `resource_optimization_files` fields in Manifest with NoneToList and remove the manual post-validator.