### PR TITLE
drop installation of kustomize since it is already available

### DIFF
--- a/deploy/kustomize/patches/koku-reads.yaml
+++ b/deploy/kustomize/patches/koku-reads.yaml
@@ -13,7 +13,7 @@
       env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: SCHEMA_SUFFI
+        - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
           value: ${TRINO_S3A_OR_S3}


### PR DESCRIPTION
## Description

This change will remove the installation of kustomize during the clowdapp.sh sanity check. It occasionally fails due to rate limits because we install kustomize directly from github.

Kustomize is actually a tool already available in the github-runner, so we don't need to install it (list of installed tools: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md).

## Testing

1. make a change to a patch file or the clowdapp and do not run `make clowdapp`. ([see example](https://github.com/project-koku/koku/actions/runs/16417716225/job/46387671371))
2. push to github and see that the sanity test fails appropriately.


## Summary by Sourcery

Enhancements:
- Drop curl-based kustomize install in .github/scripts/check_clowdapp.sh