### PR TITLE
[COST-6335] Handle invalid version error

### DIFF
--- a/koku/api/provider/provider_manager.py
+++ b/koku/api/provider/provider_manager.py
@@ -14,6 +14,7 @@ from django.db.models.signals import post_delete
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django_tenants.utils import tenant_context
+from packaging.version import InvalidVersion
 from packaging.version import Version
 
 from api.common import log_json
@@ -224,7 +225,11 @@ class ProviderManager:
             latest_version = utils.get_latest_operator_version()
             current_version = self.manifest.operator_version.split(":")[-1].lstrip("v")
             base_additional_context["operator_update_available"] = current_version != latest_version
-            base_additional_context["vm_cpu_core_cost_model_support"] = Version(current_version) >= Version("4.0.0")
+            try:
+                is_supported = Version(current_version) >= Version("4.0.0")
+            except InvalidVersion:
+                is_supported = False
+            base_additional_context["vm_cpu_core_cost_model_support"] = is_supported
         return base_additional_context
 
     def is_removable_by_user(self, current_user):


### PR DESCRIPTION
## Jira Ticket

[COST-6335](https://issues.redhat.com/browse/COST-6335)

## Description

While developing, I updated a payload from the demo cluster and hit the sources endpoint and got a 500 error. The issue is that my local version of the operator was invalid:

```
koku_server    |   File "/opt/koku/.venv/lib/python3.11/site-packages/django/utils/decorators.py", line 134, in _wrapper_view
koku_server    |     response = view_func(request, *args, **kwargs)
koku_server    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
koku_server    |   File "/koku/koku/sources/api/view.py", line 274, in list
koku_server    |     source["additional_context"] = manager.get_additional_context()
koku_server    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
koku_server    |   File "/koku/koku/api/provider/provider_manager.py", line 227, in get_additional_context
koku_server    |     base_additional_context["vm_cpu_core_cost_model_support"] = Version(current_version) >= Version("4.0.0")
koku_server    |                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^
koku_server    |   File "/opt/koku/.venv/lib/python3.11/site-packages/packaging/version.py", line 202, in __init__
koku_server    |     raise InvalidVersion(f"Invalid version: {version!r}")
koku_server    | packaging.version.InvalidVersion: Invalid version: '0db33daca9509e124506d064bfa01bce3f9d9798'
```

This PR will catch the error and just make the vm_cpu_core_cost_model_support false. I think we should cover this scenario in case we forget to update the `OPERATOR_VERSIONS` parameters.

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Release Notes
- [ ] proposed release note

```markdown
* [COST-####](https://issues.redhat.com/browse/COST-####) Fix some things
```
