### PR TITLE
enable manage tables failback

### DIFF
--- a/koku/masu/processor/__init__.py
+++ b/koku/masu/processor/__init__.py
@@ -106,10 +106,10 @@ def is_validation_enabled(account):  # pragma: no cover
 
 def is_managed_ocp_cloud_summary_enabled(account, provider_type):
     context = {"provider_type": provider_type}
-    if UNLEASH_CLIENT.is_enabled("cost-management.backend.feature-cost-5129-provider-type", context):
+    if UNLEASH_CLIENT.is_enabled("cost-management.backend.feature-cost-5129-provider-type", context, fallback_development_true):
         account = convert_account(account)
         context = {"schema": account}
-        result = UNLEASH_CLIENT.is_enabled("cost-management.backend.feature-cost-5129-ocp-cloud-summary", context)
+        result = UNLEASH_CLIENT.is_enabled("cost-management.backend.feature-cost-5129-ocp-cloud-summary", context, fallback_development_true)
         LOG.info(log_json(msg=f"managed table summary enabled: {result}", schema=account, provider_type=provider_type))
         return result
     return False

--- a/koku/masu/processor/__init__.py
+++ b/koku/masu/processor/__init__.py
@@ -106,10 +106,12 @@ def is_validation_enabled(account):  # pragma: no cover
 
 def is_managed_ocp_cloud_summary_enabled(account, provider_type):
     context = {"provider_type": provider_type}
-    if UNLEASH_CLIENT.is_enabled("cost-management.backend.feature-cost-5129-provider-type", context, fallback_development_true):
+    provider_flag = "cost-management.backend.feature-cost-5129-provider-type"
+    if UNLEASH_CLIENT.is_enabled(provider_flag, context, fallback_development_true):
         account = convert_account(account)
         context = {"schema": account}
-        result = UNLEASH_CLIENT.is_enabled("cost-management.backend.feature-cost-5129-ocp-cloud-summary", context, fallback_development_true)
+        summary_flag = "cost-management.backend.feature-cost-5129-ocp-cloud-summary"
+        result = UNLEASH_CLIENT.is_enabled(summary_flag, context, fallback_development_true)
         LOG.info(log_json(msg=f"managed table summary enabled: {result}", schema=account, provider_type=provider_type))
         return result
     return False


### PR DESCRIPTION
## Jira Ticket

[COST-####](https://issues.redhat.com/browse/COST-####)

## Description

This change will ...

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Release Notes
- [ ] proposed release note

```markdown
* [COST-####](https://issues.redhat.com/browse/COST-####) Fix some things
```

## Summary by Sourcery

Include a development-mode fallback in Unleash feature flag checks for managed OCP cloud summaries

Enhancements:
- Add fallback_development_true to `UNLEASH_CLIENT.is_enabled` calls for provider-type and OCP cloud summary flags
- Extract feature flag string literals into `provider_flag` and `summary_flag` variables for clarity