### PR TITLE
[COST-7404] fix exclude query param for gpu report endpoint

### DIFF
--- a/koku/api/report/ocp/serializers.py
+++ b/koku/api/report/ocp/serializers.py
@@ -421,6 +421,20 @@ class OCPGpuOrderBySerializer(OrderSerializer):
     sup_total = serializers.ChoiceField(choices=OrderSerializer.ORDER_CHOICES, required=False)
 
 
+class OCPGpuExcludeSerializer(BaseExcludeSerializer):
+    """Serializer for handling GPU query parameter exclude."""
+
+    _opfields = ("cluster", "node", "project", "gpu_vendor", "gpu_model", "gpu_mode", "mig_profile")
+
+    cluster = StringOrListField(child=serializers.CharField(), required=False)
+    node = StringOrListField(child=serializers.CharField(), required=False)
+    project = StringOrListField(child=serializers.CharField(), required=False)
+    gpu_vendor = StringOrListField(child=serializers.CharField(), required=False)
+    gpu_model = StringOrListField(child=serializers.CharField(), required=False)
+    gpu_mode = StringOrListField(child=serializers.CharField(), required=False)
+    mig_profile = StringOrListField(child=serializers.CharField(), required=False)
+
+
 class OCPGpuQueryParamSerializer(OCPQueryParamSerializer):
     """Serializer for handling GPU query parameters."""
 
@@ -439,6 +453,7 @@ class OCPGpuQueryParamSerializer(OCPQueryParamSerializer):
     GROUP_BY_SERIALIZER = OCPGpuGroupBySerializer
     FILTER_SERIALIZER = OCPGpuFilterSerializer
     ORDER_BY_SERIALIZER = OCPGpuOrderBySerializer
+    EXCLUDE_SERIALIZER = OCPGpuExcludeSerializer
 
     def __init__(self, *args, **kwargs):
         """Strip tag keys from filter/exclude/group_by so nested serializers are created with cleaned data."""

--- a/koku/api/report/test/ocp/view/test_gpu_view.py
+++ b/koku/api/report/test/ocp/view/test_gpu_view.py
@@ -370,6 +370,32 @@ class OCPGpuViewTest(IamTestCase):
                 )
 
     @patch("api.report.ocp.view.is_feature_flag_enabled_by_schema", return_value=True)
+    def test_gpu_endpoint_exclude_validation(self, mock_unleash):
+        """Test that exclude accepts supported fields and rejects unsupported ones."""
+        # (exclude_field, exclude_value, group_by_field, expected_status)
+        exclude_test_matrix = [
+            ("gpu_mode", "MIG", "gpu_mode", status.HTTP_200_OK),
+            ("gpu_vendor", "nvidia", "gpu_vendor", status.HTTP_200_OK),
+            ("gpu_model", "A100", "gpu_model", status.HTTP_200_OK),
+            ("cluster", "test-cluster", "cluster", status.HTTP_200_OK),
+            ("project", "test-project", "project", status.HTTP_200_OK),
+            ("node", "gpu-node-0", "cluster", status.HTTP_200_OK),
+            ("mig_profile", "1g.5gb", "mig_profile", status.HTTP_200_OK),
+            ("unsupported_field", "value", "cluster", status.HTTP_400_BAD_REQUEST),
+        ]
+        for exclude_field, exclude_value, group_by_field, expected_status in exclude_test_matrix:
+            with self.subTest(exclude=exclude_field, expected=expected_status):
+                url = reverse("reports-openshift-gpu")
+                query_params = {f"exclude[{exclude_field}]": exclude_value, f"group_by[{group_by_field}]": "*"}
+                url = url + "?" + urlencode(query_params, doseq=True)
+                response = self.client.get(url, **self.headers)
+                self.assertEqual(
+                    response.status_code,
+                    expected_status,
+                    f"exclude[{exclude_field}]={exclude_value} expected {expected_status}, got: {response.data}",
+                )
+
+    @patch("api.report.ocp.view.is_feature_flag_enabled_by_schema", return_value=True)
     def test_mig_profiles_endpoint_accepts_tag_filter_without_error(self, mock_unleash):
         """MIG profiles API drops tag filters like GPU; UI may send them without FieldError."""
         url = reverse("reports-openshift-gpu-mig-profiles")

--- a/koku/api/report/test/ocp/view/test_gpu_view.py
+++ b/koku/api/report/test/ocp/view/test_gpu_view.py
@@ -16,6 +16,8 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 from api.iam.test.iam_test_case import IamTestCase
+from api.report.ocp.serializers import OCPGpuExcludeSerializer
+from api.report.ocp.serializers import OCPGpuGroupBySerializer
 from reporting.provider.ocp.models import OCPGpuSummaryP
 
 
@@ -371,18 +373,16 @@ class OCPGpuViewTest(IamTestCase):
 
     @patch("api.report.ocp.view.is_feature_flag_enabled_by_schema", return_value=True)
     def test_gpu_endpoint_exclude_validation(self, mock_unleash):
-        """Test that exclude accepts supported fields and rejects unsupported ones."""
-        # (exclude_field, exclude_value, group_by_field, expected_status)
-        exclude_test_matrix = [
-            ("gpu_mode", "MIG", "gpu_mode", status.HTTP_200_OK),
-            ("gpu_vendor", "nvidia", "gpu_vendor", status.HTTP_200_OK),
-            ("gpu_model", "A100", "gpu_model", status.HTTP_200_OK),
-            ("cluster", "test-cluster", "cluster", status.HTTP_200_OK),
-            ("project", "test-project", "project", status.HTTP_200_OK),
-            ("node", "gpu-node-0", "cluster", status.HTTP_200_OK),
-            ("mig_profile", "1g.5gb", "mig_profile", status.HTTP_200_OK),
-            ("unsupported_field", "value", "cluster", status.HTTP_400_BAD_REQUEST),
-        ]
+        """Test that exclude accepts all fields from OCPGpuExcludeSerializer and rejects unknown ones."""
+        group_by_fields = set(OCPGpuGroupBySerializer().fields.keys()) - {"tag", "and", "or", "exact"}
+        default_group_by = "cluster"
+
+        exclude_test_matrix = []
+        for field in OCPGpuExcludeSerializer._opfields:
+            group_by = field if field in group_by_fields else default_group_by
+            exclude_test_matrix.append((field, "test-value", group_by, status.HTTP_200_OK))
+        exclude_test_matrix.append(("unsupported_field", "value", default_group_by, status.HTTP_400_BAD_REQUEST))
+
         for exclude_field, exclude_value, group_by_field, expected_status in exclude_test_matrix:
             with self.subTest(exclude=exclude_field, expected=expected_status):
                 url = reverse("reports-openshift-gpu")


### PR DESCRIPTION
## Jira Ticket

[COST-7404](https://issues.redhat.com/browse/COST-7404)

## Description

This change fixes a GPU exclude serializer to support allowed params on the OpenShift GPU reports endpoint.

## Testing

1. Checkout branch.
2. Load test OCP data
3. Verify the fix:

    ```bash
    http://localhost:8000/api/cost-management/v1/reports/openshift/gpu/?filter[resolution]=daily&filter[time_scope_value]=-10&filter[time_scope_units]=day&exclude[gpu_mode]=MIG&group_by[gpu_mode]=*
    ```

    - You should see `200` (previously returned `400`).

4. Verify unsupported exclude fields still return `400`:

    ```bash
    http://localhost:8000/api/cost-management/v1/reports/openshift/gpu/?exclude[bad_field]=value&group_by[cluster]=*
    ```

    - You should see `{"exclude": {"bad_field": ["Unsupported parameter or invalid value"]}}`.


## Release Notes
- [ ] proposed release note

```markdown
* Fix exclude query parameter validation on OpenShift GPU reports endpoint
```