### PR TITLE
Clarify cost-models name filter behavior in OpenAPI spec

### DIFF
--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -184,10 +184,11 @@
                         "name": "name",
                         "required": false,
                         "in": "query",
-                        "description": "Filter response on cost model name.",
+                        "description": "Filter response on cost model name using case-insensitive substring matching. Accepts comma-separated values as an AND filter (e.g. 'gpu,demo' returns only models whose name contains both 'gpu' AND 'demo').",
                         "schema": {
                             "type": "string"
-                        }
+                        },
+                        "example": "OpenShift"
                     },
                     {
                         "name": "currency",


### PR DESCRIPTION
## Description

The `name` query parameter on `GET /cost-models/` supports comma-separated values, but the behavior is **AND** (not OR) using case-insensitive substring matching (`icontains` per term).

For example, `?name=gpu,demo` returns only models whose name contains **both** `gpu` AND `demo`. It will **not** return two separate models named `"GPU Model"` and `"Demo Model"`.

The previous description (`"Filter response on cost model name."`) gave no indication of this behavior, which caused confusion for UI/QE consumers of the API.

## Changes

- Updated the `name` parameter description in `docs/specs/openapi.json` to explicitly document the comma-separated AND semantics and case-insensitive matching.
- Added an `example` field.

## Testing

Validated locally via curl:
- `?name=Cost` → returns model whose name contains "Cost" ✅
- `?name=demo` → returns 0 (no model contains "demo") ✅
- `?name=Cost,demo` → returns 0 (AND: one term doesn't match) ✅
- `?name=Cost,OpenShift` → returns 1 (both terms present in same name) ✅

Made with [Cursor](https://cursor.com)