### PR TITLE
bump local Trino image to 480-001

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -709,7 +709,7 @@ services:
 
   trino:
     container_name: trino
-    image: quay.io/redhat-services-prod/cost-mgmt-dev-tenant/ubi-trino:479-001
+    image: quay.io/redhat-services-prod/cost-mgmt-dev-tenant/ubi-trino:480-001
     user: root
     ports:
       - 8080:8080


### PR DESCRIPTION
## Jira Ticket

None

## Description

This change will bump the local `trino` container image in `docker-compose.yml` from `ubi-trino:479-001` to `ubi-trino:480-001`.

## Testing

1. Checkout branch.
2. Restart Koku Trino with the updated image:
   - `docker compose pull trino && docker compose up -d trino`
3. Verify the running Trino container is using the new tag:
   - `docker compose images trino`
    1. You should see `quay.io/redhat-services-prod/cost-mgmt-dev-tenant/ubi-trino:480-001`.
4. Verify Trino is healthy after restart:
   - `curl -s http://localhost:8080/v1/info`
   - You should get a `200` JSON response from Trino (service is up and reachable).

## Release Notes
- [ ] proposed release note

```markdown
* Bump local Trino dev image from `ubi-trino:479-001` to `ubi-trino:480-001`