### PR TITLE
[COST-6532] more managed table GCP cleanup

### DIFF
--- a/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_compute_summary_p.sql
+++ b/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_compute_summary_p.sql
@@ -31,8 +31,8 @@ INSERT INTO postgres.{{schema | sqlsafe}}.reporting_ocpgcp_compute_summary_p (
         cast({{gcp_source_uuid}} as uuid) as source_uuid,
         sum(credit_amount) as credit_amount,
         invoice_month
-    FROM hive.{{schema | sqlsafe}}.{{trino_table | sqlsafe}}
-    WHERE {{column_name | sqlsafe}} = {{gcp_source_uuid}}
+    FROM hive.{{schema | sqlsafe}}.managed_reporting_ocpgcpcostlineitem_project_daily_summary
+    WHERE source = {{gcp_source_uuid}}
         AND ocp_source = {{ocp_source_uuid}}
         AND year = {{year}}
         AND lpad(month, 2, '0') = {{month}} -- Zero pad the month when fewer than 2 characters

--- a/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_cost_summary_by_account_p.sql
+++ b/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_cost_summary_by_account_p.sql
@@ -25,8 +25,8 @@ INSERT INTO postgres.{{schema | sqlsafe}}.reporting_ocpgcp_cost_summary_by_accou
         cast({{gcp_source_uuid}} as uuid) as source_uuid,
         sum(credit_amount) as credit_amount,
         invoice_month
-    FROM hive.{{schema | sqlsafe}}.{{trino_table | sqlsafe}}
-    WHERE {{column_name | sqlsafe}} = {{gcp_source_uuid}}
+    FROM hive.{{schema | sqlsafe}}.managed_reporting_ocpgcpcostlineitem_project_daily_summary
+    WHERE source = {{gcp_source_uuid}}
         AND ocp_source = {{ocp_source_uuid}}
         AND year = {{year}}
         AND lpad(month, 2, '0') = {{month}} -- Zero pad the month when fewer than 2 characters

--- a/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_cost_summary_by_gcp_project_p.sql
+++ b/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_cost_summary_by_gcp_project_p.sql
@@ -27,8 +27,8 @@ INSERT INTO postgres.{{schema | sqlsafe}}.reporting_ocpgcp_cost_summary_by_gcp_p
         cast({{gcp_source_uuid}} as uuid) as source_uuid,
         sum(credit_amount) as credit_amount,
         invoice_month
-    FROM hive.{{schema | sqlsafe}}.{{trino_table | sqlsafe}}
-    WHERE {{column_name | sqlsafe}} = {{gcp_source_uuid}}
+    FROM hive.{{schema | sqlsafe}}.managed_reporting_ocpgcpcostlineitem_project_daily_summary
+    WHERE source = {{gcp_source_uuid}}
         AND ocp_source = {{ocp_source_uuid}}
         AND year = {{year}}
         AND lpad(month, 2, '0') = {{month}} -- Zero pad the month when fewer than 2 characters

--- a/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_cost_summary_by_region_p.sql
+++ b/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_cost_summary_by_region_p.sql
@@ -27,8 +27,8 @@ INSERT INTO postgres.{{schema | sqlsafe}}.reporting_ocpgcp_cost_summary_by_regio
         cast({{gcp_source_uuid}} as uuid) as source_uuid,
         sum(credit_amount) as credit_amount,
         invoice_month
-    FROM hive.{{schema | sqlsafe}}.{{trino_table | sqlsafe}}
-    WHERE {{column_name | sqlsafe}} = {{gcp_source_uuid}}
+    FROM hive.{{schema | sqlsafe}}.managed_reporting_ocpgcpcostlineitem_project_daily_summary
+    WHERE source = {{gcp_source_uuid}}
         AND ocp_source = {{ocp_source_uuid}}
         AND year = {{year}}
         AND lpad(month, 2, '0') = {{month}} -- Zero pad the month when fewer than 2 characters

--- a/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_cost_summary_by_service_p.sql
+++ b/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_cost_summary_by_service_p.sql
@@ -29,8 +29,8 @@ INSERT INTO postgres.{{schema | sqlsafe}}.reporting_ocpgcp_cost_summary_by_servi
         cast({{gcp_source_uuid}} as uuid) as source_uuid,
         sum(credit_amount) as credit_amount,
         invoice_month
-    FROM hive.{{schema | sqlsafe}}.{{trino_table | sqlsafe}}
-    WHERE {{column_name | sqlsafe}} = {{gcp_source_uuid}}
+    FROM hive.{{schema | sqlsafe}}.managed_reporting_ocpgcpcostlineitem_project_daily_summary
+    WHERE source = {{gcp_source_uuid}}
         AND ocp_source = {{ocp_source_uuid}}
         AND year = {{year}}
         AND lpad(month, 2, '0') = {{month}} -- Zero pad the month when fewer than 2 characters

--- a/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_cost_summary_p.sql
+++ b/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_cost_summary_p.sql
@@ -25,8 +25,8 @@ INSERT INTO postgres.{{schema | sqlsafe}}.reporting_ocpgcp_cost_summary_p (
         sum(credit_amount) as credit_amount,
         invoice_month,
         max(cost_category_id)
-    FROM hive.{{schema | sqlsafe}}.{{trino_table | sqlsafe}}
-    WHERE {{column_name | sqlsafe}} = {{gcp_source_uuid}}
+    FROM hive.{{schema | sqlsafe}}.managed_reporting_ocpgcpcostlineitem_project_daily_summary
+    WHERE source = {{gcp_source_uuid}}
         AND ocp_source = {{ocp_source_uuid}}
         AND year = {{year}}
         AND lpad(month, 2, '0') = {{month}} -- Zero pad the month when fewer than 2 characters

--- a/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_database_summary_p.sql
+++ b/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_database_summary_p.sql
@@ -33,9 +33,8 @@ INSERT INTO postgres.{{schema | sqlsafe}}.reporting_ocpgcp_database_summary_p (
         cast({{gcp_source_uuid}} as uuid) as gcp_source,
         sum(credit_amount) as credit_amount,
         invoice_month
-    FROM hive.{{schema | sqlsafe}}.{{trino_table | sqlsafe}}
-    -- Get data for this month or last month
-    WHERE {{column_name | sqlsafe}} = {{gcp_source_uuid}}
+    FROM hive.{{schema | sqlsafe}}.managed_reporting_ocpgcpcostlineitem_project_daily_summary
+    WHERE source = {{gcp_source_uuid}}
         AND ocp_source = {{ocp_source_uuid}}
         AND year = {{year}}
         AND lpad(month, 2, '0') = {{month}} -- Zero pad the month when fewer than 2 characters

--- a/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_network_summary_p.sql
+++ b/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_network_summary_p.sql
@@ -33,9 +33,8 @@ INSERT INTO postgres.{{schema | sqlsafe}}.reporting_ocpgcp_network_summary_p (
         cast({{gcp_source_uuid}} as uuid) as source_uuid,
         sum(credit_amount) as credit_amount,
         invoice_month
-    FROM hive.{{schema | sqlsafe}}.{{trino_table | sqlsafe}}
-    -- Get data for this month or last month
-    WHERE {{column_name | sqlsafe}} = {{gcp_source_uuid}}
+    FROM hive.{{schema | sqlsafe}}.managed_reporting_ocpgcpcostlineitem_project_daily_summary
+    WHERE source = {{gcp_source_uuid}}
         AND ocp_source = {{ocp_source_uuid}}
         AND year = {{year}}
         AND lpad(month, 2, '0') = {{month}} -- Zero pad the month when fewer than 2 characters

--- a/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_storage_summary_p.sql
+++ b/koku/masu/database/trino_sql/gcp/openshift/reporting_ocpgcp_storage_summary_p.sql
@@ -33,9 +33,9 @@ INSERT INTO postgres.{{schema | sqlsafe}}.reporting_ocpgcp_storage_summary_p (
         cast({{gcp_source_uuid}} as uuid) as source_uuid,
         sum(credit_amount) as credit_amount,
         invoice_month
-    FROM hive.{{schema | sqlsafe}}.{{trino_table | sqlsafe}}
+    FROM hive.{{schema | sqlsafe}}.managed_reporting_ocpgcpcostlineitem_project_daily_summary
     -- Get data for this month or last month
-    WHERE {{column_name | sqlsafe}} = {{gcp_source_uuid}}
+    WHERE source = {{gcp_source_uuid}}
         AND ocp_source = {{ocp_source_uuid}}
         AND year = {{year}}
         AND lpad(month, 2, '0') = {{month}} -- Zero pad the month when fewer than 2 characters

--- a/koku/masu/test/database/test_gcp_report_db_accessor.py
+++ b/koku/masu/test/database/test_gcp_report_db_accessor.py
@@ -161,25 +161,7 @@ class GCPReportDBAccessorTest(MasuTestCase):
         mock_trino.assert_called()
 
     @patch("masu.database.gcp_report_db_accessor.GCPReportDBAccessor._execute_trino_raw_sql_query")
-    def test_populate_ocp_on_gcp_ui_summary_tables_trino(
-        self,
-        mock_trino,
-    ):
-        """Test that Trino is used to populate UI summary."""
-        start_date = self.dh.today.date()
-        end_date = start_date + datetime.timedelta(days=1)
-        self.accessor.populate_ocp_on_gcp_ui_summary_tables_trino(
-            start_date, end_date, self.gcp_test_provider_uuid, self.ocp_test_provider_uuid
-        )
-        mock_trino.assert_called()
-
-    @patch("masu.database.gcp_report_db_accessor.GCPReportDBAccessor._execute_trino_raw_sql_query")
-    @patch("masu.database.gcp_report_db_accessor.is_managed_ocp_cloud_summary_enabled", return_value=True)
-    def test_populate_ocp_on_gcp_ui_summary_tables_trino_managed(
-        self,
-        mock_unleash,
-        mock_trino,
-    ):
+    def test_populate_ocp_on_gcp_ui_summary_tables_trino_managed(self, mock_trino):
         """Test that Trino is used to populate UI summary."""
         start_date = self.dh.today.date()
         end_date = start_date + datetime.timedelta(days=1)


### PR DESCRIPTION
## Jira Ticket

[COST-6532](https://issues.redhat.com/browse/COST-6532)

## Description

This change will cleanup some additional OCP-on-GCP managed table code.

## Release Notes
- [x] proposed release note

```markdown
* [COST-6532] more managed table GCP cleanup
```

## Summary by Sourcery

Clean up OCP-on-GCP managed table code by removing conditional branching, updating SQL templates to target the managed reporting table, and adjusting tests accordingly

Enhancements:
- Remove legacy toggle logic in populate_ocp_on_gcp_ui_summary_tables_trino and always use the managed_summary table with the `source` column
- Simplify SQL templates to hardcode the managed_reporting_ocpgcpcostlineitem_project_daily_summary table and source filter

Tests:
- Remove obsolete non-managed summary test and update the managed flow test signature