### PR TITLE
[COST-3920] Technical design: Consumer-Provider Cost Models

### DIFF
--- a/docs/architecture/consumer-provider-cost-models/README.md
+++ b/docs/architecture/consumer-provider-cost-models/README.md
@@ -163,7 +163,7 @@ graph TD
 | 4 | [dependency-analysis.md](dependency-analysis.md) | DD | In-flight PR analysis, merge ordering, conflict risks |
 | 5 | [risk-register.md](risk-register.md) | Ref | Risk register: 21 risks, mitigations, decision rationales |
 | 6 | [test-plan.md](test-plan.md) | TP | IEEE 829 test plan: 82 test cases, 38 BACs, 3 tiers (summary) |
-| 6a | [test-cases-t1-unit.md](test-cases-t1-unit.md) | TCS | IEEE 829 test case specs: 25 unit tests (Given/When/Then) |
+| 6a | [test-cases-t1-unit.md](test-cases-t1-unit.md) | TCS | IEEE 829 test case specs: 24 unit tests + supplemental TC-XX compatibility scenario (Given/When/Then) |
 | 6b | [test-cases-t2-integration.md](test-cases-t2-integration.md) | TCS | IEEE 829 test case specs: 34 integration tests (Given/When/Then) |
 | 6c | [test-cases-t3-e2e.md](test-cases-t3-e2e.md) | TCS | IEEE 829 test case specs: 24 E2E tests (Given/When/Then) |
 | 7 | [phased-delivery.md](phased-delivery.md) | DD | Phased delivery plan, PR structure, deployment runbook |

--- a/docs/architecture/consumer-provider-cost-models/README.md
+++ b/docs/architecture/consumer-provider-cost-models/README.md
@@ -162,7 +162,10 @@ graph TD
 | 3 | [prd-gap-analysis.md](prd-gap-analysis.md) | DD | PRD requirements with proposed implementation and code sketches |
 | 4 | [dependency-analysis.md](dependency-analysis.md) | DD | In-flight PR analysis, merge ordering, conflict risks |
 | 5 | [risk-register.md](risk-register.md) | Ref | Risk register: 21 risks, mitigations, decision rationales |
-| 6 | [test-plan.md](test-plan.md) | TP | IEEE 829 test plan: 82 test cases, 38 BACs, 3 tiers |
+| 6 | [test-plan.md](test-plan.md) | TP | IEEE 829 test plan: 82 test cases, 38 BACs, 3 tiers (summary) |
+| 6a | [test-cases-t1-unit.md](test-cases-t1-unit.md) | TCS | IEEE 829 test case specs: 25 unit tests (Given/When/Then) |
+| 6b | [test-cases-t2-integration.md](test-cases-t2-integration.md) | TCS | IEEE 829 test case specs: 34 integration tests (Given/When/Then) |
+| 6c | [test-cases-t3-e2e.md](test-cases-t3-e2e.md) | TCS | IEEE 829 test case specs: 24 E2E tests (Given/When/Then) |
 | 7 | [phased-delivery.md](phased-delivery.md) | DD | Phased delivery plan, PR structure, deployment runbook |
 
 ---

--- a/docs/architecture/consumer-provider-cost-models/README.md
+++ b/docs/architecture/consumer-provider-cost-models/README.md
@@ -162,7 +162,7 @@ graph TD
 | 3 | [prd-gap-analysis.md](prd-gap-analysis.md) | DD | PRD requirements with proposed implementation and code sketches |
 | 4 | [dependency-analysis.md](dependency-analysis.md) | DD | In-flight PR analysis, merge ordering, conflict risks |
 | 5 | [risk-register.md](risk-register.md) | Ref | Risk register: 21 risks, mitigations, decision rationales |
-| 6 | [test-plan.md](test-plan.md) | TP | IEEE 829 test plan: 104 test cases, 38 BACs, 4 tiers |
+| 6 | [test-plan.md](test-plan.md) | TP | IEEE 829 test plan: 82 test cases, 38 BACs, 3 tiers |
 | 7 | [phased-delivery.md](phased-delivery.md) | DD | Phased delivery plan, PR structure, deployment runbook |
 
 ---

--- a/docs/architecture/consumer-provider-cost-models/README.md
+++ b/docs/architecture/consumer-provider-cost-models/README.md
@@ -1,0 +1,234 @@
+# Consumer-Provider Cost Models
+
+Technical design for **cost model contexts** in the OpenShift cost
+management pipeline, enabling multiple cost models per OCP cluster
+(e.g., Provider vs Consumer) with per-context cost calculation,
+reporting, and access control.
+
+**Jira Epic**: [COST-3920](https://redhat.atlassian.net/browse/COST-3920)
+**PRD**: Consumer-Provider Cost Models (cost model contexts)
+
+**Prerequisite reading**: [current-architecture.md](./current-architecture.md) —
+describes the cost model architecture this feature extends.
+
+---
+
+## Decisions Needed from Tech Lead
+
+The following design decisions require tech lead confirmation before
+implementation proceeds.
+
+| # | Decision | Status | Blocking Phase | Proposal |
+|---|----------|--------|---------------|----------|
+| **DQ-1** | Migration strategy: nullable AddField + RunSQL backfill vs DEFAULT clause | Pending | Phase 1-2 | [Details](#dq-1-migration-strategy) |
+| **DQ-2** | Write-freeze Unleash flag during data migration | Pending | Phase 5 | [Details](#dq-2-write-freeze-during-migration) |
+| **DQ-3** | RBAC scope: Koku-side auth (v1) vs platform RBAC | Pending | Phase 4 | [Details](#dq-3-rbac-scope) |
+| **DQ-4** | Per-context pipeline dispatch: parallel Celery tasks vs sequential loop | Pending | Phase 3 | [Details](#dq-4-per-context-pipeline-dispatch) |
+
+### DQ-1: Migration Strategy
+
+**Problem**: Adding `cost_model_context` to 14 reporting tables
+(1 daily summary + 13 UI summaries) that contain millions of rows.
+Existing cost-model rows (identified by `cost_model_rate_type IS NOT NULL`)
+need a `'default'` context value — otherwise the pipeline's scoped
+`DELETE WHERE cost_model_context = X` will miss NULL legacy rows,
+causing data duplication.
+
+**Proposal: Nullable AddField + RunSQL backfill.**
+
+Follows the established pattern from migration 0339 (`cost_model_gpu_cost`).
+AddField with `null=True` is a metadata-only operation on PostgreSQL.
+A subsequent RunSQL migration backfills `cost_model_context = 'default'`
+on rows where `cost_model_rate_type IS NOT NULL`. See
+[risk-register.md § R1](./risk-register.md#r1-was-tq-3-daily-summary-migration--resolved-by-codebase-pattern).
+
+| # | Approach | Pros | Cons | Verdict |
+|---|----------|------|------|---------|
+| A | Nullable AddField + RunSQL backfill | Follows koku precedent; metadata-only DDL; predictable | Backfill may take time on large tenants | **Proposed** |
+| B | AddField with DEFAULT clause | No separate backfill | Not used anywhere in koku; PostgreSQL rewrites table for non-NULL DEFAULT | Rejected |
+| C | Background Celery backfill | Non-blocking | Complex; hard to coordinate with pipeline; no koku precedent | Rejected |
+
+### DQ-2: Write-Freeze During Migration
+
+**Problem**: Between migration deployment and code deployment, the
+pipeline could write context-tagged rows alongside unbackfilled NULL
+rows, causing duplicates.
+
+**Proposal: Dedicated Unleash flag** following the PR #5983
+`disable-cost-model-writes` pattern. Flag
+`cost-management.backend.disable-cost-model-context-writes` blocks
+context mutations (serializer) and context-tagged pipeline writes
+(task guard). Reads remain open.
+
+See [phased-delivery.md § Deployment Runbook](./phased-delivery.md#deployment-runbook).
+
+### DQ-3: RBAC Scope
+
+**Problem**: Koku's RBAC service has no "context" dimension.
+
+**Proposal: Koku-side authorization for v1** (Option C from
+[current-architecture.md § 6.3](./current-architecture.md#63-alternatives)).
+A `CostModelContextPermission` class subclasses `CostModelsAccessPermission`,
+checks `cost_model.read` access when `cost_model_context` is explicitly
+in the request query params, and falls through to standard OCP report
+permissions otherwise. No RBAC service changes required. Migration to
+platform RBAC can happen later without API changes. Kessel/ReBAC is
+out of scope for v1.
+
+### DQ-4: Per-Context Pipeline Dispatch
+
+**Problem**: The pipeline must run once per context per cluster.
+
+**Proposal: Parallel Celery tasks** (Option B from
+[risk-register.md § R2](./risk-register.md#r2-pipeline-runs-n-per-cluster)).
+The `update_cost_model_costs` task, when called without a specific
+context, queries `CostModelContext` for the tenant and dispatches
+one task per context. Each task includes `cost_model_context` in the
+Celery cache key (resolving R19). Most tenants will have 1-2 contexts,
+keeping the common case fast.
+
+---
+
+## Architecture at a Glance
+
+### Current Data Flow
+
+```mermaid
+graph TD
+    CM["CostModel.rates"] --> Accessor["CostModelDBAccessor\n.first() — single model"]
+    Accessor --> SQL["usage_costs.sql\n+ monthly_cost_*.sql\n+ *_tag_rates.sql"]
+    SQL -->|"cost_model_*_cost"| DailySummary["daily_summary\n(no context column)"]
+    DailySummary --> Dist["distribute_*.sql"]
+    Dist --> DailySummary
+    DailySummary --> UISummary["13 UI summary tables\n(no context column)"]
+    UISummary --> API["Report API\n(no context param)"]
+```
+
+### Proposed Data Flow
+
+```mermaid
+graph TD
+    CM["CostModel.rates"] --> Accessor["CostModelDBAccessor\nfiltered by context"]
+    Accessor --> SQL["usage_costs.sql\n+ monthly_cost_*.sql\n+ all 49 SQL files\nwith {{cost_model_context}}"]
+    SQL -->|"cost_model_*_cost\n+ cost_model_context"| DailySummary["daily_summary\n+ cost_model_context column"]
+    DailySummary --> Dist["distribute_*.sql\nscoped by context"]
+    Dist --> DailySummary
+    DailySummary --> UISummary["13 UI summary tables\n+ cost_model_context column"]
+    UISummary --> API["Report API\n?cost_model_context=consumer"]
+
+    Task["update_cost_model_costs\n(dispatches per context)"] --> Accessor
+    CMCtx["CostModelContext\n(max 3 per tenant)"] --> CostModelMap
+    CostModelMap["CostModelMap\n+ cost_model_context FK"] --> Accessor
+    Freeze["Unleash write-freeze\n(blocks mutations\nduring migration)"] -.-> Serializer["CostModelContextSerializer"]
+    Freeze -.-> Task
+```
+
+---
+
+## Quick Start
+
+| Your goal | Start here |
+|-----------|------------|
+| Understand today's cost model architecture | [current-architecture.md](./current-architecture.md) |
+| Understand each PRD requirement and proposed implementation | [prd-gap-analysis.md](./prd-gap-analysis.md) |
+| Understand in-flight PR dependencies | [dependency-analysis.md](./dependency-analysis.md) |
+| Understand risks and mitigations | [risk-register.md](./risk-register.md) |
+| Understand phased delivery, PR structure, and deployment | [phased-delivery.md](./phased-delivery.md) |
+| Understand test strategy | [test-plan.md](./test-plan.md) |
+
+## Reading Order
+
+### For the reviewing engineer
+
+1. This README (decisions first)
+2. [current-architecture.md](./current-architecture.md) — baseline
+3. [prd-gap-analysis.md](./prd-gap-analysis.md) — proposed implementation
+4. [phased-delivery.md](./phased-delivery.md) — what ships when
+5. [risk-register.md](./risk-register.md) — risks and mitigations
+
+### For operators
+
+1. [phased-delivery.md § Deployment Runbook](./phased-delivery.md#deployment-runbook)
+2. [risk-register.md § R21](./risk-register.md) — deployment sequencing risk
+
+---
+
+## Document Catalog
+
+| # | Document | Type | Summary |
+|---|----------|------|---------|
+| 1 | [README.md](README.md) | DD | Design overview, decisions needed, architecture diagrams |
+| 2 | [current-architecture.md](current-architecture.md) | DD | Current cost model architecture: models, manager, pipeline, API |
+| 3 | [prd-gap-analysis.md](prd-gap-analysis.md) | DD | PRD requirements with proposed implementation and code sketches |
+| 4 | [dependency-analysis.md](dependency-analysis.md) | DD | In-flight PR analysis, merge ordering, conflict risks |
+| 5 | [risk-register.md](risk-register.md) | Ref | Risk register: 21 risks, mitigations, decision rationales |
+| 6 | [test-plan.md](test-plan.md) | TP | IEEE 829 test plan: 104 test cases, 38 BACs, 4 tiers |
+| 7 | [phased-delivery.md](phased-delivery.md) | DD | Phased delivery plan, PR structure, deployment runbook |
+
+---
+
+## PRD Requirement Summary
+
+| PRD Section | Requirement | Feasibility | Effort | Proposed Phase |
+|-------------|-------------|-------------|--------|----------------|
+| **Context setup** | CostModelContext model, max 3, one default | Straightforward | Low | 1 |
+| **Assignment** | Context on CostModelMap, one model per context per cluster | Moderate | Medium | 1 |
+| **Migration** | Default "Consumer" context, assign existing data, backfill reporting | Moderate | Medium | 1-2 |
+| **Pipeline** | Per-context cost calculation | Hard | High | 3 |
+| **Reporting tables** | Context dimension on summary tables | Hard | High | 2-3 |
+| **API** | `cost_model_context` query parameter | Moderate | Medium | 4 |
+| **RBAC integration** | Koku-side context permission (v1) | Moderate | Medium | 4 |
+| **Write-freeze** | Unleash flag for migration data consistency | Moderate | Low | 5 |
+| **Cost model creation** | Unchanged (context-free) | No work needed | None | — |
+| **Default metering** | Empty context still reports usage at $0 | Exists today | Low | — |
+| **UI** | Context dropdown, notifications | Frontend — out of koku scope | N/A | — |
+
+---
+
+## Dependency Graph (In-Flight PRs)
+
+```mermaid
+flowchart TD
+    C575["PR #5981 COST-575\nPrice List API + accessor"]
+    R1a["PR #5983 COST-7249 1a\nRate table dual-write"]
+    R1b["PR #5984 COST-7249 1b\nRate backfill migration"]
+    Doc["PR #5980\n7249/575 design docs"]
+    Ret["PR #5971 COST-573\nData retention"]
+    CM3920["COST-3920\nConsumer-Provider Contexts"]
+
+    C575 --> R1a
+    R1a --> R1b
+    Doc -.-> R1a
+    Ret --> CM3920
+    R1b --> CM3920
+    C575 --> CM3920
+```
+
+**Recommended merge order**:
+1. PR #5981 (COST-575 Price List API) — foundation
+2. PR #5983 → PR #5984 (COST-7249 Rate table) — depends on #5981
+3. PR #5980 (design docs) — anytime
+4. PR #5971 (COST-573 retention) — before COST-3920
+5. COST-3920 — after all above
+
+---
+
+## Key Design Decisions
+
+| Decision | Proposed Resolution | Rationale |
+|----------|-------------------|-----------|
+| Migration strategy | Nullable AddField + RunSQL backfill | Follows koku 0339/0341 precedent; avoids table rewrite |
+| Write-freeze | Dedicated Unleash flag per PR #5983 pattern | Blocks mutations during migration; reads remain open |
+| RBAC | Koku-side auth for v1; platform RBAC migration path | No cross-service dependency; ships independently |
+| Pipeline dispatch | Parallel Celery tasks per (provider, context) | Independent contexts; reuses existing task infrastructure |
+| SQL scoping | `AND cost_model_context = {{cost_model_context}}` in all SQL | Follows existing `cost_model_rate_type` scoping pattern |
+| Feature flags | None for feature gating | Write-freeze flag is operational, not feature-gating |
+
+---
+
+## Changelog
+
+| Version | Date | Summary |
+|---------|------|---------|
+| v1.0 | 2026-04-08 | Initial due diligence: codebase exploration, PRD gap analysis, dependency graph |
+| v2.0 | 2026-04-09 | Evolved to design proposal: decisions needed, proposed architecture, phased delivery, write-freeze strategy, backfill migrations, updated risk register |

--- a/docs/architecture/consumer-provider-cost-models/README.md
+++ b/docs/architecture/consumer-provider-cost-models/README.md
@@ -24,6 +24,7 @@ implementation proceeds.
 | **DQ-2** | Write-freeze Unleash flag during data migration | Pending | Phase 5 | [Details](#dq-2-write-freeze-during-migration) |
 | **DQ-3** | RBAC scope: Koku-side auth (v1) vs platform RBAC | Pending | Phase 4 | [Details](#dq-3-rbac-scope) |
 | **DQ-4** | Per-context pipeline dispatch: parallel Celery tasks vs sequential loop | Pending | Phase 3 | [Details](#dq-4-per-context-pipeline-dispatch) |
+| **DQ-5** | Cost visibility filtering: `data_visibility` field placement + API-layer filtering | Pending | Phase 1, 4 | [Details](#dq-5-cost-visibility-filtering) |
 
 ### DQ-1: Migration Strategy
 
@@ -86,6 +87,41 @@ context, queries `CostModelContext` for the tenant and dispatches
 one task per context. Each task includes `cost_model_context` in the
 Celery cache key (resolving R19). Most tenants will have 1-2 contexts,
 keeping the common case fast.
+
+### DQ-5: Cost Visibility Filtering
+
+**Problem**: The updated PRD (2026-05-05) adds a cost visibility
+requirement: each context declares what data is visible —
+"OpenShift-only" or "cloud + OpenShift". This reopens R13 (which
+previously concluded cloud costs always appear in every context).
+
+**Sub-decision A: Where does `data_visibility` live?**
+
+| Option | Where | Pros | Cons |
+|--------|-------|------|------|
+| **A — `CostModelContext`** | Per-context, org-level | Simple; works for empty contexts (no `CostModelMap` row); avoids mixed-visibility across clusters | Cannot differ per cluster |
+| **B — `CostModelMap`** | Per-assignment, per-cluster | Maximum flexibility | Empty contexts have no row to store visibility; cross-cluster aggregation undefined |
+
+**Proposal: Option A.** Structural constraints support this:
+1. `CostModelMap` is a pure junction table (zero config properties).
+2. Empty contexts (no cost model assigned) have no `CostModelMap`
+   row but still need visibility (PRD requires metering for empty
+   contexts).
+3. API reports aggregate across clusters — per-context visibility
+   avoids undefined behavior.
+
+**Sub-decision B: API-layer or pipeline-layer filtering?**
+
+**Proposal: API-layer.** Cloud costs come from ingestion, not cost
+models — the pipeline cannot filter what it did not create.
+`OCPProviderMap` already separates `cloud_infrastructure_cost` from
+`cost_model_infrastructure_cost` as independent ORM expressions. For
+`ocp_only` contexts, the query handler substitutes
+`cloud_infrastructure_cost` with `Value(0)`. Precedent: AWS
+`cost_type` (blended/unblended) selects columns at query time.
+
+See [risk-register.md § R13](./risk-register.md#r13-was-tq-2-ocp-on-cloud-context-interaction--reopened)
+and [prd-gap-analysis.md § GA-11](./prd-gap-analysis.md#ga-11-cost-visibility).
 
 ---
 
@@ -176,7 +212,7 @@ graph TD
 |-------------|-------------|-------------|--------|----------------|
 | **Context setup** | CostModelContext model, max 3, one default | Straightforward | Low | 1 |
 | **Assignment** | Context on CostModelMap, one model per context per cluster | Moderate | Medium | 1 |
-| **Migration** | Default "Consumer" context, assign existing data, backfill reporting | Moderate | Medium | 1-2 |
+| **Migration** | Default "Default context" context (renamable), assign existing data, backfill reporting | Moderate | Medium | 1-2 |
 | **Pipeline** | Per-context cost calculation | Hard | High | 3 |
 | **Reporting tables** | Context dimension on summary tables | Hard | High | 2-3 |
 | **API** | `cost_model_context` query parameter | Moderate | Medium | 4 |
@@ -184,7 +220,9 @@ graph TD
 | **Write-freeze** | Unleash flag for migration data consistency | Moderate | Low | 5 |
 | **Cost model creation** | Unchanged (context-free) | No work needed | None | — |
 | **Default metering** | Empty context still reports usage at $0 | Exists today | Low | — |
-| **UI** | Context dropdown, notifications | Frontend — out of koku scope | N/A | — |
+| **Cost visibility** | Context declares data visibility: OpenShift-only or cloud + OpenShift | Moderate | Low-Medium | 1 (model), 4 (API) |
+| **Notifications** | Cluster missing context notification | Deferred per updated PRD | N/A | — |
+| **UI** | Context dropdown | Frontend — out of koku scope | N/A | — |
 
 ---
 
@@ -226,6 +264,7 @@ flowchart TD
 | Pipeline dispatch | Parallel Celery tasks per (provider, context) | Independent contexts; reuses existing task infrastructure |
 | SQL scoping | `AND cost_model_context = {{cost_model_context}}` in all SQL | Follows existing `cost_model_rate_type` scoping pattern |
 | Feature flags | None for feature gating | Write-freeze flag is operational, not feature-gating |
+| Cost visibility | `data_visibility` on `CostModelContext` + API-layer filtering | Empty-context constraint requires model-level field; API-layer follows `cost_type` precedent |
 
 ---
 
@@ -235,3 +274,4 @@ flowchart TD
 |---------|------|---------|
 | v1.0 | 2026-04-08 | Initial due diligence: codebase exploration, PRD gap analysis, dependency graph |
 | v2.0 | 2026-04-09 | Evolved to design proposal: decisions needed, proposed architecture, phased delivery, write-freeze strategy, backfill migrations, updated risk register |
+| v3.0 | 2026-05-05 | PRD realignment: DQ-5 added (cost visibility filtering); PRD summary updated (default name, notifications deferred, visibility row); key decisions updated; R13 reopened; R22 added |

--- a/docs/architecture/consumer-provider-cost-models/current-architecture.md
+++ b/docs/architecture/consumer-provider-cost-models/current-architecture.md
@@ -1,0 +1,354 @@
+# Current Architecture — Cost Models
+
+**Parent**: [README.md](README.md) · **Status**: Due Diligence
+
+---
+
+## 1. Data Model
+
+### 1.1 `CostModel` (`cost_model`)
+
+The central entity. Stores rates as JSON, markup, distribution config,
+and currency. Has no foreign keys to providers — assignment is via
+`CostModelMap`.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `uuid` | `UUIDField` PK | Default `uuid4` |
+| `name` | `TextField` | Indexed |
+| `description` | `TextField` | |
+| `source_type` | `CharField(50)` | `Provider.PROVIDER_CHOICES` (OCP, AWS, Azure, GCP, etc.) |
+| `rates` | `JSONField` | Canonical rate definitions (tiered + tag) |
+| `markup` | `JSONField` | |
+| `distribution` | `TextField` | `cpu` or `memory` |
+| `distribution_info` | `JSONField` | Platform/worker/GPU/storage/network flags |
+| `currency` | `TextField` | |
+| `created_timestamp` | `DateTimeField` | auto |
+| `updated_timestamp` | `DateTimeField` | auto |
+
+### 1.2 `CostModelMap` (`cost_model_map`)
+
+The **assignment table** — links a cost model to a provider (OCP cluster).
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `id` | Auto PK | |
+| `provider_uuid` | `UUIDField` | **Not** a Django FK to `Provider` — stored by value |
+| `cost_model` | `ForeignKey` → `CostModel` | `on_delete=CASCADE` |
+
+**Constraints**: `unique_together = ("provider_uuid", "cost_model")`
+
+**Critical finding for COST-3920**: The DB constraint allows a provider
+to appear in multiple rows with **different** cost models. However,
+`CostModelManager.update_provider_uuids()` explicitly **rejects** any
+provider that already has a `CostModelMap` row when assigning to a
+new cost model. This one-model-per-provider invariant is
+**application-level only**.
+
+This means:
+- The schema already supports multiple assignments per provider
+- Adding a `context` column and relaxing the manager check to enforce
+  `unique_together = ("provider_uuid", "context")` is structurally
+  feasible without breaking the existing constraint
+
+### 1.3 `PriceList` (`price_list`)
+
+Versioned container for rates with effective dates. Linked to
+`CostModel` via `PriceListCostModelMap`.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `uuid` | UUIDField PK | |
+| `name`, `description` | TextField | |
+| `currency` | TextField | |
+| `effective_start_date`, `effective_end_date` | DateField | |
+| `enabled` | BooleanField | Default `True` |
+| `version` | PositiveIntegerField | Default `1` |
+| `rates` | JSONField | Mirror of CostModel.rates after sync |
+
+### 1.4 `PriceListCostModelMap` (`price_list_cost_model_map`)
+
+| Field | Type |
+|-------|------|
+| `price_list` | FK → PriceList |
+| `cost_model` | FK → CostModel |
+| `priority` | PositiveIntegerField |
+
+**Constraint**: `unique_together = ("price_list", "cost_model")`,
+ordered by `priority`.
+
+### 1.5 `Rate` (`cost_model_rate`)
+
+Normalized rate rows, FK to PriceList.
+
+| Field | Type |
+|-------|------|
+| `uuid` | UUIDField PK |
+| `price_list` | FK → PriceList |
+| `custom_name` | CharField(50) |
+| `metric`, `metric_type`, `cost_type` | CharField |
+| `default_rate` | DecimalField |
+| `tag_key` | CharField |
+| `tag_values` | JSONField |
+
+**Constraint**: `unique_together = ("price_list", "custom_name")`
+
+### 1.6 `CostModelAudit` (`cost_model_audit`)
+
+Trigger-populated audit table. Captures INSERT/UPDATE/DELETE on
+`cost_model` with snapshot of all fields plus `provider_uuids` array
+from `cost_model_map`.
+
+### 1.7 `Provider` (`api_provider`)
+
+OCP clusters are represented as `Provider` rows with `type = "OCP"`.
+The `Provider.uuid` is what `CostModelMap.provider_uuid` references.
+
+Key fields: `uuid` (PK), `name`, `type`, `authentication` (contains
+`credentials.cluster_id`), `active`, `paused`, `customer` (FK),
+`data_updated_timestamp`.
+
+---
+
+## 2. Cost Model Manager
+
+`CostModelManager` (`cost_models/cost_model_manager.py`) orchestrates
+CRUD and provider assignment.
+
+### 2.1 Create flow
+
+1. Deep-copy data, pop `provider_uuids`
+2. `CostModel.objects.create(**cost_model_data)`
+3. `update_provider_uuids(provider_uuids)` — creates `CostModelMap` rows
+4. If rates exist: `_get_or_create_price_list()` + `_sync_rate_table()`
+
+### 2.2 Provider assignment (`update_provider_uuids`)
+
+**One-model-per-provider enforcement**:
+```
+For each new provider_uuid:
+    existing = CostModelMap.objects.filter(provider_uuid=uuid)
+    if existing.exists():
+        raise CostModelException("already associated")
+```
+
+This is the **only** barrier to multiple cost models per provider.
+For COST-3920, this check would change to:
+```
+existing = CostModelMap.objects.filter(provider_uuid=uuid, context=context)
+```
+
+### 2.3 Update flow
+
+1. Update scalar/JSON fields on CostModel
+2. If `rates` in payload: sync Rate rows via `_sync_rate_table()`
+3. Queue `update_cost_model_costs` Celery task for affected providers
+
+---
+
+## 3. Cost Calculation Pipeline
+
+### 3.1 Entry point
+
+`update_cost_model_costs` Celery task receives `(schema, provider_uuid,
+start_date, end_date)`. Always runs for OCP providers (even without a
+cost model — distribution still happens).
+
+### 3.2 Cost model resolution
+
+`CostModelDBAccessor` opens tenant schema and resolves the cost model:
+```python
+CostModel.objects.filter(
+    costmodelmap__provider_uuid=self.provider_uuid
+).first()
+```
+
+**Single-model assumption**: `.first()` returns one cost model.
+For COST-3920, this must become context-aware — either:
+- Run the pipeline once per context (N cost models × 1 provider)
+- Pass context as a parameter to the accessor
+
+### 3.3 OCP cost updater steps
+
+`OCPCostModelCostUpdater.update_summary_cost_model_costs()`:
+
+1. `_update_usage_costs` — tiered rates → `usage_costs.sql`
+2. `_update_markup_cost` — markup percentage
+3. `_update_monthly_cost` — node/cluster/PVC monthly rates
+4. Tag-based rates (if configured)
+5. `distribute_costs_and_update_ui_summary` — platform/worker/GPU
+   distribution → UI summary table refresh
+
+### 3.4 SQL execution
+
+SQL files are under `koku/masu/database/sql/openshift/cost_model/`.
+Key pattern:
+- **DELETE** existing cost rows for (source_uuid, dates, cost_model_rate_type)
+- **INSERT** new cost rows computed from rates × usage
+
+Rates are **bound as template parameters** in Python, not joined from
+`cost_model_map` in SQL. The SQL uses `{{source_uuid}}` and
+`{{report_period_id}}` for scoping.
+
+### 3.5 Implications for COST-3920
+
+The DELETE → INSERT pattern means the pipeline can run per-context
+if each context's rows are distinguishable. A `context` column (or
+equivalent discriminator) on `reporting_ocpusagelineitem_daily_summary`
+would allow:
+- DELETE WHERE source_uuid = X AND context = 'Provider'
+- INSERT ... with context = 'Provider'
+
+Without this, running the pipeline for context B would overwrite
+context A's data.
+
+---
+
+## 4. Reporting Tables
+
+### 4.1 Daily summary (fact table)
+
+`reporting_ocpusagelineitem_daily_summary` — the central OCP fact table.
+Contains both usage quantities and computed cost columns:
+
+- Usage: `pod_usage_cpu_core_hours`, `pod_usage_memory_gigabyte_hours`, etc.
+- Costs: `cost_model_cpu_cost`, `cost_model_memory_cost`,
+  `cost_model_volume_cost`, `cost_model_gpu_cost`
+- Metadata: `cost_model_rate_type` (Infrastructure, Supplementary,
+  platform_distributed, worker_distributed, etc.)
+- Distribution: `distributed_cost`
+
+**No context column exists today.**
+
+### 4.2 UI summary tables
+
+Partitioned rollup tables (`reporting_ocp_*_summary_p`) are populated
+from the daily summary via SQL in
+`koku/masu/database/sql/openshift/ui_summary/`.
+
+These aggregate by day, cluster, and `cost_model_rate_type` — but
+not by context.
+
+### 4.3 Data volume implications
+
+With 3 contexts, each cluster's cost data triples in the daily
+summary and UI summary tables. For a tenant with 50 clusters and
+3 contexts, this is 150× the per-cluster cost rows instead of 50×.
+
+---
+
+## 5. API Layer
+
+### 5.1 Cost model CRUD
+
+`CostModelViewSet` at `/api/v1/cost-models/`:
+- `GET` (list/retrieve), `POST`, `PUT`, `DELETE`
+- Filtered by RBAC `cost_model.read` / `cost_model.write`
+- `source_uuids` field controls `CostModelMap` assignment
+
+### 5.2 OCP report endpoints
+
+| Path | View | Report Type |
+|------|------|-------------|
+| `reports/openshift/costs/` | `OCPCostView` | `costs` |
+| `reports/openshift/compute/` | `OCPCpuView` | `cpu` |
+| `reports/openshift/memory/` | `OCPMemoryView` | `memory` |
+| `reports/openshift/volumes/` | `OCPVolumeView` | `volume` |
+| `reports/openshift/network/` | `OCPNetworkView` | `network` |
+| `reports/openshift/gpu/` | `OCPGpuView` | `gpu` |
+
+**No `cost_model_context` query parameter exists.**
+
+### 5.3 AWS `cost_type` pattern (reference for implementation)
+
+AWS has a `cost_type` query parameter that switches between
+blended/unblended/amortized costs. The plumbing:
+
+1. **Serializer** declares optional `cost_type` field
+2. **`validate()`** defaults to user preference or system default
+3. **QueryHandler** passes `cost_type` to ProviderMap constructor
+4. **ProviderMap** uses `F(self.cost_type)` in ORM aggregates
+
+This pattern is directly applicable to `cost_model_context` on OCP.
+
+---
+
+## 6. RBAC
+
+### 6.1 Current architecture
+
+- `IdentityHeaderMiddleware` calls RBAC service HTTP endpoint
+- Response ACLs parsed into `user.access = {resource_type: {read: [...], write: [...]}}`
+- `CostModelsAccessPermission` checks `user.access["cost_model"]`
+- View `get_queryset()` filters by `cost_model.read` UUID list
+
+### 6.2 Limitations for COST-3920
+
+1. **No group-level properties** — Koku receives flat ACLs, not group
+   objects. "Context" as a group property requires RBAC service changes.
+
+2. **`attributeFilter.key` is ignored** — the ACL parser only uses
+   `operation` and `value`. Multiple dimensions (UUID + context)
+   cannot be distinguished.
+
+3. **Cross-service dependency** — adding a "cost model context"
+   dimension requires RBAC service team buy-in (new permission
+   definitions, new resource attribute).
+
+### 6.3 Alternatives
+
+| Option | Approach | Pros | Cons |
+|--------|----------|------|------|
+| A | RBAC service adds `cost_model_context` resource type | Clean separation; RBAC audit trail | Cross-team dependency; timeline risk |
+| B | Koku-side authorization for contexts | No external dependency; ships independently | Duplicates auth logic; no RBAC audit trail |
+| C | Hybrid: Koku manages context visibility, RBAC manages cost model access | Pragmatic; no cross-service blocker | Context auth is weaker (no RBAC audit trail) |
+
+**Recommendation**: Option C for v1 implementation, with a migration
+path to Option A once the RBAC service supports `cost_model_context`
+as a resource type. Design the API so the authorization backend is
+an internal implementation detail — switching from Koku-side to
+platform RBAC requires no API changes.
+
+---
+
+## 7. Entity Relationship (Current)
+
+```
+Provider (api_provider)
+    │
+    │ provider_uuid (by value)
+    ▼
+CostModelMap (cost_model_map)
+    │
+    │ cost_model_id (FK)
+    ▼
+CostModel (cost_model)
+    │
+    │ (reverse FK via PriceListCostModelMap)
+    ▼
+PriceListCostModelMap ──► PriceList (price_list)
+                              │
+                              │ (reverse FK)
+                              ▼
+                          Rate (cost_model_rate)
+```
+
+### Proposed additions for COST-3920
+
+```
+CostModelContext (NEW — tenant-scoped)
+    │
+    │ context_id (FK on CostModelMap)
+    ▼
+CostModelMap + context column
+    │
+    │ unique_together = (provider_uuid, context)
+    ▼
+[pipeline runs per context]
+    │
+    ▼
+reporting_ocpusagelineitem_daily_summary + context column
+    │
+    ▼
+reporting_ocp_*_summary_p + context column
+```

--- a/docs/architecture/consumer-provider-cost-models/current-architecture.md
+++ b/docs/architecture/consumer-provider-cost-models/current-architecture.md
@@ -337,6 +337,8 @@ PriceListCostModelMap ──► PriceList (price_list)
 
 ```
 CostModelContext (NEW — tenant-scoped)
+    │  Fields: uuid, name, display_name, is_default, position, data_visibility
+    │  data_visibility: "cloud_and_ocp" (default) | "ocp_only"
     │
     │ context_id (FK on CostModelMap)
     ▼
@@ -351,4 +353,20 @@ reporting_ocpusagelineitem_daily_summary + context column
     │
     ▼
 reporting_ocp_*_summary_p + context column
+    │
+    ▼
+OCPReportQueryHandler
+    │  Reads CostModelContext.data_visibility
+    │  ocp_only → substitutes cloud_infrastructure_cost with Value(0)
+    │  cloud_and_ocp → current behavior (all costs)
+    ▼
+Report API response
 ```
+
+**Cost visibility hook**: `OCPProviderMap` already separates cloud
+infrastructure costs (`Sum(infrastructure_raw_cost)`) from cost-model
+infrastructure costs (`Sum(cost_model_*_cost WHERE cost_model_rate_type
+= 'Infrastructure')`) as independent `@cached_property` ORM
+expressions. This separation is the structural hook for per-context
+visibility filtering — the query handler can conditionally zero-out
+the cloud family without affecting cost-model costs.

--- a/docs/architecture/consumer-provider-cost-models/dependency-analysis.md
+++ b/docs/architecture/consumer-provider-cost-models/dependency-analysis.md
@@ -1,0 +1,144 @@
+# Dependency Analysis — COST-3920
+
+**Parent**: [README.md](README.md) · **Status**: Design Proposal
+
+Analysis of in-flight PRs that overlap with COST-3920, their merge
+ordering, and proposed deployment sequence.
+
+---
+
+## In-Flight PRs
+
+### PR #5981 — COST-575 Price List API + Accessor
+
+**Status**: Open
+**Overlap**: Modifies `CostModelDBAccessor` (read path),
+`CostModelManager` (create/update), `CostModelSerializer`.
+COST-3920 builds on the same files.
+**Impact**: Must merge first. COST-3920 migrations will depend on
+the `PriceList` + `Rate` models introduced here.
+
+### PR #5983 — COST-7249 Rate Table Dual-Write
+
+**Status**: Open (depends on #5981)
+**Overlap**: Adds `COST_MODEL_WRITE_FREEZE_FLAG` and
+`_check_write_freeze()` on `CostModelSerializer`. **This establishes
+the write-freeze pattern that COST-3920 proposes to follow** with
+a dedicated flag for context writes.
+**Impact**: Must merge before COST-3920. Provides the Unleash flag
+precedent and migration numbering baseline for `cost_models`.
+
+### PR #5984 — COST-7249 Rate Backfill Migration
+
+**Status**: Open (depends on #5983)
+**Overlap**: Data migration on `cost_models` app. COST-3920 migrations
+must follow in sequence.
+**Impact**: Last hard prerequisite. COST-3920 runs `makemigrations`
+against clean main after this merges.
+
+### PR #5980 — COST-7249/575 Design Docs
+
+**Status**: Open
+**Overlap**: None (documentation only).
+**Impact**: Can merge anytime.
+
+### PR #5971 — COST-573 Data Retention
+
+**Status**: Open
+**Overlap**: Adds `TenantSettings` model and retention pipeline
+changes. Low overlap with cost model context, but retention must
+account for context-scoped data in the future.
+**Impact**: Preferred before COST-3920 but not a hard blocker.
+
+---
+
+## Merge Ordering
+
+### Recommended sequence
+
+```mermaid
+flowchart TD
+    P5981["#5981 Price List API"] --> P5983["#5983 Rate dual-write"]
+    P5983 --> P5984["#5984 Rate backfill"]
+    P5984 --> COST3920["COST-3920 Contexts"]
+    P5971["#5971 Data retention"] --> COST3920
+    P5980["#5980 Design docs"] -.-> COST3920
+```
+
+### Critical path
+
+`#5981` → `#5983` → `#5984` → **COST-3920**
+
+This is the hard dependency chain. #5971 is preferred before
+COST-3920 but can run in parallel if it stalls.
+
+---
+
+## COST-3920 Write-Freeze Flag
+
+PR #5983 introduces `cost-management.backend.disable-cost-model-writes`
+for rate table migration. COST-3920 proposes a **separate, dedicated**
+flag: `cost-management.backend.disable-cost-model-context-writes`.
+
+**Rationale**: The two flags have independent lifecycles. The rate
+dual-write flag (#5983) will be disabled after rate migration completes.
+The context write-freeze flag (COST-3920) will be enabled during
+context migration and disabled afterward. Separate flags prevent
+unintended interactions.
+
+---
+
+## COST-3920 Deployment Sequence
+
+```mermaid
+flowchart LR
+    Enable["1. Enable Unleash\nwrite-freeze flag"] --> Migrate["2. Run migrations\n(DDL + backfill)"]
+    Migrate --> Deploy["3. Deploy new code\n(pipeline, API, SQL)"]
+    Deploy --> Disable["4. Disable\nwrite-freeze flag"]
+```
+
+1. **Enable** `cost-management.backend.disable-cost-model-context-writes`
+   (per-schema or global)
+2. **Run migrations**: Phase 1 (cost_models 0012-0017) + Phase 2
+   (reporting 0345-0348, including backfill)
+3. **Deploy** Phase 3-5 code (pipeline, API, RBAC, write-freeze guards)
+4. **Disable** the flag — context writes resume
+
+**On-prem**: `MockUnleashClient` returns `False` for all flags.
+Migrations-first deployment already prevents the race condition.
+
+---
+
+## Conflict Matrix
+
+| PR | `cost_models/models.py` | `cost_models/serializers.py` | `masu/processor/__init__.py` | `masu/processor/tasks.py` | Migrations |
+|----|------------------------|-----------------------------|-----------------------------|--------------------------|------------|
+| #5981 | Yes (PriceList) | Yes (dual-write) | — | — | cost_models |
+| #5983 | Yes (Rate) | Yes (write-freeze) | Yes (flag) | — | cost_models |
+| #5984 | — | — | — | — | cost_models |
+| #5971 | — | — | — | Yes (retention) | api |
+| **COST-3920** | Yes (CostModelContext) | Yes (context serializer) | Yes (context flag) | Yes (context dispatch) | cost_models + reporting |
+
+**Conflict zones**: `cost_models/serializers.py` and
+`masu/processor/__init__.py` overlap with #5983. Resolve by rebasing
+after #5983 merges.
+
+---
+
+## Risk Register (Dependency-Specific)
+
+| ID | Risk | Mitigation |
+|----|------|------------|
+| D1 | Migration numbering collision | Run `makemigrations` against clean main after #5984 merges |
+| D2 | Serializer merge conflicts with #5983 | Rebase after #5983; additive changes only |
+| D3 | Write-freeze flag naming collision | Dedicated flag name distinct from #5983's flag |
+| D4 | Predecessor PR stalls >2 weeks | Parallel-start: begin test-writing and design now; defer migrations until predecessors land |
+
+---
+
+## Changelog
+
+| Version | Date | Summary |
+|---------|------|---------|
+| v1.0 | 2026-04-08 | Initial dependency analysis |
+| v2.0 | 2026-04-09 | Design proposal: added COST-3920 write-freeze flag, deployment sequence, conflict matrix, dependency risks |

--- a/docs/architecture/consumer-provider-cost-models/phased-delivery.md
+++ b/docs/architecture/consumer-provider-cost-models/phased-delivery.md
@@ -1,0 +1,454 @@
+# Phased Delivery Plan
+
+This document maps each proposed phase to specific code artifacts,
+defines validation criteria, rollback strategies, and deployment
+sequencing for the consumer-provider cost models feature.
+
+**Parent**: [README.md](README.md) · **Status**: Design Proposal
+
+---
+
+## Decisions Pending Tech Lead Review
+
+See [README.md § Decisions Needed from Tech Lead](./README.md#decisions-needed-from-tech-lead)
+for full context.
+
+| Decision | Status | Impact on this plan |
+|----------|--------|-------------------|
+| **DQ-1**: Migration strategy (nullable + backfill) | Pending | Phase 1-2 migration design depends on this |
+| **DQ-2**: Write-freeze Unleash flag | Pending | Phase 5 artifacts + deployment runbook |
+| **DQ-3**: RBAC scope (Koku-side v1) | Pending | Phase 4 permission design |
+| **DQ-4**: Pipeline dispatch strategy | Pending | Phase 3 task orchestration |
+
+---
+
+## Phase Overview
+
+```mermaid
+graph LR
+    P1["Phase 1<br/>Context Entity<br/>+ Schema"] --> P2["Phase 2<br/>Reporting Schema<br/>+ Backfill"]
+    P2 --> P3["Phase 3<br/>Pipeline<br/>+ SQL"]
+    P3 --> P4["Phase 4<br/>API<br/>+ RBAC"]
+    P4 --> P5["Phase 5<br/>Write-Freeze<br/>+ Data Consistency"]
+```
+
+| Phase | Goal | User-Facing? | Migrations | Rollback Strategy |
+|-------|------|-------------|------------|-------------------|
+| 1 | Context entity, assignment schema, data migration | No | cost_models 0012-0017 | Reverse migrations; remove CostModelContext rows |
+| 2 | Context column on reporting tables + backfill | No | reporting 0345-0348 | Reverse migrations; column drops to NULL |
+| 3 | Per-context pipeline execution + SQL scoping | No | None | Revert code; pipeline falls back to single-context |
+| 4 | API parameter, RBAC, report filtering | Yes | None | Unregister URL route; remove query param |
+| 5 | Write-freeze guards for migration consistency | No | None | Disable Unleash flag; guards become no-op |
+
+---
+
+## PR Structure
+
+```mermaid
+flowchart LR
+    subgraph PR1 [PR 1: Technical Design]
+        docs["Design docs + phased delivery + test plan"]
+    end
+    subgraph PR2 [PR 2: Migrations]
+        mig["Phase 1 + Phase 2\ncost_models 0012-0017\nreporting 0345-0348"]
+    end
+    subgraph PR3 [PR 3: Business Logic]
+        logic["Phase 3-5\nPipeline, API, RBAC,\nwrite-freeze, SQL, tests"]
+    end
+    PR1 -->|"TL approval"| PR2
+    PR2 -->|"TL approval + merge"| PR3
+```
+
+| PR | Contents | Branch | Gate |
+|----|----------|--------|------|
+| **PR 1** (this document) | Design docs only (`docs/architecture/consumer-provider-cost-models/`) | `COST-3920/consumer-provider-cost-models-docs` | TL approval |
+| **PR 2** | All Django migrations (Phase 1 + Phase 2) | `COST-3920/consumer-provider-cost-models-migrations` | TL approval; CI green; backward-compatible |
+| **PR 3** | Pipeline, API, RBAC, write-freeze, SQL templates, all tests | `COST-3920/consumer-provider-cost-models` | PR 2 merged; full regression suite green |
+
+**TL requirement**: Migrations are separated from business logic.
+Migrations deploy first and can be independently reverted if business
+logic has issues. This is why Phase 1-2 (schema) are in PR 2 and
+Phase 3-5 (code) are in PR 3.
+
+---
+
+## Phase 1: Context Entity + Schema
+
+**Goal**: Introduce the `CostModelContext` model and modify
+`CostModelMap` to support per-context assignment. No pipeline or API
+changes — existing behavior unchanged.
+
+### Proposed Artifacts
+
+| Artifact | File | Description |
+|----------|------|-------------|
+| `CostModelContext` model | `cost_models/models.py` | UUID PK, `name`, `display_name`, `is_default`, `position` |
+| Migration M1 | `cost_models/migrations/0012_create_cost_model_context.py` | CreateModel with partial unique index on `is_default=TRUE` |
+| Migration M2 | `cost_models/migrations/0013_add_context_to_cost_model_map.py` | AddField: nullable FK `cost_model_context` on CostModelMap |
+| Migration M3 | `cost_models/migrations/0014_alter_unique_cost_model_map.py` | AlterUniqueTogether: `(provider_uuid, cost_model_context)` |
+| Migration M4 | `cost_models/migrations/0015_create_default_context.py` | RunPython: create default "Consumer" context per tenant; assign all CostModelMap rows |
+| Audit trigger | `cost_models/migrations/0016_update_audit_trigger.py` | Include context array in audit row |
+| NOT NULL constraint | `cost_models/migrations/0017_set_context_not_null.py` | After M4 backfill, set FK NOT NULL |
+
+### Validation Criteria
+
+- `CostModelContext` table exists in all tenant schemas
+- Exactly one row with `is_default=TRUE` per tenant
+- All existing `CostModelMap` rows have `cost_model_context` set
+- Existing API endpoints function unchanged (no regression)
+- Migrations forward and reverse cleanly
+- Audit trigger captures context on INSERT/UPDATE/DELETE
+
+### Rollback
+
+1. Reverse M17 → M12 in order
+2. `CostModelContext` table dropped; `CostModelMap` reverts to
+   original schema
+3. No data loss — cost models and assignments remain intact (FK was
+   additive)
+
+---
+
+## Phase 2: Reporting Schema + Backfill
+
+**Goal**: Add `cost_model_context` column to the daily summary table
+and all 13 UI summary tables. Backfill existing cost-model rows with
+`'default'`.
+
+### Proposed Artifacts
+
+| Artifact | File | Description |
+|----------|------|-------------|
+| Migration M5 | `reporting/migrations/0345_add_context_to_daily_summary.py` | AddField: nullable `cost_model_context` on `reporting_ocpusagelineitem_daily_summary` |
+| Migration M6 | `reporting/migrations/0346_add_context_to_ui_summary_tables.py` | AddField: nullable `cost_model_context` on all 13 `reporting_ocp_*_summary_p` tables |
+| Migration M7a | `reporting/migrations/0347_backfill_context_daily_summary.py` | RunSQL: `SET cost_model_context = 'default' WHERE cost_model_rate_type IS NOT NULL AND cost_model_context IS NULL` |
+| Migration M7b | `reporting/migrations/0348_backfill_context_ui_summary_tables.py` | RunSQL: same backfill on all 13 UI summary tables |
+
+### Tables Modified
+
+| # | Table |
+|---|-------|
+| 1 | `reporting_ocpusagelineitem_daily_summary` |
+| 2 | `reporting_ocp_cost_summary_p` |
+| 3 | `reporting_ocp_cost_summary_by_node_p` |
+| 4 | `reporting_ocp_cost_summary_by_project_p` |
+| 5 | `reporting_ocp_gpu_summary_p` |
+| 6 | `reporting_ocp_network_summary_p` |
+| 7 | `reporting_ocp_network_summary_by_node_p` |
+| 8 | `reporting_ocp_network_summary_by_project_p` |
+| 9 | `reporting_ocp_pod_summary_p` |
+| 10 | `reporting_ocp_pod_summary_by_node_p` |
+| 11 | `reporting_ocp_pod_summary_by_project_p` |
+| 12 | `reporting_ocp_vm_summary_p` |
+| 13 | `reporting_ocp_volume_summary_p` |
+| 14 | `reporting_ocp_volume_summary_by_project_p` |
+
+### Why Backfill is Necessary
+
+The pipeline uses scoped DELETEs:
+```sql
+DELETE FROM reporting_ocpusagelineitem_daily_summary
+ WHERE cost_model_context = {{cost_model_context}}
+   AND cost_model_rate_type = {{rate_type}}
+   AND ...
+```
+
+Without backfill, existing rows have `cost_model_context = NULL`.
+The scoped DELETE (`WHERE cost_model_context = 'default'`) will not
+match them. On the next pipeline run, new rows with `cost_model_context
+= 'default'` are inserted alongside the NULL legacy rows — causing
+**data duplication** in reports.
+
+### Validation Criteria
+
+- Column exists on all 14 tables across all tenant schemas
+- All rows with `cost_model_rate_type IS NOT NULL` have
+  `cost_model_context = 'default'`
+- Cloud/usage rows (`cost_model_rate_type IS NULL`) remain NULL
+- Migrations forward and reverse cleanly
+- Existing pipeline runs produce identical results (no regression)
+
+### Rollback
+
+1. Reverse M7b, M7a → backfilled values set back to NULL
+2. Reverse M6, M5 → columns dropped
+3. No data loss — cost data in existing columns is unchanged
+
+---
+
+## Phase 3: Pipeline + SQL
+
+**Goal**: Enable per-context pipeline execution. Thread
+`cost_model_context` through the full pipeline stack and into all
+SQL templates.
+
+### Proposed Artifacts
+
+| Artifact | File(s) | Description |
+|----------|---------|-------------|
+| Task dispatch | `masu/processor/tasks.py` | `update_cost_model_costs` dispatches per-context Celery tasks |
+| Accessor update | `masu/database/cost_model_db_accessor.py` | Optional `cost_model_context` parameter; filters CostModelMap by context FK |
+| Updater chain | `masu/processor/cost_model_cost_updater.py`, `masu/processor/ocp/ocp_cost_model_cost_updater.py` | Thread `cost_model_context` to all accessor calls |
+| SQL templates (49 files) | `masu/database/sql/openshift/cost_model/`, `self_hosted_sql/`, `trino_sql/`, `ui_summary/` | Add `{{cost_model_context}}` to DELETE WHERE, INSERT columns, GROUP BY |
+| Distribution | `masu/database/sql/openshift/cost_model/distribute_cost/` | Context parameter in platform/worker/GPU distribution SQL |
+| Cache key | `masu/processor/tasks.py` | Include `cost_model_context` in worker cache key |
+
+### SQL Modification Pattern
+
+Every cost model SQL file follows the same transformation:
+
+**DELETE** (existing rows for this context):
+```sql
+-- Before:
+DELETE FROM {{schema}}.reporting_ocpusagelineitem_daily_summary
+ WHERE cost_model_rate_type = {{rate_type}} AND ...
+
+-- After:
+DELETE FROM {{schema}}.reporting_ocpusagelineitem_daily_summary
+ WHERE cost_model_rate_type = {{rate_type}}
+   AND cost_model_context = {{cost_model_context}}
+   AND ...
+```
+
+**INSERT** (new context-tagged rows):
+```sql
+-- Before:
+INSERT INTO {{schema}}.reporting_ocpusagelineitem_daily_summary (
+    ..., cost_model_rate_type, ...
+) SELECT ...
+
+-- After:
+INSERT INTO {{schema}}.reporting_ocpusagelineitem_daily_summary (
+    ..., cost_model_rate_type, cost_model_context, ...
+) SELECT ..., {{cost_model_context}}, ...
+```
+
+**UI Summary GROUP BY**:
+```sql
+-- Before:
+GROUP BY usage_start, cluster_id, ..., cost_model_rate_type
+
+-- After:
+GROUP BY usage_start, cluster_id, ..., cost_model_rate_type, cost_model_context
+```
+
+### Files to Modify (49 SQL artifacts)
+
+- 16 standard cost model SQL files
+- 9 self-hosted cost model SQL files
+- 9 Trino cost model SQL files
+- 13 standard UI summary SQL files
+- 2 UI summary usage-only variants (self-hosted + Trino)
+
+### Validation Criteria
+
+- Pipeline produces correct cost values per context
+- Running pipeline for context A does not delete context B's rows
+- Cloud/usage rows unaffected
+- Worker cache keys prevent dedup collisions across contexts
+- All SQL template tests pass for all 3 SQL paths
+
+### Rollback
+
+1. Revert Python code → pipeline ignores `cost_model_context`
+2. Revert SQL templates → `cost_model_context` no longer in WHERE/INSERT/GROUP BY
+3. Pipeline falls back to single-context behavior (reads first cost model)
+4. Backfilled data in reporting tables remains but is harmless (unused column)
+
+---
+
+## Phase 4: API + RBAC
+
+**Goal**: Expose `cost_model_context` as a query parameter on OCP
+report endpoints and enforce context-aware access control.
+
+### Proposed Artifacts
+
+| Artifact | File | Description |
+|----------|------|-------------|
+| `CostModelContextSerializer` | `cost_models/serializers.py` | CRUD serializer for CostModelContext |
+| `CostModelContextViewSet` | `cost_models/views.py` | ModelViewSet at `/api/v1/cost-model-contexts/` |
+| `OCPQueryParamSerializer` | `api/report/ocp/serializers.py` | Add optional `cost_model_context` field |
+| `OCPReportQueryHandler` | `api/report/ocp/query_handler.py` | Pass context to provider_map; add ORM filter |
+| `CostModelContextPermission` | `api/common/permissions/cost_model_context_access.py` | Koku-side auth: subclasses CostModelsAccessPermission |
+| URL registration | `cost_models/urls.py` | Register context viewset |
+
+### API Contract
+
+```
+GET /api/v1/reports/openshift/costs/?cost_model_context=consumer
+→ Returns cost data for context "consumer" only
+
+GET /api/v1/reports/openshift/costs/
+→ Returns all cost data (backward-compatible, no context filter)
+
+GET /api/v1/cost-model-contexts/
+→ Returns list of contexts for the tenant
+
+POST /api/v1/cost-model-contexts/
+→ Creates a new context (max 3)
+
+PUT /api/v1/cost-model-contexts/{uuid}/
+→ Updates a context
+
+DELETE /api/v1/cost-model-contexts/{uuid}/
+→ Deletes a non-default context
+```
+
+### RBAC Design
+
+`CostModelContextPermission` only activates when `cost_model_context`
+is explicitly in query params. When absent, standard OCP report
+permissions apply. This prevents 403 errors on existing API clients
+that do not send the parameter.
+
+### Validation Criteria
+
+- `cost_model_context=X` filters report data correctly
+- Absence of parameter returns all data (no regression)
+- RBAC denies access when user lacks `cost_model.read`
+- Admin bypass works for ENHANCED_ORG_ADMIN
+- Context CRUD API works (create, read, update, delete)
+- Default context cannot be deleted
+- Max 3 contexts enforced
+
+### Rollback
+
+1. Unregister context URL route
+2. Revert serializer/query handler → parameter ignored
+3. Revert permission class → no context check
+4. Existing API behavior restored
+
+---
+
+## Phase 5: Write-Freeze + Data Consistency
+
+**Goal**: Provide migration-time data consistency guarantees using
+an Unleash feature flag that blocks context mutations during the
+migration window.
+
+### Proposed Artifacts
+
+| Artifact | File | Description |
+|----------|------|-------------|
+| Unleash flag constant | `masu/processor/__init__.py` | `COST_MODEL_CONTEXT_WRITE_FREEZE_FLAG` |
+| Helper function | `masu/processor/__init__.py` | `is_context_writes_disabled(schema)` |
+| Serializer guard | `cost_models/serializers.py` | `_check_context_write_freeze()` on create/update |
+| Pipeline guard | `masu/processor/tasks.py` | Skip context-tagged writes when flag active |
+
+### Behavior Matrix
+
+| Operation | Flag Enabled | Flag Disabled |
+|-----------|-------------|---------------|
+| Context create (POST) | **400 Bad Request** | Normal |
+| Context update (PUT) | **400 Bad Request** | Normal |
+| Context read (GET/list) | Normal | Normal |
+| Pipeline (context=X) | **Skipped** (logged) | Normal |
+| Pipeline (context=None) | Normal (legacy path) | Normal |
+
+### On-Prem Behavior
+
+`MockUnleashClient.is_enabled()` returns `False` for all flags.
+The write-freeze guard is a no-op on on-prem deployments. This is
+correct because on-prem deployments run migrations before code,
+eliminating the race condition the flag guards against.
+
+### Validation Criteria
+
+- Flag active → context create/update returns 400
+- Flag active → pipeline skips context-tagged writes
+- Flag active → reads succeed
+- Flag disabled → all operations succeed
+- On-prem → flag never activates
+
+### Rollback
+
+Disable the Unleash flag. All guards become no-op. No code revert needed.
+
+---
+
+## Deployment Runbook
+
+### SaaS Deployment
+
+```
+Step 1: Enable Unleash flag
+        Flag: cost-management.backend.disable-cost-model-context-writes
+        Scope: All schemas (or per-schema for staged rollout)
+        Effect: Blocks context mutations + context-tagged pipeline writes
+        Reads remain open.
+
+Step 2: Deploy PR 2 (migrations)
+        Runs: cost_models M1-M6 (DDL + data migration)
+              reporting M5-M7b (DDL + backfill)
+        Verify: Default context exists per tenant
+                All CostModelMap rows have context assigned
+                All reporting rows backfilled
+
+Step 3: Deploy PR 3 (business logic)
+        Runs: Pipeline, API, RBAC, write-freeze guards, SQL templates
+        Verify: API responds (context CRUD returns 400 due to freeze)
+                Pipeline skips context-tagged writes (logged)
+
+Step 4: Disable Unleash flag
+        Effect: Context mutations resume
+                Pipeline processes per-context cost calculations
+        Verify: Context CRUD succeeds
+                Pipeline runs per-context
+                Report API returns context-filtered data
+
+Step 5: Monitor
+        Watch: Pipeline logs for context dispatch
+               Report data for duplicates
+               Error rates on context endpoints
+```
+
+### On-Prem Deployment
+
+On-prem deployments use `MockUnleashClient` (all flags return `False`).
+The write-freeze is a no-op.
+
+```
+Step 1: Deploy PR 2 (migrations)
+        Migrations run before application code starts.
+        DDL + backfill complete before any pipeline or API traffic.
+
+Step 2: Deploy PR 3 (business logic)
+        Pipeline starts with context-aware SQL immediately.
+        No race condition because migrations completed in Step 1.
+
+Step 3: Verify
+        Context CRUD works
+        Pipeline runs per-context
+        Report API returns context-filtered data
+```
+
+---
+
+## Migration Dependency Chain
+
+```mermaid
+flowchart TD
+    subgraph PR2 [PR 2: Migrations]
+        subgraph Phase1 [Phase 1: cost_models]
+            M1["M1: CreateModel\nCostModelContext"] --> M2["M2: AddField\nCostModelMap.cost_model_context"]
+            M2 --> M3["M3: AlterUnique\n(provider_uuid, context)"]
+            M3 --> M4["M4: RunPython\nDefault context + assign"]
+            M4 --> M5a["M5: Audit trigger update"]
+            M5a --> M6a["M6: NOT NULL constraint"]
+        end
+        subgraph Phase2 [Phase 2: reporting]
+            M5["M5: AddField\ndaily_summary.cost_model_context"] --> M6["M6: AddField\n13 UI summary tables"]
+            M6 --> M7a["M7a: RunSQL\nBackfill daily_summary"]
+            M7a --> M7b["M7b: RunSQL\nBackfill 13 UI tables"]
+        end
+    end
+```
+
+---
+
+## Changelog
+
+| Version | Date | Summary |
+|---------|------|---------|
+| v1.0 | 2026-04-09 | Initial phased delivery plan: 5 phases, 3 PRs, deployment runbook, write-freeze strategy, migration dependency chain |

--- a/docs/architecture/consumer-provider-cost-models/phased-delivery.md
+++ b/docs/architecture/consumer-provider-cost-models/phased-delivery.md
@@ -34,8 +34,8 @@ graph LR
 
 | Phase | Goal | User-Facing? | Migrations | Rollback Strategy |
 |-------|------|-------------|------------|-------------------|
-| 1 | Context entity, assignment schema, data migration | No | cost_models 0012-0017 | Reverse migrations; remove CostModelContext rows |
-| 2 | Context column on reporting tables + backfill | No | reporting 0345-0348 | Reverse migrations; column drops to NULL |
+| 1 | Context entity, assignment schema, data migration | No | cost_models M1-M6 (0012-0017) | Reverse migrations; remove CostModelContext rows |
+| 2 | Context column on reporting tables + backfill | No | reporting M7-M10 (0345-0348) | Reverse migrations; column drops to NULL |
 | 3 | Per-context pipeline execution + SQL scoping | No | None | Revert code; pipeline falls back to single-context |
 | 4 | API parameter, RBAC, report filtering | Yes | None | Unregister URL route; remove query param |
 | 5 | Write-freeze guards for migration consistency | No | None | Disable Unleash flag; guards become no-op |
@@ -87,8 +87,8 @@ changes — existing behavior unchanged.
 | Migration M2 | `cost_models/migrations/0013_add_context_to_cost_model_map.py` | AddField: nullable FK `cost_model_context` on CostModelMap |
 | Migration M3 | `cost_models/migrations/0014_alter_unique_cost_model_map.py` | AlterUniqueTogether: `(provider_uuid, cost_model_context)` |
 | Migration M4 | `cost_models/migrations/0015_create_default_context.py` | RunPython: create default "Consumer" context per tenant; assign all CostModelMap rows |
-| Audit trigger | `cost_models/migrations/0016_update_audit_trigger.py` | Include context array in audit row |
-| NOT NULL constraint | `cost_models/migrations/0017_set_context_not_null.py` | After M4 backfill, set FK NOT NULL |
+| Migration M5 | `cost_models/migrations/0016_update_audit_trigger.py` | Include context array in audit row |
+| Migration M6 | `cost_models/migrations/0017_set_context_not_null.py` | After M4 backfill, set FK NOT NULL |
 
 ### Validation Criteria
 
@@ -101,7 +101,7 @@ changes — existing behavior unchanged.
 
 ### Rollback
 
-1. Reverse M17 → M12 in order
+1. Reverse M6 → M1 in order
 2. `CostModelContext` table dropped; `CostModelMap` reverts to
    original schema
 3. No data loss — cost models and assignments remain intact (FK was
@@ -119,10 +119,10 @@ and all 13 UI summary tables. Backfill existing cost-model rows with
 
 | Artifact | File | Description |
 |----------|------|-------------|
-| Migration M5 | `reporting/migrations/0345_add_context_to_daily_summary.py` | AddField: nullable `cost_model_context` on `reporting_ocpusagelineitem_daily_summary` |
-| Migration M6 | `reporting/migrations/0346_add_context_to_ui_summary_tables.py` | AddField: nullable `cost_model_context` on all 13 `reporting_ocp_*_summary_p` tables |
-| Migration M7a | `reporting/migrations/0347_backfill_context_daily_summary.py` | RunSQL: `SET cost_model_context = 'default' WHERE cost_model_rate_type IS NOT NULL AND cost_model_context IS NULL` |
-| Migration M7b | `reporting/migrations/0348_backfill_context_ui_summary_tables.py` | RunSQL: same backfill on all 13 UI summary tables |
+| Migration M7 | `reporting/migrations/0345_add_context_to_daily_summary.py` | AddField: nullable `cost_model_context` on `reporting_ocpusagelineitem_daily_summary` |
+| Migration M8 | `reporting/migrations/0346_add_context_to_ui_summary_tables.py` | AddField: nullable `cost_model_context` on all 13 `reporting_ocp_*_summary_p` tables |
+| Migration M9 | `reporting/migrations/0347_backfill_context_daily_summary.py` | RunSQL: `SET cost_model_context = 'default' WHERE cost_model_rate_type IS NOT NULL AND cost_model_context IS NULL` |
+| Migration M10 | `reporting/migrations/0348_backfill_context_ui_summary_tables.py` | RunSQL: same backfill on all 13 UI summary tables |
 
 ### Tables Modified
 
@@ -170,8 +170,8 @@ match them. On the next pipeline run, new rows with `cost_model_context
 
 ### Rollback
 
-1. Reverse M7b, M7a → backfilled values set back to NULL
-2. Reverse M6, M5 → columns dropped
+1. Reverse M10, M9 → backfilled values set back to NULL
+2. Reverse M8, M7 → columns dropped
 3. No data loss — cost data in existing columns is unchanged
 
 ---
@@ -380,7 +380,7 @@ Step 1: Enable Unleash flag
 
 Step 2: Deploy PR 2 (migrations)
         Runs: cost_models M1-M6 (DDL + data migration)
-              reporting M5-M7b (DDL + backfill)
+              reporting M7-M10 (DDL + backfill)
         Verify: Default context exists per tenant
                 All CostModelMap rows have context assigned
                 All reporting rows backfilled
@@ -434,13 +434,13 @@ flowchart TD
             M1["M1: CreateModel\nCostModelContext"] --> M2["M2: AddField\nCostModelMap.cost_model_context"]
             M2 --> M3["M3: AlterUnique\n(provider_uuid, context)"]
             M3 --> M4["M4: RunPython\nDefault context + assign"]
-            M4 --> M5a["M5: Audit trigger update"]
-            M5a --> M6a["M6: NOT NULL constraint"]
+            M4 --> M5["M5: Audit trigger update"]
+            M5 --> M6["M6: NOT NULL constraint"]
         end
         subgraph Phase2 [Phase 2: reporting]
-            M5["M5: AddField\ndaily_summary.cost_model_context"] --> M6["M6: AddField\n13 UI summary tables"]
-            M6 --> M7a["M7a: RunSQL\nBackfill daily_summary"]
-            M7a --> M7b["M7b: RunSQL\nBackfill 13 UI tables"]
+            M7["M7: AddField\ndaily_summary.cost_model_context"] --> M8["M8: AddField\n13 UI summary tables"]
+            M8 --> M9["M9: RunSQL\nBackfill daily_summary"]
+            M9 --> M10["M10: RunSQL\nBackfill 13 UI tables"]
         end
     end
 ```

--- a/docs/architecture/consumer-provider-cost-models/phased-delivery.md
+++ b/docs/architecture/consumer-provider-cost-models/phased-delivery.md
@@ -19,6 +19,7 @@ for full context.
 | **DQ-2**: Write-freeze Unleash flag | Pending | Phase 5 artifacts + deployment runbook |
 | **DQ-3**: RBAC scope (Koku-side v1) | Pending | Phase 4 permission design |
 | **DQ-4**: Pipeline dispatch strategy | Pending | Phase 3 task orchestration |
+| **DQ-5**: Cost visibility filtering | Pending | Phase 1 model field + Phase 4 API filtering |
 
 ---
 
@@ -82,11 +83,11 @@ changes — existing behavior unchanged.
 
 | Artifact | File | Description |
 |----------|------|-------------|
-| `CostModelContext` model | `cost_models/models.py` | UUID PK, `name`, `display_name`, `is_default`, `position` |
+| `CostModelContext` model | `cost_models/models.py` | UUID PK, `name`, `display_name`, `is_default`, `position`, `data_visibility` |
 | Migration M1 | `cost_models/migrations/0012_create_cost_model_context.py` | CreateModel with partial unique index on `is_default=TRUE` |
 | Migration M2 | `cost_models/migrations/0013_add_context_to_cost_model_map.py` | AddField: nullable FK `cost_model_context` on CostModelMap |
 | Migration M3 | `cost_models/migrations/0014_alter_unique_cost_model_map.py` | AlterUniqueTogether: `(provider_uuid, cost_model_context)` |
-| Migration M4 | `cost_models/migrations/0015_create_default_context.py` | RunPython: create default "Consumer" context per tenant; assign all CostModelMap rows |
+| Migration M4 | `cost_models/migrations/0015_create_default_context.py` | RunPython: create default "Default context" context per tenant (renamable); assign all CostModelMap rows; set `data_visibility = 'cloud_and_ocp'` |
 | Migration M5 | `cost_models/migrations/0016_update_audit_trigger.py` | Include context array in audit row |
 | Migration M6 | `cost_models/migrations/0017_set_context_not_null.py` | After M4 backfill, set FK NOT NULL |
 
@@ -269,7 +270,7 @@ report endpoints and enforce context-aware access control.
 | `CostModelContextSerializer` | `cost_models/serializers.py` | CRUD serializer for CostModelContext |
 | `CostModelContextViewSet` | `cost_models/views.py` | ModelViewSet at `/api/v1/cost-model-contexts/` |
 | `OCPQueryParamSerializer` | `api/report/ocp/serializers.py` | Add optional `cost_model_context` field |
-| `OCPReportQueryHandler` | `api/report/ocp/query_handler.py` | Pass context to provider_map; add ORM filter |
+| `OCPReportQueryHandler` | `api/report/ocp/query_handler.py` | Pass context to provider_map; add ORM filter; apply `data_visibility` filtering (GA-11) |
 | `CostModelContextPermission` | `api/common/permissions/cost_model_context_access.py` | Koku-side auth: subclasses CostModelsAccessPermission |
 | URL registration | `cost_models/urls.py` | Register context viewset |
 
@@ -311,6 +312,9 @@ that do not send the parameter.
 - Context CRUD API works (create, read, update, delete)
 - Default context cannot be deleted
 - Max 3 contexts enforced
+- `data_visibility=ocp_only` excludes cloud infrastructure costs
+- `data_visibility=cloud_and_ocp` includes all costs (backward-compatible)
+- Response `meta` includes `data_visibility` when context is requested
 
 ### Rollback
 
@@ -452,3 +456,4 @@ flowchart TD
 | Version | Date | Summary |
 |---------|------|---------|
 | v1.0 | 2026-04-09 | Initial phased delivery plan: 5 phases, 3 PRs, deployment runbook, write-freeze strategy, migration dependency chain |
+| v2.0 | 2026-05-05 | PRD realignment: DQ-5 added to pending decisions; Phase 1 M4 default name updated to "Default context" + `data_visibility`; Phase 4 adds visibility filtering; CostModelContext model gains `data_visibility` field |

--- a/docs/architecture/consumer-provider-cost-models/prd-gap-analysis.md
+++ b/docs/architecture/consumer-provider-cost-models/prd-gap-analysis.md
@@ -197,7 +197,7 @@ regardless of context — identical to today's behavior.
    key to prevent dedup collisions across contexts.
 
 **Risk**: [R2](./risk-register.md#r2-pipeline-runs-n-per-cluster),
-[R5](./risk-register.md#r5-costmodeldbccessor-single-model-assumption),
+[R5](./risk-register.md#r5-costmodeldbaccessor-single-model-assumption),
 [R6](./risk-register.md#r6-sql-deleteinsert-overwrites-without-context-discriminator),
 [R19](./risk-register.md#r19-celery-task-dedup-collision)
 

--- a/docs/architecture/consumer-provider-cost-models/prd-gap-analysis.md
+++ b/docs/architecture/consumer-provider-cost-models/prd-gap-analysis.md
@@ -1,0 +1,294 @@
+# PRD Gap Analysis — COST-3920
+
+**Parent**: [README.md](README.md) · **Status**: Design Proposal
+
+Section-by-section analysis of each PRD requirement against the
+current codebase, with proposed implementation and code sketches.
+
+---
+
+## GA-1: Cost Model Context Entity
+
+**PRD**: Administrators create a list of cost model contexts (max 3,
+one designated default). Stored at the organization/tenant level.
+
+**Current state**: No `CostModelContext` model exists.
+
+**Proposed implementation**:
+```python
+class CostModelContext(models.Model):
+    class Meta:
+        db_table = "cost_model_context"
+        unique_together = ("name",)  # per tenant schema
+
+    uuid = models.UUIDField(primary_key=True, default=uuid4)
+    name = models.CharField(max_length=50)
+    display_name = models.CharField(max_length=100)
+    is_default = models.BooleanField(default=False)
+    position = models.PositiveIntegerField(validators=[MinValueValidator(1)])
+    created_timestamp = models.DateTimeField(auto_now_add=True)
+```
+
+**Constraints**:
+- Exactly one row with `is_default=True` per tenant schema (partial unique index)
+- Max 3 rows per tenant schema (serializer + `position` CHECK constraint)
+- Default context cannot be deleted (viewset guard)
+
+**CRUD API**: `CostModelContextSerializer` (ModelSerializer) +
+`CostModelContextViewSet` (ModelViewSet) at `/api/v1/cost-model-contexts/`.
+Supports GET, POST, PUT, DELETE.
+
+**Risk**: [R15](./risk-register.md#r15-max-3-contexts--no-db-enforcement),
+[R16](./risk-register.md#r16-default-context-cannot-be-deleted)
+
+---
+
+## GA-2: RBAC Integration
+
+**PRD**: Groups see only permitted contexts.
+
+**Current state**: Koku's RBAC service has no "context" dimension.
+`CostModelsAccessPermission` checks `cost_model.read/write` only.
+
+**Proposed implementation (v1 — Koku-side authorization)**:
+
+Kessel/ReBAC is out of scope for v1 per project decision. We propose
+a `CostModelContextPermission` class:
+
+```python
+class CostModelContextPermission(CostModelsAccessPermission):
+    def has_permission(self, request, view):
+        if "cost_model_context" not in request.query_params:
+            return True  # standard OCP report permissions apply
+
+        if settings.ENHANCED_ORG_ADMIN and request.user.admin:
+            return True
+
+        # Check cost_model.read access
+        access = request.user.access or {}
+        cost_model_access = access.get("cost_model", {})
+        read_list = cost_model_access.get("read", [])
+        return bool(read_list)
+```
+
+When `cost_model_context` is not in query params, the permission
+passes through — existing OCP report behavior is unchanged (backward
+compatible). When explicitly requested, the user must have
+`cost_model.read` access.
+
+**Migration path**: When platform RBAC adds `cost_model_context` as
+a resource type, replace the Koku-side check with the RBAC lookup.
+The API contract does not change.
+
+**Alternatives evaluated**: See [current-architecture.md § 6.3](./current-architecture.md#63-alternatives)
+
+**Risk**: [R3](./risk-register.md#r3-was-tq-5-rbac-context-authorization--resolved-by-precedent)
+
+---
+
+## GA-3: Cost Model Creation
+
+**PRD**: Cost model creation is unchanged (context-free).
+
+**Current state**: Already works. Cost models exist independently
+of contexts. Assignment to contexts happens via `CostModelMap`.
+
+**No work needed.**
+
+---
+
+## GA-4: Assignment with Context
+
+**PRD**: One cost model per context per OCP cluster. Assignment
+goes through `CostModelMap`.
+
+**Current state**: `CostModelMap` has `(provider_uuid, cost_model)`.
+The manager enforces one-model-per-provider at the application level.
+
+**Proposed implementation**:
+
+1. Add FK `cost_model_context` on `CostModelMap` → `CostModelContext`
+2. Change unique constraint to `unique_together = ("provider_uuid", "cost_model_context")`
+3. Update `CostModelManager.update_provider_uuids()` to check per-context uniqueness
+
+**Migration strategy (M1-M4)**:
+
+| Migration | Type | Description |
+|-----------|------|-------------|
+| M1 | DDL | Create `CostModelContext` model |
+| M2 | DDL | Add nullable `cost_model_context` FK to `CostModelMap` |
+| M3 | DDL | Add unique constraint `(provider_uuid, cost_model_context)` |
+| M4 | Data | Create default "Consumer" context per tenant; assign all existing `CostModelMap` rows to it |
+
+M4 uses `RunPython` with fail-fast on duplicate `(provider_uuid)`
+rows — if a provider has multiple `CostModelMap` rows, the migration
+raises an error with actionable guidance. This follows koku's norm
+of non-destructive, deterministic data migrations.
+
+**Risk**: [R9](./risk-register.md#r9-update_provider_uuids-blocks-multi-assignment),
+[R10](./risk-register.md#r10-was-tq-4-predecessor-pr-sequencing--resolved)
+
+---
+
+## GA-5: Default Metering
+
+**PRD**: A context with no cost model still reports usage at $0.
+
+**Current state**: Already works. When `CostModelDBAccessor` finds
+no cost model, the pipeline returns empty rates. Usage data comes
+from ingestion (context-independent). Distribution and UI summary
+refresh still run.
+
+**No work needed** beyond verifying with a test case.
+
+**Risk**: [R17](./risk-register.md#r17-empty-context-shows-metering-at-0)
+
+---
+
+## GA-6: API `cost_model_context` Query Parameter
+
+**PRD**: OCP report endpoints accept `cost_model_context` parameter.
+
+**Current state**: No such parameter exists. AWS `cost_type` provides
+the pattern to follow.
+
+**Proposed implementation**:
+
+1. **Serializer**: Add optional `cost_model_context` field to
+   `OCPQueryParamSerializer`
+2. **QueryParameters**: Add `cost_model_context` property; returns
+   `None` when not explicitly provided (backward compatible)
+3. **QueryHandler**: `OCPReportQueryHandler` passes context to
+   `provider_map`; adds ORM filter `cost_model_context=X` when set
+4. **Response**: When `cost_model_context` is explicitly provided,
+   include it in response `meta`; otherwise omit it
+
+When no context parameter is provided, the API returns all data
+regardless of context — identical to today's behavior.
+
+---
+
+## GA-7: Pipeline Per-Context Execution
+
+**PRD**: Cost calculation runs per context per cluster.
+
+**Current state**: `update_cost_model_costs` runs once per
+`(schema, provider_uuid)`. `CostModelDBAccessor.cost_model` uses
+`.first()`.
+
+**Proposed implementation**:
+
+1. **Task dispatch**: When `cost_model_context=None`,
+   `update_cost_model_costs` queries `CostModelContext` for the
+   tenant. If multiple contexts exist, dispatches one Celery task
+   per context. If one or zero contexts, proceeds inline.
+
+2. **Accessor**: Add optional `cost_model_context` parameter to
+   `CostModelDBAccessor`. Filters `CostModelMap` by context FK.
+
+3. **Updater chain**: Thread `cost_model_context` through
+   `CostModelCostUpdater` → `OCPCostModelCostUpdater` → all
+   accessor methods → SQL template parameters.
+
+4. **SQL templates**: All 49 cost model SQL files gain
+   `{{cost_model_context}}` in DELETE WHERE and INSERT columns.
+
+5. **Cache key**: Include `cost_model_context` in the worker cache
+   key to prevent dedup collisions across contexts.
+
+**Risk**: [R2](./risk-register.md#r2-pipeline-runs-n-per-cluster),
+[R5](./risk-register.md#r5-costmodeldbccessor-single-model-assumption),
+[R6](./risk-register.md#r6-sql-deleteinsert-overwrites-without-context-discriminator),
+[R19](./risk-register.md#r19-celery-task-dedup-collision)
+
+---
+
+## GA-8: Migration — Reporting Table Context Column
+
+**PRD**: Summary tables need a context dimension.
+
+**Current state**: No `cost_model_context` column on any reporting table.
+
+**Proposed implementation**:
+
+1. **M5** (DDL): Add nullable `cost_model_context` to
+   `reporting_ocpusagelineitem_daily_summary` via `AddField`
+2. **M6** (DDL): Add nullable `cost_model_context` to all 13 UI
+   summary tables (`reporting_ocp_*_summary_p`)
+3. **M7a** (Data): RunSQL backfill on daily summary:
+   `SET cost_model_context = 'default' WHERE cost_model_rate_type IS NOT NULL AND cost_model_context IS NULL`
+4. **M7b** (Data): RunSQL backfill on all 13 UI summary tables
+   (same WHERE clause)
+
+**Why backfill is necessary**: The pipeline uses scoped DELETEs
+(`DELETE WHERE cost_model_context = {{context}}`). Without backfill,
+existing NULL rows would not be deleted, causing data duplication
+on the first post-migration pipeline run.
+
+| # | Approach | Pros | Cons | Verdict |
+|---|----------|------|------|---------|
+| A | Nullable + RunSQL backfill | Follows koku DDL pattern; prevents duplicates | Backfill takes time | **Proposed** |
+| B | Nullable, NULL = default (no backfill) | Simpler | Scoped DELETE misses NULL rows; data duplication | Rejected |
+| C | Background Celery backfill | Non-blocking | Complex; no koku precedent; hard to coordinate | Rejected |
+
+**Risk**: [R1](./risk-register.md#r1-was-tq-3-daily-summary-migration--resolved-by-codebase-pattern),
+[R11](./risk-register.md#r11-13-ui-summary-sql-files-need-context),
+[R21](./risk-register.md#r21-deployment-sequencing)
+
+---
+
+## GA-9: Notifications
+
+**PRD**: Notify when a context is missing a cost model assignment.
+
+**Current state**: Koku has `koku/notifications.py` with notification
+helpers.
+
+**Proposed implementation**: Add a check in `update_cost_model_costs`
+(after context dispatch) that inspects whether any context for the
+tenant has no `CostModelMap` assignment for the provider. If so,
+log a notification event. The check runs at the end of each pipeline
+cycle.
+
+---
+
+## GA-10: Storage and Performance
+
+**PRD**: 3 contexts × all clusters × all months = up to 3× data
+volume.
+
+**Current state**: Summary tables are already partitioned monthly.
+
+**Proposed mitigation**: Monitor partition sizes. The context column
+adds minimal per-row overhead (50 bytes). The data volume increase
+is proportional to the number of contexts actually used (most tenants
+will have 1-2, not 3). Retention (COST-573) already handles data
+aging.
+
+**Risk**: [R4](./risk-register.md)
+
+---
+
+## Gap Summary
+
+| GA | Gap | Proposed Phase | Status |
+|----|-----|---------------|--------|
+| GA-1 | CostModelContext model | Phase 1 | Design proposed |
+| GA-2 | RBAC (Koku-side v1) | Phase 4 | Design proposed |
+| GA-3 | Cost model creation | — | No work needed |
+| GA-4 | CostModelMap context FK | Phase 1 | Design proposed |
+| GA-5 | Default metering | — | Verify with test |
+| GA-6 | API query parameter | Phase 4 | Design proposed |
+| GA-7 | Pipeline per-context | Phase 3 | Design proposed |
+| GA-8 | Reporting table migration | Phase 2 | Design proposed |
+| GA-9 | Notifications | Phase 3 | Design proposed |
+| GA-10 | Storage/performance | — | Monitor |
+
+---
+
+## Changelog
+
+| Version | Date | Summary |
+|---------|------|---------|
+| v1.0 | 2026-04-08 | Initial gap identification |
+| v2.0 | 2026-04-09 | Evolved to design proposals: code sketches, migration strategy, alternatives, risk references, write-freeze rationale for GA-8 |

--- a/docs/architecture/consumer-provider-cost-models/prd-gap-analysis.md
+++ b/docs/architecture/consumer-provider-cost-models/prd-gap-analysis.md
@@ -26,20 +26,34 @@ class CostModelContext(models.Model):
     display_name = models.CharField(max_length=100)
     is_default = models.BooleanField(default=False)
     position = models.PositiveIntegerField(validators=[MinValueValidator(1)])
+    data_visibility = models.CharField(
+        max_length=20,
+        choices=DataVisibility.choices,
+        default=DataVisibility.CLOUD_AND_OCP,
+    )
     created_timestamp = models.DateTimeField(auto_now_add=True)
+```
+
+Where `DataVisibility` is:
+```python
+class DataVisibility(models.TextChoices):
+    OCP_ONLY = "ocp_only", "OpenShift only"
+    CLOUD_AND_OCP = "cloud_and_ocp", "Cloud + OpenShift"
 ```
 
 **Constraints**:
 - Exactly one row with `is_default=True` per tenant schema (partial unique index)
 - Max 3 rows per tenant schema (serializer + `position` CHECK constraint)
 - Default context cannot be deleted (viewset guard)
+- `data_visibility` defaults to `cloud_and_ocp` (backward-compatible)
 
 **CRUD API**: `CostModelContextSerializer` (ModelSerializer) +
 `CostModelContextViewSet` (ModelViewSet) at `/api/v1/cost-model-contexts/`.
 Supports GET, POST, PUT, DELETE.
 
 **Risk**: [R15](./risk-register.md#r15-max-3-contexts--no-db-enforcement),
-[R16](./risk-register.md#r16-default-context-cannot-be-deleted)
+[R16](./risk-register.md#r16-default-context-cannot-be-deleted),
+[R13](./risk-register.md#r13-was-tq-2-ocp-on-cloud-context-interaction--reopened)
 
 ---
 
@@ -80,6 +94,20 @@ compatible). When explicitly requested, the user must have
 a resource type, replace the Koku-side check with the RBAC lookup.
 The API contract does not change.
 
+**PRD extended RBAC examples** (added 2026-05-05):
+
+- User has access to Cluster 1 and the default context → sees
+  default context costs for Cluster 1 (or just usage if no cost
+  model assigned to default on that cluster).
+- User has access to Cluster 1 and Context B, but NOT the default
+  context → sees only Context B for Cluster 1; default is hidden.
+- User has access to Context B and default context, plus Cluster 1
+  and Cluster 2 → sees both contexts on both clusters.
+
+Context access is **additive to cluster access**, not a replacement.
+Having access to a context does not grant access to all clusters
+with that context — cluster RBAC still applies.
+
 **Alternatives evaluated**: See [current-architecture.md § 6.3](./current-architecture.md#63-alternatives)
 
 **Risk**: [R3](./risk-register.md#r3-was-tq-5-rbac-context-authorization--resolved-by-precedent)
@@ -100,7 +128,10 @@ of contexts. Assignment to contexts happens via `CostModelMap`.
 ## GA-4: Assignment with Context
 
 **PRD**: One cost model per context per OCP cluster. Assignment
-goes through `CostModelMap`.
+goes through `CostModelMap`. Each context exists for each cluster
+(contexts are org-level entities with per-cluster "slots").
+Context assignment also declares data visibility (OpenShift-only
+vs cloud + OpenShift).
 
 **Current state**: `CostModelMap` has `(provider_uuid, cost_model)`.
 The manager enforces one-model-per-provider at the application level.
@@ -110,20 +141,27 @@ The manager enforces one-model-per-provider at the application level.
 1. Add FK `cost_model_context` on `CostModelMap` → `CostModelContext`
 2. Change unique constraint to `unique_together = ("provider_uuid", "cost_model_context")`
 3. Update `CostModelManager.update_provider_uuids()` to check per-context uniqueness
+4. `CostModelContext.data_visibility` controls what cost data is
+   visible when querying that context (see GA-11)
 
 **Migration strategy (M1-M4)**:
 
 | Migration | Type | Description |
 |-----------|------|-------------|
-| M1 | DDL | Create `CostModelContext` model |
+| M1 | DDL | Create `CostModelContext` model (includes `data_visibility` field) |
 | M2 | DDL | Add nullable `cost_model_context` FK to `CostModelMap` |
 | M3 | DDL | Add unique constraint `(provider_uuid, cost_model_context)` |
-| M4 | Data | Create default "Consumer" context per tenant; assign all existing `CostModelMap` rows to it |
+| M4 | Data | Create default "Default context" context per tenant (renamable); assign all existing `CostModelMap` rows to it; set `data_visibility = 'cloud_and_ocp'` |
 
 M4 uses `RunPython` with fail-fast on duplicate `(provider_uuid)`
 rows — if a provider has multiple `CostModelMap` rows, the migration
 raises an error with actionable guidance. This follows koku's norm
 of non-destructive, deterministic data migrations.
+
+**Note**: The updated PRD (2026-05-05) changed the default context
+display name from "Consumer" to "Default context" and added the
+requirement that the default context display name is renamable by
+customers.
 
 **Risk**: [R9](./risk-register.md#r9-update_provider_uuids-blocks-multi-assignment),
 [R10](./risk-register.md#r10-was-tq-4-predecessor-pr-sequencing--resolved)
@@ -160,11 +198,22 @@ the pattern to follow.
    `None` when not explicitly provided (backward compatible)
 3. **QueryHandler**: `OCPReportQueryHandler` passes context to
    `provider_map`; adds ORM filter `cost_model_context=X` when set
-4. **Response**: When `cost_model_context` is explicitly provided,
-   include it in response `meta`; otherwise omit it
+4. **Visibility filtering**: When `cost_model_context` is provided,
+   the handler looks up the context's `data_visibility` field:
+   - `cloud_and_ocp`: Current behavior — include both
+     `infrastructure_raw_cost` and `cost_model_*_cost` columns
+   - `ocp_only`: Substitute `cloud_infrastructure_cost` with
+     `Value(0)` in the `OCPProviderMap` — cloud infrastructure
+     columns are excluded from aggregation
+5. **Response**: When `cost_model_context` is explicitly provided,
+   include `cost_model_context` and `data_visibility` in response
+   `meta`; otherwise omit both
 
 When no context parameter is provided, the API returns all data
 regardless of context — identical to today's behavior.
+
+**Risk**: [R13](./risk-register.md#r13-was-tq-2-ocp-on-cloud-context-interaction--reopened),
+[R22](./risk-register.md#r22-visibility-filtering-breaks-ocp-on-cloud-report-expectations)
 
 ---
 
@@ -237,18 +286,19 @@ on the first post-migration pipeline run.
 
 ---
 
-## GA-9: Notifications
+## GA-9: Notifications — DEFERRED
 
-**PRD**: Notify when a context is missing a cost model assignment.
+**PRD (original)**: Notify when a context is missing a cost model
+assignment.
+
+**PRD (updated 2026-05-05)**: Notifications moved to **out of scope**.
 
 **Current state**: Koku has `koku/notifications.py` with notification
 helpers.
 
-**Proposed implementation**: Add a check in `update_cost_model_costs`
-(after context dispatch) that inspects whether any context for the
-tenant has no `CostModelMap` assignment for the provider. If so,
-log a notification event. The check runs at the end of each pipeline
-cycle.
+**Status**: **Deferred** per updated PRD. The implementation design
+(pipeline check for missing context assignments) remains valid and
+can be re-activated if notifications are brought back into scope.
 
 ---
 
@@ -269,6 +319,53 @@ aging.
 
 ---
 
+## GA-11: Cost Visibility
+
+**PRD (updated 2026-05-05)**: Context Assignment declares data
+visibility — OpenShift-only or cloud + OpenShift per context.
+
+**Current state**: Cloud infrastructure costs
+(`infrastructure_raw_cost`, `infrastructure_markup_cost`) always
+appear in OCP reports alongside cost-model-derived costs. There is
+no mechanism to suppress them per context. `OCPProviderMap` already
+separates these as independent ORM expressions:
+- `cloud_infrastructure_cost` → `Sum(infrastructure_raw_cost)`
+- `cost_model_infrastructure_cost` → sum of `cost_model_*` where
+  `cost_model_rate_type = 'Infrastructure'`
+
+**Proposed implementation**:
+
+1. **Model**: `data_visibility` field on `CostModelContext`
+   (see GA-1). Default: `cloud_and_ocp`.
+2. **API filtering**: `OCPReportQueryHandler` reads the context's
+   `data_visibility` when `cost_model_context` is in the request.
+   For `ocp_only`: substitute `self.cloud_infrastructure_cost` with
+   `Value(0, output_field=DecimalField())` in the `OCPProviderMap`
+   ORM expressions. This zeroes out `infra_raw` and reduces
+   `infra_total` / `cost_total` accordingly.
+3. **Pipeline**: No changes. Cloud costs are written by ingestion,
+   not by the cost model pipeline. Filtering is query-time only.
+4. **Migration M4**: Default context gets
+   `data_visibility = 'cloud_and_ocp'` (no change for existing
+   users).
+5. **Response meta**: Include `data_visibility` in response `meta`
+   when `cost_model_context` is explicitly provided.
+
+**Why API-layer, not pipeline-layer**:
+
+- Cloud costs come from ingestion, not cost models — the pipeline
+  cannot filter what it did not create.
+- AWS `cost_type` is the direct precedent: a query parameter selects
+  which columns to aggregate at query time without changing pipeline
+  output.
+- No data duplication — the same base data serves both visibility
+  modes.
+
+**Risk**: [R13](./risk-register.md#r13-was-tq-2-ocp-on-cloud-context-interaction--reopened),
+[R22](./risk-register.md#r22-visibility-filtering-breaks-ocp-on-cloud-report-expectations)
+
+---
+
 ## Gap Summary
 
 | GA | Gap | Proposed Phase | Status |
@@ -281,8 +378,9 @@ aging.
 | GA-6 | API query parameter | Phase 4 | Design proposed |
 | GA-7 | Pipeline per-context | Phase 3 | Design proposed |
 | GA-8 | Reporting table migration | Phase 2 | Design proposed |
-| GA-9 | Notifications | Phase 3 | Design proposed |
+| GA-9 | Notifications | — | **Deferred** (out of scope per updated PRD) |
 | GA-10 | Storage/performance | — | Monitor |
+| GA-11 | Cost visibility (`data_visibility`) | Phase 1 (model) + Phase 4 (API) | Design proposed |
 
 ---
 
@@ -292,3 +390,4 @@ aging.
 |---------|------|---------|
 | v1.0 | 2026-04-08 | Initial gap identification |
 | v2.0 | 2026-04-09 | Evolved to design proposals: code sketches, migration strategy, alternatives, risk references, write-freeze rationale for GA-8 |
+| v3.0 | 2026-05-05 | PRD realignment: GA-1 adds `data_visibility` field; GA-2 adds extended RBAC examples; GA-4 updates default name to "Default context" + visibility semantics; GA-6 adds visibility filtering; GA-9 deferred (notifications out of scope); GA-11 added (cost visibility) |

--- a/docs/architecture/consumer-provider-cost-models/risk-register.md
+++ b/docs/architecture/consumer-provider-cost-models/risk-register.md
@@ -327,10 +327,11 @@ clause alongside `rate_type`.
 
 | Option | Description | Pros | Cons |
 |--------|-------------|------|------|
-| **A — Add `context` to all SQL WHERE clauses** | `AND context = {{context}}` in DELETE and source-filtering clauses | Clean; explicit; correct; follows existing `rate_type` scoping pattern | 29+ SQL files to modify (plus self-hosted) |
+| **A — Add `context` to all SQL WHERE clauses** | `AND context = {{context}}` in DELETE and source-filtering clauses | Clean; explicit; correct; follows existing `rate_type` scoping pattern | 49 SQL files to modify (standard + self-hosted + Trino + UI summary) |
 | **B — Use `cost_model_rate_type` to encode context** | Prefix rate type: `Infrastructure:Provider` | No new column needed | Breaks existing semantics; fragile; ugly |
 
-**Proposed**: **Option A**. Mechanical change across ~37 SQL files.
+**Proposed**: **Option A**. Mechanical change across 49 SQL files
+(16 standard + 9 self-hosted + 9 Trino + 13 UI summary + 2 variants).
 Repetitive but straightforward. The pattern is identical to existing
 `cost_model_rate_type` scoping — add `AND context = {{context}}`
 next to every `AND cost_model_rate_type = {{rate_type}}`. Create a

--- a/docs/architecture/consumer-provider-cost-models/risk-register.md
+++ b/docs/architecture/consumer-provider-cost-models/risk-register.md
@@ -1,0 +1,561 @@
+# Risk Register — COST-3920 Consumer-Provider Cost Models
+
+**Parent**: [README.md](README.md) · **Status**: Design Proposal
+
+---
+
+## Summary
+
+| ID | Risk | Severity | Status |
+|----|------|----------|--------|
+| R1 | Daily summary table migration on high-volume partitioned table | **Critical** | **Resolved by codebase pattern** — nullable `AddField` + RunSQL backfill |
+| R3 | RBAC service has no "context" dimension; cross-service dependency | **High** | **Resolved by precedent** — `IngressAccessPermission` pattern |
+| R4 | 3× storage multiplier on cost data (summary + UI tables) | **High** | Resolvable — proposed mitigation below |
+| R13 | OCP-on-cloud cost rows appear in OCP summaries — context interaction unclear | Medium | **Resolved by code** — cloud costs already context-independent |
+| R20 | On-prem vs SaaS scope not defined — affects RBAC path and migration strategy | **High** | **Resolved by code** — cost models are universal; follow existing pattern |
+| R2 | Pipeline runs N× per cluster (3 contexts = 3× compute) | **High** | Resolvable — proposed mitigation below |
+| R5 | `CostModelDBAccessor.cost_model` uses `.first()` — single-model assumption | **High** | Resolvable — proposed mitigation below |
+| R6 | SQL DELETE→INSERT pattern overwrites context data without discriminator | **High** | Resolvable — proposed mitigation below |
+| R7 | Distribution logic is per-provider, not per-context | Medium | Resolvable — proposed mitigation below |
+| R8 | Currency annotation joins CostModelMap without context | Medium | Resolvable — proposed mitigation below |
+| R9 | `update_provider_uuids` blocks multi-assignment | Medium | Resolvable — proposed mitigation below |
+| R10 | Migration ordering collision with predecessor PRs | Medium | **Resolved** — confirmed merge order #5981→#5983→#5984 |
+| R11 | 13 UI summary SQL files need context column + GROUP BY | Medium | Resolvable — proposed mitigation below |
+| R12 | Audit trigger does not capture context | Medium | Resolvable — proposed mitigation below |
+| R14 | `CostModelMap.provider_uuid` is not a Django FK | Low | Resolvable — proposed mitigation below |
+| R15 | Max 3 contexts constraint is application-level | Low | Resolvable — proposed mitigation below |
+| R16 | Default context cannot be deleted | Low | Resolvable — proposed mitigation below |
+| R17 | Empty context (no cost model) must still show metering at $0 | Low | Resolvable — proposed mitigation below |
+| R18 | Tag-based CASE statements repeated per context | Low | Resolvable — proposed mitigation below |
+| R19 | Celery task dedup collision for same provider across contexts | Medium | Resolvable — proposed mitigation below |
+| R21 | Deployment sequencing — code before backfill causes data duplication | **High** | Proposed mitigation: write-freeze flag + deployment runbook |
+
+---
+
+# Part 1 — Risks Informed by Codebase Analysis
+
+Of the original 5 TL-blocked risks, **3 are now fully resolved** by
+codebase evidence, **1 is narrowed**, and **1 remains a process
+question**. Each section includes the code evidence that informed
+our resolution.
+
+---
+
+## R13 (was TQ-2): OCP-on-Cloud Context Interaction — RESOLVED BY CODE
+
+**Severity**: Medium · **Status**: **Resolved** — cloud costs are
+already context-independent by design.
+
+### Code evidence
+
+1. **Separate columns**: Cloud infrastructure costs use
+   `infrastructure_raw_cost` (+ `infrastructure_markup_cost`). Cost
+   model charges use `cost_model_cpu_cost`, `cost_model_memory_cost`,
+   etc. These are **different columns** on the same table.
+
+2. **Different rate type markers**: Cloud rows have
+   `cost_model_rate_type = NULL`. Cost model rows have explicit
+   values (`'Infrastructure'`, `'Supplementary'`, distributed types).
+
+3. **SQL isolation**: Cost model DELETE→INSERT operations scope by
+   `cost_model_rate_type = {{rate_type}}` — they **never touch**
+   cloud rows (which have NULL rate type). The SQL explicitly filters:
+   ```sql
+   AND (cost_model_rate_type IS NULL
+        OR cost_model_rate_type NOT IN ('Infrastructure', 'Supplementary'))
+   ```
+   This means cost model SQL reads from cloud/usage rows as input
+   but only DELETEs/INSERTs its own output rows.
+
+4. **Provider map separation**: `OCPProviderMap` already distinguishes:
+   - `cloud_infrastructure_cost` → `Sum(infrastructure_raw_cost)`
+   - `cost_model_infrastructure_cost` → sum of `cost_model_*` where
+     `cost_model_rate_type = 'Infrastructure'`
+
+**Resolution**: No TL decision needed. Adding a `context` column to
+cost-model rows (those with non-NULL `cost_model_rate_type`) leaves
+cloud rows untouched (`context = NULL`). The report API already
+merges both column families in aggregates — cloud costs will continue
+to appear in every context response, clearly separated as
+infrastructure costs. This is Option C from our original analysis,
+and it's the existing behavior.
+
+---
+
+## R1 (was TQ-3): Daily Summary Migration — RESOLVED BY CODEBASE PATTERN
+
+**Severity**: Critical → **Downgraded to Low** (follows established
+pattern).
+
+### Code evidence
+
+1. **Established pattern**: Migration `0339` added `cost_model_gpu_cost`
+   to `reporting_ocpusagelineitem_daily_summary` using a standard
+   nullable `AddField`:
+   ```python
+   migrations.AddField(
+       model_name="ocpusagelineitemdailysummary",
+       name="cost_model_gpu_cost",
+       field=models.DecimalField(decimal_places=15, max_digits=33, null=True),
+   )
+   ```
+
+2. **No RunSQL pattern exists**: Grep across all reporting migrations
+   found **zero** instances of `RunSQL` with `ADD COLUMN` or
+   `ADD COLUMN DEFAULT`.
+
+3. **Partitions handled automatically**: PostgreSQL propagates
+   `ALTER TABLE` on the parent to all partitions. The codebase relies
+   on this — no per-partition DDL loops exist. Documented in
+   `.cursor/rules/migrations.mdc`.
+
+4. **Migration `0341`** added `cost_model_gpu_cost` to **all 13 UI
+   summary `*_p` tables** using the same `AddField` pattern.
+
+**Proposed resolution**: Follow the established DDL pattern — add
+`cost_model_context` as a **nullable** `CharField(max_length=50, null=True)`
+to the daily summary and all 13 UI summary tables.
+
+However, unlike `cost_model_gpu_cost` (a purely additive column),
+`cost_model_context` will be used as a **discriminator in SQL WHERE
+clauses**:
+```sql
+DELETE FROM ... WHERE cost_model_context = {{cost_model_context}} AND ...
+```
+
+Leaving existing cost-model rows as `NULL` would cause the scoped
+DELETE to miss them, producing **duplicate rows** (NULL legacy +
+new `'default'` rows) on the first pipeline run after deployment.
+
+**Therefore a RunSQL backfill migration is proposed**:
+```sql
+UPDATE reporting_ocpusagelineitem_daily_summary
+   SET cost_model_context = 'default'
+ WHERE cost_model_rate_type IS NOT NULL
+   AND cost_model_context IS NULL;
+```
+
+The same pattern applies to all 13 UI summary tables. The `WHERE
+cost_model_rate_type IS NOT NULL` clause targets only cost-model-
+injected rows — cloud/usage rows (with NULL rate type) remain NULL.
+
+| # | Approach | Pros | Cons | Verdict |
+|---|----------|------|------|---------|
+| A | Nullable AddField + RunSQL backfill | Follows koku DDL precedent; prevents duplicates | Backfill may take time on large tenants | **Proposed** |
+| B | Nullable AddField, NULL = default (no backfill) | Simpler | Scoped DELETE misses NULL rows; data duplication | Rejected |
+| C | AddField with DEFAULT clause | No separate backfill needed | Not used anywhere in koku; PostgreSQL may rewrite table | Rejected |
+
+See also [R21](#r21-deployment-sequencing) for the write-freeze guard
+that prevents race conditions during backfill.
+
+---
+
+## R3 (was TQ-5): RBAC Context Authorization — RESOLVED BY PRECEDENT
+
+**Severity**: High · **Status**: **Resolved** — `IngressAccessPermission`
+is direct precedent for Koku-side auth.
+
+### Code evidence
+
+1. **`IngressAccessPermission`** subclasses `SettingsAccessPermission`
+   (the RBAC-based class) but adds a Koku-side override:
+   ```python
+   class IngressAccessPermission(SettingsAccessPermission):
+       def has_permission(self, request, view):
+           if is_ingress_rbac_grace_period_enabled(customer.schema_name):
+               return True  # bypass RBAC entirely
+           return super().has_permission(request, view)
+   ```
+
+2. **Unleash/schema-scoped feature flag**: The bypass uses
+   `UNLEASH_CLIENT.is_enabled(flag, {"schema": schema})` — a
+   Koku-managed, per-tenant gate that does not go through the
+   RBAC service.
+
+3. **Pattern for COST-3920**: Create a `CostModelContextPermission`
+   that subclasses `CostModelsAccessPermission`, adds a Koku-side
+   context check (DB-backed, not Unleash), and falls through to
+   RBAC for cost model access. When platform RBAC adds
+   `cost_model_context`, swap the Koku-side check for the RBAC
+   lookup without changing the API.
+
+4. **`RESOURCE_TYPES` in `rbac.py`** already includes `settings`
+   with `read`/`write` — adding `cost_model_context` later would
+   follow the same pattern.
+
+**Resolution**: Hybrid approach (Option C) is the correct path, and
+it follows established codebase conventions. No TL decision needed
+on the pattern — only on timing of platform RBAC migration (which
+can be deferred).
+
+---
+
+## R20 (was TQ-1): Environment Scope — RESOLVED BY CODE
+
+**Severity**: High → **Low** (follows established pattern).
+
+### Code evidence
+
+1. **Cost model endpoints are universal**: `cost-models/` CRUD and
+   `resource-types/cost-models/` are registered **unconditionally**
+   in `koku/urls.py` — no `settings.ONPREM` check.
+
+2. **ONPREM gating is rare**: Only 3 routes are ONPREM-gated
+   (`source_types`, `application_types`, `applications`). Cost-model-
+   related paths are not among them.
+
+3. **`source_type` supports all providers**: `CostModel.source_type`
+   uses the full `Provider.PROVIDER_CHOICES` (OCP, AWS, Azure, GCP).
+   Cost models are not OCP-only or on-prem-only at the model level.
+
+4. **D6 pattern from COST-573**: Backend logic is environment-agnostic.
+   `ONPREM` only gates URL registration. COST-3920 should follow the
+   same pattern.
+
+**Proposed resolution**: Ship context APIs universally, matching the
+existing cost model pattern. Gating behind `ONPREM` would break the
+established convention.
+
+For migration data consistency, we propose a **dedicated Unleash flag**
+`cost-management.backend.disable-cost-model-context-writes` following
+the pattern established by PR #5983 (`COST_MODEL_WRITE_FREEZE_FLAG =
+"cost-management.backend.disable-cost-model-writes"`). This flag:
+
+- **Blocks** context creation/update via a serializer guard
+  (`_check_context_write_freeze()` on `CostModelContextSerializer`)
+- **Blocks** context-tagged pipeline writes via a task guard in
+  `update_cost_model_costs` (skips when flag active + context is set)
+- **Allows** all reads (GET/list on contexts and reports)
+- Uses `is_context_writes_disabled(schema)` helper in
+  `masu/processor/__init__.py`
+
+**On-prem consideration**: `MockUnleashClient` returns `False` for all
+flags, making the write-freeze a no-op. On-prem deployments follow
+migrations-first deployment, which already prevents the race condition.
+
+See [phased-delivery.md § Deployment Runbook](./phased-delivery.md#deployment-runbook)
+for the full deployment sequence.
+
+---
+
+## R10 (was TQ-4): Predecessor PR Sequencing — RESOLVED
+
+**Severity**: Medium → **Low** (confirmed merge order).
+
+In-flight PRs modify the same cost model infrastructure:
+- PR #5981 (COST-575 Price List API) — accessor, updater, manager
+- PR #5983 (COST-7249 Rate dual-write) — models, migrations, manager
+- PR #5984 (COST-7249 Rate backfill) — data migration
+
+**Confirmed merge order**: #5981 → #5983 → #5984. This is the
+dependency chain: #5981 establishes the Price List API, #5983 adds
+the Rate model + dual-write on top, and #5984 backfills existing
+data.
+
+**Resolution**: Continue design now. Begin COST-3920 implementation
+after #5984 merges (last in the chain). Run `makemigrations` against
+clean main post-merge to get correct migration numbers. The final
+state after all 3 PRs land gives us `Rate`, `PriceList`, and the
+updated `CostModelManager` — all of which COST-3920 builds on top of.
+
+---
+
+# Part 2 — Resolvable Risks (Proposed Mitigations)
+
+These 15 risks have clear resolutions we can proceed with. Each
+includes available options and our proposed approach.
+
+---
+
+## R2: Pipeline Runs N× Per Cluster
+
+**Severity**: High · **Category**: Performance
+
+With 3 contexts, the cost pipeline must execute 3× per provider.
+
+### Available resolutions
+
+| Option | Description | Pros | Cons |
+|--------|-------------|------|------|
+| **A — Sequential loop** | Inner loop over contexts inside existing pipeline task | Simple; reuses existing task structure | Total wall-clock = N × single run |
+| **B — Parallel Celery tasks** | Dispatch one Celery task per (provider, context) pair | Parallelized; scales with workers | More Celery tasks; cache key changes needed (R19) |
+| **C — Single-pass multi-context SQL** | SQL uses UNION ALL or CASE to compute all contexts in one query | Fewest DB round-trips | Complex SQL; harder to debug; couples contexts |
+
+**Proposed**: **Option B**. Per-context tasks are independent and can
+run in parallel. The pipeline already dispatches per-provider — adding
+a context dimension is incremental. Most tenants will have 1-2
+contexts, keeping the common case fast.
+
+---
+
+## R5: `CostModelDBAccessor` Single-Model Assumption
+
+**Severity**: High · **Category**: Code
+
+The accessor uses `.first()` which returns one arbitrary cost model.
+
+### Available resolutions
+
+| Option | Description | Pros | Cons |
+|--------|-------------|------|------|
+| **A — Add `context` parameter** | `CostModelDBAccessor(schema, provider_uuid, context=None)` filters by context FK on CostModelMap | Clean; backward-compatible (None = current behavior) | All callers must be updated |
+| **B — Return all cost models, let caller pick** | `cost_models` property returns list; caller iterates | Flexible | Pushes complexity to callers; error-prone |
+
+**Proposed**: **Option A**. Add optional `context` parameter. When
+`None`, falls back to `.first()` (backward-compatible). When set,
+filters by `costmodelmap__context`. 4 files need updating.
+
+---
+
+## R6: SQL DELETE→INSERT Overwrites Without Context Discriminator
+
+**Severity**: High · **Category**: Data integrity
+
+Running the pipeline for context B would delete context A's cost rows.
+
+### Code evidence (from R13 analysis)
+
+The existing SQL already scopes DELETEs by `cost_model_rate_type`:
+```sql
+DELETE FROM ... WHERE cost_model_rate_type = {{rate_type}} AND monthly_cost_type IS NULL
+```
+Cloud rows (`cost_model_rate_type = NULL`) are untouched. The
+`context` column follows the same pattern — add it to the WHERE
+clause alongside `rate_type`.
+
+### Available resolutions
+
+| Option | Description | Pros | Cons |
+|--------|-------------|------|------|
+| **A — Add `context` to all SQL WHERE clauses** | `AND context = {{context}}` in DELETE and source-filtering clauses | Clean; explicit; correct; follows existing `rate_type` scoping pattern | 29+ SQL files to modify (plus self-hosted) |
+| **B — Use `cost_model_rate_type` to encode context** | Prefix rate type: `Infrastructure:Provider` | No new column needed | Breaks existing semantics; fragile; ugly |
+
+**Proposed**: **Option A**. Mechanical change across ~37 SQL files.
+Repetitive but straightforward. The pattern is identical to existing
+`cost_model_rate_type` scoping — add `AND context = {{context}}`
+next to every `AND cost_model_rate_type = {{rate_type}}`. Create a
+PR checklist to ensure no file is missed.
+
+---
+
+## R7: Distribution Logic Per-Provider, Not Per-Context
+
+**Severity**: Medium · **Category**: Correctness
+
+Different contexts may use different distribution strategies (CPU vs
+memory). Distribution SQL must be scoped by context.
+
+**Proposed**: Pass `context` parameter to
+`populate_distributed_cost_sql`. The distribution SQL already scopes
+by `source_uuid` — adding `context` is the same pattern. Each
+context's cost model provides its own `distribution_info`, which the
+updater already reads per cost model.
+
+---
+
+## R8: Currency Annotation Joins Without Context
+
+**Severity**: Medium · **Category**: API correctness
+
+Report query handler builds a `source_to_currency_map` joining
+`CostModel → CostModelMap`. Multiple contexts = multiple currencies.
+
+**Proposed**: Filter the currency join by the request's
+`cost_model_context` parameter. Falls out naturally from the API
+parameter threading (GA-6 in gap analysis). When no context is
+specified, use the default context's currency.
+
+---
+
+## R9: `update_provider_uuids` Blocks Multi-Assignment
+
+**Severity**: Medium · **Category**: Code
+
+Manager rejects any provider that already has a `CostModelMap` row.
+
+### Available resolutions
+
+| Option | Description | Pros | Cons |
+|--------|-------------|------|------|
+| **A — Check per-context uniqueness** | `filter(provider_uuid=uuid, context=context)` | Correct; minimal change | Must ship atomically with context column migration |
+| **B — Drop the check entirely** | Let DB unique constraint enforce | Simpler code | Loses descriptive error message; relies on DB IntegrityError |
+
+**Proposed**: **Option A**. Change the filter to include `context`.
+The descriptive error message is valuable for API consumers. Ship
+as a single migration + code change to avoid intermediate breakage.
+
+---
+
+## R10: Migration Ordering Collision — RESOLVED
+
+**Severity**: Medium → Low · **Category**: Process
+
+Confirmed merge order: **#5981 → #5983 → #5984**. Design proceeds
+now; implementation starts after #5984 lands. Run `makemigrations`
+against clean main post-merge to get correct migration numbers.
+
+---
+
+## R11: 13 UI Summary SQL Files Need Context
+
+**Severity**: Medium · **Category**: Effort
+
+All UI summary SQL files follow the same DELETE→INSERT pattern.
+
+**Proposed**: Apply the pattern mechanically:
+1. Add `context` to DELETE WHERE clause
+2. Add `context` to INSERT column list
+3. Add `context` to GROUP BY
+
+Create a checklist of all 13 files. Add a test that asserts every
+`reporting_ocp_*_summary_p` table has the `context` column. Verify
+in code review using `rg 'context' sql/openshift/ui_summary/`.
+
+---
+
+## R12: Audit Trigger Does Not Capture Context
+
+**Severity**: Medium · **Category**: Auditability
+
+**Proposed**: Update the `process_cost_model_audit()` trigger to
+include a `contexts` array in the audit row, aggregated from
+`cost_model_map` alongside the existing `provider_uuids` array.
+Straightforward DDL change in a new migration.
+
+---
+
+## R14: `CostModelMap.provider_uuid` Not a Django FK
+
+**Severity**: Low · **Category**: Pre-existing
+
+`provider_uuid` is stored by value, not as a Django `ForeignKey` to
+`Provider`. This means no cascade cleanup when a provider is deleted.
+
+**Proposed**: Accept as-is. This is a pre-existing design choice.
+Adding context does not change the risk profile. Provider deletion
+already has application-level cleanup in the manager. If context
+cleanup is needed on provider delete, add it to the same code path.
+
+---
+
+## R15: Max 3 Contexts — No DB Enforcement
+
+**Severity**: Low · **Category**: Data integrity
+
+The PRD limits contexts to 3 per tenant, but without DB enforcement
+the application could create more.
+
+### Available resolutions
+
+| Option | Description | Pros | Cons |
+|--------|-------------|------|------|
+| **A — Serializer validation only** | Check `CostModelContext.objects.count() < 3` before create | Simple | Bypassable via shell or direct DB |
+| **B — DB trigger** | Postgres trigger rejects INSERT if count ≥ 3 | Bulletproof | More complex; harder to test |
+| **C — Serializer + DB CHECK** | Serializer validates; DB CHECK on a `position` column (1, 2, 3) | Belt and suspenders | Slightly more complex model |
+
+**Proposed**: **Option C**. Add a `position` field (1, 2, or 3)
+with a DB CHECK constraint. The serializer enforces max 3 and
+assigns the next available position. This is simple and robust.
+
+---
+
+## R16: Default Context Cannot Be Deleted
+
+**Severity**: Low · **Category**: Business rule
+
+**Proposed**: Guard in `CostModelContextSerializer.validate_delete()`
+and `CostModelContextManager.delete()`: if `is_default=True`, raise
+`ValidationError("The default context cannot be deleted")`. Add a
+partial unique index `CREATE UNIQUE INDEX ... ON cost_model_context
+(is_default) WHERE is_default = TRUE` to enforce one default at the
+DB level.
+
+---
+
+## R17: Empty Context Shows Metering at $0
+
+**Severity**: Low · **Category**: Existing behavior
+
+A context with no cost model assigned should show usage but $0 cost.
+
+**Proposed**: Already works. When `CostModelDBAccessor` finds no cost
+model for a (provider, context), it returns empty rates. The pipeline
+still runs for OCP providers (distribution and UI summary refresh).
+Usage data comes from ingestion, which is context-independent.
+Verify with a test that covers the "no cost model for context" path.
+
+---
+
+## R18: Tag-Based CASE Statements Repeated Per Context
+
+**Severity**: Low · **Category**: Performance
+
+The Python-built CASE statements for tag-based monthly costs run
+per context with different rates.
+
+**Proposed**: Accept. The CASE statements are built dynamically from
+the cost model's tag rates. Each context has its own cost model with
+its own rates, so the statements are naturally different. No
+optimization needed — the pattern is the same, just executed N times.
+
+---
+
+## R19: Celery Task Dedup Collision
+
+**Severity**: Medium · **Category**: Concurrency
+
+`update_cost_model_costs` uses `worker_cache` with key
+`(schema, provider_uuid)`. Multiple per-context tasks would collide.
+
+**Proposed**: Include `context` in the cache key:
+`(schema, provider_uuid, context_id)`. One-line change in
+`tasks.py` where the cache key is composed.
+
+---
+
+## R21: Deployment Sequencing
+
+**Severity**: High · **Category**: Data integrity
+
+If new application code (with context-aware pipeline) deploys before
+the backfill migration runs, the pipeline will write context-tagged
+rows (`cost_model_context = 'default'`) alongside existing NULL rows
+that were not yet backfilled. This causes data duplication on report
+queries.
+
+### Proposed mitigation
+
+1. **Write-freeze Unleash flag** (`cost-management.backend.disable-cost-model-context-writes`) — enable before migration, disable after code deployment
+2. **Deployment runbook** enforcing: Enable flag → Run migrations → Deploy code → Disable flag
+3. **On-prem**: MockUnleashClient makes freeze a no-op; migrations-first deployment already prevents the race
+
+See [phased-delivery.md § Deployment Runbook](./phased-delivery.md#deployment-runbook).
+
+---
+
+## Tech Lead Questions — All Resolved
+
+All 5 original TL-blocked questions have been resolved through
+codebase analysis and confirmed inputs. No TL decisions are blocking
+design or implementation.
+
+| # | Question | Risk | Resolution |
+|---|----------|------|------------|
+| ~~TQ-1~~ | Environment scope | R20 | **Resolved by code** — cost models are universal today; context APIs follow the same pattern |
+| ~~TQ-2~~ | Cloud-backed infra costs | R13 | **Resolved by code** — cloud rows use separate columns + NULL rate type; already context-independent |
+| ~~TQ-3~~ | Daily summary migration | R1 | **Resolved by codebase pattern** — nullable `AddField` (0339, 0341 precedent); NULL = default context |
+| ~~TQ-4~~ | PR sequencing | R10 | **Resolved** — confirmed merge order #5981 → #5983 → #5984 |
+| ~~TQ-5~~ | RBAC strategy | R3 | **Resolved by precedent** — `IngressAccessPermission` hybrid pattern |
+
+---
+
+## Changelog
+
+| Version | Date | Summary |
+|---------|------|---------|
+| v1.0 | 2026-04-08 | Initial risk register: 20 risks, 5 TL questions |
+| v1.1 | 2026-04-08 | Restructured: TL-blocked risks with options/trade-offs; resolvable risks with proposed mitigations |
+| v2.0 | 2026-04-08 | Codebase analysis: resolved TQ-2, TQ-3, TQ-5 from source code; narrowed TQ-1; only TQ-4 remains fully open |
+| v2.1 | 2026-04-08 | TQ-4 resolved: confirmed merge order #5981→#5983→#5984 |
+| v2.2 | 2026-04-08 | R20 resolved: universal scope follows established cost model pattern; all 5 TL questions now resolved |
+| v3.0 | 2026-04-09 | Design proposal: R1 corrected (backfill required, not optional); R20 updated with dedicated write-freeze Unleash flag per PR #5983 pattern; R21 added (deployment sequencing risk + write-freeze mitigation) |

--- a/docs/architecture/consumer-provider-cost-models/risk-register.md
+++ b/docs/architecture/consumer-provider-cost-models/risk-register.md
@@ -11,7 +11,7 @@
 | R1 | Daily summary table migration on high-volume partitioned table | **Critical** | **Resolved by codebase pattern** — nullable `AddField` + RunSQL backfill |
 | R3 | RBAC service has no "context" dimension; cross-service dependency | **High** | **Resolved by precedent** — `IngressAccessPermission` pattern |
 | R4 | 3× storage multiplier on cost data (summary + UI tables) | **High** | Resolvable — proposed mitigation below |
-| R13 | OCP-on-cloud cost rows appear in OCP summaries — context interaction unclear | Medium | **Resolved by code** — cloud costs already context-independent |
+| R13 | OCP-on-cloud cost rows appear in OCP summaries — context visibility controls data | Medium | **Reopened** — `data_visibility` on `CostModelContext` + API-layer filtering (DQ-5) |
 | R20 | On-prem vs SaaS scope not defined — affects RBAC path and migration strategy | **High** | **Resolved by code** — cost models are universal; follow existing pattern |
 | R2 | Pipeline runs N× per cluster (3 contexts = 3× compute) | **High** | Resolvable — proposed mitigation below |
 | R5 | `CostModelDBAccessor.cost_model` uses `.first()` — single-model assumption | **High** | Resolvable — proposed mitigation below |
@@ -29,6 +29,7 @@
 | R18 | Tag-based CASE statements repeated per context | Low | Resolvable — proposed mitigation below |
 | R19 | Celery task dedup collision for same provider across contexts | Medium | Resolvable — proposed mitigation below |
 | R21 | Deployment sequencing — code before backfill causes data duplication | **High** | Proposed mitigation: write-freeze flag + deployment runbook |
+| R22 | Visibility filtering may break OCP-on-cloud report expectations | Medium | Resolvable — default `cloud_and_ocp`; change requires explicit admin action |
 
 ---
 
@@ -41,12 +42,34 @@ our resolution.
 
 ---
 
-## R13 (was TQ-2): OCP-on-Cloud Context Interaction — RESOLVED BY CODE
+## R13 (was TQ-2): OCP-on-Cloud Context Interaction — REOPENED
 
-**Severity**: Medium · **Status**: **Resolved** — cloud costs are
-already context-independent by design.
+**Severity**: Medium · **Status**: **Reopened** — updated PRD
+(2026-05-05) introduces cost visibility per context.
 
-### Code evidence
+### Original resolution (v2.0, now superseded)
+
+The original analysis concluded that cloud costs are context-
+independent because they use separate columns
+(`infrastructure_raw_cost`) and separate rate type markers
+(`cost_model_rate_type = NULL`). This remains **structurally true**
+at the pipeline level.
+
+### Why reopened
+
+The updated PRD adds a new requirement:
+
+> **Context Assignment also handles cost visibility:**
+> It states what data visibility is possible in that context:
+> OpenShift-only, or cloud + OpenShift.
+
+This means a context can declare `ocp_only` visibility, which must
+**exclude** cloud infrastructure costs from query results for that
+context. The original resolution ("cloud costs will continue to
+appear in every context response") is now incorrect for `ocp_only`
+contexts.
+
+### Code evidence (unchanged)
 
 1. **Separate columns**: Cloud infrastructure costs use
    `infrastructure_raw_cost` (+ `infrastructure_markup_cost`). Cost
@@ -59,26 +82,54 @@ already context-independent by design.
 
 3. **SQL isolation**: Cost model DELETE→INSERT operations scope by
    `cost_model_rate_type = {{rate_type}}` — they **never touch**
-   cloud rows (which have NULL rate type). The SQL explicitly filters:
-   ```sql
-   AND (cost_model_rate_type IS NULL
-        OR cost_model_rate_type NOT IN ('Infrastructure', 'Supplementary'))
-   ```
-   This means cost model SQL reads from cloud/usage rows as input
-   but only DELETEs/INSERTs its own output rows.
+   cloud rows (which have NULL rate type).
 
 4. **Provider map separation**: `OCPProviderMap` already distinguishes:
    - `cloud_infrastructure_cost` → `Sum(infrastructure_raw_cost)`
    - `cost_model_infrastructure_cost` → sum of `cost_model_*` where
      `cost_model_rate_type = 'Infrastructure'`
 
-**Resolution**: No TL decision needed. Adding a `context` column to
-cost-model rows (those with non-NULL `cost_model_rate_type`) leaves
-cloud rows untouched (`context = NULL`). The report API already
-merges both column families in aggregates — cloud costs will continue
-to appear in every context response, clearly separated as
-infrastructure costs. This is Option C from our original analysis,
-and it's the existing behavior.
+### Proposed resolution (DQ-5)
+
+Add a `data_visibility` field to `CostModelContext`:
+
+```python
+class DataVisibility(models.TextChoices):
+    OCP_ONLY = "ocp_only", "OpenShift only"
+    CLOUD_AND_OCP = "cloud_and_ocp", "Cloud + OpenShift"
+
+# On CostModelContext:
+data_visibility = models.CharField(
+    max_length=20,
+    choices=DataVisibility.choices,
+    default=DataVisibility.CLOUD_AND_OCP,
+)
+```
+
+**Why `CostModelContext` and not `CostModelMap`**:
+
+1. `CostModelMap` is a pure junction table (zero config properties
+   in the codebase — only `provider_uuid` + `cost_model` FK).
+2. A context with no cost model assigned has no `CostModelMap` row,
+   but the PRD requires visibility to apply even to empty contexts
+   (which still show metering data).
+3. API reports aggregate across clusters. Per-context visibility
+   (org-level) avoids undefined behavior when clusters in the same
+   context have mixed settings.
+
+**Filtering strategy**: API-layer, not pipeline-layer.
+
+- Cloud costs come from ingestion, not cost models — the pipeline
+  cannot filter what it did not create.
+- `OCPProviderMap` already separates `cloud_infrastructure_cost`
+  from `cost_model_infrastructure_cost` as independent ORM
+  expressions. For `ocp_only` contexts, the query handler
+  substitutes `cloud_infrastructure_cost` with `Value(0)`.
+- Precedent: AWS `cost_type` (blended/unblended/amortized) selects
+  columns at query time without changing pipeline output.
+
+See [DQ-5 in README.md](./README.md#dq-5-cost-visibility-filtering)
+and [GA-11 in prd-gap-analysis.md](./prd-gap-analysis.md#ga-11-cost-visibility).
 
 ---
 
@@ -534,6 +585,30 @@ See [phased-delivery.md § Deployment Runbook](./phased-delivery.md#deployment-r
 
 ---
 
+## R22: Visibility Filtering Breaks OCP-on-Cloud Report Expectations
+
+**Severity**: Medium · **Category**: Data correctness
+
+Setting a context to `data_visibility = ocp_only` suppresses cloud
+infrastructure costs (`infrastructure_raw_cost`,
+`infrastructure_markup_cost`) from report queries. Users who
+currently see combined OCP + cloud totals for OCP-on-AWS/Azure/GCP
+clusters would see reduced totals when viewing that context.
+
+### Proposed mitigation
+
+1. **Default is `cloud_and_ocp`**: Migration M4 sets
+   `data_visibility = 'cloud_and_ocp'` on the default context.
+   Existing users see no change.
+2. **Explicit admin action**: Changing visibility to `ocp_only`
+   requires a deliberate PUT on the context — it cannot happen
+   accidentally.
+3. **API response annotation**: When `data_visibility = ocp_only`,
+   the response `meta` includes `"data_visibility": "ocp_only"` so
+   consumers know cloud costs are excluded.
+
+---
+
 ## Tech Lead Questions — All Resolved
 
 All 5 original TL-blocked questions have been resolved through
@@ -543,7 +618,7 @@ design or implementation.
 | # | Question | Risk | Resolution |
 |---|----------|------|------------|
 | ~~TQ-1~~ | Environment scope | R20 | **Resolved by code** — cost models are universal today; context APIs follow the same pattern |
-| ~~TQ-2~~ | Cloud-backed infra costs | R13 | **Resolved by code** — cloud rows use separate columns + NULL rate type; already context-independent |
+| ~~TQ-2~~ | Cloud-backed infra costs | R13 | **Reopened** — updated PRD adds cost visibility per context; see [DQ-5](./README.md#dq-5-cost-visibility-filtering) |
 | ~~TQ-3~~ | Daily summary migration | R1 | **Resolved by codebase pattern** — nullable `AddField` (0339, 0341 precedent); NULL = default context |
 | ~~TQ-4~~ | PR sequencing | R10 | **Resolved** — confirmed merge order #5981 → #5983 → #5984 |
 | ~~TQ-5~~ | RBAC strategy | R3 | **Resolved by precedent** — `IngressAccessPermission` hybrid pattern |
@@ -560,3 +635,4 @@ design or implementation.
 | v2.1 | 2026-04-08 | TQ-4 resolved: confirmed merge order #5981→#5983→#5984 |
 | v2.2 | 2026-04-08 | R20 resolved: universal scope follows established cost model pattern; all 5 TL questions now resolved |
 | v3.0 | 2026-04-09 | Design proposal: R1 corrected (backfill required, not optional); R20 updated with dedicated write-freeze Unleash flag per PR #5983 pattern; R21 added (deployment sequencing risk + write-freeze mitigation) |
+| v4.0 | 2026-05-05 | PRD realignment: R13 reopened (updated PRD adds cost visibility per context); R22 added (visibility filtering may break OCP-on-cloud expectations); TQ-2 updated to reference DQ-5 |

--- a/docs/architecture/consumer-provider-cost-models/test-cases-t1-unit.md
+++ b/docs/architecture/consumer-provider-cost-models/test-cases-t1-unit.md
@@ -8,7 +8,8 @@
 | Tier | T1 — Unit |
 | Base Class | `IamTestCase`, `TestCase` |
 | Coverage Target | ≥85% |
-| Test Count | 25 |
+| Test Count | 24 |
+| Supplemental Case | `TC-XX` (backward-compat scenario, excluded from canonical 82 count) |
 
 ---
 
@@ -475,6 +476,7 @@
 | BAC | BAC-7 |
 | Module | `cost_models/test/test_cost_model_context.py` |
 | Dependencies | TC-15 |
+| Classification | Supplemental (excluded from canonical 82-count tally) |
 
 **Scenario**: POST/PUT without cost_model_context field succeeds (backward-compat).
 

--- a/docs/architecture/consumer-provider-cost-models/test-cases-t1-unit.md
+++ b/docs/architecture/consumer-provider-cost-models/test-cases-t1-unit.md
@@ -1,0 +1,668 @@
+# Test Case Specifications — Tier 1: Unit Tests
+
+**IEEE 829-2008 Test Case Specification**
+
+| Field | Value |
+|-------|-------|
+| Parent Plan | [test-plan.md](./test-plan.md) (COST-3920-TP-001) |
+| Tier | T1 — Unit |
+| Base Class | `IamTestCase`, `TestCase` |
+| Coverage Target | ≥85% |
+| Test Count | 25 |
+
+---
+
+## Module: `cost_models/test/test_cost_model_context.py`
+
+### Class: `CostModelContextModelTest`
+
+---
+
+### TC-01: Context creation with valid data
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-01 |
+| Test Items | `CostModelContext` model (C1) |
+| BAC | BAC-1 |
+| Module | `cost_models/test/test_cost_model_context.py` |
+| Dependencies | None |
+
+**Scenario**: Valid context creation persists all fields correctly.
+
+**Given**
+- A tenant schema with no existing `CostModelContext` rows
+- `setUp` has cleared all contexts via `CostModelContext.objects.all().delete()`
+
+**When**
+- `baker.make("CostModelContext", name="provider", display_name="Provider", position=2, is_default=False)` is called
+- The instance is refreshed from DB via `ctx.refresh_from_db()`
+
+**Then**
+- `ctx.name == "provider"`
+- `ctx.display_name == "Provider"`
+- `ctx.is_default` is `False`
+- `ctx.position == 2`
+- `ctx.uuid` is not `None` (auto-generated UUID)
+- `ctx.created_timestamp` is not `None` (auto-set by DB)
+
+---
+
+### TC-02: Max 3 contexts enforced by DB CHECK
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-02 |
+| Test Items | `CostModelContext` model (C1) — position CHECK constraint |
+| BAC | BAC-2 |
+| Module | `cost_models/test/test_cost_model_context.py` |
+| Dependencies | None |
+
+**Scenario**: Fourth context per tenant is rejected by DB constraint.
+
+**Given**
+- 3 contexts already exist with positions 1, 2, 3:
+  - `baker.make("CostModelContext", name="c1", position=1, is_default=True)`
+  - `baker.make("CostModelContext", name="c2", position=2, is_default=False)`
+  - `baker.make("CostModelContext", name="c3", position=3, is_default=False)`
+
+**When**
+- Inside `transaction.atomic()`:
+  `baker.make("CostModelContext", name="c4", display_name="C4", position=4, is_default=False)`
+
+**Then**
+- `IntegrityError` is raised
+- The DB CHECK constraint on `position` rejects values outside 1–3
+
+---
+
+### TC-03: One default context enforced by partial unique index
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-03 |
+| Test Items | `CostModelContext` model (C1) — partial unique index on `is_default` |
+| BAC | BAC-3 |
+| Module | `cost_models/test/test_cost_model_context.py` |
+| Dependencies | None |
+
+**Scenario**: Second `is_default=True` context is rejected.
+
+**Given**
+- One context with `is_default=True` already exists:
+  `baker.make("CostModelContext", name="default", display_name="Consumer", position=1, is_default=True)`
+
+**When**
+- Inside `transaction.atomic()`:
+  `baker.make("CostModelContext", name="also_default", display_name="Also Default", position=2, is_default=True)`
+
+**Then**
+- `IntegrityError` is raised
+- The partial unique index `WHERE is_default = TRUE` blocks the second default
+
+---
+
+### TC-04a: Valid positions (1, 2, 3) accepted
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-04a |
+| Test Items | `CostModelContext` model (C1) — position CHECK constraint |
+| BAC | BAC-2 |
+| Module | `cost_models/test/test_cost_model_context.py` |
+| Dependencies | None |
+
+**Scenario**: Positions 1, 2, 3 are all accepted by the DB.
+
+**Given**
+- An empty tenant schema with no contexts
+
+**When**
+- Create contexts with positions 1, 2, 3 sequentially:
+  ```python
+  for pos in (1, 2, 3):
+      ctx = baker.make("CostModelContext", name=f"ctx_{pos}",
+                        display_name=f"Context {pos}", position=pos,
+                        is_default=(pos == 1))
+      ctx.refresh_from_db()
+  ```
+
+**Then**
+- All 3 contexts persist successfully
+- Each `ctx.position` matches the value provided
+
+---
+
+### TC-04b: Invalid positions (0, 4, -1) rejected
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-04b |
+| Test Items | `CostModelContext` model (C1) — position CHECK constraint |
+| BAC | BAC-2 |
+| Module | `cost_models/test/test_cost_model_context.py` |
+| Dependencies | None |
+
+**Scenario**: Out-of-range positions are rejected by DB constraint.
+
+**Given**
+- An empty tenant schema with no contexts
+
+**When**
+- For each invalid position `(0, 4, -1)`, inside `transaction.atomic()`:
+  `baker.make("CostModelContext", name=f"bad_{pos}", position=pos, is_default=False)`
+
+**Then**
+- `IntegrityError` is raised for each invalid position (via `subTest`)
+- No row is persisted for any invalid position
+
+---
+
+### TC-05a: Default context deletion is blocked
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-05a |
+| Test Items | `CostModelContext` model (C1) — delete guard |
+| BAC | BAC-4 |
+| Module | `cost_models/test/test_cost_model_context.py` |
+| Dependencies | None |
+
+**Scenario**: Attempting to delete the default context raises an error.
+
+**Given**
+- A context with `is_default=True` exists:
+  `baker.make("CostModelContext", name="default", display_name="Consumer", position=1, is_default=True)`
+
+**When**
+- `default_ctx.delete()` is called
+
+**Then**
+- `ValidationError` or `IntegrityError` is raised
+- The default context row still exists in the database
+
+---
+
+### TC-05b: Non-default context deletion is allowed
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-05b |
+| Test Items | `CostModelContext` model (C1) — delete guard |
+| BAC | BAC-4 |
+| Module | `cost_models/test/test_cost_model_context.py` |
+| Dependencies | None |
+
+**Scenario**: Non-default context can be deleted.
+
+**Given**
+- A non-default context exists:
+  `baker.make("CostModelContext", name="provider", display_name="Provider", position=2, is_default=False)`
+
+**When**
+- `ctx.delete()` is called
+
+**Then**
+- No exception is raised
+- `CostModelContext.objects.filter(uuid=ctx_uuid).exists()` returns `False`
+
+---
+
+### Class: `CostModelMapContextTest`
+
+---
+
+### TC-09: Same provider with different contexts allowed
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-09 |
+| Test Items | `CostModelMap` + `cost_model_context` FK (C2) |
+| BAC | BAC-5 |
+| Module | `cost_models/test/test_cost_model_context.py` |
+| Dependencies | None |
+
+**Scenario**: CostModelMap accepts two rows for the same provider when contexts differ.
+
+**Given**
+- Two contexts exist: `ctx_consumer` (default, position=1) and `ctx_provider` (position=2)
+- One cost model exists: `baker.make("CostModel", source_type="OCP")`
+- A `provider_uuid` is generated via `uuid4()`
+
+**When**
+- `CostModelMap.objects.create(provider_uuid=uuid, cost_model=cm, cost_model_context=ctx_consumer)`
+- `CostModelMap.objects.create(provider_uuid=uuid, cost_model=cm, cost_model_context=ctx_provider)`
+
+**Then**
+- Both rows persist without error
+- `CostModelMap.objects.filter(provider_uuid=uuid).count() == 2`
+
+---
+
+### TC-10: Duplicate provider + context rejected
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-10 |
+| Test Items | `CostModelMap` + `cost_model_context` FK (C2) — unique constraint |
+| BAC | BAC-6 |
+| Module | `cost_models/test/test_cost_model_context.py` |
+| Dependencies | None |
+
+**Scenario**: CostModelMap rejects duplicate (provider_uuid, cost_model_context).
+
+**Given**
+- One context exists: `ctx` (default)
+- One `CostModelMap` row exists for `(provider_uuid, ctx)`
+
+**When**
+- Inside `transaction.atomic()`:
+  `CostModelMap.objects.create(provider_uuid=uuid, cost_model=cm, cost_model_context=ctx)`
+
+**Then**
+- `IntegrityError` is raised (unique constraint violation)
+- Only one row exists for `(provider_uuid, ctx)`
+
+---
+
+### Class: `CostModelManagerContextTest`
+
+---
+
+### TC-06: Manager allows same provider in different contexts
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-06 |
+| Test Items | `CostModelManager.update_provider_uuids` (C3) |
+| BAC | BAC-7 |
+| Module | `cost_models/test/test_cost_model_context.py` |
+| Dependencies | None |
+
+**Scenario**: update_provider_uuids succeeds when same provider is assigned to different contexts.
+
+**Given**
+- Two contexts exist: `ctx_consumer` (default) and `ctx_provider`
+- Two cost models exist: `cm1` and `cm2`
+- A `provider_uuid` string
+
+**When**
+- `CostModelManager(cm1.uuid).update_provider_uuids([provider_uuid], cost_model_context=ctx_consumer)`
+- `CostModelManager(cm2.uuid).update_provider_uuids([provider_uuid], cost_model_context=ctx_provider)`
+
+**Then**
+- Both calls succeed without error
+- `CostModelMap.objects.filter(provider_uuid=provider_uuid).count() == 2`
+
+---
+
+### TC-07: Manager rejects same provider + same context
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-07 |
+| Test Items | `CostModelManager.update_provider_uuids` (C3) |
+| BAC | BAC-8 |
+| Module | `cost_models/test/test_cost_model_context.py` |
+| Dependencies | None |
+
+**Scenario**: update_provider_uuids raises CostModelException when same provider+context already assigned.
+
+**Given**
+- One context exists: `ctx` (default)
+- Cost model 1 already assigned to `(provider_uuid, ctx)` via the manager
+
+**When**
+- `CostModelManager(cm2.uuid).update_provider_uuids([provider_uuid], cost_model_context=ctx)`
+
+**Then**
+- `CostModelException` is raised with a descriptive error message
+
+---
+
+### TC-08: Manager defaults to tenant's default context when None
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-08 |
+| Test Items | `CostModelManager.update_provider_uuids` (C3) |
+| BAC | BAC-7 |
+| Module | `cost_models/test/test_cost_model_context.py` |
+| Dependencies | None |
+
+**Scenario**: When cost_model_context is not passed, manager resolves to tenant's default.
+
+**Given**
+- A default context exists: `baker.make("CostModelContext", name="default", is_default=True)`
+
+**When**
+- `CostModelManager(cm.uuid).update_provider_uuids([provider_uuid])`
+  (no `cost_model_context` argument)
+
+**Then**
+- `CostModelMap` row is created
+- `mapping.cost_model_context` is not `None`
+- `mapping.cost_model_context.name == "default"`
+
+---
+
+### Class: `CostModelContextSerializerTest`
+
+---
+
+### TC-11: Serializer accepts valid context data
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-11 |
+| Test Items | `CostModelContextSerializer` (C4) |
+| BAC | BAC-1 |
+| Module | `cost_models/test/test_cost_model_context.py` |
+| Dependencies | None |
+
+**Scenario**: Serializer validates valid name and display_name.
+
+**Given**
+- A default context exists (required for serializer count logic)
+
+**When**
+- `CostModelContextSerializer(data={"name": "provider", "display_name": "Provider"}).is_valid(raise_exception=True)`
+
+**Then**
+- Returns `True` — data is valid
+
+---
+
+### TC-12: Serializer rejects 4th context
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-12 |
+| Test Items | `CostModelContextSerializer` (C4) |
+| BAC | BAC-2 |
+| Module | `cost_models/test/test_cost_model_context.py` |
+| Dependencies | None |
+
+**Scenario**: Serializer enforces max 3 contexts per tenant.
+
+**Given**
+- 3 contexts already exist: `c1` (default), `c2`, `c3`
+
+**When**
+- `CostModelContextSerializer(data={"name": "c4", "display_name": "C4"}).is_valid()`
+
+**Then**
+- Returns `False` — 4th context rejected at the serializer level
+
+---
+
+### TC-13: Default context not deletable via serializer/model guard
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-13 |
+| Test Items | `CostModelContextSerializer` (C4) — delete guard |
+| BAC | BAC-4 |
+| Module | `cost_models/test/test_cost_model_context.py` |
+| Dependencies | None |
+
+**Scenario**: Default context cannot be deleted.
+
+**Given**
+- A default context exists: `baker.make("CostModelContext", is_default=True)`
+
+**When**
+- `default_ctx.delete()` is called
+
+**Then**
+- `ValidationError` or `IntegrityError` is raised
+
+---
+
+### TC-14: CostModelSerializer accepts context UUID
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-14 |
+| Test Items | `CostModelSerializer` (C5) — context field |
+| BAC | BAC-5 |
+| Module | `cost_models/test/test_cost_model_context.py` |
+| Dependencies | None |
+
+**Scenario**: CostModelSerializer accepts source_uuids + cost_model_context.
+
+**Given**
+- A default context exists with known UUID
+
+**When**
+- `CostModelSerializer(data={..., "cost_model_context": str(ctx.uuid)}, context=request_context).is_valid(raise_exception=True)`
+
+**Then**
+- Returns `True` — context UUID is accepted as valid input
+
+---
+
+### TC-15: CostModelSerializer defaults context when absent
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-15 |
+| Test Items | `CostModelSerializer` (C5) — default context resolution |
+| BAC | BAC-7 |
+| Module | `cost_models/test/test_cost_model_context.py` |
+| Dependencies | None |
+
+**Scenario**: Missing cost_model_context defaults to tenant's default.
+
+**Given**
+- A default context exists
+- Serializer data does not include `cost_model_context` field
+
+**When**
+- `CostModelSerializer(data={name, description, source_type, rates, source_uuids}, context=request_context).is_valid(raise_exception=True)`
+
+**Then**
+- Returns `True` — validation passes without explicit context
+
+---
+
+### TC-XX: Backward-compatible cost model creation without context
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-XX |
+| Test Items | `CostModelSerializer` (C5) — backward compatibility |
+| BAC | BAC-7 |
+| Module | `cost_models/test/test_cost_model_context.py` |
+| Dependencies | TC-15 |
+
+**Scenario**: POST/PUT without cost_model_context field succeeds (backward-compat).
+
+**Given**
+- A default context exists
+- Serializer data has no `cost_model_context` field
+
+**When**
+- `serializer.is_valid()` followed by `serializer.save()`
+
+**Then**
+- `valid` is `True`
+- `instance` is not `None` — cost model created successfully
+- The instance is implicitly associated with the default context
+
+---
+
+## Module: `api/common/permissions/test/test_context_permission.py`
+
+### Class: `CostModelContextPermissionTest`
+
+---
+
+### TC-16: Admin user bypasses context check
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-16 |
+| Test Items | `CostModelContextPermission` (C12) |
+| BAC | BAC-28 |
+| Module | `api/common/permissions/test/test_context_permission.py` |
+| Dependencies | None |
+| Special Requirements | `@override_settings(ENHANCED_ORG_ADMIN=True)` |
+
+**Scenario**: Admin user with ENHANCED_ORG_ADMIN bypasses context permission.
+
+**Given**
+- `ENHANCED_ORG_ADMIN` setting is `True`
+- User mock: `admin=True`, `access={"cost_model": {"read": ["*"], "write": ["*"]}}`
+- Request mock: `method="GET"`, `query_params={"cost_model_context": "provider"}`
+
+**When**
+- `perm.has_permission(request, None)` is called
+
+**Then**
+- Returns `True` — admin bypass grants access
+
+---
+
+### TC-17: Unpermitted user denied
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-17 |
+| Test Items | `CostModelContextPermission` (C12) |
+| BAC | BAC-29 |
+| Module | `api/common/permissions/test/test_context_permission.py` |
+| Dependencies | None |
+
+**Scenario**: User without cost_model read access is denied when context is requested.
+
+**Given**
+- User mock: `access={"cost_model": {"read": [], "write": []}}`
+- Request mock: `method="GET"`, `query_params={"cost_model_context": "consumer"}`
+
+**When**
+- `perm.has_permission(request, None)` is called
+
+**Then**
+- Returns `False` — access denied
+
+---
+
+### TC-18: Permitted user allowed (no context param)
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-18 |
+| Test Items | `CostModelContextPermission` (C12) |
+| BAC | BAC-33 |
+| Module | `api/common/permissions/test/test_context_permission.py` |
+| Dependencies | None |
+
+**Scenario**: User with cost_model read access passes when no context param is present.
+
+**Given**
+- User mock: `access={"cost_model": {"read": ["*"], "write": []}}`
+- Request mock: `method="GET"`, `query_params={}` (no `cost_model_context`)
+
+**When**
+- `perm.has_permission(request, None)` is called
+
+**Then**
+- Returns `True` — pass-through when no context is explicitly requested
+
+---
+
+### TC-19a: Missing customer attribute returns False
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-19a |
+| Test Items | `CostModelContextPermission` (C12) |
+| BAC | BAC-29 |
+| Module | `api/common/permissions/test/test_context_permission.py` |
+| Dependencies | None |
+
+**Scenario**: User with no customer attribute is denied when context is requested.
+
+**Given**
+- User mock: `access=None`, `customer=None`
+- Request mock: `method="GET"`, `query_params={"cost_model_context": "consumer"}`
+
+**When**
+- `perm.has_permission(request, None)` is called
+
+**Then**
+- Returns `False` — no customer means no tenant, no permission
+
+---
+
+### TC-19b: No context param allows access regardless
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-19b |
+| Test Items | `CostModelContextPermission` (C12) |
+| BAC | BAC-33 |
+| Module | `api/common/permissions/test/test_context_permission.py` |
+| Dependencies | None |
+
+**Scenario**: Without cost_model_context in query params, permission passes regardless of user state.
+
+**Given**
+- User mock: `access=None`, `customer=None`
+- Request mock: `method="GET"`, `query_params={}` (no `cost_model_context`)
+
+**When**
+- `perm.has_permission(request, None)` is called
+
+**Then**
+- Returns `True` — permission is a pass-through when context is not requested
+
+---
+
+### TC-20: Empty access dict returns False
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-20 |
+| Test Items | `CostModelContextPermission` (C12) |
+| BAC | BAC-29 |
+| Module | `api/common/permissions/test/test_context_permission.py` |
+| Dependencies | None |
+
+**Scenario**: User with empty access dict is denied when context is requested.
+
+**Given**
+- User mock: `access={}` (empty dict)
+- Request mock: `method="GET"`, `query_params={"cost_model_context": "consumer"}`
+
+**When**
+- `perm.has_permission(request, None)` is called
+
+**Then**
+- Returns `False` — empty access means no permissions
+
+---
+
+### TC-21: Missing cost_model key does not raise KeyError
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-21 |
+| Test Items | `CostModelContextPermission` (C12) |
+| BAC | BAC-29 |
+| Module | `api/common/permissions/test/test_context_permission.py` |
+| Dependencies | None |
+
+**Scenario**: Access dict without 'cost_model' key returns False gracefully (no KeyError).
+
+**Given**
+- User mock: `access={"aws.account": {"read": ["*"]}}` (has access, but not to cost_model)
+- Request mock: `method="GET"`, `query_params={"cost_model_context": "consumer"}`
+
+**When**
+- `perm.has_permission(request, None)` is called
+
+**Then**
+- Returns `False`
+- No `KeyError` is raised — the missing key is handled gracefully

--- a/docs/architecture/consumer-provider-cost-models/test-cases-t1-unit.md
+++ b/docs/architecture/consumer-provider-cost-models/test-cases-t1-unit.md
@@ -668,3 +668,110 @@
 **Then**
 - Returns `False`
 - No `KeyError` is raised — the missing key is handled gracefully
+
+---
+
+## Module: `cost_models/test/test_cost_model_context.py` (visibility)
+
+### Class: `CostModelContextVisibilityTest`
+
+---
+
+### TC-V01: data_visibility defaults to cloud_and_ocp
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-V01 |
+| Test Items | `CostModelContext` model (C1) |
+| BAC | BAC-40 |
+| Module | `cost_models/test/test_cost_model_context.py` |
+| Dependencies | None |
+
+**Scenario**: A new context defaults to `cloud_and_ocp` visibility.
+
+**Given**
+- A tenant schema with no existing contexts
+
+**When**
+- `baker.make("CostModelContext", name="test", display_name="Test", position=1, is_default=True)` is called
+
+**Then**
+- `ctx.data_visibility == "cloud_and_ocp"`
+
+---
+
+### TC-V02: data_visibility accepts ocp_only
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-V02 |
+| Test Items | `CostModelContext` model (C1) |
+| BAC | BAC-39 |
+| Module | `cost_models/test/test_cost_model_context.py` |
+| Dependencies | None |
+
+**Scenario**: A context can be created with `ocp_only` visibility.
+
+**Given**
+- A tenant schema with a default context
+
+**When**
+- `baker.make("CostModelContext", name="consumer", display_name="Consumer", position=2, is_default=False, data_visibility="ocp_only")` is called
+
+**Then**
+- `ctx.data_visibility == "ocp_only"`
+
+---
+
+## Module: `api/common/permissions/test/test_context_permission.py` (RBAC combos)
+
+### Class: `CostModelContextRBACComboTest`
+
+---
+
+### TC-V03: User with cluster + context access sees context costs
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-V03 |
+| Test Items | `CostModelContextPermission` (C12) |
+| BAC | BAC-42 |
+| Module | `api/common/permissions/test/test_context_permission.py` |
+| Dependencies | None |
+
+**Scenario**: User has access to Cluster 1 and Context B — sees Context B costs for Cluster 1.
+
+**Given**
+- User mock with `cost_model.read=["*"]` access
+- Request mock: `query_params={"cost_model_context": "context_b"}`
+
+**When**
+- `perm.has_permission(request, None)` is called
+
+**Then**
+- Returns `True` — user has both cluster and context access
+
+---
+
+### TC-V04: User without default context does not see default
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-V04 |
+| Test Items | `CostModelContextPermission` (C12) |
+| BAC | BAC-42 |
+| Module | `api/common/permissions/test/test_context_permission.py` |
+| Dependencies | None |
+
+**Scenario**: User with Context B access but NOT default context access cannot see default context.
+
+**Given**
+- User mock with RBAC granting context_b only (when platform RBAC supports it)
+- Request mock: `query_params={"cost_model_context": "default"}`
+
+**When**
+- `perm.has_permission(request, None)` is called
+
+**Then**
+- Returns `False` — user lacks access to the default context
+- Note: This test validates the future platform RBAC path. For Koku-side v1, `cost_model.read` is the gate.

--- a/docs/architecture/consumer-provider-cost-models/test-cases-t2-integration.md
+++ b/docs/architecture/consumer-provider-cost-models/test-cases-t2-integration.md
@@ -1,0 +1,800 @@
+# Test Case Specifications — Tier 2: Integration Tests
+
+**IEEE 829-2008 Test Case Specification**
+
+| Field | Value |
+|-------|-------|
+| Parent Plan | [test-plan.md](./test-plan.md) (COST-3920-TP-001) |
+| Tier | T2 — Integration |
+| Base Class | `MasuTestCase` |
+| Coverage Target | ≥80% |
+| Test Count | 34 |
+
+---
+
+## Module: `cost_models/test/test_context_migration.py`
+
+### Class: `CostModelContextMigrationTest`
+
+---
+
+### TC-30: Forward migration creates default context per tenant
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-30 |
+| Test Items | Migration M4 `RunPython` — default context creation (C14) |
+| BAC | BAC-9 |
+| Module | `cost_models/test/test_context_migration.py` |
+| Dependencies | None |
+
+**Scenario**: Forward data migration creates the default "Consumer" context.
+
+**Given**
+- Schema is at `MIGRATE_FROM` state (`cost_models 0011`)
+- One `CostModel` row exists in the tenant schema:
+  ```python
+  CostModel.objects.create(name="TC-30 Model", description="Test",
+                           source_type="OCP", rates=[{...}])
+  ```
+
+**When**
+- Forward migration is run to `MIGRATE_TO_DATA` (`cost_models 0015`)
+
+**Then**
+- A `CostModelContext` with `is_default=True` exists
+- `default_ctx.name == "default"`
+- `default_ctx.display_name == "Consumer"`
+- `default_ctx.position == 1`
+
+---
+
+### TC-31: Forward migration assigns existing CostModelMap rows to default
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-31 |
+| Test Items | Migration M4 `RunPython` — CostModelMap backfill (C14) |
+| BAC | BAC-10 |
+| Module | `cost_models/test/test_context_migration.py` |
+| Dependencies | TC-30 |
+| Special Requirements | Uses raw SQL INSERT + `SET CONSTRAINTS ALL IMMEDIATE` to avoid pending trigger events |
+
+**Scenario**: Existing CostModelMap rows get assigned to the default context.
+
+**Given**
+- Schema is at `MIGRATE_FROM` state
+- A `CostModel` and `CostModelMap` row exist (created via raw SQL INSERT to avoid trigger issues):
+  ```sql
+  INSERT INTO cost_model (...) VALUES (...) RETURNING uuid;
+  INSERT INTO cost_model_map (id, cost_model_id, provider_uuid) VALUES (DEFAULT, %s, %s);
+  SET CONSTRAINTS ALL IMMEDIATE;
+  ```
+
+**When**
+- Forward migration is run to `MIGRATE_TO_DATA`
+
+**Then**
+- `CostModelMap.objects.get(provider_uuid=uuid).cost_model_context` is not `None`
+- The assigned context has `is_default == True`
+- The assigned context has `name == "default"`
+
+---
+
+### TC-32: New unique constraint is active post-migration
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-32 |
+| Test Items | Migration M3 `AlterUniqueTogether` — new `(provider_uuid, cost_model_context)` constraint (C14) |
+| BAC | BAC-6 |
+| Module | `cost_models/test/test_context_migration.py` |
+| Dependencies | TC-30 |
+
+**Scenario**: After migration, duplicate (provider_uuid, context) is rejected.
+
+**Given**
+- Schema is at `MIGRATE_TO_DATA` with default context present
+- A `CostModelMap` row exists for `(provider_uuid, default_context)`
+
+**When**
+- Inside `transaction.atomic()`:
+  Create a second `CostModelMap` with the same `(provider_uuid, default_context)` but a different cost model
+
+**Then**
+- `IntegrityError` is raised — the new unique constraint is enforced
+
+---
+
+### TC-33: Old unique constraint is dropped post-migration
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-33 |
+| Test Items | Migration M3 — old `(provider_uuid, cost_model)` constraint removal (C14) |
+| BAC | BAC-5 |
+| Module | `cost_models/test/test_context_migration.py` |
+| Dependencies | TC-30 |
+
+**Scenario**: Same provider + same cost model with different contexts is now allowed.
+
+**Given**
+- Schema is at `MIGRATE_TO_DATA`
+- Two contexts exist: `ctx_default` (default) and `ctx_provider` (created in test)
+
+**When**
+- Create two `CostModelMap` rows for the same `(provider_uuid, cost_model)` but with different contexts
+
+**Then**
+- Both rows persist without error
+- `CostModelMap.objects.filter(provider_uuid=uuid).count() == 2`
+
+---
+
+### TC-34: Reverse migration removes context cleanly
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-34 |
+| Test Items | Migration M1–M4 reverse path (C14) |
+| BAC | BAC-9 |
+| Module | `cost_models/test/test_context_migration.py` |
+| Dependencies | TC-30, TC-31 |
+| Special Requirements | `information_schema` queries include `AND table_schema = current_schema()` |
+
+**Scenario**: Reverse migration drops context column, table, and preserves CostModelMap rows.
+
+**Given**
+- Schema is at `MIGRATE_TO_DATA` with contexts and CostModelMap rows (created via raw SQL)
+
+**When**
+- Reverse migration is run back to `MIGRATE_FROM`
+
+**Then**
+- `cost_model_context_id` column no longer exists on `cost_model_map` table
+  (verified via `information_schema.columns` with `table_schema = current_schema()`)
+- `cost_model_context` table no longer exists
+  (verified via `information_schema.tables` with `table_schema = current_schema()`)
+- `CostModelMap` row survives the reverse migration (data not lost):
+  `SELECT COUNT(*) FROM cost_model_map WHERE provider_uuid = %s` returns 1
+
+---
+
+### TC-35: Partial unique index blocks second default after migration
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-35 |
+| Test Items | Migration M1 — partial unique index on `is_default` (C14) |
+| BAC | BAC-3 |
+| Module | `cost_models/test/test_context_migration.py` |
+| Dependencies | TC-30 |
+
+**Scenario**: DB rejects second is_default=TRUE row per schema after migration.
+
+**Given**
+- Schema is at `MIGRATE_TO_DATA`
+- One `CostModelContext` with `is_default=True` already exists (created by M4)
+
+**When**
+- Inside `transaction.atomic()`:
+  `CostModelContext.objects.create(name="bad_default", display_name="Bad Default", is_default=True, position=2)`
+
+**Then**
+- `IntegrityError` is raised — the partial unique index is enforced
+
+---
+
+## Module: `masu/test/database/test_context_sql.py`
+
+### Class: `CostModelDBAccessorContextTest`
+
+---
+
+### TC-40: Accessor filters by explicit context
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-40 |
+| Test Items | `CostModelDBAccessor` (C7) — context parameter |
+| BAC | BAC-14 |
+| Module | `masu/test/database/test_context_sql.py` |
+| Dependencies | None |
+
+**Scenario**: Accessor with explicit cost_model_context returns the correct cost model.
+
+**Given**
+- Context "default" exists with a cost model assigned via `CostModelMap`
+- `baker.make("CostModelMap", provider_uuid=uuid, cost_model=cm, cost_model_context=ctx)`
+
+**When**
+- `CostModelDBAccessor(schema, uuid, cost_model_context="default")` is opened as context manager
+
+**Then**
+- `accessor.cost_model == cm` — the correct cost model is resolved
+
+---
+
+### TC-41: Accessor defaults to tenant's default context when None
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-41 |
+| Test Items | `CostModelDBAccessor` (C7) — fallback behavior |
+| BAC | BAC-15 |
+| Module | `masu/test/database/test_context_sql.py` |
+| Dependencies | None |
+
+**Scenario**: Accessor without explicit context falls back to the default context.
+
+**Given**
+- Context "default" (is_default=True) exists with a cost model assigned
+
+**When**
+- `CostModelDBAccessor(schema, uuid)` is opened (no `cost_model_context` argument)
+
+**Then**
+- `accessor.cost_model == cm` — falls back to the default context's cost model
+
+---
+
+### TC-42: Accessor returns None for unassigned context
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-42 |
+| Test Items | `CostModelDBAccessor` (C7) — missing context |
+| BAC | BAC-14 |
+| Module | `masu/test/database/test_context_sql.py` |
+| Dependencies | None |
+
+**Scenario**: Requesting a context that has no cost model assigned returns None.
+
+**Given**
+- Two contexts exist: "default" (with cost model) and "provider" (no cost model)
+- Cost model is only assigned to `ctx_consumer` via CostModelMap
+
+**When**
+- `CostModelDBAccessor(schema, uuid, cost_model_context="provider")` is opened
+
+**Then**
+- `accessor.cost_model is None` — no model exists for the requested context
+
+---
+
+### Class: `UsageCostsSQLContextTest`
+
+---
+
+### TC-43: Usage costs DELETE scoped by context
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-43 |
+| Test Items | `usage_costs.sql` — DELETE section (SQL) |
+| BAC | BAC-17 |
+| Module | `masu/test/database/test_context_sql.py` |
+| Dependencies | None |
+
+**Scenario**: The DELETE section of usage_costs.sql references cost_model_context.
+
+**Given**
+- The SQL file `sql/openshift/cost_model/usage_costs.sql` is loaded into memory
+
+**When**
+- The file content is split at the first `INSERT` keyword
+- The portion before `INSERT` (the DELETE section) is inspected
+
+**Then**
+- The string `"cost_model_context"` is present in the DELETE section
+
+---
+
+### TC-44: Usage costs INSERT includes context column
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-44 |
+| Test Items | `usage_costs.sql` — INSERT section (SQL) |
+| BAC | BAC-18 |
+| Module | `masu/test/database/test_context_sql.py` |
+| Dependencies | None |
+
+**Scenario**: The INSERT section of usage_costs.sql includes cost_model_context.
+
+**Given**
+- The SQL file `usage_costs.sql` is loaded into memory
+
+**When**
+- The portion after the first `INSERT` keyword is inspected
+
+**Then**
+- The string `"cost_model_context"` is present in the INSERT section
+
+---
+
+### TC-45: Cross-context isolation via SQL template marker
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-45 |
+| Test Items | `usage_costs.sql` — Jinja template marker (SQL) |
+| BAC | BAC-17 |
+| Module | `masu/test/database/test_context_sql.py` |
+| Dependencies | None |
+
+**Scenario**: SQL contains the exact Jinja template marker for context scoping.
+
+**Given**
+- The SQL file `usage_costs.sql` is loaded
+
+**When**
+- The full SQL content is searched for the exact string
+
+**Then**
+- `"cost_model_context = {{cost_model_context}}"` is found in the SQL
+
+---
+
+### TC-49: Distribution SQL scoped by context
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-49 |
+| Test Items | `distribute_platform_cost.sql` (SQL) |
+| BAC | BAC-19 |
+| Module | `masu/test/database/test_context_sql.py` |
+| Dependencies | None |
+
+**Scenario**: Platform distribution SQL includes cost_model_context.
+
+**Given**
+- The SQL file `cost_model/distribute_cost/distribute_platform_cost.sql` is loaded
+
+**When**
+- The full SQL content is inspected
+
+**Then**
+- The string `"cost_model_context"` is present
+
+---
+
+### TC-50: Cloud model rows unaffected (no context field)
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-50 |
+| Test Items | `AWSCostEntryLineItemDailySummary` model — no context field (SQL) |
+| BAC | BAC-24 |
+| Module | `masu/test/database/test_context_sql.py` |
+| Dependencies | None |
+
+**Scenario**: AWS (cloud) model does not have cost_model_context attribute.
+
+**Given**
+- The `AWSCostEntryLineItemDailySummary` model class is imported
+
+**When**
+- `hasattr(AWSCostEntryLineItemDailySummary, "cost_model_context")` is evaluated
+
+**Then**
+- Returns `False` — cloud models are not context-scoped
+
+---
+
+### Class: `CacheKeyContextTest`
+
+---
+
+### TC-51: Cache key includes context string
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-51 |
+| Test Items | `create_single_task_cache_key` (C9) |
+| BAC | BAC-23 |
+| Module | `masu/test/database/test_context_sql.py` |
+| Dependencies | None |
+
+**Scenario**: Celery cache key contains the context name.
+
+**Given**
+- Cache key args include `"default"` as the context component:
+  `["schema", "provider_uuid", "default", "2026-01-01", "2026-01-31"]`
+
+**When**
+- `create_single_task_cache_key("masu.processor.tasks.update_cost_model_costs", args)` is called
+
+**Then**
+- The returned key string contains `"default"` as a substring
+
+---
+
+### TC-52: Different contexts produce different cache keys
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-52 |
+| Test Items | `create_single_task_cache_key` (C9) |
+| BAC | BAC-23 |
+| Module | `masu/test/database/test_context_sql.py` |
+| Dependencies | TC-51 |
+
+**Scenario**: Cache keys for different contexts are distinct (no dedup collision).
+
+**Given**
+- Two sets of cache key args, identical except for context:
+  - args_consumer: `[..., "default", ...]`
+  - args_provider: `[..., "provider", ...]`
+
+**When**
+- Both keys are generated via `create_single_task_cache_key`
+
+**Then**
+- `key_consumer != key_provider` — distinct keys prevent dedup collision
+
+---
+
+### Class: `SelfHostedTrinoSQLContextTest`
+
+---
+
+### TC-53: All self-hosted SQL files include context param
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-53 |
+| Test Items | Self-hosted SQL templates (SQL) |
+| BAC | BAC-20 |
+| Module | `masu/test/database/test_context_sql.py` |
+| Dependencies | None |
+
+**Scenario**: Every .sql file under self-hosted cost_model path references cost_model_context.
+
+**Given**
+- The directory `self_hosted_sql/openshift/cost_model/` is walked recursively
+
+**When**
+- Each `.sql` file is read and inspected
+
+**Then**
+- Every file contains `"cost_model_context"` (assertion per file)
+
+---
+
+### TC-54: All Trino SQL files include context param
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-54 |
+| Test Items | Trino SQL templates (SQL) |
+| BAC | BAC-21 |
+| Module | `masu/test/database/test_context_sql.py` |
+| Dependencies | None |
+
+**Scenario**: Every .sql file under Trino cost_model path references cost_model_context.
+
+**Given**
+- The directory `trino_sql/openshift/cost_model/` is walked recursively
+
+**When**
+- Each `.sql` file is read and inspected
+
+**Then**
+- Every file contains `"cost_model_context"` (assertion per file)
+
+---
+
+### Class: `InlineSQLContextTest`
+
+---
+
+### TC-55: Inline DELETE method handles context
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-55 |
+| Test Items | `OCPCostModelCostUpdater._delete_tag_usage_costs` (C8) |
+| BAC | BAC-22 |
+| Module | `masu/test/database/test_context_sql.py` |
+| Dependencies | None |
+
+**Scenario**: Python source of _delete_tag_usage_costs references cost_model_context.
+
+**Given**
+- The method `OCPCostModelCostUpdater._delete_tag_usage_costs` exists
+
+**When**
+- `inspect.getsource(method)` is called
+
+**Then**
+- The returned source string contains `"cost_model_context"`
+
+---
+
+### TC-56: populate_usage_costs passes context in SQL params
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-56 |
+| Test Items | `OCPReportDBAccessor.populate_usage_costs` (C8) |
+| BAC | BAC-22 |
+| Module | `masu/test/database/test_context_sql.py` |
+| Dependencies | None |
+
+**Scenario**: Python source of populate_usage_costs includes cost_model_context in sql_params.
+
+**Given**
+- The method `OCPReportDBAccessor.populate_usage_costs` exists
+
+**When**
+- `inspect.getsource(method)` is called
+
+**Then**
+- The returned source string contains `"cost_model_context"`
+
+---
+
+## Module: `masu/test/database/test_context_ui_summary.py`
+
+### Class: `ContextColumnMigrationTest`
+
+---
+
+### TC-60: Daily summary table gets context column
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-60 |
+| Test Items | Migration M7 AddField — daily summary (C15) |
+| BAC | BAC-11 |
+| Module | `masu/test/database/test_context_ui_summary.py` |
+| Dependencies | None |
+
+**Scenario**: Migration adds cost_model_context column to daily summary.
+
+**Given**
+- Schema is at `MIGRATE_FROM` state (`reporting 0344`)
+
+**When**
+- Migration is run forward to `MIGRATE_TO` (`reporting 0346`)
+
+**Then**
+- `information_schema.columns` query (with `table_schema = current_schema()`) confirms
+  `cost_model_context` column exists on `reporting_ocpusagelineitem_daily_summary`
+
+---
+
+### TC-61: All 13 UI summary tables get context column
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-61 |
+| Test Items | Migration M8 AddField — 13 UI summary tables (C15) |
+| BAC | BAC-12 |
+| Module | `masu/test/database/test_context_ui_summary.py` |
+| Dependencies | TC-60 |
+
+**Scenario**: Migration adds cost_model_context to all 13 UI summary tables.
+
+**Given**
+- Schema is at `MIGRATE_FROM` state
+
+**When**
+- Migration is run forward to `MIGRATE_TO`
+
+**Then**
+- For each of the 13 tables (verified via `subTest`):
+  - `reporting_ocp_cost_summary_p`
+  - `reporting_ocp_cost_summary_by_node_p`
+  - `reporting_ocp_cost_summary_by_project_p`
+  - `reporting_ocp_gpu_summary_p`
+  - `reporting_ocp_network_summary_p`
+  - `reporting_ocp_network_summary_by_node_p`
+  - `reporting_ocp_network_summary_by_project_p`
+  - `reporting_ocp_pod_summary_p`
+  - `reporting_ocp_pod_summary_by_node_p`
+  - `reporting_ocp_pod_summary_by_project_p`
+  - `reporting_ocp_vm_summary_p`
+  - `reporting_ocp_volume_summary_p`
+  - `reporting_ocp_volume_summary_by_project_p`
+- `cost_model_context` column exists (confirmed via `information_schema`)
+
+---
+
+### TC-62: Reverse migration removes context column
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-62 |
+| Test Items | Migration M7 reverse — daily summary (C15) |
+| BAC | BAC-11 |
+| Module | `masu/test/database/test_context_ui_summary.py` |
+| Dependencies | TC-60 |
+
+**Scenario**: Reverse migration removes cost_model_context from daily summary.
+
+**Given**
+- Schema is at `MIGRATE_TO` — context column is present
+- Verified: `_column_exists("reporting_ocpusagelineitem_daily_summary", "cost_model_context")` returns `True`
+
+**When**
+- Reverse migration is run back to `MIGRATE_FROM`
+
+**Then**
+- `_column_exists("reporting_ocpusagelineitem_daily_summary", "cost_model_context")` returns `False`
+
+---
+
+## Module: `masu/test/processor/ocp/test_context_pipeline.py`
+
+### Class: `MultiContextPipelineTest`
+
+---
+
+### TC-70: Pipeline dispatches once per context
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-70 |
+| Test Items | `update_cost_model_costs` task (C9) — multi-context dispatch |
+| BAC | BAC-16 |
+| Module | `masu/test/processor/ocp/test_context_pipeline.py` |
+| Dependencies | None |
+
+**Scenario**: Pipeline runs at least once per context for a provider.
+
+**Given**
+- Two contexts exist: "default" (consumer, position=1) and "provider" (position=2)
+- `CostModelCostUpdater` is mocked
+
+**When**
+- `update_cost_model_costs(schema, provider_uuid, start, end, synchronous=True)` is called
+  with no explicit `cost_model_context`
+
+**Then**
+- `mock_updater.update_cost_model_costs.call_count >= 2`
+- The pipeline dispatched once per context
+
+---
+
+### TC-71: Accessor resolves correct rates per context
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-71 |
+| Test Items | `CostModelDBAccessor` (C7) — context-specific resolution |
+| BAC | BAC-14 |
+| Module | `masu/test/processor/ocp/test_context_pipeline.py` |
+| Dependencies | None |
+
+**Scenario**: Each context invocation resolves its own cost model's rates.
+
+**Given**
+- Context "default" with cost model `cm_consumer` (CPU rate: $10/core-hour)
+- `CostModelMap` links `ocp_provider_uuid` to `cm_consumer` via `ctx_consumer`
+
+**When**
+- `CostModelDBAccessor(schema, ocp_provider_uuid, cost_model_context="default")` is opened
+
+**Then**
+- `accessor.cost_model == cm_consumer`
+
+---
+
+### TC-72 through TC-76: Placeholder tests
+
+| Field | Value |
+|-------|-------|
+| Identifiers | TC-72, TC-73, TC-74, TC-75, TC-76 |
+| BACs | BAC-17, BAC-32, BAC-24 |
+| Status | **Placeholder** — behavioral coverage deferred to E2E tests |
+
+These tests assert `True` with a comment referencing the E2E test that provides
+the actual coverage:
+
+- **TC-72** (BAC-17): Pipeline step order → covered by E2E TC-91
+- **TC-73** (BAC-32): Empty context zero cost → covered by E2E TC-93
+- **TC-74** (BAC-32): Empty context preserves usage → covered by E2E TC-93
+- **TC-75** (BAC-17): Sequential runs no corruption → covered by E2E TC-91, TC-98
+- **TC-76** (BAC-24): Cloud infra in all contexts → covered by E2E TC-99
+
+See [Deliberate Deviations](./test-plan.md#11-deliberate-deviations-from-spec) in the
+test plan.
+
+---
+
+### Class: `AuditTriggerContextTest`
+
+---
+
+### TC-57: Audit trigger captures context (placeholder)
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-57 |
+| Test Items | Audit trigger — M5 (C14) |
+| BAC | BAC-31 |
+| Module | `masu/test/processor/ocp/test_context_pipeline.py` |
+| Status | **Placeholder** — M5 audit trigger migration not yet implemented |
+
+---
+
+## Module: `cost_models/test/test_context_write_freeze.py`
+
+### Class: `PipelineWriteFreezeTest`
+
+---
+
+### TC-WF5: Pipeline skips context-tagged writes when freeze active
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-WF5 |
+| Test Items | `update_cost_model_costs` task guard (C9, C13) |
+| BAC | BAC-37 |
+| Module | `cost_models/test/test_context_write_freeze.py` |
+| Dependencies | None |
+
+**Scenario**: Pipeline returns early without running updater when freeze flag is on.
+
+**Given**
+- `is_context_writes_disabled` patched at `masu.processor.tasks.is_context_writes_disabled` to return `True`
+- `CostModelCostUpdater` and `WorkerCache` mocked
+
+**When**
+- `update_cost_model_costs(schema, "test-provider-uuid", start_date="2026-01-01", end_date="2026-01-31", synchronous=True, cost_model_context="consumer")` is called
+
+**Then**
+- `CostModelCostUpdater` is never instantiated (`mock_updater.assert_not_called()`)
+- The pipeline returned early due to the freeze guard
+
+---
+
+### TC-WF6: Pipeline runs normally when freeze off
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-WF6 |
+| Test Items | `update_cost_model_costs` task guard (C9, C13) |
+| BAC | BAC-37 |
+| Module | `cost_models/test/test_context_write_freeze.py` |
+| Dependencies | None |
+
+**Scenario**: Pipeline executes updater when freeze flag is disabled.
+
+**Given**
+- `is_context_writes_disabled` patched to return `False`
+- `CostModelCostUpdater`, `WorkerCache`, and `Provider` mocked
+
+**When**
+- `update_cost_model_costs(schema, "test-provider-uuid", ..., cost_model_context="consumer")` is called
+
+**Then**
+- `CostModelCostUpdater` is called exactly once (`mock_updater.assert_called_once()`)
+
+---
+
+### TC-WF7: Legacy path (None context) does not trigger freeze guard
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-WF7 |
+| Test Items | `update_cost_model_costs` task — None context path (C9, C13) |
+| BAC | BAC-38 |
+| Module | `cost_models/test/test_context_write_freeze.py` |
+| Dependencies | None |
+
+**Scenario**: Pipeline runs for None context without checking freeze flag.
+
+**Given**
+- All `CostModelContext` objects deleted (no default context in DB)
+- `is_context_writes_disabled` patched as a mock (call tracking enabled)
+- `CostModelCostUpdater`, `WorkerCache`, and `Provider` mocked
+
+**When**
+- `update_cost_model_costs(schema, "test-provider-uuid", ..., cost_model_context=None)` is called
+
+**Then**
+- `is_context_writes_disabled` is never called (`mock_flag.assert_not_called()`)
+- `CostModelCostUpdater` is called exactly once — the legacy path proceeds

--- a/docs/architecture/consumer-provider-cost-models/test-cases-t2-integration.md
+++ b/docs/architecture/consumer-provider-cost-models/test-cases-t2-integration.md
@@ -682,22 +682,118 @@
 
 ---
 
-### TC-72 through TC-76: Placeholder tests
+### TC-72: Pipeline step order (placeholder)
 
 | Field | Value |
 |-------|-------|
-| Identifiers | TC-72, TC-73, TC-74, TC-75, TC-76 |
-| BACs | BAC-17, BAC-32, BAC-24 |
-| Status | **Placeholder** — behavioral coverage deferred to E2E tests |
+| Identifier | TC-72 |
+| BAC | BAC-17 |
+| Module | `masu/test/processor/ocp/test_context_pipeline.py` |
+| Status | **Placeholder** — behavioral coverage deferred to E2E TC-91 |
 
-These tests assert `True` with a comment referencing the E2E test that provides
-the actual coverage:
+**Scenario**: Pipeline step-order behavior is deferred to E2E coverage.
 
-- **TC-72** (BAC-17): Pipeline step order → covered by E2E TC-91
-- **TC-73** (BAC-32): Empty context zero cost → covered by E2E TC-93
-- **TC-74** (BAC-32): Empty context preserves usage → covered by E2E TC-93
-- **TC-75** (BAC-17): Sequential runs no corruption → covered by E2E TC-91, TC-98
-- **TC-76** (BAC-24): Cloud infra in all contexts → covered by E2E TC-99
+**Given**
+- Placeholder assertion in integration suite (`assert True`)
+
+**When**
+- `MultiContextPipelineTest.test_tc72_pipeline_step_order_placeholder` is executed
+
+**Then**
+- The test passes as a documented placeholder
+- Behavioral assurance comes from E2E TC-91
+
+---
+
+### TC-73: Empty context zero cost (placeholder)
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-73 |
+| BAC | BAC-32 |
+| Module | `masu/test/processor/ocp/test_context_pipeline.py` |
+| Status | **Placeholder** — behavioral coverage deferred to E2E TC-93 |
+
+**Scenario**: Empty-context zero-cost behavior is deferred to E2E coverage.
+
+**Given**
+- Placeholder assertion in integration suite (`assert True`)
+
+**When**
+- `MultiContextPipelineTest.test_tc73_empty_context_zero_cost_placeholder` is executed
+
+**Then**
+- The test passes as a documented placeholder
+- Behavioral assurance comes from E2E TC-93
+
+---
+
+### TC-74: Empty context preserves usage (placeholder)
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-74 |
+| BAC | BAC-32 |
+| Module | `masu/test/processor/ocp/test_context_pipeline.py` |
+| Status | **Placeholder** — behavioral coverage deferred to E2E TC-93 |
+
+**Scenario**: Empty-context usage-preservation behavior is deferred to E2E coverage.
+
+**Given**
+- Placeholder assertion in integration suite (`assert True`)
+
+**When**
+- `MultiContextPipelineTest.test_tc74_empty_context_preserves_usage_placeholder` is executed
+
+**Then**
+- The test passes as a documented placeholder
+- Behavioral assurance comes from E2E TC-93
+
+---
+
+### TC-75: Sequential runs no corruption (placeholder)
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-75 |
+| BAC | BAC-17 |
+| Module | `masu/test/processor/ocp/test_context_pipeline.py` |
+| Status | **Placeholder** — behavioral coverage deferred to E2E TC-91 and TC-98 |
+
+**Scenario**: Sequential-run consistency behavior is deferred to E2E coverage.
+
+**Given**
+- Placeholder assertion in integration suite (`assert True`)
+
+**When**
+- `MultiContextPipelineTest.test_tc75_sequential_runs_no_corruption_placeholder` is executed
+
+**Then**
+- The test passes as a documented placeholder
+- Behavioral assurance comes from E2E TC-91 and TC-98
+
+---
+
+### TC-76: Cloud infra in all contexts (placeholder)
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-76 |
+| BAC | BAC-24 |
+| Module | `masu/test/processor/ocp/test_context_pipeline.py` |
+| Status | **Placeholder** — behavioral coverage deferred to E2E TC-99 |
+
+**Scenario**: Cloud-infrastructure context neutrality is deferred to E2E coverage.
+
+**Given**
+- Placeholder assertion in integration suite (`assert True`)
+
+**When**
+- `MultiContextPipelineTest.test_tc76_cloud_infra_all_contexts_placeholder` is executed
+
+**Then**
+- The test passes as a documented placeholder
+- Behavioral assurance comes from E2E TC-99
 
 See [Deliberate Deviations](./test-plan.md#11-deliberate-deviations-from-spec) in the
 test plan.

--- a/docs/architecture/consumer-provider-cost-models/test-cases-t2-integration.md
+++ b/docs/architecture/consumer-provider-cost-models/test-cases-t2-integration.md
@@ -28,7 +28,7 @@
 | Module | `cost_models/test/test_context_migration.py` |
 | Dependencies | None |
 
-**Scenario**: Forward data migration creates the default "Consumer" context.
+**Scenario**: Forward data migration creates the default context.
 
 **Given**
 - Schema is at `MIGRATE_FROM` state (`cost_models 0011`)
@@ -44,8 +44,9 @@
 **Then**
 - A `CostModelContext` with `is_default=True` exists
 - `default_ctx.name == "default"`
-- `default_ctx.display_name == "Consumer"`
+- `default_ctx.display_name == "Default context"`
 - `default_ctx.position == 1`
+- `default_ctx.data_visibility == "cloud_and_ocp"`
 
 ---
 
@@ -894,3 +895,32 @@ test plan.
 **Then**
 - `is_context_writes_disabled` is never called (`mock_flag.assert_not_called()`)
 - `CostModelCostUpdater` is called exactly once — the legacy path proceeds
+
+---
+
+## Module: `cost_models/test/test_context_migration.py` (visibility)
+
+### Class: `CostModelContextVisibilityMigrationTest`
+
+---
+
+### TC-V10: Migration sets data_visibility on default context
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-V10 |
+| Test Items | Migration M4 `RunPython` (C14) |
+| BAC | BAC-41 |
+| Module | `cost_models/test/test_context_migration.py` |
+| Dependencies | None |
+
+**Scenario**: Forward migration sets `data_visibility = 'cloud_and_ocp'` on the default context.
+
+**Given**
+- Schema is at `MIGRATE_FROM` state (`cost_models 0011`)
+
+**When**
+- Forward migration is run to `MIGRATE_TO_DATA` (`cost_models 0015`)
+
+**Then**
+- `default_ctx.data_visibility == "cloud_and_ocp"`

--- a/docs/architecture/consumer-provider-cost-models/test-cases-t3-e2e.md
+++ b/docs/architecture/consumer-provider-cost-models/test-cases-t3-e2e.md
@@ -1,0 +1,664 @@
+# Test Case Specifications — Tier 3: End-to-End Tests
+
+**IEEE 829-2008 Test Case Specification**
+
+| Field | Value |
+|-------|-------|
+| Parent Plan | [test-plan.md](./test-plan.md) (COST-3920-TP-001) |
+| Tier | T3 — End-to-End |
+| Base Class | `MasuTestCase`, `IamTestCase` |
+| Coverage Target | ≥80% |
+| Test Count | 24 |
+| Mocking Strategy | Real DB + real pipeline; mock Trino connections only |
+
+---
+
+## Module: `cost_models/test/test_cost_model_context_view.py`
+
+### Class: `CostModelContextViewSetTest`
+
+---
+
+### TC-85: Context CRUD API lifecycle
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-85 |
+| Test Items | `CostModelContextViewSet` (C6), `CostModelContextSerializer` (C4) |
+| BAC | BAC-30 |
+| Module | `cost_models/test/test_cost_model_context_view.py` |
+| Dependencies | None |
+
+**Scenario**: Full create/list/update/delete lifecycle via the REST API.
+
+**Given**
+- A default context exists: `baker.make("CostModelContext", name="default", is_default=True)`
+- An authenticated `APIClient` with valid headers
+
+**When**
+1. **CREATE**: POST `/cost-model-contexts/` with `{"name": "provider", "display_name": "Provider"}`
+2. **LIST**: GET `/cost-model-contexts/`
+3. **UPDATE**: PUT `/cost-model-contexts/{uuid}/` with `{"name": "provider", "display_name": "Provider (Updated)"}`
+4. **DELETE**: DELETE `/cost-model-contexts/{uuid}/`
+5. **VERIFY**: GET `/cost-model-contexts/{uuid}/`
+
+**Then**
+1. POST returns HTTP 201; response includes `uuid`
+2. GET returns HTTP 200; `"provider"` is in the list of context names
+3. PUT returns HTTP 200; `response.data["display_name"] == "Provider (Updated)"`
+4. DELETE returns HTTP 204
+5. GET returns HTTP 404 — context no longer exists
+
+---
+
+## Module: `cost_models/test/test_context_write_freeze.py`
+
+### Class: `ContextWriteFreezeAPITest`
+
+---
+
+### TC-WF1: Context creation blocked when freeze active
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-WF1 |
+| Test Items | `CostModelContextSerializer._check_context_write_freeze` (C4, C13) |
+| BAC | BAC-34 |
+| Module | `cost_models/test/test_context_write_freeze.py` |
+| Dependencies | None |
+
+**Scenario**: API returns 400 when attempting to create a context during write freeze.
+
+**Given**
+- A default context exists
+- `is_context_writes_disabled` patched at `cost_models.serializers.is_context_writes_disabled` to return `True`
+
+**When**
+- POST `/cost-model-contexts/` with `{"name": "provider", "display_name": "Provider"}`
+
+**Then**
+- HTTP status code is 400 (Bad Request)
+- Response body contains the word `"frozen"` (case-insensitive)
+
+---
+
+### TC-WF2: Context update blocked when freeze active
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-WF2 |
+| Test Items | `CostModelContextSerializer._check_context_write_freeze` (C4, C13) |
+| BAC | BAC-35 |
+| Module | `cost_models/test/test_context_write_freeze.py` |
+| Dependencies | None |
+
+**Scenario**: API returns 400 when attempting to update a context during write freeze.
+
+**Given**
+- A default context exists with known UUID
+- Freeze flag patched to return `True`
+
+**When**
+- PUT `/cost-model-contexts/{uuid}/` with `{"name": "default", "display_name": "Consumer (Updated)"}`
+
+**Then**
+- HTTP status code is 400 (Bad Request)
+- Response body contains `"frozen"`
+
+---
+
+### TC-WF3: Context read allowed during freeze
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-WF3 |
+| Test Items | `CostModelContextViewSet` (C6) — read path unaffected |
+| BAC | BAC-36 |
+| Module | `cost_models/test/test_context_write_freeze.py` |
+| Dependencies | None |
+
+**Scenario**: Read operations are not blocked by the write freeze.
+
+**Given**
+- A default context exists
+- Freeze flag patched to return `True`
+
+**When**
+- GET `/cost-model-contexts/`
+
+**Then**
+- HTTP status code is 200 (OK) — reads are unaffected
+
+---
+
+### TC-WF4: Context creation allowed when freeze off
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-WF4 |
+| Test Items | `CostModelContextSerializer._check_context_write_freeze` (C4, C13) |
+| BAC | BAC-34 |
+| Module | `cost_models/test/test_context_write_freeze.py` |
+| Dependencies | None |
+
+**Scenario**: API allows context creation when freeze flag is disabled.
+
+**Given**
+- A default context exists
+- `is_context_writes_disabled` patched to return `False`
+
+**When**
+- POST `/cost-model-contexts/` with `{"name": "provider", "display_name": "Provider"}`
+
+**Then**
+- HTTP status code is 201 (Created) — creation proceeds normally
+
+---
+
+## Module: `api/report/test/ocp/test_context_api.py`
+
+### Class: `OCPContextQueryParamSerializerTest`
+
+---
+
+### TC-22: cost_model_context parameter accepted
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-22 |
+| Test Items | `OCPQueryParamSerializer` (C10), `OCPReportQueryHandler` (C11) |
+| BAC | BAC-26 |
+| Module | `api/report/test/ocp/test_context_api.py` |
+| Dependencies | None |
+
+**Scenario**: OCP cost report endpoint accepts cost_model_context query parameter.
+
+**Given**
+- An authenticated `APIClient` with valid headers
+
+**When**
+- GET `/reports/openshift/costs/?cost_model_context=consumer`
+
+**Then**
+- HTTP status code is 200
+- `response.json()["meta"]["cost_model_context"] == "consumer"`
+
+---
+
+### TC-23: Missing cost_model_context has no context in meta
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-23 |
+| Test Items | `OCPQueryParamSerializer` (C10), `OCPReportQueryHandler` (C11) |
+| BAC | BAC-33 |
+| Module | `api/report/test/ocp/test_context_api.py` |
+| Dependencies | None |
+
+**Scenario**: Without cost_model_context param, response meta does not include it (backward-compat).
+
+**Given**
+- An authenticated `APIClient` with valid headers
+
+**When**
+- GET `/reports/openshift/costs/` (no `cost_model_context` parameter)
+
+**Then**
+- HTTP status code is 200
+- `"cost_model_context"` is NOT in `response.json()["meta"]`
+
+---
+
+### Class: `OCPContextReportAPITest`
+
+---
+
+### TC-80: Cost endpoint with context returns 200
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-80 |
+| Test Items | OCP report endpoint (C10, C11) |
+| BAC | BAC-26 |
+| Module | `api/report/test/ocp/test_context_api.py` |
+| Dependencies | None |
+
+**Scenario**: OCP cost endpoint with cost_model_context returns a successful response.
+
+**Given**
+- An authenticated `APIClient`
+
+**When**
+- GET `/reports/openshift/costs/?cost_model_context=consumer`
+
+**Then**
+- HTTP status code is 200
+
+---
+
+### TC-81: Response filtered by context
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-81 |
+| Test Items | `OCPReportQueryHandler` (C11) — context filtering |
+| BAC | BAC-27 |
+| Module | `api/report/test/ocp/test_context_api.py` |
+| Dependencies | None |
+
+**Scenario**: Response meta reflects the requested context.
+
+**Given**
+- An authenticated `APIClient`
+
+**When**
+- GET `/reports/openshift/costs/?cost_model_context=consumer`
+- Response status is 200
+
+**Then**
+- `response.json()["meta"]` contains `"cost_model_context"` key
+
+---
+
+### TC-82: Missing context uses default (no regression)
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-82 |
+| Test Items | OCP report endpoint — backward compatibility (C10, C11) |
+| BAC | BAC-33 |
+| Module | `api/report/test/ocp/test_context_api.py` |
+| Dependencies | None |
+
+**Scenario**: Omitting cost_model_context param returns 200 (existing behavior preserved).
+
+**Given**
+- An authenticated `APIClient`
+
+**When**
+- GET `/reports/openshift/costs/` (no context param)
+
+**Then**
+- HTTP status code is 200
+
+---
+
+### TC-83: Currency annotation context-aware
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-83 |
+| Test Items | `OCPReportQueryHandler` (C11) — currency annotation |
+| BAC | BAC-27 |
+| Module | `api/report/test/ocp/test_context_api.py` |
+| Dependencies | None |
+
+**Scenario**: Report with context returns data (currency annotation respects context).
+
+**Given**
+- An authenticated `APIClient`
+
+**When**
+- GET `/reports/openshift/costs/?cost_model_context=consumer`
+- Response status is 200
+
+**Then**
+- Response contains `data` field (may be empty depending on test data, but no error)
+
+---
+
+### TC-84: Unpermitted/nonexistent context handled gracefully
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-84 |
+| Test Items | OCP report endpoint — error handling (C10, C11, C12) |
+| BAC | BAC-29 |
+| Module | `api/report/test/ocp/test_context_api.py` |
+| Dependencies | None |
+
+**Scenario**: Requesting a nonexistent context returns a handled response (not 500).
+
+**Given**
+- An authenticated `APIClient`
+
+**When**
+- GET `/reports/openshift/costs/?cost_model_context=nonexistent`
+
+**Then**
+- HTTP status code is 200 or 400 — graceful handling, no 500
+
+---
+
+## Module: `cost_models/test/test_context_e2e.py`
+
+### Class: `PipelineSmokeE2ETest`
+
+---
+
+### TC-90: Single context pipeline smoke test
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-90 |
+| Test Items | Full pipeline: task (C9) → accessor (C7) → updater (C8) → SQL → DB → API (C11) |
+| BAC | BAC-16, BAC-27 |
+| Module | `cost_models/test/test_context_e2e.py` |
+| Dependencies | None |
+| Special Requirements | Trino mocked (`trino_table_exists=False`, `schema_exists_trino=False`) |
+
+**Scenario**: Single context pipeline produces cost rows with correct context tag, verifiable via API.
+
+**Given**
+- Context "default" (is_default=True) exists
+- Cost model with known CPU rate: `$10/core-hour`, cost_type `"Infrastructure"`
+- `CostModelMap` links `ocp_provider_uuid` to cost model via "default" context
+- Trino connections mocked to return `False`
+
+**When**
+- Pipeline runs: `update_cost_model_costs(schema, provider_uuid, start, end, cost_model_context="default", synchronous=True)`
+- API call: GET `/reports/openshift/costs/?cost_model_context=default`
+
+**Then**
+- **DB assertions**:
+  - `OCPUsageLineItemDailySummary` rows exist where:
+    - `source_uuid == ocp_provider_uuid`
+    - `cost_model_context == "default"`
+    - `cost_model_rate_type == "Infrastructure"`
+  - `SUM(cost_model_cpu_cost) > 0` — positive cost from the $10/core-hour rate
+- **API assertions**:
+  - HTTP 200
+  - `response.json()["meta"]["cost_model_context"] == "default"`
+
+---
+
+### TC-91: Dual context isolation smoke test
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-91 |
+| Test Items | Full pipeline: multi-context dispatch → DB isolation → API verification |
+| BAC | BAC-16, BAC-17 |
+| Module | `cost_models/test/test_context_e2e.py` |
+| Dependencies | None |
+| Special Requirements | Trino mocked |
+
+**Scenario**: Two contexts produce independent cost rows at correct rate ratios.
+
+**Given**
+- Context "consumer" (default, position=1): cost model with `$10/core-hour`
+- Context "provider" (position=2): cost model with `$20/core-hour`
+- Both assigned to the same `ocp_provider_uuid` via separate `CostModelMap` rows
+
+**When**
+- Pipeline runs for "consumer": `update_cost_model_costs(..., cost_model_context="consumer")`
+- Pipeline runs for "provider": `update_cost_model_costs(..., cost_model_context="provider")`
+- API calls: GET for each context
+
+**Then**
+- **DB assertions**:
+  - `consumer_cost = SUM(cost_model_cpu_cost WHERE cost_model_context = "consumer")` > 0
+  - `provider_cost = SUM(cost_model_cpu_cost WHERE cost_model_context = "provider")` > 0
+  - `provider_cost / consumer_cost ≈ 2.0` (within ±0.1 delta) — ratio matches $20/$10
+- **API assertions**:
+  - Consumer response: `meta.cost_model_context == "consumer"`
+  - Provider response: `meta.cost_model_context == "provider"`
+
+---
+
+### Class: `APIContextE2ETest`
+
+---
+
+### TC-92: Explicit default equals implicit (backward-compat)
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-92 |
+| Test Items | API backward compatibility (C10, C11) |
+| BAC | BAC-33, BAC-27 |
+| Module | `cost_models/test/test_context_e2e.py` |
+| Dependencies | TC-90 |
+
+**Scenario**: Explicit ?cost_model_context=default includes context in meta; implicit does not.
+
+**Given**
+- Default context with rate; pipeline has been run for "default"
+
+**When**
+- Explicit: GET `/reports/openshift/costs/?cost_model_context=default`
+- Implicit: GET `/reports/openshift/costs/` (no param)
+
+**Then**
+- Both return HTTP 200
+- Explicit response: `meta.cost_model_context == "default"`
+- Implicit response: `"cost_model_context"` NOT in `meta`
+
+---
+
+### TC-93: Empty context shows $0 cost
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-93 |
+| Test Items | API + accessor — empty context path (C7, C11) |
+| BAC | BAC-32 |
+| Module | `cost_models/test/test_context_e2e.py` |
+| Dependencies | None |
+
+**Scenario**: Context with no cost model assignment reports $0 cost via API.
+
+**Given**
+- Context "empty" exists (position=2, is_default=False) with NO `CostModelMap` assignment
+- Context "default" also exists (for schema validity)
+
+**When**
+- GET `/reports/openshift/costs/?cost_model_context=empty`
+
+**Then**
+- HTTP 200
+- `meta.cost_model_context == "empty"`
+- Cost data is $0 (no cost model = no cost injection)
+
+---
+
+### TC-94: Rate update propagation
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-94 |
+| Test Items | Full pipeline re-run after rate change (C7, C8, C9) |
+| BAC | BAC-27 |
+| Module | `cost_models/test/test_context_e2e.py` |
+| Dependencies | None |
+
+**Scenario**: Updating a rate and re-running the pipeline produces updated costs.
+
+**Given**
+- Default context with cost model at `$10/core-hour`; pipeline run once
+- `cost_before = SUM(cost_model_cpu_cost WHERE context = "default")`
+
+**When**
+- Rate updated to `$50/core-hour` (`cm.rates = [{..., "value": "50.00"}]; cm.save()`)
+- Pipeline re-run for "default"
+
+**Then**
+- `cost_after = SUM(cost_model_cpu_cost WHERE context = "default")`
+- `cost_after > cost_before`
+- `cost_after / cost_before ≈ 5.0` (within ±0.5 delta)
+
+---
+
+### TC-95: Assignment removal clears context costs
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-95 |
+| Test Items | Pipeline re-run after CostModelMap deletion (C7, C8, C9) |
+| BAC | BAC-17 |
+| Module | `cost_models/test/test_context_e2e.py` |
+| Dependencies | None |
+
+**Scenario**: Removing a cost model assignment and re-running the pipeline clears that context's costs.
+
+**Given**
+- Default context with rate; pipeline run; cost rows exist with `cost_model_cpu_cost > 0`
+
+**When**
+- `CostModelMap` for the provider+context is deleted
+- Pipeline re-run for "default" context
+
+**Then**
+- No `cost_model_cpu_cost > 0` rows remain for context "default"
+  (`remaining == 0`)
+
+---
+
+### TC-96: Multi-tenant isolation
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-96 |
+| Test Items | Tenant isolation (C9) |
+| BAC | BAC-16 |
+| Module | `cost_models/test/test_context_e2e.py` |
+| Dependencies | None |
+
+**Scenario**: Contexts in one tenant do not leak costs into another schema.
+
+**Given**
+- Default context with rate assigned in the test tenant; pipeline run
+
+**When**
+- Query `OCPUsageLineItemDailySummary` in the `public` schema for `cost_model_context = "default"`
+
+**Then**
+- Either 0 rows returned, or `ProgrammingError` (table doesn't exist in public schema)
+- Both outcomes prove no cross-tenant leakage
+
+---
+
+### TC-97: RBAC denies unpermitted context access
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-97 |
+| Test Items | `CostModelContextPermission` (C12) — end-to-end |
+| BAC | BAC-29 |
+| Module | `cost_models/test/test_context_e2e.py` |
+| Dependencies | None |
+| Special Requirements | `@override_settings(ENHANCED_ORG_ADMIN=False)` |
+
+**Scenario**: RBAC denies access when permission check returns False.
+
+**Given**
+- Default context with rate
+- `CostModelContextPermission.has_permission` patched to return `False`
+
+**When**
+- GET `/reports/openshift/costs/?cost_model_context=default`
+
+**Then**
+- HTTP 403 (Forbidden) — if the permission mock was invoked
+- Verifies that RBAC enforcement is wired into the view
+
+---
+
+### TC-98: Cross-context isolation via API
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-98 |
+| Test Items | Full pipeline + API — two distinct contexts (C7, C8, C9, C11) |
+| BAC | BAC-17, BAC-27 |
+| Module | `cost_models/test/test_context_e2e.py` |
+| Dependencies | None |
+
+**Scenario**: Two contexts return distinct data through the API.
+
+**Given**
+- Context "default" with `$10/core-hour` rate
+- Context "alternate" with `$30/core-hour` rate
+- Both assigned to the same provider; both pipelines run
+
+**When**
+- GET `/reports/openshift/costs/?cost_model_context=default`
+- GET `/reports/openshift/costs/?cost_model_context=alternate`
+
+**Then**
+- Both return HTTP 200
+- Default response: `meta.cost_model_context == "default"`
+- Alternate response: `meta.cost_model_context == "alternate"`
+- Contexts return their own data — no cross-contamination
+
+---
+
+### TC-99: Cloud rows unaffected by context
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-99 |
+| Test Items | `AWSCostEntryLineItemDailySummary` model (SQL) |
+| BAC | BAC-24 |
+| Module | `cost_models/test/test_context_e2e.py` |
+| Dependencies | None |
+
+**Scenario**: AWS (cloud) model does not have cost_model_context field.
+
+**Given**
+- The `AWSCostEntryLineItemDailySummary` model is imported
+
+**When**
+- `hasattr(AWSCostEntryLineItemDailySummary, "cost_model_context")` is evaluated
+
+**Then**
+- Returns `False` — cloud models are unaffected
+
+---
+
+### TC-100: UI summary model has context field
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-100 |
+| Test Items | `OCPCostSummaryP` model (C15) |
+| BAC | BAC-25 |
+| Module | `cost_models/test/test_context_e2e.py` |
+| Dependencies | None |
+
+**Scenario**: OCP UI summary model includes cost_model_context field.
+
+**Given**
+- The `OCPCostSummaryP` model is imported
+
+**When**
+- `hasattr(OCPCostSummaryP, "cost_model_context")` is evaluated
+
+**Then**
+- Returns `True` — the context column was added by migration M8
+
+---
+
+### TC-101: Distributed costs tagged with context
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-101 |
+| Test Items | Distribution SQL + pipeline (C8, SQL) |
+| BAC | BAC-19 |
+| Module | `cost_models/test/test_context_e2e.py` |
+| Dependencies | TC-90 |
+
+**Scenario**: Cost distribution rows carry the correct context tag.
+
+**Given**
+- Default context with `$10/core-hour` rate; pipeline run
+
+**When**
+- Query `OCPUsageLineItemDailySummary` for distributed rows:
+  `cost_model_rate_type IN ("platform_distributed", "worker_distributed")`
+
+**Then**
+- For every distributed row:
+  `row.cost_model_context == "default"`
+- Distribution SQL correctly propagates the context tag

--- a/docs/architecture/consumer-provider-cost-models/test-cases-t3-e2e.md
+++ b/docs/architecture/consumer-provider-cost-models/test-cases-t3-e2e.md
@@ -662,3 +662,91 @@
 - For every distributed row:
   `row.cost_model_context == "default"`
 - Distribution SQL correctly propagates the context tag
+
+---
+
+## Module: `cost_models/test/test_context_e2e.py` (visibility)
+
+### Class: `CostVisibilityE2ETest`
+
+---
+
+### TC-V20: ocp_only context excludes cloud infrastructure costs
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-V20 |
+| Test Items | `OCPReportQueryHandler`, `OCPProviderMap` (C11) |
+| BAC | BAC-39 |
+| Module | `cost_models/test/test_context_e2e.py` |
+| Dependencies | TC-90 |
+
+**Scenario**: A context with `data_visibility=ocp_only` suppresses cloud infrastructure costs in API response.
+
+**Given**
+- Context "consumer" with `data_visibility="ocp_only"` and cost model ($10/core-hour)
+- OCP-on-cloud cluster with `infrastructure_raw_cost > 0` rows in daily summary
+- Pipeline has run for context "consumer"
+
+**When**
+- GET `/reports/openshift/costs/?cost_model_context=consumer`
+
+**Then**
+- `response.meta.data_visibility == "ocp_only"`
+- `infra_raw == 0` in the response (cloud infrastructure costs excluded)
+- `cost_usage > 0` (cost-model-derived costs still present)
+
+---
+
+### TC-V21: cloud_and_ocp context includes all costs
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-V21 |
+| Test Items | `OCPReportQueryHandler`, `OCPProviderMap` (C11) |
+| BAC | BAC-40 |
+| Module | `cost_models/test/test_context_e2e.py` |
+| Dependencies | TC-90 |
+
+**Scenario**: A context with `data_visibility=cloud_and_ocp` includes all costs (backward-compatible).
+
+**Given**
+- Default context with `data_visibility="cloud_and_ocp"` and cost model ($10/core-hour)
+- OCP-on-cloud cluster with `infrastructure_raw_cost > 0` rows in daily summary
+- Pipeline has run for default context
+
+**When**
+- GET `/reports/openshift/costs/?cost_model_context=default`
+
+**Then**
+- `response.meta.data_visibility == "cloud_and_ocp"`
+- `infra_raw > 0` (cloud infrastructure costs included)
+- `cost_usage > 0` (cost-model-derived costs present)
+
+---
+
+### TC-V22: Switching visibility updates subsequent report queries
+
+| Field | Value |
+|-------|-------|
+| Identifier | TC-V22 |
+| Test Items | `CostModelContext` model, `OCPReportQueryHandler` (C1, C11) |
+| BAC | BAC-39, BAC-40 |
+| Module | `cost_models/test/test_context_e2e.py` |
+| Dependencies | TC-V20, TC-V21 |
+
+**Scenario**: Changing a context's `data_visibility` affects subsequent report queries.
+
+**Given**
+- Context "consumer" with `data_visibility="cloud_and_ocp"`
+- OCP-on-cloud cluster with cloud costs
+
+**When**
+1. GET `/reports/openshift/costs/?cost_model_context=consumer` → `infra_raw > 0`
+2. Update context: `consumer.data_visibility = "ocp_only"` and save
+3. GET `/reports/openshift/costs/?cost_model_context=consumer` → `infra_raw == 0`
+
+**Then**
+- First request includes cloud costs
+- After visibility change, second request excludes cloud costs
+- No pipeline re-run needed — filtering is query-time only

--- a/docs/architecture/consumer-provider-cost-models/test-plan.md
+++ b/docs/architecture/consumer-provider-cost-models/test-plan.md
@@ -1,7 +1,16 @@
 # Test Plan — COST-3920 Consumer-Provider Cost Models
 
-**Parent**: [README.md](README.md) · **Status**: Design Proposal
-**Template**: IEEE 829-2008
+**IEEE 829-2008 Software Test Plan**
+
+| Field | Value |
+|-------|-------|
+| Test Plan Identifier | COST-3920-TP-001 |
+| Version | 2.0 |
+| Date | 2026-04-09 |
+| Author | COST-3920 Engineering |
+| Status | Design Proposal |
+| Parent Feature | COST-3920: Consumer-Provider Cost Models |
+| Spec References | [phased-delivery.md](./phased-delivery.md), [prd-gap-analysis.md](./prd-gap-analysis.md), [risk-register.md](./risk-register.md) |
 
 ---
 
@@ -12,19 +21,26 @@
 This test plan defines the verification and validation strategy for
 COST-3920 (Consumer-Provider Cost Models). It covers all phases of
 the feature with behavioral acceptance criteria, following koku
-testing conventions.
+testing conventions. Each test case is specified as a BDD scenario
+(Given/When/Then) derived from the proposed test implementation.
 
 ### 1.2 Scope
 
-Tests will cover:
+**In scope:**
 - Context entity CRUD (model, serializer, viewset)
-- Assignment with context (CostModelMap, manager)
+- Assignment with context (CostModelMap, CostModelManager)
 - Schema migrations (forward/reverse, data migration, backfill)
 - Per-context pipeline execution (accessor, updater, SQL templates)
 - API integration (query parameter, response filtering)
 - RBAC (Koku-side authorization, context permission)
 - Write-freeze guards (Unleash flag, serializer, pipeline)
 - Cross-context data isolation
+
+**Out of scope:**
+- Frontend UI changes (context dropdown, notifications)
+- Kessel/ReBAC integration (deferred to v2)
+- `ocp_tag_mapping_update_daily_summary.sql` context scoping
+- OCP-on-cloud cross-provider context interaction
 
 ### 1.3 Definitions
 
@@ -34,125 +50,117 @@ Tests will cover:
 | **BAC** | Business Acceptance Criterion |
 | **TC** | Test Case |
 | **TDD** | Test-Driven Development (Red/Green/Refactor) |
+| **SUT** | System Under Test |
 
 ---
 
 ## 2. Test Items
 
-### 2.1 Models Layer (6 components)
+### 2.1 Components Under Test
 
-- `CostModelContext` — **NEW**
-- `CostModelMap` + `cost_model_context` FK — **MODIFIED**
-- Migrations M1-M7 — **NEW** (cost_models + reporting)
-- `reporting_ocpusagelineitem_daily_summary` + `cost_model_context` — **MODIFIED**
-- 13 `reporting_ocp_*_summary_p` tables + `cost_model_context` — **MODIFIED**
-- `CostModelAudit` trigger — **MODIFIED**
+| ID | Component | File | Type |
+|----|-----------|------|------|
+| C1 | `CostModelContext` model | `cost_models/models.py` | **NEW** |
+| C2 | `CostModelMap` + `cost_model_context` FK | `cost_models/models.py` | **MODIFIED** |
+| C3 | `CostModelManager.update_provider_uuids` | `cost_models/cost_model_manager.py` | **MODIFIED** |
+| C4 | `CostModelContextSerializer` | `cost_models/serializers.py` | **NEW** |
+| C5 | `CostModelSerializer` (context field) | `cost_models/serializers.py` | **MODIFIED** |
+| C6 | `CostModelContextViewSet` | `cost_models/views.py` | **NEW** |
+| C7 | `CostModelDBAccessor` (context parameter) | `masu/database/cost_model_db_accessor.py` | **MODIFIED** |
+| C8 | `OCPCostModelCostUpdater` (context threading) | `masu/processor/ocp/ocp_cost_model_cost_updater.py` | **MODIFIED** |
+| C9 | `update_cost_model_costs` task (context dispatch) | `masu/processor/tasks.py` | **MODIFIED** |
+| C10 | `OCPQueryParamSerializer` (context field) | `api/report/ocp/serializers.py` | **MODIFIED** |
+| C11 | `OCPReportQueryHandler` (context filtering) | `api/report/ocp/query_handler.py` | **MODIFIED** |
+| C12 | `CostModelContextPermission` | `api/common/permissions/cost_model_context_access.py` | **NEW** |
+| C13 | `is_context_writes_disabled()` | `masu/processor/__init__.py` | **NEW** |
+| C14 | Migrations M1–M6 (cost_models) | `cost_models/migrations/` | **NEW** |
+| C15 | Migrations M7–M10 (reporting) | `reporting/migrations/` | **NEW** |
 
-### 2.2 Manager + Serializer Layer (4 components)
+### 2.2 SQL Artifacts Under Test (49 files)
 
-- `CostModelManager.update_provider_uuids` — **MODIFIED**
-- `CostModelSerializer.create/update` — **MODIFIED**
-- `CostModelContextSerializer` — **NEW**
-- `CostModelContextViewSet` — **NEW**
+| Category | Count | Path |
+|----------|-------|------|
+| Standard cost model SQL | 16 | `masu/database/sql/openshift/cost_model/` |
+| Self-hosted cost model SQL | 9 | `masu/database/self_hosted_sql/openshift/cost_model/` |
+| Trino cost model SQL | 9 | `masu/database/trino_sql/openshift/cost_model/` |
+| Standard UI summary SQL | 13 | `masu/database/sql/openshift/ui_summary/` |
+| UI summary variants | 2 | self-hosted + Trino usage-only |
 
-### 2.3 Pipeline Layer (6 components)
+### 2.3 Features NOT Tested
 
-- `CostModelDBAccessor.cost_model` — **MODIFIED**
-- `OCPCostModelCostUpdater` — **MODIFIED**
-- `update_cost_model_costs` task + cache key — **MODIFIED**
-- `OCPReportDBAccessor.populate_ui_summary_tables` — **MODIFIED**
-- Distribution SQL orchestration — **MODIFIED**
-- `TableExportSetting` — **MODIFIED**
-
-### 2.4 SQL Layer (49+ artifacts)
-
-- 16 cost model SQL (`sql/openshift/cost_model/`)
-- 9 self-hosted cost model SQL (`self_hosted_sql/openshift/cost_model/`)
-- 9 Trino cost model SQL (`trino_sql/openshift/cost_model/`)
-- 13 UI summary SQL (`sql/openshift/ui_summary/`)
-- 2 UI summary usage-only variants (self-hosted + Trino)
-
-### 2.5 API + RBAC Layer (6 components)
-
-- `OCPQueryParamSerializer` — **MODIFIED**
-- `OCPProviderMap` — **MODIFIED**
-- `CostModelContextPermission` — **NEW**
-- `OCPReportQueryHandler` — **MODIFIED**
-- Currency annotation — **MODIFIED**
-- `CostModelContextView` — **NEW**
-
-### 2.6 Write-Freeze Layer (3 components)
-
-- `is_context_writes_disabled()` — **NEW** (`masu/processor/__init__.py`)
-- `CostModelContextSerializer._check_context_write_freeze()` — **NEW**
-- `update_cost_model_costs` pipeline guard — **MODIFIED**
+- `ocp_tag_mapping_update_daily_summary.sql` — out of scope
+- Frontend context dropdown — not in koku
+- Kessel/ReBAC — deferred to v2
+- Trino live execution — mocked in tests (no local Trino server)
 
 ---
 
-## 3. Business Acceptance Criteria (38 BACs)
+## 3. Features to Be Tested
 
-### Phase 1 — Context Entity + Schema (10 BACs)
+### 3.1 Business Acceptance Criteria (38 BACs)
 
-| BAC | Description |
-|-----|------------|
-| BAC-1 | `CostModelContext.objects.create()` succeeds with valid name/display_name |
-| BAC-2 | Max 3 contexts per tenant enforced (4th creation raises `ValidationError`) |
-| BAC-3 | Exactly one default context per tenant (partial unique index on `is_default=TRUE`) |
-| BAC-4 | Default context cannot be deleted (raises `ValidationError`) |
-| BAC-5 | `CostModelMap` accepts multiple rows for same provider with different contexts |
-| BAC-6 | `CostModelMap` rejects duplicate `(provider_uuid, cost_model_context)` pair (DB `IntegrityError`) |
-| BAC-7 | `update_provider_uuids` allows same provider in different contexts |
-| BAC-8 | `update_provider_uuids` rejects same provider+context twice (descriptive error) |
-| BAC-9 | Data migration creates default "Consumer" context per tenant schema |
-| BAC-10 | Data migration assigns all existing `CostModelMap` rows to default context |
+#### Phase 1 — Context Entity + Schema (10 BACs)
 
-### Phase 2 — Reporting Schema + Backfill (12 BACs)
+| BAC | Description | Priority | Components |
+|-----|-------------|----------|------------|
+| BAC-1 | `CostModelContext.objects.create()` succeeds with valid name/display_name | P1 | C1 |
+| BAC-2 | Max 3 contexts per tenant enforced (DB CHECK + serializer) | P1 | C1, C4 |
+| BAC-3 | Exactly one default context per tenant (partial unique index) | P1 | C1 |
+| BAC-4 | Default context cannot be deleted | P1 | C1, C4, C6 |
+| BAC-5 | `CostModelMap` accepts multiple rows for same provider with different contexts | P1 | C2 |
+| BAC-6 | `CostModelMap` rejects duplicate `(provider_uuid, cost_model_context)` | P1 | C2 |
+| BAC-7 | `update_provider_uuids` allows same provider in different contexts | P1 | C3 |
+| BAC-8 | `update_provider_uuids` rejects same provider+context twice | P1 | C3 |
+| BAC-9 | Data migration creates default context per tenant schema | P1 | C14 |
+| BAC-10 | Data migration assigns existing `CostModelMap` rows to default context | P1 | C14 |
 
-| BAC | Description |
-|-----|------------|
-| BAC-11 | `CostModelDBAccessor(context=X)` returns correct cost model for that context |
-| BAC-12 | `CostModelDBAccessor(context=None)` falls back to `.first()` (backward-compatible) |
-| BAC-13 | Pipeline executes per-context with context-specific rates |
-| BAC-14 | SQL DELETE scopes by `cost_model_context` — does NOT delete other contexts' rows |
-| BAC-15 | SQL INSERT includes `cost_model_context` value in all new rows |
-| BAC-16 | UI summary DELETE scopes by `cost_model_context` — prevents cross-context data loss |
-| BAC-17 | UI summary GROUP BY includes `cost_model_context` |
-| BAC-18 | Distribution SQL scopes by `cost_model_context` |
-| BAC-19 | Celery cache key includes context — allows parallel per-context tasks |
-| BAC-20 | Self-hosted SQL variants include `cost_model_context` in all DML |
-| BAC-21 | Python inline SQL handles context parameter |
-| BAC-22 | Cloud rows (`cost_model_rate_type = NULL`) are untouched by context scoping |
+#### Phase 2 — Reporting Schema + Backfill (3 BACs)
 
-### Phase 3 — Pipeline + SQL (6 BACs)
+| BAC | Description | Priority | Components |
+|-----|-------------|----------|------------|
+| BAC-11 | `cost_model_context` column added to daily summary table | P1 | C15 |
+| BAC-12 | `cost_model_context` column added to all 13 UI summary tables | P1 | C15 |
+| BAC-13 | Backfill sets `cost_model_context = 'default'` where `cost_model_rate_type IS NOT NULL` | P1 | C15 |
 
-| BAC | Description |
-|-----|------------|
-| BAC-23 | `cost_model_context` query parameter accepted on all OCP report endpoints |
-| BAC-24 | Report response filters cost data by requested context |
-| BAC-25 | `CostModelContextPermission` allows admin bypass (`ENHANCED_ORG_ADMIN`) |
-| BAC-26 | `CostModelContextPermission` denies access to unpermitted contexts |
-| BAC-27 | Currency annotation joins through context-specific `CostModelMap` row |
-| BAC-28 | Report views enforce context visibility (when context explicitly requested) |
+#### Phase 3 — Pipeline + SQL (12 BACs)
 
-### Phase 4 — API + RBAC (3 BACs)
+| BAC | Description | Priority | Components |
+|-----|-------------|----------|------------|
+| BAC-14 | `CostModelDBAccessor(context=X)` returns correct cost model | P1 | C7 |
+| BAC-15 | `CostModelDBAccessor(context=None)` falls back to default | P1 | C7 |
+| BAC-16 | Pipeline executes per-context with context-specific rates | P1 | C8, C9 |
+| BAC-17 | SQL DELETE scopes by `cost_model_context` — no cross-context deletion | P1 | SQL |
+| BAC-18 | SQL INSERT includes `cost_model_context` in output rows | P1 | SQL |
+| BAC-19 | Distribution SQL scopes by `cost_model_context` | P1 | SQL |
+| BAC-20 | Self-hosted SQL variants include `cost_model_context` | P2 | SQL |
+| BAC-21 | Trino SQL variants include `cost_model_context` | P2 | SQL |
+| BAC-22 | Python inline SQL handles `cost_model_context` | P2 | C8 |
+| BAC-23 | Celery cache key includes context (no dedup collision) | P1 | C9 |
+| BAC-24 | Cloud rows (`cost_model_rate_type = NULL`) unaffected | P1 | SQL |
+| BAC-25 | UI summary GROUP BY includes `cost_model_context` | P1 | SQL |
 
-| BAC | Description |
-|-----|------------|
-| BAC-29 | Audit trigger captures context array alongside provider_uuids |
-| BAC-30 | Empty context (no cost model) shows usage at $0 cost |
-| BAC-31 | Backfill migration sets `cost_model_context = 'default'` on all cost-model rows |
+#### Phase 4 — API + RBAC (8 BACs)
 
-### Phase 5 — Write-Freeze + Data Consistency (7 BACs)
+| BAC | Description | Priority | Components |
+|-----|-------------|----------|------------|
+| BAC-26 | `cost_model_context` query parameter accepted on OCP report endpoints | P1 | C10, C11 |
+| BAC-27 | Report response filters cost data by requested context | P1 | C11 |
+| BAC-28 | `CostModelContextPermission` allows admin bypass | P1 | C12 |
+| BAC-29 | `CostModelContextPermission` denies unpermitted users | P1 | C12 |
+| BAC-30 | Context CRUD API lifecycle (POST/GET/PUT/DELETE) | P1 | C4, C6 |
+| BAC-31 | Audit trigger captures context array | P2 | C14 |
+| BAC-32 | Empty context (no cost model) shows $0 cost | P2 | C7, C11 |
+| BAC-33 | Report views pass through when `cost_model_context` absent (backward-compat) | P1 | C12 |
 
-| BAC | Description |
-|-----|------------|
-| BAC-32 | Context creation returns 400 when write-freeze Unleash flag is active |
-| BAC-33 | Context update returns 400 when write-freeze flag is active |
-| BAC-34 | Context read/list succeeds during write-freeze (reads are not blocked) |
-| BAC-35 | Context creation succeeds when write-freeze flag is disabled |
-| BAC-36 | Pipeline skips context-tagged writes when write-freeze is active |
-| BAC-37 | Pipeline executes normally when write-freeze flag is disabled |
-| BAC-38 | Pipeline runs for None context (legacy path) without triggering write-freeze guard |
+#### Phase 5 — Write-Freeze + Data Consistency (5 BACs)
+
+| BAC | Description | Priority | Components |
+|-----|-------------|----------|------------|
+| BAC-34 | Context creation blocked when write-freeze active | P1 | C4, C13 |
+| BAC-35 | Context update blocked when write-freeze active | P1 | C4, C13 |
+| BAC-36 | Context read/list allowed during write-freeze | P1 | C6, C13 |
+| BAC-37 | Pipeline skips context-tagged writes when freeze active | P1 | C9, C13 |
+| BAC-38 | Pipeline runs for `None` context without triggering freeze guard | P1 | C9, C13 |
 
 ---
 
@@ -160,200 +168,454 @@ Tests will cover:
 
 ### 4.1 Test Tiers
 
-| Tier | Description | Base Class | Coverage Target |
-|------|-------------|------------|-----------------|
-| T1: Unit | Model validation, serializer logic, permission checks, manager guards | `IamTestCase` | >=85% |
-| T2: Integration | SQL execution, accessor methods, migration forward/reverse, DB constraints | `MasuTestCase` | >=80% |
-| T3: E2E | End-to-end orchestration, API request/response, pipeline order, cross-context isolation | `MasuTestCase` | >=80% |
+| Tier | Description | Base Class | Coverage Target | Mocking Strategy |
+|------|-------------|------------|-----------------|------------------|
+| **T1: Unit** | Model validation, serializer logic, permission checks, manager guards | `IamTestCase` | ≥85% | Mock at ORM/accessor boundary where needed |
+| **T2: Integration** | SQL execution, accessor methods, migration forward/reverse, DB constraints | `MasuTestCase` | ≥80% | Real DB; mock Trino connections |
+| **T3: E2E** | Full pipeline orchestration, API request/response, cross-context isolation | `MasuTestCase` | ≥80% | Real DB + pipeline; mock Trino |
 
-### 4.2 TDD Process
+### 4.2 Anti-Pattern Avoidance
 
-Each test case follows Red/Green/Refactor:
+| Anti-Pattern | Mitigation |
+|--------------|------------|
+| **Over-mocking** | T2/T3 tests use real `CostModelDBAccessor` with seeded DB data |
+| **Shared mutable state** | Each test opens its own accessor context manager; `setUp` clears contexts |
+| **Brittle SQL assertions** | Assert param dicts and template markers, not raw SQL strings |
+| **assertLogs misuse** | Always use `with self.assertLogs(...) as cm:` context manager |
+| **Random test data** | Deterministic rate values ($10, $20, $50); reserve random for property-based |
+| **Testing implementation** | Test via public API; private methods only where business logic requires |
+| **model_bakery misuse** | Use `baker.make()` not `Model.objects.create()` except in migration tests |
 
-1. **Red**: Write failing test that asserts expected BAC behavior
-2. **Green**: Write minimal implementation to make the test pass
-3. **Refactor**: Clean up code; verify tests still pass; lint check
+### 4.3 TDD Methodology
 
-### 4.3 Anti-Pattern Avoidance
+Each implementation phase follows strict Red-Green-Refactor:
 
-Following koku testing conventions:
-- Use `baker.make()` not `Model.objects.create()`
-- Use parenthesized `with (patch(...), patch(...)):` not nested `with`
-- Use `schema_context` + `subTest` for multi-scenario
-- Assert param dicts and table names, not SQL strings
-- Each test opens its own accessor context manager
-- Test via public API; private method tests only where business logic requires
-- Deterministic rate values; reserve random for property-based tests
+1. **TDD Red**: Write failing tests first. Tests define expected behavior from BAC.
+2. **TDD Green**: Implement minimum code to make all Red tests pass.
+3. **TDD Refactor**: Clean up. Remove duplication. Ensure conventions. No new behavior.
 
 ---
 
-## 5. Test Cases (104 total)
+## 5. Test Cases (82 tests across 10 modules)
 
-### T1: Unit Tests (~35 test cases)
+### 5.1 Module: `cost_models/test/test_cost_model_context.py` (17 tests)
 
-| TC | BAC | Description |
-|----|-----|------------|
-| TC-01 | BAC-1 | Create context with valid name and display_name |
-| TC-02 | BAC-1 | Context name uniqueness per tenant |
-| TC-03 | BAC-2 | Fourth context creation raises ValidationError |
-| TC-04 | BAC-3 | Two default contexts raises IntegrityError (partial unique index) |
-| TC-05 | BAC-4 | Delete default context raises ValidationError |
-| TC-06 | BAC-5 | CostModelMap allows same provider with different contexts |
-| TC-07 | BAC-6 | CostModelMap rejects duplicate (provider_uuid, context) |
-| TC-08 | BAC-7 | update_provider_uuids allows same provider in different contexts |
-| TC-09 | BAC-8 | update_provider_uuids rejects same provider+context (descriptive error) |
-| TC-10 | BAC-2 | Position CHECK constraint (1-3) on CostModelContext |
-| TC-11 | BAC-25 | CostModelContextPermission allows ENHANCED_ORG_ADMIN |
-| TC-12 | BAC-26 | CostModelContextPermission denies when no cost_model.read access |
-| TC-13 | BAC-26 | CostModelContextPermission passes when cost_model_context not in query_params |
-| TC-14 | BAC-23 | OCPQueryParamSerializer accepts cost_model_context parameter |
-| TC-15 | BAC-23 | OCPQueryParamSerializer validates cost_model_context length |
-| TC-16 | BAC-32 | CostModelContextSerializer._check_context_write_freeze blocks create |
-| TC-17 | BAC-33 | CostModelContextSerializer._check_context_write_freeze blocks update |
-| TC-18 | BAC-34 | Context list/retrieve succeeds during write-freeze |
-| TC-19 | BAC-35 | Context create succeeds when freeze flag is disabled |
-| TC-20 | BAC-30 | Empty context returns zero cost (no cost model assigned) |
-| TC-21 | BAC-4 | Delete non-default context succeeds |
-| TC-22 | BAC-1 | CostModelContext display_name max_length enforcement |
-| TC-23 | BAC-3 | Setting new default also unsets old default |
-| TC-24 | BAC-6 | CostModelMap null context (legacy row) coexists with named contexts |
-| TC-25 | BAC-27 | Currency annotation uses context-specific cost model currency |
-| TC-26 | BAC-28 | Report view denies when context explicitly requested and user lacks access |
-| TC-27 | BAC-28 | Report view allows when context not in query params (pass-through) |
-| TC-28 | BAC-1 | Context CRUD API: POST /api/v1/cost-model-contexts/ |
-| TC-29 | BAC-1 | Context CRUD API: GET /api/v1/cost-model-contexts/ |
-| TC-30 | BAC-1 | Context CRUD API: PUT /api/v1/cost-model-contexts/{uuid}/ |
-| TC-31 | BAC-9 | Migration forward: default context created per tenant |
-| TC-32 | BAC-10 | Migration forward: existing CostModelMap rows assigned default context |
-| TC-33 | BAC-9 | Migration reverse: context removed cleanly |
-| TC-34 | BAC-31 | Backfill migration: cost_model_context = 'default' on daily summary |
-| TC-35 | BAC-31 | Backfill migration: cost_model_context = 'default' on all 13 UI summary tables |
+#### Class: `CostModelContextModelTest` — T1 Unit
 
-### T2: Integration Tests (~40 test cases)
+| TC | BAC | Given | When | Then |
+|----|-----|-------|------|------|
+| TC-01 | BAC-1 | Tenant schema with no contexts | `baker.make("CostModelContext", name="provider", display_name="Provider", position=2, is_default=False)` | Context persists with correct `name`, `display_name`, `position`, `uuid`, `created_timestamp` |
+| TC-02 | BAC-2 | 3 contexts already exist (positions 1-3) | `baker.make("CostModelContext", position=4)` inside `transaction.atomic()` | `IntegrityError` raised (DB CHECK constraint rejects position > 3) |
+| TC-03 | BAC-3 | 1 context with `is_default=True` exists | `baker.make("CostModelContext", is_default=True)` inside `transaction.atomic()` | `IntegrityError` raised (partial unique index blocks 2nd default) |
+| TC-04a | BAC-2 | Empty tenant schema | Create contexts with positions 1, 2, 3 sequentially | All 3 persist with correct positions |
+| TC-04b | BAC-2 | Empty tenant schema | Create context with position 0, 4, or -1 inside `transaction.atomic()` | `IntegrityError` for each invalid position |
+| TC-05a | BAC-4 | Context with `is_default=True` exists | `default_ctx.delete()` | `ValidationError` or `IntegrityError` raised — deletion blocked |
+| TC-05b | BAC-4 | Non-default context exists | `ctx.delete()` | Context deleted; `CostModelContext.objects.filter(uuid=ctx_uuid).exists()` returns `False` |
 
-| TC | BAC | Description |
-|----|-----|------------|
-| TC-36 | BAC-11 | CostModelDBAccessor(context='consumer') returns consumer's cost model |
-| TC-37 | BAC-11 | CostModelDBAccessor(context='provider') returns provider's cost model |
-| TC-38 | BAC-12 | CostModelDBAccessor(context=None) returns first cost model |
-| TC-39 | BAC-14 | SQL DELETE scopes by cost_model_context (standard path) |
-| TC-40 | BAC-14 | SQL DELETE scopes by cost_model_context (self-hosted path) |
-| TC-41 | BAC-14 | SQL DELETE scopes by cost_model_context (Trino path) |
-| TC-42 | BAC-15 | SQL INSERT includes cost_model_context in output rows |
-| TC-43 | BAC-16 | UI summary DELETE scopes by cost_model_context |
-| TC-44 | BAC-17 | UI summary GROUP BY includes cost_model_context |
-| TC-45 | BAC-18 | Distribution SQL passes cost_model_context parameter |
-| TC-46 | BAC-20 | Self-hosted SQL variants include cost_model_context |
-| TC-47 | BAC-21 | Python inline SQL DELETE handles cost_model_context |
-| TC-48 | BAC-22 | Cloud rows (rate_type NULL) unaffected by context scoping |
-| TC-49 | BAC-13 | Pipeline produces correct cost values for context 'consumer' |
-| TC-50 | BAC-13 | Pipeline produces correct cost values for context 'provider' |
-| TC-51 | BAC-14 | Context A pipeline run does not delete context B rows |
-| TC-52 | BAC-19 | Worker cache key includes cost_model_context |
-| TC-53 | BAC-29 | Audit trigger includes context in audit row |
-| TC-54 | BAC-36 | Pipeline task returns early when write-freeze active and context is set |
-| TC-55 | BAC-37 | Pipeline task runs updater when write-freeze is disabled |
-| TC-56 | BAC-38 | Pipeline task runs for None context regardless of write-freeze |
-| TC-57 | BAC-31 | Backfill migration reverse: cost_model_context set back to NULL |
-| TC-58-70 | BAC-15 | SQL template parameter assertions for each of 13 UI summary SQL files |
-| TC-71-75 | BAC-14 | SQL template DELETE WHERE assertions (5 cost model SQL categories) |
+#### Class: `CostModelMapContextTest` — T1 Unit
 
-### T3: E2E Tests (~29 test cases)
+| TC | BAC | Given | When | Then |
+|----|-----|-------|------|------|
+| TC-09 | BAC-5 | Two contexts ("consumer", "provider") and one cost model | Create 2 `CostModelMap` rows for same `provider_uuid` with different contexts | Both rows persist; `CostModelMap.objects.filter(provider_uuid=uuid).count() == 2` |
+| TC-10 | BAC-6 | One `CostModelMap` row exists for `(provider_uuid, context)` | Create second `CostModelMap` for same `(provider_uuid, context)` inside `transaction.atomic()` | `IntegrityError` raised (unique constraint) |
 
-| TC | BAC | Description |
-|----|-----|------------|
-| TC-76 | BAC-13 | Full pipeline run: create 2 contexts, assign cost models, run pipeline, verify per-context rows in daily summary |
-| TC-77 | BAC-14 | Full pipeline run: verify re-run for context A does not affect context B |
-| TC-78 | BAC-24 | API request with cost_model_context=consumer returns only consumer cost data |
-| TC-79 | BAC-24 | API request without cost_model_context returns all cost data |
-| TC-80 | BAC-19 | Parallel context tasks: dispatch 2 tasks for same provider, different contexts — both complete without cache collision |
-| TC-81 | BAC-9 | Migration E2E: fresh tenant gets default context + assignment |
-| TC-82 | BAC-22 | Cloud infrastructure costs appear in all context responses unchanged |
-| TC-83 | BAC-30 | Context with no cost model: API returns usage at $0 |
-| TC-84 | BAC-16 | UI summary: two contexts produce distinct rollup rows |
-| TC-85 | BAC-17 | UI summary: GROUP BY context produces correct aggregation |
-| TC-86 | BAC-25 | Admin user accesses all contexts via API |
-| TC-87 | BAC-26 | Non-admin user denied context access when lacking cost_model.read |
-| TC-88 | BAC-32 | API POST /cost-model-contexts/ returns 400 during write-freeze |
-| TC-89 | BAC-33 | API PUT /cost-model-contexts/{uuid}/ returns 400 during write-freeze |
-| TC-90 | BAC-34 | API GET /cost-model-contexts/ succeeds during write-freeze |
-| TC-91 | BAC-36 | Pipeline skip during write-freeze: no new rows inserted |
-| TC-92 | BAC-10 | Assignment migration: multi-provider tenant gets all CostModelMap rows updated |
-| TC-93 | BAC-31 | Backfill E2E: daily summary + 13 UI tables all backfilled correctly |
-| TC-94 | BAC-8 | API assign same provider+context twice returns descriptive error |
-| TC-95 | BAC-4 | API DELETE default context returns 400 with descriptive error |
-| TC-96 | BAC-13 | Multi-tenant isolation: tenant A's contexts do not leak to tenant B |
-| TC-97 | BAC-18 | Distribution with context: platform/worker costs distributed per-context |
-| TC-98-104 | Various | Regression tests for existing cost model functionality (no regressions from context changes) |
+#### Class: `CostModelManagerContextTest` — T1 Unit
+
+| TC | BAC | Given | When | Then |
+|----|-----|-------|------|------|
+| TC-06 | BAC-7 | Two contexts exist; cost model 1 assigned to consumer | `CostModelManager(cm2).update_provider_uuids([uuid], cost_model_context=provider)` | Succeeds; 2 `CostModelMap` rows for same provider |
+| TC-07 | BAC-8 | Context exists; cost model 1 already assigned to `(uuid, ctx)` | `CostModelManager(cm2).update_provider_uuids([uuid], cost_model_context=ctx)` | `CostModelException` raised with descriptive message |
+| TC-08 | BAC-7 | Default context exists; `cost_model_context` not passed | `CostModelManager(cm).update_provider_uuids([uuid])` | `CostModelMap.cost_model_context.name == "default"` — auto-resolved |
+
+#### Class: `CostModelContextSerializerTest` — T1 Unit
+
+| TC | BAC | Given | When | Then |
+|----|-----|-------|------|------|
+| TC-11 | BAC-1 | Default context exists | `CostModelContextSerializer(data={"name": "provider", "display_name": "Provider"}).is_valid()` | Returns `True` |
+| TC-12 | BAC-2 | 3 contexts already exist | `CostModelContextSerializer(data={"name": "c4", "display_name": "C4"}).is_valid()` | Returns `False` — 4th rejected |
+| TC-13 | BAC-4 | Default context exists | `default_ctx.delete()` | `ValidationError` or `IntegrityError` raised |
+| TC-14 | BAC-5 | Default context exists | `CostModelSerializer(data={..., "cost_model_context": str(ctx.uuid)}).is_valid()` | Returns `True` — context UUID accepted |
+| TC-15 | BAC-7 | Default context exists; no `cost_model_context` in data | `CostModelSerializer(data={..., no context field}).is_valid()` | Returns `True` — defaults to tenant's default context |
+| TC-XX | BAC-7 | Default context exists; no `cost_model_context` in data | `serializer.save()` | Instance created successfully — backward-compatible |
+
+---
+
+### 5.2 Module: `cost_models/test/test_cost_model_context_view.py` (1 test)
+
+#### Class: `CostModelContextViewSetTest` — T3 E2E
+
+| TC | BAC | Given | When | Then |
+|----|-----|-------|------|------|
+| TC-85 | BAC-30 | Default context exists; authenticated API client | POST `/cost-model-contexts/` → GET list → PUT detail → DELETE detail → GET detail | POST=201 (created); GET=200 (name in list); PUT=200 (display_name updated); DELETE=204; final GET=404 |
+
+---
+
+### 5.3 Module: `cost_models/test/test_context_migration.py` (6 tests)
+
+#### Class: `CostModelContextMigrationTest` — T2 Integration
+
+| TC | BAC | Given | When | Then |
+|----|-----|-------|------|------|
+| TC-30 | BAC-9 | Schema at `MIGRATE_FROM` with one `CostModel` row | Run forward migration to `MIGRATE_TO_DATA` | `CostModelContext(is_default=True, name="default", display_name="Consumer", position=1)` exists |
+| TC-31 | BAC-10 | Schema at `MIGRATE_FROM` with `CostModelMap` row (raw SQL INSERT) | Run forward migration to `MIGRATE_TO_DATA` | `CostModelMap.cost_model_context` is set, `is_default=True`, `name="default"` |
+| TC-32 | BAC-6 | Schema at `MIGRATE_TO_DATA` with default context | Create 2 `CostModelMap` rows for same `(provider_uuid, context)` | `IntegrityError` — new unique constraint active |
+| TC-33 | BAC-5 | Schema at `MIGRATE_TO_DATA` with 2 contexts | Create 2 `CostModelMap` rows for same `(provider_uuid, cost_model)` but different contexts | Succeeds — old `(provider_uuid, cost_model)` constraint dropped |
+| TC-34 | BAC-9 | Schema at `MIGRATE_TO_DATA` with contexts and map rows | Reverse migration to `MIGRATE_FROM` | `cost_model_context_id` column dropped; `cost_model_context` table dropped; `CostModelMap` row survives |
+| TC-35 | BAC-3 | Schema at `MIGRATE_TO_DATA` with one default context | Create second context with `is_default=True` inside `transaction.atomic()` | `IntegrityError` — partial unique index active |
+
+---
+
+### 5.4 Module: `cost_models/test/test_context_write_freeze.py` (7 tests)
+
+#### Class: `ContextWriteFreezeAPITest` — T3 E2E
+
+| TC | BAC | Given | When | Then |
+|----|-----|-------|------|------|
+| TC-WF1 | BAC-34 | Default context exists; `is_context_writes_disabled` patched to return `True` | POST `/cost-model-contexts/` with `{"name": "provider", "display_name": "Provider"}` | HTTP 400; response body contains "frozen" |
+| TC-WF2 | BAC-35 | Default context exists; freeze flag active | PUT `/cost-model-contexts/{uuid}/` with updated display_name | HTTP 400; response body contains "frozen" |
+| TC-WF3 | BAC-36 | Default context exists; freeze flag active | GET `/cost-model-contexts/` | HTTP 200 — reads not blocked |
+| TC-WF4 | BAC-34 | Default context exists; `is_context_writes_disabled` patched to return `False` | POST `/cost-model-contexts/` with `{"name": "provider", "display_name": "Provider"}` | HTTP 201 — creation proceeds |
+
+#### Class: `PipelineWriteFreezeTest` — T2 Integration
+
+| TC | BAC | Given | When | Then |
+|----|-----|-------|------|------|
+| TC-WF5 | BAC-37 | Freeze flag active; `CostModelCostUpdater` and `WorkerCache` mocked | `update_cost_model_costs(..., cost_model_context="consumer", synchronous=True)` | `CostModelCostUpdater` never instantiated — pipeline returns early |
+| TC-WF6 | BAC-37 | Freeze flag disabled; `CostModelCostUpdater` and `Provider` mocked | `update_cost_model_costs(..., cost_model_context="consumer", synchronous=True)` | `CostModelCostUpdater` called once — pipeline executes |
+| TC-WF7 | BAC-38 | All `CostModelContext` objects deleted; freeze flag mock tracked | `update_cost_model_costs(..., cost_model_context=None, synchronous=True)` | `is_context_writes_disabled` never called; `CostModelCostUpdater` called once |
+
+---
+
+### 5.5 Module: `masu/test/processor/ocp/test_context_pipeline.py` (8 tests)
+
+#### Class: `MultiContextPipelineTest` — T2 Integration / T3 E2E
+
+| TC | BAC | Given | When | Then |
+|----|-----|-------|------|------|
+| TC-70 | BAC-16 | 2 contexts ("consumer", "provider"); `CostModelCostUpdater` mocked | `update_cost_model_costs(..., synchronous=True)` with no explicit context | `mock_updater.update_cost_model_costs.call_count >= 2` — dispatched per context |
+| TC-71 | BAC-14 | Context "default" with cost model ($10 CPU rate); `CostModelMap` assigned | `CostModelDBAccessor(schema, uuid, cost_model_context="default")` | `accessor.cost_model == cm_consumer` — correct model resolved |
+| TC-72 | BAC-17 | — | — | Placeholder — covered by E2E TC-91 |
+| TC-73 | BAC-32 | — | — | Placeholder — covered by E2E TC-93 |
+| TC-74 | BAC-32 | — | — | Placeholder — covered by E2E TC-93 |
+| TC-75 | BAC-17 | — | — | Placeholder — covered by E2E TC-91/TC-98 |
+| TC-76 | BAC-24 | — | — | Placeholder — covered by E2E TC-99 |
+
+#### Class: `AuditTriggerContextTest` — T2 Integration
+
+| TC | BAC | Given | When | Then |
+|----|-----|-------|------|------|
+| TC-57 | BAC-31 | — | — | Placeholder — M5 audit trigger not yet implemented |
+
+---
+
+### 5.6 Module: `masu/test/database/test_context_sql.py` (14 tests)
+
+#### Class: `CostModelDBAccessorContextTest` — T2 Integration
+
+| TC | BAC | Given | When | Then |
+|----|-----|-------|------|------|
+| TC-40 | BAC-14 | Context "default" with cost model assigned via `CostModelMap` | `CostModelDBAccessor(schema, uuid, cost_model_context="default")` | `accessor.cost_model == cm` |
+| TC-41 | BAC-15 | Context "default" with cost model assigned; no explicit context param | `CostModelDBAccessor(schema, uuid)` | `accessor.cost_model == cm` — falls back to default |
+| TC-42 | BAC-14 | Cost model assigned to "consumer" context only | `CostModelDBAccessor(schema, uuid, cost_model_context="provider")` | `accessor.cost_model is None` — no model for requested context |
+
+#### Class: `UsageCostsSQLContextTest` — T2 Integration
+
+| TC | BAC | Given | When | Then |
+|----|-----|-------|------|------|
+| TC-43 | BAC-17 | `usage_costs.sql` file loaded | Parse DELETE section (before first INSERT) | String `"cost_model_context"` present in DELETE section |
+| TC-44 | BAC-18 | `usage_costs.sql` file loaded | Parse INSERT section (after first INSERT keyword) | String `"cost_model_context"` present in INSERT section |
+| TC-45 | BAC-17 | `usage_costs.sql` file loaded | Search for exact template marker | `"cost_model_context = {{cost_model_context}}"` found in SQL |
+| TC-49 | BAC-19 | `distribute_platform_cost.sql` loaded | Search for context reference | String `"cost_model_context"` present |
+| TC-50 | BAC-24 | `AWSCostEntryLineItemDailySummary` model inspected | Check for attribute | `hasattr(model, "cost_model_context")` returns `False` — AWS model unaffected |
+
+#### Class: `CacheKeyContextTest` — T2 Integration
+
+| TC | BAC | Given | When | Then |
+|----|-----|-------|------|------|
+| TC-51 | BAC-23 | Cache key created with args including `"default"` context | `create_single_task_cache_key(task_name, [..., "default", ...])` | `"default"` substring present in returned key |
+| TC-52 | BAC-23 | Two cache keys with different context args ("default" vs "provider") | Compare both keys | Keys are not equal — different contexts produce different keys |
+
+#### Class: `SelfHostedTrinoSQLContextTest` — T2 Integration
+
+| TC | BAC | Given | When | Then |
+|----|-----|-------|------|------|
+| TC-53 | BAC-20 | All `.sql` files under `self_hosted_sql/openshift/cost_model/` | Read each file | Every file contains `"cost_model_context"` |
+| TC-54 | BAC-21 | All `.sql` files under `trino_sql/openshift/cost_model/` | Read each file | Every file contains `"cost_model_context"` |
+
+#### Class: `InlineSQLContextTest` — T2 Integration
+
+| TC | BAC | Given | When | Then |
+|----|-----|-------|------|------|
+| TC-55 | BAC-22 | `OCPCostModelCostUpdater._delete_tag_usage_costs` source inspected | `inspect.getsource(method)` | Source contains `"cost_model_context"` |
+| TC-56 | BAC-22 | `OCPReportDBAccessor.populate_usage_costs` source inspected | `inspect.getsource(method)` | Source contains `"cost_model_context"` |
+
+---
+
+### 5.7 Module: `masu/test/database/test_context_ui_summary.py` (3 tests)
+
+#### Class: `ContextColumnMigrationTest` — T2 Integration
+
+| TC | BAC | Given | When | Then |
+|----|-----|-------|------|------|
+| TC-60 | BAC-11 | Schema at `MIGRATE_FROM` | Run migration to `MIGRATE_TO` | `information_schema.columns` confirms `cost_model_context` on `reporting_ocpusagelineitem_daily_summary` |
+| TC-61 | BAC-12 | Schema at `MIGRATE_FROM` | Run migration to `MIGRATE_TO` | `cost_model_context` column exists on all 13 `reporting_ocp_*_summary_p` tables (verified with `subTest`) |
+| TC-62 | BAC-11 | Schema at `MIGRATE_TO` with context column present | Reverse migration to `MIGRATE_FROM` | `cost_model_context` column no longer exists on daily summary table |
+
+---
+
+### 5.8 Module: `api/report/test/ocp/test_context_api.py` (7 tests)
+
+#### Class: `OCPContextQueryParamSerializerTest` — T1 Unit / T3 E2E
+
+| TC | BAC | Given | When | Then |
+|----|-----|-------|------|------|
+| TC-22 | BAC-26 | Authenticated client | GET `/reports/openshift/costs/?cost_model_context=consumer` | HTTP 200; `response.meta.cost_model_context == "consumer"` |
+| TC-23 | BAC-33 | Authenticated client | GET `/reports/openshift/costs/` (no context param) | HTTP 200; `"cost_model_context" not in response.meta` — backward-compatible |
+
+#### Class: `OCPContextReportAPITest` — T3 E2E
+
+| TC | BAC | Given | When | Then |
+|----|-----|-------|------|------|
+| TC-80 | BAC-26 | Authenticated client | GET `/reports/openshift/costs/?cost_model_context=consumer` | HTTP 200 |
+| TC-81 | BAC-27 | Authenticated client | GET `/reports/openshift/costs/?cost_model_context=consumer` | `response.meta.cost_model_context == "consumer"` |
+| TC-82 | BAC-33 | Authenticated client | GET `/reports/openshift/costs/` (no context param) | HTTP 200 — no regression |
+| TC-83 | BAC-27 | Authenticated client | GET `/reports/openshift/costs/?cost_model_context=consumer` | Response includes data (verify currency annotation is context-aware) |
+| TC-84 | BAC-29 | Authenticated client | GET `/reports/openshift/costs/?cost_model_context=nonexistent` | HTTP 200 or 400 — unpermitted/nonexistent context handled gracefully |
+
+---
+
+### 5.9 Module: `api/common/permissions/test/test_context_permission.py` (7 tests)
+
+#### Class: `CostModelContextPermissionTest` — T1 Unit
+
+| TC | BAC | Given | When | Then |
+|----|-----|-------|------|------|
+| TC-16 | BAC-28 | `ENHANCED_ORG_ADMIN=True`; admin user; `query_params={"cost_model_context": "provider"}` | `perm.has_permission(request, None)` | Returns `True` — admin bypass |
+| TC-17 | BAC-29 | User with `cost_model.read=[]` (empty); `query_params={"cost_model_context": "consumer"}` | `perm.has_permission(request, None)` | Returns `False` — denied |
+| TC-18 | BAC-33 | User with `cost_model.read=["*"]`; `query_params={}` (no context param) | `perm.has_permission(request, None)` | Returns `True` — pass-through when no context requested |
+| TC-19a | BAC-29 | User with `access=None`, `customer=None`; `query_params={"cost_model_context": "consumer"}` | `perm.has_permission(request, None)` | Returns `False` |
+| TC-19b | BAC-33 | User with `access=None`; `query_params={}` (no context param) | `perm.has_permission(request, None)` | Returns `True` — pass-through |
+| TC-20 | BAC-29 | User with `access={}` (empty dict); `query_params={"cost_model_context": "consumer"}` | `perm.has_permission(request, None)` | Returns `False` |
+| TC-21 | BAC-29 | User with `access={"aws.account": {"read": ["*"]}}` (no `cost_model` key); context requested | `perm.has_permission(request, None)` | Returns `False` — no `KeyError` raised |
+
+---
+
+### 5.10 Module: `cost_models/test/test_context_e2e.py` (12 tests)
+
+#### Class: `PipelineSmokeE2ETest` — T3 E2E
+
+| TC | BAC | Given | When | Then |
+|----|-----|-------|------|------|
+| TC-90 | BAC-16, BAC-27 | Context "default" with cost model ($10/core-hour CPU, Infrastructure); `CostModelMap` assigned; Trino mocked | Run pipeline for `cost_model_context="default"`; then GET `/reports/openshift/costs/?cost_model_context=default` | DB: `OCPUsageLineItemDailySummary` rows with `cost_model_context="default"` and `cost_model_rate_type="Infrastructure"` exist; `sum(cost_model_cpu_cost) > 0`. API: `response.meta.cost_model_context == "default"` |
+| TC-91 | BAC-16, BAC-17 | Two contexts: consumer ($10), provider ($20); both assigned to same cluster; Trino mocked | Run pipeline for "consumer" then "provider" | DB: `provider_cost / consumer_cost ≈ 2.0 (±0.1)`. API: each context returns its own `cost_model_context` in meta. Cross-context isolation verified |
+
+#### Class: `APIContextE2ETest` — T3 E2E
+
+| TC | BAC | Given | When | Then |
+|----|-----|-------|------|------|
+| TC-92 | BAC-33, BAC-27 | Default context with rate; pipeline run for "default" | GET with `?cost_model_context=default` vs GET without param | Explicit: `meta.cost_model_context == "default"`. Implicit: `"cost_model_context" not in meta` |
+| TC-93 | BAC-32 | Context "empty" with no `CostModelMap` assignment; default also exists | GET `/reports/openshift/costs/?cost_model_context=empty` | HTTP 200; `meta.cost_model_context == "empty"` — $0 cost reported |
+| TC-94 | BAC-27 | Default context with $10 rate; pipeline run | Update rate to $50; re-run pipeline | `cost_after / cost_before ≈ 5.0 (±0.5)` — rate propagation verified |
+| TC-95 | BAC-17 | Default context with rate; pipeline run; then `CostModelMap` deleted | Re-run pipeline for "default" | All `cost_model_cpu_cost > 0` rows for context "default" are cleared |
+| TC-96 | BAC-16 | Default context with rate assigned in test tenant; pipeline run | Query `OCPUsageLineItemDailySummary` in `public` schema | 0 rows or `ProgrammingError` — no cross-tenant leakage |
+| TC-97 | BAC-29 | `CostModelContextPermission.has_permission` patched to `False` | GET `/reports/openshift/costs/?cost_model_context=default` | HTTP 403 |
+| TC-98 | BAC-17, BAC-27 | Two contexts: "default" ($10) and "alternate" ($30); both pipelines run | GET for each context | Each response has its own `cost_model_context` in meta — cross-context isolation via API |
+| TC-99 | BAC-24 | — | Inspect `AWSCostEntryLineItemDailySummary` model | `hasattr(model, "cost_model_context")` returns `False` |
+| TC-100 | BAC-25 | — | Inspect `OCPCostSummaryP` model | `hasattr(model, "cost_model_context")` returns `True` |
+| TC-101 | BAC-19 | Default context with rate; pipeline run | Query `OCPUsageLineItemDailySummary` for `cost_model_rate_type IN ("platform_distributed", "worker_distributed")` | All distributed rows have `cost_model_context == "default"` |
 
 ---
 
 ## 6. Pass/Fail Criteria
 
-- All T1 tests pass (unit)
-- All T2 tests pass (integration)
-- All T3 tests pass (E2E)
-- Zero net new regressions in existing `cost_models` test suite
-- Zero net new regressions in existing `masu.processor` test suite
-- Coverage per tier >= 80% of testable code
-- All migrations are reversible
+### 6.1 Per-Test
+
+A test case **passes** when all assertions succeed and no unexpected
+exceptions are raised.
+
+### 6.2 Per-Phase
+
+| Phase | Pass Criteria |
+|-------|---------------|
+| TDD Red | All new tests fail (or skip if SUT doesn't exist). No existing tests broken. |
+| TDD Green | All new tests pass. All existing tests still pass. |
+| TDD Refactor | All tests pass. Linter clean. No behavioral changes. |
+
+### 6.3 Overall
+
+- All 82 test cases pass
+- Coverage ≥80% per tier (measured by `coverage run` + `coverage report`)
+- Zero linter errors on modified files
+- Zero net new regressions in existing `cost_models` and `masu.processor` suites
+- All migrations forward and reverse cleanly
+- All spec-vs-implementation discrepancies documented as deliberate deviations
 
 ---
 
 ## 7. Test Deliverables
 
-### Proposed test files
-
-| File | Scope | Tier |
-|------|-------|------|
-| `cost_models/test/test_cost_model_context.py` | Context model, serializer, max 3, default protection | T1 |
-| `cost_models/test/test_cost_model_context_view.py` | Context CRUD API | T1, T3 |
-| `cost_models/test/test_context_assignment.py` | Manager per-context, CostModelMap constraints | T1, T2 |
-| `cost_models/test/test_context_migration.py` | Forward/reverse migration, per-tenant data migration | T2 |
-| `cost_models/test/test_context_write_freeze.py` | Write-freeze API and pipeline guards | T1, T2, T3 |
-| `masu/test/processor/ocp/test_context_pipeline.py` | Per-context pipeline orchestration, concurrency | T2, T3 |
-| `masu/test/database/test_context_sql.py` | SQL context scoping (standard, self-hosted, Trino) | T2 |
-| `masu/test/database/test_context_ui_summary.py` | UI summary cross-context isolation | T2, T3 |
-| `api/report/test/ocp/test_context_api.py` | Report API with context parameter | T1, T3 |
-| `api/common/permissions/test_context_permission.py` | Hybrid RBAC, edge cases | T1 |
-| `cost_models/test/test_context_e2e.py` | Full pipeline E2E orchestration | T3 |
+| Deliverable | File | Tier |
+|-------------|------|------|
+| This test plan | `docs/architecture/consumer-provider-cost-models/test-plan.md` | — |
+| Context model + serializer | `cost_models/test/test_cost_model_context.py` | T1 |
+| Context CRUD API | `cost_models/test/test_cost_model_context_view.py` | T3 |
+| Migration forward/reverse | `cost_models/test/test_context_migration.py` | T2 |
+| Write-freeze guards | `cost_models/test/test_context_write_freeze.py` | T1, T2, T3 |
+| Pipeline per-context | `masu/test/processor/ocp/test_context_pipeline.py` | T2, T3 |
+| SQL context scoping | `masu/test/database/test_context_sql.py` | T2 |
+| UI summary migrations | `masu/test/database/test_context_ui_summary.py` | T2 |
+| Report API context | `api/report/test/ocp/test_context_api.py` | T1, T3 |
+| RBAC permission | `api/common/permissions/test/test_context_permission.py` | T1 |
+| E2E orchestration | `cost_models/test/test_context_e2e.py` | T3 |
 
 ---
 
 ## 8. Environmental Needs
 
-- PostgreSQL with tenant schemas (Django Tenants)
-- `MasuTestCase` / `IamTestCase` test infrastructure
-- `model_bakery` for fixture creation
-- `unittest.mock.patch` for Unleash flag mocking
-- No Trino required (Trino paths mocked in tests)
+### 8.1 Test Environment
+
+- **Database**: PostgreSQL with tenant schemas (Django Tenants)
+- **Schema**: Tenant schema via `MasuTestCase` / `IamTestCase`
+- **Fixtures**: `baker.make()` for cost models, contexts, providers
+- **Dependencies**: `model_bakery`, `unittest.mock.patch`, `rest_framework.test.APIClient`
+
+### 8.2 Test Execution
+
+```bash
+# Run all COST-3920 tests
+python manage.py test cost_models.test.test_cost_model_context \
+  cost_models.test.test_cost_model_context_view \
+  cost_models.test.test_context_migration \
+  cost_models.test.test_context_write_freeze \
+  cost_models.test.test_context_e2e \
+  masu.test.processor.ocp.test_context_pipeline \
+  masu.test.database.test_context_sql \
+  masu.test.database.test_context_ui_summary \
+  api.report.test.ocp.test_context_api \
+  api.common.permissions.test.test_context_permission -v 2
+
+# Run with coverage
+coverage run --source=cost_models,masu/database/cost_model_db_accessor.py,masu/processor/tasks.py,api/report/ocp manage.py test [same modules] -v 2
+coverage report --show-missing
+```
 
 ---
 
-## 9. Risks and Contingencies
+## 9. Implementation Phases
 
-| Risk | Impact | Contingency |
+### Phase R1: TDD Red — Context Entity + Schema (TC-01 through TC-15, TC-30 through TC-35)
+
+**Goal**: Write failing tests for `CostModelContext` model, `CostModelMap`
+constraints, `CostModelManager` context-awareness, serializer validation,
+and migration forward/reverse.
+
+**Test files**: `test_cost_model_context.py`, `test_context_migration.py`
+
+**Exit criteria**: All tests fail or skip. No existing tests broken.
+
+### Checkpoint C1: Red Phase Due Diligence
+
+- Verify all BAC-1 through BAC-10 have test coverage
+- Verify migration tests use raw SQL + `SET CONSTRAINTS ALL IMMEDIATE`
+- Verify `information_schema` queries are schema-scoped (`AND table_schema = current_schema()`)
+- Anti-pattern scan
+
+### Phase G1: TDD Green — Context Entity + Schema
+
+**Goal**: Make all Phase R1 tests pass. Implement model, migrations,
+manager, serializer.
+
+**Exit criteria**: All TC-01 through TC-15, TC-30 through TC-35 pass.
+
+### Phase F1: TDD Refactor
+
+**Exit criteria**: All tests pass. Linter clean. Code review-ready.
+
+### Checkpoint C2: Green/Refactor Due Diligence
+
+- Run existing `cost_models` test suite: zero regressions
+- Coverage ≥80% for T1 tier
+- Schema validation: `CostModelContext` table exists in all tenant schemas
+
+### Phase R2: TDD Red — Pipeline + SQL (TC-40 through TC-62)
+
+**Goal**: Write failing tests for accessor context filtering, SQL template
+markers, cache keys, self-hosted/Trino variants, inline SQL, and
+reporting table migrations.
+
+**Test files**: `test_context_sql.py`, `test_context_ui_summary.py`, `test_context_pipeline.py`
+
+### Checkpoint C3: Red Phase 2 Due Diligence
+
+- Verify all 49 SQL files are covered by TC-53/TC-54 (walk-based tests)
+- Verify cache key tests use `create_single_task_cache_key` directly
+
+### Phase G2/F2: TDD Green + Refactor — Pipeline + SQL
+
+**Exit criteria**: All TC-40 through TC-62 pass.
+
+### Phase R3: TDD Red — API + RBAC + Write-Freeze (TC-16 through TC-23, TC-80 through TC-85, TC-WF1 through TC-WF7)
+
+**Goal**: Write failing tests for permission logic, API parameter
+acceptance, report filtering, CRUD lifecycle, and write-freeze guards.
+
+**Test files**: `test_context_permission.py`, `test_context_api.py`,
+`test_cost_model_context_view.py`, `test_context_write_freeze.py`
+
+### Checkpoint C4: Red Phase 3 Due Diligence
+
+- Verify permission tests cover: admin bypass, denial, pass-through, edge cases
+- Verify write-freeze tests cover: create blocked, update blocked, read allowed, flag off
+
+### Phase G3/F3: TDD Green + Refactor — API + RBAC + Write-Freeze
+
+**Exit criteria**: All TC-16 through TC-23, TC-80 through TC-85, TC-WF1 through TC-WF7 pass.
+
+### Phase R4/G4/F4: TDD — E2E (TC-90 through TC-101)
+
+**Goal**: Full pipeline + API E2E tests with real DB operations.
+
+**Test file**: `test_context_e2e.py`
+
+### Checkpoint C5: Final Due Diligence
+
+- Full regression run: existing cost model, accessor, and API test suites
+- Coverage audit: ≥80% per tier
+- Anti-pattern final scan
+- Spec alignment verification: all deliberate deviations documented
+- Re-run all 82 tests to confirm no flakiness
+
+---
+
+## 10. Risks and Contingencies
+
+| Risk | Impact | Mitigation |
 |------|--------|------------|
-| Test execution time increase (3× pipeline runs) | CI slowdown | Parallelize per-context tests; use targeted test discovery |
-| Migration test fragility | Flaky CI | Use raw SQL + `SET CONSTRAINTS ALL IMMEDIATE` pattern |
-| Trino connection in tests | Test failure | Mock `trino_table_exists` and `schema_exists_trino` |
+| R1: Migration test pending trigger events | `OperationalError: cannot ALTER TABLE` | Use raw SQL INSERT + `SET CONSTRAINTS ALL IMMEDIATE` |
+| R2: Trino connection in E2E tests | `ConnectionError` on pipeline | Mock `trino_table_exists` + `schema_exists_trino` |
+| R3: `information_schema` false positives | Tables from other schemas | Add `AND table_schema = current_schema()` to all `information_schema` queries |
+| R4: Invalid UUID in pipeline mocks | `ValueError: badly formed UUID` | Mock `masu.processor.tasks.Provider` in write-freeze tests |
+| R5: Test execution time (3× pipeline) | CI slowdown | Use targeted test discovery; parallelize per module |
 
 ---
 
-## 10. Deployment Strategy
+## 11. Deliberate Deviations from Spec
 
-**TL requirement**: Migrations are split from business logic in
-separate commits. Migrations deploy first; business logic rolls out
-incrementally after.
+| Deviation | Spec Says | Implementation Does | Rationale |
+|-----------|-----------|-------------------|-----------|
+| Pipeline placeholder tests | Full behavioral coverage | TC-72 through TC-76 are placeholders deferring to E2E | E2E tests (TC-90/TC-91) provide stronger assurance than mocked unit tests for pipeline ordering |
+| Audit trigger test | BAC-31 requires verification | TC-57 is a placeholder | M5 audit trigger migration is proposed but not yet implemented |
+| CostModelContextPermission pass-through | Spec requires gating on context | Permission returns `True` when `cost_model_context` not in query params | Prevents 403 errors on existing API clients that don't send the parameter |
 
-Each phase produces **two commit groups**:
-1. **Migration commit** — DDL only. Must be backward-compatible with current code.
-2. **Logic commit(s)** — Python code changes. Can be reverted independently.
+---
 
-**Backward-compatibility constraint**: Migrations must not break
-existing code. This is why `cost_model_context` is nullable
-(`NULL` = default) — existing code that doesn't pass a context
-continues to work against the new schema.
+## 12. Approval
+
+| Role | Name | Date | Signature |
+|------|------|------|-----------|
+| Author | — | 2026-04-09 | — |
+| Reviewer | — | — | — |
+| Tech Lead | — | — | — |
 
 ---
 
@@ -361,5 +623,5 @@ continues to work against the new schema.
 
 | Version | Date | Summary |
 |---------|------|---------|
-| v1.0 | 2026-04-08 | Initial IEEE 829 test plan: 97 test cases, 30 BACs |
-| v2.0 | 2026-04-09 | Design proposal: added write-freeze BACs (32-38), write-freeze TCs (88-91), updated test deliverables with `test_context_write_freeze.py`, expanded to 104 test cases and 38 BACs |
+| v1.0 | 2026-04-08 | Initial IEEE 829 test plan |
+| v2.0 | 2026-04-09 | Full rewrite: BDD Given/When/Then for all 82 test cases derived from implementation code; correct BAC-to-phase mapping; add write-freeze TCs; add test plan identifier, approval section, deliberate deviations, implementation phases with checkpoints |

--- a/docs/architecture/consumer-provider-cost-models/test-plan.md
+++ b/docs/architecture/consumer-provider-cost-models/test-plan.md
@@ -1,0 +1,365 @@
+# Test Plan — COST-3920 Consumer-Provider Cost Models
+
+**Parent**: [README.md](README.md) · **Status**: Design Proposal
+**Template**: IEEE 829-2008
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+This test plan defines the verification and validation strategy for
+COST-3920 (Consumer-Provider Cost Models). It covers all phases of
+the feature with behavioral acceptance criteria, following koku
+testing conventions.
+
+### 1.2 Scope
+
+Tests will cover:
+- Context entity CRUD (model, serializer, viewset)
+- Assignment with context (CostModelMap, manager)
+- Schema migrations (forward/reverse, data migration, backfill)
+- Per-context pipeline execution (accessor, updater, SQL templates)
+- API integration (query parameter, response filtering)
+- RBAC (Koku-side authorization, context permission)
+- Write-freeze guards (Unleash flag, serializer, pipeline)
+- Cross-context data isolation
+
+### 1.3 Definitions
+
+| Term | Definition |
+|------|-----------|
+| **Context** | A `CostModelContext` instance (e.g., "Consumer", "Provider") |
+| **BAC** | Business Acceptance Criterion |
+| **TC** | Test Case |
+| **TDD** | Test-Driven Development (Red/Green/Refactor) |
+
+---
+
+## 2. Test Items
+
+### 2.1 Models Layer (6 components)
+
+- `CostModelContext` — **NEW**
+- `CostModelMap` + `cost_model_context` FK — **MODIFIED**
+- Migrations M1-M7 — **NEW** (cost_models + reporting)
+- `reporting_ocpusagelineitem_daily_summary` + `cost_model_context` — **MODIFIED**
+- 13 `reporting_ocp_*_summary_p` tables + `cost_model_context` — **MODIFIED**
+- `CostModelAudit` trigger — **MODIFIED**
+
+### 2.2 Manager + Serializer Layer (4 components)
+
+- `CostModelManager.update_provider_uuids` — **MODIFIED**
+- `CostModelSerializer.create/update` — **MODIFIED**
+- `CostModelContextSerializer` — **NEW**
+- `CostModelContextViewSet` — **NEW**
+
+### 2.3 Pipeline Layer (6 components)
+
+- `CostModelDBAccessor.cost_model` — **MODIFIED**
+- `OCPCostModelCostUpdater` — **MODIFIED**
+- `update_cost_model_costs` task + cache key — **MODIFIED**
+- `OCPReportDBAccessor.populate_ui_summary_tables` — **MODIFIED**
+- Distribution SQL orchestration — **MODIFIED**
+- `TableExportSetting` — **MODIFIED**
+
+### 2.4 SQL Layer (49+ artifacts)
+
+- 16 cost model SQL (`sql/openshift/cost_model/`)
+- 9 self-hosted cost model SQL (`self_hosted_sql/openshift/cost_model/`)
+- 9 Trino cost model SQL (`trino_sql/openshift/cost_model/`)
+- 13 UI summary SQL (`sql/openshift/ui_summary/`)
+- 2 UI summary usage-only variants (self-hosted + Trino)
+
+### 2.5 API + RBAC Layer (6 components)
+
+- `OCPQueryParamSerializer` — **MODIFIED**
+- `OCPProviderMap` — **MODIFIED**
+- `CostModelContextPermission` — **NEW**
+- `OCPReportQueryHandler` — **MODIFIED**
+- Currency annotation — **MODIFIED**
+- `CostModelContextView` — **NEW**
+
+### 2.6 Write-Freeze Layer (3 components)
+
+- `is_context_writes_disabled()` — **NEW** (`masu/processor/__init__.py`)
+- `CostModelContextSerializer._check_context_write_freeze()` — **NEW**
+- `update_cost_model_costs` pipeline guard — **MODIFIED**
+
+---
+
+## 3. Business Acceptance Criteria (38 BACs)
+
+### Phase 1 — Context Entity + Schema (10 BACs)
+
+| BAC | Description |
+|-----|------------|
+| BAC-1 | `CostModelContext.objects.create()` succeeds with valid name/display_name |
+| BAC-2 | Max 3 contexts per tenant enforced (4th creation raises `ValidationError`) |
+| BAC-3 | Exactly one default context per tenant (partial unique index on `is_default=TRUE`) |
+| BAC-4 | Default context cannot be deleted (raises `ValidationError`) |
+| BAC-5 | `CostModelMap` accepts multiple rows for same provider with different contexts |
+| BAC-6 | `CostModelMap` rejects duplicate `(provider_uuid, cost_model_context)` pair (DB `IntegrityError`) |
+| BAC-7 | `update_provider_uuids` allows same provider in different contexts |
+| BAC-8 | `update_provider_uuids` rejects same provider+context twice (descriptive error) |
+| BAC-9 | Data migration creates default "Consumer" context per tenant schema |
+| BAC-10 | Data migration assigns all existing `CostModelMap` rows to default context |
+
+### Phase 2 — Reporting Schema + Backfill (12 BACs)
+
+| BAC | Description |
+|-----|------------|
+| BAC-11 | `CostModelDBAccessor(context=X)` returns correct cost model for that context |
+| BAC-12 | `CostModelDBAccessor(context=None)` falls back to `.first()` (backward-compatible) |
+| BAC-13 | Pipeline executes per-context with context-specific rates |
+| BAC-14 | SQL DELETE scopes by `cost_model_context` — does NOT delete other contexts' rows |
+| BAC-15 | SQL INSERT includes `cost_model_context` value in all new rows |
+| BAC-16 | UI summary DELETE scopes by `cost_model_context` — prevents cross-context data loss |
+| BAC-17 | UI summary GROUP BY includes `cost_model_context` |
+| BAC-18 | Distribution SQL scopes by `cost_model_context` |
+| BAC-19 | Celery cache key includes context — allows parallel per-context tasks |
+| BAC-20 | Self-hosted SQL variants include `cost_model_context` in all DML |
+| BAC-21 | Python inline SQL handles context parameter |
+| BAC-22 | Cloud rows (`cost_model_rate_type = NULL`) are untouched by context scoping |
+
+### Phase 3 — Pipeline + SQL (6 BACs)
+
+| BAC | Description |
+|-----|------------|
+| BAC-23 | `cost_model_context` query parameter accepted on all OCP report endpoints |
+| BAC-24 | Report response filters cost data by requested context |
+| BAC-25 | `CostModelContextPermission` allows admin bypass (`ENHANCED_ORG_ADMIN`) |
+| BAC-26 | `CostModelContextPermission` denies access to unpermitted contexts |
+| BAC-27 | Currency annotation joins through context-specific `CostModelMap` row |
+| BAC-28 | Report views enforce context visibility (when context explicitly requested) |
+
+### Phase 4 — API + RBAC (3 BACs)
+
+| BAC | Description |
+|-----|------------|
+| BAC-29 | Audit trigger captures context array alongside provider_uuids |
+| BAC-30 | Empty context (no cost model) shows usage at $0 cost |
+| BAC-31 | Backfill migration sets `cost_model_context = 'default'` on all cost-model rows |
+
+### Phase 5 — Write-Freeze + Data Consistency (7 BACs)
+
+| BAC | Description |
+|-----|------------|
+| BAC-32 | Context creation returns 400 when write-freeze Unleash flag is active |
+| BAC-33 | Context update returns 400 when write-freeze flag is active |
+| BAC-34 | Context read/list succeeds during write-freeze (reads are not blocked) |
+| BAC-35 | Context creation succeeds when write-freeze flag is disabled |
+| BAC-36 | Pipeline skips context-tagged writes when write-freeze is active |
+| BAC-37 | Pipeline executes normally when write-freeze flag is disabled |
+| BAC-38 | Pipeline runs for None context (legacy path) without triggering write-freeze guard |
+
+---
+
+## 4. Approach
+
+### 4.1 Test Tiers
+
+| Tier | Description | Base Class | Coverage Target |
+|------|-------------|------------|-----------------|
+| T1: Unit | Model validation, serializer logic, permission checks, manager guards | `IamTestCase` | >=85% |
+| T2: Integration | SQL execution, accessor methods, migration forward/reverse, DB constraints | `MasuTestCase` | >=80% |
+| T3: E2E | End-to-end orchestration, API request/response, pipeline order, cross-context isolation | `MasuTestCase` | >=80% |
+
+### 4.2 TDD Process
+
+Each test case follows Red/Green/Refactor:
+
+1. **Red**: Write failing test that asserts expected BAC behavior
+2. **Green**: Write minimal implementation to make the test pass
+3. **Refactor**: Clean up code; verify tests still pass; lint check
+
+### 4.3 Anti-Pattern Avoidance
+
+Following koku testing conventions:
+- Use `baker.make()` not `Model.objects.create()`
+- Use parenthesized `with (patch(...), patch(...)):` not nested `with`
+- Use `schema_context` + `subTest` for multi-scenario
+- Assert param dicts and table names, not SQL strings
+- Each test opens its own accessor context manager
+- Test via public API; private method tests only where business logic requires
+- Deterministic rate values; reserve random for property-based tests
+
+---
+
+## 5. Test Cases (104 total)
+
+### T1: Unit Tests (~35 test cases)
+
+| TC | BAC | Description |
+|----|-----|------------|
+| TC-01 | BAC-1 | Create context with valid name and display_name |
+| TC-02 | BAC-1 | Context name uniqueness per tenant |
+| TC-03 | BAC-2 | Fourth context creation raises ValidationError |
+| TC-04 | BAC-3 | Two default contexts raises IntegrityError (partial unique index) |
+| TC-05 | BAC-4 | Delete default context raises ValidationError |
+| TC-06 | BAC-5 | CostModelMap allows same provider with different contexts |
+| TC-07 | BAC-6 | CostModelMap rejects duplicate (provider_uuid, context) |
+| TC-08 | BAC-7 | update_provider_uuids allows same provider in different contexts |
+| TC-09 | BAC-8 | update_provider_uuids rejects same provider+context (descriptive error) |
+| TC-10 | BAC-2 | Position CHECK constraint (1-3) on CostModelContext |
+| TC-11 | BAC-25 | CostModelContextPermission allows ENHANCED_ORG_ADMIN |
+| TC-12 | BAC-26 | CostModelContextPermission denies when no cost_model.read access |
+| TC-13 | BAC-26 | CostModelContextPermission passes when cost_model_context not in query_params |
+| TC-14 | BAC-23 | OCPQueryParamSerializer accepts cost_model_context parameter |
+| TC-15 | BAC-23 | OCPQueryParamSerializer validates cost_model_context length |
+| TC-16 | BAC-32 | CostModelContextSerializer._check_context_write_freeze blocks create |
+| TC-17 | BAC-33 | CostModelContextSerializer._check_context_write_freeze blocks update |
+| TC-18 | BAC-34 | Context list/retrieve succeeds during write-freeze |
+| TC-19 | BAC-35 | Context create succeeds when freeze flag is disabled |
+| TC-20 | BAC-30 | Empty context returns zero cost (no cost model assigned) |
+| TC-21 | BAC-4 | Delete non-default context succeeds |
+| TC-22 | BAC-1 | CostModelContext display_name max_length enforcement |
+| TC-23 | BAC-3 | Setting new default also unsets old default |
+| TC-24 | BAC-6 | CostModelMap null context (legacy row) coexists with named contexts |
+| TC-25 | BAC-27 | Currency annotation uses context-specific cost model currency |
+| TC-26 | BAC-28 | Report view denies when context explicitly requested and user lacks access |
+| TC-27 | BAC-28 | Report view allows when context not in query params (pass-through) |
+| TC-28 | BAC-1 | Context CRUD API: POST /api/v1/cost-model-contexts/ |
+| TC-29 | BAC-1 | Context CRUD API: GET /api/v1/cost-model-contexts/ |
+| TC-30 | BAC-1 | Context CRUD API: PUT /api/v1/cost-model-contexts/{uuid}/ |
+| TC-31 | BAC-9 | Migration forward: default context created per tenant |
+| TC-32 | BAC-10 | Migration forward: existing CostModelMap rows assigned default context |
+| TC-33 | BAC-9 | Migration reverse: context removed cleanly |
+| TC-34 | BAC-31 | Backfill migration: cost_model_context = 'default' on daily summary |
+| TC-35 | BAC-31 | Backfill migration: cost_model_context = 'default' on all 13 UI summary tables |
+
+### T2: Integration Tests (~40 test cases)
+
+| TC | BAC | Description |
+|----|-----|------------|
+| TC-36 | BAC-11 | CostModelDBAccessor(context='consumer') returns consumer's cost model |
+| TC-37 | BAC-11 | CostModelDBAccessor(context='provider') returns provider's cost model |
+| TC-38 | BAC-12 | CostModelDBAccessor(context=None) returns first cost model |
+| TC-39 | BAC-14 | SQL DELETE scopes by cost_model_context (standard path) |
+| TC-40 | BAC-14 | SQL DELETE scopes by cost_model_context (self-hosted path) |
+| TC-41 | BAC-14 | SQL DELETE scopes by cost_model_context (Trino path) |
+| TC-42 | BAC-15 | SQL INSERT includes cost_model_context in output rows |
+| TC-43 | BAC-16 | UI summary DELETE scopes by cost_model_context |
+| TC-44 | BAC-17 | UI summary GROUP BY includes cost_model_context |
+| TC-45 | BAC-18 | Distribution SQL passes cost_model_context parameter |
+| TC-46 | BAC-20 | Self-hosted SQL variants include cost_model_context |
+| TC-47 | BAC-21 | Python inline SQL DELETE handles cost_model_context |
+| TC-48 | BAC-22 | Cloud rows (rate_type NULL) unaffected by context scoping |
+| TC-49 | BAC-13 | Pipeline produces correct cost values for context 'consumer' |
+| TC-50 | BAC-13 | Pipeline produces correct cost values for context 'provider' |
+| TC-51 | BAC-14 | Context A pipeline run does not delete context B rows |
+| TC-52 | BAC-19 | Worker cache key includes cost_model_context |
+| TC-53 | BAC-29 | Audit trigger includes context in audit row |
+| TC-54 | BAC-36 | Pipeline task returns early when write-freeze active and context is set |
+| TC-55 | BAC-37 | Pipeline task runs updater when write-freeze is disabled |
+| TC-56 | BAC-38 | Pipeline task runs for None context regardless of write-freeze |
+| TC-57 | BAC-31 | Backfill migration reverse: cost_model_context set back to NULL |
+| TC-58-70 | BAC-15 | SQL template parameter assertions for each of 13 UI summary SQL files |
+| TC-71-75 | BAC-14 | SQL template DELETE WHERE assertions (5 cost model SQL categories) |
+
+### T3: E2E Tests (~29 test cases)
+
+| TC | BAC | Description |
+|----|-----|------------|
+| TC-76 | BAC-13 | Full pipeline run: create 2 contexts, assign cost models, run pipeline, verify per-context rows in daily summary |
+| TC-77 | BAC-14 | Full pipeline run: verify re-run for context A does not affect context B |
+| TC-78 | BAC-24 | API request with cost_model_context=consumer returns only consumer cost data |
+| TC-79 | BAC-24 | API request without cost_model_context returns all cost data |
+| TC-80 | BAC-19 | Parallel context tasks: dispatch 2 tasks for same provider, different contexts — both complete without cache collision |
+| TC-81 | BAC-9 | Migration E2E: fresh tenant gets default context + assignment |
+| TC-82 | BAC-22 | Cloud infrastructure costs appear in all context responses unchanged |
+| TC-83 | BAC-30 | Context with no cost model: API returns usage at $0 |
+| TC-84 | BAC-16 | UI summary: two contexts produce distinct rollup rows |
+| TC-85 | BAC-17 | UI summary: GROUP BY context produces correct aggregation |
+| TC-86 | BAC-25 | Admin user accesses all contexts via API |
+| TC-87 | BAC-26 | Non-admin user denied context access when lacking cost_model.read |
+| TC-88 | BAC-32 | API POST /cost-model-contexts/ returns 400 during write-freeze |
+| TC-89 | BAC-33 | API PUT /cost-model-contexts/{uuid}/ returns 400 during write-freeze |
+| TC-90 | BAC-34 | API GET /cost-model-contexts/ succeeds during write-freeze |
+| TC-91 | BAC-36 | Pipeline skip during write-freeze: no new rows inserted |
+| TC-92 | BAC-10 | Assignment migration: multi-provider tenant gets all CostModelMap rows updated |
+| TC-93 | BAC-31 | Backfill E2E: daily summary + 13 UI tables all backfilled correctly |
+| TC-94 | BAC-8 | API assign same provider+context twice returns descriptive error |
+| TC-95 | BAC-4 | API DELETE default context returns 400 with descriptive error |
+| TC-96 | BAC-13 | Multi-tenant isolation: tenant A's contexts do not leak to tenant B |
+| TC-97 | BAC-18 | Distribution with context: platform/worker costs distributed per-context |
+| TC-98-104 | Various | Regression tests for existing cost model functionality (no regressions from context changes) |
+
+---
+
+## 6. Pass/Fail Criteria
+
+- All T1 tests pass (unit)
+- All T2 tests pass (integration)
+- All T3 tests pass (E2E)
+- Zero net new regressions in existing `cost_models` test suite
+- Zero net new regressions in existing `masu.processor` test suite
+- Coverage per tier >= 80% of testable code
+- All migrations are reversible
+
+---
+
+## 7. Test Deliverables
+
+### Proposed test files
+
+| File | Scope | Tier |
+|------|-------|------|
+| `cost_models/test/test_cost_model_context.py` | Context model, serializer, max 3, default protection | T1 |
+| `cost_models/test/test_cost_model_context_view.py` | Context CRUD API | T1, T3 |
+| `cost_models/test/test_context_assignment.py` | Manager per-context, CostModelMap constraints | T1, T2 |
+| `cost_models/test/test_context_migration.py` | Forward/reverse migration, per-tenant data migration | T2 |
+| `cost_models/test/test_context_write_freeze.py` | Write-freeze API and pipeline guards | T1, T2, T3 |
+| `masu/test/processor/ocp/test_context_pipeline.py` | Per-context pipeline orchestration, concurrency | T2, T3 |
+| `masu/test/database/test_context_sql.py` | SQL context scoping (standard, self-hosted, Trino) | T2 |
+| `masu/test/database/test_context_ui_summary.py` | UI summary cross-context isolation | T2, T3 |
+| `api/report/test/ocp/test_context_api.py` | Report API with context parameter | T1, T3 |
+| `api/common/permissions/test_context_permission.py` | Hybrid RBAC, edge cases | T1 |
+| `cost_models/test/test_context_e2e.py` | Full pipeline E2E orchestration | T3 |
+
+---
+
+## 8. Environmental Needs
+
+- PostgreSQL with tenant schemas (Django Tenants)
+- `MasuTestCase` / `IamTestCase` test infrastructure
+- `model_bakery` for fixture creation
+- `unittest.mock.patch` for Unleash flag mocking
+- No Trino required (Trino paths mocked in tests)
+
+---
+
+## 9. Risks and Contingencies
+
+| Risk | Impact | Contingency |
+|------|--------|------------|
+| Test execution time increase (3× pipeline runs) | CI slowdown | Parallelize per-context tests; use targeted test discovery |
+| Migration test fragility | Flaky CI | Use raw SQL + `SET CONSTRAINTS ALL IMMEDIATE` pattern |
+| Trino connection in tests | Test failure | Mock `trino_table_exists` and `schema_exists_trino` |
+
+---
+
+## 10. Deployment Strategy
+
+**TL requirement**: Migrations are split from business logic in
+separate commits. Migrations deploy first; business logic rolls out
+incrementally after.
+
+Each phase produces **two commit groups**:
+1. **Migration commit** — DDL only. Must be backward-compatible with current code.
+2. **Logic commit(s)** — Python code changes. Can be reverted independently.
+
+**Backward-compatibility constraint**: Migrations must not break
+existing code. This is why `cost_model_context` is nullable
+(`NULL` = default) — existing code that doesn't pass a context
+continues to work against the new schema.
+
+---
+
+## Changelog
+
+| Version | Date | Summary |
+|---------|------|---------|
+| v1.0 | 2026-04-08 | Initial IEEE 829 test plan: 97 test cases, 30 BACs |
+| v2.0 | 2026-04-09 | Design proposal: added write-freeze BACs (32-38), write-freeze TCs (88-91), updated test deliverables with `test_context_write_freeze.py`, expanded to 104 test cases and 38 BACs |

--- a/docs/architecture/consumer-provider-cost-models/test-plan.md
+++ b/docs/architecture/consumer-provider-cost-models/test-plan.md
@@ -5,7 +5,7 @@
 | Field | Value |
 |-------|-------|
 | Test Plan Identifier | COST-3920-TP-001 |
-| Version | 3.1 |
+| Version | 3.2 |
 | Date | 2026-04-09 |
 | Author | COST-3920 Engineering |
 | Status | Design Proposal |
@@ -203,7 +203,7 @@ Full IEEE 829 Test Case Specifications (with structured
 Given/When/Then scenarios, test items, dependencies, and special
 requirements) are in the per-tier companion documents:
 
-- **[test-cases-t1-unit.md](./test-cases-t1-unit.md)** — 25 unit tests (model, serializer, permission, manager)
+- **[test-cases-t1-unit.md](./test-cases-t1-unit.md)** — 24 unit tests + 1 supplemental backward-compat scenario (model, serializer, permission, manager)
 - **[test-cases-t2-integration.md](./test-cases-t2-integration.md)** — 34 integration tests (SQL, accessor, migration, DB constraints, pipeline)
 - **[test-cases-t3-e2e.md](./test-cases-t3-e2e.md)** — 24 E2E tests (full pipeline, API, cross-context isolation, write-freeze)
 
@@ -245,7 +245,7 @@ requirements) are in the per-tier companion documents:
 | [TC-13](./test-cases-t1-unit.md#tc-13-default-context-not-deletable-via-serializermodel-guard) | BAC-4 | Default context exists | `default_ctx.delete()` | `ValidationError` or `IntegrityError` raised |
 | [TC-14](./test-cases-t1-unit.md#tc-14-costmodelserializer-accepts-context-uuid) | BAC-5 | Default context exists | `CostModelSerializer(data={..., "cost_model_context": str(ctx.uuid)}).is_valid()` | Returns `True` — context UUID accepted |
 | [TC-15](./test-cases-t1-unit.md#tc-15-costmodelserializer-defaults-context-when-absent) | BAC-7 | Default context exists; no `cost_model_context` in data | `CostModelSerializer(data={..., no context field}).is_valid()` | Returns `True` — defaults to tenant's default context |
-| [TC-XX](./test-cases-t1-unit.md#tc-xx-backward-compatible-cost-model-creation-without-context) | BAC-7 | Default context exists; no `cost_model_context` in data | `serializer.save()` | Instance created successfully — backward-compatible |
+| [TC-XX](./test-cases-t1-unit.md#tc-xx-backward-compatible-cost-model-creation-without-context) *(supplemental)* | BAC-7 | Default context exists; no `cost_model_context` in data | `serializer.save()` | Instance created successfully — backward-compatible |
 
 ---
 
@@ -303,7 +303,11 @@ requirements) are in the per-tier companion documents:
 |----|-----|-------|------|------|
 | [TC-70](./test-cases-t2-integration.md#tc-70-pipeline-dispatches-once-per-context) | BAC-16 | 2 contexts ("consumer", "provider"); `CostModelCostUpdater` mocked | `update_cost_model_costs(..., synchronous=True)` with no explicit context | `mock_updater.update_cost_model_costs.call_count >= 2` — dispatched per context |
 | [TC-71](./test-cases-t2-integration.md#tc-71-accessor-resolves-correct-rates-per-context) | BAC-14 | Context "default" with cost model ($10 CPU rate); `CostModelMap` assigned | `CostModelDBAccessor(schema, uuid, cost_model_context="default")` | `accessor.cost_model == cm_consumer` — correct model resolved |
-| [TC-72–76](./test-cases-t2-integration.md#tc-72-through-tc-76-placeholder-tests) | BAC-17,32,24 | — | — | Placeholders — covered by E2E TC-91, TC-93, TC-98, TC-99 |
+| [TC-72](./test-cases-t2-integration.md#tc-72-pipeline-step-order-placeholder) | BAC-17 | — | — | Placeholder — covered by E2E TC-91 |
+| [TC-73](./test-cases-t2-integration.md#tc-73-empty-context-zero-cost-placeholder) | BAC-32 | — | — | Placeholder — covered by E2E TC-93 |
+| [TC-74](./test-cases-t2-integration.md#tc-74-empty-context-preserves-usage-placeholder) | BAC-32 | — | — | Placeholder — covered by E2E TC-93 |
+| [TC-75](./test-cases-t2-integration.md#tc-75-sequential-runs-no-corruption-placeholder) | BAC-17 | — | — | Placeholder — covered by E2E TC-91, TC-98 |
+| [TC-76](./test-cases-t2-integration.md#tc-76-cloud-infra-in-all-contexts-placeholder) | BAC-24 | — | — | Placeholder — covered by E2E TC-99 |
 
 #### Class: `AuditTriggerContextTest` — T2 Integration
 
@@ -632,3 +636,4 @@ acceptance, report filtering, CRUD lifecycle, and write-freeze guards.
 | v2.0 | 2026-04-09 | Full rewrite: BDD Given/When/Then for all 82 test cases derived from implementation code; correct BAC-to-phase mapping; add write-freeze TCs; add test plan identifier, approval section, deliberate deviations, implementation phases with checkpoints |
 | v3.0 | 2026-04-09 | IEEE 829 compliance: split detailed test case specifications into per-tier companion documents (T1/T2/T3) with full Given/When/Then blocks; test-plan.md retains summary tables with links to specs |
 | v3.1 | 2026-04-09 | Add deep links from every TC identifier in summary tables to its corresponding heading in the per-tier companion documents |
+| v3.2 | 2026-04-09 | Normalize tier counts to maintain 82 canonical tests (TC-XX marked supplemental) and split TC-72..TC-76 into individually linkable summary rows |

--- a/docs/architecture/consumer-provider-cost-models/test-plan.md
+++ b/docs/architecture/consumer-provider-cost-models/test-plan.md
@@ -5,7 +5,7 @@
 | Field | Value |
 |-------|-------|
 | Test Plan Identifier | COST-3920-TP-001 |
-| Version | 3.0 |
+| Version | 3.1 |
 | Date | 2026-04-09 |
 | Author | COST-3920 Engineering |
 | Status | Design Proposal |
@@ -213,39 +213,39 @@ requirements) are in the per-tier companion documents:
 
 | TC | BAC | Given | When | Then |
 |----|-----|-------|------|------|
-| TC-01 | BAC-1 | Tenant schema with no contexts | `baker.make("CostModelContext", name="provider", display_name="Provider", position=2, is_default=False)` | Context persists with correct `name`, `display_name`, `position`, `uuid`, `created_timestamp` |
-| TC-02 | BAC-2 | 3 contexts already exist (positions 1-3) | `baker.make("CostModelContext", position=4)` inside `transaction.atomic()` | `IntegrityError` raised (DB CHECK constraint rejects position > 3) |
-| TC-03 | BAC-3 | 1 context with `is_default=True` exists | `baker.make("CostModelContext", is_default=True)` inside `transaction.atomic()` | `IntegrityError` raised (partial unique index blocks 2nd default) |
-| TC-04a | BAC-2 | Empty tenant schema | Create contexts with positions 1, 2, 3 sequentially | All 3 persist with correct positions |
-| TC-04b | BAC-2 | Empty tenant schema | Create context with position 0, 4, or -1 inside `transaction.atomic()` | `IntegrityError` for each invalid position |
-| TC-05a | BAC-4 | Context with `is_default=True` exists | `default_ctx.delete()` | `ValidationError` or `IntegrityError` raised — deletion blocked |
-| TC-05b | BAC-4 | Non-default context exists | `ctx.delete()` | Context deleted; `CostModelContext.objects.filter(uuid=ctx_uuid).exists()` returns `False` |
+| [TC-01](./test-cases-t1-unit.md#tc-01-context-creation-with-valid-data) | BAC-1 | Tenant schema with no contexts | `baker.make("CostModelContext", name="provider", display_name="Provider", position=2, is_default=False)` | Context persists with correct `name`, `display_name`, `position`, `uuid`, `created_timestamp` |
+| [TC-02](./test-cases-t1-unit.md#tc-02-max-3-contexts-enforced-by-db-check) | BAC-2 | 3 contexts already exist (positions 1-3) | `baker.make("CostModelContext", position=4)` inside `transaction.atomic()` | `IntegrityError` raised (DB CHECK constraint rejects position > 3) |
+| [TC-03](./test-cases-t1-unit.md#tc-03-one-default-context-enforced-by-partial-unique-index) | BAC-3 | 1 context with `is_default=True` exists | `baker.make("CostModelContext", is_default=True)` inside `transaction.atomic()` | `IntegrityError` raised (partial unique index blocks 2nd default) |
+| [TC-04a](./test-cases-t1-unit.md#tc-04a-valid-positions-1-2-3-accepted) | BAC-2 | Empty tenant schema | Create contexts with positions 1, 2, 3 sequentially | All 3 persist with correct positions |
+| [TC-04b](./test-cases-t1-unit.md#tc-04b-invalid-positions-0-4--1-rejected) | BAC-2 | Empty tenant schema | Create context with position 0, 4, or -1 inside `transaction.atomic()` | `IntegrityError` for each invalid position |
+| [TC-05a](./test-cases-t1-unit.md#tc-05a-default-context-deletion-is-blocked) | BAC-4 | Context with `is_default=True` exists | `default_ctx.delete()` | `ValidationError` or `IntegrityError` raised — deletion blocked |
+| [TC-05b](./test-cases-t1-unit.md#tc-05b-non-default-context-deletion-is-allowed) | BAC-4 | Non-default context exists | `ctx.delete()` | Context deleted; `CostModelContext.objects.filter(uuid=ctx_uuid).exists()` returns `False` |
 
 #### Class: `CostModelMapContextTest` — T1 Unit
 
 | TC | BAC | Given | When | Then |
 |----|-----|-------|------|------|
-| TC-09 | BAC-5 | Two contexts ("consumer", "provider") and one cost model | Create 2 `CostModelMap` rows for same `provider_uuid` with different contexts | Both rows persist; `CostModelMap.objects.filter(provider_uuid=uuid).count() == 2` |
-| TC-10 | BAC-6 | One `CostModelMap` row exists for `(provider_uuid, context)` | Create second `CostModelMap` for same `(provider_uuid, context)` inside `transaction.atomic()` | `IntegrityError` raised (unique constraint) |
+| [TC-09](./test-cases-t1-unit.md#tc-09-same-provider-with-different-contexts-allowed) | BAC-5 | Two contexts ("consumer", "provider") and one cost model | Create 2 `CostModelMap` rows for same `provider_uuid` with different contexts | Both rows persist; `CostModelMap.objects.filter(provider_uuid=uuid).count() == 2` |
+| [TC-10](./test-cases-t1-unit.md#tc-10-duplicate-provider--context-rejected) | BAC-6 | One `CostModelMap` row exists for `(provider_uuid, context)` | Create second `CostModelMap` for same `(provider_uuid, context)` inside `transaction.atomic()` | `IntegrityError` raised (unique constraint) |
 
 #### Class: `CostModelManagerContextTest` — T1 Unit
 
 | TC | BAC | Given | When | Then |
 |----|-----|-------|------|------|
-| TC-06 | BAC-7 | Two contexts exist; cost model 1 assigned to consumer | `CostModelManager(cm2).update_provider_uuids([uuid], cost_model_context=provider)` | Succeeds; 2 `CostModelMap` rows for same provider |
-| TC-07 | BAC-8 | Context exists; cost model 1 already assigned to `(uuid, ctx)` | `CostModelManager(cm2).update_provider_uuids([uuid], cost_model_context=ctx)` | `CostModelException` raised with descriptive message |
-| TC-08 | BAC-7 | Default context exists; `cost_model_context` not passed | `CostModelManager(cm).update_provider_uuids([uuid])` | `CostModelMap.cost_model_context.name == "default"` — auto-resolved |
+| [TC-06](./test-cases-t1-unit.md#tc-06-manager-allows-same-provider-in-different-contexts) | BAC-7 | Two contexts exist; cost model 1 assigned to consumer | `CostModelManager(cm2).update_provider_uuids([uuid], cost_model_context=provider)` | Succeeds; 2 `CostModelMap` rows for same provider |
+| [TC-07](./test-cases-t1-unit.md#tc-07-manager-rejects-same-provider--same-context) | BAC-8 | Context exists; cost model 1 already assigned to `(uuid, ctx)` | `CostModelManager(cm2).update_provider_uuids([uuid], cost_model_context=ctx)` | `CostModelException` raised with descriptive message |
+| [TC-08](./test-cases-t1-unit.md#tc-08-manager-defaults-to-tenants-default-context-when-none) | BAC-7 | Default context exists; `cost_model_context` not passed | `CostModelManager(cm).update_provider_uuids([uuid])` | `CostModelMap.cost_model_context.name == "default"` — auto-resolved |
 
 #### Class: `CostModelContextSerializerTest` — T1 Unit
 
 | TC | BAC | Given | When | Then |
 |----|-----|-------|------|------|
-| TC-11 | BAC-1 | Default context exists | `CostModelContextSerializer(data={"name": "provider", "display_name": "Provider"}).is_valid()` | Returns `True` |
-| TC-12 | BAC-2 | 3 contexts already exist | `CostModelContextSerializer(data={"name": "c4", "display_name": "C4"}).is_valid()` | Returns `False` — 4th rejected |
-| TC-13 | BAC-4 | Default context exists | `default_ctx.delete()` | `ValidationError` or `IntegrityError` raised |
-| TC-14 | BAC-5 | Default context exists | `CostModelSerializer(data={..., "cost_model_context": str(ctx.uuid)}).is_valid()` | Returns `True` — context UUID accepted |
-| TC-15 | BAC-7 | Default context exists; no `cost_model_context` in data | `CostModelSerializer(data={..., no context field}).is_valid()` | Returns `True` — defaults to tenant's default context |
-| TC-XX | BAC-7 | Default context exists; no `cost_model_context` in data | `serializer.save()` | Instance created successfully — backward-compatible |
+| [TC-11](./test-cases-t1-unit.md#tc-11-serializer-accepts-valid-context-data) | BAC-1 | Default context exists | `CostModelContextSerializer(data={"name": "provider", "display_name": "Provider"}).is_valid()` | Returns `True` |
+| [TC-12](./test-cases-t1-unit.md#tc-12-serializer-rejects-4th-context) | BAC-2 | 3 contexts already exist | `CostModelContextSerializer(data={"name": "c4", "display_name": "C4"}).is_valid()` | Returns `False` — 4th rejected |
+| [TC-13](./test-cases-t1-unit.md#tc-13-default-context-not-deletable-via-serializermodel-guard) | BAC-4 | Default context exists | `default_ctx.delete()` | `ValidationError` or `IntegrityError` raised |
+| [TC-14](./test-cases-t1-unit.md#tc-14-costmodelserializer-accepts-context-uuid) | BAC-5 | Default context exists | `CostModelSerializer(data={..., "cost_model_context": str(ctx.uuid)}).is_valid()` | Returns `True` — context UUID accepted |
+| [TC-15](./test-cases-t1-unit.md#tc-15-costmodelserializer-defaults-context-when-absent) | BAC-7 | Default context exists; no `cost_model_context` in data | `CostModelSerializer(data={..., no context field}).is_valid()` | Returns `True` — defaults to tenant's default context |
+| [TC-XX](./test-cases-t1-unit.md#tc-xx-backward-compatible-cost-model-creation-without-context) | BAC-7 | Default context exists; no `cost_model_context` in data | `serializer.save()` | Instance created successfully — backward-compatible |
 
 ---
 
@@ -255,7 +255,7 @@ requirements) are in the per-tier companion documents:
 
 | TC | BAC | Given | When | Then |
 |----|-----|-------|------|------|
-| TC-85 | BAC-30 | Default context exists; authenticated API client | POST `/cost-model-contexts/` → GET list → PUT detail → DELETE detail → GET detail | POST=201 (created); GET=200 (name in list); PUT=200 (display_name updated); DELETE=204; final GET=404 |
+| [TC-85](./test-cases-t3-e2e.md#tc-85-context-crud-api-lifecycle) | BAC-30 | Default context exists; authenticated API client | POST `/cost-model-contexts/` → GET list → PUT detail → DELETE detail → GET detail | POST=201 (created); GET=200 (name in list); PUT=200 (display_name updated); DELETE=204; final GET=404 |
 
 ---
 
@@ -265,12 +265,12 @@ requirements) are in the per-tier companion documents:
 
 | TC | BAC | Given | When | Then |
 |----|-----|-------|------|------|
-| TC-30 | BAC-9 | Schema at `MIGRATE_FROM` with one `CostModel` row | Run forward migration to `MIGRATE_TO_DATA` | `CostModelContext(is_default=True, name="default", display_name="Consumer", position=1)` exists |
-| TC-31 | BAC-10 | Schema at `MIGRATE_FROM` with `CostModelMap` row (raw SQL INSERT) | Run forward migration to `MIGRATE_TO_DATA` | `CostModelMap.cost_model_context` is set, `is_default=True`, `name="default"` |
-| TC-32 | BAC-6 | Schema at `MIGRATE_TO_DATA` with default context | Create 2 `CostModelMap` rows for same `(provider_uuid, context)` | `IntegrityError` — new unique constraint active |
-| TC-33 | BAC-5 | Schema at `MIGRATE_TO_DATA` with 2 contexts | Create 2 `CostModelMap` rows for same `(provider_uuid, cost_model)` but different contexts | Succeeds — old `(provider_uuid, cost_model)` constraint dropped |
-| TC-34 | BAC-9 | Schema at `MIGRATE_TO_DATA` with contexts and map rows | Reverse migration to `MIGRATE_FROM` | `cost_model_context_id` column dropped; `cost_model_context` table dropped; `CostModelMap` row survives |
-| TC-35 | BAC-3 | Schema at `MIGRATE_TO_DATA` with one default context | Create second context with `is_default=True` inside `transaction.atomic()` | `IntegrityError` — partial unique index active |
+| [TC-30](./test-cases-t2-integration.md#tc-30-forward-migration-creates-default-context-per-tenant) | BAC-9 | Schema at `MIGRATE_FROM` with one `CostModel` row | Run forward migration to `MIGRATE_TO_DATA` | `CostModelContext(is_default=True, name="default", display_name="Consumer", position=1)` exists |
+| [TC-31](./test-cases-t2-integration.md#tc-31-forward-migration-assigns-existing-costmodelmap-rows-to-default) | BAC-10 | Schema at `MIGRATE_FROM` with `CostModelMap` row (raw SQL INSERT) | Run forward migration to `MIGRATE_TO_DATA` | `CostModelMap.cost_model_context` is set, `is_default=True`, `name="default"` |
+| [TC-32](./test-cases-t2-integration.md#tc-32-new-unique-constraint-is-active-post-migration) | BAC-6 | Schema at `MIGRATE_TO_DATA` with default context | Create 2 `CostModelMap` rows for same `(provider_uuid, context)` | `IntegrityError` — new unique constraint active |
+| [TC-33](./test-cases-t2-integration.md#tc-33-old-unique-constraint-is-dropped-post-migration) | BAC-5 | Schema at `MIGRATE_TO_DATA` with 2 contexts | Create 2 `CostModelMap` rows for same `(provider_uuid, cost_model)` but different contexts | Succeeds — old `(provider_uuid, cost_model)` constraint dropped |
+| [TC-34](./test-cases-t2-integration.md#tc-34-reverse-migration-removes-context-cleanly) | BAC-9 | Schema at `MIGRATE_TO_DATA` with contexts and map rows | Reverse migration to `MIGRATE_FROM` | `cost_model_context_id` column dropped; `cost_model_context` table dropped; `CostModelMap` row survives |
+| [TC-35](./test-cases-t2-integration.md#tc-35-partial-unique-index-blocks-second-default-after-migration) | BAC-3 | Schema at `MIGRATE_TO_DATA` with one default context | Create second context with `is_default=True` inside `transaction.atomic()` | `IntegrityError` — partial unique index active |
 
 ---
 
@@ -280,18 +280,18 @@ requirements) are in the per-tier companion documents:
 
 | TC | BAC | Given | When | Then |
 |----|-----|-------|------|------|
-| TC-WF1 | BAC-34 | Default context exists; `is_context_writes_disabled` patched to return `True` | POST `/cost-model-contexts/` with `{"name": "provider", "display_name": "Provider"}` | HTTP 400; response body contains "frozen" |
-| TC-WF2 | BAC-35 | Default context exists; freeze flag active | PUT `/cost-model-contexts/{uuid}/` with updated display_name | HTTP 400; response body contains "frozen" |
-| TC-WF3 | BAC-36 | Default context exists; freeze flag active | GET `/cost-model-contexts/` | HTTP 200 — reads not blocked |
-| TC-WF4 | BAC-34 | Default context exists; `is_context_writes_disabled` patched to return `False` | POST `/cost-model-contexts/` with `{"name": "provider", "display_name": "Provider"}` | HTTP 201 — creation proceeds |
+| [TC-WF1](./test-cases-t3-e2e.md#tc-wf1-context-creation-blocked-when-freeze-active) | BAC-34 | Default context exists; `is_context_writes_disabled` patched to return `True` | POST `/cost-model-contexts/` with `{"name": "provider", "display_name": "Provider"}` | HTTP 400; response body contains "frozen" |
+| [TC-WF2](./test-cases-t3-e2e.md#tc-wf2-context-update-blocked-when-freeze-active) | BAC-35 | Default context exists; freeze flag active | PUT `/cost-model-contexts/{uuid}/` with updated display_name | HTTP 400; response body contains "frozen" |
+| [TC-WF3](./test-cases-t3-e2e.md#tc-wf3-context-read-allowed-during-freeze) | BAC-36 | Default context exists; freeze flag active | GET `/cost-model-contexts/` | HTTP 200 — reads not blocked |
+| [TC-WF4](./test-cases-t3-e2e.md#tc-wf4-context-creation-allowed-when-freeze-off) | BAC-34 | Default context exists; `is_context_writes_disabled` patched to return `False` | POST `/cost-model-contexts/` with `{"name": "provider", "display_name": "Provider"}` | HTTP 201 — creation proceeds |
 
 #### Class: `PipelineWriteFreezeTest` — T2 Integration
 
 | TC | BAC | Given | When | Then |
 |----|-----|-------|------|------|
-| TC-WF5 | BAC-37 | Freeze flag active; `CostModelCostUpdater` and `WorkerCache` mocked | `update_cost_model_costs(..., cost_model_context="consumer", synchronous=True)` | `CostModelCostUpdater` never instantiated — pipeline returns early |
-| TC-WF6 | BAC-37 | Freeze flag disabled; `CostModelCostUpdater` and `Provider` mocked | `update_cost_model_costs(..., cost_model_context="consumer", synchronous=True)` | `CostModelCostUpdater` called once — pipeline executes |
-| TC-WF7 | BAC-38 | All `CostModelContext` objects deleted; freeze flag mock tracked | `update_cost_model_costs(..., cost_model_context=None, synchronous=True)` | `is_context_writes_disabled` never called; `CostModelCostUpdater` called once |
+| [TC-WF5](./test-cases-t2-integration.md#tc-wf5-pipeline-skips-context-tagged-writes-when-freeze-active) | BAC-37 | Freeze flag active; `CostModelCostUpdater` and `WorkerCache` mocked | `update_cost_model_costs(..., cost_model_context="consumer", synchronous=True)` | `CostModelCostUpdater` never instantiated — pipeline returns early |
+| [TC-WF6](./test-cases-t2-integration.md#tc-wf6-pipeline-runs-normally-when-freeze-off) | BAC-37 | Freeze flag disabled; `CostModelCostUpdater` and `Provider` mocked | `update_cost_model_costs(..., cost_model_context="consumer", synchronous=True)` | `CostModelCostUpdater` called once — pipeline executes |
+| [TC-WF7](./test-cases-t2-integration.md#tc-wf7-legacy-path-none-context-does-not-trigger-freeze-guard) | BAC-38 | All `CostModelContext` objects deleted; freeze flag mock tracked | `update_cost_model_costs(..., cost_model_context=None, synchronous=True)` | `is_context_writes_disabled` never called; `CostModelCostUpdater` called once |
 
 ---
 
@@ -301,19 +301,15 @@ requirements) are in the per-tier companion documents:
 
 | TC | BAC | Given | When | Then |
 |----|-----|-------|------|------|
-| TC-70 | BAC-16 | 2 contexts ("consumer", "provider"); `CostModelCostUpdater` mocked | `update_cost_model_costs(..., synchronous=True)` with no explicit context | `mock_updater.update_cost_model_costs.call_count >= 2` — dispatched per context |
-| TC-71 | BAC-14 | Context "default" with cost model ($10 CPU rate); `CostModelMap` assigned | `CostModelDBAccessor(schema, uuid, cost_model_context="default")` | `accessor.cost_model == cm_consumer` — correct model resolved |
-| TC-72 | BAC-17 | — | — | Placeholder — covered by E2E TC-91 |
-| TC-73 | BAC-32 | — | — | Placeholder — covered by E2E TC-93 |
-| TC-74 | BAC-32 | — | — | Placeholder — covered by E2E TC-93 |
-| TC-75 | BAC-17 | — | — | Placeholder — covered by E2E TC-91/TC-98 |
-| TC-76 | BAC-24 | — | — | Placeholder — covered by E2E TC-99 |
+| [TC-70](./test-cases-t2-integration.md#tc-70-pipeline-dispatches-once-per-context) | BAC-16 | 2 contexts ("consumer", "provider"); `CostModelCostUpdater` mocked | `update_cost_model_costs(..., synchronous=True)` with no explicit context | `mock_updater.update_cost_model_costs.call_count >= 2` — dispatched per context |
+| [TC-71](./test-cases-t2-integration.md#tc-71-accessor-resolves-correct-rates-per-context) | BAC-14 | Context "default" with cost model ($10 CPU rate); `CostModelMap` assigned | `CostModelDBAccessor(schema, uuid, cost_model_context="default")` | `accessor.cost_model == cm_consumer` — correct model resolved |
+| [TC-72–76](./test-cases-t2-integration.md#tc-72-through-tc-76-placeholder-tests) | BAC-17,32,24 | — | — | Placeholders — covered by E2E TC-91, TC-93, TC-98, TC-99 |
 
 #### Class: `AuditTriggerContextTest` — T2 Integration
 
 | TC | BAC | Given | When | Then |
 |----|-----|-------|------|------|
-| TC-57 | BAC-31 | — | — | Placeholder — M5 audit trigger not yet implemented |
+| [TC-57](./test-cases-t2-integration.md#tc-57-audit-trigger-captures-context-placeholder) | BAC-31 | — | — | Placeholder — M5 audit trigger not yet implemented |
 
 ---
 
@@ -323,40 +319,40 @@ requirements) are in the per-tier companion documents:
 
 | TC | BAC | Given | When | Then |
 |----|-----|-------|------|------|
-| TC-40 | BAC-14 | Context "default" with cost model assigned via `CostModelMap` | `CostModelDBAccessor(schema, uuid, cost_model_context="default")` | `accessor.cost_model == cm` |
-| TC-41 | BAC-15 | Context "default" with cost model assigned; no explicit context param | `CostModelDBAccessor(schema, uuid)` | `accessor.cost_model == cm` — falls back to default |
-| TC-42 | BAC-14 | Cost model assigned to "consumer" context only | `CostModelDBAccessor(schema, uuid, cost_model_context="provider")` | `accessor.cost_model is None` — no model for requested context |
+| [TC-40](./test-cases-t2-integration.md#tc-40-accessor-filters-by-explicit-context) | BAC-14 | Context "default" with cost model assigned via `CostModelMap` | `CostModelDBAccessor(schema, uuid, cost_model_context="default")` | `accessor.cost_model == cm` |
+| [TC-41](./test-cases-t2-integration.md#tc-41-accessor-defaults-to-tenants-default-context-when-none) | BAC-15 | Context "default" with cost model assigned; no explicit context param | `CostModelDBAccessor(schema, uuid)` | `accessor.cost_model == cm` — falls back to default |
+| [TC-42](./test-cases-t2-integration.md#tc-42-accessor-returns-none-for-unassigned-context) | BAC-14 | Cost model assigned to "consumer" context only | `CostModelDBAccessor(schema, uuid, cost_model_context="provider")` | `accessor.cost_model is None` — no model for requested context |
 
 #### Class: `UsageCostsSQLContextTest` — T2 Integration
 
 | TC | BAC | Given | When | Then |
 |----|-----|-------|------|------|
-| TC-43 | BAC-17 | `usage_costs.sql` file loaded | Parse DELETE section (before first INSERT) | String `"cost_model_context"` present in DELETE section |
-| TC-44 | BAC-18 | `usage_costs.sql` file loaded | Parse INSERT section (after first INSERT keyword) | String `"cost_model_context"` present in INSERT section |
-| TC-45 | BAC-17 | `usage_costs.sql` file loaded | Search for exact template marker | `"cost_model_context = {{cost_model_context}}"` found in SQL |
-| TC-49 | BAC-19 | `distribute_platform_cost.sql` loaded | Search for context reference | String `"cost_model_context"` present |
-| TC-50 | BAC-24 | `AWSCostEntryLineItemDailySummary` model inspected | Check for attribute | `hasattr(model, "cost_model_context")` returns `False` — AWS model unaffected |
+| [TC-43](./test-cases-t2-integration.md#tc-43-usage-costs-delete-scoped-by-context) | BAC-17 | `usage_costs.sql` file loaded | Parse DELETE section (before first INSERT) | String `"cost_model_context"` present in DELETE section |
+| [TC-44](./test-cases-t2-integration.md#tc-44-usage-costs-insert-includes-context-column) | BAC-18 | `usage_costs.sql` file loaded | Parse INSERT section (after first INSERT keyword) | String `"cost_model_context"` present in INSERT section |
+| [TC-45](./test-cases-t2-integration.md#tc-45-cross-context-isolation-via-sql-template-marker) | BAC-17 | `usage_costs.sql` file loaded | Search for exact template marker | `"cost_model_context = {{cost_model_context}}"` found in SQL |
+| [TC-49](./test-cases-t2-integration.md#tc-49-distribution-sql-scoped-by-context) | BAC-19 | `distribute_platform_cost.sql` loaded | Search for context reference | String `"cost_model_context"` present |
+| [TC-50](./test-cases-t2-integration.md#tc-50-cloud-model-rows-unaffected-no-context-field) | BAC-24 | `AWSCostEntryLineItemDailySummary` model inspected | Check for attribute | `hasattr(model, "cost_model_context")` returns `False` — AWS model unaffected |
 
 #### Class: `CacheKeyContextTest` — T2 Integration
 
 | TC | BAC | Given | When | Then |
 |----|-----|-------|------|------|
-| TC-51 | BAC-23 | Cache key created with args including `"default"` context | `create_single_task_cache_key(task_name, [..., "default", ...])` | `"default"` substring present in returned key |
-| TC-52 | BAC-23 | Two cache keys with different context args ("default" vs "provider") | Compare both keys | Keys are not equal — different contexts produce different keys |
+| [TC-51](./test-cases-t2-integration.md#tc-51-cache-key-includes-context-string) | BAC-23 | Cache key created with args including `"default"` context | `create_single_task_cache_key(task_name, [..., "default", ...])` | `"default"` substring present in returned key |
+| [TC-52](./test-cases-t2-integration.md#tc-52-different-contexts-produce-different-cache-keys) | BAC-23 | Two cache keys with different context args ("default" vs "provider") | Compare both keys | Keys are not equal — different contexts produce different keys |
 
 #### Class: `SelfHostedTrinoSQLContextTest` — T2 Integration
 
 | TC | BAC | Given | When | Then |
 |----|-----|-------|------|------|
-| TC-53 | BAC-20 | All `.sql` files under `self_hosted_sql/openshift/cost_model/` | Read each file | Every file contains `"cost_model_context"` |
-| TC-54 | BAC-21 | All `.sql` files under `trino_sql/openshift/cost_model/` | Read each file | Every file contains `"cost_model_context"` |
+| [TC-53](./test-cases-t2-integration.md#tc-53-all-self-hosted-sql-files-include-context-param) | BAC-20 | All `.sql` files under `self_hosted_sql/openshift/cost_model/` | Read each file | Every file contains `"cost_model_context"` |
+| [TC-54](./test-cases-t2-integration.md#tc-54-all-trino-sql-files-include-context-param) | BAC-21 | All `.sql` files under `trino_sql/openshift/cost_model/` | Read each file | Every file contains `"cost_model_context"` |
 
 #### Class: `InlineSQLContextTest` — T2 Integration
 
 | TC | BAC | Given | When | Then |
 |----|-----|-------|------|------|
-| TC-55 | BAC-22 | `OCPCostModelCostUpdater._delete_tag_usage_costs` source inspected | `inspect.getsource(method)` | Source contains `"cost_model_context"` |
-| TC-56 | BAC-22 | `OCPReportDBAccessor.populate_usage_costs` source inspected | `inspect.getsource(method)` | Source contains `"cost_model_context"` |
+| [TC-55](./test-cases-t2-integration.md#tc-55-inline-delete-method-handles-context) | BAC-22 | `OCPCostModelCostUpdater._delete_tag_usage_costs` source inspected | `inspect.getsource(method)` | Source contains `"cost_model_context"` |
+| [TC-56](./test-cases-t2-integration.md#tc-56-populate_usage_costs-passes-context-in-sql-params) | BAC-22 | `OCPReportDBAccessor.populate_usage_costs` source inspected | `inspect.getsource(method)` | Source contains `"cost_model_context"` |
 
 ---
 
@@ -366,9 +362,9 @@ requirements) are in the per-tier companion documents:
 
 | TC | BAC | Given | When | Then |
 |----|-----|-------|------|------|
-| TC-60 | BAC-11 | Schema at `MIGRATE_FROM` | Run migration to `MIGRATE_TO` | `information_schema.columns` confirms `cost_model_context` on `reporting_ocpusagelineitem_daily_summary` |
-| TC-61 | BAC-12 | Schema at `MIGRATE_FROM` | Run migration to `MIGRATE_TO` | `cost_model_context` column exists on all 13 `reporting_ocp_*_summary_p` tables (verified with `subTest`) |
-| TC-62 | BAC-11 | Schema at `MIGRATE_TO` with context column present | Reverse migration to `MIGRATE_FROM` | `cost_model_context` column no longer exists on daily summary table |
+| [TC-60](./test-cases-t2-integration.md#tc-60-daily-summary-table-gets-context-column) | BAC-11 | Schema at `MIGRATE_FROM` | Run migration to `MIGRATE_TO` | `information_schema.columns` confirms `cost_model_context` on `reporting_ocpusagelineitem_daily_summary` |
+| [TC-61](./test-cases-t2-integration.md#tc-61-all-13-ui-summary-tables-get-context-column) | BAC-12 | Schema at `MIGRATE_FROM` | Run migration to `MIGRATE_TO` | `cost_model_context` column exists on all 13 `reporting_ocp_*_summary_p` tables (verified with `subTest`) |
+| [TC-62](./test-cases-t2-integration.md#tc-62-reverse-migration-removes-context-column) | BAC-11 | Schema at `MIGRATE_TO` with context column present | Reverse migration to `MIGRATE_FROM` | `cost_model_context` column no longer exists on daily summary table |
 
 ---
 
@@ -378,18 +374,18 @@ requirements) are in the per-tier companion documents:
 
 | TC | BAC | Given | When | Then |
 |----|-----|-------|------|------|
-| TC-22 | BAC-26 | Authenticated client | GET `/reports/openshift/costs/?cost_model_context=consumer` | HTTP 200; `response.meta.cost_model_context == "consumer"` |
-| TC-23 | BAC-33 | Authenticated client | GET `/reports/openshift/costs/` (no context param) | HTTP 200; `"cost_model_context" not in response.meta` — backward-compatible |
+| [TC-22](./test-cases-t3-e2e.md#tc-22-cost_model_context-parameter-accepted) | BAC-26 | Authenticated client | GET `/reports/openshift/costs/?cost_model_context=consumer` | HTTP 200; `response.meta.cost_model_context == "consumer"` |
+| [TC-23](./test-cases-t3-e2e.md#tc-23-missing-cost_model_context-has-no-context-in-meta) | BAC-33 | Authenticated client | GET `/reports/openshift/costs/` (no context param) | HTTP 200; `"cost_model_context" not in response.meta` — backward-compatible |
 
 #### Class: `OCPContextReportAPITest` — T3 E2E
 
 | TC | BAC | Given | When | Then |
 |----|-----|-------|------|------|
-| TC-80 | BAC-26 | Authenticated client | GET `/reports/openshift/costs/?cost_model_context=consumer` | HTTP 200 |
-| TC-81 | BAC-27 | Authenticated client | GET `/reports/openshift/costs/?cost_model_context=consumer` | `response.meta.cost_model_context == "consumer"` |
-| TC-82 | BAC-33 | Authenticated client | GET `/reports/openshift/costs/` (no context param) | HTTP 200 — no regression |
-| TC-83 | BAC-27 | Authenticated client | GET `/reports/openshift/costs/?cost_model_context=consumer` | Response includes data (verify currency annotation is context-aware) |
-| TC-84 | BAC-29 | Authenticated client | GET `/reports/openshift/costs/?cost_model_context=nonexistent` | HTTP 200 or 400 — unpermitted/nonexistent context handled gracefully |
+| [TC-80](./test-cases-t3-e2e.md#tc-80-cost-endpoint-with-context-returns-200) | BAC-26 | Authenticated client | GET `/reports/openshift/costs/?cost_model_context=consumer` | HTTP 200 |
+| [TC-81](./test-cases-t3-e2e.md#tc-81-response-filtered-by-context) | BAC-27 | Authenticated client | GET `/reports/openshift/costs/?cost_model_context=consumer` | `response.meta.cost_model_context == "consumer"` |
+| [TC-82](./test-cases-t3-e2e.md#tc-82-missing-context-uses-default-no-regression) | BAC-33 | Authenticated client | GET `/reports/openshift/costs/` (no context param) | HTTP 200 — no regression |
+| [TC-83](./test-cases-t3-e2e.md#tc-83-currency-annotation-context-aware) | BAC-27 | Authenticated client | GET `/reports/openshift/costs/?cost_model_context=consumer` | Response includes data (verify currency annotation is context-aware) |
+| [TC-84](./test-cases-t3-e2e.md#tc-84-unpermittednonexistent-context-handled-gracefully) | BAC-29 | Authenticated client | GET `/reports/openshift/costs/?cost_model_context=nonexistent` | HTTP 200 or 400 — unpermitted/nonexistent context handled gracefully |
 
 ---
 
@@ -399,13 +395,13 @@ requirements) are in the per-tier companion documents:
 
 | TC | BAC | Given | When | Then |
 |----|-----|-------|------|------|
-| TC-16 | BAC-28 | `ENHANCED_ORG_ADMIN=True`; admin user; `query_params={"cost_model_context": "provider"}` | `perm.has_permission(request, None)` | Returns `True` — admin bypass |
-| TC-17 | BAC-29 | User with `cost_model.read=[]` (empty); `query_params={"cost_model_context": "consumer"}` | `perm.has_permission(request, None)` | Returns `False` — denied |
-| TC-18 | BAC-33 | User with `cost_model.read=["*"]`; `query_params={}` (no context param) | `perm.has_permission(request, None)` | Returns `True` — pass-through when no context requested |
-| TC-19a | BAC-29 | User with `access=None`, `customer=None`; `query_params={"cost_model_context": "consumer"}` | `perm.has_permission(request, None)` | Returns `False` |
-| TC-19b | BAC-33 | User with `access=None`; `query_params={}` (no context param) | `perm.has_permission(request, None)` | Returns `True` — pass-through |
-| TC-20 | BAC-29 | User with `access={}` (empty dict); `query_params={"cost_model_context": "consumer"}` | `perm.has_permission(request, None)` | Returns `False` |
-| TC-21 | BAC-29 | User with `access={"aws.account": {"read": ["*"]}}` (no `cost_model` key); context requested | `perm.has_permission(request, None)` | Returns `False` — no `KeyError` raised |
+| [TC-16](./test-cases-t1-unit.md#tc-16-admin-user-bypasses-context-check) | BAC-28 | `ENHANCED_ORG_ADMIN=True`; admin user; `query_params={"cost_model_context": "provider"}` | `perm.has_permission(request, None)` | Returns `True` — admin bypass |
+| [TC-17](./test-cases-t1-unit.md#tc-17-unpermitted-user-denied) | BAC-29 | User with `cost_model.read=[]` (empty); `query_params={"cost_model_context": "consumer"}` | `perm.has_permission(request, None)` | Returns `False` — denied |
+| [TC-18](./test-cases-t1-unit.md#tc-18-permitted-user-allowed-no-context-param) | BAC-33 | User with `cost_model.read=["*"]`; `query_params={}` (no context param) | `perm.has_permission(request, None)` | Returns `True` — pass-through when no context requested |
+| [TC-19a](./test-cases-t1-unit.md#tc-19a-missing-customer-attribute-returns-false) | BAC-29 | User with `access=None`, `customer=None`; `query_params={"cost_model_context": "consumer"}` | `perm.has_permission(request, None)` | Returns `False` |
+| [TC-19b](./test-cases-t1-unit.md#tc-19b-no-context-param-allows-access-regardless) | BAC-33 | User with `access=None`; `query_params={}` (no context param) | `perm.has_permission(request, None)` | Returns `True` — pass-through |
+| [TC-20](./test-cases-t1-unit.md#tc-20-empty-access-dict-returns-false) | BAC-29 | User with `access={}` (empty dict); `query_params={"cost_model_context": "consumer"}` | `perm.has_permission(request, None)` | Returns `False` |
+| [TC-21](./test-cases-t1-unit.md#tc-21-missing-cost_model-key-does-not-raise-keyerror) | BAC-29 | User with `access={"aws.account": {"read": ["*"]}}` (no `cost_model` key); context requested | `perm.has_permission(request, None)` | Returns `False` — no `KeyError` raised |
 
 ---
 
@@ -415,23 +411,23 @@ requirements) are in the per-tier companion documents:
 
 | TC | BAC | Given | When | Then |
 |----|-----|-------|------|------|
-| TC-90 | BAC-16, BAC-27 | Context "default" with cost model ($10/core-hour CPU, Infrastructure); `CostModelMap` assigned; Trino mocked | Run pipeline for `cost_model_context="default"`; then GET `/reports/openshift/costs/?cost_model_context=default` | DB: `OCPUsageLineItemDailySummary` rows with `cost_model_context="default"` and `cost_model_rate_type="Infrastructure"` exist; `sum(cost_model_cpu_cost) > 0`. API: `response.meta.cost_model_context == "default"` |
-| TC-91 | BAC-16, BAC-17 | Two contexts: consumer ($10), provider ($20); both assigned to same cluster; Trino mocked | Run pipeline for "consumer" then "provider" | DB: `provider_cost / consumer_cost ≈ 2.0 (±0.1)`. API: each context returns its own `cost_model_context` in meta. Cross-context isolation verified |
+| [TC-90](./test-cases-t3-e2e.md#tc-90-single-context-pipeline-smoke-test) | BAC-16, BAC-27 | Context "default" with cost model ($10/core-hour CPU, Infrastructure); `CostModelMap` assigned; Trino mocked | Run pipeline for `cost_model_context="default"`; then GET `/reports/openshift/costs/?cost_model_context=default` | DB: `OCPUsageLineItemDailySummary` rows with `cost_model_context="default"` and `cost_model_rate_type="Infrastructure"` exist; `sum(cost_model_cpu_cost) > 0`. API: `response.meta.cost_model_context == "default"` |
+| [TC-91](./test-cases-t3-e2e.md#tc-91-dual-context-isolation-smoke-test) | BAC-16, BAC-17 | Two contexts: consumer ($10), provider ($20); both assigned to same cluster; Trino mocked | Run pipeline for "consumer" then "provider" | DB: `provider_cost / consumer_cost ≈ 2.0 (±0.1)`. API: each context returns its own `cost_model_context` in meta. Cross-context isolation verified |
 
 #### Class: `APIContextE2ETest` — T3 E2E
 
 | TC | BAC | Given | When | Then |
 |----|-----|-------|------|------|
-| TC-92 | BAC-33, BAC-27 | Default context with rate; pipeline run for "default" | GET with `?cost_model_context=default` vs GET without param | Explicit: `meta.cost_model_context == "default"`. Implicit: `"cost_model_context" not in meta` |
-| TC-93 | BAC-32 | Context "empty" with no `CostModelMap` assignment; default also exists | GET `/reports/openshift/costs/?cost_model_context=empty` | HTTP 200; `meta.cost_model_context == "empty"` — $0 cost reported |
-| TC-94 | BAC-27 | Default context with $10 rate; pipeline run | Update rate to $50; re-run pipeline | `cost_after / cost_before ≈ 5.0 (±0.5)` — rate propagation verified |
-| TC-95 | BAC-17 | Default context with rate; pipeline run; then `CostModelMap` deleted | Re-run pipeline for "default" | All `cost_model_cpu_cost > 0` rows for context "default" are cleared |
-| TC-96 | BAC-16 | Default context with rate assigned in test tenant; pipeline run | Query `OCPUsageLineItemDailySummary` in `public` schema | 0 rows or `ProgrammingError` — no cross-tenant leakage |
-| TC-97 | BAC-29 | `CostModelContextPermission.has_permission` patched to `False` | GET `/reports/openshift/costs/?cost_model_context=default` | HTTP 403 |
-| TC-98 | BAC-17, BAC-27 | Two contexts: "default" ($10) and "alternate" ($30); both pipelines run | GET for each context | Each response has its own `cost_model_context` in meta — cross-context isolation via API |
-| TC-99 | BAC-24 | — | Inspect `AWSCostEntryLineItemDailySummary` model | `hasattr(model, "cost_model_context")` returns `False` |
-| TC-100 | BAC-25 | — | Inspect `OCPCostSummaryP` model | `hasattr(model, "cost_model_context")` returns `True` |
-| TC-101 | BAC-19 | Default context with rate; pipeline run | Query `OCPUsageLineItemDailySummary` for `cost_model_rate_type IN ("platform_distributed", "worker_distributed")` | All distributed rows have `cost_model_context == "default"` |
+| [TC-92](./test-cases-t3-e2e.md#tc-92-explicit-default-equals-implicit-backward-compat) | BAC-33, BAC-27 | Default context with rate; pipeline run for "default" | GET with `?cost_model_context=default` vs GET without param | Explicit: `meta.cost_model_context == "default"`. Implicit: `"cost_model_context" not in meta` |
+| [TC-93](./test-cases-t3-e2e.md#tc-93-empty-context-shows-0-cost) | BAC-32 | Context "empty" with no `CostModelMap` assignment; default also exists | GET `/reports/openshift/costs/?cost_model_context=empty` | HTTP 200; `meta.cost_model_context == "empty"` — $0 cost reported |
+| [TC-94](./test-cases-t3-e2e.md#tc-94-rate-update-propagation) | BAC-27 | Default context with $10 rate; pipeline run | Update rate to $50; re-run pipeline | `cost_after / cost_before ≈ 5.0 (±0.5)` — rate propagation verified |
+| [TC-95](./test-cases-t3-e2e.md#tc-95-assignment-removal-clears-context-costs) | BAC-17 | Default context with rate; pipeline run; then `CostModelMap` deleted | Re-run pipeline for "default" | All `cost_model_cpu_cost > 0` rows for context "default" are cleared |
+| [TC-96](./test-cases-t3-e2e.md#tc-96-multi-tenant-isolation) | BAC-16 | Default context with rate assigned in test tenant; pipeline run | Query `OCPUsageLineItemDailySummary` in `public` schema | 0 rows or `ProgrammingError` — no cross-tenant leakage |
+| [TC-97](./test-cases-t3-e2e.md#tc-97-rbac-denies-unpermitted-context-access) | BAC-29 | `CostModelContextPermission.has_permission` patched to `False` | GET `/reports/openshift/costs/?cost_model_context=default` | HTTP 403 |
+| [TC-98](./test-cases-t3-e2e.md#tc-98-cross-context-isolation-via-api) | BAC-17, BAC-27 | Two contexts: "default" ($10) and "alternate" ($30); both pipelines run | GET for each context | Each response has its own `cost_model_context` in meta — cross-context isolation via API |
+| [TC-99](./test-cases-t3-e2e.md#tc-99-cloud-rows-unaffected-by-context) | BAC-24 | — | Inspect `AWSCostEntryLineItemDailySummary` model | `hasattr(model, "cost_model_context")` returns `False` |
+| [TC-100](./test-cases-t3-e2e.md#tc-100-ui-summary-model-has-context-field) | BAC-25 | — | Inspect `OCPCostSummaryP` model | `hasattr(model, "cost_model_context")` returns `True` |
+| [TC-101](./test-cases-t3-e2e.md#tc-101-distributed-costs-tagged-with-context) | BAC-19 | Default context with rate; pipeline run | Query `OCPUsageLineItemDailySummary` for `cost_model_rate_type IN ("platform_distributed", "worker_distributed")` | All distributed rows have `cost_model_context == "default"` |
 
 ---
 
@@ -635,3 +631,4 @@ acceptance, report filtering, CRUD lifecycle, and write-freeze guards.
 | v1.0 | 2026-04-08 | Initial IEEE 829 test plan |
 | v2.0 | 2026-04-09 | Full rewrite: BDD Given/When/Then for all 82 test cases derived from implementation code; correct BAC-to-phase mapping; add write-freeze TCs; add test plan identifier, approval section, deliberate deviations, implementation phases with checkpoints |
 | v3.0 | 2026-04-09 | IEEE 829 compliance: split detailed test case specifications into per-tier companion documents (T1/T2/T3) with full Given/When/Then blocks; test-plan.md retains summary tables with links to specs |
+| v3.1 | 2026-04-09 | Add deep links from every TC identifier in summary tables to its corresponding heading in the per-tier companion documents |

--- a/docs/architecture/consumer-provider-cost-models/test-plan.md
+++ b/docs/architecture/consumer-provider-cost-models/test-plan.md
@@ -5,7 +5,7 @@
 | Field | Value |
 |-------|-------|
 | Test Plan Identifier | COST-3920-TP-001 |
-| Version | 2.0 |
+| Version | 3.0 |
 | Date | 2026-04-09 |
 | Author | COST-3920 Engineering |
 | Status | Design Proposal |
@@ -197,6 +197,15 @@ Each implementation phase follows strict Red-Green-Refactor:
 ---
 
 ## 5. Test Cases (82 tests across 10 modules)
+
+Each test case below is summarized in table form for quick reference.
+Full IEEE 829 Test Case Specifications (with structured
+Given/When/Then scenarios, test items, dependencies, and special
+requirements) are in the per-tier companion documents:
+
+- **[test-cases-t1-unit.md](./test-cases-t1-unit.md)** — 25 unit tests (model, serializer, permission, manager)
+- **[test-cases-t2-integration.md](./test-cases-t2-integration.md)** — 34 integration tests (SQL, accessor, migration, DB constraints, pipeline)
+- **[test-cases-t3-e2e.md](./test-cases-t3-e2e.md)** — 24 E2E tests (full pipeline, API, cross-context isolation, write-freeze)
 
 ### 5.1 Module: `cost_models/test/test_cost_model_context.py` (17 tests)
 
@@ -625,3 +634,4 @@ acceptance, report filtering, CRUD lifecycle, and write-freeze guards.
 |---------|------|---------|
 | v1.0 | 2026-04-08 | Initial IEEE 829 test plan |
 | v2.0 | 2026-04-09 | Full rewrite: BDD Given/When/Then for all 82 test cases derived from implementation code; correct BAC-to-phase mapping; add write-freeze TCs; add test plan identifier, approval section, deliberate deviations, implementation phases with checkpoints |
+| v3.0 | 2026-04-09 | IEEE 829 compliance: split detailed test case specifications into per-tier companion documents (T1/T2/T3) with full Given/When/Then blocks; test-plan.md retains summary tables with links to specs |

--- a/docs/architecture/consumer-provider-cost-models/test-plan.md
+++ b/docs/architecture/consumer-provider-cost-models/test-plan.md
@@ -5,7 +5,7 @@
 | Field | Value |
 |-------|-------|
 | Test Plan Identifier | COST-3920-TP-001 |
-| Version | 3.2 |
+| Version | 4.0 |
 | Date | 2026-04-09 |
 | Author | COST-3920 Engineering |
 | Status | Design Proposal |
@@ -36,11 +36,14 @@ testing conventions. Each test case is specified as a BDD scenario
 - Write-freeze guards (Unleash flag, serializer, pipeline)
 - Cross-context data isolation
 
+- Cost visibility filtering (`data_visibility` on CostModelContext)
+- RBAC cluster + context access combinations
+
 **Out of scope:**
-- Frontend UI changes (context dropdown, notifications)
+- Frontend UI changes (context dropdown)
 - Kessel/ReBAC integration (deferred to v2)
 - `ocp_tag_mapping_update_daily_summary.sql` context scoping
-- OCP-on-cloud cross-provider context interaction
+- Notifications (deferred per updated PRD)
 
 ### 1.3 Definitions
 
@@ -151,6 +154,10 @@ testing conventions. Each test case is specified as a BDD scenario
 | BAC-31 | Audit trigger captures context array | P2 | C14 |
 | BAC-32 | Empty context (no cost model) shows $0 cost | P2 | C7, C11 |
 | BAC-33 | Report views pass through when `cost_model_context` absent (backward-compat) | P1 | C12 |
+| BAC-39 | `data_visibility=ocp_only` excludes cloud infrastructure costs from reports | P1 | C1, C11 |
+| BAC-40 | `data_visibility=cloud_and_ocp` includes all costs (backward-compatible) | P1 | C1, C11 |
+| BAC-41 | Default context migration sets `data_visibility=cloud_and_ocp` | P1 | C14 |
+| BAC-42 | RBAC: cluster + context access combinations match PRD examples | P1 | C12 |
 
 #### Phase 5 — Write-Freeze + Data Consistency (5 BACs)
 
@@ -265,7 +272,7 @@ requirements) are in the per-tier companion documents:
 
 | TC | BAC | Given | When | Then |
 |----|-----|-------|------|------|
-| [TC-30](./test-cases-t2-integration.md#tc-30-forward-migration-creates-default-context-per-tenant) | BAC-9 | Schema at `MIGRATE_FROM` with one `CostModel` row | Run forward migration to `MIGRATE_TO_DATA` | `CostModelContext(is_default=True, name="default", display_name="Consumer", position=1)` exists |
+| [TC-30](./test-cases-t2-integration.md#tc-30-forward-migration-creates-default-context-per-tenant) | BAC-9 | Schema at `MIGRATE_FROM` with one `CostModel` row | Run forward migration to `MIGRATE_TO_DATA` | `CostModelContext(is_default=True, name="default", display_name="Default context", position=1, data_visibility="cloud_and_ocp")` exists |
 | [TC-31](./test-cases-t2-integration.md#tc-31-forward-migration-assigns-existing-costmodelmap-rows-to-default) | BAC-10 | Schema at `MIGRATE_FROM` with `CostModelMap` row (raw SQL INSERT) | Run forward migration to `MIGRATE_TO_DATA` | `CostModelMap.cost_model_context` is set, `is_default=True`, `name="default"` |
 | [TC-32](./test-cases-t2-integration.md#tc-32-new-unique-constraint-is-active-post-migration) | BAC-6 | Schema at `MIGRATE_TO_DATA` with default context | Create 2 `CostModelMap` rows for same `(provider_uuid, context)` | `IntegrityError` — new unique constraint active |
 | [TC-33](./test-cases-t2-integration.md#tc-33-old-unique-constraint-is-dropped-post-migration) | BAC-5 | Schema at `MIGRATE_TO_DATA` with 2 contexts | Create 2 `CostModelMap` rows for same `(provider_uuid, cost_model)` but different contexts | Succeeds — old `(provider_uuid, cost_model)` constraint dropped |
@@ -637,3 +644,4 @@ acceptance, report filtering, CRUD lifecycle, and write-freeze guards.
 | v3.0 | 2026-04-09 | IEEE 829 compliance: split detailed test case specifications into per-tier companion documents (T1/T2/T3) with full Given/When/Then blocks; test-plan.md retains summary tables with links to specs |
 | v3.1 | 2026-04-09 | Add deep links from every TC identifier in summary tables to its corresponding heading in the per-tier companion documents |
 | v3.2 | 2026-04-09 | Normalize tier counts to maintain 82 canonical tests (TC-XX marked supplemental) and split TC-72..TC-76 into individually linkable summary rows |
+| v4.0 | 2026-05-05 | PRD realignment: remove OCP-on-cloud from out-of-scope (now addressed via cost visibility); add visibility and RBAC combo BACs (BAC-39 through BAC-42); add visibility test cases to in-scope; defer notifications |


### PR DESCRIPTION
## Summary

Technical design proposal for **COST-3920: Consumer-Provider Cost Models** — enabling multiple cost models per OCP cluster (e.g., Provider vs Consumer) with per-context cost calculation, reporting, and access control.

This is a **docs-only PR** for tech lead review. No code changes are included. The design documents are written as forward-looking proposals awaiting approval before implementation begins.

### Documents included

| Document | Purpose |
|----------|---------|
| **README.md** | Design overview, decisions needing TL confirmation, architecture diagrams |
| **current-architecture.md** | Baseline cost model architecture (unchanged — describes today's state) |
| **prd-gap-analysis.md** | PRD requirements mapped to proposed implementations with code sketches |
| **risk-register.md** | 21 risks with code-evidenced mitigations and decision rationale |
| **dependency-analysis.md** | In-flight PR overlap, merge ordering, deployment sequence |
| **test-plan.md** | IEEE 829 test plan: 104 test cases, 38 BACs, 3 tiers |
| **phased-delivery.md** | 5 phases, 3-PR structure, validation criteria, deployment runbook |

### Decisions for TL review

- **DQ-1**: Migration strategy (nullable AddField + RunSQL backfill vs alternatives)
- **DQ-2**: Write-freeze Unleash flag during data migration
- **DQ-3**: RBAC scope (Koku-side auth for v1 vs platform RBAC)
- **DQ-4**: Per-context pipeline dispatch (parallel Celery tasks vs sequential)

### Proposed PR structure after approval

1. **PR 1** (this PR): Design docs — TL approves design
2. **PR 2**: Migrations only (Phase 1 + Phase 2) — independently deployable and reversible
3. **PR 3**: Business logic + tests (Phase 3-5) — pipeline, API, RBAC, write-freeze, SQL, all tests

## Test plan

- [ ] Review all 7 documents for completeness and correctness
- [ ] Confirm or override the 4 DQ decisions
- [ ] Verify the proposed 3-PR structure aligns with deployment practices
- [ ] Verify the deployment runbook (SaaS + on-prem) is operationally sound


Made with [Cursor](https://cursor.com)