### PR TITLE
docker - do not ignore migration files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,8 +11,11 @@
 !scripts/
 
 # keep the test files out of the final image
-# WARNING - This will also remove any file that contains test in the name like latest.
-**/*test*
+**/test/
+**/test_*
+**/conftest.py
+**/*_test.py
+**/koku_test_runner.py
 **/__pycache__
 **/*.log
 


### PR DESCRIPTION
## Jira Ticket

None

## Description

This change fixes the `.dockerignore` to stop excluding Django migration files from the Docker image. The old pattern `**/*test*` was overly broad — it matched any file containing the substring "test" anywhere in the name. This caused migration files like `0349_ratestousage_composite_index.py` and `0350_widen_ratestousage_label_hash.py to be silently excluded from the production image, preventing `migrate_schemas` from discovering and applying them.

The fix replaces the single glob with targeted patterns that only exclude actual test artifacts: `**/test/` directories, `**/test_*` files, `**/conftest.py`, `**/*_test.py`, and `**/koku_test_runner.py`.

## Testing

1. Checkout the branch.
2. Build the Docker image:
    ```bash
    docker build -t koku-test .
    ```
3. Verify that the previously-excluded migration files are present in the image:
    ```bash
    docker run --rm koku-test find /opt/koku/koku -name '0349_ratestousage*' -o -name '0350_widen_ratestousage*'
    ```
    1. You should see both migration files listed:
        ```
        /opt/koku/koku/reporting/migrations/0349_ratestousage_composite_index.py
        /opt/koku/koku/reporting/migrations/0350_widen_ratestousage_label_hash.py
        ```
4. Verify that test files are still excluded:
    ```bash
    docker run --rm koku-test find /opt/koku/koku -path '*/test/*' -name '*.py' | head -5
    docker run --rm koku-test find /opt/koku/koku -name 'test_*.py' | head -5
    docker run --rm koku-test find /opt/koku/koku -name 'conftest.py' | head -5
    ```
    1. All three commands should return no output (test files are excluded).
5. Verify that `migrate_schemas` can discover the migrations:
    ```bash
    docker run --rm koku-test python koku/manage.py showmigrations reporting | grep ratestousage
    ```
    1. You should see the migration entries listed (unchecked since no DB is connected, but present).

## Release Notes
- [ ] proposed release note

```markdown
* Fix .dockerignore excluding migration files whose names contain "test" as a substring
```