### PR TITLE
[COST-6689] strip prefixes when looking up db table

### DIFF
--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -49,7 +49,7 @@ from api.report.constants import URL_ENCODED_SAFE
 LOG = logging.getLogger(__name__)
 
 
-def strip_prefix(key, prefix):
+def strip_prefix(key, prefix=""):
     """Remove the query prefix from a key."""
     return key.replace(prefix, "").replace("and:", "").replace("or:", "").replace("exact:", "")
 
@@ -127,24 +127,24 @@ class ReportQueryHandler(QueryHandler):
     @cached_property
     def query_table_access_keys(self):
         """Return the access keys specific for selecting the query table."""
-        return set(self.parameters.get("access", {}).keys())
+        return {strip_prefix(key) for key in self.parameters.get("access", {}).keys()}
 
     @cached_property
     def query_table_group_by_keys(self):
         """Return the group by keys specific for selecting the query table."""
-        return set(self.parameters.get("group_by", {}).keys())
+        return {strip_prefix(key) for key in self.parameters.get("group_by", {}).keys()}
 
     @cached_property
     def query_table_filter_keys(self):
         """Return the filter keys specific for selecting the query table."""
         excluded_filters = {"time_scope_value", "time_scope_units", "resolution", "limit", "offset"}
-        filter_keys = set(self.parameters.get("filter", {}).keys())
+        filter_keys = {strip_prefix(key) for key in self.parameters.get("filter", {}).keys()}
         return filter_keys.difference(excluded_filters)
 
     @cached_property
     def query_table_exclude_keys(self):
         """Return the exclude keys specific for selecting the query table."""
-        return set(self.parameters.get("exclude", {}).keys())
+        return {strip_prefix(key) for key in self.parameters.get("exclude", {}).keys()}
 
     @property
     def report_annotations(self):

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -188,7 +188,7 @@ class ReportQueryHandler(QueryHandler):
 
         try:
             query_table = self._mapper.views[report_type][report_group]
-            LOG.info(f"{report_group} for {report_type} has entry in views. Using {query_table}.")
+            LOG.debug(f"{report_group} for {report_type} has entry in views. Using {query_table}.")
         except KeyError:
             msg = f"{report_group} for {report_type} has no entry in views. Using the default."
             LOG.warning(msg)

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -188,6 +188,7 @@ class ReportQueryHandler(QueryHandler):
 
         try:
             query_table = self._mapper.views[report_type][report_group]
+            LOG.info(f"{report_group} for {report_type} has entry in views. Using {query_table}.")
         except KeyError:
             msg = f"{report_group} for {report_type} has no entry in views. Using the default."
             LOG.warning(msg)


### PR DESCRIPTION
## Jira Ticket

[COST-6689](https://issues.redhat.com/browse/COST-6689)

## Description

This change will strip query prefixes ('and:', 'or:', 'exact:') when looking up the db table to query.

## Testing

1. load AWS data
2. hit [http://localhost:8000/api/cost-management/v1/reports/aws/costs/?cost_type=blended_cost&currency=USD&filter[exact:account]=9999999999998&filter[resolution]=monthly&filter[time_scope_units]=month&filter[time_scope_value]=-1&group_by[account]=*](http://localhost:8000/api/cost-management/v1/reports/aws/costs/?cost_type=blended_cost&currency=USD&filter[exact:account]=9999999999998&filter[resolution]=monthly&filter[time_scope_units]=month&filter[time_scope_value]=-1&group_by[account]=*)
3. see log result:
```
[2025-08-28 15:20:14,602] INFO None None None 76937 ('account',) for costs has entry in views. Using <class 'reporting.provider.aws.models.AWSCostSummaryByAccountP'>.
```

## Release Notes
- [x] proposed release note

```markdown
* [COST-6689] strip prefixes when looking up db table
```

## Summary by Sourcery

Improve query table selection to ignore query prefixes and log chosen mappings

Enhancements:
- Strip 'and:', 'or:', and 'exact:' prefixes from access, group_by, filter, and exclude parameter keys when selecting the database table
- Add info-level logging when a report view mapping is found and used