### PR TITLE
COST-7249: Align cost breakdown design with COST-575 PriceList infrastructure

### DIFF
--- a/docs/architecture/cost-breakdown/README.md
+++ b/docs/architecture/cost-breakdown/README.md
@@ -13,6 +13,14 @@ of aggregated totals.
 the current cost model architecture, rate types, distribution, and data
 model that this feature extends.
 
+**Prerequisite work**: [COST-575](https://redhat.atlassian.net/browse/COST-575) —
+PriceList infrastructure (model, dual-write, data migration) landed on
+`main` via PRs [#5963](https://github.com/project-koku/koku/pull/5963)
+and [#5957](https://github.com/project-koku/koku/pull/5957). Phase 1 of
+this design builds on top of that infrastructure. See the tech lead's
+[migration coordination gist](https://gist.github.com/myersCody/91195a531ada9c09d39a5c5234993654)
+for the shared dual-write strategy.
+
 ---
 
 ## Decisions Needed from Tech Lead
@@ -24,10 +32,10 @@ where noted.
 |---|----------|--------|---------------|----------|--------------|
 | **IQ-1** | Single source of truth: RatesToUsage with aggregation to daily summary. | **RESOLVED** | ~Phase 2~ | [Details](#iq-1-aggregation-granularity-mismatch-phase-2-3) | [`poc/insert_usage_rates_to_usage.sql`](./poc/insert_usage_rates_to_usage.sql) demonstrates fine-grained GROUP BY |
 | **IQ-3** | Flat-row DB storage with both flat and nested API response formats. | **RESOLVED** | ~Phase 4~ | [Details](#iq-3-breakdown-api-response-format-phase-4) | [`poc/reporting_ocp_cost_breakdown_p.sql`](./poc/reporting_ocp_cost_breakdown_p.sql) produces flat rows with path columns |
-| **IQ-6** | Remove speculative `PriceList.usage_start` / `usage_end` fields (not in PRD). | **RESOLVED** | ~Phase 1~ | [Details](#iq-6-pricelistusage_startusage_end-phase-1) | — |
+| **IQ-6** | `PriceList` date fields. COST-575 shipped `effective_start_date`/`effective_end_date` — kept as-is. | **SUPERSEDED** | ~Phase 1~ | [Details](#iq-6-pricelistusage_startusage_end-phase-1) | — |
 | **IQ-7** | `custom_name` optional with auto-generation from `description` or `metric.name`. Backward compatible. | **RESOLVED** | ~Phase 1~ | [Details](#iq-7-backward-compatibility-for-custom_name-phase-1) | [`poc/price_list_compat.py`](./poc/price_list_compat.py) validates backward-compatible format |
 | **IQ-8** | `cost_type` on `OCPCostUIBreakDownP`. | **RESOLVED** | ~Phase 4~ | [Details](#iq-8-cost_type-on-ocpcostuibreakdownp-phase-4) | — |
-| **IQ-9** | Distribution per-rate identity: preserve per-rate breakdown for distributed costs. | **RESOLVED** | ~Phase 4~ | Distribution rewritten to operate on per-rate `RatesToUsage` rows (Option 1). Old distribution SQL deprecated; new files read from `RatesToUsage` + daily summary usage metrics. [Details](#iq-9-distribution-per-rate-identity-gap) | [sql-pipeline.md](./sql-pipeline.md) (pipeline sketches; Option 2 back-allocation retained as fallback) |
+| **IQ-9** | Distribution per-rate identity: preserve per-rate breakdown for distributed costs. | **RESOLVED** | ~Phase 4~ | Distribution rewritten to operate on per-rate `RatesToUsage` rows (Option 1). Old distribution SQL deprecated; new files read from `RatesToUsage` + daily summary usage metrics. [Details](#iq-9-distribution-per-rate-identity-gap) | [sql-pipeline.md](./sql-pipeline.md) (pipeline sketches for the selected Option 1 path) |
 
 ### What the spikes resolved
 
@@ -303,8 +311,8 @@ see [`poc/reporting_ocp_cost_breakdown_p.sql`](./poc/reporting_ocp_cost_breakdow
 Source 2. With **IQ-9 Option 1** (selected), per-rate distribution is
 reflected in `RatesToUsage` (`distributed_cost` rows); breakdown
 population reads those rows (see [IQ-9](#iq-9-distribution-per-rate-identity-gap)).
-Option 2 (back-allocation in breakdown SQL only) remains documented as a
-viable fallback — see [README § IQ-9 Options](#iq-9-distribution-per-rate-identity-gap).
+Option 2 (back-allocation in breakdown SQL only) remains documented in
+historical notes for context, but is not an active fallback path.
 
 ### IQ-5: SQL approach for RatesToUsage INSERTs (Phase 2)
 
@@ -355,16 +363,16 @@ The `label_hash` column (R13 mitigation) is computed in the CTE and
 used by the aggregation step for GROUP BY / JOIN instead of JSONB
 equality. See [sql-pipeline.md § The Aggregation Step](./sql-pipeline.md#the-aggregation-step).
 
-### IQ-6: `PriceList.usage_start/usage_end` (Phase 1)
+### IQ-6: `PriceList.usage_start/usage_end` (Phase 1) — SUPERSEDED
 
 **Problem**: Speculative fields not in the PRD.
 
-**Proposal: Remove them.**
+**Original proposal**: Remove them (YAGNI principle).
 
-Koku's existing models are minimal. `CostModel` has no date-bounding
-on rates. Adding speculative fields contradicts the YAGNI principle.
-If time-bounded pricing is needed later, the columns can be added in a
-future migration with no impact on existing data.
+**Superseded**: COST-575 shipped the `PriceList` model with
+`effective_start_date` and `effective_end_date` fields already on
+`main`. These fields are kept as-is. The original proposal to remove
+date-bounding fields is moot — no action required.
 
 ### IQ-7: Backward compatibility for `custom_name` (Phase 1) — RESOLVED
 
@@ -383,7 +391,7 @@ custom_name = serializers.CharField(max_length=50, required=False, allow_blank=T
 ```
 
 If not provided, auto-generate from `description` or `metric.name`
-using the same `generate_custom_name()` logic from migration M3. This
+using the same `generate_custom_name()` logic from migration M2. This
 is backward compatible — existing API consumers work without changes,
 and new consumers can set meaningful names.
 
@@ -478,7 +486,7 @@ orchestration (`ocp_cost_model_cost_updater.py`,
 | # | Approach | Invasiveness | Per-rate identity | Infrastructure handling | Risk |
 |---|----------|-------------|-------------------|------------------------|------|
 | 1 | **Rewrite distribution SQL** to read from `RatesToUsage` + daily summary usage (**selected**) | HIGH (new distribution files; deprecate old; GPU sequencing unchanged in importance) | Full | Raw cost as dedicated `RatesToUsage` row (`monthly_cost_type = 'raw_cost'`) | Regression risk mitigated by new files + rollback via old file set |
-| 2 | Back-allocate proportionally (breakdown population only) | MEDIUM (no distribution rewrite) | Cost model rates: full. Infrastructure: one aggregate entry. | "Infrastructure" entry under each distribution node | Proportional approximation; join complexity — **viable fallback** |
+| 2 | Back-allocate proportionally (breakdown population only) | MEDIUM (no distribution rewrite) | Cost model rates: full. Infrastructure: one aggregate entry. | "Infrastructure" entry under each distribution node | Proportional approximation; join complexity — **historical alternative (not selected)** |
 | 3 | Show aggregate only | NONE | None | N/A | Feature value reduced for overhead drill-down |
 
 #### Recommendation: Option 1 — distribute at per-rate level
@@ -518,9 +526,8 @@ orchestration (`ocp_cost_model_cost_updater.py`,
    `RatesToUsage` per namespace/day (`monthly_cost_type = 'raw_cost'`),
    included in the same distribution and aggregation path.
 
-Option 2 (back-allocation) remains a documented fallback if the team
-needs to avoid touching distribution SQL — see
-[sql-pipeline.md § Back-Allocation SQL](./sql-pipeline.md#back-allocation-sql-sketch).
+Option 2 (back-allocation) is retained only as historical context in
+design notes. It is not a runtime fallback path for implementation.
 
 #### Resolved
 
@@ -563,21 +570,24 @@ open questions on this decision set.
 
 | Document | Type | Summary |
 |----------|------|---------|
-| [data-model.md](./data-model.md) | DD | New Django models (`PriceList`, `Rate`, `RatesToUsage` / `rates_to_usage`, `OCPCostUIBreakDownP`), `custom_name` migration strategy, tree structure definition |
+| [data-model.md](./data-model.md) | DD | Django models (`Rate` (new), `RatesToUsage` / `rates_to_usage` (new), `OCPCostUIBreakDownP` (new), `PriceList` (existing, COST-575)), `custom_name` migration strategy, tree structure definition |
 | [sql-pipeline.md](./sql-pipeline.md) | DD | Current vs proposed data flow, SQL file inventory (20+ files across 3 paths), `CostModelDBAccessor` changes, aggregation step design |
 | [api-and-frontend.md](./api-and-frontend.md) | DD | Cost model API changes (`custom_name`, dual-write), new breakdown endpoint, frontend components, export integration |
 | [phased-delivery.md](./phased-delivery.md) | DD | 5-phase plan with per-phase artifacts, validation criteria, rollback strategy, risk register |
-| [risk-register.md](./risk-register.md) | Ref | Consolidated risk register (R1-R19), decision rationales, benchmarking plan, phase matrix |
+| [risk-register.md](./risk-register.md) | Ref | Consolidated risk register (R1-R20), decision rationales, benchmarking plan, phase matrix |
+| [open-concerns.md](./open-concerns.md) | Ref | Concerns register (all resolved): 5 concerns with due diligence findings, Gaps A-F closed with conservative defaults in `api-and-frontend.md`. |
+| [test-plan.md](./test-plan.md) | QA | IEEE 829 test plan for Phase 1: 7 TDD phases, 68 test cases, 7 checkpoints, 12 due diligence findings. |
 
 ---
 
 ## Architecture at a Glance
 
-### Current Data Flow
+### Current Data Flow (Post–COST-575)
 
 ```mermaid
 graph TD
-    CM["CostModel.rates<br/>(JSON blob)"] --> Accessor["CostModelDBAccessor<br/>price_list property"]
+    CM["CostModel.rates<br/>(JSON blob)"] -->|"dual-write<br/>(COST-575)"| PL["PriceList.rates<br/>(JSON mirror)"]
+    CM --> Accessor["CostModelDBAccessor<br/>price_list property"]
     Accessor --> UsageSQL["usage_costs.sql<br/>+ monthly_cost_*.sql<br/>+ *_tag_rates.sql"]
     UsageSQL -->|"cost_model_cpu_cost<br/>cost_model_memory_cost<br/>cost_model_volume_cost<br/>(aggregated scalars)"| DailySummary["reporting_ocpusagelineitem<br/>_daily_summary"]
     DailySummary --> DistSQL["distribute_platform_cost.sql<br/>distribute_worker_cost.sql<br/>+ 3 more"]
@@ -591,7 +601,7 @@ graph TD
 
 ```mermaid
 graph TD
-    CM["CostModel.rates (JSON)<br/>+ Rate table (new)"] --> Accessor["CostModelDBAccessor<br/>reads from Rate table"]
+    CM["CostModel.rates (JSON)<br/>+ PriceList (COST-575)<br/>+ Rate table (new)"] --> Accessor["CostModelDBAccessor<br/>reads from Rate table"]
 
     Accessor --> RTU_SQL["insert_usage_rates_to_usage.sql<br/>+ monthly_cost_*.sql<br/>+ *_tag_rates.sql<br/>+ raw cost row per ns/day"]
     RTU_SQL -->|"per-rate rows at fine grain<br/>(pod_labels, volume_labels,<br/>persistentvolumeclaim, all_labels)"| RatesToUsage["RatesToUsage<br/>(new, partitioned)<br/>table: rates_to_usage"]
@@ -638,8 +648,9 @@ validation query verifies aggregation correctness in integration tests.
 | Aggregation step | Kept (single source of truth) | Tech lead confirmed: eliminates dual-path maintenance and data integrity risk |
 | Breakdown API format | Flat DB rows, both flat and nested API responses | Tech lead confirmed: UI mocks require both views; flat DB storage with server-side tree construction for nested view |
 | `custom_name` backward compatibility | `required=False` with auto-generation | Tech lead confirmed: existing API consumers work unchanged; new consumers can set meaningful names |
-| Feature flags | None | Dual-write (JSON + Rate table) is the rollback mechanism; no Unleash flags |
-| Distribution SQL changes | **RESOLVED** — IQ-9 Option 1 (distribute at per-rate level) | Distribution rewritten: reads per-rate costs from `RatesToUsage` and usage metrics from daily summary; **DELETE + INSERT** of `distributed_cost` rows back to `RatesToUsage`; aggregation then rolls up to daily summary. Old SQL files deprecated, new files for rollback. Option 2 (back-allocate) remains a documented fallback. |
+| PriceList table | Reuse COST-575's existing `price_list` table | Single PriceList concept shared between COST-575 (lifecycle management) and cost breakdown (per-rate normalization). Avoids parallel tables. See [migration coordination gist](https://gist.github.com/myersCody/91195a531ada9c09d39a5c5234993654). |
+| Feature flags | Unleash write-freeze for migration windows | `cost-management.backend.disable-cost-model-writes` blocks API writes during M2 and M5; dual-write remains the rollback mechanism for schema changes |
+| Distribution SQL changes | **RESOLVED** — IQ-9 Option 1 (distribute at per-rate level) | Distribution rewritten: reads per-rate costs from `RatesToUsage` and usage metrics from daily summary; **DELETE + INSERT** of `distributed_cost` rows back to `RatesToUsage`; aggregation then rolls up to daily summary. Old SQL files deprecated, new files for rollback. Option 2 is retained only as historical design context, not as an implementation fallback. |
 | Sankey chart changes | None | Sankey reads from existing report API which is unchanged |
 | Rate table read path | Switched in Phase 1, permanent in Phase 5 | Dual-write preserves JSON for rollback |
 | Future scalability | Single source of truth scales for upcoming features | Price List Lifecycles (multiple price lists) and Consumer & Provider (multiple cost models) compound dual-write overhead; single calculation point avoids this |
@@ -665,3 +676,7 @@ are versioned together. Each version corresponds to a commit on the
 | v3.0 | 2026-03-19 | — | **IQ-9 RESOLVED (Option 1)**, **IQ-6 RESOLVED**, **IQ-8 RESOLVED**. Adopt per-rate distribution (Option 1): distribution reads from `RatesToUsage` + daily summary usage, writes per-rate distributed rows back to `RatesToUsage`. Drop `cost_type` from `OCPCostUIBreakDownP`. Rename `CostModelRatesToUsage` → `RatesToUsage` / `cost_model_rates_to_usage` → `rates_to_usage`. Add `distributed_cost` column and infrastructure raw cost row. Update mermaid: distribution before aggregation. R14 eliminated, R15 replaced, R18 added. |
 | v3.1 | 2026-03-19 | — | **Risk extraction.** Create [risk-register.md](./risk-register.md) as consolidated risk reference (R1-R19). Slim down decision rationale tables in data-model.md, sql-pipeline.md, phased-delivery.md to one-line links. Add R19 (aggregation + `distributed_cost` — open). Update document catalog. |
 | v3.2 | 2026-03-23 | — | **R19 RESOLVED (Option A).** Aggregation sums both `calculated_cost` and `distributed_cost`. R18 mitigation confirmed: existing integration tests sufficient. Update residual risks. |
+| v4.0 | 2026-04-02 | — | **Align with COST-575.** Phase 1 now builds on existing `price_list` table from COST-575 ([#5963](https://github.com/project-koku/koku/pull/5963), [#5957](https://github.com/project-koku/koku/pull/5957)). IQ-6 superseded. Migration numbers renumbered (M1-M5). Current Data Flow updated to show COST-575 dual-write. Reference tech lead's [migration coordination gist](https://gist.github.com/myersCody/91195a531ada9c09d39a5c5234993654). All documents updated. |
+| v4.1 | 2026-04-02 | — | **R20: Migration write-freeze flag.** Add Unleash flag `cost-management.backend.disable-cost-model-writes` to block API writes during M2/M5 migration windows. Update Key Design Decisions (feature flags). R20 added to risk-register.md with decision rationale. All documents updated. |
+| v4.2 | 2026-04-02 | — | **Critical review fixes.** Move write-freeze gating from `CostModelManager` to `CostModelSerializer` (manager lacks schema context; serializer has `self.customer.schema_name`). Add `@transaction.atomic` to `create()` pseudocode. Fix Document Catalog risk range (R1-R20). Add `Decimal()` conversion note to M2 pseudocode. Clarify PriceList.rates lifecycle comment. |
+| v4.3 | 2026-04-03 | — | **Tech lead follow-up consistency pass.** Remove stale Option 2 fallback language from active IQ-9 guidance and document catalog. Align distribution decision text with tech lead direction (Option 1 is the implementation path). |

--- a/docs/architecture/cost-breakdown/api-and-frontend.md
+++ b/docs/architecture/cost-breakdown/api-and-frontend.md
@@ -204,6 +204,15 @@ class CostModelManager:
 
 **Diff-based sync design decisions**:
 
+- **Client recommendation: always round-trip `rate_id`**. Once a GET
+  response includes `rate_id`, clients (UI and API consumers) should
+  persist and send it back on every subsequent PUT. This enables
+  stable UUID matching, safe renames (the backend identifies the rate
+  by UUID, not name), and unlocks CASCADE + scoped recalculation in
+  later phases. Omitting `rate_id` should be treated as **legacy-only
+  behavior** — it triggers `custom_name` fallback matching, which
+  makes renames ambiguous (effectively delete + create) and prevents
+  the backend from distinguishing "rename" from "replace".
 - **Backward compatibility**: When `rate_id` is absent from the payload,
   the backend matches by `custom_name` (using the existing
   `unique_together` constraint). This preserves `Rate.uuid` for

--- a/docs/architecture/cost-breakdown/api-and-frontend.md
+++ b/docs/architecture/cost-breakdown/api-and-frontend.md
@@ -7,34 +7,59 @@ breakdown endpoint, and the frontend integration plan.
 
 ## Cost Model API Changes
 
-### `RateSerializer` — Add `custom_name` Field
+### `RateSerializer` — Add `custom_name` and `rate_id` Fields
 
 File: `cost_models/serializers.py`
 
 `RateSerializer` currently handles `metric`, `cost_type`, `description`,
-`tiered_rates`, and `tag_rates`. Add `custom_name`:
+`tiered_rates`, and `tag_rates`. Add `custom_name` and `rate_id`:
 
 ```python
 class RateSerializer(serializers.Serializer):
+    rate_id = serializers.UUIDField(required=False, allow_null=True)
     custom_name = serializers.CharField(max_length=50, required=False, allow_blank=True)
     metric = serializers.DictField(required=True)
     cost_type = serializers.ChoiceField(choices=COST_TYPE_CHOICES, required=True)
     description = serializers.CharField(required=False, allow_blank=True)
     tiered_rates = TieredRateSerializer(many=True, required=False)
     tag_rates = TagRateSerializer(required=False)
+
+    def to_representation(self, rate_obj):
+        out = super().to_representation(rate_obj)
+        # rate_obj is a dict from the JSON blob — rate_id is injected
+        # during dual-write (see _sync_rate_table). The existing
+        # to_representation builds a fixed output dict; rate_id must be
+        # added explicitly since the base method only emits declared
+        # fields that are present in rate_obj.
+        if "rate_id" in rate_obj:
+            out["rate_id"] = rate_obj["rate_id"]
+        return out
 ```
 
-**Validation rules**:
+**`rate_id` field notes**:
+
+- `rate_id` is the `Rate.uuid` (primary key). It is read-write:
+  GET responses include it; PUT requests may include it.
+- `rate_id` must be declared as an explicit field (not rely on the
+  custom `to_internal_value()` passthrough, which is fragile).
+- `to_representation()` must explicitly include `rate_id` because the
+  existing implementation builds a fixed output dict from the JSON blob
+  and does not pass through arbitrary extra keys.
+- `rate_id` is injected into the JSON blob during dual-write (see
+  `_sync_rate_table` below), so it is available in `rate_obj` for
+  GET serialization.
+
+**`custom_name` validation rules**:
 
 - `custom_name` is optional — if not provided, auto-generated from
-  `description` or `metric.name` (same logic as migration M3)
+  `description` or `metric.name` (same logic as migration M2)
 - `custom_name` must be unique within the cost model's rates (validated
   at `CostModelSerializer` level, not per-rate)
 - `custom_name` max length: 50 characters
 
 **IQ-7 RESOLVED**: Tech lead confirmed. `custom_name` is added as
 `required=False` with auto-generation from `description` or
-`metric.name` (same logic as migration M3). This is backward
+`metric.name` (same logic as migration M2). This is backward
 compatible — existing API consumers work unchanged.
 See [README.md § IQ-7](../cost-breakdown/README.md#iq-7-backward-compatibility-for-custom_name-phase-1).
 
@@ -51,70 +76,185 @@ On `create()` and `update()`, the serializer delegates to
 `CostModelManager.update()`. The dual-write logic belongs in
 `CostModelManager`, not in the serializer.
 
-**Transaction safety note**: `CostModelManager.create()` already uses
-`@transaction.atomic`, but `update()` does not — it only calls
-`self._model.save()`. Adding `_sync_rate_table()` to `update()` means
-the JSON save and the Rate table sync must be atomic. Wrap `update()`
-in `@transaction.atomic` to prevent partial writes.
+**Transaction safety note**: `CostModelManager.update()` already has
+`@transaction.atomic` (added by COST-575 PR #5963). Adding
+`_sync_rate_table()` to `update()` means the JSON save, PriceList.rates
+sync, and Rate table sync are all atomic — no additional wrapping needed.
 
 ```python
-# cost_models/cost_model_manager.py (modified)
+# cost_models/cost_model_manager.py (modified — extends COST-575 dual-write)
 class CostModelManager:
+    @transaction.atomic  # already present from COST-575
     def create(self, **kwargs):
         # Existing: creates CostModel with rates JSON
         cost_model = CostModel.objects.create(**cost_model_data)
         # ...existing provider mapping logic...
 
-        # New: sync to relational tables
-        self._sync_rate_table(cost_model, kwargs.get("rates", []))
+        # COST-575: _get_or_create_price_list() already creates PriceList + mapping
+        # New: sync to Rate table
+        if self._model.rates:
+            pl = self._get_or_create_price_list()  # existing COST-575 method
+            self._sync_rate_table(pl, kwargs.get("rates", []))
         return cost_model
 
-    @transaction.atomic   # REQUIRED: existing update() has no transaction!
+    @transaction.atomic   # already present from COST-575
     def update(self, **kwargs):
         # Existing: updates CostModel fields including rates JSON
-        self.instance.rates = kwargs.get("rates", self.instance.rates)
-        self.instance.save()
-        # ...existing logic...
+        self._model.rates = kwargs.get("rates", self._model.rates)
+        self._model.save()
 
-        # New: sync to relational tables
-        self._sync_rate_table(self.instance, kwargs.get("rates", []))
+        # COST-575: syncs PriceList.rates JSON
+        if "rates" in kwargs:
+            pl = self._get_or_create_price_list()
+            if pl:
+                pl.rates = self._model.rates
+                pl.save(update_fields=["rates", "updated_timestamp"])
+                # New: sync to Rate table
+                self._sync_rate_table(pl, kwargs.get("rates", []))
 
     def _sync_rate_table(self, price_list, rates_data):
-        """Sync Rate table rows using diff-based sync.
+        """Diff-based sync of Rate table rows.
 
-        Matching: rate_id (UUID) first, then custom_name fallback.
-        Operations: delete stale -> update matched -> create new.
-        Raises CostModelException for invalid/unowned rate_id.
-        Note: tag_values defaults to list (not dict) to match JSON shape.
+        Matches incoming rates to existing Rate rows by rate_id (if
+        present) or custom_name (backward-compat fallback). Operations
+        are ordered delete → update → create to avoid transient
+        UniqueConstraint violations on (price_list, custom_name).
+
+        After sync, injects rate_id (Rate.uuid) back into the JSON
+        blob so GET responses include it.
         """
-        existing_by_uuid = {r.uuid: r for r in Rate.objects.filter(price_list=price_list)}
-        existing_by_name = {r.custom_name: r for r in existing_by_uuid.values()}
-        # ... classify incoming rates into to_update / to_create ...
+        existing = {r.uuid: r for r in price_list.rate_rows.all()}
+        existing_by_name = {r.custom_name: r for r in existing.values()}
+        incoming_ids = set()
+        to_update = []
+        to_create = []
 
-        # Phase 1: DELETE stale rows
-        Rate.objects.filter(price_list=price_list, uuid__in=to_delete_uuids).delete()
+        for rate_data in rates_data:
+            rate_id = rate_data.get("rate_id")
+            if rate_id:
+                if rate_id not in existing:
+                    raise CostModelException(f"Invalid rate_id: {rate_id}")
+                # Validate ownership: rate_id must belong to this price_list
+                rate_obj = existing[rate_id]
+                incoming_ids.add(rate_id)
+                to_update.append((rate_obj, rate_data))
+            else:
+                # Backward-compat: match by custom_name if no rate_id
+                name = rate_data.get("custom_name") or generate_custom_name(rate_data)
+                if name in existing_by_name:
+                    rate_obj = existing_by_name[name]
+                    incoming_ids.add(rate_obj.uuid)
+                    to_update.append((rate_obj, rate_data))
+                else:
+                    to_create.append(rate_data)
 
-        # Phase 2: UPDATE matched rows (via _apply_rate_fields)
+        # Phase 1: delete → update → create (ordering avoids unique constraint violations)
+        to_delete = [r for uid, r in existing.items() if uid not in incoming_ids]
+        for rate_obj in to_delete:
+            rate_obj.delete()
+
         for rate_obj, rate_data in to_update:
-            self._apply_rate_fields(rate_obj, rate_data)
-            rate_obj.save()
+            changed = self._apply_rate_fields(rate_obj, rate_data)
+            if changed:
+                rate_obj.save()
+            rate_data["rate_id"] = str(rate_obj.uuid)
 
-        # Phase 3: CREATE new rows
-        Rate.objects.bulk_create([
-            Rate(price_list=price_list, **self._rate_fields_from_data(rd))
-            for rd in to_create_data
-        ])
+        for rate_data in to_create:
+            rate_obj = Rate.objects.create(
+                price_list=price_list,
+                **self._rate_fields_from_data(rate_data),
+            )
+            rate_data["rate_id"] = str(rate_obj.uuid)
+
+        # Inject rate_id back into JSON blobs for GET serialization
+        self._model.rates = rates_data
+        self._model.save(update_fields=["rates"])
+        price_list.rates = rates_data
+        price_list.save(update_fields=["rates", "updated_timestamp"])
+
+    COST_AFFECTING_FIELDS = {"default_rate", "tag_values", "metric", "cost_type"}
+
+    def _apply_rate_fields(self, rate_obj, rate_data):
+        """Update rate_obj fields from rate_data. Returns True if any
+        cost-affecting field changed (requires recalculation)."""
+        fields = self._rate_fields_from_data(rate_data)
+        changed = False
+        for attr, value in fields.items():
+            if getattr(rate_obj, attr) != value:
+                setattr(rate_obj, attr, value)
+                if attr in self.COST_AFFECTING_FIELDS:
+                    changed = True
+        return changed
+
+    @staticmethod
+    def _rate_fields_from_data(rate_data):
+        """Extract Rate model fields from a rate data dict."""
+        tag_rates = rate_data.get("tag_rates", {})
+        return {
+            "custom_name": rate_data.get("custom_name") or generate_custom_name(rate_data),
+            "description": rate_data.get("description", ""),
+            "metric": rate_data["metric"]["name"],
+            "metric_type": derive_metric_type(rate_data["metric"]["name"]),
+            "cost_type": rate_data["cost_type"],
+            "default_rate": extract_default_rate(rate_data),
+            "tag_key": tag_rates.get("tag_key", ""),
+            "tag_values": tag_rates.get("tag_values", []),
+        }
 ```
+
+**Diff-based sync design decisions**:
+
+- **Backward compatibility**: When `rate_id` is absent from the payload,
+  the backend matches by `custom_name` (using the existing
+  `unique_together` constraint). This preserves `Rate.uuid` for
+  unchanged rates even before the frontend ships `rate_id` support.
+  Renaming a rate without `rate_id` behaves as delete + create (the
+  old name is unmatched, the new name is created).
+- **Validation**: `rate_id` is validated for both existence AND
+  ownership — it must belong to the correct price_list. This prevents
+  a user from referencing a `rate_id` from a different cost model
+  within the same schema.
+- **Operation ordering**: Deletes run first, then updates, then creates.
+  This avoids transient `UniqueConstraint` violations on
+  `(price_list, custom_name)` when a rate is renamed and a new rate
+  takes its old name in the same request.
+- **Change detection**: `COST_AFFECTING_FIELDS` defines which fields
+  trigger recalculation. Metadata-only changes (`description`,
+  `custom_name`) update the Rate row but do not trigger the Celery
+  recalculation task. Phase 1 uses a conservative approach — any
+  cost-affecting field change triggers full-window recalculation
+  (current month). Scoped per-rate recalculation is a future
+  optimization (see below).
+- **`rate_id` injection**: After sync, `rate_id` (as string UUID) is
+  injected back into `rates_data` and saved to both `CostModel.rates`
+  and `PriceList.rates` JSON blobs. This ensures GET responses include
+  `rate_id` without changing the read path.
+
+**Scoped recalculation — deferred optimization**:
+
+Phase 1 triggers full-window recalculation (current month) on any
+cost-affecting change, regardless of how many rates changed. This is
+the existing behavior and is correct.
+
+Scoped recalculation (passing `affected_rate_ids` to the Celery task
+so only changed rates are reprocessed) requires non-trivial changes to
+the `update_cost_model_costs` task signature, worker cache dedup key,
+and the monolithic `update_summary_cost_model_costs()` pipeline in
+`ocp_cost_model_cost_updater.py`. The aggregation step must still
+process all rates (it's a SUM over all `RatesToUsage` rows), so savings
+are limited to the INSERT step. This optimization is deferred to a
+future phase.
 
 ### `CostModelDBAccessor` — Read Path
 
 File: `masu/database/cost_model_db_accessor.py`
 
-Switch `price_list` property to read from the `Rate` table. The
-dual-write approach (JSON + Rate table) ensures the JSON path can be
-restored by reverting the code if needed. The output dict format must be
-identical to the current JSON-based path so all downstream callers work
-unchanged. See
+Switch `price_list` property to read from the `Rate` table. The query
+path is: `CostModel → PriceListCostModelMap → PriceList → Rate`. The
+dual-write approach (JSON + PriceList.rates + Rate table) ensures the
+JSON path can be restored by reverting the code if needed. The output
+dict format must be identical to the current JSON-based path so all
+downstream callers work unchanged. See
 [sql-pipeline.md § CostModelDBAccessor Changes](./sql-pipeline.md#costmodeldbcaccessor-changes).
 
 ---
@@ -286,14 +426,90 @@ Database-level pagination per PRD:
 - Consistent `ORDER BY path, depth` before pagination
 - All filter/order columns are indexed
 
-### No Feature Flags
+### Migration Write-Freeze Flag (Unleash)
 
-No feature flags are used for any part of this feature. The breakdown
+An Unleash feature flag gates cost model API writes during critical
+migration windows to prevent data corruption from concurrent writes.
+
+**Flag name**: `cost-management.backend.disable-cost-model-writes`
+
+**Convention**: Follows the existing "enable flag to disable writes"
+pattern used by `is_cloud_source_processing_disabled` and
+`is_summary_processing_disabled` in `masu/processor/__init__.py`.
+
+**Helper function** (new, in `masu/processor/__init__.py`):
+
+```python
+COST_MODEL_WRITE_FREEZE_FLAG = "cost-management.backend.disable-cost-model-writes"
+
+def is_cost_model_writes_disabled(schema):  # pragma: no cover
+    """Disable cost model writes during migration windows."""
+    context = {"schema": schema}
+    res = UNLEASH_CLIENT.is_enabled(COST_MODEL_WRITE_FREEZE_FLAG, context)
+    if res:
+        LOG.info(log_json(msg="cost model writes disabled for migration", context=context))
+    return res
+```
+
+**Gating in `CostModelSerializer`** (in `cost_models/serializers.py`):
+
+The check belongs in the serializer — not `CostModelManager` — because
+`validated_data` does not carry a `schema` key, while the serializer
+already accesses `self.customer.schema_name` for provider validation.
+
+```python
+from masu.processor import is_cost_model_writes_disabled
+
+class CostModelSerializer(BaseSerializer):
+    # ... existing fields ...
+
+    def create(self, validated_data):
+        schema = self.customer.schema_name if self.customer else None
+        if schema and is_cost_model_writes_disabled(schema):
+            raise serializers.ValidationError(
+                error_obj("cost-models", "Cost model writes are temporarily disabled during migration.")
+            )
+        source_uuids = validated_data.pop("source_uuids", [])
+        validated_data.update({"provider_uuids": source_uuids})
+        try:
+            return CostModelManager().create(**validated_data)
+        except CostModelException as error:
+            raise serializers.ValidationError(error_obj("cost-models", str(error)))
+
+    def update(self, instance, validated_data, *args, **kwargs):
+        schema = self.customer.schema_name if self.customer else None
+        if schema and is_cost_model_writes_disabled(schema):
+            raise serializers.ValidationError(
+                error_obj("cost-models", "Cost model writes are temporarily disabled during migration.")
+            )
+        # ... existing update logic (CostModelManager().update) ...
+```
+
+**API response**: `serializers.ValidationError` with a write-freeze
+message is returned by the serializer. The view should catch this
+specific case and return `HTTP 503 Service Unavailable` with a
+`Retry-After` header. This follows the HTTP semantics for temporary
+unavailability and matches the existing `CostModelException` handling
+pattern.
+
+**When to enable / disable**:
+
+| Window | Enable before | Disable after |
+|--------|--------------|---------------|
+| M2 data migration (Phase 1) | `django-admin migrate` for M2 | M2 completes + validation passes |
+| M5 column drop (Phase 5) | `django-admin migrate` for M5 | M5 completes + regression passes |
+
+**On-prem behavior**: `MockUnleashClient` returns `False` by default,
+so the write-freeze flag is never active on-prem. On-prem deployments
+manage migration windows through operator coordination (maintenance
+window in `koku-metrics-operator`).
+
+**No other feature flags** are used for this feature. The breakdown
 endpoint returns empty results if `OCPCostUIBreakDownP` is not populated
 (Phases 1-3). Phase 4 populates the table and the endpoint starts
-returning data. The dual-write approach (JSON + Rate table) is the
-rollback mechanism for the backend schema changes — reverting code
-restores the JSON read path.
+returning data. The dual-write approach (JSON + Rate table) remains the
+rollback mechanism for schema changes — reverting code restores the JSON
+read path.
 
 ---
 
@@ -421,4 +637,6 @@ CSV columns per PRD: `Project, Level 1 (Category), Level 2 (Sub-Category), Metri
 | v2.2 | 2026-03-17 | IQ-3 resolved: split single serializer into CostBreakdownFlatItemSerializer + CostBreakdownTreeNodeSerializer. Add ?view=tree query param. Update flat and tree JSON response examples. |
 | v2.3 | 2026-03-17 | Blast-radius triage: fix RateSerializer `custom_name` from `required=True` to `required=False` (align with IQ-7 resolution). Update validation rules. |
 | v3.0 | 2026-03-19 | **IQ-8 RESOLVED.** Drop `cost_type` from provider map, serializers, and JSON examples (PM + tech lead confirmed not needed). |
-| v3.1 | 2026-04-06 | **Spec-vs-impl alignment.** Update `_sync_rate_table` pseudocode: rate_id matching first (then custom_name fallback), delete→update→create ordering, `tag_values` defaults to list. |
+| v4.0 | 2026-04-02 | **Align with COST-575.** Update `_sync_rate_table` to use existing `PriceList` via `_get_or_create_price_list()` (COST-575 method). `related_name` is `rate_rows`. `@transaction.atomic` already present from COST-575. Update read path to query through `PriceListCostModelMap`. |
+| v4.1 | 2026-04-02 | **Migration write-freeze flag (R20).** Replace "No Feature Flags" section with Unleash write-freeze flag (`cost-management.backend.disable-cost-model-writes`). Add helper function, `CostModelManager` gating, HTTP 503 behavior, enable/disable windows, on-prem behavior. |
+| v4.2 | 2026-04-02 | **Critical review.** Move write-freeze gating from `CostModelManager` to `CostModelSerializer` — `validated_data` lacks schema context; serializer has `self.customer.schema_name`. Add `@transaction.atomic` to `create()` pseudocode. |

--- a/docs/architecture/cost-breakdown/data-model.md
+++ b/docs/architecture/cost-breakdown/data-model.md
@@ -51,37 +51,102 @@ Example JSON structure:
 name, and sums tiered rate values when multiple rates share the same
 metric and cost type. Per-rate identity is lost at this point.
 
+### COST-575 Foundation (Already on `main`)
+
+[COST-575](https://redhat.atlassian.net/browse/COST-575) landed a
+`PriceList` infrastructure that this design builds on. Two PRs
+established the base:
+
+| PR | What it delivered | Migration |
+|----|-------------------|-----------|
+| [#5963](https://github.com/project-koku/koku/pull/5963) | `PriceList` model (`price_list` table), `PriceListCostModelMap` junction table, dual-write in `CostModelManager` | `0010_add_price_list_models` |
+| [#5957](https://github.com/project-koku/koku/pull/5957) | Data migration copying `CostModel.rates` JSON into `PriceList.rates` for all existing cost models | `0011_migrate_cost_model_rates_to_price_lists` |
+
+The existing `PriceList` stores rates as a **JSON blob** — the same
+denormalized format as `CostModel.rates`. This design extends it with
+a normalized `Rate` table that extracts individual rates into relational
+rows, adding the `custom_name` field required for per-rate breakdown
+display.
+
+The tech lead's [migration coordination gist](https://gist.github.com/myersCody/91195a531ada9c09d39a5c5234993654)
+describes the shared dual-write strategy that both COST-575 and cost
+breakdown follow:
+
+```
+CostModel (1) ──< (many) PriceList (1) ──< (many) Rate
+```
+
+**Key design decision**: We reuse the existing `price_list` table and
+`price_list_cost_model_map` junction table from COST-575 rather than
+creating parallel tables. The `Rate` table is the only new schema
+addition in Phase 1.
+
+The existing models on `main`:
+
+```python
+# cost_models/models.py (existing, from COST-575)
+class PriceList(models.Model):
+    class Meta:
+        db_table = "price_list"
+        ordering = ["name"]
+        indexes = [
+            models.Index(fields=["name"], name="price_list_name_idx"),
+            models.Index(fields=["effective_start_date", "effective_end_date"], name="price_list_validity_idx"),
+        ]
+
+    uuid = models.UUIDField(primary_key=True, default=uuid4)
+    name = models.TextField()
+    description = models.TextField()
+    currency = models.TextField()
+    effective_start_date = models.DateField()
+    effective_end_date = models.DateField()
+    enabled = models.BooleanField(default=True)
+    version = models.PositiveIntegerField(default=1)
+    rates = JSONField()                                    # denormalized — supplemented by Rate table in Phase 1, dropped in Phase 5
+    created_timestamp = models.DateTimeField(auto_now_add=True)
+    updated_timestamp = models.DateTimeField(auto_now=True)
+
+class PriceListCostModelMap(models.Model):
+    class Meta:
+        db_table = "price_list_cost_model_map"
+        ordering = ["priority"]
+        unique_together = ("price_list", "cost_model")
+
+    price_list = models.ForeignKey("PriceList", on_delete=models.CASCADE, related_name="cost_model_maps")
+    cost_model = models.ForeignKey("CostModel", on_delete=models.CASCADE, related_name="price_list_maps")
+    priority = models.PositiveIntegerField()
+```
+
+**What COST-575 dual-write already does** (in `CostModelManager`):
+
+- On `create()`: if rates are present, calls `_get_or_create_price_list()`
+  which creates a `PriceList` row with the JSON blob and links it via
+  `PriceListCostModelMap`
+- On `update()`: if rates changed, syncs `PriceList.rates` JSON from
+  `CostModel.rates`. Wrapped in `@transaction.atomic`.
+- Data migration `0011`: for existing cost models, creates `PriceList`
+  rows locked with `SELECT ... FOR UPDATE`, skips already-mapped models
+  (idempotent)
+
 ---
 
 ## New Models
 
-### PriceList
+### PriceList (Existing — from COST-575)
 
-Normalizes the relationship between a cost model and its rates.
-Replaces the JSON blob as the source of truth (via dual-write from
-`CostModelManager` during Phases 1-4).
+The `PriceList` model and `PriceListCostModelMap` junction table already
+exist on `main` (see [Current State § COST-575 Foundation](#cost-575-foundation-already-on-main)).
+No new PriceList table is created in Phase 1.
 
-```python
-# cost_models/models.py (new)
-class PriceList(models.Model):
-    class Meta:
-        db_table = "cost_model_price_list"
-        indexes = [
-            models.Index(fields=["cost_model"], name="pricelist_cost_model_idx"),
-        ]
+The existing `price_list` table includes `effective_start_date` and
+`effective_end_date` fields. **IQ-6 is superseded**: the original
+proposal to remove date-bounding fields is moot because COST-575
+shipped them. They remain as-is.
 
-    uuid = models.UUIDField(primary_key=True, default=uuid4)
-    cost_model = models.ForeignKey("CostModel", on_delete=models.CASCADE, related_name="price_lists")
-    primary = models.BooleanField(default=True)
-    fallback = models.BooleanField(default=False)
-    # IQ-6 PROPOSAL: Remove usage_start/usage_end — PRD does not
-    # require time-bounded pricing. Can be added in a future migration.
-```
-
-**IQ-6 PROPOSAL**: Remove `usage_start` and `usage_end`. Koku's
-existing models are minimal (`CostModel` has no date-bounding). The
-PRD doesn't require time-bounded rates. See
-[README.md § IQ-6](./README.md#iq-6-pricelistusage_startusage_end-phase-1).
+The link between `CostModel` and `PriceList` is through the
+`PriceListCostModelMap` junction table (many-to-many), not a direct FK.
+This supports future scenarios where multiple cost models share a price
+list, or a cost model has multiple price lists.
 
 ### Rate
 
@@ -89,7 +154,7 @@ Individual rate definition. The `custom_name` field is the key addition
 that enables per-rate breakdown display.
 
 ```python
-# cost_models/models.py (new)
+# cost_models/models.py (new — Phase 1)
 class Rate(models.Model):
     class Meta:
         db_table = "cost_model_rate"
@@ -107,12 +172,15 @@ class Rate(models.Model):
     metric = models.CharField(max_length=100)              # e.g. "cpu_core_usage_per_hour"
     metric_type = models.CharField(max_length=20)          # cpu, memory, storage, gpu
     cost_type = models.CharField(max_length=20)            # Infrastructure, Supplementary
-    default_rate = models.DecimalField(max_digits=33, decimal_places=15, null=True)  # null for tag-only rates
+    default_rate = models.DecimalField(max_digits=33, decimal_places=15)
     tag_key = models.CharField(max_length=253, blank=True, default="")
-    tag_values = JSONField(default=list)                   # [{tag_value, value, unit, ...}]
-    created_timestamp = models.DateTimeField(auto_now_add=True)
-    updated_timestamp = models.DateTimeField(auto_now=True)
+    tag_values = JSONField(default=dict)                   # [{tag_value, value, unit, ...}]
 ```
+
+The `Rate` FK points to the existing `price_list` table from COST-575.
+The `related_name` is `rate_rows` (not `rates`) to avoid collision with
+the existing `PriceList.rates` JSONField. The path from `CostModel` to
+`Rate` is: `CostModel → PriceListCostModelMap → PriceList → Rate`.
 
 **Constraints**:
 
@@ -383,78 +451,59 @@ later migrations depend on earlier ones.
 
 ### Migration Sequence Overview
 
+COST-575 migrations `0010` and `0011` are prerequisites. Phase 1 adds
+only the `Rate` table (M1) and a data migration to populate it (M2).
+
 ```mermaid
 graph TD
+    subgraph COST575["COST-575 (already on main)"]
+        M0010["0010: PriceList +<br/>PriceListCostModelMap"]
+        M0011["0011: Data migration<br/>CostModel.rates → PriceList.rates"]
+        M0010 --> M0011
+    end
+
     subgraph Phase1["Phase 1: Schema Normalization"]
-        M1["M1: Create PriceList table"]
-        M2["M2: Create Rate table"]
-        M3["M3: Data migration<br/>JSON → Rate rows + custom_name"]
-        M1 --> M2 --> M3
+        M1["M1: Create Rate table"]
+        M2["M2: Data migration<br/>PriceList.rates JSON → Rate rows + custom_name"]
+        M1 --> M2
     end
 
     subgraph Phase2["Phase 2: Rate Calculation Isolation"]
-        M4["M4: Create RatesToUsage<br/>(partitioned)"]
+        M3["M3: Create RatesToUsage<br/>(partitioned)"]
     end
 
     subgraph Phase4["Phase 4: Breakdown UI"]
-        M5["M5: Create OCPCostUIBreakDownP<br/>(partitioned)"]
+        M4["M4: Create OCPCostUIBreakDownP<br/>(partitioned)"]
     end
 
     subgraph Phase5["Phase 5: Cleanup"]
-        M6["M6: Drop CostModel.rates<br/>JSONField column"]
+        M5["M5: Drop CostModel.rates<br/>+ PriceList.rates JSONFields"]
     end
 
-    Phase1 --> Phase2 --> Phase4 --> Phase5
+    COST575 --> Phase1 --> Phase2 --> Phase4 --> Phase5
 ```
 
 ---
 
-### M1: Create `cost_model_price_list` Table
-
-**Phase**: 1
-**Type**: Schema migration (auto-generated by `makemigrations`)
-**App**: `cost_models`
-**Depends on**: latest existing `cost_models` migration
-
-```sql
-CREATE TABLE cost_model_price_list (
-    uuid         UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-    cost_model_id UUID NOT NULL REFERENCES cost_model(uuid) ON DELETE CASCADE,
-    "primary"    BOOLEAN NOT NULL DEFAULT TRUE,
-    fallback     BOOLEAN NOT NULL DEFAULT FALSE
-    -- IQ-6 PROPOSAL: usage_start and usage_end removed.
-    -- PRD does not require time-bounded pricing.
-    -- Can be added in a future migration if needed.
-);
-
-CREATE INDEX pricelist_cost_model_idx ON cost_model_price_list (cost_model_id);
-```
-
-**Rollback**: `DROP TABLE cost_model_price_list CASCADE;`
-
----
-
-### M2: Create `cost_model_rate` Table
+### M1: Create `cost_model_rate` Table
 
 **Phase**: 1
 **Type**: Schema migration (auto-generated)
 **App**: `cost_models`
-**Depends on**: M1
+**Depends on**: `0011_migrate_cost_model_rates_to_price_lists` (COST-575)
 
 ```sql
 CREATE TABLE cost_model_rate (
     uuid          UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-    price_list_id UUID NOT NULL REFERENCES cost_model_price_list(uuid) ON DELETE CASCADE,
+    price_list_id UUID NOT NULL REFERENCES price_list(uuid) ON DELETE CASCADE,
     custom_name   VARCHAR(50) NOT NULL,
     description   TEXT NOT NULL DEFAULT '',
     metric        VARCHAR(100) NOT NULL,
     metric_type   VARCHAR(20) NOT NULL,
     cost_type     VARCHAR(20) NOT NULL,
-    default_rate  NUMERIC(33, 15),              -- nullable for tag-only rates
+    default_rate  NUMERIC(33, 15) NOT NULL,
     tag_key       VARCHAR(253) NOT NULL DEFAULT '',
-    tag_values    JSONB NOT NULL DEFAULT '[]'::jsonb,  -- list, not dict
-    created_timestamp TIMESTAMPTZ NOT NULL DEFAULT now(),
-    updated_timestamp TIMESTAMPTZ NOT NULL DEFAULT now(),
+    tag_values    JSONB NOT NULL DEFAULT '{}'::jsonb,
 
     UNIQUE (price_list_id, custom_name)
 );
@@ -464,81 +513,101 @@ CREATE INDEX rate_custom_name_idx ON cost_model_rate (custom_name);
 CREATE INDEX rate_metric_idx ON cost_model_rate (metric);
 ```
 
-**Rollback**: `DROP TABLE cost_model_rate CASCADE;` (cascades from
-`cost_model_price_list` if M1 is also rolled back)
+The FK references the existing `price_list` table (COST-575), not a new
+table. This ensures a single `PriceList` concept shared between COST-575
+(lifecycle management) and cost breakdown (per-rate normalization).
+
+**Rollback**: `DROP TABLE cost_model_rate CASCADE;`
 
 ---
 
-### M3: Data Migration — JSON to Rate Rows
+### M2: Data Migration — PriceList JSON to Rate Rows
 
 **Phase**: 1
 **Type**: Data migration (`RunPython`)
 **App**: `cost_models`
-**Depends on**: M2
+**Depends on**: M1
 
-This is the critical migration that populates `PriceList` and `Rate`
-from the existing `CostModel.rates` JSON blob.
+This migration extracts individual rates from the existing
+`PriceList.rates` JSON blob (populated by COST-575's migration `0011`)
+into normalized `Rate` rows with auto-generated `custom_name`.
 
 ```python
 # Pseudocode for the RunPython forward function
-def migrate_rates_to_tables(apps, schema_editor):
-    CostModel = apps.get_model("cost_models", "CostModel")
+def migrate_rates_to_rate_table(apps, schema_editor):
     PriceList = apps.get_model("cost_models", "PriceList")
+    PriceListCostModelMap = apps.get_model("cost_models", "PriceListCostModelMap")
     Rate = apps.get_model("cost_models", "Rate")
+    CostModel = apps.get_model("cost_models", "CostModel")
 
-    for cost_model in CostModel.objects.all():
-        if not cost_model.rates:
-            continue
+    mapping_ids = list(
+        PriceListCostModelMap.objects.select_related("price_list", "cost_model")
+        .values_list("id", flat=True)
+    )
 
-        # 1. Create one PriceList per CostModel
-        price_list = PriceList.objects.create(
-            cost_model=cost_model,
-            primary=True,
-            fallback=False,
-        )
+    for mapping_id in mapping_ids:
+        with transaction.atomic():
+            mapping = PriceListCostModelMap.objects.select_related(
+                "price_list", "cost_model"
+            ).get(id=mapping_id)
+            price_list = PriceList.objects.select_for_update().get(uuid=mapping.price_list_id)
+            cost_model = CostModel.objects.select_for_update().get(uuid=mapping.cost_model_id)
 
-        # 2. Generate custom_name for each rate and create Rate rows
-        used_names = set()
-        rates_json = cost_model.rates if isinstance(cost_model.rates, list) else []
-        updated_rates = []
+            if not price_list.rates:
+                continue
 
-        for rate_json in rates_json:
-            custom_name = generate_custom_name(
-                description=rate_json.get("description", ""),
-                metric=rate_json.get("metric", {}).get("name", "unknown"),
-                used_names=used_names,
-            )
-            used_names.add(custom_name)
+            # 1. Generate custom_name for each rate and create Rate rows
+            used_names = set()
+            rates_json = price_list.rates if isinstance(price_list.rates, list) else []
+            updated_rates = []
 
-            # Determine metric_type from metric name
-            metric_name = rate_json.get("metric", {}).get("name", "")
-            metric_type = derive_metric_type(metric_name)
+            for rate_json in rates_json:
+                custom_name = generate_custom_name(
+                    description=rate_json.get("description", ""),
+                    metric=rate_json.get("metric", {}).get("name", "unknown"),
+                    used_names=used_names,
+                )
+                used_names.add(custom_name)
 
-            # Extract rate value
-            tiered_rates = rate_json.get("tiered_rates", [])
-            tag_rates = rate_json.get("tag_rates", {})
-            default_rate = tiered_rates[0].get("value", 0) if tiered_rates else 0
+                metric_name = rate_json.get("metric", {}).get("name", "")
+                metric_type = derive_metric_type(metric_name)
 
-            Rate.objects.create(
-                price_list=price_list,
-                custom_name=custom_name,
-                description=rate_json.get("description", ""),
-                metric=metric_name,
-                metric_type=metric_type,
-                cost_type=rate_json.get("cost_type", "Infrastructure"),
-                default_rate=default_rate,
-                tag_key=tag_rates.get("tag_key", ""),
-                tag_values=tag_rates.get("tag_values", {}),
-            )
+                tiered_rates = rate_json.get("tiered_rates", [])
+                tag_rates = rate_json.get("tag_rates", {})
+                raw_value = tiered_rates[0].get("value", 0) if tiered_rates else 0
+                default_rate = Decimal(str(raw_value))  # JSON values may be strings ("0.0070000000")
 
-            # 3. Inject custom_name back into JSON for dual-write compatibility
-            rate_json["custom_name"] = custom_name
-            updated_rates.append(rate_json)
+                Rate.objects.create(
+                    price_list=price_list,
+                    custom_name=custom_name,
+                    description=rate_json.get("description", ""),
+                    metric=metric_name,
+                    metric_type=metric_type,
+                    cost_type=rate_json.get("cost_type", "Infrastructure"),
+                    default_rate=default_rate,
+                    tag_key=tag_rates.get("tag_key", ""),
+                    tag_values=tag_rates.get("tag_values", {}),
+                )
 
-        # 4. Update the JSON blob with custom_name added
-        cost_model.rates = updated_rates
-        cost_model.save(update_fields=["rates"])
+                # 2. Inject custom_name back into JSON for dual-write compatibility
+                rate_json["custom_name"] = custom_name
+                updated_rates.append(rate_json)
+
+            # 3. Update both JSON blobs with custom_name added
+            price_list.rates = updated_rates
+            price_list.save(update_fields=["rates", "updated_timestamp"])
+            cost_model.rates = updated_rates
+            cost_model.save(update_fields=["rates"])
 ```
+
+**Row-level locking** (`select_for_update`): Each mapping is processed
+inside its own `transaction.atomic()` block with `select_for_update()`
+on both the `PriceList` and `CostModel` rows. This matches COST-575's
+migration `0011` pattern and serves as defense-in-depth for on-prem
+deployments where the Unleash write-freeze flag is not available
+(`MockUnleashClient` returns `False` by default). On SaaS, the Unleash
+flag blocks API writes at a higher level; `select_for_update()` is a
+complementary safeguard.
 
 **`generate_custom_name` algorithm**:
 
@@ -597,33 +666,44 @@ def derive_metric_type(metric_name: str) -> str:
 | `storage_gb_request_per_month` | `storage` |
 | `cluster_core_cost_per_hour` | `cpu` |
 
+**Precondition**: Enable the Unleash write-freeze flag
+(`cost-management.backend.disable-cost-model-writes`) before running M2.
+This prevents concurrent API writes from modifying `CostModel.rates` or
+`PriceList.rates` JSON while the migration is iterating and injecting
+`custom_name`. Disable the flag after M2 completes and validation passes.
+See [api-and-frontend.md § Migration Write-Freeze Flag](./api-and-frontend.md#migration-write-freeze-flag-unleash)
+and [risk-register.md § R20](./risk-register.md#r20--migration-write-corruption).
+
 **What this migration does NOT do**:
 
+- Does not create `PriceList` rows (COST-575's `0011` already did that)
 - Does not modify `CostModelDBAccessor` read path (that's a code change,
   not a migration)
-- Does not remove the `rates` JSON column (that's Phase 5)
+- Does not remove the `rates` JSON columns (that's Phase 5)
 - Does not create partitioned tables (those are separate migrations)
 
-**Rollback**: `RunPython(reverse_code=migrate_tables_to_json)` — deletes
-all `Rate` and `PriceList` rows, removes `custom_name` key from
-`CostModel.rates` JSON blobs.
+**Rollback**: `RunPython(reverse_code=reverse_rate_migration)` — deletes
+all `Rate` rows, removes `custom_name` key from `CostModel.rates` and
+`PriceList.rates` JSON blobs. Does NOT delete `PriceList` rows (those
+belong to COST-575).
 
-**Estimated runtime**: O(N) where N = total number of cost models.
-Typically small (hundreds, not millions). Should complete in seconds.
+**Estimated runtime**: O(N) where N = total number of price list
+mappings. Typically small (hundreds, not millions). Should complete in
+seconds.
 
 ---
 
-### M4: Create `rates_to_usage` Table (Partitioned)
+### M3: Create `rates_to_usage` Table (Partitioned)
 
 **Phase**: 2
 **Type**: Schema migration
 **App**: `reporting` (lives in `reporting/provider/ocp/models.py`)
-**Depends on**: M2 (needs `cost_model_rate` table for FK)
+**Depends on**: M1 (needs `cost_model_rate` table for FK)
 
 ```sql
 CREATE TABLE rates_to_usage (
     uuid                 UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-    rate_id              UUID REFERENCES cost_model_rate(uuid) ON DELETE SET NULL,
+    rate_id              UUID REFERENCES cost_model_rate(uuid) ON DELETE SET NULL,  -- FK to new Rate table (Phase 1)
     cost_model_id        UUID REFERENCES cost_model(uuid) ON DELETE SET NULL,
     report_period_id     INTEGER,
     source_uuid          TEXT NOT NULL,
@@ -689,12 +769,12 @@ for that month. See `write_to_self_hosted_table()` in
 
 ---
 
-### M5: Create `reporting_ocp_cost_breakdown_p` Table (Partitioned)
+### M4: Create `reporting_ocp_cost_breakdown_p` Table (Partitioned)
 
 **Phase**: 4
 **Type**: Schema migration
 **App**: `reporting`
-**Depends on**: M4
+**Depends on**: M3
 
 ```sql
 CREATE TABLE reporting_ocp_cost_breakdown_p (
@@ -740,16 +820,21 @@ revert the `UI_SUMMARY_TABLES` / cleaner changes.
 
 ---
 
-### M6: Drop `CostModel.rates` JSONField
+### M5: Drop `CostModel.rates` and `PriceList.rates` JSONFields
 
 **Phase**: 5
 **Type**: Schema migration (auto-generated by `makemigrations`)
 **App**: `cost_models`
-**Depends on**: M3, M4, M5, and confirmation that all tenants are migrated
+**Depends on**: M2, M3, M4, and confirmation that all tenants are migrated
 
 ```sql
 ALTER TABLE cost_model DROP COLUMN rates;
+ALTER TABLE price_list DROP COLUMN rates;
 ```
+
+Both JSON columns are dropped — `CostModel.rates` (the original) and
+`PriceList.rates` (the COST-575 mirror). By this point, the `Rate`
+table is the sole source of truth.
 
 **Preconditions** (must all be true before running):
 
@@ -758,9 +843,12 @@ ALTER TABLE cost_model DROP COLUMN rates;
 - `CostModelDBAccessor` reads exclusively from the `Rate` table
   (JSON read path removed)
 - All SQL files use `RatesToUsage` path (no fallback to JSON)
-- Backup of `cost_model` table taken
+- Backup of `cost_model` and `price_list` tables taken
+- Unleash write-freeze flag (`cost-management.backend.disable-cost-model-writes`)
+  enabled before running M5
 
 **Rollback**: `ALTER TABLE cost_model ADD COLUMN rates JSONB DEFAULT '{}'::jsonb;`
+and `ALTER TABLE price_list ADD COLUMN rates JSONB DEFAULT '{}'::jsonb;`
 followed by a data migration to repopulate from the `Rate` table. This is
 the only migration that is practically irreversible without a backup.
 
@@ -770,23 +858,25 @@ the only migration that is practically irreversible without a backup.
 
 ```mermaid
 graph LR
-    M1["M1<br/>PriceList table"] --> M2["M2<br/>Rate table"]
-    M2 --> M3["M3<br/>JSON → Rate<br/>data migration"]
-    M2 --> M4["M4<br/>RatesToUsage<br/>(partitioned)"]
-    M4 --> M5["M5<br/>BreakdownP<br/>(partitioned)"]
-    M3 --> M6["M6<br/>Drop JSON column"]
-    M4 --> M6
-    M5 --> M6
+    C575_0010["COST-575<br/>0010: PriceList"] --> C575_0011["COST-575<br/>0011: Data migration"]
+    C575_0011 --> M1["M1<br/>Rate table"]
+    M1 --> M2["M2<br/>JSON → Rate<br/>data migration"]
+    M1 --> M3["M3<br/>RatesToUsage<br/>(partitioned)"]
+    M3 --> M4["M4<br/>BreakdownP<br/>(partitioned)"]
+    M2 --> M5["M5<br/>Drop JSON columns"]
+    M3 --> M5
+    M4 --> M5
 ```
 
 ### Phase-to-Migration Mapping
 
 | Phase | Migrations | Reversible? | Estimated Runtime |
 |-------|-----------|-------------|-------------------|
-| 1 | M1, M2, M3 | Yes (drop tables, revert JSON) | Seconds |
-| 2 | M4 | Yes (drop table) | Seconds (empty table creation) |
-| 4 | M5 | Yes (drop table) | Seconds (empty table creation) |
-| 5 | M6 | Requires backup | Seconds (column drop) |
+| (prereq) | COST-575: 0010, 0011 | Yes (already on main) | N/A |
+| 1 | M1, M2 | Yes (drop Rate table, revert JSON) | Seconds |
+| 2 | M3 | Yes (drop table) | Seconds (empty table creation) |
+| 4 | M4 | Yes (drop table) | Seconds (empty table creation) |
+| 5 | M5 | Requires backup | Seconds (column drop) |
 
 ### On-Prem Considerations
 
@@ -805,7 +895,7 @@ sequence is the same. The only difference:
 ## Migration Strategy: `custom_name` Generation
 
 Since `custom_name` is new and mandatory, existing rates must be migrated.
-This is handled by M3 above.
+This is handled by M2 above.
 
 ### Edge Cases
 
@@ -817,8 +907,9 @@ This is handled by M3 above.
   separate `custom_name` values.
 - **Very long descriptions**: Truncated descriptions that collide after
   truncation get the incremental suffix treatment.
-- **Empty cost models**: Cost models with `rates = {}` or `rates = []` are
-  skipped — no `PriceList` or `Rate` rows are created.
+- **Empty cost models**: Cost models with empty rates are skipped. Note
+  that COST-575's data migration `0011` already skips these for PriceList
+  creation, so no `PriceListCostModelMap` exists to iterate in M2.
 - **Rates with no tiered_rates or tag_rates**: These exist in the JSON but
   are skipped by `CostModelDBAccessor.price_list` today. They should still
   get `Rate` rows (with `default_rate = 0`) so the migration is complete.
@@ -837,4 +928,7 @@ This is handled by M3 above.
 | v2.4 | 2026-03-17 | R13 mitigation: add `label_hash` column to RatesToUsage model and M4 DDL. Add `ratestousage_label_hash_idx` index. Add full decision rationale with 5 options evaluated, collision risk analysis, and computation details. |
 | v3.0 | 2026-03-19 | **IQ-9 Option 1 adopted.** Add `distributed_cost` column to `RatesToUsage` model and M4 DDL. Drop `cost_type` from `OCPCostUIBreakDownP` and M5 DDL. Rename `CostModelRatesToUsage` → `RatesToUsage` / `cost_model_rates_to_usage` → `rates_to_usage`. Update tree structure for per-rate distribution. |
 | v3.1 | 2026-03-19 | **Risk extraction.** Move R13 decision rationale table to [risk-register.md](./risk-register.md). Retain problem statement and computation details inline. |
-| v3.2 | 2026-04-06 | **Spec-vs-impl alignment.** Fix Rate model pseudocode: `tag_values` default `list` (not `dict`), `default_rate` nullable, add `created_timestamp`/`updated_timestamp`, `related_name="rate_rows"`. Fix M2 DDL to match. |
+| v4.0 | 2026-04-02 | **Align Phase 1 with COST-575.** Remove proposed `cost_model_price_list` model — reuse existing `price_list` table from COST-575 ([#5963](https://github.com/project-koku/koku/pull/5963), [#5957](https://github.com/project-koku/koku/pull/5957)). `Rate` FK now references `price_list(uuid)`. Drop M1 (PriceList creation) — already exists via COST-575 migrations `0010`/`0011`. Renumber M2→M1, M3→M2, M4→M3, M5→M4, M6→M5. M5 now drops both `CostModel.rates` and `PriceList.rates` JSON columns. IQ-6 superseded (COST-575 shipped `effective_start_date`/`effective_end_date`). Add COST-575 Foundation section to Current State. Reference tech lead's [migration coordination gist](https://gist.github.com/myersCody/91195a531ada9c09d39a5c5234993654). |
+| v4.1 | 2026-04-02 | **R20: Migration write-freeze.** Add Unleash write-freeze precondition to M2 and M5. |
+| v4.2 | 2026-04-02 | **Critical review.** Add `Decimal()` conversion to M2 pseudocode `default_rate`. Clarify `PriceList.rates` lifecycle comment (supplemented in Phase 1, dropped in Phase 5). |
+| v4.3 | 2026-04-02 | **Self-resolve Concern 4.** Add `transaction.atomic()` + `select_for_update()` to M2 pseudocode for on-prem defense-in-depth, matching COST-575 0011 pattern. |

--- a/docs/architecture/cost-breakdown/open-concerns.md
+++ b/docs/architecture/cost-breakdown/open-concerns.md
@@ -1,0 +1,359 @@
+# Concerns Register — Cost Breakdown Design Review
+
+This document captures concerns identified during a critical review of the
+cost breakdown technical design ([COST-7249](https://redhat.atlassian.net/browse/COST-7249)).
+Each concern is grounded in code evidence, not supposition.
+
+All five concerns are now resolved. Concerns 1, 2, 3, and 4 were
+self-resolved by folding fixes directly into the design specs.
+Concern 5 was resolved by the tech lead (Option 1 is non-negotiable;
+remove Option 2 fallback language). Concern 3's six implementation
+gaps (A-F) have been closed with conservative defaults documented in
+[api-and-frontend.md](./api-and-frontend.md).
+
+---
+
+## Design Strengths
+
+Before diving into concerns, the design has several notable strengths
+worth acknowledging:
+
+- **Grounded in source code triage.** All 4 open questions (OQ-1 through
+  OQ-4) and 9 implementation questions (IQ-1 through IQ-9) were resolved
+  by reading koku source, not by assumption.
+- **Reuses COST-575 infrastructure.** Phase 1 builds on the existing
+  `price_list` table and `PriceListCostModelMap` junction table rather
+  than creating parallel tables.
+- **Every phase has a realistic rollback.** Phases 1-4 can be reverted
+  with code changes + data cleanup. Phase 5's rollback honestly requires
+  a backup.
+- **Risk register with concrete decision rationales.** 20 risks (R1-R20)
+  with alternatives-evaluated tables, benchmarks with acceptance criteria,
+  and a phase matrix.
+
+---
+
+## Self-Resolved Concerns (Concern 3 and Gaps A-F)
+
+### Concern 3: `_sync_rate_table()` Delete-All Pattern and `RatesToUsage.rate_id` FK — RESOLVED
+
+**Status**: Self-resolved. All 6 implementation gaps (A-F) closed with
+conservative defaults documented in
+[api-and-frontend.md](./api-and-frontend.md#diff-based-sync-design-decisions).
+No tech lead escalation required — decisions use safe defaults that can
+be refined later without rework.
+
+#### Tech Lead Response Summary
+
+The tech lead proposed:
+1. Replace delete-all + recreate with **diff-based sync** (update
+   existing rates by `rate_id`, create new rates, delete only removed
+   rates) — preserves `Rate.uuid` for unchanged rates.
+2. Include `rate_id` in **API payloads** so the frontend can round-trip
+   stable Rate UUIDs.
+3. Change `RatesToUsage.rate` FK from **`SET_NULL` to `CASCADE`**.
+4. **Scoped recalculation** — only recalculate the changed rate's costs.
+
+#### Blast Radius Re-Triage
+
+##### Critical finding: `rate_id` is never populated in the SQL pipeline
+
+The PoC SQL `insert_usage_rates_to_usage.sql` INSERT column list omits
+`rate_id` entirely. The `custom_name` column serves as the denormalized
+per-rate identifier. This means:
+
+- Under the current design, `RatesToUsage.rate_id = NULL` for **all** rows
+- `CASCADE` vs `SET_NULL` on the `rate` FK is **moot** — NULL FKs don't cascade
+- The FK constraint is decorative until the SQL pipeline populates it
+
+**Why this gap exists**: Under the original delete-all + recreate
+pattern, `Rate.uuid` values were **ephemeral** — every cost model API
+update deleted all Rate rows and created new ones with new UUIDs.
+Populating `rate_id` in `RatesToUsage` would have been pointless because
+the referenced UUIDs would go stale on the next update. The `custom_name`
+denormalization was the intentional per-rate identifier. The `rate` FK
+on the model was future-proofing, not a functional dependency.
+
+The tech lead's diff-based sync changes this: `Rate.uuid` values are now
+**stable** across updates (unchanged rates keep their UUID). This makes
+`rate_id` in `RatesToUsage` a durable, meaningful link — but the SQL
+pipeline hasn't been updated to reflect this architectural pivot.
+
+**Adopted mitigation**: Populate `rate_id` starting in **Phase 2**,
+when the first SQL INSERT into `rates_to_usage` ships. The Python
+orchestration already knows which rate it's processing — it passes
+`custom_name` as a SQL parameter and can pass `Rate.uuid` alongside
+it. Each SQL file adds one column to its INSERT list. Phase 3's 25
+files follow the same pattern. This unlocks CASCADE, scoped
+recalculation, and any future JOIN from `RatesToUsage` back to `Rate`.
+
+For `CASCADE` to have real effect, **every SQL INSERT into
+`rates_to_usage` must populate `rate_id`** — this is now scoped for
+Phase 2 onward. `SET_NULL` stays on the FK until `rate_id` is
+populated; CASCADE switch deferred until Phase 2 benchmarks confirm
+performance on large partitions.
+
+##### Layer 1: Diff-based `_sync_rate_table()` (Phase 1)
+
+| What changes | Where | Impact |
+|---|---|---|
+| `_sync_rate_table()` rewrite | `cost_model_manager.py` | Match by `rate_id` (if present) or `custom_name`, update/create/delete individually |
+| `RateSerializer` adds `rate_id` | `serializers.py` | Optional UUID, read-write. GET includes it; PUT may include it. |
+| Frontend `RateRequest` adds `rate_id` | `koku-ui` `api/rates.ts` | Coordinated frontend change. Backward-compatible: omitting degrades to match-by-`custom_name`. |
+| API contract documented | `api-and-frontend.md` | New field in rate objects |
+| Phase 1 validation expanded | `phased-delivery.md` | Test: update cost model → unchanged rates keep their UUID |
+
+**Backward compatibility**: If the frontend doesn't send `rate_id`, the
+backend diffs by `custom_name` (using the existing `unique_together`
+constraint). Rename = delete + create rather than update. Full
+diff-based sync activates once the frontend ships `rate_id` support.
+
+##### Layer 2: `rate_id` in SQL pipeline (currently unscoped)
+
+For the `rate` FK to be meaningful, every SQL INSERT into `rates_to_usage`
+must populate `rate_id`. This requires either:
+- Passing `rate_id` as a SQL parameter (Python looks up `Rate.uuid` by
+  `(price_list_id, custom_name)` before running SQL), or
+- Adding a JOIN to `cost_model_rate` in the SQL itself
+
+**Scope impact**: 1 PoC SQL + 1 Phase 2 SQL + 25 Phase 3 SQL files +
+5 Phase 4 distribution SQL files + 6 accessor methods = **38 file
+modifications** not currently scoped in any phase.
+
+Markup rows: `rate_id = NULL` (correct — markup has no Rate row).
+
+##### Layer 3: `SET_NULL` → `CASCADE` (only meaningful after Layer 2)
+
+| Change | Impact |
+|---|---|
+| Django model FK and M3 DDL | `on_delete=CASCADE` |
+| Rate deleted via diff-based sync | CASCADE deletes all `RatesToUsage` rows for that rate **across ALL monthly partitions** |
+| Current-month recalculation | Recreates current month's data correctly |
+| **Historical months** | Lose `RatesToUsage` data for deleted rate permanently |
+
+**Why CASCADE is safe**: `RatesToUsage` is intermediate computation
+data, not source-of-truth. The daily summary and `OCPCostUIBreakDownP`
+have already materialized the values. A future historical recalculation
+would correctly exclude the deleted rate. No existing SQL JOINs
+`rates_to_usage` to `cost_model_rate` (confirmed by full search of all
+design docs, PoC SQL, and `sql-pipeline.md`).
+
+**Performance concern**: For large tenants, a single Rate deletion
+could CASCADE-delete millions of rows across partitions. Should be
+benchmarked as part of Phase 2.
+
+##### Layer 4: Scoped recalculation (deferred optimization)
+
+Requires `rate_id` populated in `RatesToUsage` (Layer 2) to know which
+rows to recalculate. Non-trivial SQL and Celery changes. Not a Phase 1
+requirement — current full-window recalculation is correct, just less
+efficient.
+
+##### Confirmed safe (no blast radius)
+
+| Area | Why safe |
+|---|---|
+| Aggregation SQL | Uses `custom_name`, not `rate_id` |
+| Breakdown table population | Reads `RatesToUsage` directly, no FK to `Rate` |
+| Daily summary | No FK to `Rate`; aggregation is one-way SUM |
+| Markup rows (`rate=None`) | CASCADE doesn't touch NULL FKs |
+| Partition cleanup (`purge_expired_report_data_by_date`) | Drops whole partitions, not individual rows |
+| `cost_model` FK on `RatesToUsage` | Already populated by SQL; same pattern, not raised by tech lead |
+
+##### Missing from current design (gap)
+
+| Gap | Impact |
+|---|---|
+| `rate_id` column not in PoC SQL INSERT | FK is decorative; CASCADE has no effect |
+| No index on `rates_to_usage(rate_id)` | CASCADE performance on millions of rows; needed for future scoped recalculation |
+| 38 SQL files need `rate_id` parameter | Significant Phase 2/3 scope expansion |
+| `cost_model` FK also `SET_NULL` | Same CASCADE reasoning applies; already populated in SQL unlike `rate_id` |
+
+#### Due Diligence Findings
+
+The following gaps were identified by verifying the tech lead's proposal
+claim by claim against the actual koku codebase (`serializers.py`,
+`cost_model_manager.py`, `ocp_cost_model_cost_updater.py`, `tasks.py`).
+
+##### Gap A: GET responses won't include `rate_id` without explicit work — CLOSED
+
+**Finding**: `RateSerializer.to_representation()` builds a fixed output
+dict and does not pass through arbitrary extra keys from the JSON blob.
+
+**Resolution**: `rate_id` declared as explicit `UUIDField(required=False,
+allow_null=True)` on `RateSerializer`. `to_representation()` updated to
+emit `rate_id` when present. `_sync_rate_table()` injects `Rate.uuid`
+into the JSON blob during dual-write. See
+[api-and-frontend.md](./api-and-frontend.md#rateserializer--add-custom_name-and-rate_id-fields).
+
+##### Gap B: Backward-compatible path + CASCADE = historical data loss — CLOSED
+
+**Finding**: If clients don't send `rate_id` and all existing rates are
+treated as deleted, CASCADE would destroy all historical `RatesToUsage`
+data (not automatically rebuilt for months before current).
+
+**Resolution**: The `_sync_rate_table()` pseudocode matches by
+`custom_name` when `rate_id` is absent, preserving `Rate.uuid` for
+unchanged rates. CASCADE only fires for genuinely removed rates. No
+deployment ordering dependency on the frontend. See
+[api-and-frontend.md](./api-and-frontend.md#diff-based-sync-design-decisions).
+
+##### Gap C: Scoped recalculation is significantly harder than described — CLOSED
+
+**Finding**: The `update_summary_cost_model_costs()` pipeline is
+monolithic — scoped per-rate filtering requires Celery task signature
+changes, dedup key modifications, and per-method branching. The
+aggregation step must still process all rates regardless.
+
+**Resolution**: Scoped recalculation is documented as a deferred
+optimization (not Phase 1 or 2 scope). Phase 1 uses full-window
+recalculation, which is correct but less efficient. See
+[api-and-frontend.md](./api-and-frontend.md#scoped-recalculation--deferred-optimization).
+
+##### Gap D: `rate_id` security validation — CLOSED
+
+**Finding**: Existence check alone is insufficient — a user could send
+a `rate_id` from a different cost model within the same schema.
+
+**Resolution**: The `_sync_rate_table()` pseudocode validates `rate_id`
+against the existing rates dict (keyed by UUID), which is scoped to the
+current `price_list`. Invalid or foreign `rate_id` values raise
+`CostModelException`. See
+[api-and-frontend.md](./api-and-frontend.md) § `_sync_rate_table()`.
+
+##### Gap E: Unique constraint ordering in diff operations — CLOSED
+
+**Finding**: Rename + create-with-old-name in the same PUT causes
+transient `UniqueConstraint` violations if operations aren't ordered.
+
+**Resolution**: The `_sync_rate_table()` pseudocode enforces
+**delete → update → create** ordering within the transaction. See
+[api-and-frontend.md](./api-and-frontend.md) § `_sync_rate_table()`.
+
+##### Gap F: Change detection needs field classification — CLOSED
+
+**Finding**: Without field classification, every metadata edit (e.g.
+`description` typo fix) triggers unnecessary full recalculation.
+
+**Resolution**: `COST_AFFECTING_FIELDS = {default_rate, tag_values,
+metric, cost_type}` is defined in the `_sync_rate_table()` pseudocode.
+`description` and `custom_name` are metadata-only — they update the
+Rate row but do not trigger Celery recalculation. Stale `custom_name`
+on existing `RatesToUsage` rows is acceptable (refreshed on next full
+recalculation cycle). See
+[api-and-frontend.md](./api-and-frontend.md#diff-based-sync-design-decisions).
+
+#### Resolution Summary — Gaps A-F
+
+All gaps have been closed with conservative defaults. The full
+pseudocode is in [api-and-frontend.md](./api-and-frontend.md).
+
+| Gap | Resolution | Where documented |
+|-----|-----------|------------------|
+| **A**: GET won't emit `rate_id` | `rate_id` declared as explicit `UUIDField` on `RateSerializer`. `to_representation()` updated to include it. `rate_id` injected into JSON blob during `_sync_rate_table()` dual-write. | `api-and-frontend.md` § RateSerializer |
+| **B**: Backward-compat + CASCADE = data loss | Backend matches by `custom_name` when `rate_id` is absent (preserves UUIDs). CASCADE only fires for genuinely removed rates. No deployment ordering dependency on frontend. | `api-and-frontend.md` § Diff-based sync |
+| **C**: Scoped recalculation harder than described | Deferred as a future optimization. Phase 1 uses full-window recalculation (current month). Monolithic pipeline is correct, just less efficient. | `api-and-frontend.md` § Scoped recalculation |
+| **D**: `rate_id` security validation | Validated for ownership — `rate_id` must belong to the correct `price_list` for this cost model, not just exist. | `api-and-frontend.md` § `_sync_rate_table()` pseudocode |
+| **E**: Unique constraint ordering | Diff operations ordered: deletes → updates → creates. Avoids transient `UniqueConstraint` violations without `DEFERRABLE` constraints. | `api-and-frontend.md` § `_sync_rate_table()` pseudocode |
+| **F**: Change detection classification | `COST_AFFECTING_FIELDS = {default_rate, tag_values, metric, cost_type}` triggers recalculation. `description` and `custom_name` are metadata-only (no recalc). Conservative Phase 1 approach. | `api-and-frontend.md` § Diff-based sync |
+
+**`rate_id` in SQL pipeline**: Scoped for Phase 2 onward. Each SQL
+INSERT into `rates_to_usage` adds `rate_id` as a parameter (Python
+looks up `Rate.uuid` before running SQL). `SET_NULL` stays on the FK
+until `rate_id` is populated; CASCADE switch deferred until Phase 2
+benchmarks confirm performance on large partitions.
+
+## Tech Lead Resolved Concern
+
+### Concern 5: No Defined Fallback Trigger from IQ-9 Option 1 to Option 2 — RESOLVED
+
+**Status**: Resolved by tech lead decision
+
+#### Tech lead decision
+
+The tech lead confirmed that back-allocation (Option 2) should **not**
+be kept as a runtime fallback. The target architecture is Option 1
+end-to-end (distribution maintains per-rate identity) and issues in that
+path should be fixed directly rather than switching approaches.
+
+#### Due diligence note
+
+This decision is directionally sound, but the current design still needs
+Concern 3 Layer 2 implementation (`rate_id` populated in SQL writes to
+`rates_to_usage`) before "rate_id flows through naturally" is true in
+practice. Until then, Option 1 remains the selected architecture, but
+its FK continuity is only partially realized.
+
+#### Actions taken
+
+- Remove Option 2 fallback language from active design guidance in
+  `README.md`.
+- Keep stronger R18 integration-test assertions (10 checks) as the
+  primary correctness safety net for Option 1.
+- Concern 3 subsequently self-resolved — all gaps (A-F) closed with
+  conservative defaults in `api-and-frontend.md`.
+
+---
+
+## Self-Resolved Concerns (Concerns 1, 2, 4)
+
+The following concerns were identified during the critical review and
+have been addressed by updating the design specifications directly.
+They are retained here for audit trail.
+
+### Concern 1: Distribution SQL Tests Verify Orchestration, Not Correctness — RESOLVED
+
+**What we found**: Distribution tests in `test_ocp_report_db_accessor.py`
+mock `_execute_raw_sql_query` and assert `mock_sql_execute.assert_called()`.
+No test runs actual SQL or checks `distributed_cost` values. The
+distribution SQL files contain commented-out validation SQL
+(`distribute_platform_cost.sql`, lines 163-176) that is never executed.
+
+**What we did**: Added distribution integration tests as a Phase 4
+artifact in [phased-delivery.md](./phased-delivery.md#concern-1-resolution--distribution-integration-tests).
+Updated R18's mitigation in [risk-register.md](./risk-register.md) to
+reflect the stronger test plan. Tests will execute actual SQL against
+schema-scoped test databases and assert per-rate proportional
+correctness, sum consistency, and edge cases.
+
+### Concern 2: No Observability Instrumentation — RESOLVED
+
+**What we found**: `ocp_cost_model_cost_updater.py` has zero timing
+instrumentation. The only related Prometheus metric is
+`charge_update_attempts_count` (attempt counter). Koku has Prometheus
+infrastructure (`WORKER_REGISTRY`, probe server, Grafana dashboards)
+but doesn't instrument the cost model pipeline.
+
+**What we did**: Added Prometheus histograms and gauge as a Phase 2
+artifact in [phased-delivery.md](./phased-delivery.md#concern-2-resolution--observability-instrumentation).
+Metrics: `cost_model_rtu_insert_duration_seconds`,
+`cost_model_aggregation_duration_seconds`, `cost_model_rtu_row_count`,
+`cost_model_update_total_duration_seconds`. Thresholds mirror Phase 2
+benchmark acceptance criteria.
+
+### Concern 4: On-Prem M2 Migration Without Write Protection — RESOLVED
+
+**What we found**: `MockUnleashClient.is_enabled()` returns `False` by
+default (no `fallback_function`). COST-575's migration `0011` used
+`select_for_update()` per row. Our M2 pseudocode lacked row-level
+locking.
+
+**What we did**: Updated M2 pseudocode in
+[data-model.md](./data-model.md#m2-data-migration--pricelist-json-to-rate-rows)
+to use `transaction.atomic()` + `select_for_update()` per mapping,
+matching 0011's pattern. This provides defense-in-depth for on-prem
+(row-level locking) while SaaS uses the Unleash flag (API-level
+blocking). Both mechanisms are independent and complementary.
+
+---
+
+## Changelog
+
+| Version | Date | Summary |
+|---------|------|---------|
+| v1.0 | 2026-04-02 | Initial: 5 open concerns from critical review. |
+| v1.1 | 2026-04-02 | Triage: concerns 1, 2, 4 self-resolved (folded into design specs). Concerns 3, 5 retained for tech lead review with specific questions. |
+| v1.2 | 2026-04-03 | Concern 3: blast radius re-triage after tech lead response. Key finding: `rate_id` never populated in SQL pipeline — CASCADE is moot until Layer 2 is scoped. Added 4 decision points. Concern 1 tests strengthened: 10 assertions (up from 4), including Option 2's formula as cross-check (#5). |
+| v1.3 | 2026-04-03 | Concern 3: due diligence findings from verifying tech lead's proposal against codebase. Added Gaps A-F: GET serializer won't emit `rate_id` without explicit changes (Gap A), backward-compat + CASCADE = historical data loss (Gap B), scoped recalc harder than described (Gap C), `rate_id` needs price_list ownership validation (Gap D), diff operations need delete→update→create ordering for unique constraint (Gap E), change detection field classification needed (Gap F). Expanded decision points from 3 to 6. |
+| v1.4 | 2026-04-03 | Concern 5 marked RESOLVED per tech lead decision: Option 1 is non-negotiable, remove Option 2 fallback language. Clarify Gap B wording ("not automatically rebuilt" instead of "permanently lost") and soften Gap C implementation estimate ("multiple call sites" instead of fixed count). |
+| v2.0 | 2026-04-03 | All concerns resolved. Concern 3 Gaps A-F closed with conservative defaults: diff-based `_sync_rate_table()` with `custom_name` fallback (B), `rate_id` on `RateSerializer` + `to_representation()` (A), ownership validation (D), delete→update→create ordering (E), `COST_AFFECTING_FIELDS` classification (F), scoped recalc deferred (C). Pseudocode added to `api-and-frontend.md`. No open concerns remain. |

--- a/docs/architecture/cost-breakdown/phased-delivery.md
+++ b/docs/architecture/cost-breakdown/phased-delivery.md
@@ -32,11 +32,12 @@ graph LR
 
 | Phase | Goal | User-Facing? | Migrations | Rollback Strategy |
 |-------|------|-------------|------------|-------------------|
-| 1 | Normalize rate storage | No | M1, M2, M3 | Revert code to JSON read path; dual-write preserves JSON |
-| 2 | Per-rate cost tracking (usage costs only) | No | M4 | Revert code; truncate `RatesToUsage`; direct-write still active |
+| (prereq) | PriceList infrastructure | No | COST-575: 0010, 0011 | Already on `main` |
+| 1 | Normalize rate storage | No | M1, M2 | Drop Rate table; revert JSON; PriceList stays (COST-575) |
+| 2 | Per-rate cost tracking (usage costs only) | No | M3 | Revert code; truncate `RatesToUsage`; direct-write still active |
 | 3 | Migrate all remaining SQL files | No | None | Revert individual SQL files |
-| 4 | Expose breakdown data to UI | Yes | M5 | Unregister URL; leave table empty |
-| 5 | Remove legacy JSON path | No | M6 | Restore from backup |
+| 4 | Expose breakdown data to UI | Yes | M4 | Unregister URL; leave table empty |
+| 5 | Remove legacy JSON path | No | M5 | Restore from backup |
 
 ---
 
@@ -44,23 +45,37 @@ graph LR
 
 **Goal**: Normalize rate storage without changing cost calculation behavior.
 
+**Prerequisite**: COST-575 migrations `0010` (PriceList + PriceListCostModelMap
+models) and `0011` (data migration copying CostModel.rates to PriceList.rates)
+are already on `main`. Phase 1 builds on this foundation by adding a
+normalized `Rate` table underneath the existing `PriceList`.
+
 ### Artifacts
 
 | Artifact | File | Description |
 |----------|------|-------------|
-| `PriceList` model | `cost_models/models.py` | New Django model |
-| `Rate` model | `cost_models/models.py` | New Django model with `custom_name` |
-| Migration M1 | `cost_models/migrations/XXXX_create_price_list.py` | DDL for `cost_model_price_list` |
-| Migration M2 | `cost_models/migrations/XXXX_create_rate.py` | DDL for `cost_model_rate` |
-| Migration M3 | `cost_models/migrations/XXXX_migrate_json_to_rate.py` | Data migration: JSON → Rate rows |
-| `RateSerializer` update | `cost_models/serializers.py` | Add `custom_name` field (required) |
-| `CostModelSerializer` update | `cost_models/serializers.py` | Dual-write to JSON + Rate table |
-| `CostModelDBAccessor` update | `masu/database/cost_model_db_accessor.py` | Read from Rate table (dual-write preserves JSON as fallback) |
+| `Rate` model | `cost_models/models.py` | New Django model with `custom_name`, FK to existing `PriceList` |
+| Migration M1 | `cost_models/migrations/0012_create_rate.py` | DDL for `cost_model_rate` (depends on `0011`) |
+| Migration M2 | `cost_models/migrations/0013_migrate_json_to_rate.py` | Data migration: PriceList.rates JSON → Rate rows |
+| `RateSerializer` update | `cost_models/serializers.py` | Add `custom_name` field (`required=False`) |
+| `CostModelSerializer` update | `cost_models/serializers.py` | Extend dual-write: JSON + PriceList.rates + Rate table |
+| `CostModelManager` update | `cost_models/cost_model_manager.py` | Add `_sync_rate_table()` — delete + recreate Rate rows on every write |
+| Write-freeze flag helper | `masu/processor/__init__.py` | `is_cost_model_writes_disabled()` — Unleash flag to block cost model writes during migration |
+| Write-freeze gating | `cost_models/serializers.py` | Check flag in `CostModelSerializer.create()` and `update()` via `self.customer.schema_name` → HTTP 503 |
+| `CostModelDBAccessor` update | `masu/database/cost_model_db_accessor.py` | Read from Rate table via PriceListCostModelMap (dual-write preserves JSON as fallback) |
+
+### Deployment Procedure for M2
+
+1. Enable Unleash flag `cost-management.backend.disable-cost-model-writes`
+   (blocks cost model API writes with HTTP 503)
+2. Run `django-admin migrate` (executes M1 + M2)
+3. Validate: all `PriceList` rows with rates have corresponding `Rate` rows
+4. Disable Unleash flag (restores normal API writes)
 
 ### Validation
 
-- All existing `CostModel` rows have corresponding `PriceList` + `Rate`
-  rows after M3
+- All existing `PriceList` rows with non-empty rates have corresponding
+  `Rate` rows after M2
 - `custom_name` is populated for every rate (no NULLs)
 - API backward-compatible: `GET /cost-models/{uuid}/` returns rates with
   `custom_name` added (existing fields unchanged)
@@ -72,9 +87,10 @@ graph LR
 
 1. Revert `CostModelDBAccessor` code → reads from JSON (which is still
    populated via dual-write)
-2. Revert dual-write code → API writes to JSON only
-3. Reverse M3 → remove `custom_name` from JSON, delete Rate/PriceList rows
-4. Drop tables via reverse M2, M1
+2. Revert `_sync_rate_table()` code → API writes to JSON + PriceList.rates only
+3. Reverse M2 → remove `custom_name` from JSON blobs, delete Rate rows
+4. Drop Rate table via reverse M1
+5. PriceList and PriceListCostModelMap remain untouched (COST-575 owns them)
 
 ---
 
@@ -91,7 +107,7 @@ costs (`usage_costs.sql` only).
 | Artifact | File | Description |
 |----------|------|-------------|
 | `RatesToUsage` model | `reporting/provider/ocp/models.py` | New partitioned Django model |
-| Migration M4 | `reporting/migrations/XXXX_create_rates_to_usage.py` | DDL for `rates_to_usage` |
+| Migration M3 | `reporting/migrations/XXXX_create_rates_to_usage.py` | DDL for `rates_to_usage` |
 | RatesToUsage INSERT SQL | `masu/database/sql/openshift/cost_model/insert_usage_rates_to_usage.sql` | CTE + UNION ALL producing per-rate rows at fine granularity — **replaces** `usage_costs.sql` direct-write. See [PoC](./poc/insert_usage_rates_to_usage.sql) |
 | Aggregation SQL | `masu/database/sql/openshift/cost_model/aggregate_rates_to_daily_summary.sql` | DELETE + INSERT: aggregates `RatesToUsage` → daily summary `cost_model_*_cost` columns. Replaces `usage_costs.sql` direct-write. |
 | Orchestration update | `masu/processor/ocp/ocp_cost_model_cost_updater.py` | Replace `self._update_usage_costs()` with RatesToUsage INSERT + aggregation. No dual-path. |
@@ -101,6 +117,36 @@ costs (`usage_costs.sql` only).
 | Partition wiring | `masu/processor/ocp/ocp_cost_model_cost_updater.py` | Call `get_or_create_partition()` before writing to `RatesToUsage` (not in `UI_SUMMARY_TABLES`) |
 | Purge update | `masu/processor/ocp/ocp_report_db_cleaner.py` | Add `rates_to_usage` to `purge_expired_report_data_by_date()` |
 | DELETE for recalculation | `masu/database/ocp_report_db_accessor.py` | New `delete_rates_to_usage()` method — runs before each recalculation cycle |
+| Prometheus instrumentation | `masu/prometheus_stats.py`, `masu/processor/ocp/ocp_cost_model_cost_updater.py` | Histograms and gauge for cost model pipeline timing and row counts. See [Concern 2 resolution](#concern-2-resolution--observability-instrumentation). |
+
+### Concern 2 Resolution — Observability Instrumentation
+
+`ocp_cost_model_cost_updater.py` currently has zero timing
+instrumentation. The only related Prometheus metric is
+`charge_update_attempts_count` (a task attempt counter in
+`masu/prometheus_stats.py`). Koku has Prometheus infrastructure in
+place (`WORKER_REGISTRY` in `masu/prometheus_stats.py`, exposed via
+`/metrics` in `koku/probe_server.py`, Grafana dashboards in
+`dashboards/`), but the cost model calculation pipeline is not
+instrumented.
+
+Phase 2 adds the following metrics, registered in
+`masu/prometheus_stats.py` using `WORKER_REGISTRY` (existing pattern):
+
+| Metric | Type | Labels | Threshold |
+|--------|------|--------|-----------|
+| `cost_model_rtu_insert_duration_seconds` | Histogram | `schema`, `source_uuid` | Benchmark #2: < 60s |
+| `cost_model_aggregation_duration_seconds` | Histogram | `schema`, `source_uuid` | Benchmark #3: < 30s |
+| `cost_model_rtu_row_count` | Gauge | `schema`, `source_uuid` | Benchmark #1: < 100M/month |
+| `cost_model_update_total_duration_seconds` | Histogram | `schema`, `source_uuid` | Benchmark #7: < 5 min |
+
+Instrumentation is added in `ocp_cost_model_cost_updater.py` around
+the `RatesToUsage` INSERT, aggregation, and end-to-end update calls
+using `time.perf_counter()` (same pattern as other koku timing code).
+
+Thresholds mirror the Phase 2 benchmark acceptance criteria, enabling
+Grafana dashboard panels and alerting rules to monitor the new pipeline
+in production.
 
 ### Validation
 
@@ -248,7 +294,7 @@ self-hosted (mirrors Trino). Tag-rate files before monthly-cost files
 | Artifact | File | Description |
 |----------|------|-------------|
 | `OCPCostUIBreakDownP` model | `reporting/provider/ocp/models.py` | New partitioned Django model |
-| Migration M5 | `reporting/migrations/XXXX_create_breakdown_p.py` | DDL for `reporting_ocp_cost_breakdown_p` |
+| Migration M4 | `reporting/migrations/XXXX_create_breakdown_p.py` | DDL for `reporting_ocp_cost_breakdown_p` |
 | Breakdown population SQL | `masu/database/sql/openshift/ui_summary/reporting_ocp_cost_breakdown_p.sql` | Populate from **single source** `RatesToUsage` (per-rate costs and per-rate distributed rows after IQ-9 Option 1) with tree paths — no separate back-allocation in breakdown SQL |
 | Distribution per-rate SQL (IQ-9 Option 1) | 5 new distribution SQL files | Read per-rate costs from `RatesToUsage` + usage from daily summary, write per-rate distributed rows back to `RatesToUsage`. Old files deprecated. |
 | `UI_SUMMARY_TABLES` update | `reporting/provider/ocp/models.py` | Add to tuple for partition cleanup |
@@ -261,6 +307,58 @@ self-hosted (mirrors Trino). Tag-rate files before monthly-cost files
 | Frontend: flat list | `routes/details/components/costOverview/` | `CostBreakdownTable` component |
 | Frontend: tab restructure | `routes/details/components/breakdown/breakdownBase.tsx` | Move usage cards to "Usage overview" tab |
 | Frontend: export | `api/export/ocpExport.ts` | Breakdown CSV export |
+| Distribution integration tests | `masu/test/database/test_ocp_report_db_accessor.py` | Execute actual distribution SQL against test data (not mocked); assert per-rate proportional correctness and edge cases. See [Concern 1 resolution](#concern-1-resolution--distribution-integration-tests). |
+
+### Concern 1 Resolution — Distribution Integration Tests
+
+Existing distribution tests in `test_ocp_report_db_accessor.py` mock
+`_execute_raw_sql_query` and assert orchestration (method was called),
+not mathematical correctness. The distribution SQL files contain
+commented-out validation SQL that is never executed by tests. This means
+R18's original mitigation ("existing integration tests sufficient") only
+verifies the code path, not the numbers.
+
+Phase 4 adds integration tests that execute the actual distribution SQL
+against the test database (using `OCPReportDBAccessor` without mocking
+the SQL execution layer) and assert:
+
+1. Per-rate proportional correctness:
+   `distributed_cost[rate] / total_distributed == rate_cost / total_cost`
+2. `SUM(per-rate distributed rows)` = aggregate `distributed_cost` per
+   (namespace, day, distribution_type)
+3. No orphaned distributed rows (every row traces to a valid source)
+4. Edge cases: single-node clusters (100% to one node), zero-cost
+   namespaces (no divide-by-zero), GPU distribution by GPU-specific
+   metrics
+5. **Independent cross-check (Option 2's formula)**: Compute the expected
+   per-rate distributed cost by proportionally splitting the daily
+   summary's aggregate `distributed_cost` by `rate_cost / total_cost`.
+   Assert it matches the actual per-rate `RatesToUsage` distributed rows
+   within NUMERIC(33,15) precision. This encodes Option 2's back-allocation
+   math as a test assertion — the mathematical safety net that Option 2
+   would have provided in production.
+6. **Cost conservation**: Net `SUM(distributed_cost)` across source
+   (negative) + recipient (positive) rows = 0 per (day,
+   distribution_type). Total distributed to recipients equals total
+   removed from source namespaces.
+7. **Sign invariant**: Source namespace rows have negative
+   `distributed_cost`, recipient rows have positive, for each (day,
+   distribution_type, rate).
+8. **Idempotency**: Run distribution twice → identical `RatesToUsage`
+   state. The DELETE + INSERT pattern guarantees this; the test confirms
+   no duplication or partial deletes.
+9. **Multi-rate proportionality**: With rate A at cost 3× rate B,
+   `distributed_cost[A] / distributed_cost[B] = 3` for the same
+   (namespace, day). Tests with 3+ rates of varying magnitudes.
+10. **Rate mutation regression**: Modify a rate value, trigger
+    recalculation, and verify distributed costs reflect the updated
+    value (no stale cached amounts surviving recalculation).
+
+These 10 assertions collectively replicate the safety net that IQ-9
+Option 2 (back-allocation) would have provided at runtime. The tech lead
+should be aware that these tests are now the sole verification mechanism
+for per-rate distribution correctness, replacing Option 2 as the
+fallback.
 
 ### Validation
 
@@ -291,7 +389,7 @@ direct-write code.
 
 | Artifact | File | Description |
 |----------|------|-------------|
-| Migration M6 | `cost_models/migrations/XXXX_drop_rates_json.py` | `ALTER TABLE cost_model DROP COLUMN rates` |
+| Migration M5 | `cost_models/migrations/XXXX_drop_rates_json.py` | `ALTER TABLE cost_model DROP COLUMN rates` + `ALTER TABLE price_list DROP COLUMN rates` |
 | Remove dual-write | `cost_models/serializers.py` | API writes to Rate table only |
 | Remove JSON read path | `masu/database/cost_model_db_accessor.py` | Remove `_price_list_from_json()` fallback |
 | Remove `usage_costs.sql` direct-write | `masu/database/sql/openshift/cost_model/usage_costs.sql`, `ocp_report_db_accessor.py` | Dead code since Phase 2 aggregation took over. Remove the direct-write INSERT and its orchestration call. |
@@ -303,8 +401,9 @@ All of these must be verified before executing Phase 5:
 
 - [ ] All tenants have been processed through the Rate table path
 - [ ] No code path reads from `CostModel.rates` JSON
-- [ ] Backup of `cost_model` table taken
+- [ ] Backup of `cost_model` and `price_list` tables taken
 - [ ] Full regression test suite passes
+- [ ] Unleash write-freeze flag (`cost-management.backend.disable-cost-model-writes`) enabled
 
 ### Validation
 
@@ -314,7 +413,7 @@ All of these must be verified before executing Phase 5:
 
 ### Rollback
 
-- Restore `rates` column from backup
+- Restore `rates` column on both `cost_model` and `price_list` from backup
 - Re-add dual-write code
 - This is the only phase where rollback is practically difficult
 
@@ -338,7 +437,7 @@ Full details, decision rationales, and mitigation plans are in
 | R9 | Frontend tab restructure | Active |
 | R10 | Trino SQL dialect | Active |
 | R11 | Concurrent updates | Active |
-| R12 | Missing `@transaction.atomic` | Active |
+| R12 | Missing `@transaction.atomic` | **MITIGATED** |
 | R13 | JSONB JOIN performance | **MITIGATED** |
 | R14 | Back-allocation rounding | **N/A** |
 | R15 | Back-allocation JOIN complexity | **REPLACED** |
@@ -346,6 +445,7 @@ Full details, decision rationales, and mitigation plans are in
 | R17 | Markup ORM overhead | **MITIGATED** |
 | R18 | Distribution SQL rewrite regression | Active |
 | R19 | Aggregation + `distributed_cost` | **RESOLVED** |
+| R20 | Migration write-corruption | **MITIGATED** |
 
 ### Risk × Phase Matrix
 
@@ -390,7 +490,8 @@ set of rate configurations.
 
 ## Timeline Considerations
 
-Phase 1 can start immediately — it has no open questions. The
+Phase 1 can start immediately — COST-575 prerequisites are on `main`
+(migrations `0010`, `0011`) and all open questions are resolved. The
 `_price_list_from_rate_table()` format compatibility has been validated
 by PoC tests ([`poc/price_list_compat.py`](./poc/price_list_compat.py),
 6/6 pass).
@@ -414,7 +515,7 @@ for a sufficient period (recommended: at least one full billing cycle).
 ### Blocking dependencies
 
 ```
-Phase 1 ← no blockers (start now)
+Phase 1 ← COST-575 on main (0010, 0011) ✅
 Phase 2 ← Phase 1 (IQ-1 confirmed — single source of truth, no dual-path)
 Phase 3 ← Phase 2 + R13 benchmark acceptable
 Phase 4 ← Phase 3 (IQ-3 confirmed — flat DB rows, both API formats)
@@ -435,3 +536,8 @@ Phase 5 ← Phase 4 validated in production
 | v2.5 | 2026-03-17 | Decision rationales: add alternatives-evaluated tables for R6 (per-file-per-PR, 4 options) and R2/R3 (DELETE+INSERT aggregation, 3 options + threshold derivation). |
 | v3.0 | 2026-03-19 | **IQ-9 RESOLVED (Option 1).** Phase 4: replace back-allocation with 5 new per-rate distribution SQL files. Risk register: R14 eliminated, R15 replaced, R18 added (distribution rewrite regression). Rename `CostModelRatesToUsage` → `RatesToUsage`. |
 | v3.1 | 2026-03-19 | **Risk extraction.** Move full risk register and decision rationales to [risk-register.md](./risk-register.md). Compact risk table retained here. Add R19. Replace R2/R3 and R6 rationale tables with links. |
+| v4.0 | 2026-04-02 | **Align with COST-575.** Phase 1 prerequisite: COST-575 0010/0011 on `main`. Remove M1 (PriceList creation). Phase 1 artifacts: `Rate` model + M1 (Rate table) + M2 (data migration). Renumber M4→M3, M5→M4, M6→M5. Phase 1 rollback updated: PriceList stays (COST-575 owns it). Phase 5 drops both `CostModel.rates` and `PriceList.rates`. |
+| v4.1 | 2026-04-02 | **R20: Migration write-freeze.** Add Unleash write-freeze flag to Phase 1 artifacts. Add deployment procedure for M2 (enable/disable flag around migration). Add flag to Phase 5 preconditions. Add R20 to risk summary. |
+| v4.2 | 2026-04-02 | **Critical review.** Move write-freeze gating artifact from `cost_model_manager.py` to `serializers.py` (serializer has schema context). |
+| v4.3 | 2026-04-02 | **Self-resolve concerns 1, 2.** Add distribution integration tests as Phase 4 artifact (Concern 1). Add Prometheus instrumentation as Phase 2 artifact (Concern 2). |
+| v4.4 | 2026-04-03 | **Strengthen Concern 1 tests.** Expand distribution integration test assertions from 4 to 10. Add Option 2's back-allocation formula as independent cross-check (#5), cost conservation (#6), sign invariant (#7), idempotency (#8), multi-rate proportionality (#9), rate mutation regression (#10). These replace Option 2 as the safety net for per-rate distribution correctness. |

--- a/docs/architecture/cost-breakdown/phased-delivery.md
+++ b/docs/architecture/cost-breakdown/phased-delivery.md
@@ -39,6 +39,27 @@ graph LR
 | 4 | Expose breakdown data to UI | Yes | M4 | Unregister URL; leave table empty |
 | 5 | Remove legacy JSON path | No | M5 | Restore from backup |
 
+### `rate_id` Enforcement by Phase
+
+The target architecture uses `rate_id` as a durable FK link from
+`RatesToUsage` to `Rate`. This capability is built incrementally —
+**the database does not enforce it until the SQL INSERT paths are
+updated in Phase 2+**. The table below clarifies what is actually
+enforced vs. aspirational in each phase.
+
+| Phase | `Rate` table | `rate_id` in API | `rate_id` in SQL INSERT | FK mode | CASCADE safe? |
+|-------|-------------|-----------------|------------------------|---------|---------------|
+| 1 | Created and populated | GET emits it; PUT accepts it | **Not populated** (`NULL`) | `SET_NULL` | No — NULL FKs don't cascade |
+| 2 | Stable UUIDs (diff-based sync) | Round-tripped by clients | **Populated** (usage costs SQL) | `SET_NULL` → benchmarks | Pending benchmarks |
+| 3 | Same as Phase 2 | Same | Populated (all 25 SQL files) | Same | Same |
+| 4 | Same | Same | Populated (distribution SQL) | Switch to `CASCADE` if benchmarks pass | Yes |
+| 5 | Same | Same | Same | `CASCADE` | Yes |
+
+> **Important**: Until Phase 2 ships, `RatesToUsage.rate_id = NULL` for
+> all rows. JOINs from `RatesToUsage` to `Rate` and CASCADE deletes
+> have **no effect**. Do not assume FK continuity is active before
+> Phase 2 is deployed and validated.
+
 ---
 
 ## Phase 1: Schema Normalization

--- a/docs/architecture/cost-breakdown/phased-delivery.md
+++ b/docs/architecture/cost-breakdown/phased-delivery.md
@@ -59,7 +59,7 @@ normalized `Rate` table underneath the existing `PriceList`.
 | Migration M2 | `cost_models/migrations/0013_migrate_json_to_rate.py` | Data migration: PriceList.rates JSON → Rate rows |
 | `RateSerializer` update | `cost_models/serializers.py` | Add `custom_name` field (`required=False`) |
 | `CostModelSerializer` update | `cost_models/serializers.py` | Extend dual-write: JSON + PriceList.rates + Rate table |
-| `CostModelManager` update | `cost_models/cost_model_manager.py` | Add `_sync_rate_table()` — delete + recreate Rate rows on every write |
+| `CostModelManager` update | `cost_models/cost_model_manager.py` | Add `_sync_rate_table()` — diff-based sync (match by `rate_id` or `custom_name`; delete → update → create) preserving stable Rate UUIDs |
 | Write-freeze flag helper | `masu/processor/__init__.py` | `is_cost_model_writes_disabled()` — Unleash flag to block cost model writes during migration |
 | Write-freeze gating | `cost_models/serializers.py` | Check flag in `CostModelSerializer.create()` and `update()` via `self.customer.schema_name` → HTTP 503 |
 | `CostModelDBAccessor` update | `masu/database/cost_model_db_accessor.py` | Read from Rate table via PriceListCostModelMap (dual-write preserves JSON as fallback) |

--- a/docs/architecture/cost-breakdown/poc/price_list_compat.py
+++ b/docs/architecture/cost-breakdown/poc/price_list_compat.py
@@ -156,7 +156,7 @@ def supplementary_rates_from_price_list(price_list: dict) -> dict:
 def json_rates_to_rate_rows(rates_json: list[dict]) -> list[RateRow]:
     """
     Convert a CostModel.rates JSON blob into simulated RateRow objects.
-    This mirrors what migration M3 would do.
+    This mirrors what migration M2 would do.
     """
     rows = []
     used_names: set[str] = set()

--- a/docs/architecture/cost-breakdown/risk-register.md
+++ b/docs/architecture/cost-breakdown/risk-register.md
@@ -18,7 +18,7 @@ design documents link here for details.
 | R4 | Monthly cost rates produce more rows than expected | **MITIGATED** | 3 | GROUP BY quantified (OQ-2). |
 | R5 | Cost category reclassification invalidates breakdown tree | **MITIGATED** | 4 | Existing `update_summary_tables` chain handles it (OQ-4). |
 | R6 | 25 SQL file modifications introduce regressions | Active | 3 | Per-file-per-PR + 8-point checklist. |
-| R7 | Dual-write divergence (JSON ↔ PriceList.rates ↔ Rate table) | Active | 1-4 | COST-575 already dual-writes JSON ↔ PriceList.rates. Phase 1 extends with delete-all + recreate Rate rows on every write. Three-way sync wrapped in `@transaction.atomic`. |
+| R7 | Dual-write divergence (JSON ↔ PriceList.rates ↔ Rate table) | Active | 1-4 | COST-575 already dual-writes JSON ↔ PriceList.rates. Phase 1 extends with diff-based `_sync_rate_table()` (match by `rate_id`/`custom_name`; delete → update → create) preserving stable Rate UUIDs. Three-way sync wrapped in `@transaction.atomic`. |
 | R8 | `custom_name` migration produces ugly names | Active | 1 | Acceptable per PRD; users can rename. |
 | R9 | Frontend tab restructure breaks workflows | Active | 4 | Usage cards move to adjacent tab, not removed. |
 | R10 | Trino SQL dialect issues | Active | 3 | Test with Trino locally. |

--- a/docs/architecture/cost-breakdown/risk-register.md
+++ b/docs/architecture/cost-breakdown/risk-register.md
@@ -310,6 +310,22 @@ API write during column drop could fail with a database error.
 See [api-and-frontend.md § Migration Write-Freeze Flag](./api-and-frontend.md#migration-write-freeze-flag-unleash)
 for full implementation details.
 
+### On-Prem Migration Checklist
+
+On-prem deployments lack the Unleash write-freeze flag. Operators
+running M2 or M5 migrations should follow this checklist:
+
+| # | Step | When | How to verify |
+|---|------|------|---------------|
+| 1 | **Announce maintenance window** | Before migration | Notify all cost model editors that writes are suspended |
+| 2 | **Scale down API replicas** (optional but recommended) | Before migration | `kubectl scale deployment/<koku-api> --replicas=0` — prevents any concurrent writes |
+| 3 | **Run migrations** | During window | `./manage.py migrate cost_models` — executes M1 + M2 (or M5) |
+| 4 | **Validate M2**: Rate rows match PriceList JSON | After M2 | `SELECT COUNT(*) FROM cost_model_rate` matches total rates across all PriceLists |
+| 5 | **Validate M2**: `custom_name` populated | After M2 | `SELECT COUNT(*) FROM cost_model_rate WHERE custom_name IS NULL` = 0 |
+| 6 | **Validate M5**: JSON columns dropped | After M5 | `\d cost_model` — confirm `rates` column absent |
+| 7 | **Scale up API replicas** | After validation | `kubectl scale deployment/<koku-api> --replicas=<N>` |
+| 8 | **Resume normal operations** | After scale-up | Confirm API responds to cost model GET/PUT |
+
 ---
 
 ## Risk × Phase Matrix

--- a/docs/architecture/cost-breakdown/risk-register.md
+++ b/docs/architecture/cost-breakdown/risk-register.md
@@ -18,19 +18,20 @@ design documents link here for details.
 | R4 | Monthly cost rates produce more rows than expected | **MITIGATED** | 3 | GROUP BY quantified (OQ-2). |
 | R5 | Cost category reclassification invalidates breakdown tree | **MITIGATED** | 4 | Existing `update_summary_tables` chain handles it (OQ-4). |
 | R6 | 25 SQL file modifications introduce regressions | Active | 3 | Per-file-per-PR + 8-point checklist. |
-| R7 | Dual-write divergence (JSON ↔ Rate table) | Active | 1-4 | Delete-all + recreate on every write. |
+| R7 | Dual-write divergence (JSON ↔ PriceList.rates ↔ Rate table) | Active | 1-4 | COST-575 already dual-writes JSON ↔ PriceList.rates. Phase 1 extends with delete-all + recreate Rate rows on every write. Three-way sync wrapped in `@transaction.atomic`. |
 | R8 | `custom_name` migration produces ugly names | Active | 1 | Acceptable per PRD; users can rename. |
 | R9 | Frontend tab restructure breaks workflows | Active | 4 | Usage cards move to adjacent tab, not removed. |
 | R10 | Trino SQL dialect issues | Active | 3 | Test with Trino locally. |
 | R11 | Concurrent cost model updates create duplicate rows | Active | 2-3 | Redis lock + DELETE-before-INSERT. |
-| R12 | `CostModelManager.update()` missing `@transaction.atomic` | Active | 1 | Add `@transaction.atomic`. |
+| R12 | `CostModelManager.update()` missing `@transaction.atomic` | **MITIGATED** | 1 | COST-575 PR [#5963](https://github.com/project-koku/koku/pull/5963) already added `@transaction.atomic` to `update()`. |
 | R13 | JSONB JOIN performance in aggregation | **MITIGATED** | 2 | `label_hash` column replaces JSONB GROUP BY. |
 | R14 | Back-allocation rounding | **N/A** | — | Eliminated by IQ-9 Option 1. |
 | R15 | Back-allocation JOIN complexity | **REPLACED** | 4 | Replaced by simpler RTU × daily summary JOIN. |
 | R16 | Aggregation GROUP BY granularity mismatch | Active | 2 | `resource_id` confirmed absent from GROUP BY. |
 | R17 | Markup ORM overhead | **MITIGATED** | 2 | ORM-first + SQL fallback if >30s. |
-| R18 | Distribution SQL rewrite regression | Active | 4 | Old files preserved for rollback; existing integration tests sufficient per tech lead. |
+| R18 | Distribution SQL rewrite regression | Active | 4 | Old files preserved for rollback; new integration tests execute actual SQL and assert per-rate correctness (Phase 4 artifact). |
 | R19 | Aggregation handling of `distributed_cost` | **RESOLVED** | 4 | Aggregation sums both `calculated_cost` and `distributed_cost` (Option A). |
+| R20 | Concurrent API writes during migration corrupt data | **MITIGATED** | 1, 5 | Unleash write-freeze flag blocks cost model API writes during M2 and M5. |
 
 ---
 
@@ -196,7 +197,12 @@ files. Old files preserved for rollback (code revert, no Unleash flag).
 
 Per tech lead: existing integration tests that check distribution
 amounts on the daily summary table are sufficient to confirm no
-regressions. No separate CI gate or staging dataset comparison needed.
+regressions at the aggregate level. However, those tests mock
+`_execute_raw_sql_query` and verify orchestration (method was called),
+not mathematical correctness. Phase 4 adds **new integration tests**
+that execute the actual distribution SQL against the test database and
+assert per-rate proportional correctness, sum consistency, and edge
+cases. See [phased-delivery.md § Concern 1 Resolution](./phased-delivery.md#concern-1-resolution--distribution-integration-tests).
 
 | # | Criterion | Threshold |
 |---|-----------|-----------|
@@ -207,6 +213,14 @@ regressions. No separate CI gate or staging dataset comparison needed.
 | 5 | Single-node clusters | Distribution degenerates correctly (100% to the single node) |
 | 6 | GPU distribution | GPU rates distribute by GPU-specific metrics, not CPU/memory |
 | 7 | Execution time | New per-rate distribution ≤ 2× old distribution time per (source, date range) |
+| 8 | **Independent cross-check** | Per-rate distributed amounts match Option 2's formula: `(rate_cost / total_cost) × aggregate_distributed_cost` within NUMERIC precision |
+| 9 | Cost conservation | Net SUM(distributed_cost) across source + recipient rows = 0 per (day, distribution_type) |
+| 10 | Idempotency | Distribution run twice produces identical RatesToUsage state |
+
+Criteria 8-10 were added to compensate for removing IQ-9 Option 2 as a
+runtime fallback. Criterion 8 is the most critical — it encodes Option
+2's back-allocation math as a test assertion, providing the mathematical
+cross-check that Option 2 would have provided in production.
 
 ### Orchestration phasing note
 
@@ -250,6 +264,54 @@ needed.
 
 ---
 
+## R20 — Migration Write-Corruption
+
+**Status**: **MITIGATED** — Unleash write-freeze flag
+
+### Problem
+
+M2 (data migration) iterates `PriceListCostModelMap` rows, creates
+`Rate` rows from `PriceList.rates` JSON, and injects `custom_name` back
+into both `CostModel.rates` and `PriceList.rates` JSON blobs. Unlike
+COST-575's migration `0011` (which uses `SELECT ... FOR UPDATE` per
+row), M2 processes multiple price lists sequentially without row-level
+locking across the full migration window.
+
+If a user concurrently updates a cost model via the API during M2:
+
+1. The API write could overwrite `custom_name` that M2 just injected
+2. A new rate added via API would not have a corresponding `Rate` row
+3. A rate deleted via API would leave orphaned `Rate` rows
+
+The same concern applies to M5 (dropping JSON columns) — any in-flight
+API write during column drop could fail with a database error.
+
+### Decision: Unleash write-freeze flag
+
+| # | Approach | Pros | Cons | Verdict |
+|---|----------|------|------|---------|
+| A | Row-level `SELECT FOR UPDATE` in M2 | No external dependency | Does not prevent new cost models created during migration; complex locking across multiple tables | **Rejected** |
+| B | **Unleash write-freeze flag** | Simple, operator-controlled, follows existing koku patterns | Requires Unleash access; brief API downtime for cost model writes | **Selected** |
+| C | Maintenance window (manual) | No code changes | Error-prone; no enforcement mechanism | **Rejected** |
+
+### Implementation
+
+- **Flag**: `cost-management.backend.disable-cost-model-writes`
+- **Helper**: `is_cost_model_writes_disabled(schema)` in
+  `masu/processor/__init__.py` (follows existing pattern)
+- **Gating**: `CostModelSerializer.create()` and `update()` check the
+  flag via `self.customer.schema_name`; raise `ValidationError` → HTTP 503
+  with `Retry-After`
+- **On-prem**: `MockUnleashClient` returns `False` by default; on-prem
+  manages migration windows through operator coordination
+- **Windows**: Enable before M2 / M5; disable after completion +
+  validation
+
+See [api-and-frontend.md § Migration Write-Freeze Flag](./api-and-frontend.md#migration-write-freeze-flag-unleash)
+for full implementation details.
+
+---
+
 ## Risk × Phase Matrix
 
 ```
@@ -265,7 +327,7 @@ R8          ██
 R9                                           ██
 R10                               ██
 R11                    ██         ██
-R12         ██
+R12         ✓ (mitigated — COST-575 added @transaction.atomic)
 R13                    ✓ (mitigated — label_hash)
 R14                                         — (eliminated — Option 1)
 R15                                         ██ (Option 1 distribution JOINs)
@@ -273,6 +335,7 @@ R16                    ██ (GROUP BY granularity)
 R17                    ██         ██ (markup ORM)
 R18                                         ██ (distribution regression)
 R19                                         ✓ (resolved — aggregation sums both columns)
+R20         ✓ (mitigated — Unleash write-freeze)                       ✓ (mitigated)
 ```
 
 ---
@@ -283,3 +346,8 @@ R19                                         ✓ (resolved — aggregation sums b
 |---------|------|---------|
 | v1.0 | 2026-03-19 | Initial: extracted from phased-delivery.md, data-model.md, sql-pipeline.md. Full risk register (R1-R19), decision rationales (R2/R3, R6, R11, R13, R17), Phase 2 benchmarks, R18 regression test approach, R19 aggregation question. |
 | v1.1 | 2026-03-23 | **R19 RESOLVED (Option A)**: aggregation sums both `calculated_cost` and `distributed_cost`. R18: acceptance criteria confirmed — existing integration tests sufficient per tech lead. |
+| v1.2 | 2026-04-02 | **Align with COST-575.** R7: updated to reflect three-way sync (JSON + PriceList.rates + Rate table). R12: **MITIGATED** — `@transaction.atomic` already added to `update()` by COST-575 PR #5963. |
+| v1.3 | 2026-04-02 | **R20: Migration write-corruption.** Add risk for concurrent API writes during M2/M5 migration windows. Mitigation: Unleash write-freeze flag (`cost-management.backend.disable-cost-model-writes`). Decision rationale (3 options evaluated). Update Risk × Phase Matrix. |
+| v1.4 | 2026-04-02 | **Critical review.** Fix R20 gating location: `CostModelSerializer` (not `CostModelManager`) — serializer has `self.customer.schema_name`, manager does not. |
+| v1.5 | 2026-04-02 | **Self-resolve Concern 1.** Strengthen R18 mitigation: add integration tests that execute actual distribution SQL (not mocked) as Phase 4 artifact. |
+| v1.6 | 2026-04-03 | **R18 criteria expanded.** Add criteria 8 (independent cross-check via Option 2's formula), 9 (cost conservation), 10 (idempotency) to compensate for removing IQ-9 Option 2 as runtime fallback. |

--- a/docs/architecture/cost-breakdown/test-plan.md
+++ b/docs/architecture/cost-breakdown/test-plan.md
@@ -1,0 +1,1019 @@
+# Test Plan — COST-7249 Phase 1: Schema Normalization
+
+**IEEE 829 Format** | Version 1.0 | 2026-04-06
+
+---
+
+## 1. Test Plan Identifier
+
+`TP-COST-7249-P1-v1.0`
+
+---
+
+## 2. References
+
+| ID | Document | Location |
+|----|----------|----------|
+| REF-1 | Cost breakdown technical design | `docs/architecture/cost-breakdown/README.md` |
+| REF-2 | Data model spec | `docs/architecture/cost-breakdown/data-model.md` |
+| REF-3 | API and frontend spec | `docs/architecture/cost-breakdown/api-and-frontend.md` |
+| REF-4 | Phased delivery plan | `docs/architecture/cost-breakdown/phased-delivery.md` |
+| REF-5 | Risk register | `docs/architecture/cost-breakdown/risk-register.md` |
+| REF-6 | Concerns register | `docs/architecture/cost-breakdown/open-concerns.md` |
+| REF-7 | COST-575 PR #5957 | Migration 0011: CostModel → PriceList data migration |
+| REF-8 | COST-575 PR #5963 | Dual-write CostModel rates to PriceList |
+| REF-9 | Tech lead gist | Migration coordination / dual-write strategy |
+| REF-10 | Design PR #5980 | Alignment with COST-575 (approved, pending merge) |
+
+---
+
+## 3. Introduction
+
+Phase 1 normalizes rate storage from a JSON blob (`CostModel.rates`)
+into a relational `Rate` table, introduces diff-based synchronization
+(`_sync_rate_table`), and adds an Unleash write-freeze flag for
+migration safety. This test plan covers all Phase 1 deliverables.
+
+### 3.1 Scope
+
+| In Scope | Out of Scope |
+|----------|-------------|
+| `Rate` Django model (M1 DDL) | `RatesToUsage` model (Phase 2) |
+| Data migration M2 (JSON → Rate rows) | SQL pipeline changes (Phase 2-3) |
+| Diff-based `_sync_rate_table()` | Breakdown API/UI (Phase 4) |
+| `RateSerializer` updates (`rate_id`, `custom_name`) | JSON column drop (Phase 5) |
+| Unleash write-freeze flag + serializer gating | Frontend `rate_id` support (separate PR) |
+| Helper functions (`generate_custom_name`, `derive_metric_type`, `extract_default_rate`) | `CostModelDBAccessor` read-path changes (Phase 1b) |
+
+---
+
+## 4. Test Items
+
+| ID | Item | Source File(s) | Priority |
+|----|------|---------------|----------|
+| TI-1 | `Rate` model | `cost_models/models.py` | P0 |
+| TI-2 | Migration 0012 (Rate DDL) | `cost_models/migrations/0012_*.py` | P0 |
+| TI-3 | Migration 0013 (data migration) | `cost_models/migrations/0013_*.py` | P0 |
+| TI-4 | `generate_custom_name()` | `cost_models/cost_model_manager.py` | P0 |
+| TI-5 | `derive_metric_type()` | `cost_models/cost_model_manager.py` | P0 |
+| TI-6 | `extract_default_rate()` | `cost_models/cost_model_manager.py` | P0 |
+| TI-7 | `RateSerializer` (`rate_id`, `custom_name`, `to_representation`) | `cost_models/serializers.py` | P0 |
+| TI-8 | `_sync_rate_table()` (diff-based sync) | `cost_models/cost_model_manager.py` | P0 |
+| TI-9 | `_apply_rate_fields()`, `_rate_fields_from_data()` | `cost_models/cost_model_manager.py` | P1 |
+| TI-10 | `is_cost_model_writes_disabled()` | `masu/processor/__init__.py` | P0 |
+| TI-11 | Write-freeze gating in `CostModelSerializer` | `cost_models/serializers.py` | P0 |
+| TI-12 | Integration: create → sync → GET round-trip | Multiple | P0 |
+| TI-13 | Integration: update → diff-sync → GET round-trip | Multiple | P0 |
+
+---
+
+## 5. Software Risk Issues — Pre-Implementation Due Diligence
+
+The following findings were identified by tracing the actual codebase
+against the design specifications. Each finding has a severity, impact
+assessment, and resolution that is incorporated into the implementation
+phases below.
+
+### F1: `related_name="rates"` conflicts with `PriceList.rates` JSONField
+
+**Severity**: BLOCKER (Django will refuse to create the model)
+
+**Evidence**: `PriceList` has `rates = JSONField()` (line 137,
+`models.py`). The design doc's `Rate` model specifies
+`related_name="rates"` on the `price_list` FK. Django raises
+`SystemCheckError` when a reverse relation name collides with an
+existing field.
+
+**Resolution**: Use `related_name="rate_rows"`. The `_sync_rate_table`
+pseudocode already uses `price_list.rate_rows.all()`, confirming this
+was the intended name.
+
+### F2: Design doc `PriceList` schema diverges from COST-575 implementation
+
+**Severity**: HIGH (wrong FK target, wrong table name)
+
+**Evidence**: `data-model.md` § New Models describes `PriceList` with
+`db_table = "cost_model_price_list"`, a direct `cost_model` FK, and
+`primary`/`fallback` fields. The actual `PriceList` (COST-575, line
+109, `models.py`) uses `db_table = "price_list"`, has `name`,
+`description`, `currency`, date fields, and links via
+`PriceListCostModelMap` junction table.
+
+**Resolution**: Implementation follows the COST-575 code, not the
+pre-alignment data-model.md. The Rate model's FK points to the
+existing `PriceList`. Migration M2 iterates `PriceListCostModelMap`
+entries. The design PR (#5980) updated `api-and-frontend.md` and
+`open-concerns.md` to reflect this alignment.
+
+### F3: `tag_values` default should be `list` not `dict`
+
+**Severity**: MEDIUM (incorrect default, data shape mismatch)
+
+**Evidence**: Design doc specifies `tag_values = JSONField(default=dict)`.
+Actual tag rate data in `CostModel.rates` stores `tag_values` as a list
+of dicts: `[{"tag_value": "smoke", "value": 123, ...}]`. Gemini
+code-assist flagged this (PR #5980 review).
+
+**Resolution**: Use `JSONField(default=list)` in the Rate model and
+migration. Tests must verify both empty default and populated list.
+
+### F4: `default_rate` extraction ignores tag rates
+
+**Severity**: MEDIUM (tag-based rates get `default_rate=0`)
+
+**Evidence**: M2 migration pseudocode extracts `default_rate` from
+`tiered_rates[0].get("value", 0)`. For tag-based rates, `tiered_rates`
+is empty/absent — the default rate should come from the tag_values
+entry where `default=True`.
+
+**Resolution**: `extract_default_rate()` checks `tiered_rates` first,
+then falls back to the default tag value. Tests cover both paths.
+
+### F5: M2 migration uses `create()` in loop instead of `bulk_create`
+
+**Severity**: LOW (performance, not correctness)
+
+**Evidence**: M2 pseudocode calls `Rate.objects.create()` per rate
+inside the mapping loop. Gemini code-assist flagged this.
+
+**Resolution**: Collect Rate instances per mapping, `bulk_create` after
+the loop. Must still inject `rate_id` back — `bulk_create` returns
+objects with populated PKs (Django 4.2+, PostgreSQL).
+
+### F6: `auto_now` field not in `update_fields` for second save
+
+**Severity**: LOW (timestamp slightly stale, not incorrect)
+
+**Evidence**: `_sync_rate_table` calls
+`self._model.save(update_fields=["rates"])` which does NOT update
+`updated_timestamp` (Django's `auto_now` requires explicit inclusion
+in `update_fields`). However, `update()` calls `self._model.save()`
+(no `update_fields`) immediately before, which DOES update the
+timestamp. The second save is moments later — the timestamp is at most
+milliseconds stale.
+
+**Resolution**: Acceptable. The first save in `update()` sets the
+authoritative timestamp. Document the two-save pattern in code
+comments. If precision matters, add `"updated_timestamp"` to the
+second save's `update_fields`.
+
+### F7: Redundant PriceList save in `update()` flow
+
+**Severity**: LOW (extra DB write, not incorrect)
+
+**Evidence**: `update()` saves `pl.rates` directly, then calls
+`_sync_rate_table()` which saves `pl.rates` again (with `rate_id`
+injected). Two PriceList writes per update.
+
+**Resolution**: Remove the direct PriceList save from `update()`. Let
+`_sync_rate_table()` handle the final save after `rate_id` injection.
+The `create()` flow is clean (no pre-save).
+
+### F8: Monthly/node/cluster/PVC metrics absent from `USAGE_METRIC_MAP`
+
+**Severity**: MEDIUM (unmapped metrics → `derive_metric_type` fails)
+
+**Evidence**: `USAGE_METRIC_MAP` (line 323, `constants.py`) only maps 9
+usage-hour/storage-month metrics. Monthly cost metrics like
+`node_cost_per_month`, `cluster_cost_per_month`, `pvc_cost_per_month`,
+`project_per_month`, `vm_cost_per_month`, and `gpu_cost_per_month` are
+NOT in the map. A cost model can contain any `METRIC_CHOICES` metric.
+
+```python
+USAGE_METRIC_MAP = {
+    "cpu_core_usage_per_hour": "cpu",
+    "cpu_core_request_per_hour": "cpu",
+    "cpu_core_effective_usage_per_hour": "cpu",
+    "memory_gb_usage_per_hour": "memory",
+    "memory_gb_request_per_hour": "memory",
+    "memory_gb_effective_usage_per_hour": "memory",
+    "storage_gb_usage_per_month": "storage",
+    "storage_gb_request_per_month": "storage",
+    "cluster_core_cost_per_hour": "cpu",
+}
+```
+
+Missing from map:
+- `node_cost_per_month` → should map to `"node"` or `"other"`
+- `node_core_cost_per_hour` → `"cpu"` (node-level)
+- `node_core_cost_per_month` → `"cpu"` (node-level)
+- `cluster_cost_per_month` → `"other"` (cluster-level)
+- `cluster_cost_per_hour` → `"other"` (cluster-level)
+- `pvc_cost_per_month` → `"storage"` (PVC-level)
+- `vm_cost_per_month/hour/core` → `"other"` (VM-level)
+- `project_per_month` → `"other"` (project-level, tag-only)
+- `gpu_cost_per_month` → `"gpu"`
+
+**Resolution**: `derive_metric_type()` must handle ALL `METRIC_CHOICES`
+values. Use a local extended map or heuristic-based derivation (parse
+the metric name for keywords: `cpu`/`core` → `"cpu"`,
+`mem`/`memory` → `"memory"`, `storage`/`gb`/`pvc` → `"storage"`,
+`gpu` → `"gpu"`, else → `"other"`). Tests must cover every
+`METRIC_CHOICES` value.
+
+### F9: Write-freeze returns HTTP 400 instead of 503
+
+**Severity**: LOW (semantic, not functional)
+
+**Evidence**: Design doc mentions HTTP 503 Service Unavailable for the
+write-freeze. The serializer-level implementation uses
+`serializers.ValidationError(...)` which returns HTTP 400 Bad Request.
+
+**Resolution**: Accept HTTP 400 for Phase 1 — the message clearly
+states "Cost model writes are temporarily disabled during migration."
+HTTP 503 would require a custom DRF exception class. Documented as a
+future refinement. Tests assert the error message content, not the
+status code (so upgrading to 503 later requires minimal test changes).
+
+### F10: `CostModel.rates` is `JSONField(default=dict)` but stores a list
+
+**Severity**: MEDIUM (type ambiguity in migration and sync)
+
+**Evidence**: Empty cost models: `rates = {}`. Populated cost models:
+`rates = [{...}, {...}]`. Migration 0011 handles this with
+`.exclude(rates=[]).exclude(rates={})`. The sync code must also handle
+`{}` as "no rates".
+
+**Resolution**: `_sync_rate_table()` treats both `{}` and `[]` as
+empty. M2 migration follows 0011's exclusion pattern. Tests cover
+both empty shapes.
+
+### F11: No coverage threshold enforced in CI
+
+**Severity**: LOW (process, not correctness)
+
+**Evidence**: `.coveragerc` has no `fail_under` setting. `tox.ini`
+runs `coverage report` without enforcing a minimum.
+
+**Resolution**: The 80% per-tier target is self-enforced. Each TDD
+checkpoint includes a coverage measurement. Final checkpoint asserts
+80% across all new code.
+
+### F12: Serializer `update()` calls `update_provider_uuids` before `update()`
+
+**Severity**: INFO (pre-existing, not introduced by Phase 1)
+
+**Evidence**: `CostModelSerializer.update()` calls
+`manager.update_provider_uuids(...)` (which queues Celery tasks)
+before `manager.update(...)` (which syncs Rate table). These are
+separate `@transaction.atomic` methods. A Celery task could
+theoretically run between them, seeing stale Rate data.
+
+**Resolution**: Pre-existing behavior, not introduced by Phase 1. The
+Celery task reads `CostModel.rates` JSON (not the Rate table yet).
+Phase 2 changes the read path. Documented as a known limitation for
+Phase 2 migration.
+
+---
+
+## 6. Features to be Tested
+
+### 6.1 Rate Model (TI-1, TI-2)
+
+| TC-ID | Description | Business Criterion |
+|-------|-------------|-------------------|
+| TC-1.1 | Create Rate with valid fields | Rate rows persist correctly |
+| TC-1.2 | `unique_together` constraint on (price_list, custom_name) | No duplicate rate names per price list |
+| TC-1.3 | FK cascade: delete PriceList → deletes Rate rows | Referential integrity |
+| TC-1.4 | FK cascade: delete CostModel → PriceListCostModelMap → PriceList → Rate rows | Full cascade chain |
+| TC-1.5 | `default_rate` stores Decimal(33,15) precision | Financial accuracy |
+| TC-1.6 | `tag_values` stores list of dicts (not dict) | Correct JSON shape |
+| TC-1.7 | `metric` field accepts all `METRIC_CHOICES` values | Full metric coverage |
+| TC-1.8 | `custom_name` max length 50 enforced | UI constraint |
+| TC-1.9 | `related_name="rate_rows"` accessible from PriceList | Reverse relation works |
+
+### 6.2 Helper Functions (TI-4, TI-5, TI-6)
+
+| TC-ID | Description | Business Criterion |
+|-------|-------------|-------------------|
+| TC-2.1 | `generate_custom_name` from description | User-friendly label |
+| TC-2.2 | `generate_custom_name` from metric.name when no description | Automatic labeling |
+| TC-2.3 | `generate_custom_name` deduplication within batch | No `unique_together` violations |
+| TC-2.4 | `generate_custom_name` truncation at 50 chars | Max length respected |
+| TC-2.5 | `derive_metric_type` for all 20 `METRIC_CHOICES` | Correct classification |
+| TC-2.6 | `derive_metric_type` for unknown metric | Graceful fallback |
+| TC-2.7 | `extract_default_rate` from tiered rate | Correct Decimal extraction |
+| TC-2.8 | `extract_default_rate` from tag rate (default entry) | Tag rate support |
+| TC-2.9 | `extract_default_rate` from empty rate | Zero fallback |
+| TC-2.10 | `extract_default_rate` Decimal conversion from string | JSON string → Decimal |
+
+### 6.3 Data Migration M2 (TI-3)
+
+| TC-ID | Description | Business Criterion |
+|-------|-------------|-------------------|
+| TC-3.1 | CostModel with tiered rates → Rate rows created | Data migrated correctly |
+| TC-3.2 | CostModel with tag rates → Rate rows created | Tag rate support |
+| TC-3.3 | CostModel with mixed rates → all Rate rows created | Mixed rate types |
+| TC-3.4 | CostModel without rates → skipped | No false positives |
+| TC-3.5 | CostModel with `rates={}` → skipped | Empty dict handling |
+| TC-3.6 | CostModel with `rates=[]` → skipped | Empty list handling |
+| TC-3.7 | `custom_name` injected into JSON blobs | Dual-write consistency |
+| TC-3.8 | `rate_id` injected into JSON blobs | rate_id round-trip support |
+| TC-3.9 | Already-migrated CostModel → skipped | Idempotency |
+| TC-3.10 | Reverse migration deletes Rate rows | Clean rollback |
+| TC-3.11 | Duplicate metric names get unique custom_names | No constraint violations |
+| TC-3.12 | `default_rate` is Decimal, not float | Financial precision |
+| TC-3.13 | `select_for_update()` prevents concurrent modification | Race condition safety |
+
+### 6.4 RateSerializer Updates (TI-7)
+
+| TC-ID | Description | Business Criterion |
+|-------|-------------|-------------------|
+| TC-4.1 | `rate_id` field accepts valid UUID | API contract |
+| TC-4.2 | `rate_id` field allows null | Backward compatibility |
+| TC-4.3 | `rate_id` field omitted → no error | Backward compatibility |
+| TC-4.4 | `custom_name` field accepts string | API contract |
+| TC-4.5 | `custom_name` field omitted → auto-generated | IQ-7 resolution |
+| TC-4.6 | `to_representation` includes `rate_id` when present | GET response contract |
+| TC-4.7 | `to_representation` omits `rate_id` when absent | Clean legacy output |
+| TC-4.8 | `to_representation` includes `custom_name` | GET response contract |
+| TC-4.9 | Existing fields (`metric`, `cost_type`, etc.) unchanged | Backward compatibility |
+| TC-4.10 | Full serializer round-trip: input → validate → save → output | End-to-end |
+
+### 6.5 Diff-Based `_sync_rate_table()` (TI-8, TI-9)
+
+| TC-ID | Description | Business Criterion |
+|-------|-------------|-------------------|
+| TC-5.1 | Create cost model with rates → Rate rows created | Basic sync |
+| TC-5.2 | Update: add a new rate → Rate row created | Incremental add |
+| TC-5.3 | Update: remove a rate → Rate row deleted | Incremental remove |
+| TC-5.4 | Update: modify rate value → Rate row updated, UUID preserved | Diff-based update |
+| TC-5.5 | Update: unchanged rates keep UUID | UUID stability |
+| TC-5.6 | Backward compat: no `rate_id` → match by `custom_name` | Legacy client support |
+| TC-5.7 | Backward compat: rename without `rate_id` → delete + create | Expected degradation |
+| TC-5.8 | Invalid `rate_id` (nonexistent) → CostModelException | Ownership validation |
+| TC-5.9 | Invalid `rate_id` (belongs to other price_list) → CostModelException | Cross-model protection |
+| TC-5.10 | Rename rate + create with old name in same request → succeeds | Delete→update→create ordering |
+| TC-5.11 | Metadata-only change (`description`) → no Celery recalculation | Change detection |
+| TC-5.12 | Cost-affecting change (`default_rate`) → triggers recalculation | Change detection |
+| TC-5.13 | `rate_id` injected into JSON blob after sync | GET response consistency |
+| TC-5.14 | `rate_id` injected into PriceList.rates after sync | Dual-write consistency |
+| TC-5.15 | Empty rates → all Rate rows deleted | Clear all |
+| TC-5.16 | `COST_AFFECTING_FIELDS` classification correct | Optimization correctness |
+
+### 6.6 Unleash Write-Freeze (TI-10, TI-11)
+
+| TC-ID | Description | Business Criterion |
+|-------|-------------|-------------------|
+| TC-6.1 | `is_cost_model_writes_disabled` returns True when flag enabled | Flag detection |
+| TC-6.2 | `is_cost_model_writes_disabled` returns False when flag disabled | Normal operation |
+| TC-6.3 | `MockUnleashClient` returns False (on-prem default) | On-prem safety |
+| TC-6.4 | `CostModelSerializer.create()` rejects when flag enabled | Write protection |
+| TC-6.5 | `CostModelSerializer.update()` rejects when flag enabled | Write protection |
+| TC-6.6 | `CostModelSerializer.create()` succeeds when flag disabled | Normal operation |
+| TC-6.7 | `CostModelSerializer.update()` succeeds when flag disabled | Normal operation |
+| TC-6.8 | No customer context → flag check skipped | Internal calls unblocked |
+| TC-6.9 | Error message identifies migration as cause | User clarity |
+| TC-6.10 | GET/DELETE requests unaffected by flag | Read/delete not gated |
+
+---
+
+## 7. Features Not to be Tested
+
+| Feature | Rationale |
+|---------|-----------|
+| `RatesToUsage` model and SQL pipeline | Phase 2 scope |
+| `OCPCostUIBreakDownP` table and breakdown API | Phase 4 scope |
+| Frontend `rate_id` round-trip | Separate koku-ui PR |
+| `CostModelDBAccessor` read-path from Rate table | Phase 1b (read path switch) |
+| JSON column drop (`CostModel.rates`, `PriceList.rates`) | Phase 5 scope |
+| Celery task execution and recalculation SQL | Pre-existing; mocked in Phase 1 tests |
+| RBAC permissions for cost model endpoints | Pre-existing; covered by existing test suite |
+
+---
+
+## 8. Approach
+
+### 8.1 Test-Driven Development (TDD) Cycle
+
+Each implementation phase follows strict Red-Green-Refactor:
+
+1. **TDD Red**: Write failing tests first. Tests define the expected
+   behavior from business acceptance criteria. All tests MUST fail
+   before implementation begins.
+2. **TDD Green**: Write the minimum code to make tests pass. No
+   premature optimization.
+3. **TDD Refactor**: Improve code quality (extract helpers, reduce
+   duplication, add docstrings) while keeping tests green.
+
+### 8.2 Test Tiers
+
+| Tier | Scope | Framework | Target Coverage |
+|------|-------|-----------|----------------|
+| Unit | Individual functions, model constraints | Django `TestCase` | ≥ 80% of new code |
+| Integration | Manager + serializer + model interaction | Django `TestCase` with `IamTestCase` base | ≥ 80% of new code |
+| Migration | Schema + data migration correctness | Django `TransactionTestCase` | 100% of migration paths |
+
+### 8.3 Anti-Patterns Avoided
+
+| Anti-Pattern | How Avoided |
+|-------------|-------------|
+| **Testing implementation details** | Tests assert observable behavior (DB state, API response shape), not internal method calls |
+| **Excessive mocking** | Only mock Celery tasks and Unleash client. All DB operations hit the test database. |
+| **Test interdependence** | Each test creates its own data in `setUp`. No shared mutable state between tests. |
+| **Snapshot/golden-file tests** | Tests assert specific field values, not serialized blobs |
+| **Testing Django/DRF internals** | Don't test that `models.UUIDField` generates UUIDs; test that our constraints and business rules work |
+| **Ignoring edge cases** | Explicit tests for empty rates, duplicate metrics, max-length strings, Decimal precision |
+| **Hard-coded dates/UUIDs** | Use `uuid4()`, `DateHelper()`, `Faker` for dynamic test data |
+| **Missing teardown** | `IamTestCase`/`MasuTestCase` handle schema cleanup; `@transaction.atomic` test isolation |
+
+### 8.4 Test Data Strategy
+
+| Data Type | Source | Pattern |
+|-----------|--------|---------|
+| `Provider` | Pre-seeded OCP provider from `MasuTestCase` | `Provider.objects.filter(type=Provider.PROVIDER_OCP).first()` |
+| `CostModel` | Created per test via `CostModelManager().create()` | Patching `update_cost_model_costs` to avoid Celery |
+| `PriceList` | Auto-created by `CostModelManager._get_or_create_price_list()` | Verified via `PriceListCostModelMap` |
+| `Rate` | Created by `_sync_rate_table()` or `Rate.objects.create()` | Verified via `price_list.rate_rows.all()` |
+| Unleash flags | `@patch("masu.processor.is_cost_model_writes_disabled")` | Consistent with existing flag mock pattern |
+
+### 8.5 Mocking Strategy
+
+```python
+# Celery task (always mocked — no async execution in tests)
+@patch("cost_models.cost_model_manager.update_cost_model_costs")
+
+# Unleash flag (mocked at the helper level, not the client)
+@patch("cost_models.serializers.is_cost_model_writes_disabled")
+
+# Provider creation side effects
+@patch("masu.celery.tasks.check_report_updates")
+```
+
+---
+
+## 9. Item Pass/Fail Criteria
+
+### 9.1 Pass Criteria
+
+- All test cases in all TDD phases pass (`manage.py test cost_models`)
+- Coverage ≥ 80% for each new module:
+  - `cost_models/models.py` (new Rate class) — ≥ 80%
+  - `cost_models/cost_model_manager.py` (new methods) — ≥ 80%
+  - `cost_models/serializers.py` (new/modified methods) — ≥ 80%
+  - `masu/processor/__init__.py` (new function) — ≥ 80%
+- Existing test suite passes without modification (backward compat)
+- Migration M2 forward and reverse pass against test database
+- No Django `SystemCheckError` from model definitions
+
+### 9.2 Fail Criteria
+
+- Any test case fails
+- Coverage < 80% for any new module after refactor phase
+- Existing tests fail (regression)
+- Migration raises exception during forward or reverse execution
+
+---
+
+## 10. Suspension Criteria and Resumption Requirements
+
+### 10.1 Suspension
+
+- Design doc PR #5980 rejected or requires material changes
+- COST-575 migrations (0010, 0011) reverted from main
+- Fundamental disagreement on Rate model schema
+
+### 10.2 Resumption
+
+- Design alignment confirmed
+- Prerequisite migrations stable on main
+- Schema changes agreed upon
+
+---
+
+## 11. Test Deliverables
+
+| Deliverable | Path |
+|-------------|------|
+| Rate model unit tests | `cost_models/test/test_rate_model.py` |
+| Helper function unit tests | `cost_models/test/test_rate_helpers.py` |
+| Migration tests | `cost_models/test/test_rate_migration.py` |
+| Serializer tests | `cost_models/test/test_serializers.py` (extended) |
+| Manager tests | `cost_models/test/test_cost_model_manager.py` (extended) |
+| Write-freeze tests | `cost_models/test/test_write_freeze.py` |
+| Integration tests | `cost_models/test/test_rate_integration.py` |
+| This test plan | `docs/tests/COST-7249/test-plan.md` |
+| Due diligence findings | § 5 of this document |
+| Coverage report | Generated per checkpoint |
+
+---
+
+## 12. Environmental Needs
+
+- PostgreSQL (test database via `KokuTestRunner`)
+- Django test framework (`manage.py test`)
+- Coverage tool (`coverage run` + `coverage report`)
+- Schema `org1234567` (pre-seeded by `MasuTestCase`)
+- Pre-seeded OCP provider (from `ModelBakeryDataLoader`)
+
+---
+
+## 13. TDD Implementation Phases
+
+Each phase follows the Red → Green → Refactor cycle. Checkpoints
+between phases perform rigorous due diligence before proceeding.
+
+---
+
+### Phase 1: Rate Model + Migration M1 (DDL)
+
+**Covers**: TI-1, TI-2 | **Test Cases**: TC-1.1 through TC-1.9
+
+#### Phase 1 — TDD Red
+
+Write failing tests that define Rate model behavior:
+
+```
+test_rate_model.py:
+├── TestRateModel
+│   ├── test_create_rate_with_valid_fields             (TC-1.1)
+│   ├── test_unique_together_price_list_custom_name    (TC-1.2)
+│   ├── test_cascade_delete_price_list_deletes_rates   (TC-1.3)
+│   ├── test_cascade_delete_cost_model_chain           (TC-1.4)
+│   ├── test_default_rate_decimal_precision             (TC-1.5)
+│   ├── test_tag_values_stores_list                     (TC-1.6)
+│   ├── test_metric_accepts_all_metric_choices          (TC-1.7)
+│   ├── test_custom_name_max_length_enforced            (TC-1.8)
+│   └── test_rate_rows_reverse_relation                 (TC-1.9)
+```
+
+**Acceptance**: All 9 tests fail with `ImportError` or `DoesNotExist`
+(Rate model doesn't exist yet).
+
+#### Phase 1 — TDD Green
+
+Implement:
+1. `Rate` class in `cost_models/models.py`
+2. Migration `0012_create_rate_table.py`
+
+Key implementation decisions (from due diligence):
+- `related_name="rate_rows"` (F1)
+- `tag_values = JSONField(default=list)` (F3)
+- `db_table = "cost_model_rate"`
+- FK to existing `PriceList` (F2)
+
+**Acceptance**: All 9 tests pass. `makemigrations --check` clean.
+
+#### Phase 1 — TDD Refactor
+
+- Add model `__str__` method
+- Verify index names don't collide with existing indexes
+- Confirm migration is reversible
+
+---
+
+### CHECKPOINT 1: Rate Model Due Diligence
+
+| Check | Method | Pass Criterion |
+|-------|--------|---------------|
+| Django system checks pass | `manage.py check` | No errors |
+| Migration applies cleanly | `manage.py migrate --run-syncdb` | No exceptions |
+| Migration reverses cleanly | `manage.py migrate cost_models 0011` | Rate table dropped |
+| No `related_name` clash | Inspect `PriceList._meta.related_objects` | `rate_rows` present, no `rates` conflict |
+| All `METRIC_CHOICES` accepted | Parameterized test with all 20 values | All pass |
+| Coverage ≥ 80% for Rate model | `coverage report --include="*/models.py"` | ≥ 80% of new lines |
+
+---
+
+### Phase 2: Helper Functions
+
+**Covers**: TI-4, TI-5, TI-6 | **Test Cases**: TC-2.1 through TC-2.10
+
+#### Phase 2 — TDD Red
+
+Write failing tests for all three helper functions:
+
+```
+test_rate_helpers.py:
+├── TestGenerateCustomName
+│   ├── test_from_description                           (TC-2.1)
+│   ├── test_from_metric_name_when_no_description       (TC-2.2)
+│   ├── test_deduplication_within_batch                  (TC-2.3)
+│   └── test_truncation_at_50_chars                      (TC-2.4)
+├── TestDeriveMetricType
+│   ├── test_all_metric_choices_mapped                   (TC-2.5)
+│   └── test_unknown_metric_returns_other                (TC-2.6)
+├── TestExtractDefaultRate
+│   ├── test_from_tiered_rate                            (TC-2.7)
+│   ├── test_from_tag_rate_default_entry                 (TC-2.8)
+│   ├── test_from_empty_rate                             (TC-2.9)
+│   └── test_decimal_conversion_from_string              (TC-2.10)
+```
+
+**Acceptance**: All 10 tests fail with `ImportError` (functions don't
+exist yet).
+
+#### Phase 2 — TDD Green
+
+Implement in `cost_models/cost_model_manager.py` (or a new
+`cost_models/rate_helpers.py` if cleaner):
+
+- `generate_custom_name(rate_data, existing_names=None) → str`
+- `derive_metric_type(metric_name) → str`
+- `extract_default_rate(rate_data) → Decimal`
+
+Key implementation decisions (from due diligence):
+- `derive_metric_type` uses heuristic for metrics not in
+  `USAGE_METRIC_MAP` (F8): parse metric name for `cpu`/`core` →
+  `"cpu"`, `mem` → `"memory"`, `storage`/`pvc` → `"storage"`,
+  `gpu` → `"gpu"`, else → `"other"`
+- `extract_default_rate` checks tag_values default entry (F4)
+- `generate_custom_name` appends ` (N)` suffix for duplicates
+
+**Acceptance**: All 10 tests pass.
+
+#### Phase 2 — TDD Refactor
+
+- Ensure `derive_metric_type` is deterministic and documented
+- Add type hints to all three functions
+- Extract metric parsing into a testable constant/map
+
+---
+
+### CHECKPOINT 2: Helper Functions Due Diligence
+
+| Check | Method | Pass Criterion |
+|-------|--------|---------------|
+| All 20 `METRIC_CHOICES` mapped | `test_all_metric_choices_mapped` | All return non-empty string |
+| `extract_default_rate` returns Decimal | Type assertion in tests | `isinstance(result, Decimal)` |
+| `generate_custom_name` idempotent | Same input → same output | Deterministic |
+| No import cycle | `python -c "from cost_models.cost_model_manager import generate_custom_name"` | No error |
+| Coverage ≥ 80% for helpers | `coverage report` | ≥ 80% of new lines |
+
+---
+
+### Phase 3: Data Migration M2
+
+**Covers**: TI-3 | **Test Cases**: TC-3.1 through TC-3.13
+
+#### Phase 3 — TDD Red
+
+Write failing tests for the data migration:
+
+```
+test_rate_migration.py:
+├── TestMigrateJsonToRateRows
+│   ├── test_tiered_rates_migrated                      (TC-3.1)
+│   ├── test_tag_rates_migrated                         (TC-3.2)
+│   ├── test_mixed_rates_migrated                       (TC-3.3)
+│   ├── test_no_rates_skipped                           (TC-3.4)
+│   ├── test_empty_dict_rates_skipped                   (TC-3.5)
+│   ├── test_empty_list_rates_skipped                   (TC-3.6)
+│   ├── test_custom_name_injected_into_json             (TC-3.7)
+│   ├── test_rate_id_injected_into_json                 (TC-3.8)
+│   ├── test_already_migrated_skipped                   (TC-3.9)
+│   ├── test_reverse_migration_deletes_rates            (TC-3.10)
+│   ├── test_duplicate_metric_unique_custom_names       (TC-3.11)
+│   ├── test_default_rate_is_decimal                    (TC-3.12)
+│   └── test_select_for_update_locking                  (TC-3.13)
+```
+
+**Acceptance**: All 13 tests fail (migration doesn't exist yet).
+
+#### Phase 3 — TDD Green
+
+Implement migration `0013_migrate_json_to_rate_rows.py`:
+
+- `RunPython` with `atomic=False` on the migration class
+- Per-mapping `transaction.atomic()` + `select_for_update()`
+- `bulk_create` Rate rows per mapping (F5)
+- Inject `custom_name` and `rate_id` back into JSON blobs
+- Skip mappings where Rate rows already exist (idempotency)
+- `tag_values` defaults to `[]` not `{}` (F3)
+- `default_rate` extracted from tag default entry (F4)
+- Decimal conversion via `Decimal(str(value))` (TC-3.12)
+- Reverse function deletes Rate rows
+
+**Acceptance**: All 13 tests pass.
+
+#### Phase 3 — TDD Refactor
+
+- Extract migration helper functions (testable outside migration)
+- Ensure reverse migration is safe (doesn't delete manually-created
+  Rate rows — scope deletion to auto-migrated ones)
+- Performance: verify `bulk_create` batch size
+
+---
+
+### CHECKPOINT 3: Data Migration Due Diligence
+
+| Check | Method | Pass Criterion |
+|-------|--------|---------------|
+| Forward migration succeeds | `manage.py migrate cost_models` | No exceptions |
+| Reverse migration succeeds | `manage.py migrate cost_models 0012` | Rate rows removed |
+| Forward then reverse then forward | Triple-apply test | Idempotent |
+| JSON blobs updated with custom_name | Query `CostModel.rates` after migration | All entries have `custom_name` |
+| JSON blobs updated with rate_id | Query `CostModel.rates` after migration | All entries have `rate_id` (UUID string) |
+| Rate count matches JSON rate count | `Rate.objects.count()` vs `sum(len(cm.rates) for cm)` | Equal |
+| No `unique_together` violations | Migration completes without `IntegrityError` | Clean |
+| Coverage ≥ 80% for migration | `coverage report` | ≥ 80% of migration code |
+
+---
+
+### Phase 4: RateSerializer Updates
+
+**Covers**: TI-7 | **Test Cases**: TC-4.1 through TC-4.10
+
+#### Phase 4 — TDD Red
+
+Extend `test_serializers.py` with new test methods:
+
+```
+test_serializers.py (extended):
+├── CostModelSerializerTest
+│   ├── test_rate_id_field_accepts_uuid                 (TC-4.1)
+│   ├── test_rate_id_field_allows_null                  (TC-4.2)
+│   ├── test_rate_id_field_omitted_no_error             (TC-4.3)
+│   ├── test_custom_name_field_accepts_string           (TC-4.4)
+│   ├── test_custom_name_field_omitted_auto_generated   (TC-4.5)
+│   ├── test_to_representation_includes_rate_id         (TC-4.6)
+│   ├── test_to_representation_omits_rate_id_if_absent  (TC-4.7)
+│   ├── test_to_representation_includes_custom_name     (TC-4.8)
+│   ├── test_existing_fields_unchanged                  (TC-4.9)
+│   └── test_serializer_round_trip                      (TC-4.10)
+```
+
+**Acceptance**: Tests for `rate_id` and `custom_name` fail (fields
+don't exist on `RateSerializer` yet). Tests for existing fields pass.
+
+#### Phase 4 — TDD Green
+
+Modify `cost_models/serializers.py`:
+
+- Add `rate_id = serializers.UUIDField(required=False, allow_null=True)`
+  to `RateSerializer`
+- Add `custom_name = serializers.CharField(max_length=50, required=False,
+  allow_blank=True)` to `RateSerializer`
+- Update `to_representation()` to include `rate_id` and `custom_name`
+  when present in the rate dict
+- Ensure `to_internal_value()` preserves `rate_id` and `custom_name`
+
+**Acceptance**: All 10 tests pass. Existing serializer tests still pass.
+
+#### Phase 4 — TDD Refactor
+
+- Consolidate `to_representation` logic
+- Ensure `rate_id` is UUID-formatted in output (not raw string)
+- Add validation: `custom_name` max 50 chars
+
+---
+
+### CHECKPOINT 4: RateSerializer Due Diligence
+
+| Check | Method | Pass Criterion |
+|-------|--------|---------------|
+| All existing serializer tests pass | `manage.py test cost_models.test.test_serializers` | 0 failures |
+| `rate_id` absent from legacy GET response | Test with pre-existing CostModel | No `rate_id` key |
+| `rate_id` present in new GET response | Test after `_sync_rate_table` | UUID string |
+| `custom_name` appears in GET response | Test after create/update | Non-empty string |
+| `to_internal_value` preserves extra fields | Test with `rate_id` + `custom_name` in input | Both survive |
+| Coverage ≥ 80% for serializer changes | `coverage report` | ≥ 80% of modified lines |
+
+---
+
+### Phase 5: Diff-Based `_sync_rate_table()`
+
+**Covers**: TI-8, TI-9 | **Test Cases**: TC-5.1 through TC-5.16
+
+#### Phase 5 — TDD Red
+
+Extend `test_cost_model_manager.py` with new test methods:
+
+```
+test_cost_model_manager.py (extended):
+├── CostModelManagerTest
+│   ├── test_create_with_rates_creates_rate_rows        (TC-5.1)
+│   ├── test_update_add_rate_creates_row                (TC-5.2)
+│   ├── test_update_remove_rate_deletes_row             (TC-5.3)
+│   ├── test_update_modify_rate_preserves_uuid          (TC-5.4)
+│   ├── test_update_unchanged_rate_keeps_uuid           (TC-5.5)
+│   ├── test_no_rate_id_matches_by_custom_name          (TC-5.6)
+│   ├── test_rename_without_rate_id_is_delete_create    (TC-5.7)
+│   ├── test_invalid_rate_id_raises_exception           (TC-5.8)
+│   ├── test_foreign_rate_id_raises_exception           (TC-5.9)
+│   ├── test_rename_and_create_old_name_succeeds        (TC-5.10)
+│   ├── test_description_change_no_recalculation        (TC-5.11)
+│   ├── test_default_rate_change_triggers_recalc        (TC-5.12)
+│   ├── test_rate_id_injected_into_model_json           (TC-5.13)
+│   ├── test_rate_id_injected_into_price_list_json      (TC-5.14)
+│   ├── test_empty_rates_deletes_all_rows               (TC-5.15)
+│   └── test_cost_affecting_fields_classification       (TC-5.16)
+```
+
+**Acceptance**: All 16 tests fail (`_sync_rate_table` doesn't exist).
+
+#### Phase 5 — TDD Green
+
+Implement in `cost_models/cost_model_manager.py`:
+
+- `_sync_rate_table(self, price_list, rates_data)`
+- `_apply_rate_fields(self, rate_obj, rate_data) → bool`
+- `_rate_fields_from_data(rate_data) → dict`
+- `COST_AFFECTING_FIELDS` class constant
+- Modify `create()` to call `_sync_rate_table()`
+- Modify `update()` to call `_sync_rate_table()` and remove
+  redundant PriceList save (F7)
+
+Key implementation decisions:
+- Delete → update → create ordering (Gap E)
+- `custom_name` backward-compat matching (Gap B)
+- `rate_id` ownership validation against `existing` dict (Gap D)
+- `rate_id` injection into JSON blobs
+
+**Acceptance**: All 16 tests pass. All existing manager tests pass.
+
+#### Phase 5 — TDD Refactor
+
+- Extract `COST_AFFECTING_FIELDS` to module level for reuse
+- Add logging for rate create/update/delete operations
+- Profile: ensure single-digit queries per sync call (no N+1)
+
+---
+
+### CHECKPOINT 5: Sync Due Diligence
+
+| Check | Method | Pass Criterion |
+|-------|--------|---------------|
+| All existing manager tests pass | `manage.py test cost_models.test.test_cost_model_manager` | 0 failures |
+| UUID stability verified | Create, update unrelated field, check UUID | Same UUID |
+| Backward compat verified | Update without `rate_id` → match by name | UUID preserved for unchanged rates |
+| Operation ordering verified | Rename A→B + create A in same request | No `IntegrityError` |
+| JSON blobs contain `rate_id` after create | Query `CostModel.rates` | Each entry has `rate_id` |
+| JSON blobs contain `rate_id` after update | Query `CostModel.rates` | Each entry has `rate_id` |
+| No N+1 queries | `assertNumQueries` or query logging | Bounded query count |
+| Coverage ≥ 80% for sync methods | `coverage report` | ≥ 80% of new lines |
+
+---
+
+### Phase 6: Unleash Write-Freeze
+
+**Covers**: TI-10, TI-11 | **Test Cases**: TC-6.1 through TC-6.10
+
+#### Phase 6 — TDD Red
+
+Write tests in a new file:
+
+```
+test_write_freeze.py:
+├── TestIsWriteDisabled
+│   ├── test_returns_true_when_flag_enabled             (TC-6.1)
+│   ├── test_returns_false_when_flag_disabled           (TC-6.2)
+│   └── test_mock_client_returns_false                  (TC-6.3)
+├── TestWriteFreezeGating
+│   ├── test_create_rejected_when_disabled              (TC-6.4)
+│   ├── test_update_rejected_when_disabled              (TC-6.5)
+│   ├── test_create_succeeds_when_enabled               (TC-6.6)
+│   ├── test_update_succeeds_when_enabled               (TC-6.7)
+│   ├── test_no_customer_skips_check                    (TC-6.8)
+│   ├── test_error_message_content                      (TC-6.9)
+│   └── test_get_delete_unaffected                      (TC-6.10)
+```
+
+**Acceptance**: All 10 tests fail.
+
+#### Phase 6 — TDD Green
+
+Implement:
+
+1. In `masu/processor/__init__.py`:
+   - `COST_MODEL_WRITE_FREEZE_FLAG = "cost-management.backend.disable-cost-model-writes"`
+   - `is_cost_model_writes_disabled(schema) → bool`
+
+2. In `cost_models/serializers.py`:
+   - Import `is_cost_model_writes_disabled`
+   - Add gate at top of `create()` and `update()`:
+     ```python
+     schema = self.customer.schema_name if self.customer else None
+     if schema and is_cost_model_writes_disabled(schema):
+         raise serializers.ValidationError(
+             error_obj("cost-models", "Cost model writes are temporarily disabled during migration.")
+         )
+     ```
+
+**Acceptance**: All 10 tests pass.
+
+#### Phase 6 — TDD Refactor
+
+- Extract gate logic into private method `_check_write_freeze()`
+- Add `# pragma: no cover` to `is_cost_model_writes_disabled` (matches
+  existing pattern for Unleash helpers)
+- Verify `LOG.info` message in gate function
+
+---
+
+### CHECKPOINT 6: Write-Freeze Due Diligence
+
+| Check | Method | Pass Criterion |
+|-------|--------|---------------|
+| Flag constant follows naming convention | Grep for `cost-management.backend.` prefix | Consistent |
+| `MockUnleashClient` returns False | Unit test (TC-6.3) | On-prem safe |
+| Serializer gate uses `self.customer` | Code review | Not `data.get("schema")` |
+| GET/DELETE unaffected | View-level test (TC-6.10) | 200 OK |
+| Error message is actionable | Assertion on message string | Contains "migration" |
+| Coverage ≥ 80% for write-freeze code | `coverage report` | ≥ 80% |
+
+---
+
+### Phase 7: Integration Tests
+
+**Covers**: TI-12, TI-13 | **Test Cases**: Full end-to-end
+
+#### Phase 7 — TDD Red
+
+Write integration tests that exercise the full stack:
+
+```
+test_rate_integration.py:
+├── TestRateIntegration
+│   ├── test_create_cost_model_with_rates_full_round_trip
+│   │   → Creates cost model via serializer
+│   │   → Verifies Rate rows exist
+│   │   → Verifies GET response includes rate_id + custom_name
+│   │   → Verifies JSON blobs consistent with Rate table
+│   │
+│   ├── test_update_cost_model_rates_diff_sync
+│   │   → Creates cost model with 3 rates
+│   │   → Updates: modify 1, remove 1, add 1
+│   │   → Verifies Rate row UUIDs: 1 preserved, 1 deleted, 1 new
+│   │   → Verifies GET response reflects changes
+│   │
+│   ├── test_update_then_get_rate_id_stability
+│   │   → Creates cost model
+│   │   → GET → captures rate_ids
+│   │   → PUT with same rates (including rate_ids)
+│   │   → GET → rate_ids unchanged
+│   │
+│   ├── test_write_freeze_blocks_create_and_update
+│   │   → Enable flag mock
+│   │   → POST cost model → 400 with message
+│   │   → PUT cost model → 400 with message
+│   │   → GET cost model → 200 (unaffected)
+│   │
+│   ├── test_backward_compat_no_rate_id_in_payload
+│   │   → Creates cost model (rates get rate_ids)
+│   │   → PUT with same rates but WITHOUT rate_ids
+│   │   → Verifies rates matched by custom_name
+│   │   → Verifies UUIDs preserved for unchanged rates
+│   │
+│   └── test_migration_then_api_update_consistency
+│       → Runs M2 migration on test data
+│       → Updates cost model via API
+│       → Verifies Rate table, JSON blobs, and API response all consistent
+```
+
+**Acceptance**: All integration tests fail initially (components not
+wired together yet — depends on Phase 5 completion).
+
+#### Phase 7 — TDD Green
+
+Wire all components together. The integration tests should pass once
+Phases 1-6 are complete and properly integrated.
+
+**Acceptance**: All integration tests pass. Full existing test suite
+passes.
+
+#### Phase 7 — TDD Refactor
+
+- Consolidate shared test setup into helper methods
+- Profile query counts for integration scenarios
+- Run full coverage report
+
+---
+
+### CHECKPOINT 7: Final Due Diligence
+
+| Check | Method | Pass Criterion |
+|-------|--------|---------------|
+| Full test suite passes | `manage.py test` | 0 failures |
+| Coverage ≥ 80% per tier | `coverage report` per new file | All ≥ 80% |
+| No migration conflicts | `makemigrations --check` | Clean |
+| Backward compatibility | Existing API tests unchanged | 0 regressions |
+| JSON blob + Rate table consistency | Integration test | Matching data |
+| `rate_id` round-trip: create → GET → PUT → GET | Integration test | UUID stable |
+| Write-freeze blocks writes only | View test with flag on/off | Create/update blocked, GET/DELETE pass |
+| On-prem safety (MockUnleashClient) | Unit test | Flag returns False |
+| No Django system check errors | `manage.py check` | 0 errors |
+| Performance: query count per create/update | `assertNumQueries` | Bounded, no N+1 |
+
+---
+
+## 14. Schedule
+
+| Phase | Estimated Duration | Dependencies |
+|-------|-------------------|-------------|
+| Phase 1: Rate Model + M1 | 0.5 day | Design PR merged or aligned |
+| Phase 2: Helper Functions | 0.5 day | Phase 1 |
+| Phase 3: Data Migration M2 | 1 day | Phase 1, Phase 2 |
+| Phase 4: RateSerializer | 0.5 day | Phase 1 |
+| Phase 5: `_sync_rate_table()` | 1.5 days | Phase 1, Phase 2, Phase 4 |
+| Phase 6: Write-Freeze | 0.5 day | None (independent) |
+| Phase 7: Integration Tests | 1 day | All phases |
+| **Total** | **~5.5 days** | |
+
+---
+
+## 15. Changelog
+
+| Version | Date | Summary |
+|---------|------|---------|
+| v1.0 | 2026-04-06 | Initial test plan. 13 test items, 68 test cases across 7 TDD phases with 7 checkpoints. 12 due diligence findings documented and addressed. |


### PR DESCRIPTION
## Summary

- **Align Phase 1 with COST-575**: Phase 1 now builds on top of the existing `price_list` table and `PriceListCostModelMap` from COST-575 ([#5963](https://github.com/project-koku/koku/pull/5963), [#5957](https://github.com/project-koku/koku/pull/5957)). Migration numbers renumbered (M1-M5). References tech lead's [migration coordination gist](https://gist.github.com/myersCody/91195a531ada9c09d39a5c5234993654).
- **R20: Unleash write-freeze flag**: Add `cost-management.backend.disable-cost-model-writes` to block API writes during M2 and M5 migration windows. Helper function in `masu/processor/__init__.py`, gating in `CostModelSerializer`.
- **Critical review fixes (v4.2)**: Move write-freeze gating from `CostModelManager` to `CostModelSerializer` (manager lacks schema context), add `@transaction.atomic` to `create()` pseudocode, fix risk range, add `Decimal()` conversion to M2 pseudocode.
- **Open concerns document**: [`open-concerns.md`](docs/architecture/cost-breakdown/open-concerns.md) with 5 code-grounded concerns for tech lead review (see below).

## Open Concerns for Review

The following concerns were identified during a critical review. Each is grounded in code evidence and includes a proposed action. See [open-concerns.md](docs/architecture/cost-breakdown/open-concerns.md) for full details.

1. **Distribution SQL tests verify orchestration, not correctness** — Tests mock `_execute_raw_sql_query` and assert it was called; no test runs actual distribution SQL against data or checks math. R18 mitigation may be weaker than stated.
2. **No observability instrumentation for the cost model pipeline** — `ocp_cost_model_cost_updater.py` has zero timing. Only metric is `charge_update_attempts_count` (attempts, not duration). Phase 2 replaces the core cost path with no production metrics to monitor.
3. **`_sync_rate_table()` delete-all and `RatesToUsage.rate_id` FK** — Every PUT triggers delete-all + recreate of Rate rows, NULLing `rate_id` on all historical `RatesToUsage` rows via `SET_NULL`. Not a bug, but undocumented tradeoff.
4. **On-prem M2 migration runs without write protection** — `MockUnleashClient.is_enabled()` returns `False`; M2 pseudocode lacks `select_for_update()` (unlike COST-575's 0011 migration). On-prem has no defense against concurrent writes during migration.
5. **No defined fallback trigger from IQ-9 Option 1 to Option 2** — Option 2 is documented as "viable fallback" but no decision gate defines when to switch. Team could spend sprints debugging Option 1 without a pre-agreed trigger.

## Test plan

- [ ] All design documents render correctly in GitHub markdown
- [ ] Cross-document references and links are valid
- [ ] Open concerns are grounded in code evidence (file paths, method names, code snippets verified against `main`)
- [ ] Tech lead reviews and comments on open-concerns.md


Made with [Cursor](https://cursor.com)