### PR TITLE
[COST-4908] Add unattributed storage to OCP on GCP flow

### DIFF
--- a/koku/masu/database/trino_sql/gcp/openshift/populate_daily_summary/2_summarize_data_by_cluster.sql
+++ b/koku/masu/database/trino_sql/gcp/openshift/populate_daily_summary/2_summarize_data_by_cluster.sql
@@ -31,6 +31,12 @@ FROM hive.{{schema | sqlsafe}}.gcp_line_items as gcp
 WHERE gcp.resource_global_name in (
         SELECT temp.resource_global_name as resource_global_name
         FROM hive.{{schema | sqlsafe}}.managed_gcp_openshift_daily_temp as temp
+        INNER JOIN hive.{{schema | sqlsafe}}.openshift_storage_usage_line_items_daily as ocp
+            ON temp.usage_start = DATE(ocp.interval_start)
+                AND (
+                    (ocp.csi_volume_handle != '' AND strpos(temp.resource_global_name, ocp.csi_volume_handle) != 0)
+                    OR (ocp.csi_volume_handle != '' AND strpos(temp.resource_name, ocp.csi_volume_handle) != 0)
+                )
         WHERE temp.resource_global_name LIKE '%/disk/%'
         AND temp.service_description = 'Compute Engine'
         AND lower(temp.sku_description) LIKE '% pd %'
@@ -38,6 +44,7 @@ WHERE gcp.resource_global_name in (
         AND temp.month = {{month}}
         AND temp.source = {{cloud_provider_uuid}}
         AND temp.ocp_source = {{ocp_provider_uuid}}
+        AND temp.usage_amount > 0
         GROUP BY temp.resource_global_name
     )
     AND month = {{month}}
@@ -52,6 +59,307 @@ WHERE ocp_source = {{ocp_provider_uuid}}
 AND source = {{cloud_provider_uuid}}
 AND year = {{year}}
 AND month = {{month}};
+
+{%- if unattributed_storage -%}
+-- Storage disk resource id matching
+-- Algorthim:
+-- (PV Capacity) / Disk Capacity * Cost of Disk
+INSERT INTO hive.{{schema | sqlsafe}}.managed_reporting_ocpgcpcostlineitem_project_daily_summary_temp (
+    row_uuid,
+    cluster_id,
+    cluster_alias,
+    data_source,
+    namespace,
+    node,
+    persistentvolumeclaim,
+    persistentvolume,
+    storageclass,
+    pod_labels,
+    resource_name,
+    resource_id,
+    usage_start,
+    usage_end,
+    account_id,
+    project_id,
+    project_name,
+    instance_type,
+    service_id,
+    service_alias,
+    sku_id,
+    sku_alias,
+    region,
+    unit,
+    usage_amount,
+    currency,
+    invoice_month,
+    credit_amount,
+    unblended_cost,
+    markup_cost,
+    pod_effective_usage_cpu_core_hours,
+    pod_effective_usage_memory_gigabyte_hours,
+    node_capacity_cpu_core_hours,
+    node_capacity_memory_gigabyte_hours,
+    volume_labels,
+    tags,
+    cost_category_id,
+    resource_id_matched,
+    source,
+    ocp_source,
+    year,
+    month
+)
+SELECT cast(uuid() as varchar) as row_uuid,
+    max(ocp.cluster_id) as cluster_id,
+    max(ocp.cluster_alias) as cluster_alias,
+    max(ocp.data_source),
+    ocp.namespace,
+    max(ocp.node) as node,
+    max(nullif(ocp.persistentvolumeclaim, '')) as persistentvolumeclaim,
+    max(nullif(ocp.persistentvolume, '')) as persistentvolume,
+    max(nullif(ocp.storageclass, '')) as storageclass,
+    ocp.pod_labels as pod_labels,
+    max(gcp.resource_name) as resource_name,
+    max(ocp.resource_id) as resource_id,
+    max(gcp.usage_start) as usage_start,
+    max(gcp.usage_start) as usage_end,
+    max(gcp.account_id) as account_id,
+    max(gcp.project_id) as project_id,
+    max(gcp.project_name) as project_name,
+    max(instance_type) as instance_type,
+    max(nullif(gcp.service_id, '')) as service_id,
+    max(gcp.service_alias) as service_alias,
+    max(gcp.sku_id) as sku_id,
+    max(gcp.sku_alias) as sku_alias,
+    max(nullif(gcp.region, '')) as region,
+    max(gcp.unit) as unit,
+    max(gcp.usage_amount) as usage_amount,
+    max(gcp.currency) as currency,
+    max(gcp.invoice_month) as invoice_month,
+    CASE
+        WHEN max(gcp_disk.capacity) < max(ocp.persistentvolumeclaim_capacity_gigabyte) or max(gcp_disk.capacity) = 0
+        THEN max(gcp.credit_amount)
+        ELSE max(ocp.persistentvolumeclaim_capacity_gigabyte) / max(gcp_disk.capacity) * max(gcp.credit_amount)
+    END as credit_amount,
+    CASE
+        WHEN max(gcp_disk.capacity) < max(ocp.persistentvolumeclaim_capacity_gigabyte) or max(gcp_disk.capacity) = 0
+        THEN max(gcp.unblended_cost)
+        ELSE max(ocp.persistentvolumeclaim_capacity_gigabyte) / max(gcp_disk.capacity) * max(gcp.unblended_cost)
+    END as unblended_cost,
+    CASE
+        WHEN max(gcp_disk.capacity) < max(ocp.persistentvolumeclaim_capacity_gigabyte) or max(gcp_disk.capacity) = 0
+        THEN max(gcp.unblended_cost * {{markup | sqlsafe}})
+        ELSE max(ocp.persistentvolumeclaim_capacity_gigabyte) / max(gcp_disk.capacity) * max(gcp.unblended_cost * {{markup | sqlsafe}})
+    END as markup_cost,
+    sum(ocp.pod_effective_usage_cpu_core_hours) as pod_effective_usage_cpu_core_hours,
+    sum(ocp.pod_effective_usage_memory_gigabyte_hours) as pod_effective_usage_memory_gigabyte_hours,
+    max(ocp.node_capacity_cpu_core_hours) as node_capacity_cpu_core_hours,
+    max(ocp.node_capacity_memory_gigabyte_hours) as node_capacity_memory_gigabyte_hours,
+    ocp.volume_labels,
+    max(gcp.labels) as tags,
+    max(ocp.cost_category_id) as cost_category_id,
+    TRUE as resource_id_matched,
+    {{cloud_provider_uuid}} as source,
+    {{ocp_provider_uuid}} as ocp_source,
+    max(gcp.year) as year,
+    max(gcp.month) as month
+FROM hive.{{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary as ocp
+JOIN hive.{{schema | sqlsafe}}.managed_gcp_openshift_daily_temp as gcp
+    ON gcp.usage_start = ocp.usage_start
+        AND (
+            strpos(gcp.resource_global_name, ocp.csi_volume_handle) != 0
+            OR strpos(gcp.resource_name, ocp.csi_volume_handle) != 0
+        )
+        AND gcp.ocp_source = ocp.source_uuid
+        AND gcp.month = lpad(ocp.month, 2, '0')
+        AND gcp.year = ocp.year
+JOIN hive.{{schema | sqlsafe}}.managed_gcp_openshift_disk_capacities_temp as gcp_disk
+    ON  gcp_disk.usage_start = gcp.usage_start
+        AND gcp_disk.resource_global_name = gcp.resource_global_name
+        AND gcp_disk.year = gcp.year
+        AND gcp_disk.month = gcp.month
+        AND gcp_disk.source = gcp.source
+        AND gcp_disk.ocp_source = gcp.ocp_source
+WHERE ocp.source = {{ocp_provider_uuid}}
+    AND ocp.data_source = 'Storage'
+    AND ocp.year = {{year}}
+    AND lpad(ocp.month, 2, '0') = {{month}} -- Zero pad the month when fewer than 2 characters
+    AND ocp.day IN {{days_tup | inclause}}
+    AND (ocp.csi_volume_handle IS NOT NULL AND ocp.csi_volume_handle != '')
+    AND (ocp.resource_id IS NOT NULL AND ocp.resource_id != '')
+    AND gcp.ocp_source = {{ocp_provider_uuid}}
+    AND gcp.source = {{cloud_provider_uuid}}
+    AND gcp.year = {{year}}
+    AND gcp.month = {{month}}
+    -- Filter out Node Network Costs because they cannot be tied to namespace level
+    AND data_transfer_direction IS NULL
+    AND gcp.resource_id_matched = TRUE
+GROUP BY gcp.row_uuid, ocp.namespace, ocp.pod_labels, ocp.volume_labels
+{% endif %}
+;
+
+{%- if unattributed_storage -%}
+INSERT INTO hive.{{schema | sqlsafe}}.managed_reporting_ocpgcpcostlineitem_project_daily_summary_temp (
+    row_uuid,
+    cluster_id,
+    cluster_alias,
+    data_source,
+    namespace,
+    node,
+    persistentvolumeclaim,
+    persistentvolume,
+    storageclass,
+    pod_labels,
+    resource_name,
+    resource_id,
+    usage_start,
+    usage_end,
+    account_id,
+    project_id,
+    project_name,
+    instance_type,
+    service_id,
+    service_alias,
+    sku_id,
+    sku_alias,
+    region,
+    unit,
+    usage_amount,
+    currency,
+    invoice_month,
+    credit_amount,
+    unblended_cost,
+    markup_cost,
+    pod_effective_usage_cpu_core_hours,
+    pod_effective_usage_memory_gigabyte_hours,
+    node_capacity_cpu_core_hours,
+    node_capacity_memory_gigabyte_hours,
+    volume_labels,
+    tags,
+    cost_category_id,
+    resource_id_matched,
+    source,
+    ocp_source,
+    year,
+    month
+)
+WITH cte_total_pv_capacity as (
+    SELECT
+        gcp_resource_name,
+        SUM(combined_requests.capacity) as total_pv_capacity,
+        count(distinct cluster_id) as cluster_count
+    FROM (
+        SELECT
+            ocp.persistentvolume,
+            max(ocp.persistentvolumeclaim_capacity_gigabyte) as capacity,
+            gcp.resource_global_name as gcp_resource_name,
+            ocp.cluster_id
+        FROM hive.{{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary as ocp
+        JOIN hive.{{schema | sqlsafe}}.managed_gcp_openshift_daily_temp as gcp
+            ON (gcp.usage_start = ocp.usage_start)
+            AND strpos(gcp.resource_global_name, ocp.csi_volume_handle) > 0
+            AND ocp.csi_volume_handle is not null
+            AND ocp.csi_volume_handle != ''
+        WHERE ocp.year = {{year}}
+            AND lpad(ocp.month, 2, '0') = {{month}}
+            AND ocp.usage_start >= {{start_date}}
+            AND ocp.usage_start < date_add('day', 1, {{end_date}})
+            AND gcp.ocp_source = {{ocp_provider_uuid}}
+            AND gcp.year = {{year}}
+            AND gcp.month = {{month}}
+            AND gcp.resource_id_matched = True
+        GROUP BY ocp.persistentvolume, gcp.resource_global_name, ocp.cluster_id
+    ) as combined_requests group by gcp_resource_name
+)
+SELECT cast(uuid() as varchar) as row_uuid,
+    max(ocp.cluster_id) as cluster_id,
+    max(ocp.cluster_alias) as cluster_alias,
+    max(ocp.data_source),
+    'Unattributed storage',
+    max(ocp.node) as node,
+    max(nullif(ocp.persistentvolumeclaim, '')) as persistentvolumeclaim,
+    max(nullif(ocp.persistentvolume, '')) as persistentvolume,
+    max(nullif(ocp.storageclass, '')) as storageclass,
+    ocp.pod_labels as pod_labels,
+    max(gcp.resource_name) as resource_name,
+    max(ocp.resource_id) as resource_id,
+    max(gcp.usage_start) as usage_start,
+    max(gcp.usage_start) as usage_end,
+    max(gcp.account_id) as account_id,
+    max(gcp.project_id) as project_id,
+    max(gcp.project_name) as project_name,
+    max(instance_type) as instance_type,
+    max(nullif(gcp.service_id, '')) as service_id,
+    max(gcp.service_alias) as service_alias,
+    max(gcp.sku_id) as sku_id,
+    max(gcp.sku_alias) as sku_alias,
+    max(nullif(gcp.region, '')) as region,
+    max(gcp.unit) as unit,
+    max(gcp.usage_amount) as usage_amount,
+    max(gcp.currency) as currency,
+    max(gcp.invoice_month) as invoice_month,
+    CASE
+        WHEN max(gcp_disk.capacity) < max(pv_cap.total_pv_capacity) or max(gcp_disk.capacity) = 0
+        THEN max(0)
+        ELSE (max(gcp_disk.capacity) - max(pv_cap.total_pv_capacity)) / max(gcp_disk.capacity) * max(gcp.credit_amount) / max(pv_cap.cluster_count)
+    END as credit_amount,
+    CASE
+        WHEN max(gcp_disk.capacity) < max(pv_cap.total_pv_capacity) or max(gcp_disk.capacity) = 0
+        THEN max(0)
+        ELSE (max(gcp_disk.capacity) - max(pv_cap.total_pv_capacity)) / max(gcp_disk.capacity) * max(gcp.unblended_cost) / max(pv_cap.cluster_count)
+    END as unblended_cost,
+    CASE
+        WHEN max(gcp_disk.capacity) < max(pv_cap.total_pv_capacity) or max(gcp_disk.capacity) = 0
+        THEN max(0)
+        ELSE (max(gcp_disk.capacity) - max(pv_cap.total_pv_capacity)) / max(gcp_disk.capacity) * max(gcp.unblended_cost * {{markup | sqlsafe}}) / max(pv_cap.cluster_count)
+    END as markup_cost,
+    sum(ocp.pod_effective_usage_cpu_core_hours) as pod_effective_usage_cpu_core_hours,
+    sum(ocp.pod_effective_usage_memory_gigabyte_hours) as pod_effective_usage_memory_gigabyte_hours,
+    max(ocp.node_capacity_cpu_core_hours) as node_capacity_cpu_core_hours,
+    max(ocp.node_capacity_memory_gigabyte_hours) as node_capacity_memory_gigabyte_hours,
+    ocp.volume_labels,
+    max(gcp.labels) as tags,
+    max(ocp.cost_category_id) as cost_category_id,
+    TRUE as resource_id_matched,
+    {{cloud_provider_uuid}} as source,
+    {{ocp_provider_uuid}} as ocp_source,
+    max(gcp.year) as year,
+    max(gcp.month) as month
+FROM hive.{{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary as ocp
+JOIN hive.{{schema | sqlsafe}}.managed_gcp_openshift_daily_temp as gcp
+    ON gcp.usage_start = ocp.usage_start
+        AND (
+            strpos(gcp.resource_global_name, ocp.csi_volume_handle) != 0
+            OR strpos(gcp.resource_name, ocp.csi_volume_handle) != 0
+        )
+        AND gcp.ocp_source = ocp.source_uuid
+        AND gcp.month = lpad(ocp.month, 2, '0')
+        AND gcp.year = ocp.year
+JOIN hive.{{schema | sqlsafe}}.managed_gcp_openshift_disk_capacities_temp as gcp_disk
+    ON  gcp_disk.usage_start = gcp.usage_start
+        AND gcp_disk.resource_global_name = gcp.resource_global_name
+        AND gcp_disk.year = gcp.year
+        AND gcp_disk.month = gcp.month
+        AND gcp_disk.source = gcp.source
+        AND gcp_disk.ocp_source = gcp.ocp_source
+LEFT JOIN cte_total_pv_capacity as pv_cap
+    ON pv_cap.gcp_resource_name = gcp.resource_global_name
+WHERE ocp.source = {{ocp_provider_uuid}}
+    AND ocp.data_source = 'Storage'
+    AND ocp.year = {{year}}
+    AND lpad(ocp.month, 2, '0') = {{month}} -- Zero pad the month when fewer than 2 characters
+    AND ocp.day IN {{days_tup | inclause}}
+    AND (ocp.csi_volume_handle IS NOT NULL AND ocp.csi_volume_handle != '')
+    AND (ocp.resource_id IS NOT NULL AND ocp.resource_id != '')
+    AND gcp.ocp_source = {{ocp_provider_uuid}}
+    AND gcp.source = {{cloud_provider_uuid}}
+    AND gcp.year = {{year}}
+    AND gcp.month = {{month}}
+    -- Filter out Node Network Costs because they cannot be tied to namespace level
+    AND data_transfer_direction IS NULL
+    AND gcp.resource_id_matched = TRUE
+GROUP BY gcp.row_uuid, ocp.namespace, ocp.pod_labels, ocp.volume_labels
+{%- endif -%}
+;
 
 -- Direct resource_id matching
 INSERT INTO hive.{{schema | sqlsafe}}.managed_reporting_ocpgcpcostlineitem_project_daily_summary_temp (
@@ -146,10 +454,6 @@ JOIN hive.{{schema | sqlsafe}}.managed_gcp_openshift_daily_temp as gcp
         AND (
             (strpos(gcp.resource_name, ocp.node) != 0 AND ocp.data_source='Pod')
             OR (strpos(gcp.resource_name, ocp.persistentvolume) != 0 AND ocp.data_source='Storage')
-            {%- if unattributed_storage -%}
-            OR (ocp.csi_volume_handle != '' AND strpos(gcp.resource_global_name, ocp.csi_volume_handle) != 0)
-            OR (ocp.csi_volume_handle != '' AND strpos(gcp.resource_name, ocp.csi_volume_handle) != 0)
-            {% endif %}
         )
 WHERE ocp.source = {{ocp_provider_uuid}}
     AND ocp.year = {{year}}


### PR DESCRIPTION
## Jira Ticket

[COST-4908](https://issues.redhat.com/browse/COST-4908)

## Description

This change will ...

## Testing:
QE Branch: `COST-5444-Add_persistent_disk_generator_for_GCP`
Test: `test_api_ocp_on_cloud_storage_validate_data_integrity`

Start by getting an understanding of how much the disk cost is over the month:
```
select sum(cost) from gcp_line_items_daily where resource_name='projects/todays-raw-calc-id/disk/sc_gcp_shared_across_clusters_disk'
AND month='09'
AND year='2025';
```
`630.0000504000001`

Now we figure out how much of the cost has been divided to the pvcs.


```
select sum(unblended_cost)
from managed_reporting_ocpgcpcostlineitem_project_daily_summary_temp
where resource_name='projects/todays-raw-calc-id/disk/sc_gcp_shared_across_clusters_disk'
AND month='09'
AND year='2025';
```
`630.0000504000001`


```
select sum(unblended_cost),
namespace
from managed_reporting_ocpgcpcostlineitem_project_daily_summary_temp
where resource_name='projects/todays-raw-calc-id/disk/sc_gcp_shared_across_clusters_disk'
AND month='09'
AND year='2025'
GROUP by namespace;
```

```
       _col0        |      namespace
--------------------+----------------------
 168.00001344000006 | test_kikis
  252.0000201600001 | Unattributed storage
 210.00001679999994 | test_pom
 ```

Then we can get a breakdown of how the cost was distributed with:
```
SELECT max(ocp.cluster_id) as cluster_id,
    ocp.namespace,
    max(nullif(ocp.persistentvolumeclaim, '')) as persistentvolumeclaim,
    max(gcp.resource_name) as resource_name,
    max(gcp.usage_amount) as usage_amount,
    max(gcp_disk.capacity) as gcp_disk,
    max(ocp.persistentvolumeclaim_capacity_gigabyte),
    max(gcp.unblended_cost),
    max(ocp.persistentvolumeclaim_capacity_gigabyte) / max(gcp_disk.capacity) * max(gcp.unblended_cost) as portioned_cost
FROM reporting_ocpusagelineitem_daily_summary as ocp
JOIN managed_gcp_openshift_daily_temp as gcp
    ON gcp.usage_start = ocp.usage_start
        AND (
            strpos(gcp.resource_global_name, ocp.csi_volume_handle) != 0
            OR strpos(gcp.resource_name, ocp.csi_volume_handle) != 0
        )
        AND gcp.ocp_source = ocp.source_uuid
        AND gcp.month = lpad(ocp.month, 2, '0')
        AND gcp.year = ocp.year
JOIN managed_gcp_openshift_disk_capacities_temp as gcp_disk
    ON  gcp_disk.usage_start = gcp.usage_start
        AND gcp_disk.resource_global_name = gcp.resource_global_name
        AND gcp_disk.year = gcp.year
        AND gcp_disk.month = gcp.month
        AND gcp_disk.source = gcp.source
        AND gcp_disk.ocp_source = gcp.ocp_source
WHERE ocp.csi_volume_handle != ''
    AND ocp.csi_volume_handle IS NOT NULL
    AND ocp.data_source = 'Storage'
    AND ocp.year = '2025'
    AND lpad(ocp.month, 2, '0') = '09' -- Zero pad the month when fewer than 2 characters
    AND (ocp.resource_id IS NOT NULL AND ocp.resource_id != '')
    AND gcp.source = 'a75ac673-800c-45fe-87cb-73d98ac68a3a'
    AND gcp.year = '2025'
    AND gcp.month = '09'
    AND data_transfer_direction IS NULL
    AND gcp.resource_id_matched = TRUE
GROUP BY gcp.row_uuid, ocp.namespace, ocp.data_source
```

## Release Notes
- [ ] proposed release note

```markdown
* [COST-####](https://issues.redhat.com/browse/COST-####) Fix some things
```
