### PR TITLE
[COST-2768] update pr check script for fixture renaming

### DIFF
--- a/ci/functions.sh
+++ b/ci/functions.sh
@@ -56,13 +56,13 @@ function _set_IQE_filter_expressions_for_smoke_labels() {
 
     local SMOKE_LABELS="$1"
     if grep -E "aws-smoke-tests" <<< "$SMOKE_LABELS"; then
-        export IQE_FILTER_EXPRESSION="test_api_aws or test_api_ocp_on_aws or test_api_cost_model_aws or test_api_cost_model_ocp_on_aws"
+        export IQE_FILTER_EXPRESSION="test_api_aws or test_api_ocp_on_aws or test_api_ocp_for_aws or test_api_cost_model_aws or test_api_cost_model_ocp_on_aws"
     elif grep -E "azure-smoke-tests" <<< "$SMOKE_LABELS"; then
-        export IQE_FILTER_EXPRESSION="test_api_azure or test_api_ocp_on_azure or test_api_cost_model_azure or test_api_cost_model_ocp_on_azure"
+        export IQE_FILTER_EXPRESSION="test_api_azure or test_api_ocp_on_azure or test_api_ocp_for_azure or test_api_cost_model_azure or test_api_cost_model_ocp_on_azure"
     elif grep -E "gcp-smoke-tests" <<< "$SMOKE_LABELS"; then
-        export IQE_FILTER_EXPRESSION="test_api_gcp or test_api_ocp_on_gcp or test_api_cost_model_gcp or test_api_cost_model_ocp_on_gcp"
+        export IQE_FILTER_EXPRESSION="test_api_gcp or test_api_ocp_on_gcp or test_api_ocp_for_gcp or test_api_cost_model_gcp or test_api_cost_model_ocp_on_gcp"
     elif grep -E "ocp-smoke-tests" <<< "$SMOKE_LABELS"; then
-        export IQE_FILTER_EXPRESSION="(test_api_ocp or test_api_cost_model_ocp or aws_ingest_single or aws_ingest_multi) and not ocp_on_gcp and not ocp_on_azure and not ocp_on_cloud"
+        export IQE_FILTER_EXPRESSION="(test_api_ocp or test_api_cost_model_ocp or aws_ingest_single or aws_ingest_multi) and not ocp_on_gcp and not ocp_on_azure and not ocp_on_cloud and not ocp_for_gcp and not ocp_for_azure"
         export IQE_MARKER_EXPRESSION="cost_smoke and not cost_exclude_ocp_smokes"
     elif grep -E "hot-fix-smoke-tests" <<< "$SMOKE_LABELS"; then
         export IQE_FILTER_EXPRESSION="test_api"


### PR DESCRIPTION
## Jira Ticket

[COST-2768](https://issues.redhat.com/browse/COST-2768)

## Description

Updates PR check script to account for related test updates

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Release Notes
- [ ] proposed release note

```markdown
* [COST-####](https://issues.redhat.com/browse/COST-####) Fix some things
```

## Summary by Sourcery

Update PR check script to reflect renamed smoke test fixtures in IQE filter expressions for AWS, Azure, GCP, and OCP tests.

Enhancements:
- Expand AWS, Azure, and GCP smoke test filters to include the renamed "ocp_for_*" fixtures
- Refine OCP smoke test filters to exclude "ocp_for_gcp" and "ocp_for_azure" labels

CI:
- Modify IQE_FILTER_EXPRESSION in ci/functions.sh to account for the renamed test fixtures