### PR TITLE
[COST-6116] switch error log to warning

### DIFF
--- a/koku/masu/database/ocp_report_db_accessor.py
+++ b/koku/masu/database/ocp_report_db_accessor.py
@@ -511,7 +511,7 @@ GROUP BY partitions.year, partitions.month, partitions.source
         }
         cost_type_file = cost_type_file_mapping.get(cost_type)
         if not cost_type_file:
-            LOG.error(f"Invalid cost_type: {cost_type} for OCP provider. Skipping populate_monthly_cost_sql update")
+            LOG.warning(f"Invalid cost_type: {cost_type} for OCP provider. Skipping populate_monthly_cost_sql update")
             return
 
         table_name = self._table_map["line_item_daily_summary"]


### PR DESCRIPTION
## Jira Ticket

[COST-6116](https://issues.redhat.com/browse/COST-6116)

## Description

This change will switch an error log to a warning.

After adding a new cost type during feature dev, we might have a valid cost type defined in the db, but no methods to populate the cost type yet. This is fine, and the code functions as intended. This PR changes a logged error to a warning since a missing population file is not an error.

## Summary by Sourcery

Enhancements:
- Downgrade log message severity for missing cost_type from ERROR to WARNING