### PR TITLE
[FLPATH-3881] Enable 3 Unleash flags as True by default for ONPREM

### DIFF
--- a/koku/koku/feature_flags.py
+++ b/koku/koku/feature_flags.py
@@ -29,6 +29,12 @@ def fallback_development_true(feature_name: str, context: dict) -> bool:
 class MockUnleashClient:
     """Mock Unleash Client for ONPREM mode."""
 
+    ONPREM_FLAG_DEFAULTS = {
+        "cost-management.backend.ocp_gpu_cost_model": True,
+        "cost-management.backend.disable-ingress-rate-limit": True,
+        "cost-management.backend.override_customer_group_by_limit": True,
+    }
+
     def __init__(self, app_name, environment, instance_id, **kwargs):
         """Initialize mock client with static context."""
         LOG.info("Using MockUnleashClient - Unleash is disabled")
@@ -41,7 +47,9 @@ class MockUnleashClient:
 
     def is_enabled(self, feature_name: str, context: dict = None, fallback_function=None):
         """Return fallback value for feature flags."""
-        # Merge static context with runtime context
+        if feature_name in self.ONPREM_FLAG_DEFAULTS:
+            return self.ONPREM_FLAG_DEFAULTS[feature_name]
+
         merged_context = self.unleash_static_context.copy()
         merged_context.update(context or {})
 

--- a/koku/koku/feature_flags.py
+++ b/koku/koku/feature_flags.py
@@ -45,7 +45,7 @@ class MockUnleashClient:
         """No-op initialization."""
         pass
 
-    def is_enabled(self, feature_name: str, context: dict = None, fallback_function=None):
+    def is_enabled(self, feature_name: str, context: dict = None, fallback_function=None, **kwargs):
         """Return fallback value for feature flags."""
         if feature_name in self.ONPREM_FLAG_DEFAULTS:
             return self.ONPREM_FLAG_DEFAULTS[feature_name]

--- a/koku/koku/test_feature_flags.py
+++ b/koku/koku/test_feature_flags.py
@@ -36,7 +36,10 @@ class MockUnleashClientTest(TestCase):
 
     def test_override_takes_precedence_over_fallback(self):
         """Override map is checked before the fallback function."""
-        always_false = lambda name, ctx: False
+
+        def always_false(name, ctx):
+            return False
+
         result = self.client.is_enabled(
             "cost-management.backend.ocp_gpu_cost_model",
             fallback_function=always_false,

--- a/koku/koku/test_feature_flags.py
+++ b/koku/koku/test_feature_flags.py
@@ -1,0 +1,95 @@
+#
+# Copyright 2021 Red Hat Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Tests for MockUnleashClient ONPREM flag defaults."""
+from unittest import TestCase
+
+from koku.feature_flags import fallback_development_true
+from koku.feature_flags import MockUnleashClient
+
+
+class MockUnleashClientTest(TestCase):
+    """Test MockUnleashClient behavior."""
+
+    def setUp(self):
+        self.client = MockUnleashClient(
+            app_name="Cost Management",
+            environment="development",
+            instance_id="test-instance",
+        )
+
+    def test_onprem_gpu_flag_returns_true(self):
+        """Override map returns True for ocp_gpu_cost_model regardless of fallback."""
+        result = self.client.is_enabled("cost-management.backend.ocp_gpu_cost_model")
+        self.assertTrue(result)
+
+    def test_onprem_ingress_rate_limit_flag_returns_true(self):
+        """Override map returns True for disable-ingress-rate-limit."""
+        result = self.client.is_enabled("cost-management.backend.disable-ingress-rate-limit")
+        self.assertTrue(result)
+
+    def test_onprem_group_by_limit_flag_returns_true(self):
+        """Override map returns True for override_customer_group_by_limit."""
+        result = self.client.is_enabled("cost-management.backend.override_customer_group_by_limit")
+        self.assertTrue(result)
+
+    def test_override_takes_precedence_over_fallback(self):
+        """Override map is checked before the fallback function."""
+        always_false = lambda name, ctx: False
+        result = self.client.is_enabled(
+            "cost-management.backend.ocp_gpu_cost_model",
+            fallback_function=always_false,
+        )
+        self.assertTrue(result)
+
+    def test_unlisted_flag_with_fallback_uses_fallback(self):
+        """Flags not in the override map still delegate to fallback_function."""
+        result = self.client.is_enabled(
+            "cost-management.backend.some-other-flag",
+            fallback_function=fallback_development_true,
+        )
+        self.assertTrue(result)
+
+    def test_unlisted_flag_without_fallback_returns_false(self):
+        """Flags not in the override map and with no fallback return False."""
+        result = self.client.is_enabled("cost-management.backend.some-other-flag")
+        self.assertFalse(result)
+
+    def test_unlisted_flag_non_development_fallback_returns_false(self):
+        """fallback_development_true returns False when environment is not development."""
+        client = MockUnleashClient(
+            app_name="Cost Management",
+            environment="production",
+            instance_id="test-instance",
+        )
+        result = client.is_enabled(
+            "cost-management.backend.some-other-flag",
+            fallback_function=fallback_development_true,
+        )
+        self.assertFalse(result)
+
+    def test_context_merging_preserved_for_unlisted_flags(self):
+        """Runtime context is merged with static context for unlisted flags."""
+        captured = {}
+
+        def capture_fallback(name, ctx):
+            captured.update(ctx)
+            return True
+
+        self.client.is_enabled(
+            "cost-management.backend.some-other-flag",
+            context={"schema": "org1234567"},
+            fallback_function=capture_fallback,
+        )
+        self.assertEqual(captured["appName"], "Cost Management")
+        self.assertEqual(captured["environment"], "development")
+        self.assertEqual(captured["schema"], "org1234567")
+
+    def test_initialize_client_is_noop(self):
+        """initialize_client does not raise."""
+        self.client.initialize_client()
+
+    def test_destroy_is_noop(self):
+        """destroy does not raise."""
+        self.client.destroy()


### PR DESCRIPTION
## Summary

- `MockUnleashClient` now returns `True` for three Unleash flags that should be enabled in single-tenant on-prem deployments, rather than relying on implicit fallback behavior or defaulting to `False`
- First dedicated unit test coverage for `MockUnleashClient` (10 tests)

## Flags Enabled

| Flag | Previous ONPREM Default | Change | Rationale |
|------|------------------------|--------|-----------|
| `ocp_gpu_cost_model` | `True` (implicit via `fallback_development_true`) | `True` (explicit) | Removes latent coupling to `KOKU_SENTRY_ENVIRONMENT`; no behavior change |
| `disable-ingress-rate-limit` | `False` (no fallback) | `True` | Rate limiting is unnecessary overhead for single-tenant on-prem |
| `override_customer_group_by_limit` | `False` (no fallback) | `True` | Single-tenant has no multi-tenant contention; allows higher group-by cardinality |

## Implementation

Added an `ONPREM_FLAG_DEFAULTS` class attribute to `MockUnleashClient` with the 3 flags mapped to `True`. The `is_enabled()` method checks this map first; unlisted flags continue to use existing fallback behavior unchanged.

## Test plan

- [x] 3 tests: each override flag returns `True`
- [x] 1 test: override takes precedence over fallback function
- [x] 2 tests: unlisted flags delegate to fallback / return `False` (regression guard)
- [x] 1 test: `fallback_development_true` returns `False` for non-development environment
- [x] 1 test: context merging preserved for non-override flags
- [x] 2 tests: `initialize_client()` and `destroy()` no-ops
- [x] All 10 tests pass locally via `manage.py test koku.test_feature_flags`

Ref: [FLPATH-3881](https://redhat.atlassian.net/browse/FLPATH-3881) / [FLPATH-3433](https://redhat.atlassian.net/browse/FLPATH-3433)

Made with [Cursor](https://cursor.com)