### PR TITLE
[COST-6489] add parent keys to valid list

### DIFF
--- a/koku/api/query_params.py
+++ b/koku/api/query_params.py
@@ -373,7 +373,7 @@ class QueryParameters:
             self.tag_keys.update(enabled_keys)
             # Step 2: add parent keys from TagMapping
             parent_keys = (
-                TagMapping.objects.filter(parent__provider_type__in=self.tag_providers)
+                TagMapping.objects.filter(child__key__in=list(enabled_keys))
                 .values_list("parent__key", flat=True)
                 .distinct()
             )

--- a/koku/api/report/test/test_queries.py
+++ b/koku/api/report/test/test_queries.py
@@ -347,7 +347,7 @@ class ReportQueryHandlerTest(IamTestCase):
             f"group_by[and:tag:{term}]={second}"
         )
         with patch("reporting.provider.all.models.EnabledTagKeys.objects") as mock_tags:
-            mock_tags.filter.return_value.values_list.return_value.distinct.return_value = [self.mock_tag_key]
+            mock_tags.filter.return_value.distinct.return_value.values_list.return_value = [self.mock_tag_key]
             params = self.mocked_query_params(url, self.mock_view)
         mapper = {"filter": [{}], "filters": {term: {"field": term, "operation": operation}}}
         rqh = create_test_handler(params, mapper=mapper)
@@ -386,7 +386,7 @@ class ReportQueryHandlerTest(IamTestCase):
             f"group_by[or:tag:{term}]={second}"
         )
         with patch("reporting.provider.all.models.EnabledTagKeys.objects") as mock_tags:
-            mock_tags.filter.return_value.values_list.return_value.distinct.return_value = [self.mock_tag_key]
+            mock_tags.filter.return_value.distinct.return_value.values_list.return_value = [self.mock_tag_key]
             params = self.mocked_query_params(url, self.mock_view)
         mapper = {"filter": [{}], "filters": {term: {"field": term, "operation": operation}}}
         rqh = create_test_handler(params, mapper=mapper)

--- a/koku/api/test_query_params.py
+++ b/koku/api/test_query_params.py
@@ -399,7 +399,7 @@ class QueryParametersTests(TestCase):
 
     def test_has_start_end_dates_filter_no_filter(self):
         """Test the default filter query parameters with start and end dates."""
-        fake_uri = "start_date=2021-04-01&" "end_date=2021-04-13"
+        fake_uri = "start_date=2021-04-01&end_date=2021-04-13"
         fake_request = Mock(
             spec=HttpRequest,
             user=Mock(access=None, customer=Mock(schema_name=self.FAKE.word())),
@@ -420,7 +420,7 @@ class QueryParametersTests(TestCase):
 
     def test_has_filter_no_value(self):
         """Test the default filter parameters when time_scope_value is undefined."""
-        fake_uri = "filter[resolution]=monthly&" "filter[time_scope_units]=month"
+        fake_uri = "filter[resolution]=monthly&filter[time_scope_units]=month"
         fake_request = Mock(
             spec=HttpRequest,
             user=Mock(access=None, customer=Mock(schema_name=self.FAKE.word())),
@@ -439,7 +439,7 @@ class QueryParametersTests(TestCase):
 
     def test_has_filter_no_units(self):
         """Test the default filter parameters when time_scope_units is undefined."""
-        fake_uri = "filter[resolution]=monthly&" "filter[time_scope_value]=-1"
+        fake_uri = "filter[resolution]=monthly&filter[time_scope_value]=-1"
         fake_request = Mock(
             spec=HttpRequest,
             user=Mock(access=None, customer=Mock(schema_name=self.FAKE.word())),
@@ -458,7 +458,7 @@ class QueryParametersTests(TestCase):
 
     def test_has_filter_no_resolution(self):
         """Test the default filter parameters when resolution is undefined."""
-        fake_uri = "filter[time_scope_units]=month&" "filter[time_scope_value]=-1"
+        fake_uri = "filter[time_scope_units]=month&filter[time_scope_value]=-1"
         fake_request = Mock(
             spec=HttpRequest,
             user=Mock(access=None, customer=Mock(schema_name=self.FAKE.word())),
@@ -478,7 +478,7 @@ class QueryParametersTests(TestCase):
     def test_access_with_wildcard(self):
         """Test wildcard doesn't update query parameters."""
         provider = random.choice(PROVIDERS)
-        fake_uri = "group_by[account]=*&" "group_by[region]=*"
+        fake_uri = "group_by[account]=*&group_by[region]=*"
         test_access = {f"{provider}.account": {"read": ["*"]}}
         fake_request = Mock(
             spec=HttpRequest,
@@ -499,7 +499,7 @@ class QueryParametersTests(TestCase):
 
     def test_access_replace_wildcard(self):
         """Test that a group by account wildcard only has access to the proper accounts."""
-        fake_uri = "group_by[account]=*&" "group_by[region]=*"
+        fake_uri = "group_by[account]=*&group_by[region]=*"
         test_access = {"aws.account": {"read": ["account1", "account2"]}, "aws.organizational_unit": {"read": ["*"]}}
         fake_request = Mock(
             spec=HttpRequest,
@@ -524,9 +524,7 @@ class QueryParametersTests(TestCase):
         guid2 = uuid4()
         guid3 = uuid4()
         fake_uri = (
-            f"group_by[subscription_guid]={guid1}&"
-            f"group_by[subscription_guid]={guid2}&"
-            f"group_by[resource_location]=*"
+            f"group_by[subscription_guid]={guid1}&group_by[subscription_guid]={guid2}&group_by[resource_location]=*"
         )
         test_access = {"azure.subscription_guid": {"read": [str(guid1), str(guid3)]}}
         fake_request = Mock(
@@ -547,7 +545,7 @@ class QueryParametersTests(TestCase):
 
     def test_access_empty_intersection(self):
         """Test that a group by cluster filtered list causes 403 with empty intersection."""
-        fake_uri = "group_by[cluster]=cluster1&" "group_by[cluster]=cluster3"
+        fake_uri = "group_by[cluster]=cluster1&group_by[cluster]=cluster3"
         test_access = {"openshift.cluster": {"read": ["cluster4", "cluster2"]}}
         fake_request = Mock(
             spec=HttpRequest,
@@ -609,7 +607,7 @@ class QueryParametersTests(TestCase):
 
     def test_update_query_parameters_filtered_intersection(self):
         """Test that a filter by cluster filtered list causes a 403 when filtering on accounts without access."""
-        fake_uri = "filter[cluster]=cluster1&" "filter[cluster]=cluster3"
+        fake_uri = "filter[cluster]=cluster1&filter[cluster]=cluster3"
         test_access = {"openshift.cluster": {"read": ["cluster1", "cluster2"]}}
         fake_request = Mock(
             spec=HttpRequest,
@@ -662,7 +660,7 @@ class QueryParametersTests(TestCase):
             GET=Mock(urlencode=Mock(return_value=fake_uri)),
         )
         fake_objects = Mock()
-        fake_objects.objects.values_list.return_value.distinct.return_value = tag_keys
+        fake_objects.objects.distinct.return_value.values_list.return_value = tag_keys
         fake_view = Mock(
             spec=ReportView,
             provider=self.FAKE.word(),
@@ -672,7 +670,7 @@ class QueryParametersTests(TestCase):
             tag_providers=["fake"],
         )
         with patch("reporting.provider.all.models.EnabledTagKeys.objects") as mock_object:
-            mock_object.filter.return_value.values_list.return_value.distinct.return_value = tag_keys
+            mock_object.filter.return_value.distinct.return_value.values_list.return_value = tag_keys
             params = QueryParameters(fake_request, fake_view)
         self.assertEqual(params.tag_keys, expected)
 


### PR DESCRIPTION
## Jira Ticket

[COST-6489](https://issues.redhat.com/browse/COST-6489)

## Testing

1. ON MAIN: start with fresh DB
2. ingest ocp-on-aws:
```
$ make create-test-customer && make load-test-customer-data source=aws
```
allow data to finish ingestion.
3. go here:

http://localhost:8000/api/cost-management/v1/reports/openshift/costs/?currency=CZK&delta=cost&filter[limit]=10&filter[offset]=0&filter[resolution]=monthly&filter[time_scope_units]=month&filter[time_scope_value]=-1&group_by[tag:App]=*&order_by[cost]=desc

SEE FAILURE:
```
HTTP 400 Bad Request
Allow: GET, HEAD, OPTIONS
Content-Type: application/json
Vary: X_RH_IDENTITY, Accept

{
    "group_by": {
        "tag:App": [
            "Unsupported parameter or invalid value"
        ]
    }
}
```

4. change the AWS `app` key to `App`:
```
postgres=# update org1234567_mskarbek.reporting_enabledtagkeys set key='App' where key='app' and provider_type='AWS' ;
UPDATE 1
```
4. create the mapping:
get the UUID:
```
postgres=# select * from org1234567_mskarbek.reporting_enabledtagkeys where key in ('App', 'app') AND provider_type in ('AWS', 'OCP') order by provider_type ;
                 uuid                 | key | enabled | provider_type 
--------------------------------------+-----+---------+---------------
 0538ad1b-abbe-419f-b528-c0ea568edb92 | App | t       | AWS
 2a1dddf1-0b1f-4215-b54c-60ffb5e63fab | app | t       | OCP

```
PUT:
```
curl --location --request PUT 'http://localhost:8000/api/cost-management/v1/settings/tags/mappings/child/add/' --header 'Content-Type: application/json' --data '{"parent": "0538ad1b-abbe-419f-b528-c0ea568edb92","children": ["2a1dddf1-0b1f-4215-b54c-60ffb5e63fab"]}'
```
5. go here:

http://localhost:8000/api/cost-management/v1/reports/openshift/costs/?currency=CZK&delta=cost&filter[limit]=10&filter[offset]=0&filter[resolution]=monthly&filter[time_scope_units]=month&filter[time_scope_value]=-1&group_by[tag:App]=*&order_by[cost]=desc

SEE SAME FAILURE.

6. Checkout branch, ensure koku-server restarts
7. go here:

http://localhost:8000/api/cost-management/v1/reports/openshift/costs/?currency=CZK&delta=cost&filter[limit]=10&filter[offset]=0&filter[resolution]=monthly&filter[time_scope_units]=month&filter[time_scope_value]=-1&group_by[tag:App]=*&order_by[cost]=desc

SEE SUCCESS

## Release Notes
- [x] proposed release note

```markdown
* [COST-6489](https://issues.redhat.com/browse/COST-6489) add parent keys of enabled child keys to valid list of keys
```

## Summary by Sourcery

Enhancements:
- Filter TagMapping by child.key matching enabled keys when retrieving parent tag keys