### PR TITLE
Add shared cursor slash cmds and usage README for pr workflows

### DIFF
--- a/.cursor/commands/README.md
+++ b/.cursor/commands/README.md
@@ -1,0 +1,41 @@
+# Cursor Slash Commands
+
+These shared slash commands help with common Koku review and PR workflows.
+
+## How To Use
+
+1. Open Cursor chat in this repository.
+2. Type `/` and select one of these commands.
+3. Give any missing context (PR number, branch, changed files, etc.).
+4. Review the generated output before acting on it.
+
+## Available Commands
+
+### `address-github-pr-comments`
+- **Use when:** You want to work through reviewer comments on a PR end-to-end.
+- **Output:** A structured workflow for triaging comments, applying fixes, testing, and replying.
+
+### `code-review-checklist`
+- **Use when:** You want a thorough review checklist before approving or merging code.
+- **Output:** A comprehensive checklist covering functionality, quality, testing, security, docs, and more.
+
+### `create-pr-testing-instructions`
+- **Use when:** You need to write PR testing instructions in the Koku format.
+- **Output:** A templated `Jira / Description / Testing / Release Notes` section with guidance.
+
+### `light-review-existing-diffs`
+- **Use when:** You want a quick first-pass review of current diffs.
+- **Output:** A lightweight checklist for obvious correctness, style, and test/doc gaps.
+
+## Suggested Usage Pattern
+
+- Start with `light-review-existing-diffs` for fast signal.
+- Follow with `code-review-checklist` for deeper review.
+- Use `create-pr-testing-instructions` when finalizing the PR description.
+- Use `address-github-pr-comments` after reviewer feedback arrives.
+
+## Notes
+
+- These commands are guidance templates, not hard rules.
+- Keep project standards in `.cursorrules` as the source of truth.
+- If a command output conflicts with current team conventions, follow team conventions.

--- a/.cursor/commands/address-github-pr-comments.md
+++ b/.cursor/commands/address-github-pr-comments.md
@@ -1,0 +1,56 @@
+# Address GitHub PR Comments
+
+## Overview
+Systematically address and resolve all comments from GitHub pull request reviewers, ensuring each concern is properly addressed with code changes or responses.
+
+## Steps
+
+1. **Review all PR comments**
+   - Read through all comments on the PR
+   - Categorize comments by type: code changes, questions, suggestions, approvals
+   - Identify which comments require code changes vs. responses
+
+2. **Prioritize changes**
+   - Address critical issues first (bugs, security, performance)
+   - Handle style/formatting comments
+   - Address questions and clarifications
+   - Consider suggestions for improvements
+
+3. **Make code changes**
+   - For each comment requiring code changes:
+     - Understand the reviewer's concern
+     - Implement the suggested fix or improvement
+     - Ensure changes follow Koku project standards:
+       - Python 3.11+ features when appropriate
+       - PEP 8 style guidelines
+       - Black formatting (119 char line length)
+       - Type hints for function parameters and return types
+       - Django ORM best practices
+       - Proper error handling and logging
+   - Update tests if needed
+   - Verify changes don't break existing functionality
+
+4. **Test changes**
+   - Run relevant tests: `pipenv run tox -- path.to.file`
+   - Run specific test methods if needed: `pipenv run tox -- path.to.file::Class::method`
+   - Ensure all tests pass before committing
+
+5. **Respond to comments**
+   - Thank reviewers for their feedback
+   - Explain changes made in response to comments
+   - Ask for clarification if needed
+   - Mark resolved comments as resolved
+
+6. **Update PR**
+   - Commit changes with descriptive messages
+   - Push updates to the PR branch
+   - Update PR description if significant changes were made
+
+## Checklist
+- [ ] All PR comments reviewed and categorized
+- [ ] Code changes implemented for applicable comments
+- [ ] Tests updated and passing
+- [ ] Code follows Koku project standards (.cursorrules)
+- [ ] All comments responded to appropriately
+- [ ] Changes committed and pushed to PR branch
+- [ ] PR description updated if needed

--- a/.cursor/commands/code-review-checklist.md
+++ b/.cursor/commands/code-review-checklist.md
@@ -23,7 +23,7 @@ Comprehensive checklist for conducting thorough code reviews to ensure quality, 
 - [ ] Python 3.11+ features used appropriately
 - [ ] Type hints present for function parameters and return types
 - [ ] F-strings used for string formatting
-- [ ] Tuple unpacking used for multiple context managers
+- [ ] Parenthesized context managers used for multiple managers
 
 ### Import Organization
 - [ ] Standard library imports first
@@ -47,7 +47,7 @@ Comprehensive checklist for conducting thorough code reviews to ensure quality, 
 - [ ] Descriptive test method names
 - [ ] Django TestCase used for database-related tests
 - [ ] unittest.mock.patch used for mocking
-- [ ] Tuple unpacking used for multiple patches
+- [ ] Parenthesized context managers used for multiple patches
 - [ ] model_bakery (baker.make()) used for test data
 - [ ] Both positive and negative cases tested
 - [ ] Edge cases and error conditions tested

--- a/.cursor/commands/code-review-checklist.md
+++ b/.cursor/commands/code-review-checklist.md
@@ -1,0 +1,130 @@
+# Code Review Checklist
+
+## Overview
+Comprehensive checklist for conducting thorough code reviews to ensure quality, security, maintainability, and adherence to Koku project standards.
+
+## Review Categories
+
+### Functionality
+- [ ] Code does what it's supposed to do
+- [ ] Edge cases are handled appropriately
+- [ ] Error handling is appropriate and follows project patterns
+- [ ] No obvious bugs or logic errors
+- [ ] Timezone-aware datetime objects are used correctly
+- [ ] Database operations use transactions when needed
+- [ ] Bulk operations are used for large datasets
+
+### Code Quality
+- [ ] Code is readable and well-structured
+- [ ] Functions are small and focused (single responsibility)
+- [ ] Variable names are descriptive and follow snake_case
+- [ ] No code duplication
+- [ ] Follows Koku project conventions (.cursorrules)
+- [ ] Python 3.11+ features used appropriately
+- [ ] Type hints present for function parameters and return types
+- [ ] F-strings used for string formatting
+- [ ] Tuple unpacking used for multiple context managers
+
+### Import Organization
+- [ ] Standard library imports first
+- [ ] Third-party imports second
+- [ ] Local application imports last
+- [ ] Absolute imports from project root used
+- [ ] Related imports grouped with blank lines
+
+### Django Patterns
+- [ ] Django ORM methods used appropriately
+- [ ] select_related() and prefetch_related() used for performance
+- [ ] get_or_create() pattern used when appropriate
+- [ ] N+1 query problems avoided
+- [ ] Database exceptions handled gracefully
+- [ ] Models follow Django conventions
+
+### Testing
+- [ ] Tests placed in `test/` subdirectories alongside code
+- [ ] Test files named with `test_` prefix
+- [ ] Tests grouped in test classes
+- [ ] Descriptive test method names
+- [ ] Django TestCase used for database-related tests
+- [ ] unittest.mock.patch used for mocking
+- [ ] Tuple unpacking used for multiple patches
+- [ ] model_bakery (baker.make()) used for test data
+- [ ] Both positive and negative cases tested
+- [ ] Edge cases and error conditions tested
+- [ ] Mocks verified with assert_called_once(), assert_called_with()
+- [ ] Test artifacts cleaned up after tests
+
+### Error Handling & Logging
+- [ ] Custom exception classes in dedicated modules (exceptions.py)
+- [ ] Specific exception types used (not generic Exception)
+- [ ] Helpful error messages with context
+- [ ] Structured logging with log_json() utility
+- [ ] tracing_id included for request correlation
+- [ ] Appropriate log levels used (DEBUG, INFO, WARNING, ERROR)
+- [ ] Relevant context included in log messages
+
+### Performance
+- [ ] select_related() used for foreign key relationships
+- [ ] prefetch_related() used for many-to-many relationships
+- [ ] Generators used for large datasets
+- [ ] Files processed in chunks (not loaded entirely into memory)
+- [ ] Context managers used for resource management
+- [ ] Temporary files and resources cleaned up
+
+### Security
+- [ ] No obvious security vulnerabilities
+- [ ] Input validation present (Django forms/serializers)
+- [ ] File paths and names sanitized
+- [ ] File sizes and types checked before processing
+- [ ] Sensitive data handled appropriately
+- [ ] No hardcoded secrets
+- [ ] Proper authentication and authorization checks
+- [ ] Parameterized queries used (Django ORM handles this)
+
+### API Design (if applicable)
+- [ ] Django REST Framework serializers used
+- [ ] Input data validated properly
+- [ ] Nested relationships handled appropriately
+- [ ] Clear error messages for validation failures
+- [ ] Appropriate HTTP status codes used
+- [ ] Exceptions handled gracefully
+- [ ] Pagination used for large datasets
+- [ ] API endpoints documented clearly
+
+### Celery Tasks (if applicable)
+- [ ] Tasks are idempotent when possible
+- [ ] Task failures handled gracefully
+- [ ] Appropriate retry strategies used
+- [ ] Task progress and completion logged
+- [ ] Appropriate queues used for task types
+
+### File Processing (if applicable)
+- [ ] Files processed in streaming mode when possible
+- [ ] Temporary directories used for file operations
+- [ ] File formats validated before processing
+- [ ] Empty files handled gracefully
+- [ ] CSV parsing errors handled gracefully
+- [ ] Data integrity validated during processing
+
+### Documentation
+- [ ] Complex business logic documented
+- [ ] Non-obvious code patterns explained
+- [ ] Docstrings present for public functions and classes
+- [ ] Google or NumPy docstring conventions followed
+- [ ] Parameter types and return types included
+- [ ] Architecture docs updated if needed (docs/architecture/)
+- [ ] Architecture docs link to code, don't duplicate it
+
+### Git & Version Control
+- [ ] Descriptive commit messages
+- [ ] Issue numbers referenced when appropriate
+- [ ] Commits focused on single changes
+- [ ] Conventional commit format used when possible
+
+## Architecture Documentation Check
+If significant changes were made, verify:
+- [ ] Architecture docs reviewed (docs/architecture/)
+- [ ] New functions/classes linked from docs if needed
+- [ ] File paths/function names updated in docs if changed
+- [ ] New concepts explained in docs
+- [ ] Diagrams still accurate

--- a/.cursor/commands/create-pr-testing-instructions.md
+++ b/.cursor/commands/create-pr-testing-instructions.md
@@ -10,7 +10,7 @@ Use this command when preparing a PR description or a `pr-testing.md` file. If a
 
 Use this exact structure and headings:
 
-```
+````
 ## Jira Ticket
 
 [COST-####](https://issues.redhat.com/browse/COST-####)
@@ -33,7 +33,7 @@ This change will ...
 ```markdown
 * [COST-####](https://issues.redhat.com/browse/COST-####) Fix some things
 ```
-```
+````
 
 ## Jira Optional Handling
 

--- a/.cursor/commands/create-pr-testing-instructions.md
+++ b/.cursor/commands/create-pr-testing-instructions.md
@@ -1,0 +1,54 @@
+## Purpose
+
+Draft PR testing instructions using the standard Koku template. Follow the format below and keep it concise and actionable.
+
+## When to Use
+
+Use this command when preparing a PR description or a `pr-testing.md` file. If a Jira ticket exists, link it. If not, mark it as `None`.
+
+## Output Template
+
+Use this exact structure and headings:
+
+```
+## Jira Ticket
+
+[COST-####](https://issues.redhat.com/browse/COST-####)
+
+## Description
+
+This change will ...
+
+## Testing
+
+1. Checkout branch.
+2. Restart Koku.
+3. Hit endpoint or launch shell.
+    1. You should see ...
+4. Do more things...
+
+## Release Notes
+- [ ] proposed release note
+
+```markdown
+* [COST-####](https://issues.redhat.com/browse/COST-####) Fix some things
+```
+```
+
+## Jira Optional Handling
+
+If there is no Jira ticket, keep the section but use `None`:
+
+```
+## Jira Ticket
+
+None
+```
+
+## Guidance
+
+- Be specific about endpoints, identities, env vars, and expected responses.
+- Include any setup or feature flag requirements (for example, `.env` values).
+- For APIs, provide a `curl` example and the expected status or message.
+- Keep steps minimal but complete for someone else to verify the change.
+- Ensure the release note matches the change and is formatted as shown.

--- a/.cursor/commands/light-review-existing-diffs.md
+++ b/.cursor/commands/light-review-existing-diffs.md
@@ -1,0 +1,67 @@
+# Light Review Existing Diffs
+
+## Overview
+Quick review of existing git diffs to identify obvious issues, style problems, and basic code quality concerns without deep analysis.
+
+## Steps
+
+1. **Get current diffs**
+   - Review git status to see modified files
+   - Check git diff for changes
+   - Focus on files that are actually changed
+
+2. **Quick style check**
+   - [ ] Line length within 119 characters (Black formatting)
+   - [ ] Proper indentation and spacing
+   - [ ] Import organization (stdlib, third-party, local)
+   - [ ] Variable naming follows snake_case
+   - [ ] Constants use UPPER_CASE
+   - [ ] F-strings used instead of .format() or %
+   - [ ] Type hints present for new functions
+
+3. **Basic code quality**
+   - [ ] No obvious syntax errors
+   - [ ] No unused imports
+   - [ ] No commented-out code left behind
+   - [ ] No debug print statements
+   - [ ] No hardcoded values that should be constants
+   - [ ] Functions are reasonably sized and focused
+
+4. **Django-specific checks**
+   - [ ] Django ORM used appropriately (not raw SQL unless necessary)
+   - [ ] select_related()/prefetch_related() used if accessing related objects
+   - [ ] Timezone-aware datetime objects used
+   - [ ] Proper use of get_or_create() pattern if applicable
+
+5. **Error handling**
+   - [ ] Exceptions handled (not bare except clauses)
+   - [ ] Appropriate exception types used
+   - [ ] Error messages are helpful
+   - [ ] Logging used appropriately (log_json() for structured logging)
+
+6. **Security basics**
+   - [ ] No obvious SQL injection risks (Django ORM handles this, but check raw queries)
+   - [ ] Input validation present
+   - [ ] No hardcoded secrets or credentials
+   - [ ] File operations validate paths and sizes
+
+7. **Test coverage**
+   - [ ] New code has corresponding tests
+   - [ ] Tests follow project structure (test/ subdirectories)
+   - [ ] Test file named with test_ prefix
+
+8. **Documentation**
+   - [ ] Complex logic has comments
+   - [ ] Public functions/classes have docstrings
+   - [ ] Architecture docs updated if major changes
+
+## Quick Fixes to Suggest
+- Import organization issues
+- Missing type hints
+- Line length violations
+- Missing error handling
+- Unused imports/variables
+- Style inconsistencies
+
+## Notes
+This is a light review focused on quick wins and obvious issues. For deeper analysis, use the full code review checklist.

--- a/.gitignore
+++ b/.gitignore
@@ -155,4 +155,5 @@ dev/containers/unleash/cache/
 # Cursor
 .cursor/*
 !.cursor/rules/
+!.cursor/commands/
 .claude/


### PR DESCRIPTION
## Jira Ticket

None

## Description

* Add shared Cursor slash command docs under `.cursor/commands`, includes a `README` for usage. 
* Update `.gitignore` so these command files are tracked in git.
* Ref: https://cursor.com/docs/cli/reference/slash-commands

## Testing

1. Checkout branch.
2. Verify command files are present:
   - `ls .cursor/commands`
3. Confirm git tracking behavior:
   - `git status --short .cursor/commands .gitignore`
   1. You should see the command markdown files and `README.md` as tracked/staged changes (not ignored).
4. Open each command file and validate content/format:
   - `.cursor/commands/address-github-pr-comments.md`
   - `.cursor/commands/code-review-checklist.md`
   - `.cursor/commands/create-pr-testing-instructions.md`
   - `.cursor/commands/light-review-existing-diffs.md`
   - `.cursor/commands/README.md`
5. In Cursor chat, type `/` and verify the new commands appear in the slash command list.

## Release Notes
- [ ] Add shared Cursor slash commands and README for PR/review workflows.
