### PR TITLE
[COST-6681] Handle inconsistent costs when filtering

### DIFF
--- a/koku/api/report/ocp/provider_map.py
+++ b/koku/api/report/ocp/provider_map.py
@@ -953,6 +953,7 @@ class OCPProviderMap(ProviderMap):
                 ("node",): OCPPodSummaryByNodeP,
                 ("project",): OCPPodSummaryByProjectP,
                 ("cluster", "project"): OCPPodSummaryByProjectP,
+                ("cluster", "node"): OCPPodSummaryByNodeP,
             },
             "memory": {
                 "default": OCPPodSummaryP,
@@ -960,6 +961,7 @@ class OCPProviderMap(ProviderMap):
                 ("node",): OCPPodSummaryByNodeP,
                 ("project",): OCPPodSummaryByProjectP,
                 ("cluster", "project"): OCPPodSummaryByProjectP,
+                ("cluster", "node"): OCPPodSummaryByNodeP,
             },
             "volume": {
                 "default": OCPVolumeSummaryP,

--- a/koku/api/report/ocp/provider_map.py
+++ b/koku/api/report/ocp/provider_map.py
@@ -317,7 +317,7 @@ class OCPProviderMap(ProviderMap):
                             "cost_total": self.cloud_infrastructure_cost + self.markup_cost + self.cost_model_cpu_cost,
                             "cost_total_distributed": self.cloud_infrastructure_cost
                             + self.markup_cost
-                            + self.cost_model_cost
+                            + self.cost_model_cpu_cost
                             + self.distributed_platform_cost
                             + self.distributed_worker_cost
                             + self.distributed_unattributed_storage_cost
@@ -358,7 +358,7 @@ class OCPProviderMap(ProviderMap):
                             "cost_total": self.cloud_infrastructure_cost + self.markup_cost + self.cost_model_cpu_cost,
                             "cost_total_distributed": self.cloud_infrastructure_cost
                             + self.markup_cost
-                            + self.cost_model_cost
+                            + self.cost_model_cpu_cost
                             + self.distributed_platform_cost
                             + self.distributed_worker_cost
                             + self.distributed_unattributed_storage_cost
@@ -381,7 +381,7 @@ class OCPProviderMap(ProviderMap):
                             "cost_total": self.cloud_infrastructure_cost + self.markup_cost + self.cost_model_cpu_cost,
                             "cost_total_distributed": self.cloud_infrastructure_cost
                             + self.markup_cost
-                            + self.cost_model_cost
+                            + self.cost_model_cpu_cost
                             + self.distributed_platform_cost
                             + self.distributed_worker_cost
                             + self.distributed_unattributed_storage_cost
@@ -436,7 +436,7 @@ class OCPProviderMap(ProviderMap):
                             + self.cost_model_memory_cost,
                             "cost_total_distributed": self.cloud_infrastructure_cost
                             + self.markup_cost
-                            + self.cost_model_cost
+                            + self.cost_model_memory_cost
                             + self.distributed_platform_cost
                             + self.distributed_worker_cost
                             + self.distributed_unattributed_storage_cost
@@ -479,7 +479,7 @@ class OCPProviderMap(ProviderMap):
                             + self.cost_model_memory_cost,
                             "cost_total_distributed": self.cloud_infrastructure_cost
                             + self.markup_cost
-                            + self.cost_model_cost
+                            + self.cost_model_memory_cost
                             + self.distributed_platform_cost
                             + self.distributed_worker_cost
                             + self.distributed_unattributed_storage_cost
@@ -506,7 +506,7 @@ class OCPProviderMap(ProviderMap):
                             + self.cost_model_memory_cost,
                             "cost_total_distributed": self.cloud_infrastructure_cost
                             + self.markup_cost
-                            + self.cost_model_cost
+                            + self.cost_model_memory_cost
                             + self.distributed_platform_cost
                             + self.distributed_worker_cost
                             + self.distributed_unattributed_storage_cost

--- a/koku/masu/database/trino_sql/openshift/cost_model/monthly_project_tag_based.sql
+++ b/koku/masu/database/trino_sql/openshift/cost_model/monthly_project_tag_based.sql
@@ -52,6 +52,8 @@ WITH filtered_data as (
         and nsp.namespace NOT LIKE 'kube-%'
         and nsp.namespace NOT LIKE 'openshift-%'
         and nsp.namespace != 'openshift'
+        and DATE(nsp.interval_start) >= DATE({{start_date}})
+        and DATE(nsp.interval_start) <= DATE({{end_date}})
         {%- if default_rate is defined %}
             AND json_extract(nsp.namespace_labels, '$.{{ tag_key|sqlsafe }}') IS NOT NULL
         {%- else %}


### PR DESCRIPTION
## Jira Ticket

[COST-6681](https://issues.redhat.com/browse/COST-6681)

## Description

This change will use the proper cost model costs on the cpu & memory endpoint.
Add filters to the namespace labels query and add a valid views option so that we can stop defaulting back to the big table when filtering on cluster & grouping by node. 
 

## Testing
Follow reproduction steps in issue

## Release Notes
- [ ] proposed release note

```markdown
* [COST-####](https://issues.redhat.com/browse/COST-####) Fix some things
```

## Summary by Sourcery

Update OCP provider_map to use CPU-specific and memory-specific cost model metrics instead of the general cost_model_cost in cost_total and cost_total_distributed calculations.

Enhancements:
- Replace general cost_model_cost with cost_model_cpu_cost for CPU-based reports in cost calculations
- Replace general cost_model_cost with cost_model_memory_cost for memory-based reports in cost calculations