### PR TITLE
[COST-7430] Enhance Azure report query handling with subscription name fix

### DIFF
--- a/koku/api/report/azure/openshift/query_handler.py
+++ b/koku/api/report/azure/openshift/query_handler.py
@@ -92,11 +92,7 @@ class OCPAzureReportQueryHandler(AzureReportQueryHandler):
             annotations = self._mapper.report_type_map.get("annotations")
             query_data = query.values(*query_group_by).annotate(**annotations)
 
-            if (
-                "subscription_guid" in query_group_by
-                and "subscription_name" not in query_order_by
-                and "-subscription_name" not in query_order_by
-            ):
+            if "subscription_guid" in query_group_by:
                 query_data = query_data.annotate(
                     subscription_name=Coalesce(F(self._mapper.provider_map.get("alias")), "subscription_guid")
                 )

--- a/koku/api/report/azure/query_handler.py
+++ b/koku/api/report/azure/query_handler.py
@@ -158,11 +158,7 @@ class AzureReportQueryHandler(ReportQueryHandler):
             query_data = query.values(*query_group_by).annotate(**annotations)
             query_sum = self._build_sum(query)
 
-            if (
-                "subscription_guid" in query_group_by
-                and "subscription_name" not in query_order_by
-                and "-subscription_name" not in query_order_by
-            ):
+            if "subscription_guid" in query_group_by:
                 query_data = query_data.annotate(
                     subscription_name=Coalesce(F(self._mapper.provider_map.get("alias")), "subscription_guid")
                 )

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -1415,6 +1415,10 @@ class ReportQueryHandler(QueryHandler):
         if not data_list:
             return data_list
         data_frame = pd.DataFrame(data_list)
+        # Rank rows may include dimensions not selected on the main queryset (e.g. subscription_name).
+        merge_rank_keys = [col for col in rank_group_by if col in data_frame.columns]
+        if not merge_rank_keys:
+            merge_rank_keys = list(rank_group_by)
 
         rank_data_frame = pd.DataFrame(ranks)
         rank_data_frame = rank_data_frame.drop(
@@ -1432,12 +1436,12 @@ class ReportQueryHandler(QueryHandler):
             drop_columns.add(col)
             agg_fields[col] = ["max"]
 
-        aggs = data_frame.groupby(rank_group_by, dropna=False).agg(agg_fields)
+        aggs = data_frame.groupby(merge_rank_keys, dropna=False).agg(agg_fields)
         columns = aggs.columns.droplevel(1)
         aggs.columns = columns
         aggs = aggs.reset_index()
         aggs = aggs.replace({np.nan: None})
-        rank_data_frame = rank_data_frame.merge(aggs, on=rank_group_by)
+        rank_data_frame = rank_data_frame.merge(aggs, on=merge_rank_keys)
 
         # Create a dataframe of days in the query
         days = data_frame["date"].unique()
@@ -1454,7 +1458,7 @@ class ReportQueryHandler(QueryHandler):
         # Merge our data frame to "zero-fill" missing data for each rank field
         # per day in the query, using a RIGHT JOIN
         account_aliases = None
-        merge_on = rank_group_by + ["date"]
+        merge_on = merge_rank_keys + ["date"]
         if self.is_aws and "account" in group_by:
             account_aliases = data_frame[["account", "account_alias"]]
             account_aliases = account_aliases.drop_duplicates(subset="account")

--- a/koku/api/report/test/azure/openshift/test_ocp_azure_query_handler.py
+++ b/koku/api/report/test/azure/openshift/test_ocp_azure_query_handler.py
@@ -246,6 +246,25 @@ class OCPAzureQueryHandlerTest(IamTestCase):
                 self.assertIsInstance(month_item.get("subscription_guid"), str)
                 self.assertIsInstance(month_item.get("values"), list)
 
+    def test_execute_query_limit_orderby_subscription_name(self):
+        """OCP on Azure: limit + order_by subscription_name must return subscription_name on values."""
+        url = "?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[limit]=5&order_by[subscription_name]=asc&group_by[subscription_guid]=*"  # noqa: E501
+        path = reverse("reports-openshift-azure-costs")
+        query_params = self.mocked_query_params(url, OCPAzureCostView, path)
+        handler = OCPAzureReportQueryHandler(query_params)
+        query_output = handler.execute_query()
+        data = query_output.get("data")
+        self.assertIsNotNone(data)
+        cmonth_str = self.dh.this_month_start.strftime("%Y-%m")
+        for data_item in data:
+            self.assertEqual(data_item.get("date"), cmonth_str)
+            month_data = data_item.get("subscription_guids")
+            self.assertIsInstance(month_data, list)
+            for month_item in month_data:
+                self.assertIsInstance(month_item.get("subscription_guid"), str)
+                self.assertIsInstance(month_item.get("values"), list)
+                self.assertIsInstance(month_item.get("values")[0].get("subscription_name"), str)
+
     def test_execute_query_curr_month_by_subscription_guid_w_order(self):
         """Test execute_query for current month on monthly breakdown by subscription_guid with asc order."""
         url = "?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&order_by[cost]=asc&group_by[subscription_guid]=*"  # noqa: E501

--- a/koku/api/report/test/azure/test_azure_query_handler.py
+++ b/koku/api/report/test/azure/test_azure_query_handler.py
@@ -793,7 +793,83 @@ class AzureReportQueryHandlerTest(IamTestCase):
         query_params = self.mocked_query_params(url, AzureCostView, path)
         handler = AzureReportQueryHandler(query_params)
         query_output = handler.execute_query()
-        self.assertIsNotNone(query_output.get("data"))
+        data = query_output.get("data")
+        self.assertIsNotNone(data)
+        cmonth_str = self.dh.this_month_start.strftime("%Y-%m")
+        for data_item in data:
+            self.assertEqual(data_item.get("date"), cmonth_str)
+            month_data = data_item.get("subscription_guids")
+            self.assertIsInstance(month_data, list)
+            for month_item in month_data:
+                self.assertIsInstance(month_item.get("subscription_guid"), str)
+                self.assertIsInstance(month_item.get("values"), list)
+                self.assertIsInstance(month_item.get("values")[0].get("subscription_name"), str)
+
+    def test_ranked_list_merge_rank_keys_includes_subscription_name_on_rank_rows(self):
+        """When rank_group_by lists subscription_name but main rows only have subscription_guid, merge succeeds."""
+        url = "?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[limit]=2&group_by[subscription_guid]=*"  # noqa: E501
+        query_params = self.mocked_query_params(url, AzureCostView)
+        handler = AzureReportQueryHandler(query_params)
+        ranks = [
+            {"subscription_guid": "1", "subscription_name": "Sub-one", "rank": 1, "source_uuid": ["1"]},
+            {"subscription_guid": "2", "subscription_name": "Sub-two", "rank": 2, "source_uuid": ["1"]},
+        ]
+        row = {
+            "date": "2022-05",
+            "cost_markup": 1,
+            "cost_raw": 1,
+            "cost_total": 1,
+            "cost_usage": 1,
+            "infra_markup": 1,
+            "infra_raw": 1,
+            "infra_total": 1,
+            "infra_usage": 1,
+            "sup_markup": 1,
+            "sup_raw": 1,
+            "sup_total": 1,
+            "sup_usage": 1,
+            "cost_units": "USD",
+            "source_uuid": ["1"],
+        }
+        data_list = [
+            {**row, "subscription_guid": "1"},
+            {**row, "subscription_guid": "2"},
+        ]
+        rank_group_by = ["subscription_guid", "subscription_name"]
+        ranked_list = handler._ranked_list(
+            data_list, ranks, rank_fields=set(), rank_group_by=rank_group_by
+        )
+        self.assertEqual(len(ranked_list), 2)
+        self.assertEqual(ranked_list[0].get("subscription_name"), "Sub-one")
+        self.assertEqual(ranked_list[1].get("subscription_name"), "Sub-two")
+
+    def test_ranked_list_merge_rank_keys_fallback_without_overlap(self):
+        """If main rows lack every rank_group_by column, fall back to full keys (expect KeyError)."""
+        url = "?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[limit]=2&group_by[subscription_guid]=*"  # noqa: E501
+        query_params = self.mocked_query_params(url, AzureCostView)
+        handler = AzureReportQueryHandler(query_params)
+        data_list = [
+            {
+                "date": "2022-05",
+                "cost_total": 1,
+                "cost_markup": 1,
+                "cost_raw": 1,
+                "cost_usage": 1,
+                "infra_markup": 1,
+                "infra_raw": 1,
+                "infra_total": 1,
+                "infra_usage": 1,
+                "sup_markup": 1,
+                "sup_raw": 1,
+                "sup_total": 1,
+                "sup_usage": 1,
+                "cost_units": "USD",
+                "source_uuid": ["1"],
+            }
+        ]
+        ranks = [{"subscription_guid": "1", "rank": 1, "source_uuid": ["1"]}]
+        with self.assertRaises(KeyError):
+            handler._ranked_list(data_list, ranks, rank_group_by=["subscription_guid"])
 
     def test_execute_query_orderby_subscription_name(self):
         """Test execute_query with ordering by subscription_name ascending."""

--- a/koku/api/report/test/azure/test_azure_query_handler.py
+++ b/koku/api/report/test/azure/test_azure_query_handler.py
@@ -786,6 +786,15 @@ class AzureReportQueryHandlerTest(IamTestCase):
                 self.assertIsInstance(month_item.get("values"), list)
                 self.assertIsInstance(month_item.get("values")[0].get("delta_value"), Decimal)
 
+    def test_execute_query_limit_orderby_subscription_name(self):
+        """Ranked query with order_by subscription_name must include subscription_name on data rows."""
+        url = "?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[limit]=5&order_by[subscription_name]=asc&group_by[subscription_guid]=*"  # noqa: E501
+        path = reverse("reports-azure-costs")
+        query_params = self.mocked_query_params(url, AzureCostView, path)
+        handler = AzureReportQueryHandler(query_params)
+        query_output = handler.execute_query()
+        self.assertIsNotNone(query_output.get("data"))
+
     def test_execute_query_orderby_subscription_name(self):
         """Test execute_query with ordering by subscription_name ascending."""
         url = "?filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&order_by[subscription_name]=asc&group_by[subscription_guid]=*"  # noqa: E501

--- a/koku/api/report/test/azure/test_azure_query_handler.py
+++ b/koku/api/report/test/azure/test_azure_query_handler.py
@@ -836,9 +836,7 @@ class AzureReportQueryHandlerTest(IamTestCase):
             {**row, "subscription_guid": "2"},
         ]
         rank_group_by = ["subscription_guid", "subscription_name"]
-        ranked_list = handler._ranked_list(
-            data_list, ranks, rank_fields=set(), rank_group_by=rank_group_by
-        )
+        ranked_list = handler._ranked_list(data_list, ranks, rank_fields=set(), rank_group_by=rank_group_by)
         self.assertEqual(len(ranked_list), 2)
         self.assertEqual(ranked_list[0].get("subscription_name"), "Sub-one")
         self.assertEqual(ranked_list[1].get("subscription_name"), "Sub-two")


### PR DESCRIPTION
The following addresses alert seen in stage: KeyError: 'subscription_name'

- Added a new test to validate the execution of ranked queries with ordering by subscription_name, ensuring that subscription_name is included in the data rows.
- Updated the ReportQueryHandler to handle cases where rank_group_by may include dimensions not selected in the main queryset, improving the accuracy of data merging.
- Refactored the AzureReportQueryHandler to simplify the conditional logic for annotating subscription_name based on query_group_by.

This change improves the flexibility and correctness of Azure report queries, particularly in scenarios involving subscription-based data.

## Jira Ticket

[COST-####](https://issues.redhat.com/browse/COST-####)

## Description

This change will ...

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Release Notes
- [ ] proposed release note

```markdown
* [COST-####](https://issues.redhat.com/browse/COST-####) Fix some things
```
