### PR TITLE
fix unit tests

### DIFF
--- a/koku/masu/test/external/downloader/aws/test_aws_report_downloader.py
+++ b/koku/masu/test/external/downloader/aws/test_aws_report_downloader.py
@@ -692,7 +692,7 @@ class AWSReportDownloaderTest(MasuTestCase):
             return_value=start_date,
         ):
             daily_file_names, date_range = create_daily_archives(
-                "trace_id", "account", self.aws_provider_uuid, temp_path, file_name, manifest_id, start_date, None
+                "trace_id", "account", self.aws_provider_uuid, temp_path, file_name, manifest_id, start_date, {}
             )
             expected_date_range = {"start": "2023-06-01", "end": "2023-06-01"}
             mock_copy.assert_called()
@@ -721,7 +721,7 @@ class AWSReportDownloaderTest(MasuTestCase):
             return_value=start_date,
         ):
             daily_file_names, date_range = create_daily_archives(
-                "trace_id", "account", self.aws_provider_uuid, temp_path, file_name, manifest_id, start_date, None
+                "trace_id", "account", self.aws_provider_uuid, temp_path, file_name, manifest_id, start_date, {}
             )
 
         for daily_file in daily_file_names:
@@ -749,7 +749,7 @@ class AWSReportDownloaderTest(MasuTestCase):
 
         start_date = self.dh.this_month_start.replace(year=2023, month=9).date()
         daily_file_names, date_range = create_daily_archives(
-            "trace_id", "account", self.aws_provider_uuid, temp_path, file_name, manifest_id, start_date, None
+            "trace_id", "account", self.aws_provider_uuid, temp_path, file_name, manifest_id, start_date, {}
         )
         self.assertEqual(date_range, {})
         self.assertEqual(daily_file_names, [])
@@ -768,7 +768,7 @@ class AWSReportDownloaderTest(MasuTestCase):
         shutil.copy2(file_path, temp_path)
         start_date = self.dh.this_month_start.replace(year=2023, month=6).date()
         daily_file_names, date_range = create_daily_archives(
-            "trace_id", "account", self.aws_provider_uuid, temp_path, file_name, manifest_id, start_date, None
+            "trace_id", "account", self.aws_provider_uuid, temp_path, file_name, manifest_id, start_date, {}
         )
         self.assertEqual(date_range, {})
         self.assertIsInstance(daily_file_names, list)
@@ -793,7 +793,7 @@ class AWSReportDownloaderTest(MasuTestCase):
             return_value=start_date,
         ):
             daily_file_names, date_range = create_daily_archives(
-                "trace_id", "account", self.aws_provider_uuid, temp_path, file_name, manifest_id, start_date, None
+                "trace_id", "account", self.aws_provider_uuid, temp_path, file_name, manifest_id, start_date, {}
             )
             expected_date_range = {"start": "2022-07-01", "end": "2022-07-01"}
             mock_copy.assert_called()

--- a/koku/masu/test/external/downloader/azure/test_azure_report_downloader.py
+++ b/koku/masu/test/external/downloader/azure/test_azure_report_downloader.py
@@ -425,7 +425,7 @@ class AzureReportDownloaderTest(MasuTestCase):
             return_value=start_date,
         ):
             daily_file_names, date_range = create_daily_archives(
-                "trace_id", "account", self.azure_provider_uuid, temp_path, file, manifest_id, start_date, None
+                "trace_id", "account", self.azure_provider_uuid, temp_path, file, manifest_id, start_date, {}
             )
             expected_date_range = {"start": "2020-09-01", "end": "2020-09-22"}
             mock_copy.assert_called()
@@ -453,7 +453,7 @@ class AzureReportDownloaderTest(MasuTestCase):
             return_value=start_date,
         ):
             create_daily_archives(
-                "trace_id", "account", self.azure_provider_uuid, temp_path, file, manifest_id, start_date, None
+                "trace_id", "account", self.azure_provider_uuid, temp_path, file, manifest_id, start_date, {}
             )
             mock_copy.assert_not_called()
 
@@ -474,7 +474,7 @@ class AzureReportDownloaderTest(MasuTestCase):
             return_value=start_date,
         ):
             daily_file_names, date_range = create_daily_archives(
-                "trace_id", "account", self.aws_provider_uuid, temp_path, file_name, manifest_id, start_date, None
+                "trace_id", "account", self.aws_provider_uuid, temp_path, file_name, manifest_id, start_date, {}
             )
 
         for daily_file in daily_file_names:
@@ -500,7 +500,7 @@ class AzureReportDownloaderTest(MasuTestCase):
         expected_daily_files = []
         start_date = self.dh.this_month_start.replace(year=2020, month=7).date()
         daily_file_names, date_range = create_daily_archives(
-            "trace_id", "account", self.azure_provider_uuid, temp_path, file, manifest_id, start_date, None
+            "trace_id", "account", self.azure_provider_uuid, temp_path, file, manifest_id, start_date, {}
         )
         expected_date_range = {}
         self.assertEqual(date_range, expected_date_range)
@@ -519,7 +519,7 @@ class AzureReportDownloaderTest(MasuTestCase):
         expected_daily_files = []
         start_date = self.dh.this_month_start.replace(year=2020, month=7).date()
         daily_file_names, date_range = create_daily_archives(
-            "trace_id", "account", self.azure_provider_uuid, temp_path, file, manifest_id, start_date, None
+            "trace_id", "account", self.azure_provider_uuid, temp_path, file, manifest_id, start_date, {}
         )
         expected_date_range = {}
         self.assertEqual(date_range, expected_date_range)

--- a/koku/masu/test/external/downloader/azure/test_azure_report_downloader.py
+++ b/koku/masu/test/external/downloader/azure/test_azure_report_downloader.py
@@ -403,8 +403,9 @@ class AzureReportDownloaderTest(MasuTestCase):
         self.assertEqual(result.get("compression"), compression)
         self.assertIsNotNone(result.get("files"))
 
+    @patch("masu.external.downloader.azure.azure_report_downloader.check_provider_setup_complete", return_value=False)
     @patch("masu.external.downloader.azure.azure_report_downloader.copy_local_report_file_to_s3_bucket")
-    def test_create_daily_archives_alt_columns(self, mock_copy):
+    def test_create_daily_archives_alt_columns(self, mock_copy, _):
         """Test that we correctly create daily archive files with alt columns."""
         file = "azure_version_2"
         file_name = f"{file}.csv"
@@ -437,8 +438,9 @@ class AzureReportDownloaderTest(MasuTestCase):
                 os.remove(daily_file)
             os.remove(temp_path)
 
+    @patch("masu.external.downloader.azure.azure_report_downloader.check_provider_setup_complete", return_value=False)
     @patch("masu.external.downloader.azure.azure_report_downloader.copy_local_report_file_to_s3_bucket")
-    def test_create_daily_archives(self, mock_copy):
+    def test_create_daily_archives(self, mock_copy, _):
         """Test that we correctly create daily archive files."""
         file = "costreport_a243c6f2-199f-4074-9a2c-40e671cf1584"
         file_name = f"{file}.csv"
@@ -457,8 +459,9 @@ class AzureReportDownloaderTest(MasuTestCase):
             )
             mock_copy.assert_not_called()
 
+    @patch("masu.external.downloader.azure.azure_report_downloader.check_provider_setup_complete", return_value=False)
     @patch("masu.external.downloader.azure.azure_report_downloader.copy_local_report_file_to_s3_bucket")
-    def test_create_daily_archives_check_leading_zeros(self, mock_copy):
+    def test_create_daily_archives_check_leading_zeros(self, mock_copy, _):
         """Check that the leading zeros are kept when downloading."""
         file = "costreport_a243c6f2-199f-4074-9a2c-40e671cf1584"
         file_name = f"{file}.csv"
@@ -487,8 +490,9 @@ class AzureReportDownloaderTest(MasuTestCase):
 
         os.remove(temp_path)
 
+    @patch("masu.external.downloader.azure.azure_report_downloader.check_provider_setup_complete", return_value=False)
     @patch("masu.external.downloader.azure.azure_report_downloader.copy_local_report_file_to_s3_bucket")
-    def test_create_daily_archives_dates_out_of_range(self, mock_copy):
+    def test_create_daily_archives_dates_out_of_range(self, mock_copy, _):
         """Test that we correctly create daily archive files."""
         file = "costreport_a243c6f2-199f-4074-9a2c-40e671cf1584"
         file_name = f"{file}.csv"
@@ -507,7 +511,8 @@ class AzureReportDownloaderTest(MasuTestCase):
         self.assertIsInstance(daily_file_names, list)
         self.assertEqual(daily_file_names, expected_daily_files)
 
-    def test_create_daily_archives_empty_frames(self):
+    @patch("masu.external.downloader.azure.azure_report_downloader.check_provider_setup_complete", return_value=False)
+    def test_create_daily_archives_empty_frames(self, _):
         """Test that we correctly create daily archive files."""
         file = "empty_frame"
         file_name = f"{file}.csv"

--- a/koku/masu/test/external/downloader/gcp/test_gcp_report_downloader.py
+++ b/koku/masu/test/external/downloader/gcp/test_gcp_report_downloader.py
@@ -211,7 +211,7 @@ class GCPReportDownloaderTest(MasuTestCase):
         ]
         start_date = self.dh.this_month_start
         daily_file_names, date_range = create_daily_archives(
-            "request_id", "account", self.gcp_provider_uuid, [temp_path], None, start_date, None
+            "request_id", "account", self.gcp_provider_uuid, [temp_path], None, start_date, {}
         )
         expected_date_range = {"start": "2022-08-01", "end": "2022-08-01"}
         self.assertEqual(date_range, expected_date_range)
@@ -234,7 +234,7 @@ class GCPReportDownloaderTest(MasuTestCase):
         shutil.copy2(file_path, temp_path)
         start_date = self.dh.this_month_start
         daily_file_names, _ = create_daily_archives(
-            "request_id", "account", self.gcp_provider_uuid, [temp_path], None, start_date, None
+            "request_id", "account", self.gcp_provider_uuid, [temp_path], None, start_date, {}
         )
         for daily_file in daily_file_names:
             with open(daily_file) as file:
@@ -252,7 +252,7 @@ class GCPReportDownloaderTest(MasuTestCase):
             err_msg = "unable to create daily archives from: fake"
             mock_open.side_effect = IOError(err_msg)
             with self.assertRaisesRegex(CreateDailyArchivesError, err_msg):
-                create_daily_archives("request_id", "acccount", self.gcp_provider_uuid, "fake", None, "fake", None)
+                create_daily_archives("request_id", "acccount", self.gcp_provider_uuid, "fake", None, "fake", {})
 
     def test_get_dataset_name(self):
         """Test _get_dataset_name helper."""

--- a/koku/masu/test/external/downloader/gcp_local/test_gcp_local_report_downloader.py
+++ b/koku/masu/test/external/downloader/gcp_local/test_gcp_local_report_downloader.py
@@ -192,7 +192,7 @@ class GCPLocalReportDownloaderTest(MasuTestCase):
 
         start_date = DateHelper().this_month_start
         daily_file_names, date_range = create_daily_archives(
-            "request_id", "account", self.gcp_provider_uuid, file_name, temp_path, None, start_date, None
+            "request_id", "account", self.gcp_provider_uuid, file_name, temp_path, None, start_date, {}
         )
         expected_date_range = {"start": "2020-11-08", "end": "2020-11-11"}
         self.assertEqual(date_range, expected_date_range)


### PR DESCRIPTION
## Jira Ticket

[COST-####](https://issues.redhat.com/browse/COST-####)

## Description

mock `check_provider_setup_complete` for AzureReportDownloaderTest. Previously, these tests relied on provider-setup=False, but that was recently changed in #5747.

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Release Notes
- [ ] proposed release note

```markdown
* [COST-####](https://issues.redhat.com/browse/COST-####) Fix some things
```
