### PR TITLE
[COST-6431] remove cost_6356 unleash flag for vm cost model metrics

### DIFF
--- a/koku/api/metrics/constants.py
+++ b/koku/api/metrics/constants.py
@@ -6,7 +6,6 @@
 import copy
 
 from api.models import Provider
-from masu.processor import is_cost_6356_enabled
 
 """Model for our cost model metric map."""
 OCP_METRIC_CPU_CORE_USAGE_HOUR = "cpu_core_usage_per_hour"
@@ -249,9 +248,6 @@ COST_MODEL_METRIC_MAP = {
         "label_measurement_unit": "project-month",
         "default_cost_type": "Infrastructure",
     },
-}
-
-UNLEASH_METRICS_COST_6356 = {
     "vm_core_cost_per_month": {
         "source_type": "OCP",
         "metric": "vm_core_cost_per_month",
@@ -273,8 +269,6 @@ UNLEASH_METRICS_COST_6356 = {
 
 def get_cost_model_metrics_map():
     map_copy = copy.deepcopy(COST_MODEL_METRIC_MAP)
-    if is_cost_6356_enabled():
-        map_copy |= copy.deepcopy(UNLEASH_METRICS_COST_6356)
     return map_copy
 
 

--- a/koku/api/metrics/views.py
+++ b/koku/api/metrics/views.py
@@ -20,7 +20,6 @@ from api.common import CACHE_RH_IDENTITY_HEADER
 from api.common.pagination import ListPaginator
 from api.metrics import constants as metric_constants
 from api.metrics.serializers import QueryParamsSerializer
-from masu.processor import is_cost_6356_enabled
 
 
 @api_view(["GET"])  # noqa: C901

--- a/koku/masu/processor/__init__.py
+++ b/koku/masu/processor/__init__.py
@@ -21,12 +21,6 @@ LOG = logging.getLogger(__name__)
 ALLOWED_COMPRESSIONS = (UNCOMPRESSED, GZIP_COMPRESSED)
 
 
-def is_cost_6356_enabled():
-    return UNLEASH_CLIENT.is_enabled(
-        "cost-management.backend.cost-6356-vm-cost-model-metrics", fallback_function=fallback_development_true
-    )
-
-
 def is_feature_unattributed_storage_enabled_azure(account):
     """Should unattributed storage feature be enabled."""
     unleash_flag = "cost-management.backend.unattributed_storage"


### PR DESCRIPTION
## Jira Ticket

[COST-6431](https://issues.redhat.com/browse/COST-6431)

## Description

This change removes the Unleash feature flag for cost-6356 VM cost model metrics and integrates VM cost metrics into the main cost model metrics map.

## Testing

1. Checkout Branch
2. Restart Koku
3. Load OCP test data
4. Hit metrics endpoint:
    ```
    http://127.0.0.1:8000/api/cost-management/v1/metrics/?limit=100
    ```
    1. You should see `vm_core_cost_per_month` and `vm_core_cost_per_hour` metrics exist in the cost model metrics map
 
## Release Notes
- [ ] proposed release note

```markdown
* [COST-6431](https://issues.redhat.com/browse/COST-6431) Remove feature flag for VM cost model metrics
```

## Summary by Sourcery

Enhancements:
- Remove the cost-6356 Unleash flag and related code (is_cost_6356_enabled, UNLEASH_METRICS_COST_6356) and integrate VM cost metrics unconditionally into the main metrics map.