### PR TITLE
[COST-6460] - fix row_uuid usage for network unallocated

### DIFF
--- a/koku/masu/database/trino_sql/gcp/openshift/populate_daily_summary/2_summarize_data_by_cluster.sql
+++ b/koku/masu/database/trino_sql/gcp/openshift/populate_daily_summary/2_summarize_data_by_cluster.sql
@@ -400,7 +400,7 @@ INSERT INTO hive.{{schema | sqlsafe}}.managed_reporting_ocpgcpcostlineitem_proje
     month,
     day
 )
-SELECT cast(uuid() as varchar) as row_uuid,
+SELECT gcp.row_uuid as row_uuid,
     max(ocp.cluster_id) as cluster_id,
     max(ocp.cluster_alias) as cluster_alias,
     max(ocp.data_source),


### PR DESCRIPTION
## Jira Ticket

[COST-6460](https://issues.redhat.com/browse/COST-6460)

## Description

This change will use the row_uuid built into the parquet tables rather than creating brand new unique identifiers. This caused some confusion while debugging because there were unexpected row_uuids that did not exist in the base tables.

This change matches the network unallocated logic in AWS and Azure sql files now.

## Testing

1. Checkout Branch
2. Restart Koku
3. OCP on GCP regression testing

## Release Notes
- [ ] proposed release note

```markdown
* [COST-6460](https://issues.redhat.com/browse/COST-6460) Use available row_uuid rather than creating new ones.
```

## Summary by Sourcery

Use existing row_uuid values in the GCP openshift daily summary query instead of generating new UUIDs to align with AWS and Azure logic.

Bug Fixes:
- Replace newly generated UUIDs with existing gcp.row_uuid in the daily summary SQL.

Enhancements:
- Align network unallocated row_uuid logic across AWS, Azure, and GCP providers.