### PR TITLE
[COST-7435] Gate cross-org cluster ID lookup behind Unleash feature flag

### DIFF
--- a/koku/masu/external/kafka_msg_handler.py
+++ b/koku/masu/external/kafka_msg_handler.py
@@ -393,6 +393,20 @@ def extract_payload(url, request_id, b64_identity, context):  # noqa: C901
             source = utils.get_source_and_provider_from_cluster_id(
                 manifest.cluster_id, org_id=org_id, skip_org_id_filter=True
             )
+            if source:
+                LOG.warning(
+                    log_json(
+                        manifest.uuid,
+                        msg="cross-org cluster lookup bypass used",
+                        context={
+                            **context,
+                            "requesting_org_id": org_id,
+                            "source_org_id": source.org_id,
+                            "cluster_id": manifest.cluster_id,
+                            "provider_uuid": str(source.koku_uuid),
+                        },
+                    )
+                )
     if not source:
         msg = f"Received unexpected OCP report from {manifest.cluster_id}"
         LOG.warning(log_json(manifest.uuid, msg=msg, context=context))

--- a/koku/masu/external/kafka_msg_handler.py
+++ b/koku/masu/external/kafka_msg_handler.py
@@ -384,13 +384,15 @@ def extract_payload(url, request_id, b64_identity, context):  # noqa: C901
         )
     )
     org_id = context["org_id"]
-    schema_name_for_flag = Customer.objects.filter(org_id=org_id).values_list("schema_name", flat=True).first()
-    skip_org_id_filter = bool(
-        schema_name_for_flag and is_feature_flag_enabled_by_schema(schema_name_for_flag, CROSS_ORG_CLUSTER_LOOKUP_FLAG)
-    )
-    source = utils.get_source_and_provider_from_cluster_id(
-        manifest.cluster_id, org_id=org_id, skip_org_id_filter=skip_org_id_filter
-    )
+    source = utils.get_source_and_provider_from_cluster_id(manifest.cluster_id, org_id=org_id)
+    if not source:
+        schema_name_for_flag = Customer.objects.filter(org_id=org_id).values_list("schema_name", flat=True).first()
+        if schema_name_for_flag and is_feature_flag_enabled_by_schema(
+            schema_name_for_flag, CROSS_ORG_CLUSTER_LOOKUP_FLAG
+        ):
+            source = utils.get_source_and_provider_from_cluster_id(
+                manifest.cluster_id, org_id=org_id, skip_org_id_filter=True
+            )
     if not source:
         msg = f"Received unexpected OCP report from {manifest.cluster_id}"
         LOG.warning(log_json(manifest.uuid, msg=msg, context=context))

--- a/koku/masu/external/kafka_msg_handler.py
+++ b/koku/masu/external/kafka_msg_handler.py
@@ -32,6 +32,7 @@ from kombu.exceptions import OperationalError as KombuOperationalError
 
 import masu.util.ocp.ocp_data_validator  # noqa: F401
 from api.common import log_json
+from api.iam.models import Customer
 from api.provider.models import Provider
 from api.settings.utils import get_data_retention_months
 from api.utils import DateHelper
@@ -47,6 +48,8 @@ from masu.config import Config
 from masu.database.report_manifest_db_accessor import ReportManifestDBAccessor
 from masu.external import UNCOMPRESSED
 from masu.external.ros_report_shipper import ROSReportShipper
+from masu.processor import CROSS_ORG_CLUSTER_LOOKUP_FLAG
+from masu.processor import is_feature_flag_enabled_by_schema
 from masu.processor._tasks.process import _process_report_file
 from masu.processor.parquet.parquet_report_processor import ParquetReportProcessorError
 from masu.processor.report_processor import ReportProcessorDBError
@@ -380,7 +383,14 @@ def extract_payload(url, request_id, b64_identity, context):  # noqa: C901
             context=context,
         )
     )
-    source = utils.get_source_and_provider_from_cluster_id(manifest.cluster_id, org_id=context["org_id"])
+    org_id = context["org_id"]
+    schema_name_for_flag = Customer.objects.filter(org_id=org_id).values_list("schema_name", flat=True).first()
+    skip_org_id_filter = bool(
+        schema_name_for_flag and is_feature_flag_enabled_by_schema(schema_name_for_flag, CROSS_ORG_CLUSTER_LOOKUP_FLAG)
+    )
+    source = utils.get_source_and_provider_from_cluster_id(
+        manifest.cluster_id, org_id=org_id, skip_org_id_filter=skip_org_id_filter
+    )
     if not source:
         msg = f"Received unexpected OCP report from {manifest.cluster_id}"
         LOG.warning(log_json(manifest.uuid, msg=msg, context=context))

--- a/koku/masu/processor/__init__.py
+++ b/koku/masu/processor/__init__.py
@@ -25,6 +25,7 @@ TAG_QUERY_RATE_LIMIT_FLAG = "cost-management.backend.rate-limit-tag-queries"
 DISABLE_PRICE_LIST_UNLEASH_FLAG = "cost-management.backend.disable_price_list"
 COST_MODEL_WRITE_FREEZE_FLAG = "cost-management.backend.disable-cost-model-writes"
 COST_BREAKDOWN_RTU_UNLEASH_FLAG = "cost-management.backend.cost_breakdown_rates_to_usage"
+CROSS_ORG_CLUSTER_LOOKUP_FLAG = "cost-management.backend.is_cross_org_cluster_lookup_enabled"
 
 
 def is_feature_flag_enabled_by_schema(schema, feature_flag, dev_fallback=False):  # pragma: no cover

--- a/koku/masu/test/external/test_kafka_msg_handler.py
+++ b/koku/masu/test/external/test_kafka_msg_handler.py
@@ -822,8 +822,8 @@ class KafkaMsgHandlerTest(MasuTestCase):
                                 shutil.rmtree(fake_dir)
                                 shutil.rmtree(fake_data_dir)
 
-    def test_extract_payload_cross_org_flag_disabled(self):
-        """Test that cluster ID lookup is called with skip_org_id_filter=False when flag is off."""
+    def test_extract_payload_cross_org_flag_not_checked_on_successful_lookup(self):
+        """Test that the feature flag is never consulted when the standard org_id lookup succeeds."""
         payload_url = "http://insights-upload.com/quarnantine/file_to_validate"
         with requests_mock.mock() as m:
             m.get(payload_url, content=self.tarball_file)
@@ -834,11 +834,10 @@ class KafkaMsgHandlerTest(MasuTestCase):
                         patch(
                             "masu.external.kafka_msg_handler.utils.get_source_and_provider_from_cluster_id",
                             return_value=self.ocp_source,
-                        ) as mock_lookup,
+                        ),
                         patch(
                             "masu.external.kafka_msg_handler.is_feature_flag_enabled_by_schema",
-                            return_value=False,
-                        ),
+                        ) as mock_flag,
                         patch("masu.external.kafka_msg_handler.create_cost_and_usage_report_manifest", return_value=1),
                         patch("masu.external.kafka_msg_handler.record_report_status", returns=None),
                     ):
@@ -848,12 +847,11 @@ class KafkaMsgHandlerTest(MasuTestCase):
                             "fake_identity",
                             {"account": "1234", "org_id": "5678"},
                         )
-                        _, call_kwargs = mock_lookup.call_args
-                        self.assertFalse(call_kwargs.get("skip_org_id_filter", False))
+                        mock_flag.assert_not_called()
                         shutil.rmtree(fake_dir)
 
-    def test_extract_payload_cross_org_flag_enabled(self):
-        """Test that get_source_and_provider_from_cluster_id is called with skip_org_id_filter=True when flag is on."""
+    def test_extract_payload_cross_org_flag_enabled_retries_without_org_filter(self):
+        """Test that when standard lookup fails and flag is on, a cross-org lookup is attempted."""
         payload_url = "http://insights-upload.com/quarnantine/file_to_validate"
         with requests_mock.mock() as m:
             m.get(payload_url, content=self.tarball_file)
@@ -863,12 +861,13 @@ class KafkaMsgHandlerTest(MasuTestCase):
                     with (
                         patch(
                             "masu.external.kafka_msg_handler.utils.get_source_and_provider_from_cluster_id",
-                            return_value=self.ocp_source,
+                            side_effect=[None, self.ocp_source],
                         ) as mock_lookup,
                         patch(
                             "masu.external.kafka_msg_handler.is_feature_flag_enabled_by_schema",
                             return_value=True,
                         ),
+                        patch("masu.external.kafka_msg_handler.Customer"),
                         patch("masu.external.kafka_msg_handler.create_cost_and_usage_report_manifest", return_value=1),
                         patch("masu.external.kafka_msg_handler.record_report_status", returns=None),
                     ):
@@ -878,8 +877,37 @@ class KafkaMsgHandlerTest(MasuTestCase):
                             "fake_identity",
                             {"account": "1234", "org_id": self.org_id},
                         )
-                        _, call_kwargs = mock_lookup.call_args
-                        self.assertTrue(call_kwargs.get("skip_org_id_filter"))
+                        self.assertEqual(mock_lookup.call_count, 2)
+                        _, second_call_kwargs = mock_lookup.call_args
+                        self.assertTrue(second_call_kwargs.get("skip_org_id_filter"))
+                        shutil.rmtree(fake_dir)
+
+    def test_extract_payload_cross_org_flag_disabled_does_not_retry(self):
+        """Test that when standard lookup fails and flag is off, no cross-org retry is attempted."""
+        payload_url = "http://insights-upload.com/quarnantine/file_to_validate"
+        with requests_mock.mock() as m:
+            m.get(payload_url, content=self.tarball_file)
+            fake_dir = tempfile.mkdtemp()
+            with patch.object(Config, "INSIGHTS_LOCAL_REPORT_DIR", fake_dir):
+                with patch.object(Config, "TMP_DIR", fake_dir):
+                    with (
+                        patch(
+                            "masu.external.kafka_msg_handler.utils.get_source_and_provider_from_cluster_id",
+                            return_value=None,
+                        ) as mock_lookup,
+                        patch(
+                            "masu.external.kafka_msg_handler.is_feature_flag_enabled_by_schema",
+                            return_value=False,
+                        ),
+                        patch("masu.external.kafka_msg_handler.Customer"),
+                    ):
+                        msg_handler.extract_payload(
+                            payload_url,
+                            "test_request_id",
+                            "fake_identity",
+                            {"account": "1234", "org_id": "5678"},
+                        )
+                        self.assertEqual(mock_lookup.call_count, 1)
                         shutil.rmtree(fake_dir)
 
     @patch("masu.external.kafka_msg_handler.ROSReportShipper")

--- a/koku/masu/test/external/test_kafka_msg_handler.py
+++ b/koku/masu/test/external/test_kafka_msg_handler.py
@@ -822,6 +822,66 @@ class KafkaMsgHandlerTest(MasuTestCase):
                                 shutil.rmtree(fake_dir)
                                 shutil.rmtree(fake_data_dir)
 
+    def test_extract_payload_cross_org_flag_disabled(self):
+        """Test that cluster ID lookup is called with skip_org_id_filter=False when flag is off."""
+        payload_url = "http://insights-upload.com/quarnantine/file_to_validate"
+        with requests_mock.mock() as m:
+            m.get(payload_url, content=self.tarball_file)
+            fake_dir = tempfile.mkdtemp()
+            with patch.object(Config, "INSIGHTS_LOCAL_REPORT_DIR", fake_dir):
+                with patch.object(Config, "TMP_DIR", fake_dir):
+                    with (
+                        patch(
+                            "masu.external.kafka_msg_handler.utils.get_source_and_provider_from_cluster_id",
+                            return_value=self.ocp_source,
+                        ) as mock_lookup,
+                        patch(
+                            "masu.external.kafka_msg_handler.is_feature_flag_enabled_by_schema",
+                            return_value=False,
+                        ),
+                        patch("masu.external.kafka_msg_handler.create_cost_and_usage_report_manifest", return_value=1),
+                        patch("masu.external.kafka_msg_handler.record_report_status", returns=None),
+                    ):
+                        msg_handler.extract_payload(
+                            payload_url,
+                            "test_request_id",
+                            "fake_identity",
+                            {"account": "1234", "org_id": "5678"},
+                        )
+                        _, call_kwargs = mock_lookup.call_args
+                        self.assertFalse(call_kwargs.get("skip_org_id_filter", False))
+                        shutil.rmtree(fake_dir)
+
+    def test_extract_payload_cross_org_flag_enabled(self):
+        """Test that get_source_and_provider_from_cluster_id is called with skip_org_id_filter=True when flag is on."""
+        payload_url = "http://insights-upload.com/quarnantine/file_to_validate"
+        with requests_mock.mock() as m:
+            m.get(payload_url, content=self.tarball_file)
+            fake_dir = tempfile.mkdtemp()
+            with patch.object(Config, "INSIGHTS_LOCAL_REPORT_DIR", fake_dir):
+                with patch.object(Config, "TMP_DIR", fake_dir):
+                    with (
+                        patch(
+                            "masu.external.kafka_msg_handler.utils.get_source_and_provider_from_cluster_id",
+                            return_value=self.ocp_source,
+                        ) as mock_lookup,
+                        patch(
+                            "masu.external.kafka_msg_handler.is_feature_flag_enabled_by_schema",
+                            return_value=True,
+                        ),
+                        patch("masu.external.kafka_msg_handler.create_cost_and_usage_report_manifest", return_value=1),
+                        patch("masu.external.kafka_msg_handler.record_report_status", returns=None),
+                    ):
+                        msg_handler.extract_payload(
+                            payload_url,
+                            "test_request_id",
+                            "fake_identity",
+                            {"account": "1234", "org_id": self.org_id},
+                        )
+                        _, call_kwargs = mock_lookup.call_args
+                        self.assertTrue(call_kwargs.get("skip_org_id_filter"))
+                        shutil.rmtree(fake_dir)
+
     @patch("masu.external.kafka_msg_handler.ROSReportShipper")
     def test_extract_payload_ROS_report(self, mock_ros_shipper):
         """Test to verify extracting a ROS payload is successful."""

--- a/koku/masu/test/util/ocp/test_common.py
+++ b/koku/masu/test/util/ocp/test_common.py
@@ -76,6 +76,29 @@ class OCPUtilTests(MasuTestCase):
         provider_uuid = utils.get_source_and_provider_from_cluster_id(cluster_id, self.org_id)
         self.assertIsNone(provider_uuid)
 
+    def test_get_source_and_provider_from_cluster_id_cross_org_filter_skipped(self):
+        """Test that skip_org_id_filter=True returns a source regardless of org_id mismatch."""
+        different_org_id = "different_org"
+        baker.make("Sources", provider=self.ocp_provider, org_id=different_org_id)
+        # Without skip, a different org_id should return None
+        source = utils.get_source_and_provider_from_cluster_id(self.ocp_cluster_id, self.org_id)
+        self.assertIsNone(source)
+        # With skip, the org_id filter is bypassed and the source is found
+        source = utils.get_source_and_provider_from_cluster_id(
+            self.ocp_cluster_id, self.org_id, skip_org_id_filter=True
+        )
+        self.assertIsNotNone(source)
+        self.assertEqual(source.provider, self.ocp_provider)
+
+    def test_get_source_and_provider_from_cluster_id_cross_org_filter_enforced(self):
+        """Test that skip_org_id_filter=False (default) enforces the org_id filter."""
+        baker.make("Sources", provider=self.ocp_provider, org_id=self.org_id)
+        wrong_org_id = "wrong_org"
+        source = utils.get_source_and_provider_from_cluster_id(
+            self.ocp_cluster_id, wrong_org_id, skip_org_id_filter=False
+        )
+        self.assertIsNone(source)
+
     def test_match_openshift_labels(self):
         """Test that a label match returns."""
         matched_tags = [{"key": "value"}, {"other_key": "other_value"}]

--- a/koku/masu/util/ocp/common.py
+++ b/koku/masu/util/ocp/common.py
@@ -559,16 +559,22 @@ def get_cluster_alias_from_cluster_id(cluster_id):
     return cluster_alias
 
 
-def get_source_and_provider_from_cluster_id(cluster_id, org_id):
-    """Return the provider given the cluster ID."""
-    source = None
+def get_source_and_provider_from_cluster_id(cluster_id, org_id, skip_org_id_filter=False):
+    """Return the provider given the cluster ID.
+
+    Args:
+        cluster_id: OCP cluster identifier.
+        org_id: Organization ID used to scope the lookup and prevent cross-org data leakage.
+        skip_org_id_filter: When True, the org_id filter is omitted. Should only be set by
+            callers that have verified the cross-org lookup Unleash flag is enabled for the
+            target schema.
+    """
     credentials = {"cluster_id": cluster_id}
-    if (
-        source := Sources.objects.select_related("provider")
-        .filter(provider__authentication__credentials=credentials)
-        .filter(org_id=org_id)
-        .first()
-    ):
+    qs = Sources.objects.select_related("provider").filter(provider__authentication__credentials=credentials)
+    if not skip_org_id_filter:
+        qs = qs.filter(org_id=org_id)
+    source = qs.first()
+    if source:
         context = {"provider_uuid": source.koku_uuid, "cluster_id": cluster_id}
         LOG.info(log_json("", msg="found provider for cluster-id", context=context))
     return source


### PR DESCRIPTION
## Jira Ticket
[COST-7435](https://issues.redhat.com/browse/COST-7435)

## Description

This change gates the cross-organization cluster ID lookup in `get_source_and_provider_from_cluster_id` behind an Unleash feature flag (`cost-management.backend.is_cross_org_cluster_lookup_enabled`).

- By default, the `org_id` filter is always applied — no behavioral change for any existing account.
- When the flag is enabled for a specific schema, `skip_org_id_filter=True` is passed to the lookup, allowing controlled cross-org payload ingestion for that account only.
- This provides a per-account toggle for ops scenarios (e.g. re-ingesting OCP payloads on behalf of a customer from a different org context) without removing the safety guard globally.

## Testing

### Unit Tests

```bash
pipenv run tox -- masu.test.util.ocp.test_common
pipenv run tox -- masu.test.external.test_kafka_msg_handler
```

### Manual Verification (Django shell)

1. Checkout the branch and start the backend:

```bash
git checkout cost-7435-cross-org-cluster-lookup-flag
export USER_ID=$(id -u) && export GROUP_ID=$(id -g)
docker compose up -d db valkey koku-server masu-server koku-worker koku-beat
```

2. Open a Django shell:

```bash
docker compose exec -w /koku/koku koku-server python manage.py shell
```

3. Run the following to validate all three scenarios:

```python
from model_bakery import baker
from masu.util.ocp.common import get_source_and_provider_from_cluster_id

CLUSTER_ID = "test-cluster-123"

auth = baker.make("ProviderAuthentication", credentials={"cluster_id": CLUSTER_ID})
provider = baker.make("Provider", authentication=auth)
source = baker.make("Sources", provider=provider, org_id="org_a")

# Should return the source — correct org
result = get_source_and_provider_from_cluster_id(CLUSTER_ID, org_id="org_a")
print("org correct:", result)  # Source ID: XXXXXXXX

# Should return None — org filter blocks cross-org lookup
result = get_source_and_provider_from_cluster_id(CLUSTER_ID, org_id="org_b")
print("org mismatch:", result)  # None

# Should return the source — filter bypassed via skip_org_id_filter=True
result = get_source_and_provider_from_cluster_id(CLUSTER_ID, org_id="org_b", skip_org_id_filter=True)
print("org mismatch + skip:", result)  # Source ID: XXXXXXXX
```

4. Expected output:
   - `org correct:` → Source object returned ✅
   - `org mismatch:` → `None` ✅
   - `org mismatch + skip:` → Source object returned ✅

## Release Notes
- [ ] proposed release note

```markdown
* [COST-7435](https://issues.redhat.com/browse/COST-7435) Gate cross-org cluster ID lookup behind Unleash feature flag
```

Made with [Cursor](https://cursor.com)