### PR TITLE
[COST-5610] Keep cloud tags for ocp infrastructure cost

### DIFF
--- a/koku/masu/database/sql/reporting_ocpstoragevolumelabel_summary.sql
+++ b/koku/masu/database/sql/reporting_ocpstoragevolumelabel_summary.sql
@@ -14,6 +14,8 @@ create table {{schema | sqlsafe}}.cte_tag_value_{{uuid | sqlsafe}} as
         AND li.usage_start <= {{end_date}}
         AND value IS NOT NULL
         AND li.volume_labels ?| (SELECT array_agg(DISTINCT key) FROM {{schema | sqlsafe}}.reporting_enabledtagkeys WHERE enabled=true AND provider_type='OCP')
+        AND li.infrastructure_project_raw_cost IS NULL
+        AND li.infrastructure_raw_cost IS NULL
     GROUP BY key, value, li.report_period_id, li.namespace, li.node
 ;
 

--- a/koku/masu/database/sql/reporting_ocpusagepodlabel_summary.sql
+++ b/koku/masu/database/sql/reporting_ocpusagepodlabel_summary.sql
@@ -14,6 +14,8 @@ create table {{schema | sqlsafe}}.cte_tag_value_{{uuid | sqlsafe}} AS
         AND li.usage_start <= {{end_date}}
         AND value IS NOT NULL
         AND li.pod_labels ?| (SELECT array_agg(DISTINCT key) FROM {{schema | sqlsafe}}.reporting_enabledtagkeys WHERE enabled=true AND provider_type='OCP')
+        AND li.infrastructure_project_raw_cost IS NULL
+        AND li.infrastructure_raw_cost IS NULL
     GROUP BY key, value, li.report_period_id, li.namespace, li.node
 ;
 

--- a/koku/masu/database/trino_sql/aws/openshift/populate_daily_summary/2_summarize_data_by_cluster.sql
+++ b/koku/masu/database/trino_sql/aws/openshift/populate_daily_summary/2_summarize_data_by_cluster.sql
@@ -697,7 +697,6 @@ INSERT INTO hive.{{schema | sqlsafe}}.managed_reporting_ocpawscostlineitem_proje
     markup_cost_savingsplan,
     calculated_amortized_cost,
     markup_cost_amortized,
-    pod_labels,
     tags,
     aws_cost_category,
     cost_category_id,
@@ -771,7 +770,6 @@ SELECT pds.row_uuid,
         THEN ({{pod_column | sqlsafe}} / nullif({{node_column | sqlsafe}}, 0)) * calculated_amortized_cost * cast({{markup}} as decimal(33,9))
         ELSE calculated_amortized_cost / aws_uuid_count * cast({{markup}} as decimal(33,9))
     END as markup_cost_amortized,
-    pds.pod_labels,
     CASE WHEN pds.pod_labels IS NOT NULL
         THEN json_format(cast(
             map_concat(
@@ -834,7 +832,7 @@ INSERT INTO hive.{{schema | sqlsafe}}.managed_reporting_ocpawscostlineitem_proje
     markup_cost_savingsplan,
     calculated_amortized_cost,
     markup_cost_amortized,
-    pod_labels,
+    tags,
     source,
     ocp_source,
     year,
@@ -873,7 +871,7 @@ SELECT
     max(savingsplan_effective_cost) * cast({{markup}} AS decimal(24,9)),
     max(calculated_amortized_cost),
     max(calculated_amortized_cost) * cast({{markup}} AS decimal(33,9)),
-    max(ocp.pod_labels),
+    max(aws.tags) as tags,
     max({{cloud_provider_uuid}}) AS source,
     max({{ocp_provider_uuid}}) AS ocp_source,
     max(cast(year(aws.usage_start) AS varchar)) AS year,

--- a/koku/masu/database/trino_sql/aws/openshift/populate_daily_summary/3_reporting_ocpawscostlineitem_project_daily_summary_p.sql
+++ b/koku/masu/database/trino_sql/aws/openshift/populate_daily_summary/3_reporting_ocpawscostlineitem_project_daily_summary_p.sql
@@ -54,12 +54,6 @@ filtered_data as (
             (k,v) -> contains(pek.keys, k)
         ) as json
      ) AS enabled_tags,
-    cast(
-        map_filter(
-            cast(json_parse(pod_labels) as map(varchar, varchar)),
-            (k,v) -> contains(pek.keys, k)
-        ) as json
-     ) AS enabled_labels,
     cluster_alias,
     data_source,
     namespace,
@@ -142,7 +136,7 @@ SELECT
     SUM(markup_cost_savingsplan) as markup_cost_savingsplan,
     SUM(calculated_amortized_cost) as calculated_amortized_cost,
     SUM(markup_cost_amortized) as markup_cost_amortized,
-    fd.enabled_labels as pod_labels,
+    fd.enabled_tags as pod_labels,
     fd.enabled_tags as tags,
     fd.aws_cost_category as aws_cost_category,
     cost_category_id,
@@ -167,7 +161,6 @@ GROUP BY
     unit,
     data_transfer_direction,
     currency_code,
-    fd.enabled_labels,
     fd.enabled_tags,
     fd.aws_cost_category,
     cost_category_id;

--- a/koku/masu/database/trino_sql/azure/openshift/populate_daily_summary/2_summarize_data_by_cluster.sql
+++ b/koku/masu/database/trino_sql/azure/openshift/populate_daily_summary/2_summarize_data_by_cluster.sql
@@ -516,7 +516,6 @@ INSERT INTO hive.{{schema | sqlsafe}}.managed_reporting_ocpazurecostlineitem_pro
     currency,
     pretax_cost,
     markup_cost,
-    pod_labels,
     tags,
     resource_id_matched,
     matched_tag,
@@ -562,7 +561,6 @@ SELECT pds.row_uuid,
         THEN ({{pod_column | sqlsafe}} / {{node_column | sqlsafe}}) * pretax_cost * cast({{markup}} as decimal(24,9))
         ELSE pretax_cost / r.row_uuid_count * cast({{markup}} as decimal(24,9))
     END as markup_cost,
-    pds.pod_labels,
     CASE WHEN pds.pod_labels IS NOT NULL
         THEN json_format(cast(
             map_concat(

--- a/koku/masu/database/trino_sql/azure/openshift/populate_daily_summary/3_reporting_ocpazurecostlineitem_project_daily_summary_p.sql
+++ b/koku/masu/database/trino_sql/azure/openshift/populate_daily_summary/3_reporting_ocpazurecostlineitem_project_daily_summary_p.sql
@@ -79,12 +79,6 @@ filtered_data as (
                 (k,v) -> contains(pek.keys, k)
             ) as json
         ) AS enabled_tags,
-        cast(
-            map_filter(
-                cast(json_parse(pod_labels) as map(varchar, varchar)),
-                (k,v) -> contains(pek.keys, k)
-            ) as json
-        ) AS enabled_labels,
         cost_category_id
     FROM hive.{{schema | sqlsafe}}.managed_reporting_ocpazurecostlineitem_project_daily_summary
     CROSS JOIN cte_pg_enabled_keys AS pek
@@ -105,7 +99,7 @@ SELECT
     persistentvolumeclaim,
     persistentvolume,
     storageclass,
-    fd.enabled_labels as pod_labels,
+    fd.enabled_tags as pod_labels,
     resource_id,
     fd.usage_start as usage_start,
     fd.usage_start as usage_end,
@@ -136,7 +130,6 @@ GROUP BY
     persistentvolumeclaim,
     persistentvolume,
     storageclass,
-    fd.enabled_labels,
     fd.enabled_tags,
     resource_id,
     subscription_guid,

--- a/koku/masu/database/trino_sql/gcp/openshift/populate_daily_summary/2_summarize_data_by_cluster.sql
+++ b/koku/masu/database/trino_sql/gcp/openshift/populate_daily_summary/2_summarize_data_by_cluster.sql
@@ -246,7 +246,6 @@ INSERT INTO hive.{{schema | sqlsafe}}.managed_reporting_ocpgcpcostlineitem_proje
     persistentvolumeclaim,
     persistentvolume,
     storageclass,
-    pod_labels,
     resource_id,
     usage_start,
     usage_end,
@@ -296,18 +295,6 @@ SELECT pds.row_uuid,
     persistentvolumeclaim,
     persistentvolume,
     storageclass,
-    CASE WHEN pds.pod_labels IS NOT NULL
-        THEN json_format(cast(
-            map_concat(
-                cast(json_parse(pds.pod_labels) as map(varchar, varchar)),
-                cast(json_parse(pds.tags) as map(varchar, varchar))
-            ) as JSON))
-        ELSE json_format(cast(
-            map_concat(
-                cast(json_parse(pds.volume_labels) as map(varchar, varchar)),
-                cast(json_parse(pds.tags) as map(varchar, varchar))
-            ) as JSON))
-    END as pod_labels,
     resource_id,
     usage_start,
     usage_end,
@@ -340,7 +327,18 @@ SELECT pds.row_uuid,
     node_capacity_cpu_core_hours,
     node_capacity_memory_gigabyte_hours,
     volume_labels,
-    tags,
+    CASE WHEN pds.pod_labels IS NOT NULL
+        THEN json_format(cast(
+            map_concat(
+                cast(json_parse(pds.pod_labels) as map(varchar, varchar)),
+                cast(json_parse(pds.tags) as map(varchar, varchar))
+            ) as JSON))
+        ELSE json_format(cast(
+            map_concat(
+                cast(json_parse(pds.volume_labels) as map(varchar, varchar)),
+                cast(json_parse(pds.tags) as map(varchar, varchar))
+            ) as JSON))
+    END as tags,
     cost_category_id,
     resource_id_matched,
     matched_tag,

--- a/koku/masu/database/trino_sql/gcp/openshift/populate_daily_summary/3_reporting_ocpgcpcostlineitem_project_daily_summary_p.sql
+++ b/koku/masu/database/trino_sql/gcp/openshift/populate_daily_summary/3_reporting_ocpgcpcostlineitem_project_daily_summary_p.sql
@@ -55,12 +55,6 @@ filtered_data as (
         storageclass,
         cast(
             map_filter(
-                cast(json_parse(pod_labels) as map(varchar, varchar)),
-                (k,v) -> contains(pek.keys, k)
-            ) as json
-        ) AS enabled_labels,
-        cast(
-            map_filter(
                 cast(json_parse(tags) as map(varchar, varchar)),
                 (k,v) -> contains(pek.keys, k)
             ) as json
@@ -122,7 +116,7 @@ SELECT
     persistentvolumeclaim,
     persistentvolume,
     storageclass,
-    fd.enabled_labels as pod_labels,
+    fd.enabled_tags as pod_labels,
     resource_id,
     fd.usage_start as usage_start,
     fd.usage_start as usage_end,
@@ -159,7 +153,6 @@ GROUP BY
     persistentvolumeclaim,
     persistentvolume,
     storageclass,
-    fd.enabled_labels,
     fd.enabled_tags,
     resource_id,
     account_id,


### PR DESCRIPTION
## Jira Ticket

[COST-5610](https://issues.redhat.com/browse/COST-5610)
[COST-5599](https://issues.redhat.com/browse/COST-5599)

## Description

This change will start utilizing the combination of pod_labels & cloud tags when back populating to the openshift summary table. 

Pros:
- Customers can utilize their cloud tags when trying to identify raw infrastructure costs (This was already available for GCP, but missing for AWS & Azure)
- We no longer have to group by  the labels and the labels + tags when populating the ocp on cloud tables. Also reduces the number of map filters we have to do. 
- Unify the labels we use for Network Unattributed project

Cons:
- I would be very surprised if this doesn't break smoke tests. 

## Testing

1. Checkout Branch
2. Run the test outlined in the linked issue
3. Hit the following endpoint:
```
http://localhost:8000/api/cost-management/v1/reports/openshift/costs/?filter[resolution]=monthly&filter[time_scope_value]=-2&filter[time_scope_units]=month&filter[cluster]=test_cost_ocp_on_aws_cluster&group_by[tag:tier]=*&exclude[project]=Platform unallocated,Worker unallocated, Network unattributed, Storage unattributed
```
4. Capture the cost total:
```
"cost": {
                "raw": {
                    "value": 4646.357928003556,
                    "units": "USD"
                },
                "markup": {
                    "value": 0.0,
                    "units": "USD"
                },
                "usage": {
                    "value": 601.4462714842889,
                    "units": "USD"
                },
                "total": {
                    "value": 5247.804199487844,
                    "units": "USD"
                }
            }
```
5. Switch to main, and resummarize the data. See that the cost total stays the same, but a lot less options are returned. 

## Release Notes
- [ ] proposed release note

```markdown
* [COST-####](https://issues.redhat.com/browse/COST-####) Fix some things
```

## Summary by Sourcery

Combine Kubernetes pod labels with cloud provider tags in the OpenShift cost summarization SQL for AWS, Azure, and GCP, and simplify the SQL by unifying tag handling and removing redundant fields.

New Features:
- Include cloud provider tags when back-populating OpenShift cost summaries for AWS and Azure
- Allow filtering and grouping by combined pod labels and cloud tags in raw infrastructure cost reports

Enhancements:
- Replace separate pod_labels and enabled_labels fields with a single unified tags column
- Remove redundant map_filter steps and streamline summarization logic across AWS, Azure, and GCP SQL modules