### PR TITLE
[COST-6438] add uuid to index for uniqueness

### DIFF
--- a/koku/masu/database/sql/openshift/create_virtualization_tmp_table.sql
+++ b/koku/masu/database/sql/openshift/create_virtualization_tmp_table.sql
@@ -6,9 +6,9 @@ CREATE TABLE IF NOT EXISTS {{schema | sqlsafe}}.tmp_virt_{{uuid | sqlsafe}} (
   mem_request FLOAT
 );
 
-CREATE INDEX IF NOT EXISTS idx_tmp_virt_vm_name
+CREATE INDEX IF NOT EXISTS idx_tmp_virt_vm_name_{{uuid | sqlsafe}}
 ON {{schema | sqlsafe}}.tmp_virt_{{uuid | sqlsafe}} (vm_name);
-CREATE INDEX IF NOT EXISTS idx_tmp_virt_pvc_name
+CREATE INDEX IF NOT EXISTS idx_tmp_virt_pvc_name_{{uuid | sqlsafe}}
 ON {{schema | sqlsafe}}.tmp_virt_{{uuid | sqlsafe}} (pvc_name);
-CREATE INDEX IF NOT EXISTS idx_tmp_virt_node
+CREATE INDEX IF NOT EXISTS idx_tmp_virt_node_{{uuid | sqlsafe}}
 ON {{schema | sqlsafe}}.tmp_virt_{{uuid | sqlsafe}} (node);


### PR DESCRIPTION
## Jira Ticket

[COST-6438](https://issues.redhat.com/browse/COST-6438)

## Description

This change will fix 
```
IntegrityError: duplicate key value violates unique constraint "pg_class_relname_nsp_index"
```
by ensuring the created indexes are unique (utilizing the same uuid that ensure uniqueness of the tmp table).



## Summary by Sourcery

Enhancements:
- Append uuid to index names in create_virtualization_tmp_table.sql for uniqueness of temporary tables