### PR TITLE
[COST-7458] Fix version increment on metadata-only price list updates

### DIFF
--- a/koku/cost_models/price_list_manager.py
+++ b/koku/cost_models/price_list_manager.py
@@ -18,6 +18,7 @@ from cost_models.rate_sync import sync_rate_table
 LOG = logging.getLogger(__name__)
 
 _ENRICHMENT_KEYS = frozenset(("rate_id", "custom_name"))
+_COMPARISON_EXCLUDE_KEYS = frozenset(("description",))
 
 
 def _strip_enrichment(rates):
@@ -25,6 +26,12 @@ def _strip_enrichment(rates):
     if not rates:
         return rates
     return [{k: v for k, v in r.items() if k not in _ENRICHMENT_KEYS} for r in rates]
+
+
+def _strip_for_comparison(rates):
+    """Strip enrichment and non-pricing metadata for rate change detection."""
+    stripped = _strip_enrichment(rates)
+    return [{k: v for k, v in r.items() if k not in _COMPARISON_EXCLUDE_KEYS} for r in stripped]
 
 
 class PriceListException(Exception):
@@ -83,7 +90,9 @@ class PriceListManager:
                     "Only name, description, and status can be updated."
                 )
 
-        rates_changed = "rates" in data and _strip_enrichment(data["rates"]) != _strip_enrichment(self._model.rates)
+        rates_changed = "rates" in data and _strip_for_comparison(data["rates"]) != _strip_for_comparison(
+            self._model.rates
+        )
         dates_changed = (
             "effective_start_date" in data and data["effective_start_date"] != self._model.effective_start_date
         ) or ("effective_end_date" in data and data["effective_end_date"] != self._model.effective_end_date)
@@ -99,9 +108,7 @@ class PriceListManager:
             self._model.version += 1
 
         self._model.save()
-
-        if rates_changed:
-            sync_rate_table(self._model, copy.deepcopy(self._model.rates) if self._model.rates else [])
+        sync_rate_table(self._model, copy.deepcopy(self._model.rates) if self._model.rates else [])
 
         if rates_changed or dates_changed:
             self._trigger_recalculation()

--- a/koku/cost_models/test/test_price_list_view.py
+++ b/koku/cost_models/test/test_price_list_view.py
@@ -14,6 +14,7 @@ from api.iam.test.iam_test_case import IamTestCase
 from cost_models.models import CostModel
 from cost_models.models import PriceList
 from cost_models.models import PriceListCostModelMap
+from cost_models.models import Rate
 
 
 class PriceListViewTests(IamTestCase):
@@ -203,6 +204,10 @@ class PriceListViewTests(IamTestCase):
         response = self.client.put(detail_url, data=update_data, format="json", **self.headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["version"], 1)
+
+        with tenant_context(self.tenant):
+            rate = Rate.objects.get(price_list__uuid=pl_uuid)
+            self.assertEqual(rate.description, "updated rate description")
 
     def test_update_currency_fails(self):
         """Test that updating currency fails - currency is immutable."""

--- a/koku/cost_models/test/test_price_list_view.py
+++ b/koku/cost_models/test/test_price_list_view.py
@@ -172,6 +172,38 @@ class PriceListViewTests(IamTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["version"], 2)
 
+    def test_update_metadata_does_not_increment_version(self):
+        """Test that metadata-only updates do not increment version."""
+        create_response = self._create_price_list()
+        pl_uuid = create_response.data["uuid"]
+        self.assertEqual(create_response.data["version"], 1)
+
+        detail_url = reverse("price-lists-detail", kwargs={"uuid": pl_uuid})
+
+        update_data = dict(create_response.data)
+        update_data["name"] = "Renamed"
+        response = self.client.put(detail_url, data=update_data, format="json", **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["version"], 1)
+
+        update_data = dict(response.data)
+        update_data["description"] = "new desc"
+        response = self.client.put(detail_url, data=update_data, format="json", **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["version"], 1)
+
+        update_data = dict(response.data)
+        response = self.client.put(detail_url, data=update_data, format="json", **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["version"], 1)
+
+        update_data = dict(response.data)
+        update_data["rates"] = [dict(r) for r in update_data["rates"]]
+        update_data["rates"][0]["description"] = "updated rate description"
+        response = self.client.put(detail_url, data=update_data, format="json", **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["version"], 1)
+
     def test_update_currency_fails(self):
         """Test that updating currency fails - currency is immutable."""
         create_response = self._create_price_list(currency="USD")


### PR DESCRIPTION
Add description to the enrichment keys stripped before rate comparison, so metadata-only PUT requests (name, description, enabled) no longer falsely increment the version field.

## Jira Ticket

[COST-7458](https://issues.redhat.com/browse/COST-7458)

## Description

This change will ...

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Release Notes
- [ ] proposed release note

```markdown
* [COST-7458](https://issues.redhat.com/browse/COST-7458) Fix some things
```
