### PR TITLE
Fix scrape_azure_storage_capacities Celery task name mismatch

### DIFF
--- a/koku/masu/celery/tasks.py
+++ b/koku/masu/celery/tasks.py
@@ -308,7 +308,7 @@ def get_daily_currency_rates():
     return rate_metrics
 
 
-@celery_app.task(name="masu.celery.scrape_azure_storage_capacities", queue=DEFAULT)
+@celery_app.task(name="masu.celery.tasks.scrape_azure_storage_capacities", queue=DEFAULT)
 def scrape_azure_storage_capacities():
     """Task to retrieve the Azure disk capacities.
 


### PR DESCRIPTION
## Description

The `scrape_azure_storage_capacities` Celery task has been silently failing since the beat schedule was introduced in March 2025 (COST-5083 / #5532).

**Root cause:** The task decorator used an incorrect `name=` that was missing the `tasks` path segment:

```python
# Before (wrong)
@celery_app.task(name="masu.celery.scrape_azure_storage_capacities", queue=DEFAULT)

# After (correct — matches beat schedule and all other tasks)
@celery_app.task(name="masu.celery.tasks.scrape_azure_storage_capacities", queue=DEFAULT)
```

The Celery beat schedule in `celery.py` correctly dispatches `masu.celery.tasks.scrape_azure_storage_capacities` at 02:00 UTC daily, but since the worker had no task registered under that name, it silently discarded every message with:

```
Received unregistered task of type 'masu.celery.tasks.scrape_azure_storage_capacities'.
The message has been ignored and discarded.
```

This was captured in GlitchTip starting 2026-05-08, occurring every day at 02:00 UTC (issues #4433170 and #4433171). The `DiskCapacity` table for Azure has not been updated since the bug surfaced.

## Testing

1. Checkout branch and restart the Celery worker
2. Trigger the task manually:
   ```bash
   docker compose exec koku-worker celery -A koku call masu.celery.tasks.scrape_azure_storage_capacities
   ```
   Expected: task executes and `DiskCapacity` rows for `PROVIDER_AZURE` are created/updated
3. Verify the existing unit tests still pass:
   ```bash
   pipenv run tox -- masu.test.celery.test_tasks
   ```

## Release Notes
- [ ] proposed release note

```markdown
* Fix silent failure of `scrape_azure_storage_capacities` Celery task caused by task name mismatch between decorator and beat schedule
```

Made with [Cursor](https://cursor.com)