### PR TITLE
remove fetch and load from init

### DIFF
--- a/koku/koku/celery.py
+++ b/koku/koku/celery.py
@@ -15,7 +15,6 @@ from celery.signals import worker_process_init
 from celery.signals import worker_process_shutdown
 from django.conf import settings
 from kombu.exceptions import OperationalError
-from UnleashClient.periodic_tasks import fetch_and_load_features
 
 from .database import FKViolation
 from koku import sentry  # noqa: F401
@@ -275,20 +274,6 @@ def init_worker(**kwargs):
 
     LOG.debug("Initializing UNLEASH_CLIENT for celery worker.")
     UNLEASH_CLIENT.initialize_client()
-    fetch_and_load_features(
-        url=UNLEASH_CLIENT.unleash_url,
-        app_name=UNLEASH_CLIENT.unleash_app_name,
-        instance_id=UNLEASH_CLIENT.unleash_instance_id,
-        headers=UNLEASH_CLIENT.metrics_headers,
-        custom_options=UNLEASH_CLIENT.unleash_custom_options,
-        cache=UNLEASH_CLIENT.cache,
-        engine=UNLEASH_CLIENT.engine,
-        request_timeout=UNLEASH_CLIENT.unleash_request_timeout,
-        request_retries=UNLEASH_CLIENT.unleash_request_retries,
-        project=UNLEASH_CLIENT.unleash_project_name,
-        event_callback=UNLEASH_CLIENT.unleash_event_callback,
-        ready_callback=UNLEASH_CLIENT._ready_callback,
-    )
 
 
 @worker_process_shutdown.connect


### PR DESCRIPTION

## Description

This change will revert https://github.com/project-koku/koku/pull/5695. This didn't resolve the issue we were seeing at the time. This may be currently preventing celery worker initialization if the unleash instance is slow to respond.

## Summary by Sourcery

Enhancements:
- Remove fetch_and_load_features invocation from Celery worker initialization to streamline Unleash client setup