### PR TITLE
[COST-6689] enable `exact` filtering tags/orgs endpoints

### DIFF
--- a/koku/api/organizations/queries.py
+++ b/koku/api/organizations/queries.py
@@ -124,14 +124,6 @@ class OrgQueryHandler(QueryHandler):
         or_composed_filters = self._set_operator_specified_filters("or")
         exact_composed_filters = self._set_operator_specified_filters("exact")
         final_filters = filters.compose() & and_composed_filters & or_composed_filters & exact_composed_filters
-        # filter_list = [composed_filters, and_composed_filters, or_composed_filters]
-        # final_filters = None
-        # for filter_option in filter_list:
-        #     if filter_option:
-        #         if final_filters is not None:
-        #             final_filters = final_filters & filter_option
-        #         else:
-        #             final_filters = filter_option
 
         LOG.debug(f"_get_filter: {final_filters}")
         return final_filters

--- a/koku/api/organizations/queries.py
+++ b/koku/api/organizations/queries.py
@@ -17,7 +17,6 @@ from api.query_filter import QueryFilter
 from api.query_filter import QueryFilterCollection
 from api.query_handler import QueryHandler
 
-
 LOG = logging.getLogger(__name__)
 
 
@@ -123,15 +122,16 @@ class OrgQueryHandler(QueryHandler):
         # Update filters that specifiy and or or in the query parameter
         and_composed_filters = self._set_operator_specified_filters("and")
         or_composed_filters = self._set_operator_specified_filters("or")
-        composed_filters = filters.compose()
-        filter_list = [composed_filters, and_composed_filters, or_composed_filters]
-        final_filters = None
-        for filter_option in filter_list:
-            if filter_option:
-                if final_filters is not None:
-                    final_filters = final_filters & filter_option
-                else:
-                    final_filters = filter_option
+        exact_composed_filters = self._set_operator_specified_filters("exact")
+        final_filters = filters.compose() & and_composed_filters & or_composed_filters & exact_composed_filters
+        # filter_list = [composed_filters, and_composed_filters, or_composed_filters]
+        # final_filters = None
+        # for filter_option in filter_list:
+        #     if filter_option:
+        #         if final_filters is not None:
+        #             final_filters = final_filters & filter_option
+        #         else:
+        #             final_filters = filter_option
 
         LOG.debug(f"_get_filter: {final_filters}")
         return final_filters
@@ -141,10 +141,10 @@ class OrgQueryHandler(QueryHandler):
         filters = QueryFilterCollection()
         composed_filter = Q()
         for filter_key in self.SUPPORTED_FILTERS:
-            operator_key = operator + ":" + filter_key
+            operator_key = f"{operator}:{filter_key}"
             filter_value = self.parameters.get_filter(operator_key)
             logical_operator = operator
-            if filter_value and len(filter_value) < 2:
+            if filter_value and len(filter_value) < 2 and logical_operator != "exact":
                 logical_operator = "or"
             if filter_value and not OrgQueryHandler.has_wildcard(filter_value):
                 filter_obj = self.FILTER_MAP.get(filter_key)

--- a/koku/api/query_filter.py
+++ b/koku/api/query_filter.py
@@ -172,7 +172,7 @@ class QueryFilterCollection:
             logical_operator (str): 'and' or 'or' -- how to combine the filters.
 
         """
-        composed_query = None
+        composed_query = Q()
         compose_dict = defaultdict(list)
         operator = "and"
         if logical_operator == "or":
@@ -183,21 +183,16 @@ class QueryFilterCollection:
             compose_dict[filt_key].append(filt)
 
         for filter_list in compose_dict.values():
-            or_filter = None
+            or_filter = Q()
             for filter_item in filter_list:
-                if or_filter is None:
-                    or_filter = filter_item.composed_Q()
-                elif filter_item.logical_operator == "and":
-                    or_filter = or_filter & filter_item.composed_Q()
+                if filter_item.logical_operator == "and":
+                    or_filter &= filter_item.composed_Q()
                 else:
-                    or_filter = or_filter | filter_item.composed_Q()
-            if composed_query is None:
-                composed_query = or_filter
+                    or_filter |= filter_item.composed_Q()
+            if operator == "or":
+                composed_query |= or_filter
             else:
-                if operator == "or":
-                    composed_query = composed_query | or_filter
-                else:
-                    composed_query = composed_query & or_filter
+                composed_query &= or_filter
         return composed_query
 
     def __contains__(self, item):

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -560,7 +560,7 @@ class ReportQueryHandler(QueryHandler):
         composed_filter = Q()
 
         for q_param, filt in fields.items():
-            q_param = operator + ":" + q_param
+            q_param = f"{operator}:{q_param}"
             group_by = self.parameters.get_group_by(q_param, list())
             if check_for_exclude:
                 list_ = self.parameters.get_exclude(q_param, list())

--- a/koku/api/tags/queries.py
+++ b/koku/api/tags/queries.py
@@ -253,16 +253,11 @@ class TagQueryHandler(QueryHandler):
         # Update filters that specifiy and or or in the query parameter
         and_composed_filters = self._set_operator_specified_filters("and")
         or_composed_filters = self._set_operator_specified_filters("or")
+        exact_composed_filters = self._set_operator_specified_filters("exact")
         composed_filters = filters.compose()
-        composed_filters = composed_filters & and_composed_filters & or_composed_filters
-        category_list = (
-            self.parameters.get("category")
-            if self.parameters.get("category")
-            else self.parameters.get_filter("category")
-        )
-        if category_list:
-            composed_category_filters = self._build_namespace_filters_from_category_list(category_list)
-            if composed_category_filters:
+        composed_filters = composed_filters & and_composed_filters & or_composed_filters & exact_composed_filters
+        if category_list := self.parameters.get("category") or self.parameters.get_filter("category"):
+            if composed_category_filters := self._build_namespace_filters_from_category_list(category_list):
                 composed_filters = composed_filters & composed_category_filters
 
         LOG.debug(f"_get_filter: {composed_filters}")
@@ -281,10 +276,10 @@ class TagQueryHandler(QueryHandler):
         filters = QueryFilterCollection()
         composed_filter = Q()
         for filter_key in self.SUPPORTED_FILTERS:
-            operator_key = operator + ":" + filter_key
+            operator_key = f"{operator}:{filter_key}"
             filter_value = self.parameters.get_filter(operator_key)
             logical_operator = operator
-            if filter_value and len(filter_value) < 2:
+            if filter_value and len(filter_value) < 2 and logical_operator != "exact":
                 logical_operator = "or"
             if filter_value and not TagQueryHandler.has_wildcard(filter_value):
                 filter_obj = self.filter_map.get(filter_key)


### PR DESCRIPTION
## Jira Ticket

[COST-6689](https://issues.redhat.com/browse/COST-6689)

## Description

This change will ...

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Release Notes
- [ ] proposed release note

```markdown
* [COST-####](https://issues.redhat.com/browse/COST-####) Fix some things
```

## Summary by Sourcery

Enable exact-match filtering for tags and organizations and refactor query filter composition for consistency.

New Features:
- Enable 'exact' operator filtering across organizations, tags, and report endpoints

Enhancements:
- Combine exact filters with existing AND/OR filters in get_filter methods
- Refactor operator key string concatenations to use f-strings
- Simplify category filter logic in tag queries with inline assignment