### PR TITLE
[COST-6527] add v4.1.0 operator commits

### DIFF
--- a/koku/masu/util/ocp/common.py
+++ b/koku/masu/util/ocp/common.py
@@ -49,6 +49,7 @@ class OCPReportTypes(Enum):
 
 
 OPERATOR_VERSIONS = {
+    "c7361974c47522d07a4810fdada6be4f39ecd75d": "costmanagement-metrics-operator:4.1.0",
     "e53f9db7c6e7f995b6aa6100a580dae74162ac3c": "costmanagement-metrics-operator:4.0.0",
     "8e957a5b174639642809df0317b39593532d6fb7": "costmanagement-metrics-operator:3.3.2",
     "6b4d72a4a629527c1de086b416faf6d226fe587a": "costmanagement-metrics-operator:3.3.1",
@@ -69,6 +70,7 @@ OPERATOR_VERSIONS = {
     "084bca2e1c48caab18c237453c17ceef61747fe2": "costmanagement-metrics-operator:1.1.3",
     "6f10d07e3af3ea4f073d4ffda9019d8855f52e7f": "costmanagement-metrics-operator:1.1.0",
     "fd764dcd7e9b993025f3e05f7cd674bb32fad3be": "costmanagement-metrics-operator:1.0.0",
+    "0f4d67606199148fd2ea04392d00a32d1387be84": "koku-metrics-operator:v4.1.0",
     "0dbe2ce263a19e05935023c46d20692213fdef90": "koku-metrics-operator:v4.0.0",
     "1dd2f05c51daa7487ea53b1f3f4894316b1759e1": "koku-metrics-operator:v3.3.2",
     "b0731873d0c54aa1d016b8b3463b29c23c9e852c": "koku-metrics-operator:v3.3.1",


### PR DESCRIPTION
## Jira Ticket

[COST-6527](https://issues.redhat.com/browse/COST-6527)

## Description

This change adds version 4.1.0 operator commits to OPERATOR_VERSIONS map.

## Release Notes
- [ ] proposed release note

```markdown
* [COST-6527](https://issues.redhat.com/browse/COST-6527) add v4.0.0 operator commits
```

## Summary by Sourcery

Add new operator version entries for costmanagement-metrics-operator and koku-metrics-operator v4.1.0.

Enhancements:
- Add costmanagement-metrics-operator v4.1.0 commit hash to OPERATOR_VERSIONS
- Add koku-metrics-operator v4.1.0 commit hash to OPERATOR_VERSIONS