### PR TITLE
[COST-7249] Phase 1b: Backfill existing rates into Rate table

### DIFF
--- a/koku/cost_models/migrations/0013_normalize_rates_to_rate_table.py
+++ b/koku/cost_models/migrations/0013_normalize_rates_to_rate_table.py
@@ -1,0 +1,167 @@
+#
+# Copyright 2021 Red Hat Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Data migration to normalize PriceList JSON rates into the Rate table."""
+import uuid
+from decimal import Decimal
+from decimal import InvalidOperation
+
+from django.db import migrations
+
+# Superset of COST_MODEL_METRIC_MAP + UNLEASH_METRICS_GPU. gpu_cost_per_month is included
+# unconditionally because existing data may contain GPU rates regardless of the Unleash flag
+# state at migration time. The flag only gates the UI/API for new rate creation.
+COST_MODEL_METRIC_MAP = {
+    "cpu_core_usage_per_hour": "CPU",
+    "cpu_core_request_per_hour": "CPU",
+    "cpu_core_effective_usage_per_hour": "CPU",
+    "memory_gb_usage_per_hour": "Memory",
+    "memory_gb_request_per_hour": "Memory",
+    "memory_gb_effective_usage_per_hour": "Memory",
+    "storage_gb_usage_per_month": "Storage",
+    "storage_gb_request_per_month": "Storage",
+    "node_core_cost_per_hour": "Node",
+    "node_cost_per_month": "Node",
+    "node_core_cost_per_month": "Node",
+    "cluster_cost_per_month": "Cluster",
+    "cluster_cost_per_hour": "Cluster",
+    "cluster_core_cost_per_hour": "Cluster",
+    "pvc_cost_per_month": "Persistent volume claims",
+    "vm_cost_per_month": "Virtual Machine",
+    "vm_cost_per_hour": "Virtual Machine",
+    "vm_core_cost_per_month": "Virtual Machine",
+    "vm_core_cost_per_hour": "Virtual Machine",
+    "project_per_month": "Project",
+    "gpu_cost_per_month": "GPU",
+}
+
+LABEL_METRIC_TO_TYPE = {
+    "CPU": "cpu",
+    "Memory": "memory",
+    "Storage": "storage",
+    "Node": "node",
+    "Cluster": "cluster",
+    "Persistent volume claims": "pvc",
+    "Virtual Machine": "vm",
+    "Project": "project",
+    "GPU": "gpu",
+}
+
+
+def _derive_metric_type(metric_name):
+    label = COST_MODEL_METRIC_MAP.get(metric_name)
+    if label:
+        return LABEL_METRIC_TO_TYPE.get(label, "other")
+    return "other"
+
+
+def _generate_custom_name(rate_data, existing_names):
+    metric_name = rate_data.get("metric", {}).get("name", "unknown")
+    cost_type = rate_data.get("cost_type", "unknown")
+    tag_key = ""
+    if rate_data.get("tag_rates"):
+        tag_key = rate_data["tag_rates"].get("tag_key", "")
+
+    if tag_key:
+        base = f"{metric_name}-{cost_type}-{tag_key}"
+    else:
+        base = f"{metric_name}-{cost_type}"
+
+    base = base[:50]
+    candidate = base
+    counter = 2
+    while candidate in existing_names:
+        suffix = f"-{counter}"
+        candidate = base[: 50 - len(suffix)] + suffix
+        counter += 1
+    return candidate
+
+
+def _extract_default_rate(rate_data):
+    tiered_rates = rate_data.get("tiered_rates", [])
+    if tiered_rates:
+        first_value = tiered_rates[0].get("value")
+        if first_value is not None:
+            try:
+                result = Decimal(str(first_value))
+                if not result.is_finite():
+                    return None
+                return result
+            except (InvalidOperation, TypeError):
+                return None
+    return None
+
+
+def forward_func(apps, schema_editor):
+    """Create Rate rows from PriceList JSON rates."""
+    PriceList = apps.get_model("cost_models", "PriceList")
+    Rate = apps.get_model("cost_models", "Rate")
+
+    for pl in PriceList.objects.all():
+        if Rate.objects.filter(price_list=pl).exists():
+            continue
+
+        rates_json = pl.rates
+        if not rates_json or not isinstance(rates_json, list):
+            continue
+
+        existing_names = set()
+        rate_objects = []
+        for rate_data in rates_json:
+            if not isinstance(rate_data, dict):
+                continue
+
+            metric_dict = rate_data.get("metric")
+            if not isinstance(metric_dict, dict):
+                continue
+
+            metric_name = metric_dict.get("name", "")
+            cost_type = rate_data.get("cost_type", "")
+            description = rate_data.get("description", "")
+            metric_type = _derive_metric_type(metric_name)
+            custom_name = _generate_custom_name(rate_data, existing_names)
+            existing_names.add(custom_name)
+            default_rate = _extract_default_rate(rate_data)
+
+            tag_key = ""
+            tag_values = []
+            tag_rates = rate_data.get("tag_rates")
+            if isinstance(tag_rates, dict) and tag_rates:
+                tag_key = tag_rates.get("tag_key", "")
+                tag_values = tag_rates.get("tag_values", [])
+
+            rate_objects.append(
+                Rate(
+                    uuid=uuid.uuid4(),
+                    price_list=pl,
+                    custom_name=custom_name,
+                    description=description,
+                    metric=metric_name,
+                    metric_type=metric_type,
+                    cost_type=cost_type,
+                    default_rate=default_rate,
+                    tag_key=tag_key,
+                    tag_values=tag_values,
+                )
+            )
+
+        if rate_objects:
+            Rate.objects.bulk_create(rate_objects)
+
+
+def reverse_func(apps, schema_editor):
+    """Remove all Rate rows (they can be recreated from JSON)."""
+    Rate = apps.get_model("cost_models", "Rate")
+    Rate.objects.all().delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("cost_models", "0012_add_rate_model"),
+    ]
+
+    operations = [
+        migrations.RunPython(forward_func, reverse_func),
+    ]

--- a/koku/cost_models/test/test_rate_migration.py
+++ b/koku/cost_models/test/test_rate_migration.py
@@ -1,0 +1,328 @@
+#
+# Copyright 2021 Red Hat Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Tests for the data migration that normalizes PriceList JSON rates into Rate rows."""
+from decimal import Decimal
+
+from django.db import connection
+from django_tenants.utils import tenant_context
+
+from cost_models.models import CostModel
+from cost_models.models import PriceList
+from cost_models.models import PriceListCostModelMap
+from cost_models.models import Rate
+from masu.test import MasuTestCase
+
+MIGRATE_FROM = ("cost_models", "0012_add_rate_model")
+MIGRATE_TO = ("cost_models", "0013_normalize_rates_to_rate_table")
+
+
+class NormalizeRatesToRateTableTest(MasuTestCase):
+    """Test the data migration that populates Rate rows from PriceList JSON."""
+
+    def _run_migration(self, target):
+        """Run migration to target state within the tenant schema."""
+        from django.db.migrations.executor import MigrationExecutor
+
+        executor = MigrationExecutor(connection)
+        executor.migrate([target])
+        executor.loader.build_graph()
+
+    def _create_cost_model_with_price_list(self, name, rates):
+        """Helper to create a CostModel + PriceList + mapping."""
+        cm = CostModel.objects.create(
+            name=name,
+            description="Test",
+            source_type="OCP",
+            rates=rates,
+        )
+        pl = PriceList.objects.create(
+            name=f"{name} prices",
+            description="Auto-created",
+            currency="USD",
+            effective_start_date="2026-03-01",
+            effective_end_date="2099-12-31",
+            enabled=True,
+            version=1,
+            rates=rates,
+        )
+        PriceListCostModelMap.objects.create(
+            price_list=pl,
+            cost_model=cm,
+            priority=1,
+        )
+        return cm, pl
+
+    def test_tiered_rate_creates_rate_row(self):
+        """Test that a tiered rate in PriceList JSON produces a Rate row."""
+        with tenant_context(self.tenant):
+            self._run_migration(MIGRATE_FROM)
+            _, pl = self._create_cost_model_with_price_list(
+                "Tiered CM",
+                [
+                    {
+                        "metric": {"name": "cpu_core_usage_per_hour"},
+                        "tiered_rates": [{"value": "0.22", "unit": "USD"}],
+                        "cost_type": "Infrastructure",
+                    }
+                ],
+            )
+            self._run_migration(MIGRATE_TO)
+            rates = Rate.objects.filter(price_list=pl)
+            self.assertEqual(rates.count(), 1)
+            rate = rates.first()
+            self.assertEqual(rate.metric, "cpu_core_usage_per_hour")
+            self.assertEqual(rate.cost_type, "Infrastructure")
+            self.assertEqual(rate.default_rate, Decimal("0.22"))
+
+    def test_tag_rate_creates_rate_row(self):
+        """Test that a tag rate produces a Rate row with tag_key and tag_values."""
+        with tenant_context(self.tenant):
+            self._run_migration(MIGRATE_FROM)
+            tag_values = [
+                {"tag_value": "web", "value": "0.5", "unit": "USD", "default": False},
+                {"tag_value": "api", "value": "0.3", "unit": "USD", "default": False},
+            ]
+            _, pl = self._create_cost_model_with_price_list(
+                "Tag CM",
+                [
+                    {
+                        "metric": {"name": "cpu_core_usage_per_hour"},
+                        "tag_rates": {
+                            "tag_key": "app",
+                            "tag_values": tag_values,
+                        },
+                        "cost_type": "Supplementary",
+                    }
+                ],
+            )
+            self._run_migration(MIGRATE_TO)
+            rate = Rate.objects.get(price_list=pl)
+            self.assertEqual(rate.tag_key, "app")
+            self.assertEqual(rate.tag_values, tag_values)
+            self.assertIsNone(rate.default_rate)
+
+    def test_multiple_rates_create_multiple_rows(self):
+        """Test that multiple rates produce multiple Rate rows."""
+        with tenant_context(self.tenant):
+            self._run_migration(MIGRATE_FROM)
+            _, pl = self._create_cost_model_with_price_list(
+                "Multi CM",
+                [
+                    {
+                        "metric": {"name": "cpu_core_usage_per_hour"},
+                        "tiered_rates": [{"value": "0.22", "unit": "USD"}],
+                        "cost_type": "Infrastructure",
+                    },
+                    {
+                        "metric": {"name": "memory_gb_usage_per_hour"},
+                        "tiered_rates": [{"value": "0.10", "unit": "USD"}],
+                        "cost_type": "Supplementary",
+                    },
+                ],
+            )
+            self._run_migration(MIGRATE_TO)
+            self.assertEqual(Rate.objects.filter(price_list=pl).count(), 2)
+
+    def test_empty_rates_creates_no_rows(self):
+        """Test that a PriceList with empty rates produces no Rate rows."""
+        with tenant_context(self.tenant):
+            self._run_migration(MIGRATE_FROM)
+            _, pl = self._create_cost_model_with_price_list("Empty CM", [])
+            self._run_migration(MIGRATE_TO)
+            self.assertEqual(Rate.objects.filter(price_list=pl).count(), 0)
+
+    def test_metric_type_derived_correctly(self):
+        """Test that metric_type is correctly derived from the metric name."""
+        with tenant_context(self.tenant):
+            self._run_migration(MIGRATE_FROM)
+            _, pl = self._create_cost_model_with_price_list(
+                "Type CM",
+                [
+                    {
+                        "metric": {"name": "memory_gb_usage_per_hour"},
+                        "tiered_rates": [{"value": "0.10", "unit": "USD"}],
+                        "cost_type": "Supplementary",
+                    }
+                ],
+            )
+            self._run_migration(MIGRATE_TO)
+            rate = Rate.objects.get(price_list=pl)
+            self.assertEqual(rate.metric_type, "memory")
+
+    def test_pvc_metric_type_is_pvc(self):
+        """Test that pvc_cost_per_month maps to metric_type 'pvc', not 'persistent volume claims'."""
+        with tenant_context(self.tenant):
+            self._run_migration(MIGRATE_FROM)
+            _, pl = self._create_cost_model_with_price_list(
+                "PVC CM",
+                [
+                    {
+                        "metric": {"name": "pvc_cost_per_month"},
+                        "tiered_rates": [{"value": "5.00", "unit": "USD"}],
+                        "cost_type": "Infrastructure",
+                    }
+                ],
+            )
+            self._run_migration(MIGRATE_TO)
+            rate = Rate.objects.get(price_list=pl)
+            self.assertEqual(rate.metric_type, "pvc")
+
+    def test_custom_name_generated(self):
+        """Test that custom_name is generated for each Rate row."""
+        with tenant_context(self.tenant):
+            self._run_migration(MIGRATE_FROM)
+            _, pl = self._create_cost_model_with_price_list(
+                "Name CM",
+                [
+                    {
+                        "metric": {"name": "cpu_core_usage_per_hour"},
+                        "tiered_rates": [{"value": "0.22", "unit": "USD"}],
+                        "cost_type": "Infrastructure",
+                    }
+                ],
+            )
+            self._run_migration(MIGRATE_TO)
+            rate = Rate.objects.get(price_list=pl)
+            self.assertEqual(rate.custom_name, "cpu_core_usage_per_hour-Infrastructure")
+
+    def test_duplicate_rates_get_deduplicated_names(self):
+        """Test that duplicate metric+cost_type combinations get unique custom_names."""
+        with tenant_context(self.tenant):
+            self._run_migration(MIGRATE_FROM)
+            _, pl = self._create_cost_model_with_price_list(
+                "Dup CM",
+                [
+                    {
+                        "metric": {"name": "cpu_core_usage_per_hour"},
+                        "tiered_rates": [{"value": "0.22", "unit": "USD"}],
+                        "cost_type": "Infrastructure",
+                    },
+                    {
+                        "metric": {"name": "cpu_core_usage_per_hour"},
+                        "tag_rates": {
+                            "tag_key": "env",
+                            "tag_values": [{"tag_value": "prod", "value": "1.0", "unit": "USD"}],
+                        },
+                        "cost_type": "Infrastructure",
+                    },
+                ],
+            )
+            self._run_migration(MIGRATE_TO)
+            rates = Rate.objects.filter(price_list=pl).order_by("custom_name")
+            names = [r.custom_name for r in rates]
+            self.assertEqual(len(names), 2)
+            self.assertEqual(len(set(names)), 2)
+
+    def test_description_preserved(self):
+        """Test that the description field is preserved from the rate dict."""
+        with tenant_context(self.tenant):
+            self._run_migration(MIGRATE_FROM)
+            _, pl = self._create_cost_model_with_price_list(
+                "Desc CM",
+                [
+                    {
+                        "metric": {"name": "cpu_core_usage_per_hour"},
+                        "tiered_rates": [{"value": "0.22", "unit": "USD"}],
+                        "cost_type": "Infrastructure",
+                        "description": "CPU infrastructure rate",
+                    }
+                ],
+            )
+            self._run_migration(MIGRATE_TO)
+            rate = Rate.objects.get(price_list=pl)
+            self.assertEqual(rate.description, "CPU infrastructure rate")
+
+    def test_reverse_migration_deletes_rate_rows(self):
+        """Test that reversing the migration removes Rate rows."""
+        with tenant_context(self.tenant):
+            self._run_migration(MIGRATE_FROM)
+            _, pl = self._create_cost_model_with_price_list(
+                "Reverse CM",
+                [
+                    {
+                        "metric": {"name": "cpu_core_usage_per_hour"},
+                        "tiered_rates": [{"value": "0.22", "unit": "USD"}],
+                        "cost_type": "Infrastructure",
+                    }
+                ],
+            )
+            self._run_migration(MIGRATE_TO)
+            self.assertEqual(Rate.objects.filter(price_list=pl).count(), 1)
+
+            self._run_migration(MIGRATE_FROM)
+            self.assertEqual(Rate.objects.filter(price_list=pl).count(), 0)
+
+    def test_rate_linked_to_correct_price_list(self):
+        """Test that Rate rows are linked to the correct PriceList."""
+        with tenant_context(self.tenant):
+            self._run_migration(MIGRATE_FROM)
+            _, pl1 = self._create_cost_model_with_price_list(
+                "CM One",
+                [
+                    {
+                        "metric": {"name": "cpu_core_usage_per_hour"},
+                        "tiered_rates": [{"value": "1.00", "unit": "USD"}],
+                        "cost_type": "Infrastructure",
+                    }
+                ],
+            )
+            _, pl2 = self._create_cost_model_with_price_list(
+                "CM Two",
+                [
+                    {
+                        "metric": {"name": "memory_gb_usage_per_hour"},
+                        "tiered_rates": [{"value": "2.00", "unit": "USD"}],
+                        "cost_type": "Supplementary",
+                    }
+                ],
+            )
+            self._run_migration(MIGRATE_TO)
+            self.assertEqual(Rate.objects.filter(price_list=pl1).first().metric, "cpu_core_usage_per_hour")
+            self.assertEqual(Rate.objects.filter(price_list=pl2).first().metric, "memory_gb_usage_per_hour")
+
+    def test_price_list_without_mapping_still_normalized(self):
+        """Test that a PriceList without a CostModel mapping still gets Rate rows."""
+        with tenant_context(self.tenant):
+            self._run_migration(MIGRATE_FROM)
+            pl = PriceList.objects.create(
+                name="Standalone PL",
+                description="No cost model",
+                currency="USD",
+                effective_start_date="2026-03-01",
+                effective_end_date="2099-12-31",
+                enabled=True,
+                version=1,
+                rates=[
+                    {
+                        "metric": {"name": "storage_gb_usage_per_month"},
+                        "tiered_rates": [{"value": "0.50", "unit": "USD"}],
+                        "cost_type": "Infrastructure",
+                    }
+                ],
+            )
+            self._run_migration(MIGRATE_TO)
+            self.assertEqual(Rate.objects.filter(price_list=pl).count(), 1)
+
+    def test_migration_idempotent_no_duplicates(self):
+        """Test that running migration twice does not create duplicate Rate rows."""
+        with tenant_context(self.tenant):
+            self._run_migration(MIGRATE_FROM)
+            _, pl = self._create_cost_model_with_price_list(
+                "Idempotent CM",
+                [
+                    {
+                        "metric": {"name": "cpu_core_usage_per_hour"},
+                        "tiered_rates": [{"value": "0.22", "unit": "USD"}],
+                        "cost_type": "Infrastructure",
+                    }
+                ],
+            )
+            self._run_migration(MIGRATE_TO)
+            count_after_first = Rate.objects.filter(price_list=pl).count()
+
+            self._run_migration(MIGRATE_FROM)
+            self._run_migration(MIGRATE_TO)
+            count_after_second = Rate.objects.filter(price_list=pl).count()
+            self.assertEqual(count_after_first, count_after_second)


### PR DESCRIPTION
## Summary

Data migration (0013) that normalizes all existing `PriceList` JSON rates into relational `Rate` rows.

**This is Part 2 of 2** — split from #5982 per TL request. Depends on #5983 (dual-write infrastructure) being merged first.

### What's included

- **Migration 0013** (`normalize_rates_to_rate_table`): self-contained `RunPython` migration
  - Iterates all `PriceList` objects, parses `.rates` JSON, `bulk_create` Rate rows
  - Idempotent: skips PriceLists that already have Rate rows
  - Reversible: `reverse_func` deletes all Rate rows
  - Frozen helper functions (standard Django migration practice — no runtime imports)
- **`test_rate_migration.py`**: full coverage of the migration forward/reverse paths

### Operational notes

- **Write-freeze recommended**: Enable `cost-management.backend.disable-cost-model-writes` before running this migration in production to prevent concurrent writes during backfill
- **Migration runtime**: O(n) where n = total rate entries across all PriceLists; uses `bulk_create` for efficiency
- **Rollback**: `./manage.py migrate cost_models 0012` reverts cleanly

### Merge order

#5983 (Part 1) must merge first — it provides the `Rate` model and migration 0012 that this migration depends on.

## Test plan

- [ ] CI sanity checks pass
- [ ] `test_rate_migration.py` passes (forward migration, reverse migration, idempotency, edge cases)
- [ ] Verify migration applies cleanly on a database that has 0012 applied
- [ ] Verify reverse migration cleanly removes Rate rows


Made with [Cursor](https://cursor.com)