### PR TITLE
Limit tag keys to enabled ones for Cloud providers and OCP in daily summary report

### DIFF
--- a/koku/masu/database/trino_sql/aws/openshift/reporting_ocpawscostlineitem_project_daily_summary_p.sql
+++ b/koku/masu/database/trino_sql/aws/openshift/reporting_ocpawscostlineitem_project_daily_summary_p.sql
@@ -43,7 +43,7 @@ INSERT INTO postgres.{{schema | sqlsafe}}.reporting_ocpawscostlineitem_project_d
     source_uuid
 )
 with cte_pg_enabled_keys as (
-    select array_agg(key order by key) as keys
+    select array['vm_kubevirt_io_name'] || array_agg(key order by key) as keys
       from postgres.{{schema | sqlsafe}}.reporting_enabledtagkeys
      where enabled = true
      and provider_type IN ('AWS', 'OCP')

--- a/koku/masu/database/trino_sql/aws/openshift/reporting_ocpawscostlineitem_project_daily_summary_p.sql
+++ b/koku/masu/database/trino_sql/aws/openshift/reporting_ocpawscostlineitem_project_daily_summary_p.sql
@@ -104,6 +104,6 @@ CROSS JOIN cte_pg_enabled_keys AS pek
 WHERE source = {{aws_source_uuid}}
     AND ocp_source = {{ocp_source_uuid}}
     AND year = {{year}}
-    AND lpad(month, 2, '0') = {{month}}
+    AND lpad(month, 2, '0') = {{month}} -- Zero pad the month when fewer than 2 characters
     AND day IN {{days | inclause}}
 ;

--- a/koku/masu/database/trino_sql/azure/openshift/reporting_ocpazurecostlineitem_project_daily_summary_p.sql
+++ b/koku/masu/database/trino_sql/azure/openshift/reporting_ocpazurecostlineitem_project_daily_summary_p.sql
@@ -34,7 +34,7 @@ INSERT INTO postgres.{{schema | sqlsafe}}.reporting_ocpazurecostlineitem_project
     source_uuid
 )
 with cte_pg_enabled_keys as (
-    select array_agg(key order by key) as keys
+    select array['vm_kubevirt_io_name'] || array_agg(key order by key) as keys
       from postgres.{{schema | sqlsafe}}.reporting_enabledtagkeys
      where enabled = true
      and provider_type IN ('Azure', 'OCP')

--- a/koku/masu/database/trino_sql/azure/openshift/reporting_ocpazurecostlineitem_project_daily_summary_p.sql
+++ b/koku/masu/database/trino_sql/azure/openshift/reporting_ocpazurecostlineitem_project_daily_summary_p.sql
@@ -37,7 +37,7 @@ with cte_pg_enabled_keys as (
     select array_agg(key order by key) as keys
       from postgres.{{schema | sqlsafe}}.reporting_enabledtagkeys
      where enabled = true
-     and provider_type IN ('AWS', 'OCP')
+     and provider_type IN ('Azure', 'OCP')
 )
 SELECT uuid(),
     {{report_period_id | sqlsafe}} as report_period_id,

--- a/koku/masu/database/trino_sql/azure/openshift/reporting_ocpazurecostlineitem_project_daily_summary_p.sql
+++ b/koku/masu/database/trino_sql/azure/openshift/reporting_ocpazurecostlineitem_project_daily_summary_p.sql
@@ -33,6 +33,12 @@ INSERT INTO postgres.{{schema | sqlsafe}}.reporting_ocpazurecostlineitem_project
     cost_category_id,
     source_uuid
 )
+with cte_pg_enabled_keys as (
+    select array_agg(key order by key) as keys
+      from postgres.{{schema | sqlsafe}}.reporting_enabledtagkeys
+     where enabled = true
+     and provider_type IN ('AWS', 'OCP')
+)
 SELECT uuid(),
     {{report_period_id | sqlsafe}} as report_period_id,
     cluster_id as cluster_id,
@@ -72,10 +78,16 @@ SELECT uuid(),
     currency,
     pretax_cost,
     markup_cost,
-    json_parse(tags),
+        cast(
+        map_filter(
+            cast(json_parse(tags) as map(varchar, varchar)),
+            (k,v) -> contains(pek.keys, k)
+        ) as json
+     ) AS tags,
     cost_category_id,
     cast(source as UUID)
 FROM hive.{{schema | sqlsafe}}.managed_reporting_ocpazurecostlineitem_project_daily_summary
+CROSS JOIN cte_pg_enabled_keys AS pek
 WHERE source = {{azure_source_uuid}}
     AND ocp_source = {{ocp_source_uuid}}
     AND year = {{year}}

--- a/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcpcostlineitem_project_daily_summary_p.sql
+++ b/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcpcostlineitem_project_daily_summary_p.sql
@@ -43,7 +43,7 @@ with cte_pg_enabled_keys as (
     select array_agg(key order by key) as keys
       from postgres.{{schema | sqlsafe}}.reporting_enabledtagkeys
      where enabled = true
-     and provider_type IN ('AWS', 'OCP')
+     and provider_type IN ('GCP', 'OCP')
 )
 SELECT uuid(),
     {{report_period_id}} as report_period_id,

--- a/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcpcostlineitem_project_daily_summary_p.sql
+++ b/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcpcostlineitem_project_daily_summary_p.sql
@@ -40,7 +40,7 @@ INSERT INTO postgres.{{schema | sqlsafe}}.reporting_ocpgcpcostlineitem_project_d
     invoice_month
 )
 with cte_pg_enabled_keys as (
-    select array_agg(key order by key) as keys
+    select array['vm_kubevirt_io_name'] || array_agg(key order by key) as keys
       from postgres.{{schema | sqlsafe}}.reporting_enabledtagkeys
      where enabled = true
      and provider_type IN ('GCP', 'OCP')

--- a/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcpcostlineitem_project_daily_summary_p.sql
+++ b/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcpcostlineitem_project_daily_summary_p.sql
@@ -39,6 +39,12 @@ INSERT INTO postgres.{{schema | sqlsafe}}.reporting_ocpgcpcostlineitem_project_d
     credit_amount,
     invoice_month
 )
+with cte_pg_enabled_keys as (
+    select array_agg(key order by key) as keys
+      from postgres.{{schema | sqlsafe}}.reporting_enabledtagkeys
+     where enabled = true
+     and provider_type IN ('AWS', 'OCP')
+)
 SELECT uuid(),
     {{report_period_id}} as report_period_id,
     cluster_id,
@@ -87,12 +93,18 @@ SELECT uuid(),
     currency,
     unblended_cost,
     markup_cost,
-    json_parse(tags),
+        cast(
+        map_filter(
+            cast(json_parse(tags) as map(varchar, varchar)),
+            (k,v) -> contains(pek.keys, k)
+        ) as json
+     ) AS tags,
     cost_category_id,
     cast(source as UUID),
     credit_amount,
     invoice_month
 FROM hive.{{schema | sqlsafe}}.managed_reporting_ocpgcpcostlineitem_project_daily_summary
+CROSS JOIN cte_pg_enabled_keys AS pek
 WHERE source = {{gcp_source_uuid}}
     AND ocp_source = {{ocp_source_uuid}}
     AND year = {{year}}


### PR DESCRIPTION
## Jira Ticket

[COST-4658](https://issues.redhat.com/browse/COST-4658)

## Description

This change will ensure that only enabled tags are inserted into the summary table.

## Testing

1. Enable the `is_managed_ocp_cloud_summary_enabled` feature flag:
```
def is_managed_ocp_cloud_summary_enabled(account, provider_type):
    return True 
```
2. On the main branch, load Cloud provider data:
`make create-test-customer; make load-test-customer-data test_source=aws`
3. Query enabled tags from the `enabledtagkeys` table (filtered by provider):
`SELECT * FROM org1234567.reporting_enabledtagkeys WHERE provider_type IN ('AWS', 'OCP') AND enabled = true;`
4. Check if some or all enabled tags are present in the summary table:
`SELECT tags, * FROM org1234567.reporting_ocpawscostlineitem_project_daily_summary_p WHERE tags ?| array['dashed-key-on-aws', 'test_new_tag', 'tier', 'Map'];`
5. Make sure you have at least one occurrence.
6. Go back to the `enabledtagkeys` table and set `enabled = false` for the tags chosen in the previous step.
7. Checkout this branch.
8. Run summarization/data ingestion again.
9. Verify that the disabled tags are no longer present in the summary table:
`SELECT tags, * FROM org1234567.reporting_ocpawscostlineitem_project_daily_summary_p WHERE tags ?| array['dashed-key-on-aws', 'test_new_tag', 'tier', 'storageclass'];`
10. You should see no occurrences.

## Release Notes
- [ ] Limit tag keys to Enabled on Cloud daily summary tables

```markdown
* [COST-4658](https://issues.redhat.com/browse/COST-4658) Limit tag keys to Enabled on Cloud daily summary tables
```

## Summary by Sourcery

Enhancements:
- Filter tags in the AWS/Azure/GCP and OCP project daily summary report to only include keys enabled in the enabledtagkeys table

## Summary by Sourcery

Enhancements:
- Add common table expression to fetch enabled tag keys from reporting_enabledtagkeys and apply map_filter on the tags JSON for AWS/OCP, Azure/OCP, and GCP/OCP summary tables.