### PR TITLE
Cost 6866 operator version check update

### DIFF
--- a/koku/api/provider/provider_manager.py
+++ b/koku/api/provider/provider_manager.py
@@ -225,7 +225,9 @@ class ProviderManager:
             latest_version = utils.get_latest_operator_version()
             current_version = self.manifest.operator_version.split(":")[-1].lstrip("v")
             try:
-                base_additional_context["operator_update_available"] = Version(current_version) < Version(latest_version)
+                base_additional_context["operator_update_available"] = Version(current_version) < Version(
+                    latest_version
+                )
                 is_supported = Version(current_version) >= Version("4.0.0")
             except InvalidVersion:
                 base_additional_context["operator_update_available"] = False

--- a/koku/api/provider/provider_manager.py
+++ b/koku/api/provider/provider_manager.py
@@ -231,7 +231,7 @@ class ProviderManager:
                 # In this case we should assume the operator is running the latest version
                 is_hash = bool(re.fullmatch(r"[0-9a-fA-F]{40}", current_version))
                 if is_hash:
-                    base_additional_context["operator_update_available"] = True
+                    base_additional_context["operator_update_available"] = False
             try:
                 is_supported = Version(current_version) >= Version("4.0.0")
             except InvalidVersion:

--- a/koku/api/provider/provider_manager.py
+++ b/koku/api/provider/provider_manager.py
@@ -4,6 +4,7 @@
 #
 """Management capabilities for Provider functionality."""
 import logging
+import re
 from datetime import timedelta
 
 from django.conf import settings
@@ -225,6 +226,12 @@ class ProviderManager:
             latest_version = utils.get_latest_operator_version()
             current_version = self.manifest.operator_version.split(":")[-1].lstrip("v")
             base_additional_context["operator_update_available"] = current_version != latest_version
+            if current_version != latest_version:
+                # If the operator has autoupgrade enabled the hash record might ahead of our code.
+                # In this case we should assume the operator is running the latest version
+                is_hash = bool(re.fullmatch(r"[0-9a-fA-F]{40}", current_version))
+                if is_hash:
+                    base_additional_context["operator_update_available"] = True 
             try:
                 is_supported = Version(current_version) >= Version("4.0.0")
             except InvalidVersion:

--- a/koku/api/provider/provider_manager.py
+++ b/koku/api/provider/provider_manager.py
@@ -4,7 +4,6 @@
 #
 """Management capabilities for Provider functionality."""
 import logging
-import re
 from datetime import timedelta
 
 from django.conf import settings
@@ -225,13 +224,7 @@ class ProviderManager:
             base_additional_context["operator_certified"] = self.manifest.operator_certified
             latest_version = utils.get_latest_operator_version()
             current_version = self.manifest.operator_version.split(":")[-1].lstrip("v")
-            base_additional_context["operator_update_available"] = current_version != latest_version
-            if current_version != latest_version:
-                # If the operator has autoupgrade enabled the hash record might ahead of our code.
-                # In this case we should assume the operator is running the latest version
-                is_hash = bool(re.fullmatch(r"[0-9a-fA-F]{40}", current_version))
-                if is_hash:
-                    base_additional_context["operator_update_available"] = False
+            base_additional_context["operator_update_available"] = current_version < latest_version
             try:
                 is_supported = Version(current_version) >= Version("4.0.0")
             except InvalidVersion:

--- a/koku/api/provider/provider_manager.py
+++ b/koku/api/provider/provider_manager.py
@@ -231,7 +231,7 @@ class ProviderManager:
                 # In this case we should assume the operator is running the latest version
                 is_hash = bool(re.fullmatch(r"[0-9a-fA-F]{40}", current_version))
                 if is_hash:
-                    base_additional_context["operator_update_available"] = True 
+                    base_additional_context["operator_update_available"] = True
             try:
                 is_supported = Version(current_version) >= Version("4.0.0")
             except InvalidVersion:

--- a/koku/api/provider/provider_manager.py
+++ b/koku/api/provider/provider_manager.py
@@ -224,7 +224,7 @@ class ProviderManager:
             base_additional_context["operator_certified"] = self.manifest.operator_certified
             latest_version = utils.get_latest_operator_version()
             current_version = self.manifest.operator_version.split(":")[-1].lstrip("v")
-            base_additional_context["operator_update_available"] = current_version < latest_version
+            base_additional_context["operator_update_available"] = Version(current_version) < Version(latest_version)
             try:
                 is_supported = Version(current_version) >= Version("4.0.0")
             except InvalidVersion:

--- a/koku/api/provider/provider_manager.py
+++ b/koku/api/provider/provider_manager.py
@@ -224,10 +224,11 @@ class ProviderManager:
             base_additional_context["operator_certified"] = self.manifest.operator_certified
             latest_version = utils.get_latest_operator_version()
             current_version = self.manifest.operator_version.split(":")[-1].lstrip("v")
-            base_additional_context["operator_update_available"] = Version(current_version) < Version(latest_version)
             try:
+                base_additional_context["operator_update_available"] = Version(current_version) < Version(latest_version)
                 is_supported = Version(current_version) >= Version("4.0.0")
             except InvalidVersion:
+                base_additional_context["operator_update_available"] = False
                 is_supported = False
             base_additional_context["vm_cpu_core_cost_model_support"] = is_supported
         return base_additional_context


### PR DESCRIPTION
## Jira Ticket

[COST-6866](https://issues.redhat.com/browse/COST-6866)

## Description

This change will check the current operator version is less than then current operator version. If the version running is lower than the latest available then we will indicate that the operator needs upgrading. Likewise if the operator version is higher than the version we have available we will take that as the operator is running the latest version.

## Testing

1. Checkout Branch
2. Restart Koku
3. Load OCP data (optionally change the Nise payload to update the version of the operator)
4. check the sources endpoint for True/False regarding "operator_update_available"

Additionally you can just update the record in the DB then reload the sources endpoint to check statuses, use the following query changing the version:

`update reporting_common_costusagereportmanifest SET operator_version = '4.0.0';`

## Release Notes
- [ ] proposed release note

```markdown
* [COST-6866](https://issues.redhat.com/browse/COST-6866) Fix latest operator version check
```

## Summary by Sourcery

Bug Fixes:
- Only flag operator updates when the current version is lower than the latest version instead of any version mismatch