### PR TITLE
Add rosa cluster name key as a specialized tag

### DIFF
--- a/koku/masu/database/trino_sql/ocp_special_matched_tags.sql
+++ b/koku/masu/database/trino_sql/ocp_special_matched_tags.sql
@@ -10,6 +10,7 @@ WITH cte_array_agg_nodes AS (
 cte_cluster_info as (
     select
         format('"openshift_cluster": "%s"', json_extract_scalar(auth.credentials, '$.cluster_id')) AS cluster_id,
+        format('"api.openshift.com/name": "%s"', provider.name) AS rosa_cluster_name,
         format('"openshift_cluster": "%s"', provider.name) as cluster_alias
     from postgres.public.api_provider as provider
     inner join postgres.public.api_providerauthentication as auth
@@ -26,6 +27,10 @@ cte_tag_matches AS (
     UNION
 
     SELECT cluster_id from cte_cluster_info
+
+    UNION
+
+    SELECT rosa_cluster_name from cte_cluster_info
 
     UNION
 


### PR DESCRIPTION
## Jira Ticket

[COST-####](https://issues.redhat.com/browse/COST-####)

## Description

This change will ...

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Release Notes
- [ ] proposed release note

```markdown
* [COST-####](https://issues.redhat.com/browse/COST-####) Fix some things
```

## Summary by Sourcery

Introduce the ROSA cluster name as a specialized matched tag in the ocp_special_matched_tags SQL by adding it to cte_cluster_info and incorporating it into the tag matches CTE

Enhancements:
- Add a new rosa_cluster_name tag formatted as "api.openshift.com/name" to the OCP special matched tags SQL query
- Include the rosa_cluster_name field in the cte_tag_matches union set