### PR TITLE
Revert "[COST-6498] add null/empty filters for PVC names"

### DIFF
--- a/koku/masu/database/trino_sql/openshift/populate_vm_tmp_table_with_vm_report.sql
+++ b/koku/masu/database/trino_sql/openshift/populate_vm_tmp_table_with_vm_report.sql
@@ -37,6 +37,4 @@ ON pvc.vm_name = latest.vm_name
 WHERE pvc.source = {{source_uuid | string}}
 AND pvc.year = {{year}}
 AND pvc.month = {{month}}
-AND pvc.vm_persistentvolumeclaim_name IS NOT NULL
-AND pvc.vm_persistentvolumeclaim_name != ''
 GROUP BY latest.vm_name, latest.node, pvc.vm_persistentvolumeclaim_name


### PR DESCRIPTION
Reverts project-koku/koku#5679

See https://issues.redhat.com/browse/COST-6618

## Summary by Sourcery

Bug Fixes:
- Remove the non-null and non-empty filters for vm_persistentvolumeclaim_name in the VM report population SQL