### PR TITLE
[COST-6672, COST-6673] add autoscalers for all download workers

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -2088,7 +2088,19 @@ objects:
           enabled: false
         public:
           enabled: false
-    - metadata:
+    - autoScaler:
+        fallback:
+          behavior: currentReplicasIfHigher
+          failureThreshold: 3
+          replicas: ${{WORKER_DOWNLOAD_XL_FALLBACK_REPLICAS}}
+        maxReplicaCount: ${{WORKER_DOWNLOAD_XL_MAX_REPLICAS}}
+        minReplicaCount: ${{WORKER_DOWNLOAD_XL_MIN_REPLICAS}}
+        triggers:
+        - metadata:
+            query: ${WORKER_DOWNLOAD_XL_TRIGGER_QUERY}
+            threshold: ${WORKER_DOWNLOAD_XL_TRIGGER_THRESHOLD}
+          type: prometheus
+      metadata:
         annotations:
           ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses
             1 pod at times for cost saving purposes
@@ -2263,13 +2275,24 @@ objects:
             - key: gcp-credentials
               path: gcp-credentials.json
             secretName: koku-gcp
-      replicas: ${{WORKER_DOWNLOAD_XL_REPLICAS}}
       webServices:
         private:
           enabled: false
         public:
           enabled: false
-    - metadata:
+    - autoScaler:
+        fallback:
+          behavior: currentReplicasIfHigher
+          failureThreshold: 3
+          replicas: ${{WORKER_DOWNLOAD_PENALTY_FALLBACK_REPLICAS}}
+        maxReplicaCount: ${{WORKER_DOWNLOAD_PENALTY_MAX_REPLICAS}}
+        minReplicaCount: ${{WORKER_DOWNLOAD_PENALTY_MIN_REPLICAS}}
+        triggers:
+        - metadata:
+            query: ${WORKER_DOWNLOAD_PENALTY_TRIGGER_QUERY}
+            threshold: ${WORKER_DOWNLOAD_PENALTY_TRIGGER_THRESHOLD}
+          type: prometheus
+      metadata:
         annotations:
           ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses
             1 pod at times for cost saving purposes
@@ -2444,7 +2467,6 @@ objects:
             - key: gcp-credentials
               path: gcp-credentials.json
             secretName: koku-gcp
-      replicas: ${{WORKER_DOWNLOAD_PENALTY_REPLICAS}}
       webServices:
         private:
           enabled: false
@@ -6050,9 +6072,25 @@ parameters:
   name: REDEPLOY_HASH_WORKER_DOWNLOAD
   value: "000000"
 - displayName: Minimum replicas
-  name: WORKER_DOWNLOAD_XL_REPLICAS
+  name: WORKER_DOWNLOAD_XL_MIN_REPLICAS
   required: true
-  value: "2"
+  value: "1"
+- displayName: Maximum replicas
+  name: WORKER_DOWNLOAD_XL_MAX_REPLICAS
+  required: true
+  value: "10"
+- displayName: Fallback replicas
+  name: WORKER_DOWNLOAD_XL_FALLBACK_REPLICAS
+  required: true
+  value: "3"
+- displayName: Trigger threshold
+  name: WORKER_DOWNLOAD_XL_TRIGGER_THRESHOLD
+  required: true
+  value: "19.5"
+- displayName: Trigger query
+  name: WORKER_DOWNLOAD_XL_TRIGGER_QUERY
+  required: true
+  value: koku:celery:download_xl_queue
 - displayName: Memory Request
   name: MEMORY_REQUEST_WORKER_DOWNLOAD_XL
   required: true
@@ -6077,9 +6115,25 @@ parameters:
   name: REDEPLOY_HASH_WORKER_DOWNLOAD_XL
   value: "000000"
 - displayName: Minimum replicas
-  name: WORKER_DOWNLOAD_PENALTY_REPLICAS
+  name: WORKER_DOWNLOAD_PENALTY_MIN_REPLICAS
   required: true
-  value: "2"
+  value: "1"
+- displayName: Maximum replicas
+  name: WORKER_DOWNLOAD_PENALTY_MAX_REPLICAS
+  required: true
+  value: "10"
+- displayName: Fallback replicas
+  name: WORKER_DOWNLOAD_PENALTY_FALLBACK_REPLICAS
+  required: true
+  value: "3"
+- displayName: Trigger threshold
+  name: WORKER_DOWNLOAD_PENALTY_TRIGGER_THRESHOLD
+  required: true
+  value: "19.5"
+- displayName: Trigger query
+  name: WORKER_DOWNLOAD_PENALTY_TRIGGER_QUERY
+  required: true
+  value: koku:celery:download_penalty_queue
 - displayName: Memory Request
   name: MEMORY_REQUEST_WORKER_DOWNLOAD_PENALTY
   required: true

--- a/deploy/kustomize/patches/worker-download-penalty.yaml
+++ b/deploy/kustomize/patches/worker-download-penalty.yaml
@@ -5,7 +5,6 @@
     metadata:
       annotations:
         ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses 1 pod at times for cost saving purposes
-    replicas: ${{WORKER_DOWNLOAD_PENALTY_REPLICAS}}
     webServices:
       public:
         enabled: false
@@ -182,13 +181,54 @@
             - key: gcp-credentials
               path: gcp-credentials.json
 
+    autoScaler:
+      maxReplicaCount: ${{WORKER_DOWNLOAD_PENALTY_MAX_REPLICAS}}
+      minReplicaCount: ${{WORKER_DOWNLOAD_PENALTY_MIN_REPLICAS}}
+      fallback:
+        failureThreshold: 3
+        replicas: ${{WORKER_DOWNLOAD_PENALTY_FALLBACK_REPLICAS}}
+        behavior: "currentReplicasIfHigher"
+      triggers:
+      - type: prometheus
+        metadata:
+          query: ${WORKER_DOWNLOAD_PENALTY_TRIGGER_QUERY}
+          threshold: ${WORKER_DOWNLOAD_PENALTY_TRIGGER_THRESHOLD}
+
 - op: add
   path: /parameters/-
   value:
     displayName: Minimum replicas
-    name: WORKER_DOWNLOAD_PENALTY_REPLICAS
+    name: WORKER_DOWNLOAD_PENALTY_MIN_REPLICAS
     required: true
-    value: '2'
+    value: '1'
+- op: add
+  path: /parameters/-
+  value:
+    displayName: Maximum replicas
+    name: WORKER_DOWNLOAD_PENALTY_MAX_REPLICAS
+    required: true
+    value: '10'
+- op: add
+  path: /parameters/-
+  value:
+    displayName: Fallback replicas
+    name: WORKER_DOWNLOAD_PENALTY_FALLBACK_REPLICAS
+    required: true
+    value: '3'
+- op: add
+  path: /parameters/-
+  value:
+    displayName: Trigger threshold
+    name: WORKER_DOWNLOAD_PENALTY_TRIGGER_THRESHOLD
+    required: true
+    value: '19.5'
+- op: add
+  path: /parameters/-
+  value:
+    displayName: Trigger query
+    name: WORKER_DOWNLOAD_PENALTY_TRIGGER_QUERY
+    required: true
+    value: 'koku:celery:download_penalty_queue'
 - op: add
   path: /parameters/-
   value:

--- a/deploy/kustomize/patches/worker-download-xl.yaml
+++ b/deploy/kustomize/patches/worker-download-xl.yaml
@@ -5,7 +5,6 @@
     metadata:
       annotations:
         ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses 1 pod at times for cost saving purposes
-    replicas: ${{WORKER_DOWNLOAD_XL_REPLICAS}}
     webServices:
       public:
         enabled: false
@@ -182,13 +181,54 @@
             - key: gcp-credentials
               path: gcp-credentials.json
 
+    autoScaler:
+      maxReplicaCount: ${{WORKER_DOWNLOAD_XL_MAX_REPLICAS}}
+      minReplicaCount: ${{WORKER_DOWNLOAD_XL_MIN_REPLICAS}}
+      fallback:
+        failureThreshold: 3
+        replicas: ${{WORKER_DOWNLOAD_XL_FALLBACK_REPLICAS}}
+        behavior: "currentReplicasIfHigher"
+      triggers:
+      - type: prometheus
+        metadata:
+          query: ${WORKER_DOWNLOAD_XL_TRIGGER_QUERY}
+          threshold: ${WORKER_DOWNLOAD_XL_TRIGGER_THRESHOLD}
+
 - op: add
   path: /parameters/-
   value:
     displayName: Minimum replicas
-    name: WORKER_DOWNLOAD_XL_REPLICAS
+    name: WORKER_DOWNLOAD_XL_MIN_REPLICAS
     required: true
-    value: '2'
+    value: '1'
+- op: add
+  path: /parameters/-
+  value:
+    displayName: Maximum replicas
+    name: WORKER_DOWNLOAD_XL_MAX_REPLICAS
+    required: true
+    value: '10'
+- op: add
+  path: /parameters/-
+  value:
+    displayName: Fallback replicas
+    name: WORKER_DOWNLOAD_XL_FALLBACK_REPLICAS
+    required: true
+    value: '3'
+- op: add
+  path: /parameters/-
+  value:
+    displayName: Trigger threshold
+    name: WORKER_DOWNLOAD_XL_TRIGGER_THRESHOLD
+    required: true
+    value: '19.5'
+- op: add
+  path: /parameters/-
+  value:
+    displayName: Trigger query
+    name: WORKER_DOWNLOAD_XL_TRIGGER_QUERY
+    required: true
+    value: 'koku:celery:download_xl_queue'
 - op: add
   path: /parameters/-
   value:


### PR DESCRIPTION
## Jira Ticket

[COST-6672](https://issues.redhat.com/browse/COST-6672)
[COST-6673](https://issues.redhat.com/browse/COST-6673)

## Description

This change will ...

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Release Notes
- [ ] proposed release note

```markdown
* [COST-####](https://issues.redhat.com/browse/COST-####) Fix some things
```

## Summary by Sourcery

Add autoscaling support for the download XL and download penalty worker deployments and parameterize related scaling settings

New Features:
- Introduce KEDA-based autoscalers for both worker-download-xl and worker-download-penalty with Prometheus triggers

Enhancements:
- Remove static replica counts and replace them with configurable min, max, and fallback replica parameters
- Parameterize autoscaling thresholds and Prometheus query metadata for each worker