### PR TITLE
[COST-6582] Remove invoice month filter for UI tables

### DIFF
--- a/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_compute_summary_p.sql
+++ b/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_compute_summary_p.sql
@@ -34,7 +34,6 @@ INSERT INTO postgres.{{schema | sqlsafe}}.reporting_ocpgcp_compute_summary_p (
     FROM hive.{{schema | sqlsafe}}.{{trino_table | sqlsafe}}
     WHERE {{column_name | sqlsafe}} = {{gcp_source_uuid}}
         AND ocp_source = {{ocp_source_uuid}}
-        AND invoice_month = {{invoice_month}}
         AND year = {{year}}
         AND lpad(month, 2, '0') = {{month}} -- Zero pad the month when fewer than 2 characters
         AND day in {{days | inclause}}

--- a/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_cost_summary_by_account_p.sql
+++ b/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_cost_summary_by_account_p.sql
@@ -28,7 +28,6 @@ INSERT INTO postgres.{{schema | sqlsafe}}.reporting_ocpgcp_cost_summary_by_accou
     FROM hive.{{schema | sqlsafe}}.{{trino_table | sqlsafe}}
     WHERE {{column_name | sqlsafe}} = {{gcp_source_uuid}}
         AND ocp_source = {{ocp_source_uuid}}
-        AND invoice_month = {{invoice_month}}
         AND year = {{year}}
         AND lpad(month, 2, '0') = {{month}} -- Zero pad the month when fewer than 2 characters
         AND day in {{days | inclause}}

--- a/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_cost_summary_by_gcp_project_p.sql
+++ b/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_cost_summary_by_gcp_project_p.sql
@@ -30,7 +30,6 @@ INSERT INTO postgres.{{schema | sqlsafe}}.reporting_ocpgcp_cost_summary_by_gcp_p
     FROM hive.{{schema | sqlsafe}}.{{trino_table | sqlsafe}}
     WHERE {{column_name | sqlsafe}} = {{gcp_source_uuid}}
         AND ocp_source = {{ocp_source_uuid}}
-        AND invoice_month = {{invoice_month}}
         AND year = {{year}}
         AND lpad(month, 2, '0') = {{month}} -- Zero pad the month when fewer than 2 characters
         AND day in {{days | inclause}}

--- a/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_cost_summary_by_region_p.sql
+++ b/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_cost_summary_by_region_p.sql
@@ -30,7 +30,6 @@ INSERT INTO postgres.{{schema | sqlsafe}}.reporting_ocpgcp_cost_summary_by_regio
     FROM hive.{{schema | sqlsafe}}.{{trino_table | sqlsafe}}
     WHERE {{column_name | sqlsafe}} = {{gcp_source_uuid}}
         AND ocp_source = {{ocp_source_uuid}}
-        AND invoice_month = {{invoice_month}}
         AND year = {{year}}
         AND lpad(month, 2, '0') = {{month}} -- Zero pad the month when fewer than 2 characters
         AND day in {{days | inclause}}

--- a/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_cost_summary_by_service_p.sql
+++ b/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_cost_summary_by_service_p.sql
@@ -32,7 +32,6 @@ INSERT INTO postgres.{{schema | sqlsafe}}.reporting_ocpgcp_cost_summary_by_servi
     FROM hive.{{schema | sqlsafe}}.{{trino_table | sqlsafe}}
     WHERE {{column_name | sqlsafe}} = {{gcp_source_uuid}}
         AND ocp_source = {{ocp_source_uuid}}
-        AND invoice_month = {{invoice_month}}
         AND year = {{year}}
         AND lpad(month, 2, '0') = {{month}} -- Zero pad the month when fewer than 2 characters
         AND day in {{days | inclause}}

--- a/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_cost_summary_p.sql
+++ b/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_cost_summary_p.sql
@@ -28,7 +28,6 @@ INSERT INTO postgres.{{schema | sqlsafe}}.reporting_ocpgcp_cost_summary_p (
     FROM hive.{{schema | sqlsafe}}.{{trino_table | sqlsafe}}
     WHERE {{column_name | sqlsafe}} = {{gcp_source_uuid}}
         AND ocp_source = {{ocp_source_uuid}}
-        AND invoice_month = {{invoice_month}}
         AND year = {{year}}
         AND lpad(month, 2, '0') = {{month}} -- Zero pad the month when fewer than 2 characters
         AND day in {{days | inclause}}

--- a/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_database_summary_p.sql
+++ b/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_database_summary_p.sql
@@ -37,7 +37,6 @@ INSERT INTO postgres.{{schema | sqlsafe}}.reporting_ocpgcp_database_summary_p (
     -- Get data for this month or last month
     WHERE {{column_name | sqlsafe}} = {{gcp_source_uuid}}
         AND ocp_source = {{ocp_source_uuid}}
-        AND invoice_month = {{invoice_month}}
         AND year = {{year}}
         AND lpad(month, 2, '0') = {{month}} -- Zero pad the month when fewer than 2 characters
         AND day in {{days | inclause}}

--- a/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_network_summary_p.sql
+++ b/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_network_summary_p.sql
@@ -37,7 +37,6 @@ INSERT INTO postgres.{{schema | sqlsafe}}.reporting_ocpgcp_network_summary_p (
     -- Get data for this month or last month
     WHERE {{column_name | sqlsafe}} = {{gcp_source_uuid}}
         AND ocp_source = {{ocp_source_uuid}}
-        AND invoice_month = {{invoice_month}}
         AND year = {{year}}
         AND lpad(month, 2, '0') = {{month}} -- Zero pad the month when fewer than 2 characters
         AND day in {{days | inclause}}

--- a/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_storage_summary_p.sql
+++ b/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_storage_summary_p.sql
@@ -37,7 +37,6 @@ INSERT INTO postgres.{{schema | sqlsafe}}.reporting_ocpgcp_storage_summary_p (
     -- Get data for this month or last month
     WHERE {{column_name | sqlsafe}} = {{gcp_source_uuid}}
         AND ocp_source = {{ocp_source_uuid}}
-        AND invoice_month = {{invoice_month}}
         AND year = {{year}}
         AND lpad(month, 2, '0') = {{month}} -- Zero pad the month when fewer than 2 characters
         AND day in {{days | inclause}}


### PR DESCRIPTION
## Jira Ticket

[COST-6582](https://issues.redhat.com/browse/COST-6582)

## Description

This change will remove the invoice month filter from the OCP on GCP UI tables population. 

## Testing

1. Checkout Branch
2. Checkout this iqe branch: [esebesto/ocp_gcp_month_crossover](https://gitlab.cee.redhat.com/insights-qe/iqe-cost-management-plugin/-/merge_requests/2393/diffs)
3. Make sure your iqe venv is on the latest version of nise
4. Inside of the IQE cost management puling find the `gcp_static_report_basic_daily_template.yml` file. 
5. Update all the generators within this file to have: `cross_over_data: True`
6. Now the first day of the month should be exactly double the cost of the second day of the month for these endpoints:
```
http://localhost:8000/api/cost-management/v1/reports/openshift/infrastructures/gcp/costs/?start_date=2025-07-01&end_date=2025-07-02&group_by[project]=*&limit=1238
```
```
http://localhost:8000/api/cost-management/v1/reports/openshift/infrastructures/gcp/costs/?start_date=2025-07-01&end_date=2025-07-02&limit=4580
```
```
http://localhost:8000/api/cost-management/v1/reports/openshift/infrastructures/gcp/instance-types/?start_date=2025-07-01&end_date=2025-07-02&limit=9832
```
Note: This is not the case when data is processed on main

## Release Notes
- [ ] proposed release note

```markdown
* [COST-####](https://issues.redhat.com/browse/COST-####) Fix some things
```

## Summary by Sourcery

Remove the invoice month filter from the OCP on GCP UI summary table population logic and SQL templates to allow data loading without that constraint.

Enhancements:
- Simplify populate_ocp_on_gcp_ui_summary_tables_trino by dropping invoice_month_list and looping directly over tables
- Remove invoice_month conditions from all GCP/OpenShift Trino SQL summary queries