### PR TITLE
fix(COST-7414): optional trailing slash for cost_models routes (cost-models & price-lists)

### DIFF
--- a/koku/api/common/permissions/cost_models_access.py
+++ b/koku/api/common/permissions/cost_models_access.py
@@ -17,7 +17,7 @@ class CostModelsAccessPermission(permissions.BasePermission):
         url_parts = request.META.get("PATH_INFO").split("/")
         try:
             given_uuid = str(UUID(url_parts[url_parts.index("cost-models") + 1]))
-        except ValueError:
+        except (IndexError, ValueError):
             given_uuid = None
         return given_uuid
 

--- a/koku/cost_models/urls.py
+++ b/koku/cost_models/urls.py
@@ -11,6 +11,7 @@ from cost_models.price_list_view import PriceListViewSet
 from cost_models.views import CostModelViewSet
 
 ROUTER = DefaultRouter()
+ROUTER.trailing_slash = "/?"
 ROUTER.register(r"cost-models", CostModelViewSet, basename="cost-models")
 ROUTER.register(r"price-lists", PriceListViewSet, basename="price-lists")
 


### PR DESCRIPTION
## Problem

The UI calls **price-lists** (and the same router serves **cost-models**) **without** a trailing slash, e.g. `PUT .../price-lists/{uuid}`. With DRF’s `DefaultRouter` default, detail routes are registered **with** a required trailing slash. The path without `/` does not match; Django’s `CommonMiddleware` (`APPEND_SLASH=True`) then returns **301 Moved Permanently** to the same URL **with** a trailing slash.

Following a **301** in the browser on **PUT** (and other writes) is unreliable: the second request may not preserve method/body correctly, which led to **400** / failed updates. This was reproduced from the **SaaS UI** on **stage** (Network tab showed the redirect chain).

The earlier PR text assumed this was **on-prem only** and that SaaS always normalized URLs before Koku. That does not match what the UI team saw in practice.

## Fix

Set `ROUTER.trailing_slash = "/?"` on the **`cost_models`** app `DefaultRouter` (see [`koku/cost_models/urls.py`](./koku/cost_models/urls.py)). That makes DRF-generated patterns accept **both** `/price-lists/{uuid}` and `/price-lists/{uuid}/` (and the same for **cost-models**), so the first request matches and **no** `APPEND_SLASH` redirect is needed.

There is **no** `ONPREM` guard: SaaS and on-prem behave the same for these endpoints.

Note: the [`sources` router in `api/urls.py`](./koku/api/urls.py) still uses optional trailing slash **only when** `settings.ONPREM`; this PR does not change that.

Relates to COST-7414
