### PR TITLE
Document PR title format and no-ticket fallback in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -648,9 +648,9 @@ SET search_path TO org1234567;
 ### PR and Commit Conventions
 
 **PR titles:**
-- Use `[ISSUE_KEY] Short description` — the issue key (Jira, etc.) in square brackets, a single space, then a concise description (imperative mood, sentence case is fine).
+- Use `[ISSUE_KEY] Short description` — the issue key (Jira, etc.) in square brackets, a single space, then a concise description (imperative mood, sentence case, under 72 characters).
 - Example: `[COST-1234] Fix something`
-- If there is no tracking issue or the key is unknown, use **only** the short description — no brackets, no invented placeholder keys (ask the author for the key when it should exist).
+- If there is no tracking issue or the key is unknown, use **only** the short description — no brackets, no invented placeholder keys (ask the user for the key when it should exist).
 
 **Commit messages:**
 - Use imperative mood: "Add GPU cost distribution" not "Added GPU cost distribution"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -647,6 +647,11 @@ SET search_path TO org1234567;
 
 ### PR and Commit Conventions
 
+**PR titles:**
+- Use `[ISSUE_KEY] Short description` — the issue key (Jira, etc.) in square brackets, a single space, then a concise description (imperative mood, sentence case is fine).
+- Example: `[COST-1234] Fix something`
+- If there is no tracking issue or the key is unknown, use **only** the short description — no brackets, no invented placeholder keys (ask the author for the key when it should exist).
+
 **Commit messages:**
 - Use imperative mood: "Add GPU cost distribution" not "Added GPU cost distribution"
 - Reference JIRA/GitHub issues when applicable: "COST-1234: Add MIG slice support"


### PR DESCRIPTION
## Summary
Adds **PR titles** guidance to the PR and Commit Conventions section in `AGENTS.md`:
- Pattern `[ISSUE_KEY] Short description` with example.
- Fallback when there is no ticket or the key is unknown: title is **only** the short description (no brackets, no placeholder keys).

## Testing
- Documentation-only change; no code or tests run.

Made with [Cursor](https://cursor.com)