### PR TITLE
Disable gunicorn control socket to fix PermissionError

### DIFF
--- a/koku/gunicorn_conf.py
+++ b/koku/gunicorn_conf.py
@@ -32,6 +32,11 @@ access_log_format = '%(h)s %(l)s %(u)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s"'
 # Allow HTTP headers up to this size
 limit_request_field_size = 16380
 
+# Control Socket (https://gunicorn.org/reference/settings/#control)
+# Disable the control socket (gunicornc) to avoid PermissionError in containers
+# where $HOME resolves to / (e.g. OpenShift random UIDs).
+control_socket_disable = True
+
 # Server Socket (https://docs.gunicorn.org/en/stable/settings.html#server-socket)
 bind = f"0.0.0.0:{CLOWDER_PORT}"
 

--- a/koku/gunicorn_conf.py
+++ b/koku/gunicorn_conf.py
@@ -13,8 +13,6 @@ from koku.probe_server import start_probe_server
 
 ENVIRONMENT = environ.Env()
 
-SOURCES = ENVIRONMENT.bool("SOURCES", default=False)
-
 CLOWDER_PORT = "8000"
 if ENVIRONMENT.bool("CLOWDER_ENABLED", default=False):
     from app_common_python import LoadedConfig
@@ -24,11 +22,11 @@ if ENVIRONMENT.bool("CLOWDER_ENABLED", default=False):
     if ENVIRONMENT.bool("MASU", default=False) or ENVIRONMENT.bool("SOURCES", default=False):
         CLOWDER_PORT = LoadedConfig.privatePort
 
-# Logging (https://docs.gunicorn.org/en/stable/settings.html#logging)
+# Logging (https://gunicorn.org/reference/settings/#logging)
 loglevel = ENVIRONMENT.get_value("GUNICORN_LOG_LEVEL", default="DEBUG")
 access_log_format = '%(h)s %(l)s %(u)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s"'
 
-# Security (https://docs.gunicorn.org/en/stable/settings.html?highlight=limit_request_field_size#security)
+# Security (https://gunicorn.org/reference/settings/#security)
 # Allow HTTP headers up to this size
 limit_request_field_size = 16380
 
@@ -37,10 +35,10 @@ limit_request_field_size = 16380
 # where $HOME resolves to / (e.g. OpenShift random UIDs).
 control_socket_disable = True
 
-# Server Socket (https://docs.gunicorn.org/en/stable/settings.html#server-socket)
+# Server Socket (https://gunicorn.org/reference/settings/#server-socket)
 bind = f"0.0.0.0:{CLOWDER_PORT}"
 
-# Worker Processes (https://docs.gunicorn.org/en/stable/settings.html#worker-processes)
+# Worker Processes (https://gunicorn.org/reference/settings/#worker-processes)
 cpu_resources = ENVIRONMENT.int("POD_CPU_LIMIT", default=multiprocessing.cpu_count())
 workers = ENVIRONMENT.int("GUNICORN_WORKERS", default=(cpu_resources * 2 + 1))
 gunicorn_threads = ENVIRONMENT.bool("GUNICORN_THREADS", default=False)
@@ -50,7 +48,7 @@ timeout = ENVIRONMENT.int("TIMEOUT", default=90)
 graceful_timeout = ENVIRONMENT.int("GRACEFUL_TIMEOUT", default=180)
 
 
-# Server Hooks (https://docs.gunicorn.org/en/stable/settings.html#server-hooks)
+# Server Hooks (https://gunicorn.org/reference/settings/#server-hooks)
 def on_starting(server):
     """Called just before the main process is initialized."""
     httpd = start_probe_server(BasicProbeServer, server.log)


### PR DESCRIPTION
## Jira Ticket

None

## Description

This change disables the gunicorn control socket (`gunicornc`) which was causing `PermissionError: [Errno 13] Permission denied: '/.gunicorn'` errors in stage. Gunicorn 25.1.0+ enables a control socket by default, and in OpenShift containers where a random UID is assigned, `$HOME` resolves to `/` which is not writable.

## Testing

1. Checkout branch.
2. Start the backend: `docker compose up -d db valkey koku-server`
3. Reproduce the original error (without fix) to confirm the issue:
    ```bash
    docker compose exec -w /opt/koku/koku --user 1000670000 koku-server \
      timeout 5 gunicorn koku.wsgi --config gunicorn_conf.py --bind 0.0.0.0:9998 --workers 1 --preload 2>&1
    ```
    1. You should see `Control server error: [Errno 13] Permission denied: '/.gunicorn'`
4. Verify the fix works (using the mounted source with the change):
    ```bash
    docker compose exec -w /koku/koku --user 1000670000 koku-server \
      timeout 5 gunicorn koku.wsgi --config gunicorn_conf.py --bind 0.0.0.0:9998 --workers 1 --preload 2>&1
    ```
    1. You should see `Control socket disabled` and **no** `PermissionError`.
5. Confirm normal startup still works:
    ```bash
    docker compose restart koku-server
    docker compose logs --since=30s koku-server 2>&1 | grep -i "error\|control"
    ```
    1. No control socket errors should appear.

## Release Notes
- [ ] proposed release note

```markdown
* Fix gunicorn PermissionError in OpenShift by disabling unused control socket