### PR TITLE
Add SQL script for updating cost line item tags in OCP AWS reporting

### DIFF
--- a/koku/masu/database/aws_report_db_accessor.py
+++ b/koku/masu/database/aws_report_db_accessor.py
@@ -367,6 +367,13 @@ class AWSReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
         sql = pkgutil.get_data("masu.database", "sql/aws/openshift/ocpaws_tag_mapping_update_daily_summary.sql")
         sql = sql.decode("utf-8")
         self._prepare_and_execute_raw_sql_query(self._table_map["ocp_on_aws_project_daily_summary"], sql, sql_params)
+        sql = pkgutil.get_data(
+            "masu.database", "sql/aws/openshift/ocpaws_tag_mapping_update_costlineitem_daily_summary.sql"
+        )
+        sql = sql.decode("utf-8")
+        self._prepare_and_execute_raw_sql_query(
+            self._table_map["reporting_ocpawscostlineitem_daily_summary_p"], sql, sql_params
+        )
 
     def populate_markup_cost(self, provider_uuid, markup, start_date, end_date, bill_ids=None):
         """Set markup costs in the database."""

--- a/koku/masu/database/aws_report_db_accessor.py
+++ b/koku/masu/database/aws_report_db_accessor.py
@@ -158,7 +158,7 @@ class AWSReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
             self._prepare_and_execute_raw_sql_query(table_name, sql, sql_params)
 
     def populate_ocp_on_aws_ui_summary_tables_trino(
-        self, start_date, end_date, openshift_provider_uuid, aws_provider_uuid, tables=OCPAWS_UI_SUMMARY_TABLES
+            self, start_date, end_date, openshift_provider_uuid, aws_provider_uuid, tables=OCPAWS_UI_SUMMARY_TABLES
     ):
         """Populate our UI summary tables (formerly materialized views)."""
         year = start_date.strftime("%Y")
@@ -191,7 +191,7 @@ class AWSReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
             self._execute_trino_raw_sql_query(sql, sql_params=sql_params, log_ref=f"{table_name}.sql")
 
     def delete_ocp_on_aws_hive_partition_by_day(
-        self, days, aws_source, ocp_source, year, month, table="reporting_ocpawscostlineitem_project_daily_summary"
+            self, days, aws_source, ocp_source, year, month, table="reporting_ocpawscostlineitem_project_daily_summary"
     ):
         """Deletes partitions individually for each day in days list."""
         if self.schema_exists_trino() and self.table_exists_trino(table):
@@ -253,15 +253,15 @@ class AWSReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
         return matched_tags
 
     def populate_ocp_on_aws_cost_daily_summary_trino(
-        self,
-        start_date,
-        end_date,
-        openshift_provider_uuid,
-        aws_provider_uuid,
-        report_period_id,
-        bill_id,
-        markup_value,
-        distribution,
+            self,
+            start_date,
+            end_date,
+            openshift_provider_uuid,
+            aws_provider_uuid,
+            report_period_id,
+            bill_id,
+            markup_value,
+            distribution,
     ):
         """Populate the daily cost aggregated summary for OCP on AWS.
 
@@ -360,7 +360,7 @@ class AWSReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
         with schema_context(self.schema):
             # Early return check to see if they have any tag mappings set.
             if not TagMapping.objects.filter(
-                Q(child__provider_type=Provider.PROVIDER_AWS) | Q(child__provider_type=Provider.PROVIDER_OCP)
+                    Q(child__provider_type=Provider.PROVIDER_AWS) | Q(child__provider_type=Provider.PROVIDER_OCP)
             ).exists():
                 LOG.debug("No tag mappings for AWS.")
                 return
@@ -372,7 +372,7 @@ class AWSReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
         )
         sql = sql.decode("utf-8")
         self._prepare_and_execute_raw_sql_query(
-            self._table_map["reporting_ocpawscostlineitem_daily_summary_p"], sql, sql_params
+            self._table_map["ocp_on_aws_daily_summary"], sql, sql_params
         )
 
     def populate_markup_cost(self, provider_uuid, markup, start_date, end_date, bill_ids=None):
@@ -460,7 +460,7 @@ class AWSReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
         return [json.loads(result[0]) for result in results]
 
     def get_openshift_on_cloud_matched_tags_trino(
-        self, aws_source_uuid, ocp_source_uuids, start_date, end_date, **kwargs
+            self, aws_source_uuid, ocp_source_uuids, start_date, end_date, **kwargs
     ):
         """Return a list of matched tags."""
         sql = pkgutil.get_data("masu.database", "trino_sql/reporting_ocpaws_matched_tags.sql")

--- a/koku/masu/database/sql/aws/openshift/ocpaws_tag_mapping_update_costlineitem_daily_summary.sql
+++ b/koku/masu/database/sql/aws/openshift/ocpaws_tag_mapping_update_costlineitem_daily_summary.sql
@@ -1,0 +1,66 @@
+WITH cte_tag_key_mapping AS (
+    SELECT DISTINCT
+        enabledtagkeys.key AS child_key,
+        parent_tags.key AS parent_key,
+        enabledtagkeys.provider_type as provider_type
+    FROM
+        {{schema | sqlsafe}}.reporting_enabledtagkeys AS enabledtagkeys
+        INNER JOIN {{schema | sqlsafe}}.reporting_tagmapping AS tag_mapping ON enabledtagkeys.uuid = tag_mapping.child_id
+        LEFT JOIN {{schema | sqlsafe}}.reporting_enabledtagkeys AS parent_tags ON tag_mapping.parent_id = parent_tags.uuid
+    WHERE
+        enabledtagkeys.enabled
+        AND (
+            enabledtagkeys.provider_type = 'AWS'
+            OR enabledtagkeys.provider_type = 'OCP'
+        )
+),
+cte_update_tag_keys as (
+    SELECT
+        lids.uuid as uuid,
+        -- mapping as mapping, --uncomment to compare
+        -- lids.tags as origianl_tags,
+        -- lids.pod_labels as original_pod_labels,
+        CASE
+            WHEN EXISTS(
+                SELECT 1 FROM cte_tag_key_mapping
+                WHERE lids.tags ? child_key
+                AND lids.tags ? parent_key)
+            THEN
+            (
+                SELECT jsonb_object_agg(
+                    COALESCE(NULLIF(tag_map->>key, ''), key),
+                    lids.tags->key
+                )
+                FROM jsonb_object_keys(lids.tags) AS key
+                WHERE key NOT IN (SELECT child_key FROM cte_tag_key_mapping)
+            )
+            ELSE
+            (
+                SELECT jsonb_object_agg(
+                    COALESCE(tag_map->>key, key),
+                    lids.tags->key
+                )
+                FROM jsonb_object_keys(lids.tags) AS key
+            )
+        END as update_tags
+    FROM
+        {{schema | sqlsafe}}.reporting_ocpawscostlineitem_daily_summary_p AS lids
+    CROSS JOIN (
+        SELECT
+            jsonb_object_agg(child_key, parent_key) AS tag_map
+        FROM cte_tag_key_mapping
+    ) AS mapping
+    WHERE lids.usage_start >= DATE({{start_date}})
+        AND lids.usage_start <= DATE({{end_date}})
+        AND lids.tags ?| ARRAY(SELECT child_key FROM cte_tag_key_mapping)
+        {% if bill_ids %}
+        AND lids.cost_entry_bill_id in {{ bill_ids | inclause }}
+        {% endif %}
+)
+
+UPDATE {{schema | sqlsafe}}.reporting_ocpawscostlineitem_daily_summary_p AS lids
+SET tags = update_data.update_tags
+FROM cte_update_tag_keys as update_data
+WHERE lids.uuid = update_data.uuid
+AND lids.usage_start >= DATE({{start_date}})
+AND lids.usage_start <= DATE({{end_date}});


### PR DESCRIPTION
## Jira Ticket

[COST-####](https://issues.redhat.com/browse/COST-####)

## Description

This change will ...

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Release Notes
- [ ] proposed release note

```markdown
* [COST-####](https://issues.redhat.com/browse/COST-####) Fix some things
```

## Summary by Sourcery

Extend OCP on AWS reporting by adding a SQL-based tag mapping update for cost line item daily summaries alongside existing project summaries.

New Features:
- Add ocpaws_tag_mapping_update_costlineitem_daily_summary.sql to generate and apply tag key mappings for cost line items in OCP on AWS reporting
- Invoke the new SQL script in populate_ocp_on_aws_tag_information to update tags on reporting_ocpawscostlineitem_daily_summary_p table