### PR TITLE
[COST-6164] Replaces inline PromQL expressions with pre-aggregated metrics

### DIFF
--- a/dashboards/grafana-dashboard-insights-hccm.configmap.yaml
+++ b/dashboards/grafana-dashboard-insights-hccm.configmap.yaml
@@ -1294,7 +1294,7 @@ data:
                 "uid": "${Datasource}"
               },
               "editorMode": "code",
-              "expr": "max(download_penalty_backlog{namespace=\"${namespace}\", pod=~\".+worker.+\"})",
+              "expr": "koku:celery:download_penalty_queue",
               "interval": "",
               "legendFormat": "Queue Size",
               "range": true,
@@ -1376,7 +1376,7 @@ data:
                 "uid": "${Datasource}"
               },
               "editorMode": "code",
-              "expr": "max(download_penalty_backlog{namespace=\"${namespace}\", pod=~\".+worker.+\"})",
+              "expr": "koku:celery:download_penalty_queue",
               "range": true,
               "refId": "A"
             }
@@ -1488,7 +1488,7 @@ data:
                 "uid": "${Datasource}"
               },
               "editorMode": "code",
-              "expr": "max(summary_penalty_backlog{namespace=\"${namespace}\", pod=~\".+worker.+\"})",
+              "expr": "koku:celery:summary_penalty_queue",
               "legendFormat": "Queue Size",
               "range": true,
               "refId": "A"
@@ -1569,7 +1569,7 @@ data:
                 "uid": "${Datasource}"
               },
               "editorMode": "code",
-              "expr": "max(summary_penalty_backlog{namespace=\"${namespace}\", pod=~\".+worker.+\"})",
+              "expr": "koku:celery:summary_penalty_queue",
               "range": true,
               "refId": "A"
             }
@@ -2443,7 +2443,7 @@ data:
                 "uid": "${Datasource}"
               },
               "editorMode": "code",
-              "expr": "max(ocp_penalty_backlog{namespace=\"${namespace}\", pod=~\".+worker.+\"})",
+              "expr": "koku:celery:ocp_penalty_queue",
               "legendFormat": "Queue Size",
               "range": true,
               "refId": "A"
@@ -2524,7 +2524,7 @@ data:
                 "uid": "${Datasource}"
               },
               "editorMode": "code",
-              "expr": "max(ocp_penalty_backlog{namespace=\"${namespace}\", pod=~\".+worker.+\"})",
+              "expr": "koku:celery:ocp_penalty_queue",
               "range": true,
               "refId": "A"
             }
@@ -2636,7 +2636,7 @@ data:
                 "uid": "${Datasource}"
               },
               "editorMode": "code",
-              "expr": "max(cost_model_penalty_backlog{namespace=\"${namespace}\", pod=~\".+worker.+\"})",
+              "expr": "koku:celery:cost_model_penalty_queue",
               "legendFormat": "Queue Size",
               "range": true,
               "refId": "A"
@@ -2717,7 +2717,7 @@ data:
                 "uid": "${Datasource}"
               },
               "editorMode": "code",
-              "expr": "max(cost_model_penalty_backlog{namespace=\"${namespace}\", pod=~\".+worker.+\"})",
+              "expr": "koku:celery:cost_model_penalty_queue",
               "range": true,
               "refId": "A"
             }
@@ -3591,7 +3591,7 @@ data:
                 "uid": "${Datasource}"
               },
               "editorMode": "code",
-              "expr": "max(priority_penalty_backlog{namespace=\"${namespace}\", pod=~\".+worker.+\"})",
+              "expr": "koku:celery:priority_penalty_queue",
               "legendFormat": "Queue Size",
               "range": true,
               "refId": "A"
@@ -3672,7 +3672,7 @@ data:
                 "uid": "${Datasource}"
               },
               "editorMode": "code",
-              "expr": "max(priority_penalty_backlog{namespace=\"${namespace}\", pod=~\".+worker.+\"})",
+              "expr": "koku:celery:priority_penalty_queue",
               "range": true,
               "refId": "A"
             }
@@ -3784,7 +3784,7 @@ data:
                 "uid": "${Datasource}"
               },
               "editorMode": "code",
-              "expr": "max(refresh_penalty_backlog{namespace=\"${namespace}\", pod=~\".+worker.+\"})",
+              "expr": "koku:celery:refresh_penalty_queue",
               "legendFormat": "Queue Size",
               "range": true,
               "refId": "A"
@@ -3865,7 +3865,7 @@ data:
                 "uid": "${Datasource}"
               },
               "editorMode": "code",
-              "expr": "max(refresh_penalty_backlog{namespace=\"${namespace}\", pod=~\".+worker.+\"})",
+              "expr": "koku:celery:refresh_penalty_queue",
               "range": true,
               "refId": "A"
             }
@@ -3977,7 +3977,7 @@ data:
                 "uid": "${Datasource}"
               },
               "editorMode": "code",
-              "expr": "max(subs_transmission_backlog{namespace=\"${namespace}\", pod=~\".+worker.+\"})",
+              "expr": "koku:celery:subs_transmission_queue",
               "range": true,
               "refId": "A"
             }
@@ -4057,7 +4057,7 @@ data:
                 "uid": "${Datasource}"
               },
               "editorMode": "code",
-              "expr": "max(subs_transmission_backlog{namespace=\"${namespace}\", pod=~\".+worker.+\"})",
+              "expr": "koku:celery:subs_transmission_queue",
               "range": true,
               "refId": "A"
             }
@@ -4169,7 +4169,7 @@ data:
                 "uid": "${Datasource}"
               },
               "editorMode": "code",
-              "expr": "max(subs_extraction_backlog{namespace=\"${namespace}\", pod=~\".+worker.+\"})",
+              "expr": "koku:celery:subs_extraction_queue",
               "range": true,
               "refId": "A"
             }
@@ -4249,7 +4249,7 @@ data:
                 "uid": "${Datasource}"
               },
               "editorMode": "code",
-              "expr": "max(subs_extraction_backlog{namespace=\"${namespace}\", pod=~\".+worker.+\"})",
+              "expr": "koku:celery:subs_extraction_queue",
               "range": true,
               "refId": "A"
             }

--- a/dashboards/grafana-dashboard-insights-hccm.configmap.yaml
+++ b/dashboards/grafana-dashboard-insights-hccm.configmap.yaml
@@ -907,7 +907,7 @@ data:
                 "uid": "${Datasource}"
               },
               "editorMode": "code",
-              "expr": "max(download_xl_backlog{namespace=\"${namespace}\", pod=~\".+worker.+\"})",
+              "expr": "koku:celery:download_xl_queue",
               "interval": "",
               "legendFormat": "Queue Size",
               "range": true,
@@ -989,7 +989,7 @@ data:
                 "uid": "${Datasource}"
               },
               "editorMode": "code",
-              "expr": "max(download_xl_backlog{namespace=\"${namespace}\", pod=~\".+worker.+\"})",
+              "expr": "koku:celery:download_xl_queue",
               "range": true,
               "refId": "A"
             }
@@ -1101,7 +1101,7 @@ data:
                 "uid": "${Datasource}"
               },
               "editorMode": "code",
-              "expr": "max(summary_xl_backlog{namespace=\"${namespace}\", pod=~\".+worker.+\"})",
+              "expr": "koku:celery:summary_xl_queue",
               "legendFormat": "Queue Size",
               "range": true,
               "refId": "A"
@@ -1182,7 +1182,7 @@ data:
                 "uid": "${Datasource}"
               },
               "editorMode": "code",
-              "expr": "max(summary_xl_backlog{namespace=\"${namespace}\", pod=~\".+worker.+\"})",
+              "expr": "koku:celery:summary_xl_queue",
               "range": true,
               "refId": "A"
             }
@@ -2057,7 +2057,7 @@ data:
                 "uid": "${Datasource}"
               },
               "editorMode": "code",
-              "expr": "max(ocp_xl_backlog{namespace=\"${namespace}\", pod=~\".+worker.+\"})",
+              "expr": "koku:celery:ocp_xl_queue",
               "legendFormat": "Queue Size",
               "range": true,
               "refId": "A"
@@ -2138,7 +2138,7 @@ data:
                 "uid": "${Datasource}"
               },
               "editorMode": "code",
-              "expr": "max(ocp_xl_backlog{namespace=\"${namespace}\", pod=~\".+worker.+\"})",
+              "expr": "koku:celery:ocp_xl_queue",
               "range": true,
               "refId": "A"
             }
@@ -2250,7 +2250,7 @@ data:
                 "uid": "${Datasource}"
               },
               "editorMode": "code",
-              "expr": "max(cost_model_xl_backlog{namespace=\"${namespace}\", pod=~\".+worker.+\"})",
+              "expr": "koku:celery:cost_model_xl_queue",
               "legendFormat": "Queue Size",
               "range": true,
               "refId": "A"
@@ -2331,7 +2331,7 @@ data:
                 "uid": "${Datasource}"
               },
               "editorMode": "code",
-              "expr": "max(cost_model_xl_backlog{namespace=\"${namespace}\", pod=~\".+worker.+\"})",
+              "expr": "koku:celery:cost_model_xl_queue",
               "range": true,
               "refId": "A"
             }
@@ -3205,7 +3205,7 @@ data:
                 "uid": "${Datasource}"
               },
               "editorMode": "code",
-              "expr": "max(priority_xl_backlog{namespace=\"${namespace}\", pod=~\".+worker.+\"})",
+              "expr": "koku:celery:priority_xl_queue",
               "legendFormat": "Queue Size",
               "range": true,
               "refId": "A"
@@ -3286,7 +3286,7 @@ data:
                 "uid": "${Datasource}"
               },
               "editorMode": "code",
-              "expr": "max(priority_xl_backlog{namespace=\"${namespace}\", pod=~\".+worker.+\"})",
+              "expr": "koku:celery:priority_xl_queue",
               "range": true,
               "refId": "A"
             }
@@ -3398,7 +3398,7 @@ data:
                 "uid": "${Datasource}"
               },
               "editorMode": "code",
-              "expr": "max(refresh_xl_backlog{namespace=\"${namespace}\", pod=~\".+worker.+\"})",
+              "expr": "koku:celery:refresh_xl_queue",
               "legendFormat": "Queue Size",
               "range": true,
               "refId": "A"
@@ -3479,7 +3479,7 @@ data:
                 "uid": "${Datasource}"
               },
               "editorMode": "code",
-              "expr": "max(refresh_xl_backlog{namespace=\"${namespace}\", pod=~\".+worker.+\"})",
+              "expr": "koku:celery:refresh_xl_queue",
               "range": true,
               "refId": "A"
             }


### PR DESCRIPTION
## Jira Ticket

[COST-6164](https://issues.redhat.com/browse/COST-6164)

## Description

This change will replace inline PromQL expressions like `max(<queue>_backlog{...})` with pre-aggregated metrics such as `koku:celery:<queue>_queue` defined in PrometheusRules.

## Why this change?
- Ensures consistency across dashboards, alerts, and autoscalers (KEDA)
- Reduces duplication of aggregation logic across the platform
- Improves readability and maintainability of the dashboard config
- Aligns the Grafana panel expressions with metrics already managed via PrometheusRules in app-interface

## Release Notes
- [ ] Replaces inline PromQL expressions with pre-aggregated metrics

```markdown
* [COST-6164](https://issues.redhat.com/browse/COST-6164) Replaces inline PromQL expressions with pre-aggregated metrics
```

## Summary by Sourcery

Enhancements:
- Swap `max(<queue>_backlog{…})` expressions for `koku:celery:<queue>_queue` metrics across multiple panels for consistency and maintainability