### PR TITLE
[COST-6490] Handle special chars in tags and cost category

### DIFF
--- a/koku/api/report/aws/query_handler.py
+++ b/koku/api/report/aws/query_handler.py
@@ -22,6 +22,7 @@ from api.report.constants import AWS_CATEGORY_PREFIX
 from api.report.constants import AWS_MARKUP_COST
 from api.report.queries import ReportQueryHandler
 from api.report.queries import strip_prefix
+from api.utils import safe_column_alias
 from reporting.provider.aws.models import AWSEnabledCategoryKeys
 from reporting.provider.aws.models import AWSOrganizationalUnit
 
@@ -96,7 +97,8 @@ class AWSReportQueryHandler(ReportQueryHandler):
         )
         for q_param, db_field in fields.items():
             if q_param in prefix_removed_parameters_list:
-                annotations[q_param] = F(db_field)
+                alias = safe_column_alias(q_param)
+                annotations[alias] = F(db_field)
         return annotations
 
     def _contains_disabled_aws_category_keys(self):

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -46,6 +46,7 @@ from api.query_handler import QueryHandler
 from api.report.constants import AWS_CATEGORY_PREFIX
 from api.report.constants import TAG_PREFIX
 from api.report.constants import URL_ENCODED_SAFE
+from api.utils import safe_column_alias
 
 LOG = logging.getLogger(__name__)
 
@@ -696,7 +697,9 @@ class ReportQueryHandler(QueryHandler):
         if aws_category_column := self._mapper.provider_map.get("aws_category_column"):
             groups = self.get_aws_category_keys("group_by")
             for aws_category in groups:
-                db_name = aws_category_column + "__" + strip_prefix(aws_category, AWS_CATEGORY_PREFIX)
+                raw_key = strip_prefix(aws_category, AWS_CATEGORY_PREFIX)
+                safe_key = safe_column_alias(raw_key)
+                db_name = f"{aws_category_column}__{safe_key}"
                 aws_category = str.encode(aws_category)
                 aws_category = quote_from_bytes(aws_category, safe=URL_ENCODED_SAFE)
                 group_pos = self.parameters.url_data.index(aws_category)

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -684,8 +684,8 @@ class ReportQueryHandler(QueryHandler):
         tag_groups = self.get_tag_group_by_keys()
         for tag in tag_groups:
             original_tag = strip_prefix(tag, TAG_PREFIX)
-            sanitized_tag = sanitize_tag(original_tag)
-            tag_db_name = self._mapper.tag_column + "__" + sanitized_tag
+            safe_tag = safe_column_alias(original_tag)
+            tag_db_name = self._mapper.tag_column + "__" + safe_tag
             encoded_tag_url = quote(original_tag, safe=URL_ENCODED_SAFE)
             group_pos = self.parameters.url_data.index(encoded_tag_url)
             group_by.append((tag_db_name, group_pos))

--- a/koku/api/utils.py
+++ b/koku/api/utils.py
@@ -608,4 +608,4 @@ def safe_column_alias(alias: str) -> str:
     """
     Sanitize column alias to be SQL-safe (no spaces, quotes, etc.).
     """
-    return alias.replace(" ", "_").replace('"', "").replace(";", "").replace("--", "")
+    return alias.replace(" ", "_").replace("/", "_").replace('"', "").replace(";", "").replace("--", "")

--- a/koku/api/utils.py
+++ b/koku/api/utils.py
@@ -602,3 +602,10 @@ def get_months_in_date_range(
 
     months = dh.list_month_tuples(dt_start, dt_end)
     return [(start, end, dt_invoice_month) for start, end in months]
+
+
+def safe_column_alias(alias: str) -> str:
+    """
+    Sanitize column alias to be SQL-safe (no spaces, quotes, etc.).
+    """
+    return alias.replace(" ", "_").replace('"', "").replace(";", "").replace("--", "")


### PR DESCRIPTION
## Jira Ticket

[COST-6490](https://issues.redhat.com/browse/COST-6490)

## Description

This change will fix the special chars handling errors in tags and cost category. 
1. Fixes the whitespace error in `&group_by[aws_category:Stage2%20OUs]=*` and
2. Fixes the tuple out of range index error in `&group_by[tag:Tirea/app-group]=*`

## Testing whitespace error fix

1. Checkout Branch
2. Restart Koku
3. Ingest AWS sample data
4. Make sure you have at least one tag key that contains a whitespace: `SELECT * FROM org1234567.reporting_awsenabledcategorykeys;`
5. Hit endpoint `/cost-management/v1/reports/aws/costs/?group_by[aws_category:<TAG-KEY-WITH-WHITESPACE-HERE>]=*`
6. It should work without any errors or warnings.

## Testing tuple out of range index error fix

1. Checkout Branch
2. Restart Koku
3. Ingest AWS sample data: you can update your `koku/dev/scripts/nise_ymls/ocp_on_aws/aws_static_data.yml` to include a tag with a backslash, for example `resourceTags/user:Tirea/app-group: testing-testing`
4. Hit endpoint `/cost-management/v1/reports/aws/costs/?group_by[tag:<TAG-WITH-BACKSLASH-HERE>]=*`
6. It should work without any errors or warnings.

## Release Notes
- [ ] Fix the special chars handling errors in tags and cost category.

```markdown
* [COST-6490](https://issues.redhat.com/browse/COST-6490) Fix the special chars handling errors in tags and cost category.
```
