### PR TITLE
[COST-7415] bracket-notation filtering, sorting, duplicate, inline cost models in PriceLists APIs

### DIFF
--- a/koku/cost_models/price_list_manager.py
+++ b/koku/cost_models/price_list_manager.py
@@ -151,6 +151,32 @@ class PriceListManager:
             except Exception as exc:
                 LOG.warning(f"Failed to dispatch recalculation for provider {provider.uuid}: {exc}")
 
+    def duplicate(self):
+        """Duplicate the current price list.
+
+        Creates a copy with name "Copy of <original>", same rates/currency/dates,
+        version=1, enabled=True, not assigned to any cost models.
+        """
+        if not self._model:
+            raise PriceListException("No price list to duplicate.")
+
+        max_length = 255
+        new_name = f"Copy of {self._model.name}"
+        if len(new_name) > max_length:
+            available = max_length - len("Copy of ")
+            new_name = f"Copy of {self._model.name[:available]}"
+
+        return self.create(
+            name=new_name,
+            description=self._model.description,
+            currency=self._model.currency,
+            effective_start_date=self._model.effective_start_date,
+            effective_end_date=self._model.effective_end_date,
+            enabled=True,
+            version=1,
+            rates=_strip_enrichment(self._model.rates),
+        )
+
     def delete(self):
         """Delete a price list. Only allowed if not assigned to any cost model."""
         if not self._model:

--- a/koku/cost_models/price_list_serializer.py
+++ b/koku/cost_models/price_list_serializer.py
@@ -30,8 +30,8 @@ class PriceListSerializer(BaseSerializer):
     name = serializers.CharField(max_length=255)
     description = serializers.CharField(allow_blank=True, required=False)
     currency = serializers.CharField(required=False)
-    effective_start_date = serializers.DateField(required=False)
-    effective_end_date = serializers.DateField(required=False)
+    effective_start_date = serializers.DateField()
+    effective_end_date = serializers.DateField()
     enabled = serializers.BooleanField(required=False)
     version = serializers.IntegerField(read_only=True)
     rates = RateSerializer(many=True, required=False)
@@ -94,3 +94,26 @@ class PriceListSerializer(BaseSerializer):
             return manager.update(**validated_data)
         except PriceListException as error:
             raise serializers.ValidationError(str(error))
+
+    def duplicate(self, instance):
+        """Duplicate a price list via the manager."""
+        self._check_write_freeze()
+        try:
+            manager = PriceListManager(instance.uuid)
+            return manager.duplicate()
+        except PriceListException as error:
+            raise serializers.ValidationError(str(error))
+
+    def to_representation(self, instance):
+        """Add assigned cost model data to the response."""
+        rep = super().to_representation(instance)
+        rep["assigned_cost_model_count"] = (
+            instance.assigned_cost_model_count
+            if hasattr(instance, "assigned_cost_model_count")
+            else instance.cost_model_maps.count()
+        )
+        rep["assigned_cost_models"] = [
+            {"uuid": str(m.cost_model.uuid), "name": m.cost_model.name, "priority": m.priority}
+            for m in instance.cost_model_maps.all()
+        ]
+        return rep

--- a/koku/cost_models/price_list_view.py
+++ b/koku/cost_models/price_list_view.py
@@ -4,21 +4,28 @@
 #
 """View for Price Lists."""
 import logging
+from functools import reduce
+from operator import and_
 
+from django.db.models import Count
+from django.db.models import Q
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import never_cache
 from django_filters import BooleanFilter
 from django_filters import CharFilter
-from django_filters import FilterSet
 from django_filters import UUIDFilter
 from django_filters.rest_framework import DjangoFilterBackend
+from querystring_parser import parser
 from rest_framework import serializers
+from rest_framework import status
 from rest_framework import viewsets
 from rest_framework.decorators import action
-from rest_framework.filters import OrderingFilter
+from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 
 from api.common.permissions.cost_models_access import CostModelsAccessPermission
+from api.report.constants import URL_ENCODED_SAFE
+from api.settings.utils import SettingsFilter
 from cost_models.models import PriceList
 from cost_models.models import PriceListCostModelMap
 from cost_models.price_list_manager import PriceListException
@@ -27,17 +34,37 @@ from cost_models.price_list_serializer import PriceListSerializer
 
 LOG = logging.getLogger(__name__)
 
+VALID_PARAMS = {"filter", "order_by", "limit", "offset"}
 
-class PriceListFilter(FilterSet):
+
+class PriceListFilter(SettingsFilter):
     """Price list custom filters."""
 
-    name = CharFilter(field_name="name", lookup_expr="icontains")
+    name = CharFilter(field_name="name", method="list_contain_filter")
     uuid = UUIDFilter(field_name="uuid")
     enabled = BooleanFilter(field_name="enabled")
+    currency = CharFilter(field_name="currency", lookup_expr="iexact")
+
+    def list_contain_filter(self, qs, name, values):
+        """Filter items that contain values in their name (AND logic for comma-separated)."""
+        lookup = "__".join([name, "icontains"])
+        value_list = values.split(",")
+        queries = [Q(**{lookup: val}) for val in value_list]
+        return qs.filter(reduce(and_, queries))
+
+    def filter_queryset(self, queryset):
+        """Validate top-level params before delegating to SettingsFilter."""
+        if self.request:
+            query_params = parser.parse(self.request.query_params.urlencode(safe=URL_ENCODED_SAFE))
+            invalid = set(query_params.keys()) - VALID_PARAMS
+            if invalid:
+                raise ValidationError({invalid.pop(): "Unsupported parameter or invalid value"})
+        return super().filter_queryset(queryset)
 
     class Meta:
         model = PriceList
-        fields = ["name", "uuid", "enabled"]
+        fields = ["name", "uuid", "enabled", "currency"]
+        default_ordering = ["name"]
 
 
 class PriceListViewSet(viewsets.ModelViewSet):
@@ -47,15 +74,18 @@ class PriceListViewSet(viewsets.ModelViewSet):
     and `list()` actions.
     """
 
-    queryset = PriceList.objects.all()
     serializer_class = PriceListSerializer
     permission_classes = (CostModelsAccessPermission,)
     lookup_field = "uuid"
-    filter_backends = (DjangoFilterBackend, OrderingFilter)
+    filter_backends = (DjangoFilterBackend,)
     filterset_class = PriceListFilter
-    ordering_fields = ("name", "effective_start_date", "updated_timestamp")
-    ordering = ("name",)
     http_method_names = ["get", "post", "head", "delete", "put"]
+
+    def get_queryset(self):
+        """Get queryset with assigned cost model count annotation and prefetch."""
+        return PriceList.objects.annotate(assigned_cost_model_count=Count("cost_model_maps")).prefetch_related(
+            "cost_model_maps__cost_model"
+        )
 
     @method_decorator(never_cache)
     def create(self, request, *args, **kwargs):
@@ -105,3 +135,12 @@ class PriceListViewSet(viewsets.ModelViewSet):
             for m in maps
         ]
         return Response(result)
+
+    @method_decorator(never_cache)
+    @action(detail=True, methods=["post"], url_path="duplicate")
+    def duplicate(self, request, uuid=None):
+        """Duplicate a price list."""
+        price_list = self.get_object()
+        serializer = self.get_serializer(price_list)
+        new_price_list = serializer.duplicate(price_list)
+        return Response(self.get_serializer(new_price_list).data, status=status.HTTP_201_CREATED)

--- a/koku/cost_models/test/test_price_list_manager.py
+++ b/koku/cost_models/test/test_price_list_manager.py
@@ -527,3 +527,75 @@ class PriceListManagerRecalcTest(MasuTestCase):
             ]
             manager2.update(rates=new_rates)
             mock_task.s.assert_not_called()
+
+
+class PriceListManagerDuplicateTest(MasuTestCase):
+    """Test cases for PriceListManager.duplicate."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        logging.disable(0)
+
+    def setUp(self):
+        super().setUp()
+        with tenant_context(self.tenant):
+            manager = PriceListManager()
+            self.price_list = manager.create(
+                name="Original PL",
+                description="Test",
+                currency="USD",
+                effective_start_date=date(2026, 1, 1),
+                effective_end_date=date(2026, 12, 31),
+                rates=[
+                    {
+                        "metric": {"name": "cpu_core_usage_per_hour"},
+                        "tiered_rates": [{"value": "1.00", "unit": "USD"}],
+                        "cost_type": "Infrastructure",
+                    }
+                ],
+            )
+
+    def test_duplicate_price_list(self):
+        """Test duplicating a price list."""
+        with tenant_context(self.tenant):
+            manager = PriceListManager(self.price_list.uuid)
+            dup = manager.duplicate()
+            self.assertEqual(dup.name, "Copy of Original PL")
+            self.assertEqual(dup.currency, self.price_list.currency)
+            self.assertEqual(dup.effective_start_date, self.price_list.effective_start_date)
+            self.assertEqual(dup.effective_end_date, self.price_list.effective_end_date)
+            self.assertTrue(dup.enabled)
+            self.assertEqual(dup.version, 1)
+            self.assertNotEqual(dup.uuid, self.price_list.uuid)
+
+    def test_duplicate_long_name_truncated(self):
+        """Test that duplicate truncates name if too long."""
+        with tenant_context(self.tenant):
+            self.price_list.name = "A" * 255
+            self.price_list.save()
+            manager = PriceListManager(self.price_list.uuid)
+            dup = manager.duplicate()
+            self.assertTrue(dup.name.startswith("Copy of "))
+            self.assertLessEqual(len(dup.name), 255)
+
+    def test_duplicate_no_cost_model_assignment(self):
+        """Test that duplicated price list is not assigned to any cost models."""
+        with tenant_context(self.tenant):
+            cost_model = CostModel.objects.first()
+            PriceListCostModelMap.objects.create(
+                price_list=self.price_list,
+                cost_model=cost_model,
+                priority=1,
+            )
+            manager = PriceListManager(self.price_list.uuid)
+            dup = manager.duplicate()
+            count = PriceListCostModelMap.objects.filter(price_list=dup).count()
+            self.assertEqual(count, 0)
+
+    def test_duplicate_nonexistent_raises(self):
+        """Test that duplicating without a model raises."""
+        with tenant_context(self.tenant):
+            manager = PriceListManager()
+            with self.assertRaises(PriceListException):
+                manager.duplicate()

--- a/koku/cost_models/test/test_price_list_view.py
+++ b/koku/cost_models/test/test_price_list_view.py
@@ -45,11 +45,28 @@ class PriceListViewTests(IamTestCase):
             ],
         }
 
+    def _create_price_list(self, **overrides):
+        """Helper to create a price list via the API."""
+        url = reverse("price-lists-list")
+        data = {**self.price_list_data, **overrides}
+        # Keep rate unit in sync with the price list currency
+        if "currency" in overrides and "rates" not in overrides:
+            data["rates"] = [
+                {
+                    **rate,
+                    "tiered_rates": [{**tr, "unit": overrides["currency"]} for tr in rate.get("tiered_rates", [])],
+                }
+                for rate in data["rates"]
+            ]
+        response = self.client.post(url, data=data, format="json", **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        return response
+
+    # --- Create ---
+
     def test_create_price_list(self):
         """Test creating a price list via the API."""
-        url = reverse("price-lists-list")
-        response = self.client.post(url, data=self.price_list_data, format="json", **self.headers)
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        response = self._create_price_list()
         self.assertEqual(response.data["name"], "Test Price List")
         self.assertEqual(response.data["version"], 1)
         self.assertIsNotNone(response.data["uuid"])
@@ -71,25 +88,24 @@ class PriceListViewTests(IamTestCase):
         response = self.client.post(url, data=data, format="json", **self.headers)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+    # --- List ---
+
     def test_list_price_lists(self):
         """Test listing price lists."""
-        url = reverse("price-lists-list")
-        # Create two price lists
-        self.client.post(url, data=self.price_list_data, format="json", **self.headers)
-        data2 = self.price_list_data.copy()
-        data2["name"] = "Second Price List"
-        self.client.post(url, data=data2, format="json", **self.headers)
+        self._create_price_list(name="First Price List")
+        self._create_price_list(name="Second Price List")
 
+        url = reverse("price-lists-list")
         response = self.client.get(url, **self.headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         results = response.data.get("data", response.data.get("results", []))
-        # At least the 2 we created (migration may add others)
         self.assertGreaterEqual(len(results), 2)
+
+    # --- Retrieve ---
 
     def test_retrieve_price_list(self):
         """Test retrieving a single price list."""
-        url = reverse("price-lists-list")
-        create_response = self.client.post(url, data=self.price_list_data, format="json", **self.headers)
+        create_response = self._create_price_list()
         pl_uuid = create_response.data["uuid"]
 
         detail_url = reverse("price-lists-detail", kwargs={"uuid": pl_uuid})
@@ -97,10 +113,17 @@ class PriceListViewTests(IamTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["name"], "Test Price List")
 
+    def test_retrieve_nonexistent_returns_404(self):
+        """Test that retrieving a nonexistent price list returns 404."""
+        detail_url = reverse("price-lists-detail", kwargs={"uuid": "00000000-0000-0000-0000-000000000099"})
+        response = self.client.get(detail_url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    # --- Update ---
+
     def test_update_price_list(self):
         """Test updating a price list via PUT."""
-        url = reverse("price-lists-list")
-        create_response = self.client.post(url, data=self.price_list_data, format="json", **self.headers)
+        create_response = self._create_price_list()
         pl_uuid = create_response.data["uuid"]
 
         detail_url = reverse("price-lists-detail", kwargs={"uuid": pl_uuid})
@@ -112,8 +135,7 @@ class PriceListViewTests(IamTestCase):
 
     def test_update_rates_increments_version(self):
         """Test that updating rates via API increments version."""
-        url = reverse("price-lists-list")
-        create_response = self.client.post(url, data=self.price_list_data, format="json", **self.headers)
+        create_response = self._create_price_list()
         pl_uuid = create_response.data["uuid"]
         self.assertEqual(create_response.data["version"], 1)
 
@@ -130,27 +152,25 @@ class PriceListViewTests(IamTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["version"], 2)
 
+    # --- Delete ---
+
     def test_delete_price_list(self):
         """Test deleting a price list."""
-        url = reverse("price-lists-list")
-        create_response = self.client.post(url, data=self.price_list_data, format="json", **self.headers)
+        create_response = self._create_price_list()
         pl_uuid = create_response.data["uuid"]
 
         detail_url = reverse("price-lists-detail", kwargs={"uuid": pl_uuid})
         response = self.client.delete(detail_url, **self.headers)
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
-        # Verify it's gone
         with tenant_context(self.tenant):
             self.assertFalse(PriceList.objects.filter(uuid=pl_uuid).exists())
 
     def test_delete_assigned_price_list_fails(self):
         """Test that deleting a price list assigned to a cost model fails."""
-        url = reverse("price-lists-list")
-        create_response = self.client.post(url, data=self.price_list_data, format="json", **self.headers)
+        create_response = self._create_price_list()
         pl_uuid = create_response.data["uuid"]
 
-        # Assign to a cost model
         with tenant_context(self.tenant):
             cost_model = CostModel.objects.first()
             PriceListCostModelMap.objects.create(
@@ -163,34 +183,174 @@ class PriceListViewTests(IamTestCase):
         response = self.client.delete(detail_url, **self.headers)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-        # Verify it still exists
         with tenant_context(self.tenant):
             self.assertTrue(PriceList.objects.filter(uuid=pl_uuid).exists())
 
-    def test_filter_by_name(self):
-        """Test filtering price lists by name."""
-        url = reverse("price-lists-list")
-        self.client.post(url, data=self.price_list_data, format="json", **self.headers)
-        data2 = self.price_list_data.copy()
-        data2["name"] = "Production Rates"
-        self.client.post(url, data=data2, format="json", **self.headers)
+    # --- Filtering (bracket notation) ---
 
-        response = self.client.get(f"{url}?name=Production", **self.headers)
+    def test_filter_by_name(self):
+        """Test filtering price lists by name using bracket notation."""
+        self._create_price_list(name="Production Rates")
+        self._create_price_list(name="Staging Rates")
+
+        url = reverse("price-lists-list")
+        response = self.client.get(f"{url}?filter[name]=Production", **self.headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         results = response.data.get("data", response.data.get("results", []))
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]["name"], "Production Rates")
 
-    def test_retrieve_nonexistent_returns_404(self):
-        """Test that retrieving a nonexistent price list returns 404."""
-        detail_url = reverse("price-lists-detail", kwargs={"uuid": "00000000-0000-0000-0000-000000000099"})
-        response = self.client.get(detail_url, **self.headers)
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+    def test_filter_by_name_comma_separated(self):
+        """Test AND filtering with comma-separated name values."""
+        self._create_price_list(name="Production OCP Rates")
+        self._create_price_list(name="Staging OCP Rates")
+        self._create_price_list(name="Production AWS Rates")
+
+        url = reverse("price-lists-list")
+        response = self.client.get(f"{url}?filter[name]=Production,OCP", **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.data.get("data", response.data.get("results", []))
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["name"], "Production OCP Rates")
+
+    def test_filter_by_enabled_true(self):
+        """Test filtering for enabled price lists."""
+        self._create_price_list(name="Enabled PL")
+        self._create_price_list(name="Disabled PL", enabled=False)
+
+        url = reverse("price-lists-list")
+        response = self.client.get(f"{url}?filter[enabled]=true", **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.data.get("data", response.data.get("results", []))
+        for result in results:
+            self.assertTrue(result["enabled"])
+
+    def test_filter_by_enabled_false(self):
+        """Test filtering for disabled price lists."""
+        self._create_price_list(name="Enabled PL")
+        self._create_price_list(name="Disabled PL", enabled=False)
+
+        url = reverse("price-lists-list")
+        response = self.client.get(f"{url}?filter[enabled]=false", **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.data.get("data", response.data.get("results", []))
+        for result in results:
+            self.assertFalse(result["enabled"])
+
+    def test_filter_enabled_omitted_returns_all(self):
+        """Test that omitting enabled filter returns both enabled and disabled."""
+        self._create_price_list(name="Enabled PL")
+        self._create_price_list(name="Disabled PL", enabled=False)
+
+        url = reverse("price-lists-list")
+        response = self.client.get(url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.data.get("data", response.data.get("results", []))
+        enabled_values = {r["enabled"] for r in results}
+        self.assertEqual(enabled_values, {True, False})
+
+    def test_filter_by_currency(self):
+        """Test filtering by currency."""
+        self._create_price_list(name="USD PL", currency="USD")
+        self._create_price_list(name="EUR PL", currency="EUR")
+
+        url = reverse("price-lists-list")
+        response = self.client.get(f"{url}?filter[currency]=EUR", **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.data.get("data", response.data.get("results", []))
+        for result in results:
+            self.assertEqual(result["currency"], "EUR")
+
+    # --- Ordering (bracket notation) ---
+
+    def test_order_by_name_asc(self):
+        """Test ordering by name ascending."""
+        self._create_price_list(name="Zebra Rates")
+        self._create_price_list(name="Alpha Rates")
+
+        url = reverse("price-lists-list")
+        response = self.client.get(f"{url}?order_by[name]=asc", **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.data.get("data", response.data.get("results", []))
+        names = [r["name"] for r in results]
+        self.assertEqual(names, sorted(names))
+
+    def test_order_by_name_desc(self):
+        """Test ordering by name descending."""
+        self._create_price_list(name="Alpha Rates")
+        self._create_price_list(name="Zebra Rates")
+
+        url = reverse("price-lists-list")
+        response = self.client.get(f"{url}?order_by[name]=desc", **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.data.get("data", response.data.get("results", []))
+        names = [r["name"] for r in results]
+        self.assertEqual(names, sorted(names, reverse=True))
+
+    def test_order_by_effective_end_date(self):
+        """Test ordering by effective_end_date."""
+        self._create_price_list(name="Short PL", effective_end_date="2026-03-31")
+        self._create_price_list(name="Long PL", effective_end_date="2026-12-31")
+
+        url = reverse("price-lists-list")
+        response = self.client.get(f"{url}?order_by[effective_end_date]=asc", **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.data.get("data", response.data.get("results", []))
+        dates = [r["effective_end_date"] for r in results]
+        self.assertEqual(dates, sorted(dates))
+
+    def test_order_by_currency(self):
+        """Test ordering by currency."""
+        self._create_price_list(name="USD PL", currency="USD")
+        self._create_price_list(name="EUR PL", currency="EUR")
+
+        url = reverse("price-lists-list")
+        response = self.client.get(f"{url}?order_by[currency]=asc", **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_order_by_assigned_cost_model_count(self):
+        """Test ordering by assigned cost model count."""
+        create_response = self._create_price_list(name="Assigned PL")
+        pl_uuid = create_response.data["uuid"]
+        self._create_price_list(name="Unassigned PL")
+
+        with tenant_context(self.tenant):
+            cost_model = CostModel.objects.first()
+            PriceListCostModelMap.objects.create(
+                price_list_id=pl_uuid,
+                cost_model=cost_model,
+                priority=1,
+            )
+
+        url = reverse("price-lists-list")
+        response = self.client.get(f"{url}?order_by[assigned_cost_model_count]=desc", **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    # --- Query param validation ---
+
+    def test_unknown_query_param_returns_400(self):
+        """Test that unknown query params return 400."""
+        url = reverse("price-lists-list")
+        response = self.client.get(f"{url}?foo=bar", **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_unknown_filter_param_returns_400(self):
+        """Test that unknown filter params return 400."""
+        url = reverse("price-lists-list")
+        response = self.client.get(f"{url}?filter[invalid_field]=value", **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_invalid_ordering_field_returns_400(self):
+        """Test that ordering by invalid field returns 400."""
+        url = reverse("price-lists-list")
+        response = self.client.get(f"{url}?order_by[nonexistent]=asc", **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    # --- Affected cost models ---
 
     def test_affected_cost_models_none(self):
         """Test affected-cost-models returns empty list when not assigned."""
-        url = reverse("price-lists-list")
-        create_response = self.client.post(url, data=self.price_list_data, format="json", **self.headers)
+        create_response = self._create_price_list()
         pl_uuid = create_response.data["uuid"]
 
         affected_url = reverse("price-lists-affected-cost-models", kwargs={"uuid": pl_uuid})
@@ -200,8 +360,7 @@ class PriceListViewTests(IamTestCase):
 
     def test_affected_cost_models_returns_linked(self):
         """Test affected-cost-models returns cost models linked to this price list."""
-        url = reverse("price-lists-list")
-        create_response = self.client.post(url, data=self.price_list_data, format="json", **self.headers)
+        create_response = self._create_price_list()
         pl_uuid = create_response.data["uuid"]
 
         with tenant_context(self.tenant):
@@ -219,3 +378,89 @@ class PriceListViewTests(IamTestCase):
         self.assertEqual(response.data[0]["uuid"], str(cost_model.uuid))
         self.assertEqual(response.data[0]["name"], cost_model.name)
         self.assertEqual(response.data[0]["priority"], 1)
+
+    # --- Inline assigned cost models ---
+
+    def test_inline_assigned_cost_models_in_response(self):
+        """Test that list response includes assigned cost model data inline."""
+        create_response = self._create_price_list()
+        pl_uuid = create_response.data["uuid"]
+
+        with tenant_context(self.tenant):
+            cost_model = CostModel.objects.first()
+            PriceListCostModelMap.objects.create(
+                price_list_id=pl_uuid,
+                cost_model=cost_model,
+                priority=1,
+            )
+
+        url = reverse("price-lists-list")
+        response = self.client.get(url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.data.get("data", response.data.get("results", []))
+        pl_result = next(r for r in results if r["uuid"] == pl_uuid)
+        self.assertEqual(pl_result["assigned_cost_model_count"], 1)
+        self.assertEqual(len(pl_result["assigned_cost_models"]), 1)
+        self.assertEqual(pl_result["assigned_cost_models"][0]["uuid"], str(cost_model.uuid))
+
+    def test_inline_assigned_cost_model_count_zero(self):
+        """Test that unassigned price list has count 0."""
+        create_response = self._create_price_list()
+
+        self.assertEqual(create_response.data["assigned_cost_model_count"], 0)
+        self.assertEqual(create_response.data["assigned_cost_models"], [])
+
+    # --- Duplicate ---
+
+    def test_duplicate_price_list(self):
+        """Test duplicating a price list."""
+        create_response = self._create_price_list(name="Original PL")
+        pl_uuid = create_response.data["uuid"]
+
+        dup_url = reverse("price-lists-duplicate", kwargs={"uuid": pl_uuid})
+        response = self.client.post(dup_url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["name"], "Copy of Original PL")
+        self.assertEqual(response.data["version"], 1)
+        self.assertEqual(response.data["enabled"], True)
+        self.assertNotEqual(response.data["uuid"], pl_uuid)
+        self.assertEqual(response.data["currency"], create_response.data["currency"])
+        self.assertEqual(response.data["effective_start_date"], create_response.data["effective_start_date"])
+        self.assertEqual(response.data["effective_end_date"], create_response.data["effective_end_date"])
+
+    def test_duplicate_not_assigned_to_cost_models(self):
+        """Test that duplicated price list is not assigned to any cost models."""
+        create_response = self._create_price_list()
+        pl_uuid = create_response.data["uuid"]
+
+        with tenant_context(self.tenant):
+            cost_model = CostModel.objects.first()
+            PriceListCostModelMap.objects.create(
+                price_list_id=pl_uuid,
+                cost_model=cost_model,
+                priority=1,
+            )
+
+        dup_url = reverse("price-lists-duplicate", kwargs={"uuid": pl_uuid})
+        response = self.client.post(dup_url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["assigned_cost_model_count"], 0)
+        self.assertEqual(response.data["assigned_cost_models"], [])
+
+    def test_duplicate_long_name_truncated(self):
+        """Test that duplicate truncates name if too long."""
+        long_name = "A" * 255
+        create_response = self._create_price_list(name=long_name)
+        pl_uuid = create_response.data["uuid"]
+
+        dup_url = reverse("price-lists-duplicate", kwargs={"uuid": pl_uuid})
+        response = self.client.post(dup_url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertTrue(response.data["name"].startswith("Copy of "))
+        self.assertLessEqual(len(response.data["name"]), 255)
+
+    def test_duplicate_nonexistent_returns_404(self):
+        """Test that duplicating a nonexistent price list returns 404."""
+        dup_url = reverse("price-lists-duplicate", kwargs={"uuid": "00000000-0000-0000-0000-000000000099"})
+        response = self.client.post(dup_url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
Switch PriceListFilter to extend SettingsFilter for filter[field] and order_by[field] bracket notation. Add sorting by currency, end date, and assigned cost model count. Inline assigned cost models in list/detail responses. Add duplicate endpoint. Reject unknown query params with 400.

## Jira Ticket

[COST-7415](https://issues.redhat.com/browse/COST-7415)

## Description

This change will ...

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Release Notes
- [ ] proposed release note

```markdown
* [COST-####](https://issues.redhat.com/browse/COST-7415) Fix some things
```
