### PR TITLE
[COST-7491] Skip dual-write when cost model rates are unchanged

### DIFF
--- a/koku/cost_models/cost_model_manager.py
+++ b/koku/cost_models/cost_model_manager.py
@@ -123,6 +123,10 @@ class CostModelManager:
     @transaction.atomic
     def update(self, **data):
         """Update the cost model object and sync rates to linked price list if one exists."""
+        incoming_rates = data.get("rates")
+        existing_rates = self._model.rates
+        sync_to_pricelist = "rates" in data and (bool(incoming_rates) or bool(existing_rates))
+
         self._model.name = data.get("name", self._model.name)
         self._model.description = data.get("description", self._model.description)
         self._model.rates = data.get("rates", self._model.rates)
@@ -132,7 +136,7 @@ class CostModelManager:
         self._model.currency = data.get("currency", self._model.currency)
         self._model.save()
 
-        if "rates" in data:
+        if sync_to_pricelist:
             pl = self._get_or_create_price_list()
             if pl:
                 rates_data = copy.deepcopy(data.get("rates", []))

--- a/koku/cost_models/test/test_cost_model_manager.py
+++ b/koku/cost_models/test/test_cost_model_manager.py
@@ -17,6 +17,7 @@ from cost_models.cost_model_manager import CostModelException
 from cost_models.cost_model_manager import CostModelManager
 from cost_models.models import CostModel
 from cost_models.models import CostModelMap
+from cost_models.models import PriceList
 from cost_models.models import PriceListCostModelMap
 
 
@@ -571,6 +572,42 @@ class CostModelManagerTest(IamTestCase):
             pl_rates = mapping.price_list.rates
             self.assertEqual(pl_rates[0]["metric"], updated_rates[0]["metric"])
             self.assertIn("rate_id", pl_rates[0])
+
+    def test_update_empty_rates_does_not_wipe_linked_price_list(self):
+        """Test that updating a cost model with empty rates does not wipe a linked price list's rates."""
+        metric = metric_constants.OCP_METRIC_CPU_CORE_USAGE_HOUR
+        rates = [
+            {
+                "metric": {"name": metric},
+                "source_type": Provider.PROVIDER_OCP,
+                "tiered_rates": [{"unit": "USD", "value": 0.5}],
+            }
+        ]
+
+        with tenant_context(self.tenant):
+            manager = CostModelManager()
+            with patch("cost_models.cost_model_manager.update_cost_model_costs"):
+                cost_model_obj = manager.create(
+                    name="CM no rates",
+                    description="Test",
+                    rates={},
+                )
+
+            pl = PriceList.objects.create(
+                name="User PL",
+                currency="USD",
+                rates=rates,
+                effective_start_date="2026-01-01",
+                effective_end_date="2099-12-31",
+            )
+            PriceListCostModelMap.objects.create(price_list=pl, cost_model=cost_model_obj, priority=1)
+
+            manager = CostModelManager(cost_model_uuid=cost_model_obj.uuid)
+            manager.update(rates={})
+
+            pl.refresh_from_db()
+            self.assertEqual(len(pl.rates), 1)
+            self.assertEqual(pl.rates[0]["tiered_rates"][0]["value"], 0.5)
 
     def test_update_without_rates_no_sync(self):
         """Test that updating without rates in data does not sync to PriceList."""


### PR DESCRIPTION
When a cost model update includes empty rates that match the existing empty rates, skip syncing to the linked price list. This prevents wiping rates on user-created price lists when only assigning price lists to a cost model.

## Jira Ticket

[COST-7491](https://issues.redhat.com/browse/COST-7491)

## Description

This change will ...

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Release Notes
- [ ] proposed release note

```markdown
* [COST-7491](https://issues.redhat.com/browse/COST-7491) Fix some things
```
