### PR TITLE
[COST-6621] add env variable to enable pod reboot

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -22,8 +22,8 @@ objects:
         env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_KOKU_READS}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_KOKU_READS}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -198,8 +198,8 @@ objects:
         env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_KOKU_WRITES}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_KOKU_WRITES}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -365,8 +365,8 @@ objects:
         env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_NGINX}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_NGINX}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -428,8 +428,8 @@ objects:
         env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_LISTENER}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_LISTENER}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -563,8 +563,8 @@ objects:
         env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_MASU}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_MASU}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -750,8 +750,8 @@ objects:
         env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_SCHEDULER}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_SCHEDULER}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -899,8 +899,8 @@ objects:
         env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_SOURCES_CLIENT}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_SOURCES_CLIENT}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -1055,8 +1055,8 @@ objects:
         env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_SOURCES_LISTENER}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_SOURCES_LISTENER}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -1208,8 +1208,8 @@ objects:
         env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_WORKER_CELERY}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_WORKER_CELERY}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -1379,8 +1379,8 @@ objects:
         env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_WORKER_COST_MODEL}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_WORKER_COST_MODEL}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -1556,8 +1556,8 @@ objects:
         env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_WORKER_COST_MODEL_XL}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_WORKER_COST_MODEL_XL}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -1733,8 +1733,8 @@ objects:
         env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_WORKER_COST_MODEL_PENALTY}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_WORKER_COST_MODEL_PENALTY}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -1922,8 +1922,8 @@ objects:
         env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_WORKER_DOWNLOAD}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_WORKER_DOWNLOAD}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -2102,8 +2102,8 @@ objects:
         env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_WORKER_DOWNLOAD_XL}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_WORKER_DOWNLOAD_XL}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -2283,8 +2283,8 @@ objects:
         env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_WORKER_DOWNLOAD_PENALTY}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_WORKER_DOWNLOAD_PENALTY}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -2464,8 +2464,8 @@ objects:
         env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_WORKER_OCP}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_WORKER_OCP}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -2643,8 +2643,8 @@ objects:
         env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_WORKER_OCP_XL}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_WORKER_OCP_XL}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -2822,8 +2822,8 @@ objects:
         env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_WORKER_OCP_PENALTY}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_WORKER_OCP_PENALTY}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -3001,8 +3001,8 @@ objects:
         env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_WORKER_PRIORITY}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_WORKER_PRIORITY}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -3186,8 +3186,8 @@ objects:
         env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_WORKER_PRIORITY_XL}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_WORKER_PRIORITY_XL}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -3371,8 +3371,8 @@ objects:
         env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_WORKER_PRIORITY_PENALTY}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_WORKER_PRIORITY_PENALTY}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -3556,8 +3556,8 @@ objects:
         env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_WORKER_REFRESH}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_WORKER_REFRESH}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -3733,8 +3733,8 @@ objects:
         env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_WORKER_REFRESH_XL}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_WORKER_REFRESH_XL}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -3910,8 +3910,8 @@ objects:
         env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_WORKER_REFRESH_PENALTY}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_WORKER_REFRESH_PENALTY}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -4087,8 +4087,8 @@ objects:
         env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_WORKER_SUMMARY}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_WORKER_SUMMARY}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -4268,8 +4268,8 @@ objects:
         env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_WORKER_SUMMARY_XL}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_WORKER_SUMMARY_XL}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -4449,8 +4449,8 @@ objects:
         env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_WORKER_SUMMARY_PENALTY}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_WORKER_SUMMARY_PENALTY}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -4630,8 +4630,8 @@ objects:
         env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_WORKER_HCS}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_WORKER_HCS}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -4805,8 +4805,8 @@ objects:
         env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_WORKER_SUBS_EXTRACTION}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_WORKER_SUBS_EXTRACTION}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -4968,8 +4968,8 @@ objects:
         env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_WORKER_SUBS_TRANSMISSION}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_WORKER_SUBS_TRANSMISSION}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -5329,7 +5329,7 @@ parameters:
   required: true
   value: quay.io/redhat-services-prod/cost-mgmt-dev-tenant/koku
 - description: change this value to restart all pods
-  name: RESTART_HASH_ALL
+  name: REDEPLOY_HASH_ALL
   value: "000000"
 - description: DEVELOPMENT ONLY - used to prevent clashing Glue databases during ephemeral
     testing
@@ -5661,7 +5661,7 @@ parameters:
   name: ENABLE_SUBS_PROVIDER_TYPES
   value: AWS
 - description: change this value to restart koku-api-reads
-  name: RESTART_HASH_KOKU_READS
+  name: REDEPLOY_HASH_KOKU_READS
   value: "000000"
 - displayName: Minimum replicas
   name: KOKU_READS_REPLICAS
@@ -5720,7 +5720,7 @@ parameters:
   required: true
   value: INFO
 - description: change this value to restart koku-writes
-  name: RESTART_HASH_KOKU_WRITES
+  name: REDEPLOY_HASH_KOKU_WRITES
   value: "000000"
 - displayName: Minimum replicas
   name: NGINX_REPLICAS
@@ -5755,7 +5755,7 @@ parameters:
   required: true
   value: registry.access.redhat.com/ubi9/nginx-124
 - description: change this value to restart nginx
-  name: RESTART_HASH_NGINX
+  name: REDEPLOY_HASH_NGINX
   value: "000000"
 - displayName: Minimum replicas
   name: LISTENER_REPLICAS
@@ -5782,7 +5782,7 @@ parameters:
   required: true
   value: INFO
 - description: change this value to restart listener
-  name: RESTART_HASH_LISTENER
+  name: REDEPLOY_HASH_LISTENER
   value: "000000"
 - displayName: Minimum replicas
   name: MASU_REPLICAS
@@ -5809,7 +5809,7 @@ parameters:
   required: true
   value: INFO
 - description: change this value to restart masu
-  name: RESTART_HASH_MASU
+  name: REDEPLOY_HASH_MASU
   value: "000000"
 - displayName: Minimum replicas
   name: SCHEDULER_REPLICAS
@@ -5842,7 +5842,7 @@ parameters:
   name: SOURCE_STATUS_SCHEDULE
   value: 0 3 * * *
 - description: change this value to restart scheduler
-  name: RESTART_HASH_SCHEDULER
+  name: REDEPLOY_HASH_SCHEDULER
   value: "000000"
 - displayName: Minimum replicas
   name: SOURCES_CLIENT_REPLICAS
@@ -5869,7 +5869,7 @@ parameters:
   required: true
   value: INFO
 - description: change this value to restart sources-client
-  name: RESTART_HASH_SOURCES_CLIENT
+  name: REDEPLOY_HASH_SOURCES_CLIENT
   value: "000000"
 - displayName: Minimum replicas
   name: SOURCES_LISTENER_REPLICAS
@@ -5896,7 +5896,7 @@ parameters:
   required: true
   value: INFO
 - description: change this value to restart sources-listener
-  name: RESTART_HASH_SOURCES_LISTENER
+  name: REDEPLOY_HASH_SOURCES_LISTENER
   value: "000000"
 - displayName: Minimum replicas
   name: WORKER_CELERY_REPLICAS
@@ -5923,7 +5923,7 @@ parameters:
   required: true
   value: celery
 - description: change this value to restart worker-celery
-  name: RESTART_HASH_WORKER_CELERY
+  name: REDEPLOY_HASH_WORKER_CELERY
   value: "000000"
 - displayName: Minimum replicas
   name: WORKER_COST_MODEL_REPLICAS
@@ -5950,7 +5950,7 @@ parameters:
   required: true
   value: cost_model
 - description: change this value to restart worker-cost-model
-  name: RESTART_HASH_WORKER_COST_MODEL
+  name: REDEPLOY_HASH_WORKER_COST_MODEL
   value: "000000"
 - displayName: Minimum replicas
   name: WORKER_COST_MODEL_XL_REPLICAS
@@ -5977,7 +5977,7 @@ parameters:
   required: true
   value: cost_model_xl
 - description: change this value to restart worker-cost-model-xl
-  name: RESTART_HASH_WORKER_COST_MODEL_XL
+  name: REDEPLOY_HASH_WORKER_COST_MODEL_XL
   value: "000000"
 - displayName: Minimum replicas
   name: WORKER_COST_MODEL_PENALTY_REPLICAS
@@ -6004,7 +6004,7 @@ parameters:
   required: true
   value: cost_model_penalty
 - description: change this value to restart worker-cost-model-penalty
-  name: RESTART_HASH_WORKER_COST_MODEL_PENALTY
+  name: REDEPLOY_HASH_WORKER_COST_MODEL_PENALTY
   value: "000000"
 - displayName: Minimum replicas
   name: WORKER_DOWNLOAD_MIN_REPLICAS
@@ -6047,7 +6047,7 @@ parameters:
   required: true
   value: download
 - description: change this value to restart worker-download
-  name: RESTART_HASH_WORKER_DOWNLOAD
+  name: REDEPLOY_HASH_WORKER_DOWNLOAD
   value: "000000"
 - displayName: Minimum replicas
   name: WORKER_DOWNLOAD_XL_REPLICAS
@@ -6074,7 +6074,7 @@ parameters:
   required: true
   value: download_xl
 - description: change this value to restart worker-download-xl
-  name: RESTART_HASH_WORKER_DOWNLOAD_XL
+  name: REDEPLOY_HASH_WORKER_DOWNLOAD_XL
   value: "000000"
 - displayName: Minimum replicas
   name: WORKER_DOWNLOAD_PENALTY_REPLICAS
@@ -6101,7 +6101,7 @@ parameters:
   required: true
   value: download_penalty
 - description: change this value to restart worker-download-penalty
-  name: RESTART_HASH_WORKER_DOWNLOAD_PENALTY
+  name: REDEPLOY_HASH_WORKER_DOWNLOAD_PENALTY
   value: "000000"
 - displayName: Minimum replicas
   name: WORKER_OCP_REPLICAS
@@ -6128,7 +6128,7 @@ parameters:
   required: true
   value: ocp
 - description: change this value to restart worker-ocp
-  name: RESTART_HASH_WORKER_OCP
+  name: REDEPLOY_HASH_WORKER_OCP
   value: "000000"
 - displayName: Minimum replicas
   name: WORKER_OCP_XL_REPLICAS
@@ -6155,7 +6155,7 @@ parameters:
   required: true
   value: ocp_xl
 - description: change this value to restart worker-ocp-xl
-  name: RESTART_HASH_WORKER_OCP_XL
+  name: REDEPLOY_HASH_WORKER_OCP_XL
   value: "000000"
 - displayName: Minimum replicas
   name: WORKER_OCP_PENALTY_REPLICAS
@@ -6182,7 +6182,7 @@ parameters:
   required: true
   value: ocp_penalty
 - description: change this value to restart worker-ocp-penalty
-  name: RESTART_HASH_WORKER_OCP_PENALTY
+  name: REDEPLOY_HASH_WORKER_OCP_PENALTY
   value: "000000"
 - displayName: Minimum replicas
   name: WORKER_PRIORITY_REPLICAS
@@ -6209,7 +6209,7 @@ parameters:
   required: true
   value: priority
 - description: change this value to restart worker-priority
-  name: RESTART_HASH_WORKER_PRIORITY
+  name: REDEPLOY_HASH_WORKER_PRIORITY
   value: "000000"
 - displayName: Minimum replicas
   name: WORKER_PRIORITY_XL_REPLICAS
@@ -6236,7 +6236,7 @@ parameters:
   required: true
   value: priority_xl
 - description: change this value to restart worker-priority-xl
-  name: RESTART_HASH_WORKER_PRIORITY_XL
+  name: REDEPLOY_HASH_WORKER_PRIORITY_XL
   value: "000000"
 - displayName: Minimum replicas
   name: WORKER_PRIORITY_PENALTY_REPLICAS
@@ -6263,7 +6263,7 @@ parameters:
   required: true
   value: priority_penalty
 - description: change this value to restart worker-priority-penalty
-  name: RESTART_HASH_WORKER_PRIORITY_PENALTY
+  name: REDEPLOY_HASH_WORKER_PRIORITY_PENALTY
   value: "000000"
 - displayName: Minimum replicas
   name: WORKER_REFRESH_REPLICAS
@@ -6290,7 +6290,7 @@ parameters:
   required: true
   value: refresh
 - description: change this value to restart worker-refresh
-  name: RESTART_HASH_WORKER_REFRESH
+  name: REDEPLOY_HASH_WORKER_REFRESH
   value: "000000"
 - displayName: Minimum replicas
   name: WORKER_REFRESH_XL_REPLICAS
@@ -6317,7 +6317,7 @@ parameters:
   required: true
   value: refresh_xl
 - description: change this value to restart worker-refresh-xl
-  name: RESTART_HASH_WORKER_REFRESH_XL
+  name: REDEPLOY_HASH_WORKER_REFRESH_XL
   value: "000000"
 - displayName: Minimum replicas
   name: WORKER_REFRESH_PENALTY_REPLICAS
@@ -6344,7 +6344,7 @@ parameters:
   required: true
   value: refresh_penalty
 - description: change this value to restart worker-refresh-penalty
-  name: RESTART_HASH_WORKER_REFRESH_PENALTY
+  name: REDEPLOY_HASH_WORKER_REFRESH_PENALTY
   value: "000000"
 - displayName: Minimum replicas
   name: WORKER_SUMMARY_REPLICAS
@@ -6371,7 +6371,7 @@ parameters:
   required: true
   value: summary
 - description: change this value to restart worker-summary
-  name: RESTART_HASH_WORKER_SUMMARY
+  name: REDEPLOY_HASH_WORKER_SUMMARY
   value: "000000"
 - displayName: Minimum replicas
   name: WORKER_SUMMARY_XL_REPLICAS
@@ -6398,7 +6398,7 @@ parameters:
   required: true
   value: summary_xl
 - description: change this value to restart worker-summary-xl
-  name: RESTART_HASH_WORKER_SUMMARY_XL
+  name: REDEPLOY_HASH_WORKER_SUMMARY_XL
   value: "000000"
 - displayName: Minimum replicas
   name: WORKER_SUMMARY_PENALTY_REPLICAS
@@ -6425,7 +6425,7 @@ parameters:
   required: true
   value: summary_penalty
 - description: change this value to restart worker-summary-penalty
-  name: RESTART_HASH_WORKER_SUMMARY_PENALTY
+  name: REDEPLOY_HASH_WORKER_SUMMARY_PENALTY
   value: "000000"
 - displayName: Minimum replicas
   name: WORKER_HCS_REPLICAS
@@ -6455,7 +6455,7 @@ parameters:
   name: ENABLE_HCS_DEBUG
   value: "False"
 - description: change this value to restart worker-hcs
-  name: RESTART_HASH_WORKER_HCS
+  name: REDEPLOY_HASH_WORKER_HCS
   value: "000000"
 - displayName: Minimum replicas
   name: WORKER_SUBS_EXTRACTION_REPLICAS
@@ -6482,7 +6482,7 @@ parameters:
   required: true
   value: subs_extraction
 - description: change this value to restart worker-subs-extraction
-  name: RESTART_HASH_WORKER_SUBS_EXTRACTION
+  name: REDEPLOY_HASH_WORKER_SUBS_EXTRACTION
   value: "000000"
 - displayName: Minimum replicas
   name: WORKER_SUBS_TRANSMISSION_REPLICAS
@@ -6509,5 +6509,5 @@ parameters:
   required: true
   value: subs_transmission
 - description: change this value to restart worker-subs-transmission
-  name: RESTART_HASH_WORKER_SUBS_TRANSMISSION
+  name: REDEPLOY_HASH_WORKER_SUBS_TRANSMISSION
   value: "000000"

--- a/deploy/kustomize/base/base.yaml
+++ b/deploy/kustomize/base/base.yaml
@@ -270,7 +270,7 @@ parameters:
   required: true
   value: quay.io/redhat-services-prod/cost-mgmt-dev-tenant/koku
 - description: change this value to restart all pods
-  name: RESTART_HASH_ALL
+  name: REDEPLOY_HASH_ALL
   value: "000000"
 - name: SCHEMA_SUFFIX
   description: DEVELOPMENT ONLY - used to prevent clashing Glue databases during ephemeral testing

--- a/deploy/kustomize/patches/koku-reads.yaml
+++ b/deploy/kustomize/patches/koku-reads.yaml
@@ -13,8 +13,8 @@
       env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_KOKU_READS}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_KOKU_READS}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -181,7 +181,7 @@
   path: /parameters/-
   value:
     description: change this value to restart koku-api-reads
-    name: RESTART_HASH_KOKU_READS
+    name: REDEPLOY_HASH_KOKU_READS
     value: "000000"
 - op: add
   path: /parameters/-

--- a/deploy/kustomize/patches/koku-writes.yaml
+++ b/deploy/kustomize/patches/koku-writes.yaml
@@ -20,8 +20,8 @@
       env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_KOKU_WRITES}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_KOKU_WRITES}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -210,5 +210,5 @@
   path: /parameters/-
   value:
     description: change this value to restart koku-writes
-    name: RESTART_HASH_KOKU_WRITES
+    name: REDEPLOY_HASH_KOKU_WRITES
     value: "000000"

--- a/deploy/kustomize/patches/listener.yaml
+++ b/deploy/kustomize/patches/listener.yaml
@@ -17,8 +17,8 @@
       env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_LISTENER}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_LISTENER}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -183,5 +183,5 @@
   path: /parameters/-
   value:
     description: change this value to restart listener
-    name: RESTART_HASH_LISTENER
+    name: REDEPLOY_HASH_LISTENER
     value: "000000"

--- a/deploy/kustomize/patches/masu.yaml
+++ b/deploy/kustomize/patches/masu.yaml
@@ -19,8 +19,8 @@
       env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_MASU}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_MASU}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -224,5 +224,5 @@
   path: /parameters/-
   value:
     description: change this value to restart masu
-    name: RESTART_HASH_MASU
+    name: REDEPLOY_HASH_MASU
     value: "000000"

--- a/deploy/kustomize/patches/nginx.yaml
+++ b/deploy/kustomize/patches/nginx.yaml
@@ -18,8 +18,8 @@
       env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_NGINX}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_NGINX}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -126,5 +126,5 @@
   path: /parameters/-
   value:
     description: change this value to restart nginx
-    name: RESTART_HASH_NGINX
+    name: REDEPLOY_HASH_NGINX
     value: "000000"

--- a/deploy/kustomize/patches/scheduler.yaml
+++ b/deploy/kustomize/patches/scheduler.yaml
@@ -29,8 +29,8 @@
       env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_SCHEDULER}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_SCHEDULER}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -213,5 +213,5 @@
   path: /parameters/-
   value:
     description: change this value to restart scheduler
-    name: RESTART_HASH_SCHEDULER
+    name: REDEPLOY_HASH_SCHEDULER
     value: "000000"

--- a/deploy/kustomize/patches/sources-client.yaml
+++ b/deploy/kustomize/patches/sources-client.yaml
@@ -19,8 +19,8 @@
       env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_SOURCES_CLIENT}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_SOURCES_CLIENT}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -197,5 +197,5 @@
   path: /parameters/-
   value:
     description: change this value to restart sources-client
-    name: RESTART_HASH_SOURCES_CLIENT
+    name: REDEPLOY_HASH_SOURCES_CLIENT
     value: "000000"

--- a/deploy/kustomize/patches/sources-listener.yaml
+++ b/deploy/kustomize/patches/sources-listener.yaml
@@ -23,8 +23,8 @@
       env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_SOURCES_LISTENER}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_SOURCES_LISTENER}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -197,5 +197,5 @@
   path: /parameters/-
   value:
     description: change this value to restart sources-listener
-    name: RESTART_HASH_SOURCES_LISTENER
+    name: REDEPLOY_HASH_SOURCES_LISTENER
     value: "000000"

--- a/deploy/kustomize/patches/worker-celery.yaml
+++ b/deploy/kustomize/patches/worker-celery.yaml
@@ -25,8 +25,8 @@
       env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_WORKER_CELERY}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_WORKER_CELERY}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -218,5 +218,5 @@
   path: /parameters/-
   value:
     description: change this value to restart worker-celery
-    name: RESTART_HASH_WORKER_CELERY
+    name: REDEPLOY_HASH_WORKER_CELERY
     value: "000000"

--- a/deploy/kustomize/patches/worker-cost-model-penalty.yaml
+++ b/deploy/kustomize/patches/worker-cost-model-penalty.yaml
@@ -25,8 +25,8 @@
       env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_WORKER_COST_MODEL_PENALTY}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_WORKER_COST_MODEL_PENALTY}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -224,5 +224,5 @@
   path: /parameters/-
   value:
     description: change this value to restart worker-cost-model-penalty
-    name: RESTART_HASH_WORKER_COST_MODEL_PENALTY
+    name: REDEPLOY_HASH_WORKER_COST_MODEL_PENALTY
     value: "000000"

--- a/deploy/kustomize/patches/worker-cost-model-xl.yaml
+++ b/deploy/kustomize/patches/worker-cost-model-xl.yaml
@@ -25,8 +25,8 @@
       env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_WORKER_COST_MODEL_XL}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_WORKER_COST_MODEL_XL}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -224,5 +224,5 @@
   path: /parameters/-
   value:
     description: change this value to restart worker-cost-model-xl
-    name: RESTART_HASH_WORKER_COST_MODEL_XL
+    name: REDEPLOY_HASH_WORKER_COST_MODEL_XL
     value: "000000"

--- a/deploy/kustomize/patches/worker-cost-model.yaml
+++ b/deploy/kustomize/patches/worker-cost-model.yaml
@@ -25,8 +25,8 @@
       env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_WORKER_COST_MODEL}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_WORKER_COST_MODEL}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -224,5 +224,5 @@
   path: /parameters/-
   value:
     description: change this value to restart worker-cost-model
-    name: RESTART_HASH_WORKER_COST_MODEL
+    name: REDEPLOY_HASH_WORKER_COST_MODEL
     value: "000000"

--- a/deploy/kustomize/patches/worker-download-penalty.yaml
+++ b/deploy/kustomize/patches/worker-download-penalty.yaml
@@ -25,8 +25,8 @@
       env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_WORKER_DOWNLOAD_PENALTY}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_WORKER_DOWNLOAD_PENALTY}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -228,5 +228,5 @@
   path: /parameters/-
   value:
     description: change this value to restart worker-download-penalty
-    name: RESTART_HASH_WORKER_DOWNLOAD_PENALTY
+    name: REDEPLOY_HASH_WORKER_DOWNLOAD_PENALTY
     value: "000000"

--- a/deploy/kustomize/patches/worker-download-xl.yaml
+++ b/deploy/kustomize/patches/worker-download-xl.yaml
@@ -25,8 +25,8 @@
       env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_WORKER_DOWNLOAD_XL}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_WORKER_DOWNLOAD_XL}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -228,5 +228,5 @@
   path: /parameters/-
   value:
     description: change this value to restart worker-download-xl
-    name: RESTART_HASH_WORKER_DOWNLOAD_XL
+    name: REDEPLOY_HASH_WORKER_DOWNLOAD_XL
     value: "000000"

--- a/deploy/kustomize/patches/worker-download.yaml
+++ b/deploy/kustomize/patches/worker-download.yaml
@@ -24,8 +24,8 @@
       env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_WORKER_DOWNLOAD}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_WORKER_DOWNLOAD}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -269,5 +269,5 @@
   path: /parameters/-
   value:
     description: change this value to restart worker-download
-    name: RESTART_HASH_WORKER_DOWNLOAD
+    name: REDEPLOY_HASH_WORKER_DOWNLOAD
     value: "000000"

--- a/deploy/kustomize/patches/worker-hcs.yaml
+++ b/deploy/kustomize/patches/worker-hcs.yaml
@@ -25,8 +25,8 @@
       env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_WORKER_HCS}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_WORKER_HCS}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -232,5 +232,5 @@
   path: /parameters/-
   value:
     description: change this value to restart worker-hcs
-    name: RESTART_HASH_WORKER_HCS
+    name: REDEPLOY_HASH_WORKER_HCS
     value: "000000"

--- a/deploy/kustomize/patches/worker-ocp-penalty.yaml
+++ b/deploy/kustomize/patches/worker-ocp-penalty.yaml
@@ -25,8 +25,8 @@
       env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_WORKER_OCP_PENALTY}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_WORKER_OCP_PENALTY}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -226,5 +226,5 @@
   path: /parameters/-
   value:
     description: change this value to restart worker-ocp-penalty
-    name: RESTART_HASH_WORKER_OCP_PENALTY
+    name: REDEPLOY_HASH_WORKER_OCP_PENALTY
     value: "000000"

--- a/deploy/kustomize/patches/worker-ocp-xl.yaml
+++ b/deploy/kustomize/patches/worker-ocp-xl.yaml
@@ -25,8 +25,8 @@
       env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_WORKER_OCP_XL}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_WORKER_OCP_XL}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -226,5 +226,5 @@
   path: /parameters/-
   value:
     description: change this value to restart worker-ocp-xl
-    name: RESTART_HASH_WORKER_OCP_XL
+    name: REDEPLOY_HASH_WORKER_OCP_XL
     value: "000000"

--- a/deploy/kustomize/patches/worker-ocp.yaml
+++ b/deploy/kustomize/patches/worker-ocp.yaml
@@ -25,8 +25,8 @@
       env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_WORKER_OCP}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_WORKER_OCP}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -226,5 +226,5 @@
   path: /parameters/-
   value:
     description: change this value to restart worker-ocp
-    name: RESTART_HASH_WORKER_OCP
+    name: REDEPLOY_HASH_WORKER_OCP
     value: "000000"

--- a/deploy/kustomize/patches/worker-priority-penalty.yaml
+++ b/deploy/kustomize/patches/worker-priority-penalty.yaml
@@ -25,8 +25,8 @@
       env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_WORKER_PRIORITY_PENALTY}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_WORKER_PRIORITY_PENALTY}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -232,5 +232,5 @@
   path: /parameters/-
   value:
     description: change this value to restart worker-priority-penalty
-    name: RESTART_HASH_WORKER_PRIORITY_PENALTY
+    name: REDEPLOY_HASH_WORKER_PRIORITY_PENALTY
     value: "000000"

--- a/deploy/kustomize/patches/worker-priority-xl.yaml
+++ b/deploy/kustomize/patches/worker-priority-xl.yaml
@@ -25,8 +25,8 @@
       env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_WORKER_PRIORITY_XL}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_WORKER_PRIORITY_XL}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -232,5 +232,5 @@
   path: /parameters/-
   value:
     description: change this value to restart worker-priority-xl
-    name: RESTART_HASH_WORKER_PRIORITY_XL
+    name: REDEPLOY_HASH_WORKER_PRIORITY_XL
     value: "000000"

--- a/deploy/kustomize/patches/worker-priority.yaml
+++ b/deploy/kustomize/patches/worker-priority.yaml
@@ -25,8 +25,8 @@
       env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_WORKER_PRIORITY}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_WORKER_PRIORITY}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -232,5 +232,5 @@
   path: /parameters/-
   value:
     description: change this value to restart worker-priority
-    name: RESTART_HASH_WORKER_PRIORITY
+    name: REDEPLOY_HASH_WORKER_PRIORITY
     value: "000000"

--- a/deploy/kustomize/patches/worker-refresh-penalty.yaml
+++ b/deploy/kustomize/patches/worker-refresh-penalty.yaml
@@ -25,8 +25,8 @@
       env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_WORKER_REFRESH_PENALTY}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_WORKER_REFRESH_PENALTY}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -224,5 +224,5 @@
   path: /parameters/-
   value:
     description: change this value to restart worker-refresh-penalty
-    name: RESTART_HASH_WORKER_REFRESH_PENALTY
+    name: REDEPLOY_HASH_WORKER_REFRESH_PENALTY
     value: "000000"

--- a/deploy/kustomize/patches/worker-refresh-xl.yaml
+++ b/deploy/kustomize/patches/worker-refresh-xl.yaml
@@ -25,8 +25,8 @@
       env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_WORKER_REFRESH_XL}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_WORKER_REFRESH_XL}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -224,5 +224,5 @@
   path: /parameters/-
   value:
     description: change this value to restart worker-refresh-xl
-    name: RESTART_HASH_WORKER_REFRESH_XL
+    name: REDEPLOY_HASH_WORKER_REFRESH_XL
     value: "000000"

--- a/deploy/kustomize/patches/worker-refresh.yaml
+++ b/deploy/kustomize/patches/worker-refresh.yaml
@@ -25,8 +25,8 @@
       env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_WORKER_REFRESH}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_WORKER_REFRESH}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -224,5 +224,5 @@
   path: /parameters/-
   value:
     description: change this value to restart worker-refresh
-    name: RESTART_HASH_WORKER_REFRESH
+    name: REDEPLOY_HASH_WORKER_REFRESH
     value: "000000"

--- a/deploy/kustomize/patches/worker-subs-extraction.yaml
+++ b/deploy/kustomize/patches/worker-subs-extraction.yaml
@@ -19,8 +19,8 @@
       env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_WORKER_SUBS_EXTRACTION}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_WORKER_SUBS_EXTRACTION}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -212,5 +212,5 @@
   path: /parameters/-
   value:
     description: change this value to restart worker-subs-extraction
-    name: RESTART_HASH_WORKER_SUBS_EXTRACTION
+    name: REDEPLOY_HASH_WORKER_SUBS_EXTRACTION
     value: "000000"

--- a/deploy/kustomize/patches/worker-subs-transmission.yaml
+++ b/deploy/kustomize/patches/worker-subs-transmission.yaml
@@ -19,8 +19,8 @@
       env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_WORKER_SUBS_TRANSMISSION}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_WORKER_SUBS_TRANSMISSION}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -210,5 +210,5 @@
   path: /parameters/-
   value:
     description: change this value to restart worker-subs-transmission
-    name: RESTART_HASH_WORKER_SUBS_TRANSMISSION
+    name: REDEPLOY_HASH_WORKER_SUBS_TRANSMISSION
     value: "000000"

--- a/deploy/kustomize/patches/worker-summary-penalty.yaml
+++ b/deploy/kustomize/patches/worker-summary-penalty.yaml
@@ -25,8 +25,8 @@
       env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_WORKER_SUMMARY_PENALTY}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_WORKER_SUMMARY_PENALTY}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -228,5 +228,5 @@
   path: /parameters/-
   value:
     description: change this value to restart worker-summary-penalty
-    name: RESTART_HASH_WORKER_SUMMARY_PENALTY
+    name: REDEPLOY_HASH_WORKER_SUMMARY_PENALTY
     value: "000000"

--- a/deploy/kustomize/patches/worker-summary-xl.yaml
+++ b/deploy/kustomize/patches/worker-summary-xl.yaml
@@ -25,8 +25,8 @@
       env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_WORKER_SUMMARY_XL}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_WORKER_SUMMARY_XL}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -228,5 +228,5 @@
   path: /parameters/-
   value:
     description: change this value to restart worker-summary-xl
-    name: RESTART_HASH_WORKER_SUMMARY_XL
+    name: REDEPLOY_HASH_WORKER_SUMMARY_XL
     value: "000000"

--- a/deploy/kustomize/patches/worker-summary.yaml
+++ b/deploy/kustomize/patches/worker-summary.yaml
@@ -25,8 +25,8 @@
       env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RESTART_HASH
-          value: ${RESTART_HASH_ALL}_${RESTART_HASH_WORKER_SUMMARY}
+        - name: REDEPLOY_HASH
+          value: ${REDEPLOY_HASH_ALL}_${REDEPLOY_HASH_WORKER_SUMMARY}
         - name: SCHEMA_SUFFIX
           value: ${SCHEMA_SUFFIX}
         - name: TRINO_S3A_OR_S3
@@ -228,5 +228,5 @@
   path: /parameters/-
   value:
     description: change this value to restart worker-summary
-    name: RESTART_HASH_WORKER_SUMMARY
+    name: REDEPLOY_HASH_WORKER_SUMMARY
     value: "000000"


### PR DESCRIPTION
## Jira Ticket

[COST-6621](https://issues.redhat.com/browse/COST-6621)

## Description

This change will add 2 params and an env variable to every deployment. This will enable pod reboots because changing an env variable on a deployment causes a redeployment. The 2 params give us more control over which deployments to redeploy: 
1. `REDEPLOY_HASH_ALL` will cause every deployment to redeploy
2. `REDEPLOY_HASH_{deployment-name}` will cause just that deployment to redeploy

## Testing:
1. smokes. Does it deploy?
<img width="694" height="86" alt="image" src="https://github.com/user-attachments/assets/a44b9774-65f0-4c67-abdd-e30ffd38c865" />


## Release Notes
- [x] proposed release note

```markdown
* [COST-6621] add env variable to enable pod reboot
```

## Summary by Sourcery

Add environment variable and parameters to enable controlled pod redeployment across all deployments

Enhancements:
- Introduce REDEPLOY_HASH_ALL and per-deployment REDEPLOY_HASH_<service> parameters to trigger global or selective pod restarts
- Inject REDEPLOY_HASH env var into every deployment, combining global and service-specific hash values