### PR TITLE
Fix GCP delete logic after kombu update

### DIFF
--- a/koku/masu/util/aws/common.py
+++ b/koku/masu/util/aws/common.py
@@ -824,7 +824,7 @@ def clear_s3_files(
         # GCP openshift data is partitioned by day
         day = start_date.strftime("%d")
         parquet_ocp_on_cloud_path_s3 += f"/day={day}"
-        list_dates = [start_date]
+        list_dates = [start_date.date()]
     for _date in list_dates:
         path = f"{og_path}{_date}"
         s3_prefixes.append(csv_s3_path + path)


### PR DESCRIPTION
## Jira Ticket

[COST-####](https://issues.redhat.com/browse/COST-####)

## Description

This change will fix the deletion logic for GCP filter flow. After the kombu updates we accidentally changed the file path prefixes to include date+time instead of just date. This change adds .date() back in to fix the deletion logic.

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Release Notes
- [ ] proposed release note

```markdown
* [COST-####](https://issues.redhat.com/browse/COST-####) Fix some things
```
