### PR TITLE
cast provider_uuid to string

### DIFF
--- a/koku/masu/processor/parquet/ocp_cloud_parquet_report_processor.py
+++ b/koku/masu/processor/parquet/ocp_cloud_parquet_report_processor.py
@@ -220,7 +220,7 @@ class OCPCloudParquetReportProcessor(ParquetReportProcessor):
         }
         for ocp_provider_uuid, infra_tuple in self.ocp_infrastructure_map.items():
             infra_provider_uuid = infra_tuple[0]
-            if infra_provider_uuid != self.provider_uuid:
+            if str(infra_provider_uuid) != str(self.provider_uuid):
                 continue
             ctx |= {
                 "ocp_provider_uuid": ocp_provider_uuid,

--- a/koku/masu/processor/parquet/parquet_report_processor.py
+++ b/koku/masu/processor/parquet/parquet_report_processor.py
@@ -109,7 +109,7 @@ class ParquetReportProcessor:
     @property
     def provider_uuid(self):
         """The provider UUID."""
-        return self._provider_uuid
+        return str(self._provider_uuid)
 
     @property
     def provider_type(self):


### PR DESCRIPTION
## Jira Ticket

[COST-####](https://issues.redhat.com/browse/COST-####)

## Description

This change will ...

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Release Notes
- [ ] proposed release note

```markdown
* [COST-####](https://issues.redhat.com/browse/COST-####) Fix some things
```

## Summary by Sourcery

Cast provider_uuid to string and adjust comparisons to avoid type mismatches when processing Parquet reports

Enhancements:
- Return provider_uuid as a string in the ParquetReportProcessor
- Compare infra_provider_uuid and provider_uuid as strings in the OCP cloud Parquet processor to ensure consistency