### PR TITLE
[COST-6553] Support fractional hours for VMs metrics (tag based)

### DIFF
--- a/koku/masu/database/ocp_report_db_accessor.py
+++ b/koku/masu/database/ocp_report_db_accessor.py
@@ -29,6 +29,7 @@ from koku.database import SQLScriptAtomicExecutorMixin
 from koku.trino_database import TrinoStatementExecError
 from masu.database import OCP_REPORT_TABLE_MAP
 from masu.database.report_db_accessor_base import ReportDBAccessorBase
+from masu.processor import is_fractional_hours_vm_cost_enabled
 from masu.util.common import filter_dictionary
 from masu.util.common import trino_table_exists
 from reporting.models import OCP_ON_ALL_PERSPECTIVES
@@ -1294,6 +1295,7 @@ GROUP BY partitions.year, partitions.month, partitions.source
         if not report_period:
             return
 
+        use_fractional_hours = is_fractional_hours_vm_cost_enabled(self.schema)
         for metric_name, file_path in metric_file_path.items():
             vm_count_params = VMParams(
                 schema=self.schema,
@@ -1308,6 +1310,8 @@ GROUP BY partitions.year, partitions.month, partitions.source
 
             sql = pkgutil.get_data("masu.database", file_path).decode("utf-8")
             for sql_params in param_list:
+                if "hourly_" in file_path:
+                    sql_params["use_fractional_hours"] = use_fractional_hours
                 LOG.info(log_json(msg=log_msg_mapping.get(metric_name)))
                 if "trino_sql/" in file_path:
                     self._execute_trino_multipart_sql_query(sql, bind_params=sql_params)

--- a/koku/masu/database/trino_sql/openshift/cost_model/hourly_cost_vm_tag_based.sql
+++ b/koku/masu/database/trino_sql/openshift/cost_model/hourly_cost_vm_tag_based.sql
@@ -51,7 +51,11 @@ JOIN (
     SELECT
         json_extract_scalar(pod_usage.pod_labels, '$.vm_kubevirt_io_name') as vm_name,
         DATE(pod_usage.interval_start) as interval_day,
+        {% if use_fractional_hours %}
+        sum(pod_usage.vm_uptime_total_seconds) / 3600 AS vm_interval_hours
+        {% else %}
         count(pod_usage.interval_start) AS vm_interval_hours
+        {% endif %}
     FROM hive.{{schema | sqlsafe}}.openshift_pod_usage_line_items pod_usage
     WHERE strpos(pod_usage.pod_labels, 'vm_kubevirt_io_name') != 0
         AND source = {{source_uuid}}

--- a/koku/masu/database/trino_sql/openshift/cost_model/hourly_cost_vm_tag_based.sql
+++ b/koku/masu/database/trino_sql/openshift/cost_model/hourly_cost_vm_tag_based.sql
@@ -36,16 +36,14 @@ SELECT uuid(),
     CASE
         {%- for value, rate in value_rates.items() %}
         WHEN json_extract_scalar(lids.pod_labels, '$.{{ tag_key|sqlsafe }}') = {{value}}
-        THEN
-            max(vmhrs.vm_interval_hours) * CAST({{rate}} as DECIMAL(33, 15))
+        THEN max(vmhrs.vm_interval_hours) * CAST({{rate}} as DECIMAL(33, 15))
         {%- endfor %}
         {%- if default_rate is defined %}
-        ELSE
-            max(vmhrs.vm_interval_hours) * CAST({{default_rate}} as DECIMAL(33, 15))
+        ELSE max(vmhrs.vm_interval_hours) * CAST({{default_rate}} as DECIMAL(33, 15))
         {%- endif %}
     END as cost_model_cpu_cost,
     {%- else %}
-        max(vmhrs.vm_interval_hours) * CAST({{default_rate}} as DECIMAL(33, 15)) AS cost_model_cpu_cost,
+    max(vmhrs.vm_interval_hours) * CAST({{default_rate}} as DECIMAL(33, 15)) AS cost_model_cpu_cost,
     {%- endif %}
     cost_category_id
 FROM postgres.{{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary AS lids

--- a/koku/masu/database/trino_sql/openshift/cost_model/hourly_vm_core_tag_based.sql
+++ b/koku/masu/database/trino_sql/openshift/cost_model/hourly_vm_core_tag_based.sql
@@ -49,11 +49,7 @@ WITH
             vm_map.vm_cpu_request_cores AS vm_cpu_cores,
             DATE(vm_map.interval_start) AS interval_day,
             vm_map.vm_name AS vm_name,
-            {% if use_fractional_hours %}
             sum(vm_map.vm_uptime_total_seconds) / 3600 AS vm_interval_hours
-            {% else %}
-            count(vm_map.interval_start) AS vm_interval_hours
-            {% endif %}
         FROM hive.{{schema | sqlsafe}}.openshift_vm_usage_line_items AS vm_map
         WHERE
             vm_map.source = {{source_uuid | string}}

--- a/koku/masu/database/trino_sql/openshift/cost_model/hourly_vm_core_tag_based.sql
+++ b/koku/masu/database/trino_sql/openshift/cost_model/hourly_vm_core_tag_based.sql
@@ -49,7 +49,11 @@ WITH
             vm_map.vm_cpu_request_cores AS vm_cpu_cores,
             DATE(vm_map.interval_start) AS interval_day,
             vm_map.vm_name AS vm_name,
+            {% if use_fractional_hours %}
+            sum(vm_map.vm_uptime_total_seconds) / 3600 AS vm_interval_hours
+            {% else %}
             count(vm_map.interval_start) AS vm_interval_hours
+            {% endif %}
         FROM hive.{{schema | sqlsafe}}.openshift_vm_usage_line_items AS vm_map
         WHERE
             vm_map.source = {{source_uuid | string}}


### PR DESCRIPTION
## Jira Ticket

[COST-6553](https://issues.redhat.com/browse/COST-6553)

## Description

This change will add the support of fractional hours for VMs cost model metrics (tag based), using the `vm_uptime_total_seconds` field. The `is_fractional_hours_vm_cost_enabled` feature flag controls if it is using fixed hours or fractional hours.

## Testing

1. Checkout Branch
2. Restart Koku
3. Create a `vm_cost_per_hour` cost model metric 
4. Set `is_fractional_hours_vm_cost_enabled` feature flag to True
5. Ingest OCP data (with `vm_seconds` [entry](https://github.com/project-koku/nise/blob/c0de46f68816cfa18e8bdbc62cfc4af88c74c917/example_ocp_static_data.yml#L81))
6. Check if the total cost matches the cost model metric and the uptime (in seconds) 
7. You can validate the fallback behavior by setting the`is_fractional_hours_vm_cost_enabled` feature flag to False

## Release Notes
- [ ] Support fractional hours for VMs metrics (tag based)

```markdown
* [COST-6553](https://issues.redhat.com/browse/COST-6553) Support fractional hours for VMs metrics (tag based)
```
