### PR TITLE
[COST-6495] - fix GCP table missing invoice month on insert

### DIFF
--- a/koku/api/report/test/util/model_bakery_loader.py
+++ b/koku/api/report/test/util/model_bakery_loader.py
@@ -330,13 +330,14 @@ class ModelBakeryDataLoader(DataLoader):
             self.create_manifest(provider, bill_date)
             bill = self.create_bill(provider_type, provider, bill_date)
             bills.append(bill)
+            invoice_month = bill_date.strftime("%Y%m")
             with schema_context(self.schema):
                 days = (end_date - start_date).days + 1
                 for i, project in product(range(days), projects):
                     baker.make_recipe(
                         "api.report.test.util.gcp_daily_summary",
                         cost_entry_bill=bill,
-                        invoice_month=bill_date.strftime("%Y%m"),
+                        invoice_month=invoice_month,
                         account_id=account_id,
                         project_id=project[0],
                         project_name=project[1],
@@ -349,7 +350,7 @@ class ModelBakeryDataLoader(DataLoader):
         bill_ids = [bill.id for bill in bills]
         with GCPReportDBAccessor(self.schema) as accessor:
             accessor.populate_tags_summary_table(bill_ids, self.first_start_date, self.last_end_date)
-            accessor.populate_ui_summary_tables(self.first_start_date, self.last_end_date, provider.uuid)
+            accessor.populate_ui_summary_tables(self.first_start_date, self.last_end_date, provider.uuid, invoice_month)
         return bills
 
     def load_openshift_data(self, cluster_id, on_cloud=False):

--- a/koku/masu/database/gcp_report_db_accessor.py
+++ b/koku/masu/database/gcp_report_db_accessor.py
@@ -60,25 +60,25 @@ class GCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
     def line_item_daily_summary_table(self):
         return GCPCostEntryLineItemDailySummary
 
-    def populate_ui_summary_tables(self, start_date, end_date, source_uuid, tables=UI_SUMMARY_TABLES):
+    def populate_ui_summary_tables(
+            self, start_date, end_date, source_uuid, invoice_month, tables=UI_SUMMARY_TABLES
+            ):
         """Populate our UI summary tables (formerly materialized views)."""
-        invoice_month_list = self.date_helper.gcp_find_invoice_months_in_date_range(start_date, end_date)
-        for invoice_month in invoice_month_list:
-            for table_name in tables:
-                sql = pkgutil.get_data("masu.database", f"sql/gcp/{table_name}.sql")
-                sql = sql.decode("utf-8")
-                # Extend the end date past the end of the month & add the invoice month
-                # in order to include cross over data.
-                extended_end_date = end_date + relativedelta(days=2)
-                sql_params = {
-                    "start_date": start_date,
-                    "end_date": extended_end_date,
-                    "schema": self.schema,
-                    "source_uuid": source_uuid,
-                    "invoice_month": invoice_month,
-                }
+        for table_name in tables:
+            sql = pkgutil.get_data("masu.database", f"sql/gcp/{table_name}.sql")
+            sql = sql.decode("utf-8")
+            # Extend the end date past the end of the month & add the invoice month
+            # in order to include cross over data.
+            extended_end_date = end_date + relativedelta(days=2)
+            sql_params = {
+                "start_date": start_date,
+                "end_date": extended_end_date,
+                "schema": self.schema,
+                "source_uuid": source_uuid,
+                "invoice_month": invoice_month,
+            }
 
-                self._prepare_and_execute_raw_sql_query(table_name, sql, sql_params, operation="DELETE/INSERT")
+            self._prepare_and_execute_raw_sql_query(table_name, sql, sql_params, operation="DELETE/INSERT")
 
     def get_cost_entry_bills_query_by_provider(self, provider_uuid):
         """Return all cost entry bills for the specified provider."""

--- a/koku/masu/database/gcp_report_db_accessor.py
+++ b/koku/masu/database/gcp_report_db_accessor.py
@@ -99,7 +99,7 @@ class GCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
         return GCPCostEntryBill.objects.filter(billing_period_start__lte=date)
 
     def populate_line_item_daily_summary_table_trino(
-        self, start_date, end_date, source_uuid, bill_id, markup_value, invoice_month_date
+        self, start_date, end_date, source_uuid, bill_id, markup_value, invoice_month
     ):
         """Populate the daily aggregated summary of line items table.
 
@@ -138,6 +138,7 @@ class GCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
             "schema": self.schema,
             "table": TRINO_LINE_ITEM_TABLE,
             "source_uuid": source_uuid,
+            "invoice_month": invoice_month,
             "markup": markup_value or 0,
             "bill_id": bill_id,
         }

--- a/koku/masu/database/trino_sql/reporting_gcpcostentrylineitem_daily_summary.sql
+++ b/koku/masu/database/trino_sql/reporting_gcpcostentrylineitem_daily_summary.sql
@@ -63,7 +63,7 @@ CROSS JOIN
 WHERE source = '{{source_uuid | sqlsafe}}'
     AND year = '{{year | sqlsafe}}'
     AND month = '{{month | sqlsafe}}'
-    AND invoice_month = '{{year | sqlsafe}}{{month | sqlsafe}}'
+    AND invoice_month = '{{invoice_month | sqlsafe}}'
     AND usage_start_time >= TIMESTAMP '{{start_date | sqlsafe}}'
     AND usage_start_time < date_add('day', 1, TIMESTAMP '{{end_date | sqlsafe}}')
 GROUP BY billing_account_id,

--- a/koku/masu/database/trino_sql/reporting_gcpcostentrylineitem_daily_summary.sql
+++ b/koku/masu/database/trino_sql/reporting_gcpcostentrylineitem_daily_summary.sql
@@ -63,6 +63,7 @@ CROSS JOIN
 WHERE source = '{{source_uuid | sqlsafe}}'
     AND year = '{{year | sqlsafe}}'
     AND month = '{{month | sqlsafe}}'
+    AND invoice_month = '{{year | sqlsafe}}{{month | sqlsafe}}'
     AND usage_start_time >= TIMESTAMP '{{start_date | sqlsafe}}'
     AND usage_start_time < date_add('day', 1, TIMESTAMP '{{end_date | sqlsafe}}')
 GROUP BY billing_account_id,

--- a/koku/masu/processor/gcp/gcp_report_parquet_summary_updater.py
+++ b/koku/masu/processor/gcp/gcp_report_parquet_summary_updater.py
@@ -110,7 +110,7 @@ class GCPReportParquetSummaryUpdater(PartitionHandlerMixin):
                     self._provider.uuid, start, end, filters
                 )
                 accessor.populate_line_item_daily_summary_table_trino(
-                    start, end, self._provider.uuid, current_bill_id, markup_value, invoice_month_date
+                    start, end, self._provider.uuid, current_bill_id, markup_value, invoice_month
                 )
                 accessor.populate_ui_summary_tables(start, end, self._provider.uuid)
             accessor.populate_tags_summary_table(bill_ids, start_date, end_date)

--- a/koku/masu/processor/gcp/gcp_report_parquet_summary_updater.py
+++ b/koku/masu/processor/gcp/gcp_report_parquet_summary_updater.py
@@ -52,7 +52,6 @@ class GCPReportParquetSummaryUpdater(PartitionHandlerMixin):
             (str, str) A start date and end date.
 
         """
-        invoice_month = kwargs.get("invoice_month")
         start_date, end_date = self._get_sql_inputs(start_date, end_date)
 
         with CostModelDBAccessor(self._schema, self._provider.uuid) as cost_model_accessor:
@@ -64,55 +63,50 @@ class GCPReportParquetSummaryUpdater(PartitionHandlerMixin):
 
         with GCPReportDBAccessor(self._schema) as accessor:
             # Need these bills on the session to update dates after processing
+            # GCP has invoice months and these should align with bill ids
+            # The problem is being they are continuious reports (not month bound)
+            # We need to update/insert for both invoice months when dates cross a boundry
             with schema_context(self._schema):
-                if invoice_month:
+                invoice_month_list = DateHelper().gcp_find_invoice_months_in_date_range(start_date, end_date)
+                for invoice_month in invoice_month_list:
                     invoice_month_date = DateHelper().invoice_month_start(invoice_month).date()
                     bills = accessor.bills_for_provider_uuid(self._provider.uuid, invoice_month_date)
                     bill_ids = [str(bill.id) for bill in bills]
                     current_bill_id = bills.first().id if bills else None
-                else:
-                    LOG.info(
-                        log_json(
-                            msg="no invoice month provided, skipping summarization",
-                            schema=self._schema,
-                            provider_uuid=self._provider.uuid,
-                            start_date=start_date,
+
+                    if current_bill_id is None:
+                        LOG.info(
+                            log_json(
+                                msg="no bill was found, skipping summarization",
+                                schema=self._schema,
+                                provider_uuid=self._provider.uuid,
+                                start_date=start_date,
+                            )
                         )
-                    )
-                    return start_date, end_date
+                        continue
 
-            if current_bill_id is None:
-                LOG.info(
-                    log_json(
-                        msg="no bill was found, skipping summarization",
-                        schema=self._schema,
-                        provider_uuid=self._provider.uuid,
-                        start_date=start_date,
-                    )
-                )
-                return start_date, end_date
-
-            for start, end in date_range_pair(start_date, end_date, step=settings.TRINO_DATE_STEP):
-                LOG.info(
-                    log_json(
-                        msg="updating GCP report summary tables from parquet",
-                        schema=self._schema,
-                        provider_uuid=self._provider.uuid,
-                        start_date=start,
-                        end_date=end,
-                        invoice_month=invoice_month,
-                    )
-                )
-                filters = {
-                    "cost_entry_bill_id": current_bill_id
-                }  # Use cost_entry_bill_id to leverage DB index on DELETE
-                accessor.delete_line_item_daily_summary_entries_for_date_range_raw(
-                    self._provider.uuid, start, end, filters
-                )
-                accessor.populate_line_item_daily_summary_table_trino(
-                    start, end, self._provider.uuid, current_bill_id, markup_value, invoice_month
-                )
-                accessor.populate_ui_summary_tables(start, end, self._provider.uuid)
+                    for start, end in date_range_pair(start_date, end_date, step=settings.TRINO_DATE_STEP):
+                        LOG.info(
+                            log_json(
+                                msg="updating GCP report summary tables from parquet",
+                                schema=self._schema,
+                                provider_uuid=self._provider.uuid,
+                                start_date=start,
+                                end_date=end,
+                                invoice_month=invoice_month,
+                                bill_id=current_bill_id
+                            )
+                        )
+                        filters = {
+                            "cost_entry_bill_id": current_bill_id
+                        }  # Use cost_entry_bill_id to leverage DB index on DELETE
+                        accessor.delete_line_item_daily_summary_entries_for_date_range_raw(
+                            self._provider.uuid, start, end, filters
+                        )
+                        accessor.populate_line_item_daily_summary_table_trino(
+                            start, end, self._provider.uuid, current_bill_id, markup_value, invoice_month
+                        )
+                        accessor.populate_ui_summary_tables(start, end, self._provider.uuid, invoice_month)
             accessor.populate_tags_summary_table(bill_ids, start_date, end_date)
             accessor.populate_gcp_topology_information_tables(self._provider, start_date, end_date, invoice_month_date)
             accessor.update_line_item_daily_summary_with_tag_mapping(start_date, end_date, bill_ids)


### PR DESCRIPTION
## Jira Ticket

[COST-6495](https://issues.redhat.com/browse/COST-6495)

## Description

This change will include invoice month when selecting data from trino to insert into postgres table `reporting_gcpcostentrylineitem_daily_summary` and adds new logic to make sure when we run cross invoice months we insert the correct bill id per invoice month.

Before this change we would run summary for both month partitions but not consider invoice month, meaning we would insert data twice if we had already ran summary for the last day of the month for a previous manifest. 
For example we have the following manifests:

 2025-07-30|2025-07-31 04:28:58+00:00
 2025-07-31|2025-08-01 04:57:13+00:00

When we run summary for the first manifest we use start and end dates of 2025-07-30 and 2025-07-31. This means we select two days of data from the year and month partitions 2025 and 07 respectively. So far so good! 

However when we run summary for the second manifest, we collect the range of months since we cross a boundary. This then means we run the following start/end dates 2025-07-31 and 2025-08-01 with both month partitions (07 + 08). 

(datetime.date(2025, 7, 31), datetime.date(2025, 8, 1)), {'year': '2025', 'month': '08'}
(datetime.date(2025, 7, 31), datetime.date(2025, 8, 1)), {'year': '2025', 'month': '07'}

The problem here is we have already inserted data for the 2025-07-31 for the invoice month 202507 with the previous manifest, but because we are not filtering on invoice month when we select the data for the new invoice month we duplicate the data being inserted for the 31st. This woudnt be a problem if the same data was deleted prior to insert but our deletions use the bill_id (which is based of invoice month).

## Testing filter flow

1. Checkout Branch
2. Restart Koku
3. Create a GCP storage only provider (using the Dev account + the lcouzens filtered data bucket)
4. Post the report already uploaded to that bucket "gcp.csv" twice once per invoice month.
5. This is done via the ingress reports api /api/cost-management/v1/ingress/reports/
6. payload should look something like this: {'source': '1', 'bill_year': '2025', 'bill_month': '07', 'reports_list': ['gcp.csv']}
7. Once ingested check trino tables for data compared to postgress, check these tables between posting. You should see no duplicated data

    TRINO: `select sum(cost), source, invoice_month from gcp_line_items_daily group by source, invoice_month order by source, invoice_month;`
    POSTGRES: select sum(unblended_cost), invoice_month from reporting_gcpcostentrylineitem_daily_summary group by invoice_month order by invoice_month;
    


## Testing standard flow

1. Checkout Branch
2. Restart Koku
3. Run IQE test with bigquery enabled `ENV_FOR_DYNACONF=local iqe tests plugin cost_management -k "api_gcp_ingest_single or api_gcp_source_raw_calc" -vv --pdb --trace` while utilising this nise branch https://github.com/project-koku/nise/pull/564 (That creates crossover data)
4. Once ingested check trino tables for data compared to postgress, you should see no duplicated data

    TRINO: `select sum(cost), source, invoice_month from gcp_line_items_daily group by source, invoice_month order by source, invoice_month;`
    POSTGRES: select sum(unblended_cost), invoice_month from reporting_gcpcostentrylineitem_daily_summary group by invoice_month order by invoice_month;


On main this above test would have duplicated date on the 1st of Aug.


## Release Notes
- [ ] proposed release note

```markdown
* [COST-6495](https://issues.redhat.com/browse/COST-6495) Fix cross over month duplication
```
