### PR TITLE
Cost 6606

### DIFF
--- a/koku/koku/celery.py
+++ b/koku/koku/celery.py
@@ -15,6 +15,7 @@ from celery.signals import worker_process_init
 from celery.signals import worker_process_shutdown
 from django.conf import settings
 from kombu.exceptions import OperationalError
+from UnleashClient.loader import load_features
 
 from .database import FKViolation
 from koku import sentry  # noqa: F401
@@ -109,7 +110,7 @@ app.config_from_object("django.conf:settings", namespace="CELERY")
 print("celery autodiscover tasks")
 
 # Specify the number of celery tasks to run before recycling the celery worker.
-MAX_CELERY_TASKS_PER_WORKER = ENVIRONMENT.int("MAX_CELERY_TASKS_PER_WORKER", default=10)
+MAX_CELERY_TASKS_PER_WORKER = ENVIRONMENT.int("MAX_CELERY_TASKS_PER_WORKER", default=1)
 app.conf.worker_max_tasks_per_child = MAX_CELERY_TASKS_PER_WORKER
 
 # Timeout threshold for a worker process to startup
@@ -274,6 +275,7 @@ def init_worker(**kwargs):
 
     LOG.debug("Initializing UNLEASH_CLIENT for celery worker.")
     UNLEASH_CLIENT.initialize_client()
+    load_features(UNLEASH_CLIENT.cache, UNLEASH_CLIENT.engine)
 
 
 @worker_process_shutdown.connect

--- a/koku/koku/celery.py
+++ b/koku/koku/celery.py
@@ -110,7 +110,7 @@ app.config_from_object("django.conf:settings", namespace="CELERY")
 print("celery autodiscover tasks")
 
 # Specify the number of celery tasks to run before recycling the celery worker.
-MAX_CELERY_TASKS_PER_WORKER = ENVIRONMENT.int("MAX_CELERY_TASKS_PER_WORKER", default=1)
+MAX_CELERY_TASKS_PER_WORKER = ENVIRONMENT.int("MAX_CELERY_TASKS_PER_WORKER", default=10)
 app.conf.worker_max_tasks_per_child = MAX_CELERY_TASKS_PER_WORKER
 
 # Timeout threshold for a worker process to startup

--- a/koku/koku/feature_flags.py
+++ b/koku/koku/feature_flags.py
@@ -7,6 +7,7 @@ import logging
 
 from django.conf import settings
 from UnleashClient import UnleashClient
+from UnleashClient.periodic_tasks import aggregate_and_send_metrics
 
 from .env import ENVIRONMENT
 
@@ -35,6 +36,19 @@ class KokuUnleashClient(UnleashClient):
         self.fl_job.remove()
         if self.metric_job:
             self.metric_job.remove()
+
+            # Flush metrics before shutting down.
+            aggregate_and_send_metrics(
+                url=self.unleash_url,
+                app_name=self.unleash_app_name,
+                connection_id=self.connection_id,
+                instance_id=self.unleash_instance_id,
+                headers=self.metrics_headers,
+                custom_options=self.unleash_custom_options,
+                request_timeout=self.unleash_request_timeout,
+                engine=self.engine,
+            )
+
         self.unleash_scheduler.shutdown()
 
 


### PR DESCRIPTION
## Jira Ticket

[COST-6606](https://issues.redhat.com/browse/COST-6606)

## Description

When new celery workers are created, we need to initialize the Unleash client. In the sdk docs ([here](https://github.com/Unleash/unleash-python-sdk?tab=readme-ov-file#initialization)), it says "Note that until the SDK has synchronized with the API, all features will evaluate to `false`". This _may_ be the reason we keep seeing this alert in stage: the client is initialized but not synced. Even tho the client should continue to use the same cache between celery workers, it's possible something needs to trigger a cache sync. This PR attempts to do that immediately after the client is initialized.

## Testing

1. ???????? run things in stage???

## Release Notes
- [ ] proposed release note

```markdown
* [COST-####](https://issues.redhat.com/browse/COST-####) Fix some things
```
