### PR TITLE
[COST-6689] fix EXACT_AWS_CATEGORY_PREFIX definition

### DIFF
--- a/koku/api/report/constants.py
+++ b/koku/api/report/constants.py
@@ -11,7 +11,7 @@ EXACT_TAG_PREFIX = "exact:tag:"
 AWS_CATEGORY_PREFIX = "aws_category:"
 AND_AWS_CATEGORY_PREFIX = "and:aws_category:"
 OR_AWS_CATEGORY_PREFIX = "or:aws_category:"
-EXACT_AWS_CATEGORY_PREFIX = "exact:aws_category"
+EXACT_AWS_CATEGORY_PREFIX = "exact:aws_category:"
 URL_ENCODED_SAFE = "[]:"
 AWS_MARKUP_COST = {
     "blended_cost": "markup_cost_blended",


### PR DESCRIPTION
## Jira Ticket

[COST-6689](https://issues.redhat.com/browse/COST-6689)

## Description

Fix the EXACT_AWS_CATEGORY_PREFIX definition

## Testing

1. ingest AWS data.
2. See success here:
[http://localhost:8000/api/cost-management/v1/reports/aws/costs/?group_by[exact:aws_category:Organization]=*](http://localhost:8000/api/cost-management/v1/reports/aws/costs/?group_by[exact:aws_category:Organization]=*)


## Release Notes
- [x] proposed release note

```markdown
* [COST-6689] fix EXACT_AWS_CATEGORY_PREFIX definition
```

## Summary by Sourcery

Bug Fixes:
- Correct the EXACT_AWS_CATEGORY_PREFIX constant to include a trailing colon for proper AWS category grouping