### PR TITLE
[COST-6635] - Fix project cost node count

### DIFF
--- a/koku/masu/database/trino_sql/openshift/cost_model/monthly_project_tag_based.sql
+++ b/koku/masu/database/trino_sql/openshift/cost_model/monthly_project_tag_based.sql
@@ -76,7 +76,7 @@ node_count as (
         CAST(count(node) AS DECIMAL(33, 15)) as node_count,
         usage_start
     from filtered_data
-    group by namespace, node, usage_start
+    group by namespace, usage_start
 )
 SELECT
     uuid(),


### PR DESCRIPTION
## Jira Ticket

[COST-6635](https://issues.redhat.com/browse/COST-6635)

## Description

This change will remove the group by on node in the CTE when we are trying to collect node counts per namespace. Leaving in this group by node means the count is always 1.

## Testing

1. Checkout Branch
2. Restart Koku
3. Create ocp provider
4. Create cost model with project per month metric
5. Create/Load nise data for cluster which contains multiple nodes running pods from the same project. (Simulating the distribution of project costs across multiple projects)
6. Check costs endpoint group by node, you should see the cost per node be a fraction of the total metric cost.

Additionally compare this with main and see that each node receives the total cost per project/node.

Example:
I have 3 distinct nodes all of which contain the `test` project, my cost model has a project metric of 100

- On main each node yields a cost of $300 because we are actually appling that cost per project per node
- Whereas this branch each node yields a cost of $33.33, since now we are dividing that project cost by the total node count of 3.


## Release Notes
- [ ] proposed release note

```markdown
* [COST-6635](https://issues.redhat.com/browse/COST-6635) Fix node_count for project monthly costs
```

## Summary by Sourcery

Bug Fixes:
- Remove node from GROUP BY in monthly_project_tag_based.sql to aggregate node_count correctly at the namespace level

## Summary by Sourcery

Bug Fixes:
- Remove node column from GROUP BY in monthly_project_tag_based.sql to correctly aggregate node_count at the namespace level