### PR TITLE
[COST-6488] Year-Month fix

### DIFF
--- a/koku/masu/database/trino_sql/gcp/openshift/populate_daily_summary/1_resource_matching_by_cluster.sql
+++ b/koku/masu/database/trino_sql/gcp/openshift/populate_daily_summary/1_resource_matching_by_cluster.sql
@@ -51,8 +51,8 @@ WITH cte_usage_date_partitions as (
 ),
 cte_gcp_resource_names AS (
     SELECT DISTINCT resource_name
-    FROM hive.{{schema | sqlsafe}}.gcp_line_items_daily
-    JOIN cte_usage_date_partitions AS ym ON year = ym.year AND month = ym.month
+    FROM hive.{{schema | sqlsafe}}.gcp_line_items_daily AS gcp
+    JOIN cte_usage_date_partitions AS ym ON gcp.year = ym.year AND gcp.month = ym.month
     WHERE source = {{cloud_provider_uuid}}
         AND usage_start_time >= {{start_date}}
         AND usage_start_time < date_add('day', 1, {{end_date}})

--- a/koku/masu/database/trino_sql/gcp/openshift/populate_daily_summary/1_resource_matching_by_cluster.sql
+++ b/koku/masu/database/trino_sql/gcp/openshift/populate_daily_summary/1_resource_matching_by_cluster.sql
@@ -46,7 +46,6 @@ WITH cte_usage_date_partitions as (
     from gcp_line_items_daily
     where usage_start_time >= {{start_date}}
     AND usage_start_time <= {{end_date}}
-    AND year in (SELECT year FROM cte_years)
     AND source = {{cloud_provider_uuid}}
     group by year, month
 ),

--- a/koku/masu/database/trino_sql/gcp/openshift/populate_daily_summary/1_resource_matching_by_cluster.sql
+++ b/koku/masu/database/trino_sql/gcp/openshift/populate_daily_summary/1_resource_matching_by_cluster.sql
@@ -39,19 +39,28 @@ INSERT INTO hive.{{schema | sqlsafe}}.managed_gcp_openshift_daily_temp (
     month,
     day
 )
+WITH cte_years AS (
+    SELECT
+    DISTINCT year
+    FROM gcp_line_items_daily
+    WHERE usage_start_time >= {{start_date}}
+    AND usage_start_time <= {{end_date}}
+    AND source = {{cloud_provider_uuid}}
+),
 WITH cte_months AS (
     SELECT
     DISTINCT month
     FROM gcp_line_items_daily
-    WHERE usage_start_time > {{start_date}}
+    WHERE usage_start_time >= {{start_date}}
     AND usage_start_time <= {{end_date}}
-    AND year = {{year}}
+    AND year in (SELECT year FROM cte_years)
+    AND source = {{cloud_provider_uuid}}
 ),
 cte_gcp_resource_names AS (
     SELECT DISTINCT resource_name
     FROM hive.{{schema | sqlsafe}}.gcp_line_items_daily
     WHERE source = {{cloud_provider_uuid}}
-        AND year = {{year}}
+        AND year in (SELECT year FROM cte_years)
         AND month in (SELECT month FROM cte_months)
         AND usage_start_time >= {{start_date}}
         AND usage_start_time < date_add('day', 1, {{end_date}})
@@ -168,7 +177,7 @@ LEFT JOIN cte_agg_tags AS tag_matches
     ON any_match(tag_matches.matched_tags, x->strpos(labels, x) != 0)
     AND resource_names.resource_name IS NULL
 WHERE gcp.source = {{cloud_provider_uuid}}
-    AND gcp.year = {{year}}
+    AND gcp.year in (SELECT year FROM cte_years)
     AND gcp.month in (SELECT month FROM cte_months)
     AND gcp.usage_start_time >= {{start_date}}
     AND gcp.usage_start_time < date_add('day', 1, {{end_date}})


### PR DESCRIPTION
## Jira Ticket

[COST-6488](https://issues.redhat.com/browse/COST-6488)

## Description

This change will fix a bug in distinct months CTE logic and also include year boundary logic.

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Release Notes
- [ ] proposed release note

```markdown
* [COST-6488](https://issues.redhat.com/browse/COST-6488) Fix distinct Year and Month CTE's
```

## Summary by Sourcery

Replace the month-only CTE with a year-month partitions CTE to fix distinct month logic and ensure proper year boundary filtering across resource matching queries

Enhancements:
- Introduce cte_usage_date_partitions to select distinct year and month partitions instead of cte_months
- Join the new partitions CTE in resource name and main queries to apply dynamic year and month filtering
- Remove static year and month filters in favor of the dynamic CTE across all query sections