### PR TITLE
[COST-6630] Don't use cost model rows to calculate node & cluster capacity

### DIFF
--- a/koku/masu/database/sql/openshift/cost_model/usage_costs.sql
+++ b/koku/masu/database/sql/openshift/cost_model/usage_costs.sql
@@ -83,6 +83,10 @@ WITH cte_node_cost as (
             AND source_uuid = {{source_uuid}}
             AND node IS NOT NULL
             AND node != ''
+            AND (
+                cost_model_rate_type IS NULL
+                OR cost_model_rate_type NOT IN ('Infrastructure', 'Supplementary')
+            )
         GROUP BY usage_start, node
     )
 )


### PR DESCRIPTION
## Jira Ticket

[COST-6630](https://issues.redhat.com/browse/COST-6630)

## Description

This change will not use cost model rows to calculate node & cluster capacity.

## Testing


## Release Notes
- [ ] proposed release note
