### PR TITLE
Expand AWS tag rate limiting to include aws_category queries

### DIFF
--- a/koku/api/common/test_throttling.py
+++ b/koku/api/common/test_throttling.py
@@ -128,8 +128,8 @@ class AwsTagQueryThrottleGetCacheKeyTest(TestCase):
         }
         self.assertIsNone(throttle.get_cache_key(request, None))
 
-    def test_get_cache_key_no_tag_returns_none(self):
-        """When query has no tag in filter or group_by, return None."""
+    def test_get_cache_key_no_tag_or_aws_category_returns_none(self):
+        """When query has no tag or aws_category in filter or group_by, return None."""
         throttle = AwsTagQueryThrottle()
         request = Mock()
         request.user.customer.schema_name = "acct123"
@@ -210,3 +210,18 @@ class AwsTagQueryThrottleGetCacheKeyTest(TestCase):
                 key = throttle.get_cache_key(request, None)
                 self.assertIsNotNone(key, f"time_scope_value={value} should be heavy")
                 self.assertEqual(key, "tag_query_throttle:aws:acct123")
+
+    @patch("api.common.throttling.is_feature_flag_enabled_by_schema", return_value=True)
+    def test_get_cache_key_aws_category_filter_returns_key(self, mock_flag):
+        """Requests with filter[aws_category:...] and heavy time scope are throttled."""
+        throttle = AwsTagQueryThrottle()
+        request = Mock()
+        request.user.customer.schema_name = "acct7049367"
+        request.query_params = {
+            "filter[aws_category:CostCenter]": "106,665,706",
+            "time_scope_units": "month",
+            "time_scope_value": "-1",
+        }
+        key = throttle.get_cache_key(request, None)
+        self.assertIsNotNone(key, "aws_category filter with month scope should be throttled")
+        self.assertEqual(key, "tag_query_throttle:aws:acct7049367")

--- a/koku/api/common/throttling.py
+++ b/koku/api/common/throttling.py
@@ -45,6 +45,13 @@ class BaseTagQueryThrottle(SimpleRateThrottle):
             return None
 
         flag_enabled = is_feature_flag_enabled_by_schema(schema_name, TAG_QUERY_RATE_LIMIT_FLAG)
+        scope = getattr(self, "cache_key_label", None) or "ocp"
+        LOG.info(
+            "Tag query throttle: schema=%s scope=%s flag_enabled=%s",
+            schema_name,
+            scope,
+            flag_enabled,
+        )
         if not flag_enabled:
             return None
 

--- a/koku/api/common/throttling.py
+++ b/koku/api/common/throttling.py
@@ -154,20 +154,11 @@ class AwsTagQueryThrottle(BaseTagQueryThrottle):
     scope = "aws_tag_query"
     cache_key_label = "aws"
 
-    @staticmethod
-    def _get_param_keys_with_tag_or_aws_category(query_params):
-        """
-        Return query param keys that contain 'tag:' or 'aws_category' in a filter or group_by context.
-        """
-        return [
-            key
-            for key in query_params
-            if ("filter" in key or "group_by" in key) and ("tag:" in key or "aws_category" in key)
-        ]
-
     def _has_tag_query(self, query_params):
         """AWS: any param with tag or aws_category in filter or group_by."""
-        return bool(self._get_param_keys_with_tag_or_aws_category(query_params))
+        return any(
+            ("filter" in key or "group_by" in key) and ("tag:" in key or "aws_category" in key) for key in query_params
+        )
 
     def _is_heavy_query(self, query_params):
         """AWS: heavy when time_scope_units=month and time_scope_value in (-1, -2, -3)."""

--- a/koku/api/common/throttling.py
+++ b/koku/api/common/throttling.py
@@ -44,7 +44,8 @@ class BaseTagQueryThrottle(SimpleRateThrottle):
         if not self._is_heavy_query(request.query_params):
             return None
 
-        if not is_feature_flag_enabled_by_schema(schema_name, TAG_QUERY_RATE_LIMIT_FLAG):
+        flag_enabled = is_feature_flag_enabled_by_schema(schema_name, TAG_QUERY_RATE_LIMIT_FLAG)
+        if not flag_enabled:
             return None
 
         cache_key = self._build_cache_key(schema_name)
@@ -144,7 +145,7 @@ class OcpTagQueryThrottle(BaseTagQueryThrottle):
 
 class AwsTagQueryThrottle(BaseTagQueryThrottle):
     """
-    Throttle heavy AWS report queries that use tag (filter or group_by) and large time scope.
+    Throttle heavy AWS report queries that use tag or aws_category (filter or group_by) and large time scope.
 
     Limits such requests to one per 12 hours per schema for customers flagged via
     the same Unleash flag as OcpTagQueryThrottle (cost-management.backend.rate-limit-tag-queries).
@@ -153,9 +154,20 @@ class AwsTagQueryThrottle(BaseTagQueryThrottle):
     scope = "aws_tag_query"
     cache_key_label = "aws"
 
+    @staticmethod
+    def _get_param_keys_with_tag_or_aws_category(query_params):
+        """
+        Return query param keys that contain 'tag:' or 'aws_category' in a filter or group_by context.
+        """
+        return [
+            key
+            for key in query_params
+            if ("filter" in key or "group_by" in key) and ("tag:" in key or "aws_category" in key)
+        ]
+
     def _has_tag_query(self, query_params):
-        """AWS: any param with tag in filter or group_by."""
-        return bool(self._get_param_keys_with_tag(query_params))
+        """AWS: any param with tag or aws_category in filter or group_by."""
+        return bool(self._get_param_keys_with_tag_or_aws_category(query_params))
 
     def _is_heavy_query(self, query_params):
         """AWS: heavy when time_scope_units=month and time_scope_value in (-1, -2, -3)."""


### PR DESCRIPTION
This change extends the existing AWS tag-query throttle so that heavy requests using **`aws_category`** (e.g. `filter[aws_category:CostCenter]=...`) are also rate-limited, in addition to requests using `tag:` in filter or group_by.

Production timeout/SIGKILL alerts have shown that a significant share of heavy AWS cost report requests use **only** `aws_category` (no `tag:` in the query). Those requests were not previously covered by the throttle and could run repeatedly, contributing to worker timeouts. This PR closes that gap. OCP throttle behavior is unchanged.

## Release Notes

- [ ] Proposed release note:

```markdown
* Expand AWS tag rate limiting to include requests using `aws_category` (e.g. filter[aws_category:CostCenter]) in addition to tag-based filters, reducing worker timeouts from heavy AWS cost report queries for flagged customers.
```
