### PR TITLE
COST-7422: Allow re-enabling disabled price list via PUT

### DIFF
--- a/koku/cost_models/price_list_manager.py
+++ b/koku/cost_models/price_list_manager.py
@@ -66,7 +66,8 @@ class PriceListManager:
         if not self._model:
             raise PriceListException("No price list to update.")
 
-        if not self._model.enabled:
+        re_enabling = data.get("enabled") is True
+        if not self._model.enabled and not re_enabling:
             allowed_fields = {"name", "description", "enabled"}
             disallowed = set(data.keys()) - allowed_fields
             if disallowed:

--- a/koku/cost_models/price_list_manager.py
+++ b/koku/cost_models/price_list_manager.py
@@ -69,6 +69,9 @@ class PriceListManager:
         re_enabling = data.get("enabled") is True
         if not self._model.enabled and not re_enabling:
             allowed_fields = {"name", "description", "enabled"}
+            # Allow currency through if the value is unchanged (auto-injected by serializer)
+            if data.get("currency") == self._model.currency:
+                allowed_fields = allowed_fields | {"currency"}
             disallowed = set(data.keys()) - allowed_fields
             if disallowed:
                 raise PriceListException(

--- a/koku/cost_models/price_list_serializer.py
+++ b/koku/cost_models/price_list_serializer.py
@@ -47,6 +47,9 @@ class PriceListSerializer(BaseSerializer):
 
     def validate(self, data):
         """Validate that effective_end_date is after effective_start_date."""
+        if not self.instance and not data.get("name"):
+            raise serializers.ValidationError({"name": "This field is required."})
+
         start = data.get("effective_start_date")
         end = data.get("effective_end_date")
 

--- a/koku/cost_models/price_list_serializer.py
+++ b/koku/cost_models/price_list_serializer.py
@@ -27,7 +27,7 @@ class PriceListSerializer(BaseSerializer):
         model = PriceList
 
     uuid = serializers.UUIDField(read_only=True)
-    name = serializers.CharField(max_length=255)
+    name = serializers.CharField(max_length=255, required=False)
     description = serializers.CharField(allow_blank=True, required=False)
     currency = serializers.CharField(required=False)
     effective_start_date = serializers.DateField(required=False)

--- a/koku/cost_models/test/test_price_list_manager.py
+++ b/koku/cost_models/test/test_price_list_manager.py
@@ -173,6 +173,22 @@ class PriceListManagerUpdateTest(MasuTestCase):
             manager.update(name="Disabled Renamed")
             self.assertEqual(manager.instance.name, "Disabled Renamed")
 
+    def test_reenable_disabled_price_list_with_full_payload(self):
+        """Test that re-enabling a disabled price list accepts a full payload (currency, rates, dates)."""
+        with tenant_context(self.tenant):
+            manager = PriceListManager(self.price_list.uuid)
+            manager.update(enabled=False)
+            # Simulates the natural GET → PUT flow where currency is auto-injected
+            manager.update(
+                name=self.price_list.name,
+                description=self.price_list.description,
+                currency="USD",
+                effective_start_date=self.price_list.effective_start_date,
+                effective_end_date=self.price_list.effective_end_date,
+                enabled=True,
+            )
+            self.assertTrue(manager.instance.enabled)
+
     def test_update_disabled_price_list_rates_rejected(self):
         """Test that rates cannot be updated on a disabled price list."""
         with tenant_context(self.tenant):

--- a/koku/cost_models/test/test_price_list_manager.py
+++ b/koku/cost_models/test/test_price_list_manager.py
@@ -173,6 +173,23 @@ class PriceListManagerUpdateTest(MasuTestCase):
             manager.update(name="Disabled Renamed")
             self.assertEqual(manager.instance.name, "Disabled Renamed")
 
+    def test_update_disabled_price_list_name_with_auto_injected_currency_ok(self):
+        """Test that updating name on a disabled price list works even with auto-injected currency."""
+        with tenant_context(self.tenant):
+            manager = PriceListManager(self.price_list.uuid)
+            manager.update(enabled=False)
+            # Simulates the serializer auto-injecting currency alongside the user's change
+            manager.update(name="Renamed While Disabled", currency=self.price_list.currency)
+            self.assertEqual(manager.instance.name, "Renamed While Disabled")
+
+    def test_update_disabled_price_list_currency_change_rejected(self):
+        """Test that changing currency on a disabled price list is still rejected."""
+        with tenant_context(self.tenant):
+            manager = PriceListManager(self.price_list.uuid)
+            manager.update(enabled=False)
+            with self.assertRaises(PriceListException):
+                manager.update(name="New Name", currency="EUR")
+
     def test_reenable_disabled_price_list_with_full_payload(self):
         """Test that re-enabling a disabled price list accepts a full payload (currency, rates, dates)."""
         with tenant_context(self.tenant):


### PR DESCRIPTION
## Summary

- The serializer always auto-injects `currency` into the validated data on every update. When a price list is disabled, the manager blocked any field outside `{name, description, enabled}`, causing `currency` to trigger a rejection even on a minimal `PUT {"name": "...", "enabled": true}`.
- The fix skips the field restriction when the payload is re-enabling the price list (`enabled=True`). A disabled list that *stays* disabled still enforces the restriction as before.
- Made `name` optional on updates (`required=False`) since the UUID already identifies the resource — no need to repeat the name on every PUT.

## Test plan

- [ ] Existing tests for disabled price list restrictions still pass (rates/validity still blocked when staying disabled)
- [ ] New test `test_reenable_disabled_price_list_with_full_payload` covers Dan's exact scenario (full payload + `enabled=true`)
- [ ] `PUT {"enabled": true}` on a disabled price list returns 200

Fixes: COST-7422

Made with [Cursor](https://cursor.com)