### PR TITLE
Fix MIG-related issues from COST-7372

### DIFF
--- a/koku/koku/settings.py
+++ b/koku/koku/settings.py
@@ -55,7 +55,6 @@ SECRET_KEY = ENVIRONMENT.get_value(
 DEBUG = ENVIRONMENT.bool("DEVELOPMENT", default=False)
 
 ONPREM = ENVIRONMENT.bool("ONPREM", default=False)
-ONPREM = False
 
 # Allow org admins to bypass RBAC permission checks
 ENHANCED_ORG_ADMIN = ENVIRONMENT.bool("ENHANCED_ORG_ADMIN", default=False)

--- a/koku/masu/database/ocp_report_db_accessor.py
+++ b/koku/masu/database/ocp_report_db_accessor.py
@@ -1500,6 +1500,15 @@ AND (month = replace(ltrim(replace('{month}', '0', ' ')),' ', '0') OR month = '{
                     self.schema, OCP_GPU_COST_MODEL_UNLEASH_FLAG, dev_fallback=True
                 ):
                     continue
+                if not cluster_params.get("cluster_id"):
+                    LOG.info(
+                        log_json(
+                            msg="No cluster_id found, skipping GPU tag based cost population.",
+                            schema=self.schema,
+                            provider_uuid=str(provider_uuid),
+                        )
+                    )
+                    continue
 
             param_list = metric_to_tag_params_map.get(name)
             if not param_list:

--- a/koku/masu/test/database/test_ocp_report_db_accessor.py
+++ b/koku/masu/test/database/test_ocp_report_db_accessor.py
@@ -1548,6 +1548,33 @@ class OCPReportDBAccessorTest(MasuTestCase):
             # Should not call SQL execution when flag is disabled
             mock_trino_exec.assert_not_called()
 
+    @patch("masu.database.ocp_report_db_accessor.trino_table_exists", return_value=True)
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query")
+    def test_gpu_tag_based_costs_skipped_when_no_cluster_id(self, mock_trino_exec, mock_trino_exists):
+        """Test that GPU tag based costs are skipped when cluster_id is None."""
+        test_mapping = {
+            metric_constants.OCP_GPU_MONTH: [
+                {
+                    "rate_type": "Infrastructure",
+                    "tag_key": "nvidia",
+                    "value_rates": {"Tesla T4": 1000},
+                    "default_rate": 1000,
+                }
+            ]
+        }
+        for empty_cluster_id in (None, ""):
+            with self.subTest(cluster_id=empty_cluster_id):
+                mock_trino_exec.reset_mock()
+                with self.accessor as acc:
+                    acc.populate_tag_based_costs(
+                        self.start_date,
+                        self.dh.this_month_end,
+                        self.ocp_provider_uuid,
+                        test_mapping,
+                        {"cluster_id": empty_cluster_id, "cluster_alias": None},
+                    )
+                    mock_trino_exec.assert_not_called()
+
 
 class OCPReportDBAccessorGPUUITest(MasuTestCase):
     """Test Cases for GPU UI summary table population."""

--- a/koku/reporting/migrations/0346_alter_ocpgpusummaryp_mig_instance_id.py
+++ b/koku/reporting/migrations/0346_alter_ocpgpusummaryp_mig_instance_id.py
@@ -1,0 +1,17 @@
+from django.db import migrations
+from django.db import models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("reporting", "0345_ocpgpusummaryp_gpu_uuid_and_more"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="ocpgpusummaryp",
+            name="mig_instance_id",
+            field=models.CharField(max_length=128, null=True),
+        ),
+    ]

--- a/koku/reporting/provider/ocp/models.py
+++ b/koku/reporting/provider/ocp/models.py
@@ -1008,7 +1008,7 @@ class OCPGpuSummaryP(models.Model):
     model_name = models.CharField(max_length=128, null=True)
     memory_capacity_gb = models.DecimalField(max_digits=33, decimal_places=15, null=True)
     gpu_count = models.IntegerField(null=True)  # TODO: Remove this field
-    mig_instance_id = models.CharField(max_length=20, null=True)
+    mig_instance_id = models.CharField(max_length=128, null=True)
     gpu_uuid = models.CharField(max_length=128, null=True)
 
     # MIG (Multi-Instance GPU) fields


### PR DESCRIPTION
## Summary

Fixes three bugs introduced by commit 0609f57 ([COST-7372] Add mig instance uuid & fix count):

- **Remove hardcoded `ONPREM = False`** in `settings.py` — debug leftover that prevents on-prem mode from working
- **Increase `mig_instance_id` max_length from 20 to 128** — MIG instance IDs are UUIDs/longer strings that exceed 20 chars, causing `DataError: value too long for type character varying(20)`
- **Add `cluster_id` null guard** in `populate_tag_based_costs` for GPU metric — prevents `IntegrityError: null value in column "cluster_id"` when populating UI summary tables

## Testing

1. Checkout branch
2. Run migrations: `docker compose exec koku-server python koku/manage.py migrate_schemas`
3. Restart koku: `docker compose restart koku-server koku-worker`
4. Re-ingest MIG workload data
5. Verify no `DataError` or `IntegrityError` in worker logs
6. IQE reproducer: `test_api_ocp_source_mig_workloads_ingest`

## Release Notes
- [ ] proposed release note

```markdown
* Fix MIG-related issues: increase mig_instance_id field length, remove hardcoded ONPREM override, guard against null cluster_id in GPU cost model
```


Made with [Cursor](https://cursor.com)