### PR TITLE
[COST-7249] Widen rates_to_usage.label_hash to VARCHAR(64)

### DIFF
--- a/koku/reporting/migrations/0350_widen_ratestousage_label_hash.py
+++ b/koku/reporting/migrations/0350_widen_ratestousage_label_hash.py
@@ -1,0 +1,15 @@
+from django.db import migrations
+from django.db import models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [("reporting", "0349_ratestousage_composite_index")]
+
+    operations = [
+        migrations.AlterField(
+            model_name="ratestousage",
+            name="label_hash",
+            field=models.CharField(max_length=64, null=True),
+        ),
+    ]

--- a/koku/reporting/provider/ocp/models.py
+++ b/koku/reporting/provider/ocp/models.py
@@ -1085,7 +1085,7 @@ class RatesToUsage(models.Model):
     distributed_cost = models.DecimalField(max_digits=33, decimal_places=15, null=True)
     cost_category = models.ForeignKey("OpenshiftCostCategory", on_delete=models.CASCADE, null=True)
     labels = JSONField(null=True)
-    label_hash = models.CharField(max_length=32, null=True)
+    label_hash = models.CharField(max_length=64, null=True)
 
 
 # Import on-prem line item models so Django can discover them for migrations


### PR DESCRIPTION
## Summary

- Extends `rates_to_usage.label_hash` from `VARCHAR(32)` to `VARCHAR(64)` in preparation for Phase 3's SHA-256 hash upgrade
- Updates the `RatesToUsage` model and adds migration `0350`
- Backwards-compatible: existing 32-char MD5 hashes are unaffected

## Context

Split out from Phase 3 PR #6043 per TL request. Merging the schema change independently keeps Phase 3 as a pure SQL/Python change with a clean git-revert rollback path (no migration entanglement).

The `AlterField` reverse naturally narrows back to `VARCHAR(32)`. If 64-char SHA-256 data exists (from Phase 3), PostgreSQL will reject the reverse — which is the correct behavior since Phase 3 must be reverted first.

## Test plan

- [ ] Migration applies cleanly on a fresh database
- [ ] Migration applies cleanly on a database with existing `rates_to_usage` rows (Phase 2 MD5 hashes)
- [ ] Existing Phase 2 cost model processing is unaffected
- [ ] CI passes

Made with [Cursor](https://cursor.com)