### PR TITLE
fix IndexError in Azure CSV download when date column is missing

### DIFF
--- a/koku/masu/external/downloader/azure/azure_report_downloader.py
+++ b/koku/masu/external/downloader/azure/azure_report_downloader.py
@@ -75,6 +75,26 @@ def get_processing_date(
     return process_date
 
 
+def _get_date_column(local_file, context, tracing_id):
+    """Return the date column name from the CSV header, or None if not recognized."""
+    expected_date_cols = {"UsageDateTime", "Date", "date", "usagedatetime"}
+    matching_cols = pd.read_csv(local_file, nrows=0).columns.intersection(expected_date_cols)
+    if matching_cols.empty:
+        msg = f"Azure report CSV is missing date columns {expected_date_cols}"
+        LOG.warning(log_json(msg=msg, context=context, tracing_id=tracing_id))
+        return None
+    time_interval = matching_cols[0]
+    if time_interval not in ["Date", "date"]:
+        msg = (
+            "Unsupported Azure report schema (legacy version) detected. "
+            "The report contains the 'UsageDateTime' column, which indicates an outdated format. "
+            "Please use a modern report schema (which uses the 'Date' column)."
+        )
+        LOG.warning(log_json(msg=msg, context=context))
+        return None
+    return time_interval
+
+
 def create_daily_archives(
     tracing_id,
     account,
@@ -108,16 +128,8 @@ def create_daily_archives(
     process_date = get_processing_date(
         s3_csv_path, manifest_id, provider_uuid, start_date, end_date, context, tracing_id, ingress_reports
     )
-    time_interval = pd.read_csv(local_file, nrows=0).columns.intersection(
-        {"UsageDateTime", "Date", "date", "usagedatetime"}
-    )[0]
-    if time_interval not in ["Date", "date"]:
-        msg = (
-            "Unsupported Azure report schema (legacy version) detected. "
-            "The report contains the 'UsageDateTime' column, which indicates an outdated format. "
-            "Please use a modern report schema (which uses the 'Date' column)."
-        )
-        LOG.warning(log_json(msg=msg, context=context))
+    time_interval = _get_date_column(local_file, context, tracing_id)
+    if time_interval is None:
         return [], {}
     try:
         with pd.read_csv(

--- a/koku/masu/external/downloader/azure/azure_report_downloader.py
+++ b/koku/masu/external/downloader/azure/azure_report_downloader.py
@@ -81,7 +81,7 @@ def _get_date_column(local_file, context, tracing_id):
     matching_cols = pd.read_csv(local_file, nrows=0).columns.intersection(expected_date_cols)
     if matching_cols.empty:
         msg = f"Azure report CSV is missing date columns {expected_date_cols}"
-        LOG.warning(log_json(msg=msg, context=context, tracing_id=tracing_id))
+        LOG.warning(log_json(tracing_id, msg=msg, context=context))
         return None
     time_interval = matching_cols[0]
     if time_interval not in ["Date", "date"]:
@@ -90,7 +90,7 @@ def _get_date_column(local_file, context, tracing_id):
             "The report contains the 'UsageDateTime' column, which indicates an outdated format. "
             "Please use a modern report schema (which uses the 'Date' column)."
         )
-        LOG.warning(log_json(msg=msg, context=context))
+        LOG.warning(log_json(tracing_id, msg=msg, context=context))
         return None
     return time_interval
 
@@ -128,10 +128,10 @@ def create_daily_archives(
     process_date = get_processing_date(
         s3_csv_path, manifest_id, provider_uuid, start_date, end_date, context, tracing_id, ingress_reports
     )
-    time_interval = _get_date_column(local_file, context, tracing_id)
-    if time_interval is None:
-        return [], {}
     try:
+        time_interval = _get_date_column(local_file, context, tracing_id)
+        if time_interval is None:
+            return [], {}
         with pd.read_csv(
             local_file,
             chunksize=settings.PARQUET_PROCESSING_BATCH_SIZE,
@@ -164,9 +164,9 @@ def create_daily_archives(
                         tracing_id, s3_csv_path, day_filepath, day_file, manifest_id, context
                     )
                     daily_file_names.append(day_filepath)
-    except Exception:
+    except Exception as err:
         msg = f"unable to create daily archives from: {base_filename}"
-        LOG.info(log_json(tracing_id, msg=msg, context=context))
+        LOG.info(log_json(tracing_id, msg=msg, context=context), exc_info=err)
         raise com_utils.CreateDailyArchivesError(msg)
     if not batch_date_range:
         return [], {}

--- a/koku/masu/test/external/downloader/azure/test_azure_report_downloader.py
+++ b/koku/masu/test/external/downloader/azure/test_azure_report_downloader.py
@@ -13,12 +13,14 @@ from tempfile import NamedTemporaryFile
 from unittest.mock import Mock
 from unittest.mock import patch
 
+import pandas as pd
 from azure.core.exceptions import HttpResponseError
 from faker import Faker
 
 from api.utils import DateHelper
 from masu.config import Config
 from masu.external import UNCOMPRESSED
+from masu.external.downloader.azure.azure_report_downloader import _get_date_column
 from masu.external.downloader.azure.azure_report_downloader import AzureReportDownloader
 from masu.external.downloader.azure.azure_report_downloader import AzureReportDownloaderError
 from masu.external.downloader.azure.azure_report_downloader import create_daily_archives
@@ -530,6 +532,24 @@ class AzureReportDownloaderTest(MasuTestCase):
         self.assertEqual(date_range, expected_date_range)
         self.assertIsInstance(daily_file_names, list)
         self.assertEqual(sorted(daily_file_names), sorted(expected_daily_files))
+
+    @patch("masu.external.downloader.azure.azure_report_downloader.pd.read_csv")
+    def test_get_date_column(self, mock_read_csv):
+        """Test _get_date_column handles various CSV column scenarios."""
+        test_matrix = [
+            ("no recognized columns", ["ColA", "ColB", "ColC"], None),
+            ("legacy UsageDateTime column", ["UsageDateTime", "MeterCategory", "PreTaxCost"], None),
+            ("valid Date column", ["Date", "MeterCategory", "PreTaxCost"], "Date"),
+            ("valid lowercase date column", ["date", "MeterCategory", "PreTaxCost"], "date"),
+            ("empty CSV", [], None),
+        ]
+        for label, columns, expected in test_matrix:
+            with self.subTest(label):
+                mock_df = Mock()
+                mock_df.columns = pd.Index(columns)
+                mock_read_csv.return_value = mock_df
+                result = _get_date_column("fake_file.csv", {}, "trace_id")
+                self.assertEqual(result, expected)
 
     @patch(
         "masu.database.report_manifest_db_accessor.ReportManifestDBAccessor.get_manifest_daily_start_date",


### PR DESCRIPTION
## Jira Ticket

[COST-7493](https://redhat.atlassian.net/browse/COST-7493)

## Description

This change fixes an `IndexError` in the Azure report downloader when a CSV file has no recognized date column. 

## Testing

1. Checkout branch.
2. Run the new unit tests:
    ```bash
    pipenv run tox -- koku.masu.test.external.downloader.azure.test_azure_report_downloader::AzureReportDownloaderTest::test_get_date_column
    ```
    1. All 5 subtests should pass (no recognized columns, legacy column, valid Date, valid date, empty CSV).
3. Run the full Azure downloader test suite to verify no regressions:
    ```bash
    pipenv run tox -- koku.masu.test.external.downloader.azure.test_azure_report_downloader
    ```
    1. All existing tests should pass.


## Release Notes
- [ ] proposed release note

```markdown
* Fix IndexError in Azure CSV download when date column is missing