### PR TITLE
COST-7405: apply filter[limit] to MIG instances instead of profiles

### DIFF
--- a/koku/api/report/ocp/provider_map.py
+++ b/koku/api/report/ocp/provider_map.py
@@ -1167,6 +1167,9 @@ class OCPProviderMap(ProviderMap):
                             {"field": "mig_profile", "operation": "gt", "parameter": ""},
                         ],
                         "group_by": ["mig_profile"],
+                        # filter[limit] ranks individual MIG instances (mig_id level), not profiles.
+                        # A node can have many instances per profile, so limiting by profile is not useful.
+                        "rank_group_by": ["mig_profile", "mig_id"],
                         # Do not synthesize an "Other(s)" bucket when filter[limit] is used; return top-N only.
                         "rank_limit_include_others": False,
                         "cost_units_key": "raw_currency",

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -1342,14 +1342,33 @@ class ReportQueryHandler(QueryHandler):
         if self.order_field == "subscription_name":
             group_by_value.append("subscription_name")
 
-        # Do not re-annotate names that are already GROUP BY columns (often the rank key).
+        # Some reports rank at a finer granularity than their response group_by.
+        # e.g. mig_profiles ranks by (mig_profile, mig_id) so filter[limit] limits
+        # individual MIG instances, not just profile groups.
+        rank_group_by = self._mapper.report_type_map.get("rank_group_by", group_by_value)
+
+        # Fields in rank_group_by that are defined in report_type_map annotations as
+        # *aliases* (e.g. mig_id = F("mig_instance_id")) are not applied by self.annotations
+        # and must be added explicitly so that .values() can resolve them.
+        # Skip fields where the annotation is just F(same_name): those are direct model
+        # fields that Django can resolve without an explicit annotation, and trying to
+        # annotate them raises "conflicts with a field on the model".
+        extra_rank_group_annotations = {
+            field: expr
+            for field in rank_group_by
+            if (expr := self.report_annotations.get(field)) is not None
+            and not (isinstance(expr, F) and expr.name == field)
+        }
+
+        # Do not re-annotate names that are already in the rank GROUP BY columns.
         # Otherwise Django raises ValueError
-        for grouped_col in group_by_value:
+        for grouped_col in rank_group_by:
             rank_annotations.pop(grouped_col, None)
 
         ranks = (
             query.annotate(**self.annotations)
-            .values(*group_by_value)
+            .annotate(**extra_rank_group_annotations)
+            .values(*rank_group_by)
             .annotate(**rank_annotations)
             .annotate(source_uuid=ArrayAgg(F("source_uuid"), filter=Q(source_uuid__isnull=False), distinct=True))
         )
@@ -1366,19 +1385,22 @@ class ReportQueryHandler(QueryHandler):
         rankings = []
         distinct_ranks = []
         for rank in ranks:
-            rank_value = (rank.get(group) for group in group_by_value)
+            rank_value = (rank.get(group) for group in rank_group_by)
             if rank_value not in rankings:
                 rankings.append(rank_value)
                 distinct_ranks.append(rank)
-        return self._ranked_list(data, distinct_ranks, set(rank_annotations))
+        return self._ranked_list(data, distinct_ranks, set(rank_annotations), rank_group_by=rank_group_by)
 
-    def _ranked_list(self, data_list, ranks, rank_fields=None):  # noqa C901
+    def _ranked_list(self, data_list, ranks, rank_fields=None, rank_group_by=None):  # noqa C901
         """Get list of ranked items less than top.
 
         Args:
             data_list (List(Dict)): List of ranked data points from the same bucket
             ranks (List): list of ranks to use; overrides ranking that may present in data_list.
             rank_fields (Set): the fields on which ranking is performed.
+            rank_group_by (List): fields used for ranking; defaults to self._get_group_by().
+                Some reports (e.g. mig_profiles) rank at a finer granularity than their
+                response group_by so that filter[limit] limits individual items, not groups.
         Returns:
             List(Dict): List of data points meeting the rank criteria
 
@@ -1387,6 +1409,8 @@ class ReportQueryHandler(QueryHandler):
             rank_fields = set()
         is_offset = "offset" in self.parameters.get("filter", {})
         group_by = self._get_group_by()
+        if rank_group_by is None:
+            rank_group_by = group_by
         self.max_rank = len(ranks)
         # Columns we drop in favor of the same named column merged in from rank data frame
         drop_columns = {"source_uuid"}
@@ -1413,12 +1437,12 @@ class ReportQueryHandler(QueryHandler):
             drop_columns.add(col)
             agg_fields[col] = ["max"]
 
-        aggs = data_frame.groupby(group_by, dropna=False).agg(agg_fields)
+        aggs = data_frame.groupby(rank_group_by, dropna=False).agg(agg_fields)
         columns = aggs.columns.droplevel(1)
         aggs.columns = columns
         aggs = aggs.reset_index()
         aggs = aggs.replace({np.nan: None})
-        rank_data_frame = rank_data_frame.merge(aggs, on=group_by)
+        rank_data_frame = rank_data_frame.merge(aggs, on=rank_group_by)
 
         # Create a dataframe of days in the query
         days = data_frame["date"].unique()
@@ -1435,7 +1459,7 @@ class ReportQueryHandler(QueryHandler):
         # Merge our data frame to "zero-fill" missing data for each rank field
         # per day in the query, using a RIGHT JOIN
         account_aliases = None
-        merge_on = group_by + ["date"]
+        merge_on = rank_group_by + ["date"]
         if self.is_aws and "account" in group_by:
             account_aliases = data_frame[["account", "account_alias"]]
             account_aliases = account_aliases.drop_duplicates(subset="account")

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -1342,17 +1342,13 @@ class ReportQueryHandler(QueryHandler):
         if self.order_field == "subscription_name":
             group_by_value.append("subscription_name")
 
-        # Some reports rank at a finer granularity than their response group_by.
-        # e.g. mig_profiles ranks by (mig_profile, mig_id) so filter[limit] limits
-        # individual MIG instances, not just profile groups.
+        # rank_group_by allows ranking at a finer granularity than the response group_by
+        # (e.g. mig_profiles ranks by (mig_profile, mig_id) so filter[limit] limits instances).
         rank_group_by = self._mapper.report_type_map.get("rank_group_by", group_by_value)
 
-        # Fields in rank_group_by that are defined in report_type_map annotations as
-        # *aliases* (e.g. mig_id = F("mig_instance_id")) are not applied by self.annotations
-        # and must be added explicitly so that .values() can resolve them.
-        # Skip fields where the annotation is just F(same_name): those are direct model
-        # fields that Django can resolve without an explicit annotation, and trying to
-        # annotate them raises "conflicts with a field on the model".
+        # Annotate alias fields in rank_group_by (e.g. mig_id = F("mig_instance_id")) that
+        # are not in self.annotations. Skip F(same_name) aliases — those are direct model
+        # fields and re-annotating them raises "conflicts with a field on the model".
         extra_rank_group_annotations = {
             field: expr
             for field in rank_group_by
@@ -1399,8 +1395,7 @@ class ReportQueryHandler(QueryHandler):
             ranks (List): list of ranks to use; overrides ranking that may present in data_list.
             rank_fields (Set): the fields on which ranking is performed.
             rank_group_by (List): fields used for ranking; defaults to self._get_group_by().
-                Some reports (e.g. mig_profiles) rank at a finer granularity than their
-                response group_by so that filter[limit] limits individual items, not groups.
+                When set, filter[limit] limits individual items rather than response groups.
         Returns:
             List(Dict): List of data points meeting the rank criteria
 

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -1385,7 +1385,7 @@ class ReportQueryHandler(QueryHandler):
         rankings = []
         distinct_ranks = []
         for rank in ranks:
-            rank_value = (rank.get(group) for group in rank_group_by)
+            rank_value = tuple(rank.get(group) for group in rank_group_by)
             if rank_value not in rankings:
                 rankings.append(rank_value)
                 distinct_ranks.append(rank)

--- a/koku/api/report/test/ocp/view/test_gpu_view.py
+++ b/koku/api/report/test/ocp/view/test_gpu_view.py
@@ -3,15 +3,20 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 """Test the GPU Report views."""
+from datetime import date
+from datetime import timedelta
 from decimal import Decimal
 from unittest.mock import patch
 from urllib.parse import urlencode
 
 from django.urls import reverse
+from django_tenants.utils import schema_context
+from model_bakery import baker
 from rest_framework import status
 from rest_framework.test import APIClient
 
 from api.iam.test.iam_test_case import IamTestCase
+from reporting.provider.ocp.models import OCPGpuSummaryP
 
 
 class OCPGpuViewTest(IamTestCase):
@@ -305,6 +310,64 @@ class OCPGpuViewTest(IamTestCase):
         err = getattr(response, "data", response.content)
         self.assertEqual(response.status_code, status.HTTP_200_OK, err)
         self.assertIn("data", response.data)
+
+    @patch("api.report.ocp.view.is_feature_flag_enabled_by_schema", return_value=True)
+    def test_mig_profiles_filter_limit_restricts_to_n_instances(self, mock_unleash):
+        """filter[limit]=N must limit individual MIG instances, not distinct profiles.
+
+        Regression test for COST-7405: previously the limit applied to mig_profile
+        groups, so with 2 profiles and limit=3 all 4 instances were returned.
+        Dataset: profile "1g.5gb" (3 instances) + profile "4g.20gb" (1 instance) = 4 total.
+        With limit=N (N<4), exactly N instances should be returned.
+        """
+        yesterday = date.today() - timedelta(days=1)
+        vendor = "nvidia_mig_limit_test"
+        model = "A100_mig_limit_test"
+        node = "node_mig_limit_test"
+
+        # "1g.5gb" sorts before "4g.20gb", so its 3 instances occupy ranks 1-3.
+        mig_rows = [
+            {"mig_profile": "1g.5gb", "mig_instance_id": "MIG-LIMIT-TEST-0001"},
+            {"mig_profile": "1g.5gb", "mig_instance_id": "MIG-LIMIT-TEST-0002"},
+            {"mig_profile": "1g.5gb", "mig_instance_id": "MIG-LIMIT-TEST-0003"},
+            {"mig_profile": "4g.20gb", "mig_instance_id": "MIG-LIMIT-TEST-0004"},
+        ]
+        with schema_context(self.schema_name):
+            for row in mig_rows:
+                baker.make(
+                    OCPGpuSummaryP,
+                    usage_start=yesterday,
+                    usage_end=yesterday,
+                    vendor_name=vendor,
+                    model_name=model,
+                    node=node,
+                    gpu_mode="MIG",
+                    raw_currency="USD",
+                    **row,
+                )
+
+        url = reverse("reports-openshift-gpu-mig-profiles")
+        base_params = {
+            "filter[gpu_vendor]": vendor,
+            "filter[gpu_model]": model,
+            "filter[node]": node,
+        }
+        for limit in (1, 2, 3):
+            with self.subTest(limit=limit):
+                params = {**base_params, "filter[limit]": str(limit)}
+                response = self.client.get(url + "?" + urlencode(params, doseq=True), **self.headers)
+                err = getattr(response, "data", response.content)
+                self.assertEqual(response.status_code, status.HTTP_200_OK, err)
+                total_instances = sum(
+                    len(p.get("values", []))
+                    for entry in response.data.get("data", [])
+                    for p in entry.get("mig_profiles", [])
+                )
+                self.assertEqual(
+                    total_instances,
+                    limit,
+                    f"filter[limit]={limit} returned {total_instances} instances; expected exactly {limit}",
+                )
 
     @patch("api.report.ocp.view.is_feature_flag_enabled_by_schema", return_value=True)
     def test_mig_profiles_endpoint_accepts_tag_filter_without_error(self, mock_unleash):


### PR DESCRIPTION
## Summary

`filter[limit]` on the `/mig_profiles/` endpoint was ranking by distinct MIG profiles, not by individual MIG instances. Since a node can have many instances per profile, the limit was effectively ignored — e.g. with 2 profiles and `filter[limit]=3`, both profiles (and all their instances) were returned.

This fix introduces a `rank_group_by` key in the provider map, allowing reports to rank at a finer granularity than their response `group_by`. For `mig_profiles`, ranking is now done at the `(mig_profile, mig_id)` level, so `filter[limit]=N` returns exactly N individual MIG instances.

**Changes:**
- `provider_map.py`: added `rank_group_by: ["mig_profile", "mig_id"]` to the `mig_profiles` report type
- `queries.py` (`_group_by_ranks`): reads `rank_group_by` from the provider map; explicitly annotates alias fields (e.g. `mig_id = F("mig_instance_id")`) that are not in `self.annotations`, skipping direct model fields to avoid Django's "conflicts with a field on the model" error
- `queries.py` (`_ranked_list`): accepts `rank_group_by` parameter and uses it for `groupby` and `merge` operations instead of the response-level `group_by`

## Testing

Manual verification with local data (2 profiles: `1g.10gb` with 3 instances, `4g.40gb` with 1 instance):

| `filter[limit]` | Before (main) | After (this PR) |
|---|---|---|
| 3 | 4 instances — both profiles returned | 3 instances — only `1g.10gb` |
| 1 | 4 instances — both profiles returned | 1 instance — only `1g.10gb` |
| 4 | 4 instances | 4 instances (all) |

Redis cache flushed between branch switches to ensure fresh computation.

Fixes: [COST-7405](https://redhat.atlassian.net/browse/COST-7405)

Made with [Cursor](https://cursor.com)