### PR TITLE
[COST-7492] Fix rate validity period filtering in RTU pipeline

### DIFF
--- a/koku/masu/database/cost_model_db_accessor.py
+++ b/koku/masu/database/cost_model_db_accessor.py
@@ -97,19 +97,24 @@ class CostModelDBAccessor:
     def price_list(self):
         """Return the rates defined on this cost model.
 
-        Reads from the Rate table (via PriceListCostModelMap -> PriceList -> Rate).
-        Output dict matches the legacy JSON-based format so all downstream
-        properties (infrastructure_rates, supplementary_rates, etc.) work unchanged.
+        When price_list_effective_on is set, scopes to the effective price list
+        for that date. Returns empty dict when no price list covers the date
+        (zero costs per PRD). Falls back to all Rate rows when no date is set.
 
         Tag rates (Rate rows with a non-empty tag_key) are skipped here;
-        they are handled by tag_based_price_list which still reads from JSON
-        until Phase 3 switches it to the Rate table.
+        they are handled by tag_based_price_list via effective_rates.
         """
         if not self.cost_model:
             return {}
-        rate_rows = Rate.objects.filter(price_list__cost_model_maps__cost_model=self.cost_model).only(
-            "metric", "cost_type", "default_rate", "description", "tag_key"
-        )
+        if self.price_list_effective_on:
+            effective_pl = self._effective_price_list
+            if not effective_pl:
+                return {}
+            rate_rows = effective_pl.rate_rows.only("metric", "cost_type", "default_rate", "description", "tag_key")
+        else:
+            rate_rows = Rate.objects.filter(price_list__cost_model_maps__cost_model=self.cost_model).only(
+                "metric", "cost_type", "default_rate", "description", "tag_key"
+            )
 
         metric_rate_map = {}
         for rate in rate_rows:

--- a/koku/masu/database/cost_model_db_accessor.py
+++ b/koku/masu/database/cost_model_db_accessor.py
@@ -6,6 +6,7 @@
 import copy
 import logging
 from collections import defaultdict
+from functools import cached_property
 
 from django.db import transaction
 
@@ -188,8 +189,10 @@ class CostModelDBAccessor:
                 return {}
             rate_rows = effective_pl.rate_rows.only("uuid", "metric", "cost_type", "custom_name", "tag_key")
         else:
-            rate_rows = Rate.objects.filter(price_list__cost_model_maps__cost_model=self.cost_model).only(
-                "uuid", "metric", "cost_type", "custom_name", "tag_key"
+            rate_rows = (
+                Rate.objects.filter(price_list__cost_model_maps__cost_model=self.cost_model)
+                .order_by("-price_list__cost_model_maps__priority")
+                .only("uuid", "metric", "cost_type", "custom_name", "tag_key")
             )
         return {
             (rate.metric, rate.cost_type, rate.tag_key or ""): {

--- a/koku/masu/database/cost_model_db_accessor.py
+++ b/koku/masu/database/cost_model_db_accessor.py
@@ -60,6 +60,15 @@ class CostModelDBAccessor:
             self._cost_model = CostModel.objects.filter(costmodelmap__provider_uuid=self.provider_uuid).first()
         return self._cost_model
 
+    @cached_property
+    def _effective_price_list(self):
+        """Resolve the effective PriceList for the billing date (cached)."""
+        if not self.cost_model or not self.price_list_effective_on:
+            return None
+        from cost_models.price_list_manager import PriceListManager
+
+        return PriceListManager.get_effective_price_list(self.cost_model.uuid, self.price_list_effective_on)
+
     @property
     def effective_rates(self):
         """Return rates from the effective price list for the target date.
@@ -76,9 +85,7 @@ class CostModelDBAccessor:
         if self.price_list_effective_on is None:
             self._effective_rates = self.cost_model.rates or {}
             return self._effective_rates
-        from cost_models.price_list_manager import PriceListManager
-
-        effective_pl = PriceListManager.get_effective_price_list(self.cost_model.uuid, self.price_list_effective_on)
+        effective_pl = self._effective_price_list
         if effective_pl:
             self._effective_rates = effective_pl.rates or {}
         else:
@@ -165,6 +172,32 @@ class CostModelDBAccessor:
     def get_rates(self, value):
         """Get the rates."""
         return self.price_list.get(value)
+
+    @cached_property
+    def rate_info_map(self):
+        """Return (metric, cost_type, tag_key) -> {rate_uuid, custom_name} for Rate rows.
+
+        Scoped to the effective price list when price_list_effective_on is set,
+        matching the resolution used by effective_rates.
+        """
+        if not self.cost_model:
+            return {}
+        if self.price_list_effective_on:
+            effective_pl = self._effective_price_list
+            if not effective_pl:
+                return {}
+            rate_rows = effective_pl.rate_rows.only("uuid", "metric", "cost_type", "custom_name", "tag_key")
+        else:
+            rate_rows = Rate.objects.filter(price_list__cost_model_maps__cost_model=self.cost_model).only(
+                "uuid", "metric", "cost_type", "custom_name", "tag_key"
+            )
+        return {
+            (rate.metric, rate.cost_type, rate.tag_key or ""): {
+                "rate_uuid": str(rate.uuid),
+                "custom_name": rate.custom_name,
+            }
+            for rate in rate_rows
+        }
 
     @property
     def metric_to_tag_params_map(self):

--- a/koku/masu/database/sql/openshift/cost_model/usage_rates/insert_usage_rates_to_usage.sql
+++ b/koku/masu/database/sql/openshift/cost_model/usage_rates/insert_usage_rates_to_usage.sql
@@ -140,14 +140,23 @@ base AS (
         cmi.distribution
 ),
 
+effective_pl AS (
+    SELECT pcm.price_list_id
+    FROM {{schema | sqlsafe}}.price_list_cost_model_map pcm
+    JOIN {{schema | sqlsafe}}.price_list pl ON pcm.price_list_id = pl.uuid
+    WHERE pcm.cost_model_id = {{cost_model_id}}
+      AND pl.effective_start_date <= {{start_date}}
+      AND pl.effective_end_date >= {{start_date}}
+    ORDER BY pcm.priority
+    LIMIT 1
+),
+
 rate_names AS (
     SELECT r.uuid AS rate_uuid, r.custom_name, r.metric,
            r.metric_type, r.default_rate, r.cost_type
     FROM {{schema | sqlsafe}}.cost_model_rate r
-    JOIN {{schema | sqlsafe}}.price_list pl ON r.price_list_id = pl.uuid
-    JOIN {{schema | sqlsafe}}.price_list_cost_model_map pcm ON pcm.price_list_id = pl.uuid
-    WHERE pcm.cost_model_id = {{cost_model_id}}
-      AND r.default_rate IS NOT NULL
+    JOIN effective_pl epl ON r.price_list_id = epl.price_list_id
+    WHERE r.default_rate IS NOT NULL
       AND r.default_rate != 0
 )
 

--- a/koku/masu/processor/ocp/ocp_cost_model_cost_updater.py
+++ b/koku/masu/processor/ocp/ocp_cost_model_cost_updater.py
@@ -248,11 +248,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
         combined_case_statements = {}
         if openshift_resource_type in ["Node", "Node_Core_Month"]:
             node_core = metric_constants.OCP_NODE_CORE_MONTH if openshift_resource_type == "Node_Core_Month" else ""
-            (
-                cost_case_statements,
-                unallocated_cost_case_statements,
-                labels_case_statement,
-            ) = self._node_statements(
+            (cost_case_statements, unallocated_cost_case_statements, labels_case_statement,) = self._node_statements(
                 rates,
                 start_date,
                 default_rates,
@@ -277,11 +273,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
 
     def _get_all_node_hour_tag_based_case_statements(self, rates, default_rates, start_date):
         """Call and organize cost, unallocated, and label case statements."""
-        (
-            cost_case_statements,
-            unallocated_cost_case_statements,
-            labels_case_statement,
-        ) = self._node_statements(
+        (cost_case_statements, unallocated_cost_case_statements, labels_case_statement,) = self._node_statements(
             rates,
             start_date,
             default_rates,

--- a/koku/masu/processor/ocp/ocp_cost_model_cost_updater.py
+++ b/koku/masu/processor/ocp/ocp_cost_model_cost_updater.py
@@ -57,6 +57,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
         self._tag_supplementary_rates = {}
         self._tag_default_supplementary_rates = {}
         self.metric_to_tag_params_map = {}
+        self._price_list_effective_on = None
 
     def _load_rates(self, price_list_effective_on):
         """Load rates from the effective price list for the given billing date."""
@@ -67,16 +68,23 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
         ) as cost_model_accessor:
             self._infra_rates = cost_model_accessor.infrastructure_rates
             self._tag_infra_rates = cost_model_accessor.tag_infrastructure_rates
-            self._tag_default_infra_rates = cost_model_accessor.tag_default_infrastructure_rates
+            self._tag_default_infra_rates = (
+                cost_model_accessor.tag_default_infrastructure_rates
+            )
             self._supplementary_rates = cost_model_accessor.supplementary_rates
             self._tag_supplementary_rates = cost_model_accessor.tag_supplementary_rates
-            self._tag_default_supplementary_rates = cost_model_accessor.tag_default_supplementary_rates
+            self._tag_default_supplementary_rates = (
+                cost_model_accessor.tag_default_supplementary_rates
+            )
             self.metric_to_tag_params_map = cost_model_accessor.metric_to_tag_params_map
+            self._price_list_effective_on = cost_model_accessor.price_list_effective_on
 
     def _ensure_rates_to_usage_partitions(self, start_date, end_date):
         """Create monthly partitions for rates_to_usage on demand."""
         with schema_context(self._schema):
-            self._handle_partitions(self._schema, ["rates_to_usage"], start_date, end_date)
+            self._handle_partitions(
+                self._schema, ["rates_to_usage"], start_date, end_date
+            )
 
     def _build_node_tag_cost_case_statements(  # noqa: C901
         self,
@@ -196,7 +204,9 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
             case_dict[tag_key] = "\n".join(statement_list)
         return case_dict
 
-    def _build_volume_tag_cost_case_statements(self, rate_dict, start_date, default_rate_dict={}):
+    def _build_volume_tag_cost_case_statements(
+        self, rate_dict, start_date, default_rate_dict={}
+    ):
         """Given a tag key, value, and rate return a CASE SQL statement."""
         case_dict = {}
         for tag_key, tag_value_rates in rate_dict.items():
@@ -221,7 +231,9 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
             )
         return case_dict
 
-    def _node_statements(self, rates, start_date, default_rates, *, node_core, amortized):
+    def _node_statements(
+        self, rates, start_date, default_rates, *, node_core, amortized
+    ):
         cost_case_statements = self._build_node_tag_cost_case_statements(
             rates, start_date, default_rates, node_core=node_core, amortized=amortized
         )
@@ -233,20 +245,32 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
             node_core=node_core,
             amortized=amortized,
         )
-        labels_case_statement = self._build_labels_case_statement(rates, "pod_labels", default_rate=default_rates)
+        labels_case_statement = self._build_labels_case_statement(
+            rates, "pod_labels", default_rate=default_rates
+        )
         return (
             cost_case_statements,
             unallocated_cost_case_statements,
             labels_case_statement,
         )
 
-    def _get_all_monthly_tag_based_case_statements(self, openshift_resource_type, rates, default_rates, start_date):
+    def _get_all_monthly_tag_based_case_statements(
+        self, openshift_resource_type, rates, default_rates, start_date
+    ):
         """Call and organize cost, unallocated, and label case statements."""
         cost_case_statements = {}
         combined_case_statements = {}
         if openshift_resource_type in ["Node", "Node_Core_Month"]:
-            node_core = metric_constants.OCP_NODE_CORE_MONTH if openshift_resource_type == "Node_Core_Month" else ""
-            (cost_case_statements, unallocated_cost_case_statements, labels_case_statement,) = self._node_statements(
+            node_core = (
+                metric_constants.OCP_NODE_CORE_MONTH
+                if openshift_resource_type == "Node_Core_Month"
+                else ""
+            )
+            (
+                cost_case_statements,
+                unallocated_cost_case_statements,
+                labels_case_statement,
+            ) = self._node_statements(
                 rates,
                 start_date,
                 default_rates,
@@ -254,7 +278,9 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                 amortized=True,
             )
         elif openshift_resource_type == "PVC":
-            cost_case_statements = self._build_volume_tag_cost_case_statements(rates, start_date, default_rates)
+            cost_case_statements = self._build_volume_tag_cost_case_statements(
+                rates, start_date, default_rates
+            )
             # No unallocated cost for volumes
             unallocated_cost_case_statements = {}
             labels_case_statement = self._build_labels_case_statement(
@@ -269,9 +295,15 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
             }
         return combined_case_statements
 
-    def _get_all_node_hour_tag_based_case_statements(self, rates, default_rates, start_date):
+    def _get_all_node_hour_tag_based_case_statements(
+        self, rates, default_rates, start_date
+    ):
         """Call and organize cost, unallocated, and label case statements."""
-        (cost_case_statements, unallocated_cost_case_statements, labels_case_statement,) = self._node_statements(
+        (
+            cost_case_statements,
+            unallocated_cost_case_statements,
+            labels_case_statement,
+        ) = self._node_statements(
             rates,
             start_date,
             default_rates,
@@ -351,12 +383,23 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                     metric_constants.INFRASTRUCTURE_COST_TYPE,
                     metric_constants.SUPPLEMENTARY_COST_TYPE,
                 ):
-                    if cost_model_cost_type == metric_constants.INFRASTRUCTURE_COST_TYPE:
+                    if (
+                        cost_model_cost_type
+                        == metric_constants.INFRASTRUCTURE_COST_TYPE
+                    ):
                         rates = self._tag_infra_rates.get(monthly_cost_metric, {})
-                        default_rates = self._tag_default_infra_rates.get(monthly_cost_metric, {})
-                    elif cost_model_cost_type == metric_constants.SUPPLEMENTARY_COST_TYPE:
-                        rates = self._tag_supplementary_rates.get(monthly_cost_metric, {})
-                        default_rates = self._tag_default_supplementary_rates.get(monthly_cost_metric, {})
+                        default_rates = self._tag_default_infra_rates.get(
+                            monthly_cost_metric, {}
+                        )
+                    elif (
+                        cost_model_cost_type == metric_constants.SUPPLEMENTARY_COST_TYPE
+                    ):
+                        rates = self._tag_supplementary_rates.get(
+                            monthly_cost_metric, {}
+                        )
+                        default_rates = self._tag_default_supplementary_rates.get(
+                            monthly_cost_metric, {}
+                        )
 
                     if not rates:
                         # The cost model has no rates for this metric
@@ -374,8 +417,10 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                         )
                     )
 
-                    per_tag_key_case_statements = self._get_all_monthly_tag_based_case_statements(
-                        openshift_resource_type, rates, default_rates, start_date
+                    per_tag_key_case_statements = (
+                        self._get_all_monthly_tag_based_case_statements(
+                            openshift_resource_type, rates, default_rates, start_date
+                        )
                     )
 
                     for tag_key, case_statements in per_tag_key_case_statements.items():
@@ -403,7 +448,9 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                     default_rates = self._tag_default_infra_rates.get(cost_metric, {})
                 elif cost_model_cost_type == metric_constants.SUPPLEMENTARY_COST_TYPE:
                     rates = self._tag_supplementary_rates.get(cost_metric, {})
-                    default_rates = self._tag_default_supplementary_rates.get(cost_metric, {})
+                    default_rates = self._tag_default_supplementary_rates.get(
+                        cost_metric, {}
+                    )
                 if not rates:
                     # The cost model has no rates for this metric
                     continue
@@ -418,8 +465,10 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                         end_date=end_date,
                     )
                 )
-                per_tag_key_case_statements = self._get_all_node_hour_tag_based_case_statements(
-                    rates, default_rates, start_date
+                per_tag_key_case_statements = (
+                    self._get_all_node_hour_tag_based_case_statements(
+                        rates, default_rates, start_date
+                    )
                 )
                 for tag_key, case_statements in per_tag_key_case_statements.items():
                     report_accessor.populate_tag_cost_sql(
@@ -441,7 +490,9 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
             metric_constants.SUPPLEMENTARY_COST_TYPE: self._supplementary_rates,
         }
         with OCPReportDBAccessor(self._schema) as report_accessor:
-            report_period = report_accessor.report_periods_for_provider_uuid(self._provider.uuid, start_date)
+            report_period = report_accessor.report_periods_for_provider_uuid(
+                self._provider.uuid, start_date
+            )
             if not report_period:
                 LOG.info(
                     log_json(
@@ -459,7 +510,9 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
             for report_type, report_type_dict in report_type_map.items():
                 report_accessor.populate_usage_costs(
                     report_type,
-                    filter_dictionary(report_type_dict, metric_constants.COST_MODEL_USAGE_RATES),
+                    filter_dictionary(
+                        report_type_dict, metric_constants.COST_MODEL_USAGE_RATES
+                    ),
                     self._distribution,
                     start_date,
                     end_date,
@@ -480,7 +533,9 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
             return
 
         with OCPReportDBAccessor(self._schema) as report_accessor:
-            report_period = report_accessor.report_periods_for_provider_uuid(self._provider.uuid, start_date)
+            report_period = report_accessor.report_periods_for_provider_uuid(
+                self._provider.uuid, start_date
+            )
             if not report_period:
                 LOG.info(
                     log_json(
@@ -517,7 +572,9 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
             )
             return
         with OCPReportDBAccessor(self._schema) as report_accessor:
-            report_period = report_accessor.report_periods_for_provider_uuid(self._provider.uuid, start_date)
+            report_period = report_accessor.report_periods_for_provider_uuid(
+                self._provider.uuid, start_date
+            )
             if not report_period:
                 LOG.info(
                     log_json(
@@ -542,7 +599,9 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
         Cleans both rates_to_usage and the daily summary cost-model rows.
         """
         with OCPReportDBAccessor(self._schema) as report_accessor:
-            report_period = report_accessor.report_periods_for_provider_uuid(self._provider.uuid, start_date)
+            report_period = report_accessor.report_periods_for_provider_uuid(
+                self._provider.uuid, start_date
+            )
             if not report_period:
                 return
             report_period_id = report_period.id
@@ -592,14 +651,18 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
             metric_constants.SUPPLEMENTARY_COST_TYPE: self._supplementary_rates,
         }
         with OCPReportDBAccessor(self._schema) as report_accessor:
-            report_period = report_accessor.report_periods_for_provider_uuid(self._provider.uuid, start_date)
+            report_period = report_accessor.report_periods_for_provider_uuid(
+                self._provider.uuid, start_date
+            )
             if not report_period:
                 return
             report_period_id = report_period.id
             for report_type, report_type_dict in report_type_map.items():
                 report_accessor.populate_vm_usage_costs(
                     report_type,
-                    filter_dictionary(report_type_dict, metric_constants.COST_MODEL_VM_USAGE_RATES),
+                    filter_dictionary(
+                        report_type_dict, metric_constants.COST_MODEL_VM_USAGE_RATES
+                    ),
                     start_date,
                     end_date,
                     self._provider.uuid,
@@ -643,7 +706,9 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                     end_date=end_date,
                 )
             )
-            accessor.populate_markup_cost(markup, start_date, end_date, self._cluster_id)
+            accessor.populate_markup_cost(
+                markup, start_date, end_date, self._cluster_id
+            )
         LOG.info(
             log_json(
                 msg="finished updating markup costs",
@@ -683,7 +748,9 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
         # Delete existing records
         with OCPReportDBAccessor(self._schema) as report_accessor:
             with schema_context(self._schema):
-                report_period = report_accessor.report_periods_for_provider_uuid(self._provider.uuid, start_date)
+                report_period = report_accessor.report_periods_for_provider_uuid(
+                    self._provider.uuid, start_date
+                )
                 if not report_period:
                     LOG.info(
                         log_json(
@@ -732,7 +799,9 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                     report_period.derived_cost_datetime = timezone.now()
                     report_period.save()
 
-    def update_summary_cost_model_costs(self, summary_range: SummaryRangeConfig) -> None:
+    def update_summary_cost_model_costs(
+        self, summary_range: SummaryRangeConfig
+    ) -> None:
         """Update the OCP summary table with the charge information.
 
         Args:
@@ -759,14 +828,30 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
 
             self._load_rates(start_date)
 
+            no_effective_pl = self._price_list_effective_on is not None and not (
+                self._infra_rates
+                or self._supplementary_rates
+                or self._tag_infra_rates
+                or self._tag_supplementary_rates
+            )
+
             rtu_enabled = is_feature_flag_enabled_by_schema(
                 self._schema, COST_BREAKDOWN_RTU_UNLEASH_FLAG, dev_fallback=True
             )
             if rtu_enabled:
-                if self._cost_model_id:
+                if self._cost_model_id and not no_effective_pl:
                     self._update_usage_rates_to_usage(start_date, end_date)
                     self._aggregate_rates_to_daily_summary(start_date, end_date)
                     self._update_vm_usage_costs(start_date, end_date)
+                elif self._cost_model_id:
+                    LOG.info(
+                        log_json(
+                            msg="no effective price list for billing month, cleaning stale RTU rows",
+                            provider_uuid=self._provider_uuid,
+                            start_date=start_date,
+                        )
+                    )
+                    self._cleanup_stale_rtu_costs(start_date, end_date)
                 else:
                     self._cleanup_stale_rtu_costs(start_date, end_date)
             else:

--- a/koku/masu/processor/ocp/ocp_cost_model_cost_updater.py
+++ b/koku/masu/processor/ocp/ocp_cost_model_cost_updater.py
@@ -68,23 +68,17 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
         ) as cost_model_accessor:
             self._infra_rates = cost_model_accessor.infrastructure_rates
             self._tag_infra_rates = cost_model_accessor.tag_infrastructure_rates
-            self._tag_default_infra_rates = (
-                cost_model_accessor.tag_default_infrastructure_rates
-            )
+            self._tag_default_infra_rates = cost_model_accessor.tag_default_infrastructure_rates
             self._supplementary_rates = cost_model_accessor.supplementary_rates
             self._tag_supplementary_rates = cost_model_accessor.tag_supplementary_rates
-            self._tag_default_supplementary_rates = (
-                cost_model_accessor.tag_default_supplementary_rates
-            )
+            self._tag_default_supplementary_rates = cost_model_accessor.tag_default_supplementary_rates
             self.metric_to_tag_params_map = cost_model_accessor.metric_to_tag_params_map
             self._price_list_effective_on = cost_model_accessor.price_list_effective_on
 
     def _ensure_rates_to_usage_partitions(self, start_date, end_date):
         """Create monthly partitions for rates_to_usage on demand."""
         with schema_context(self._schema):
-            self._handle_partitions(
-                self._schema, ["rates_to_usage"], start_date, end_date
-            )
+            self._handle_partitions(self._schema, ["rates_to_usage"], start_date, end_date)
 
     def _build_node_tag_cost_case_statements(  # noqa: C901
         self,
@@ -204,9 +198,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
             case_dict[tag_key] = "\n".join(statement_list)
         return case_dict
 
-    def _build_volume_tag_cost_case_statements(
-        self, rate_dict, start_date, default_rate_dict={}
-    ):
+    def _build_volume_tag_cost_case_statements(self, rate_dict, start_date, default_rate_dict={}):
         """Given a tag key, value, and rate return a CASE SQL statement."""
         case_dict = {}
         for tag_key, tag_value_rates in rate_dict.items():
@@ -231,9 +223,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
             )
         return case_dict
 
-    def _node_statements(
-        self, rates, start_date, default_rates, *, node_core, amortized
-    ):
+    def _node_statements(self, rates, start_date, default_rates, *, node_core, amortized):
         cost_case_statements = self._build_node_tag_cost_case_statements(
             rates, start_date, default_rates, node_core=node_core, amortized=amortized
         )
@@ -245,27 +235,19 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
             node_core=node_core,
             amortized=amortized,
         )
-        labels_case_statement = self._build_labels_case_statement(
-            rates, "pod_labels", default_rate=default_rates
-        )
+        labels_case_statement = self._build_labels_case_statement(rates, "pod_labels", default_rate=default_rates)
         return (
             cost_case_statements,
             unallocated_cost_case_statements,
             labels_case_statement,
         )
 
-    def _get_all_monthly_tag_based_case_statements(
-        self, openshift_resource_type, rates, default_rates, start_date
-    ):
+    def _get_all_monthly_tag_based_case_statements(self, openshift_resource_type, rates, default_rates, start_date):
         """Call and organize cost, unallocated, and label case statements."""
         cost_case_statements = {}
         combined_case_statements = {}
         if openshift_resource_type in ["Node", "Node_Core_Month"]:
-            node_core = (
-                metric_constants.OCP_NODE_CORE_MONTH
-                if openshift_resource_type == "Node_Core_Month"
-                else ""
-            )
+            node_core = metric_constants.OCP_NODE_CORE_MONTH if openshift_resource_type == "Node_Core_Month" else ""
             (
                 cost_case_statements,
                 unallocated_cost_case_statements,
@@ -278,9 +260,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                 amortized=True,
             )
         elif openshift_resource_type == "PVC":
-            cost_case_statements = self._build_volume_tag_cost_case_statements(
-                rates, start_date, default_rates
-            )
+            cost_case_statements = self._build_volume_tag_cost_case_statements(rates, start_date, default_rates)
             # No unallocated cost for volumes
             unallocated_cost_case_statements = {}
             labels_case_statement = self._build_labels_case_statement(
@@ -295,9 +275,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
             }
         return combined_case_statements
 
-    def _get_all_node_hour_tag_based_case_statements(
-        self, rates, default_rates, start_date
-    ):
+    def _get_all_node_hour_tag_based_case_statements(self, rates, default_rates, start_date):
         """Call and organize cost, unallocated, and label case statements."""
         (
             cost_case_statements,
@@ -383,23 +361,12 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                     metric_constants.INFRASTRUCTURE_COST_TYPE,
                     metric_constants.SUPPLEMENTARY_COST_TYPE,
                 ):
-                    if (
-                        cost_model_cost_type
-                        == metric_constants.INFRASTRUCTURE_COST_TYPE
-                    ):
+                    if cost_model_cost_type == metric_constants.INFRASTRUCTURE_COST_TYPE:
                         rates = self._tag_infra_rates.get(monthly_cost_metric, {})
-                        default_rates = self._tag_default_infra_rates.get(
-                            monthly_cost_metric, {}
-                        )
-                    elif (
-                        cost_model_cost_type == metric_constants.SUPPLEMENTARY_COST_TYPE
-                    ):
-                        rates = self._tag_supplementary_rates.get(
-                            monthly_cost_metric, {}
-                        )
-                        default_rates = self._tag_default_supplementary_rates.get(
-                            monthly_cost_metric, {}
-                        )
+                        default_rates = self._tag_default_infra_rates.get(monthly_cost_metric, {})
+                    elif cost_model_cost_type == metric_constants.SUPPLEMENTARY_COST_TYPE:
+                        rates = self._tag_supplementary_rates.get(monthly_cost_metric, {})
+                        default_rates = self._tag_default_supplementary_rates.get(monthly_cost_metric, {})
 
                     if not rates:
                         # The cost model has no rates for this metric
@@ -417,10 +384,8 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                         )
                     )
 
-                    per_tag_key_case_statements = (
-                        self._get_all_monthly_tag_based_case_statements(
-                            openshift_resource_type, rates, default_rates, start_date
-                        )
+                    per_tag_key_case_statements = self._get_all_monthly_tag_based_case_statements(
+                        openshift_resource_type, rates, default_rates, start_date
                     )
 
                     for tag_key, case_statements in per_tag_key_case_statements.items():
@@ -448,9 +413,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                     default_rates = self._tag_default_infra_rates.get(cost_metric, {})
                 elif cost_model_cost_type == metric_constants.SUPPLEMENTARY_COST_TYPE:
                     rates = self._tag_supplementary_rates.get(cost_metric, {})
-                    default_rates = self._tag_default_supplementary_rates.get(
-                        cost_metric, {}
-                    )
+                    default_rates = self._tag_default_supplementary_rates.get(cost_metric, {})
                 if not rates:
                     # The cost model has no rates for this metric
                     continue
@@ -465,10 +428,8 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                         end_date=end_date,
                     )
                 )
-                per_tag_key_case_statements = (
-                    self._get_all_node_hour_tag_based_case_statements(
-                        rates, default_rates, start_date
-                    )
+                per_tag_key_case_statements = self._get_all_node_hour_tag_based_case_statements(
+                    rates, default_rates, start_date
                 )
                 for tag_key, case_statements in per_tag_key_case_statements.items():
                     report_accessor.populate_tag_cost_sql(
@@ -490,9 +451,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
             metric_constants.SUPPLEMENTARY_COST_TYPE: self._supplementary_rates,
         }
         with OCPReportDBAccessor(self._schema) as report_accessor:
-            report_period = report_accessor.report_periods_for_provider_uuid(
-                self._provider.uuid, start_date
-            )
+            report_period = report_accessor.report_periods_for_provider_uuid(self._provider.uuid, start_date)
             if not report_period:
                 LOG.info(
                     log_json(
@@ -510,9 +469,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
             for report_type, report_type_dict in report_type_map.items():
                 report_accessor.populate_usage_costs(
                     report_type,
-                    filter_dictionary(
-                        report_type_dict, metric_constants.COST_MODEL_USAGE_RATES
-                    ),
+                    filter_dictionary(report_type_dict, metric_constants.COST_MODEL_USAGE_RATES),
                     self._distribution,
                     start_date,
                     end_date,
@@ -533,9 +490,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
             return
 
         with OCPReportDBAccessor(self._schema) as report_accessor:
-            report_period = report_accessor.report_periods_for_provider_uuid(
-                self._provider.uuid, start_date
-            )
+            report_period = report_accessor.report_periods_for_provider_uuid(self._provider.uuid, start_date)
             if not report_period:
                 LOG.info(
                     log_json(
@@ -572,9 +527,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
             )
             return
         with OCPReportDBAccessor(self._schema) as report_accessor:
-            report_period = report_accessor.report_periods_for_provider_uuid(
-                self._provider.uuid, start_date
-            )
+            report_period = report_accessor.report_periods_for_provider_uuid(self._provider.uuid, start_date)
             if not report_period:
                 LOG.info(
                     log_json(
@@ -599,9 +552,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
         Cleans both rates_to_usage and the daily summary cost-model rows.
         """
         with OCPReportDBAccessor(self._schema) as report_accessor:
-            report_period = report_accessor.report_periods_for_provider_uuid(
-                self._provider.uuid, start_date
-            )
+            report_period = report_accessor.report_periods_for_provider_uuid(self._provider.uuid, start_date)
             if not report_period:
                 return
             report_period_id = report_period.id
@@ -651,18 +602,14 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
             metric_constants.SUPPLEMENTARY_COST_TYPE: self._supplementary_rates,
         }
         with OCPReportDBAccessor(self._schema) as report_accessor:
-            report_period = report_accessor.report_periods_for_provider_uuid(
-                self._provider.uuid, start_date
-            )
+            report_period = report_accessor.report_periods_for_provider_uuid(self._provider.uuid, start_date)
             if not report_period:
                 return
             report_period_id = report_period.id
             for report_type, report_type_dict in report_type_map.items():
                 report_accessor.populate_vm_usage_costs(
                     report_type,
-                    filter_dictionary(
-                        report_type_dict, metric_constants.COST_MODEL_VM_USAGE_RATES
-                    ),
+                    filter_dictionary(report_type_dict, metric_constants.COST_MODEL_VM_USAGE_RATES),
                     start_date,
                     end_date,
                     self._provider.uuid,
@@ -706,9 +653,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                     end_date=end_date,
                 )
             )
-            accessor.populate_markup_cost(
-                markup, start_date, end_date, self._cluster_id
-            )
+            accessor.populate_markup_cost(markup, start_date, end_date, self._cluster_id)
         LOG.info(
             log_json(
                 msg="finished updating markup costs",
@@ -748,9 +693,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
         # Delete existing records
         with OCPReportDBAccessor(self._schema) as report_accessor:
             with schema_context(self._schema):
-                report_period = report_accessor.report_periods_for_provider_uuid(
-                    self._provider.uuid, start_date
-                )
+                report_period = report_accessor.report_periods_for_provider_uuid(self._provider.uuid, start_date)
                 if not report_period:
                     LOG.info(
                         log_json(
@@ -799,9 +742,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                     report_period.derived_cost_datetime = timezone.now()
                     report_period.save()
 
-    def update_summary_cost_model_costs(
-        self, summary_range: SummaryRangeConfig
-    ) -> None:
+    def update_summary_cost_model_costs(self, summary_range: SummaryRangeConfig) -> None:
         """Update the OCP summary table with the charge information.
 
         Args:

--- a/koku/masu/test/database/test_cost_model_db_accessor.py
+++ b/koku/masu/test/database/test_cost_model_db_accessor.py
@@ -492,98 +492,168 @@ class CostModelDBAccessorTagRatesPriceListTest(MasuTestCase):
             rates = cost_model_accessor.effective_rates
             self.assertEqual(rates, {})
 
-    def test_rate_info_map_no_price_list_effective_on(self):
-        """Test rate_info_map returns entries from all Rate rows when no price_list_effective_on."""
+    def _make_price_list(self, cost_model, name, start, end, priority=1):
+        """Create a PriceList linked to cost_model with a single CPU rate."""
+        pl = PriceList.objects.create(
+            name=name, effective_start_date=start, effective_end_date=end, rates=[]
+        )
+        PriceListCostModelMap.objects.create(price_list=pl, cost_model=cost_model, priority=priority)
+        rate = Rate.objects.create(
+            price_list=pl,
+            custom_name=f"{name}-cpu",
+            metric="cpu_core_usage_per_hour",
+            metric_type="cpu",
+            cost_type="Supplementary",
+            default_rate="1.50",
+        )
+        return pl, rate
+
+    def _rate_info(self, effective_on):
+        """Shortcut: return rate_info_map for self.provider_uuid on a given date."""
+        with CostModelDBAccessor(self.schema, self.provider_uuid, price_list_effective_on=effective_on) as acc:
+            return acc.rate_info_map
+
+    # -- fallback behaviour (no date constraint) --
+
+    def test_rate_info_map_without_date_returns_all_rates(self):
+        """Without price_list_effective_on, every Rate row for the cost model is returned."""
         with CostModelDBAccessor(self.schema, self.provider_uuid, price_list_effective_on=None) as accessor:
             rate_map = accessor.rate_info_map
-            if accessor.cost_model:
-                rate_count = Rate.objects.filter(
-                    price_list__cost_model_maps__cost_model=accessor.cost_model
-                ).count()
-                self.assertEqual(len(rate_map), rate_count)
-                for key, info in rate_map.items():
-                    self.assertIn("rate_uuid", info)
-                    self.assertIn("custom_name", info)
+            expected = Rate.objects.filter(
+                price_list__cost_model_maps__cost_model=accessor.cost_model
+            ).count()
+            self.assertEqual(len(rate_map), expected)
+            for info in rate_map.values():
+                self.assertIn("rate_uuid", info)
+                self.assertIn("custom_name", info)
+
+    # -- scoping to effective price list --
 
     @patch("masu.database.cost_model_db_accessor.is_feature_flag_enabled_by_schema", return_value=False)
-    def test_rate_info_map_scoped_to_effective_price_list(self, _mock_flag):
-        """Test rate_info_map returns only rates from the effective price list."""
-        target_date = date(2026, 6, 15)
+    def test_rate_info_map_returns_only_rates_from_effective_price_list(self, _):
+        """When a date is provided, only rates from the matching price list are returned."""
         with schema_context(self.schema):
             cost_model = CostModel.objects.filter(costmodelmap__provider_uuid=self.provider_uuid).first()
             PriceListCostModelMap.objects.filter(cost_model=cost_model).delete()
-            pl = PriceList.objects.create(
-                name="Scoped PL",
-                effective_start_date=date(2026, 1, 1),
-                effective_end_date=date(2026, 12, 31),
-                rates=[],
-            )
-            PriceListCostModelMap.objects.create(price_list=pl, cost_model=cost_model, priority=1)
-            rate = Rate.objects.create(
-                price_list=pl,
-                custom_name="test-cpu-rate",
-                metric="cpu_core_usage_per_hour",
-                metric_type="cpu",
-                cost_type="Infrastructure",
-                default_rate="1.50",
-            )
+            _pl, rate = self._make_price_list(cost_model, "H1-2026", date(2026, 1, 1), date(2026, 6, 30))
 
-        with CostModelDBAccessor(
-            self.schema, self.provider_uuid, price_list_effective_on=target_date
-        ) as accessor:
-            rate_map = accessor.rate_info_map
-            self.assertEqual(len(rate_map), 1)
-            key = ("cpu_core_usage_per_hour", "Infrastructure", "")
-            self.assertIn(key, rate_map)
-            self.assertEqual(rate_map[key]["rate_uuid"], str(rate.uuid))
-            self.assertEqual(rate_map[key]["custom_name"], "test-cpu-rate")
+        result = self._rate_info(effective_on=date(2026, 3, 15))
+
+        self.assertEqual(len(result), 1)
+        key = ("cpu_core_usage_per_hour", "Supplementary", "")
+        self.assertIn(key, result)
+        self.assertEqual(result[key]["rate_uuid"], str(rate.uuid))
+        self.assertEqual(result[key]["custom_name"], "H1-2026-cpu")
 
     @patch("masu.database.cost_model_db_accessor.is_feature_flag_enabled_by_schema", return_value=False)
-    def test_rate_info_map_empty_when_no_matching_price_list(self, _mock_flag):
-        """Test rate_info_map returns empty when no price list covers the date."""
-        target_date = date(2100, 6, 1)
-        with CostModelDBAccessor(
-            self.schema, self.provider_uuid, price_list_effective_on=target_date
-        ) as accessor:
-            rate_map = accessor.rate_info_map
-            self.assertEqual(rate_map, {})
+    def test_rate_info_map_empty_when_date_outside_all_price_lists(self, _):
+        """A date covered by no price list yields an empty map (zero costs)."""
+        result = self._rate_info(effective_on=date(2100, 1, 1))
+        self.assertEqual(result, {})
+
+    # -- boundary conditions on validity window --
 
     @patch("masu.database.cost_model_db_accessor.is_feature_flag_enabled_by_schema", return_value=False)
-    def test_rate_info_map_respects_validity_period_across_months(self, _mock_flag):
-        """Regression test for COST-7492: rates must not leak across validity periods.
+    def test_rate_info_map_includes_first_day_of_validity(self, _):
+        """The first day of the validity period must return rates."""
+        with schema_context(self.schema):
+            cost_model = CostModel.objects.filter(costmodelmap__provider_uuid=self.provider_uuid).first()
+            PriceListCostModelMap.objects.filter(cost_model=cost_model).delete()
+            self._make_price_list(cost_model, "Apr", date(2026, 4, 1), date(2026, 4, 30))
 
-        Creates a price list valid only for April 2026. Querying rate_info_map
-        for an April date must return the rates; querying for May must return
-        nothing, ensuring costs are not calculated outside the validity window.
+        result = self._rate_info(effective_on=date(2026, 4, 1))
+        self.assertEqual(len(result), 1)
+
+    @patch("masu.database.cost_model_db_accessor.is_feature_flag_enabled_by_schema", return_value=False)
+    def test_rate_info_map_includes_last_day_of_validity(self, _):
+        """The last day of the validity period must return rates."""
+        with schema_context(self.schema):
+            cost_model = CostModel.objects.filter(costmodelmap__provider_uuid=self.provider_uuid).first()
+            PriceListCostModelMap.objects.filter(cost_model=cost_model).delete()
+            self._make_price_list(cost_model, "Apr", date(2026, 4, 1), date(2026, 4, 30))
+
+        result = self._rate_info(effective_on=date(2026, 4, 30))
+        self.assertEqual(len(result), 1)
+
+    @patch("masu.database.cost_model_db_accessor.is_feature_flag_enabled_by_schema", return_value=False)
+    def test_rate_info_map_excludes_day_before_validity(self, _):
+        """The day before the validity period must return no rates."""
+        with schema_context(self.schema):
+            cost_model = CostModel.objects.filter(costmodelmap__provider_uuid=self.provider_uuid).first()
+            PriceListCostModelMap.objects.filter(cost_model=cost_model).delete()
+            self._make_price_list(cost_model, "Apr", date(2026, 4, 1), date(2026, 4, 30))
+
+        result = self._rate_info(effective_on=date(2026, 3, 31))
+        self.assertEqual(result, {})
+
+    @patch("masu.database.cost_model_db_accessor.is_feature_flag_enabled_by_schema", return_value=False)
+    def test_rate_info_map_excludes_day_after_validity(self, _):
+        """The day after the validity period must return no rates."""
+        with schema_context(self.schema):
+            cost_model = CostModel.objects.filter(costmodelmap__provider_uuid=self.provider_uuid).first()
+            PriceListCostModelMap.objects.filter(cost_model=cost_model).delete()
+            self._make_price_list(cost_model, "Apr", date(2026, 4, 1), date(2026, 4, 30))
+
+        result = self._rate_info(effective_on=date(2026, 5, 1))
+        self.assertEqual(result, {})
+
+    # -- multi-month / adjacent price lists --
+
+    @patch("masu.database.cost_model_db_accessor.is_feature_flag_enabled_by_schema", return_value=False)
+    def test_rate_info_map_selects_correct_price_list_per_month(self, _):
+        """Adjacent price lists: each month resolves only the rate from its own PL."""
+        with schema_context(self.schema):
+            cost_model = CostModel.objects.filter(costmodelmap__provider_uuid=self.provider_uuid).first()
+            PriceListCostModelMap.objects.filter(cost_model=cost_model).delete()
+            _apr_pl, apr_rate = self._make_price_list(
+                cost_model, "Apr", date(2026, 4, 1), date(2026, 4, 30), priority=1
+            )
+            _may_pl, may_rate = self._make_price_list(
+                cost_model, "May", date(2026, 5, 1), date(2026, 5, 31), priority=1
+            )
+
+        apr_result = self._rate_info(effective_on=date(2026, 4, 15))
+        may_result = self._rate_info(effective_on=date(2026, 5, 15))
+
+        self.assertEqual(apr_result[("cpu_core_usage_per_hour", "Supplementary", "")]["rate_uuid"], str(apr_rate.uuid))
+        self.assertEqual(may_result[("cpu_core_usage_per_hour", "Supplementary", "")]["rate_uuid"], str(may_rate.uuid))
+
+    # -- consistency: rate_info_map and effective_rates agree --
+
+    @patch("masu.database.cost_model_db_accessor.is_feature_flag_enabled_by_schema", return_value=False)
+    def test_rate_info_map_and_effective_rates_agree_on_coverage(self, _):
+        """Both properties must agree: if effective_rates is empty, rate_info_map must be too."""
+        with schema_context(self.schema):
+            cost_model = CostModel.objects.filter(costmodelmap__provider_uuid=self.provider_uuid).first()
+            PriceListCostModelMap.objects.filter(cost_model=cost_model).delete()
+            self._make_price_list(cost_model, "Apr", date(2026, 4, 1), date(2026, 4, 30))
+
+        for test_date, label in [(date(2026, 4, 15), "in-range"), (date(2026, 5, 15), "out-of-range")]:
+            with CostModelDBAccessor(self.schema, self.provider_uuid, price_list_effective_on=test_date) as acc:
+                has_rates = bool(acc.effective_rates)
+                has_info = bool(acc.rate_info_map)
+                self.assertEqual(
+                    has_rates, has_info,
+                    f"effective_rates and rate_info_map disagree for {label} date {test_date}",
+                )
+
+    # -- COST-7492 regression: costs must not leak across validity periods --
+
+    @patch("masu.database.cost_model_db_accessor.is_feature_flag_enabled_by_schema", return_value=False)
+    def test_rate_info_map_does_not_leak_rates_outside_validity_period(self, _):
+        """COST-7492: a price list valid only for April must not produce rates in May.
+
+        Reproduces the exact scenario from the bug report: ingest two months of
+        OCP data with a cost model whose price list covers April only. The May
+        cost report must show zero supplementary costs.
         """
         with schema_context(self.schema):
             cost_model = CostModel.objects.filter(costmodelmap__provider_uuid=self.provider_uuid).first()
             PriceListCostModelMap.objects.filter(cost_model=cost_model).delete()
+            self._make_price_list(cost_model, "April Only", date(2026, 4, 1), date(2026, 4, 30))
 
-            april_pl = PriceList.objects.create(
-                name="April Only PL",
-                effective_start_date=date(2026, 4, 1),
-                effective_end_date=date(2026, 4, 30),
-                rates=[],
-            )
-            PriceListCostModelMap.objects.create(price_list=april_pl, cost_model=cost_model, priority=1)
-            Rate.objects.create(
-                price_list=april_pl,
-                custom_name="april-cpu-rate",
-                metric="cpu_core_usage_per_hour",
-                metric_type="cpu",
-                cost_type="Supplementary",
-                default_rate="4.40",
-            )
+        april_map = self._rate_info(effective_on=date(2026, 4, 15))
+        may_map = self._rate_info(effective_on=date(2026, 5, 12))
 
-        with CostModelDBAccessor(
-            self.schema, self.provider_uuid, price_list_effective_on=date(2026, 4, 15)
-        ) as accessor:
-            april_map = accessor.rate_info_map
-            self.assertEqual(len(april_map), 1, "April should return the rate")
-
-        with CostModelDBAccessor(
-            self.schema, self.provider_uuid, price_list_effective_on=date(2026, 5, 12)
-        ) as accessor:
-            may_map = accessor.rate_info_map
-            self.assertEqual(may_map, {}, "May should return no rates — price list only covers April")
+        self.assertEqual(len(april_map), 1, "April is within validity — rate expected")
+        self.assertEqual(may_map, {}, "May is outside validity — no rates, zero costs")

--- a/koku/masu/test/database/test_cost_model_db_accessor.py
+++ b/koku/masu/test/database/test_cost_model_db_accessor.py
@@ -155,6 +155,29 @@ class CostModelDBAccessorTest(MasuTestCase):
         with CostModelDBAccessor(self.schema, self.provider_uuid, price_list_effective_on=None) as cost_model_accessor:
             self.assertFalse(cost_model_accessor.metric_to_tag_params_map)
 
+    def test_price_list_handles_null_default_rate(self):
+        """Rate rows with default_rate=None should be treated as 0.0."""
+        with schema_context(self.schema):
+            cost_model = CostModel.objects.filter(costmodelmap__provider_uuid=self.provider_uuid).first()
+            pl = PriceList.objects.create(
+                name="null-rate-pl",
+                effective_start_date=date(2026, 1, 1),
+                effective_end_date=date(2026, 12, 31),
+                rates=[],
+            )
+            PriceListCostModelMap.objects.create(price_list=pl, cost_model=cost_model, priority=1)
+            Rate.objects.create(
+                price_list=pl,
+                custom_name="null-default",
+                metric="gpu_request_per_hour",
+                cost_type="Infrastructure",
+                default_rate=None,
+            )
+        with CostModelDBAccessor(self.schema, self.provider_uuid, price_list_effective_on=None) as acc:
+            gpu_rate = acc.price_list.get("gpu_request_per_hour")
+            self.assertIsNotNone(gpu_rate)
+            self.assertEqual(gpu_rate["tiered_rates"]["Infrastructure"][0]["value"], 0.0)
+
 
 class CostModelDBAccessorTestNoRateOrMarkup(MasuTestCase):
     """Test Cases for the CostModelDBAccessor object."""
@@ -491,6 +514,17 @@ class CostModelDBAccessorTagRatesPriceListTest(MasuTestCase):
             cost_model_accessor.price_list_effective_on = target_date
             rates = cost_model_accessor.effective_rates
             self.assertEqual(rates, {})
+
+    @patch("masu.database.cost_model_db_accessor.is_feature_flag_enabled_by_schema", return_value=True)
+    def test_feature_flag_disables_price_list(self, _mock_flag):
+        """When DISABLE_PRICE_LIST_UNLEASH_FLAG is on, price_list_effective_on is forced to None."""
+        target_date = date(2026, 6, 15)
+        with CostModelDBAccessor(
+            self.schema, self.provider_uuid, price_list_effective_on=target_date
+        ) as acc:
+            self.assertIsNone(acc.price_list_effective_on)
+            rates = acc.effective_rates
+            self.assertEqual(rates, acc.cost_model.rates)
 
     def _make_price_list(self, cost_model, name, start, end, priority=1):
         """Create a PriceList linked to cost_model with a single CPU rate."""

--- a/koku/masu/test/database/test_cost_model_db_accessor.py
+++ b/koku/masu/test/database/test_cost_model_db_accessor.py
@@ -619,10 +619,28 @@ class CostModelDBAccessorTagRatesPriceListTest(MasuTestCase):
     @patch("masu.database.cost_model_db_accessor.is_feature_flag_enabled_by_schema", return_value=False)
     def test_rate_info_map_and_effective_rates_agree_on_coverage(self, _):
         """Both properties must agree: if effective_rates is empty, rate_info_map must be too."""
+        rates_json = [
+            {
+                "metric": {"name": "cpu_core_usage_per_hour"},
+                "tiered_rates": [{"value": "1.50", "unit": "USD"}],
+                "cost_type": "Supplementary",
+            }
+        ]
         with schema_context(self.schema):
             cost_model = CostModel.objects.filter(costmodelmap__provider_uuid=self.provider_uuid).first()
             PriceListCostModelMap.objects.filter(cost_model=cost_model).delete()
-            self._make_price_list(cost_model, "Apr", date(2026, 4, 1), date(2026, 4, 30))
+            pl = PriceList.objects.create(
+                name="Apr", effective_start_date=date(2026, 4, 1), effective_end_date=date(2026, 4, 30), rates=rates_json
+            )
+            PriceListCostModelMap.objects.create(price_list=pl, cost_model=cost_model, priority=1)
+            Rate.objects.create(
+                price_list=pl,
+                custom_name="Apr-cpu",
+                metric="cpu_core_usage_per_hour",
+                metric_type="cpu",
+                cost_type="Supplementary",
+                default_rate="1.50",
+            )
 
         for test_date, label in [(date(2026, 4, 15), "in-range"), (date(2026, 5, 15), "out-of-range")]:
             with CostModelDBAccessor(self.schema, self.provider_uuid, price_list_effective_on=test_date) as acc:

--- a/koku/masu/test/database/test_cost_model_db_accessor.py
+++ b/koku/masu/test/database/test_cost_model_db_accessor.py
@@ -630,7 +630,10 @@ class CostModelDBAccessorTagRatesPriceListTest(MasuTestCase):
             cost_model = CostModel.objects.filter(costmodelmap__provider_uuid=self.provider_uuid).first()
             PriceListCostModelMap.objects.filter(cost_model=cost_model).delete()
             pl = PriceList.objects.create(
-                name="Apr", effective_start_date=date(2026, 4, 1), effective_end_date=date(2026, 4, 30), rates=rates_json
+                name="Apr",
+                effective_start_date=date(2026, 4, 1),
+                effective_end_date=date(2026, 4, 30),
+                rates=rates_json,
             )
             PriceListCostModelMap.objects.create(price_list=pl, cost_model=cost_model, priority=1)
             Rate.objects.create(

--- a/koku/masu/test/database/test_cost_model_db_accessor.py
+++ b/koku/masu/test/database/test_cost_model_db_accessor.py
@@ -558,6 +558,45 @@ class CostModelDBAccessorTagRatesPriceListTest(MasuTestCase):
             rates = acc.effective_rates
             self.assertEqual(rates, acc.cost_model.rates)
 
+    @patch("masu.database.cost_model_db_accessor.is_feature_flag_enabled_by_schema", return_value=False)
+    def test_price_list_respects_effective_dates(self, _mock_flag):
+        """COST-7492: price_list must return empty when date is outside the PL validity period.
+
+        Reproduces the QE scenario: a price list covering April only should NOT
+        produce costs for May. infrastructure_rates and supplementary_rates
+        derive from price_list, so if price_list is empty, costs are zero.
+        """
+        with schema_context(self.schema):
+            cost_model = CostModel.objects.filter(costmodelmap__provider_uuid=self.provider_uuid).first()
+            PriceListCostModelMap.objects.filter(cost_model=cost_model).delete()
+            pl = PriceList.objects.create(
+                name="price_list_previous_month",
+                effective_start_date=date(2026, 4, 1),
+                effective_end_date=date(2026, 4, 30),
+                rates=[],
+            )
+            PriceListCostModelMap.objects.create(price_list=pl, cost_model=cost_model, priority=1)
+            Rate.objects.create(
+                price_list=pl,
+                custom_name="apr-cpu",
+                metric="cpu_core_usage_per_hour",
+                cost_type="Supplementary",
+                default_rate="3.50",
+            )
+
+        may_date = date(2026, 5, 1)
+        with CostModelDBAccessor(self.schema, self.provider_uuid, price_list_effective_on=may_date) as acc:
+            pl_map = acc.price_list
+            self.assertEqual(pl_map, {}, "price_list should be empty for May when PL only covers April")
+            self.assertEqual(acc.infrastructure_rates, {})
+            self.assertEqual(acc.supplementary_rates, {})
+
+        apr_date = date(2026, 4, 15)
+        with CostModelDBAccessor(self.schema, self.provider_uuid, price_list_effective_on=apr_date) as acc:
+            pl_map = acc.price_list
+            self.assertIn("cpu_core_usage_per_hour", pl_map, "price_list should contain rates for April")
+            self.assertNotEqual(acc.supplementary_rates, {})
+
     def _make_price_list(self, cost_model, name, start, end, priority=1):
         """Create a PriceList linked to cost_model with a single CPU rate."""
         pl = PriceList.objects.create(name=name, effective_start_date=start, effective_end_date=end, rates=[])
@@ -741,3 +780,248 @@ class CostModelDBAccessorTagRatesPriceListTest(MasuTestCase):
 
         self.assertEqual(len(april_map), 1, "April is within validity — rate expected")
         self.assertEqual(may_map, {}, "May is outside validity — no rates, zero costs")
+
+    # -- GA readiness: tag-rate properties with date scoping --
+
+    @patch("masu.database.cost_model_db_accessor.is_feature_flag_enabled_by_schema", return_value=False)
+    def test_tag_rate_properties_empty_outside_validity(self, _):
+        """All 6 tag-rate properties must return empty for a date outside the PL window.
+
+        tag_infrastructure_rates, tag_supplementary_rates,
+        tag_default_infrastructure_rates, tag_default_supplementary_rates,
+        metric_to_tag_params_map, and tag_based_price_list all derive from
+        effective_rates. If the date is outside every PL, they must all be empty.
+        """
+        tag_rates_json = [
+            {
+                "metric": {"name": "node_cost_per_month"},
+                "cost_type": "Infrastructure",
+                "tag_rates": {
+                    "tag_key": "env",
+                    "tag_values": [
+                        {"tag_value": "prod", "value": 100, "unit": "USD", "default": True, "description": ""},
+                    ],
+                },
+            },
+            {
+                "metric": {"name": "node_cost_per_month"},
+                "cost_type": "Supplementary",
+                "tag_rates": {
+                    "tag_key": "tier",
+                    "tag_values": [
+                        {"tag_value": "gold", "value": 50, "unit": "USD", "default": True, "description": ""},
+                    ],
+                },
+            },
+        ]
+        with schema_context(self.schema):
+            cost_model = CostModel.objects.filter(costmodelmap__provider_uuid=self.provider_uuid).first()
+            PriceListCostModelMap.objects.filter(cost_model=cost_model).delete()
+            pl = PriceList.objects.create(
+                name="apr-tags",
+                effective_start_date=date(2026, 4, 1),
+                effective_end_date=date(2026, 4, 30),
+                rates=tag_rates_json,
+            )
+            PriceListCostModelMap.objects.create(price_list=pl, cost_model=cost_model, priority=1)
+
+        may_date = date(2026, 5, 1)
+        with CostModelDBAccessor(self.schema, self.provider_uuid, price_list_effective_on=may_date) as acc:
+            self.assertEqual(acc.tag_based_price_list, {}, "tag_based_price_list should be empty outside PL")
+            self.assertEqual(acc.tag_infrastructure_rates, {}, "tag_infrastructure_rates should be empty")
+            self.assertEqual(acc.tag_supplementary_rates, {}, "tag_supplementary_rates should be empty")
+            self.assertEqual(
+                acc.tag_default_infrastructure_rates, {}, "tag_default_infrastructure_rates should be empty"
+            )
+            self.assertEqual(
+                acc.tag_default_supplementary_rates, {}, "tag_default_supplementary_rates should be empty"
+            )
+            self.assertEqual(acc.metric_to_tag_params_map, {}, "metric_to_tag_params_map should be empty")
+
+        apr_date = date(2026, 4, 15)
+        with CostModelDBAccessor(self.schema, self.provider_uuid, price_list_effective_on=apr_date) as acc:
+            self.assertNotEqual(acc.tag_based_price_list, {}, "tag_based_price_list should have data in April")
+            self.assertNotEqual(acc.tag_infrastructure_rates, {}, "tag_infrastructure_rates should have data")
+            self.assertNotEqual(acc.tag_supplementary_rates, {}, "tag_supplementary_rates should have data")
+            self.assertNotEqual(
+                acc.tag_default_infrastructure_rates, {}, "tag_default_infrastructure_rates should have data"
+            )
+            self.assertNotEqual(
+                acc.tag_default_supplementary_rates, {}, "tag_default_supplementary_rates should have data"
+            )
+            self.assertNotEqual(acc.metric_to_tag_params_map, {}, "metric_to_tag_params_map should have data")
+
+    # -- GA readiness: overlapping price lists with priority --
+
+    @patch("masu.database.cost_model_db_accessor.is_feature_flag_enabled_by_schema", return_value=False)
+    def test_overlapping_price_lists_lower_priority_wins(self, _):
+        """When two PLs cover the same date, the one with lower priority number wins."""
+        with schema_context(self.schema):
+            cost_model = CostModel.objects.filter(costmodelmap__provider_uuid=self.provider_uuid).first()
+            PriceListCostModelMap.objects.filter(cost_model=cost_model).delete()
+
+            pl_hi = PriceList.objects.create(
+                name="high-priority",
+                effective_start_date=date(2026, 4, 1),
+                effective_end_date=date(2026, 4, 30),
+                rates=[],
+            )
+            PriceListCostModelMap.objects.create(price_list=pl_hi, cost_model=cost_model, priority=1)
+            Rate.objects.create(
+                price_list=pl_hi,
+                custom_name="hi-cpu",
+                metric="cpu_core_usage_per_hour",
+                cost_type="Supplementary",
+                default_rate="5.00",
+            )
+
+            pl_lo = PriceList.objects.create(
+                name="low-priority",
+                effective_start_date=date(2026, 4, 1),
+                effective_end_date=date(2026, 4, 30),
+                rates=[],
+            )
+            PriceListCostModelMap.objects.create(price_list=pl_lo, cost_model=cost_model, priority=2)
+            Rate.objects.create(
+                price_list=pl_lo,
+                custom_name="lo-cpu",
+                metric="cpu_core_usage_per_hour",
+                cost_type="Supplementary",
+                default_rate="10.00",
+            )
+
+        with CostModelDBAccessor(self.schema, self.provider_uuid, price_list_effective_on=date(2026, 4, 15)) as acc:
+            cpu = acc.price_list.get("cpu_core_usage_per_hour")
+            self.assertIsNotNone(cpu)
+            value = cpu["tiered_rates"]["Supplementary"][0]["value"]
+            self.assertEqual(value, 5.0, "Priority 1 PL rate ($5) should win over priority 2 ($10)")
+
+    # -- GA readiness: gap between two price lists --
+
+    @patch("masu.database.cost_model_db_accessor.is_feature_flag_enabled_by_schema", return_value=False)
+    def test_date_in_gap_between_price_lists_returns_empty(self, _):
+        """A date falling in a gap between two PLs must return empty rates."""
+        with schema_context(self.schema):
+            cost_model = CostModel.objects.filter(costmodelmap__provider_uuid=self.provider_uuid).first()
+            PriceListCostModelMap.objects.filter(cost_model=cost_model).delete()
+            self._make_price_list(cost_model, "April", date(2026, 4, 1), date(2026, 4, 30))
+            self._make_price_list(cost_model, "June", date(2026, 6, 1), date(2026, 6, 30))
+
+        with CostModelDBAccessor(self.schema, self.provider_uuid, price_list_effective_on=date(2026, 5, 15)) as acc:
+            self.assertEqual(acc.price_list, {}, "May is in the gap — price_list should be empty")
+            self.assertEqual(acc.infrastructure_rates, {})
+            self.assertEqual(acc.supplementary_rates, {})
+            self.assertEqual(acc.rate_info_map, {})
+
+    # -- GA readiness: mid-month date matches PL --
+
+    @patch("masu.database.cost_model_db_accessor.is_feature_flag_enabled_by_schema", return_value=False)
+    def test_mid_month_date_matches_price_list(self, _):
+        """A mid-month start_date (as production callers use) must find the covering PL."""
+        with schema_context(self.schema):
+            cost_model = CostModel.objects.filter(costmodelmap__provider_uuid=self.provider_uuid).first()
+            PriceListCostModelMap.objects.filter(cost_model=cost_model).delete()
+            self._make_price_list(cost_model, "April", date(2026, 4, 1), date(2026, 4, 30))
+
+        with CostModelDBAccessor(self.schema, self.provider_uuid, price_list_effective_on=date(2026, 4, 15)) as acc:
+            self.assertIn("cpu_core_usage_per_hour", acc.price_list)
+            self.assertNotEqual(acc.supplementary_rates, {}, "Supplementary rate from _make_price_list expected")
+
+    # -- GA readiness: markup and distribution_info are date-independent --
+
+    @patch("masu.database.cost_model_db_accessor.is_feature_flag_enabled_by_schema", return_value=False)
+    def test_markup_and_distribution_stable_regardless_of_date(self, _):
+        """markup and distribution_info come from CostModel, not PL — must be the same with any date."""
+        with CostModelDBAccessor(self.schema, self.provider_uuid, price_list_effective_on=None) as acc_none:
+            markup_none = acc_none.markup
+            dist_none = acc_none.distribution_info
+
+        with CostModelDBAccessor(
+            self.schema, self.provider_uuid, price_list_effective_on=date(2100, 1, 1)
+        ) as acc_future:
+            self.assertEqual(acc_future.markup, markup_none, "markup must not depend on PL date")
+            self.assertEqual(acc_future.distribution_info, dist_none, "distribution_info must not depend on PL date")
+
+    # -- GA readiness: price_list with date=None merges all PLs --
+
+    @patch("masu.database.cost_model_db_accessor.is_feature_flag_enabled_by_schema", return_value=False)
+    def test_price_list_no_date_returns_rates_from_all_price_lists(self, _):
+        """With date=None, price_list returns rates from ALL PLs for the cost model."""
+        with schema_context(self.schema):
+            cost_model = CostModel.objects.filter(costmodelmap__provider_uuid=self.provider_uuid).first()
+            PriceListCostModelMap.objects.filter(cost_model=cost_model).delete()
+
+            pl_apr = PriceList.objects.create(
+                name="apr-only",
+                effective_start_date=date(2026, 4, 1),
+                effective_end_date=date(2026, 4, 30),
+                rates=[],
+            )
+            PriceListCostModelMap.objects.create(price_list=pl_apr, cost_model=cost_model, priority=1)
+            Rate.objects.create(
+                price_list=pl_apr,
+                custom_name="apr-cpu",
+                metric="cpu_core_usage_per_hour",
+                cost_type="Supplementary",
+                default_rate="2.00",
+            )
+
+            pl_may = PriceList.objects.create(
+                name="may-only",
+                effective_start_date=date(2026, 5, 1),
+                effective_end_date=date(2026, 5, 31),
+                rates=[],
+            )
+            PriceListCostModelMap.objects.create(price_list=pl_may, cost_model=cost_model, priority=1)
+            Rate.objects.create(
+                price_list=pl_may,
+                custom_name="may-mem",
+                metric="memory_gb_usage_per_hour",
+                cost_type="Infrastructure",
+                default_rate="4.00",
+            )
+
+        with CostModelDBAccessor(self.schema, self.provider_uuid, price_list_effective_on=None) as acc:
+            pl_map = acc.price_list
+            self.assertIn("cpu_core_usage_per_hour", pl_map, "CPU rate from April PL expected")
+            self.assertIn("memory_gb_usage_per_hour", pl_map, "Memory rate from May PL expected")
+
+    # -- GA readiness: price_list and effective_rates consistency --
+
+    @patch("masu.database.cost_model_db_accessor.is_feature_flag_enabled_by_schema", return_value=False)
+    def test_price_list_and_effective_rates_consistency(self, _):
+        """price_list and effective_rates must agree: both empty or both populated."""
+        rates_json = [
+            {
+                "metric": {"name": "cpu_core_usage_per_hour"},
+                "tiered_rates": [{"value": "1.50", "unit": "USD"}],
+                "cost_type": "Supplementary",
+            }
+        ]
+        with schema_context(self.schema):
+            cost_model = CostModel.objects.filter(costmodelmap__provider_uuid=self.provider_uuid).first()
+            PriceListCostModelMap.objects.filter(cost_model=cost_model).delete()
+            pl = PriceList.objects.create(
+                name="Apr",
+                effective_start_date=date(2026, 4, 1),
+                effective_end_date=date(2026, 4, 30),
+                rates=rates_json,
+            )
+            PriceListCostModelMap.objects.create(price_list=pl, cost_model=cost_model, priority=1)
+            Rate.objects.create(
+                price_list=pl,
+                custom_name="Apr-cpu",
+                metric="cpu_core_usage_per_hour",
+                cost_type="Supplementary",
+                default_rate="1.50",
+            )
+
+        for test_date, label in [(date(2026, 4, 15), "in-range"), (date(2026, 5, 15), "out-of-range")]:
+            with CostModelDBAccessor(self.schema, self.provider_uuid, price_list_effective_on=test_date) as acc:
+                has_pl = bool(acc.price_list)
+                has_eff = bool(acc.effective_rates)
+                self.assertEqual(
+                    has_pl,
+                    has_eff,
+                    f"price_list and effective_rates disagree for {label} date {test_date}",
+                )

--- a/koku/masu/test/database/test_cost_model_db_accessor.py
+++ b/koku/masu/test/database/test_cost_model_db_accessor.py
@@ -15,6 +15,7 @@ from api.report.test.util.constants import OCP_ON_PREM_COST_MODEL
 from cost_models.models import CostModel
 from cost_models.models import PriceList
 from cost_models.models import PriceListCostModelMap
+from cost_models.models import Rate
 from masu.database.cost_model_db_accessor import CostModelDBAccessor
 from masu.test import MasuTestCase
 from masu.test.database.helpers import ReportObjectCreator
@@ -490,3 +491,59 @@ class CostModelDBAccessorTagRatesPriceListTest(MasuTestCase):
             cost_model_accessor.price_list_effective_on = target_date
             rates = cost_model_accessor.effective_rates
             self.assertEqual(rates, {})
+
+    def test_rate_info_map_no_price_list_effective_on(self):
+        """Test rate_info_map returns entries from all Rate rows when no price_list_effective_on."""
+        with CostModelDBAccessor(self.schema, self.provider_uuid, price_list_effective_on=None) as accessor:
+            rate_map = accessor.rate_info_map
+            if accessor.cost_model:
+                rate_count = Rate.objects.filter(
+                    price_list__cost_model_maps__cost_model=accessor.cost_model
+                ).count()
+                self.assertEqual(len(rate_map), rate_count)
+                for key, info in rate_map.items():
+                    self.assertIn("rate_uuid", info)
+                    self.assertIn("custom_name", info)
+
+    @patch("masu.database.cost_model_db_accessor.is_feature_flag_enabled_by_schema", return_value=False)
+    def test_rate_info_map_scoped_to_effective_price_list(self, _mock_flag):
+        """Test rate_info_map returns only rates from the effective price list."""
+        target_date = date(2026, 6, 15)
+        with schema_context(self.schema):
+            cost_model = CostModel.objects.filter(costmodelmap__provider_uuid=self.provider_uuid).first()
+            PriceListCostModelMap.objects.filter(cost_model=cost_model).delete()
+            pl = PriceList.objects.create(
+                name="Scoped PL",
+                effective_start_date=date(2026, 1, 1),
+                effective_end_date=date(2026, 12, 31),
+                rates=[],
+            )
+            PriceListCostModelMap.objects.create(price_list=pl, cost_model=cost_model, priority=1)
+            rate = Rate.objects.create(
+                price_list=pl,
+                custom_name="test-cpu-rate",
+                metric="cpu_core_usage_per_hour",
+                metric_type="cpu",
+                cost_type="Infrastructure",
+                default_rate="1.50",
+            )
+
+        with CostModelDBAccessor(
+            self.schema, self.provider_uuid, price_list_effective_on=target_date
+        ) as accessor:
+            rate_map = accessor.rate_info_map
+            self.assertEqual(len(rate_map), 1)
+            key = ("cpu_core_usage_per_hour", "Infrastructure", "")
+            self.assertIn(key, rate_map)
+            self.assertEqual(rate_map[key]["rate_uuid"], str(rate.uuid))
+            self.assertEqual(rate_map[key]["custom_name"], "test-cpu-rate")
+
+    @patch("masu.database.cost_model_db_accessor.is_feature_flag_enabled_by_schema", return_value=False)
+    def test_rate_info_map_empty_when_no_matching_price_list(self, _mock_flag):
+        """Test rate_info_map returns empty when no price list covers the date."""
+        target_date = date(2100, 6, 1)
+        with CostModelDBAccessor(
+            self.schema, self.provider_uuid, price_list_effective_on=target_date
+        ) as accessor:
+            rate_map = accessor.rate_info_map
+            self.assertEqual(rate_map, {})

--- a/koku/masu/test/database/test_cost_model_db_accessor.py
+++ b/koku/masu/test/database/test_cost_model_db_accessor.py
@@ -547,3 +547,43 @@ class CostModelDBAccessorTagRatesPriceListTest(MasuTestCase):
         ) as accessor:
             rate_map = accessor.rate_info_map
             self.assertEqual(rate_map, {})
+
+    @patch("masu.database.cost_model_db_accessor.is_feature_flag_enabled_by_schema", return_value=False)
+    def test_rate_info_map_respects_validity_period_across_months(self, _mock_flag):
+        """Regression test for COST-7492: rates must not leak across validity periods.
+
+        Creates a price list valid only for April 2026. Querying rate_info_map
+        for an April date must return the rates; querying for May must return
+        nothing, ensuring costs are not calculated outside the validity window.
+        """
+        with schema_context(self.schema):
+            cost_model = CostModel.objects.filter(costmodelmap__provider_uuid=self.provider_uuid).first()
+            PriceListCostModelMap.objects.filter(cost_model=cost_model).delete()
+
+            april_pl = PriceList.objects.create(
+                name="April Only PL",
+                effective_start_date=date(2026, 4, 1),
+                effective_end_date=date(2026, 4, 30),
+                rates=[],
+            )
+            PriceListCostModelMap.objects.create(price_list=april_pl, cost_model=cost_model, priority=1)
+            Rate.objects.create(
+                price_list=april_pl,
+                custom_name="april-cpu-rate",
+                metric="cpu_core_usage_per_hour",
+                metric_type="cpu",
+                cost_type="Supplementary",
+                default_rate="4.40",
+            )
+
+        with CostModelDBAccessor(
+            self.schema, self.provider_uuid, price_list_effective_on=date(2026, 4, 15)
+        ) as accessor:
+            april_map = accessor.rate_info_map
+            self.assertEqual(len(april_map), 1, "April should return the rate")
+
+        with CostModelDBAccessor(
+            self.schema, self.provider_uuid, price_list_effective_on=date(2026, 5, 12)
+        ) as accessor:
+            may_map = accessor.rate_info_map
+            self.assertEqual(may_map, {}, "May should return no rates — price list only covers April")

--- a/koku/masu/test/database/test_cost_model_db_accessor.py
+++ b/koku/masu/test/database/test_cost_model_db_accessor.py
@@ -494,9 +494,7 @@ class CostModelDBAccessorTagRatesPriceListTest(MasuTestCase):
 
     def _make_price_list(self, cost_model, name, start, end, priority=1):
         """Create a PriceList linked to cost_model with a single CPU rate."""
-        pl = PriceList.objects.create(
-            name=name, effective_start_date=start, effective_end_date=end, rates=[]
-        )
+        pl = PriceList.objects.create(name=name, effective_start_date=start, effective_end_date=end, rates=[])
         PriceListCostModelMap.objects.create(price_list=pl, cost_model=cost_model, priority=priority)
         rate = Rate.objects.create(
             price_list=pl,
@@ -519,9 +517,7 @@ class CostModelDBAccessorTagRatesPriceListTest(MasuTestCase):
         """Without price_list_effective_on, every Rate row for the cost model is returned."""
         with CostModelDBAccessor(self.schema, self.provider_uuid, price_list_effective_on=None) as accessor:
             rate_map = accessor.rate_info_map
-            expected = Rate.objects.filter(
-                price_list__cost_model_maps__cost_model=accessor.cost_model
-            ).count()
+            expected = Rate.objects.filter(price_list__cost_model_maps__cost_model=accessor.cost_model).count()
             self.assertEqual(len(rate_map), expected)
             for info in rate_map.values():
                 self.assertIn("rate_uuid", info)
@@ -633,7 +629,8 @@ class CostModelDBAccessorTagRatesPriceListTest(MasuTestCase):
                 has_rates = bool(acc.effective_rates)
                 has_info = bool(acc.rate_info_map)
                 self.assertEqual(
-                    has_rates, has_info,
+                    has_rates,
+                    has_info,
                     f"effective_rates and rate_info_map disagree for {label} date {test_date}",
                 )
 

--- a/koku/masu/test/database/test_cost_model_db_accessor.py
+++ b/koku/masu/test/database/test_cost_model_db_accessor.py
@@ -519,9 +519,7 @@ class CostModelDBAccessorTagRatesPriceListTest(MasuTestCase):
     def test_feature_flag_disables_price_list(self, _mock_flag):
         """When DISABLE_PRICE_LIST_UNLEASH_FLAG is on, price_list_effective_on is forced to None."""
         target_date = date(2026, 6, 15)
-        with CostModelDBAccessor(
-            self.schema, self.provider_uuid, price_list_effective_on=target_date
-        ) as acc:
+        with CostModelDBAccessor(self.schema, self.provider_uuid, price_list_effective_on=target_date) as acc:
             self.assertIsNone(acc.price_list_effective_on)
             rates = acc.effective_rates
             self.assertEqual(rates, acc.cost_model.rates)

--- a/koku/masu/test/database/test_cost_model_db_accessor.py
+++ b/koku/masu/test/database/test_cost_model_db_accessor.py
@@ -178,6 +178,30 @@ class CostModelDBAccessorTest(MasuTestCase):
             self.assertIsNotNone(gpu_rate)
             self.assertEqual(gpu_rate["tiered_rates"]["Infrastructure"][0]["value"], 0.0)
 
+    def test_price_list_skips_tag_rates(self):
+        """Rate rows with tag_key are skipped by price_list (handled by tag_based_price_list)."""
+        with schema_context(self.schema):
+            cost_model = CostModel.objects.filter(costmodelmap__provider_uuid=self.provider_uuid).first()
+            pl = PriceList.objects.create(
+                name="tag-pl",
+                effective_start_date=date(2026, 1, 1),
+                effective_end_date=date(2026, 12, 31),
+                rates=[],
+            )
+            PriceListCostModelMap.objects.create(price_list=pl, cost_model=cost_model, priority=1)
+            Rate.objects.create(
+                price_list=pl,
+                custom_name="tagged-rate",
+                metric="cpu_core_usage_per_hour",
+                cost_type="Infrastructure",
+                default_rate="2.00",
+                tag_key="environment",
+            )
+        with CostModelDBAccessor(self.schema, self.provider_uuid, price_list_effective_on=None) as acc:
+            pl_map = acc.price_list
+            for entry in pl_map.values():
+                self.assertNotEqual(entry.get("description"), "tagged-rate")
+
 
 class CostModelDBAccessorTestNoRateOrMarkup(MasuTestCase):
     """Test Cases for the CostModelDBAccessor object."""
@@ -225,6 +249,16 @@ class CostModelDBAccessorNoCostModel(MasuTestCase):
     def test_params_with_no_cost_model(self):
         with CostModelDBAccessor(self.schema, self.provider_uuid, price_list_effective_on=None) as cost_model_accessor:
             self.assertFalse(cost_model_accessor.metric_to_tag_params_map)
+
+    def test_rate_info_map_no_cost_model(self):
+        """rate_info_map returns empty dict when there is no cost model."""
+        with CostModelDBAccessor(self.schema, self.provider_uuid, price_list_effective_on=None) as acc:
+            self.assertEqual(acc.rate_info_map, {})
+
+    def test_effective_price_list_no_cost_model(self):
+        """_effective_price_list returns None when there is no cost model."""
+        with CostModelDBAccessor(self.schema, self.provider_uuid, price_list_effective_on=date(2026, 6, 1)) as acc:
+            self.assertIsNone(acc._effective_price_list)
 
 
 class CostModelDBAccessorTagRatesTest(MasuTestCase):

--- a/koku/masu/test/processor/ocp/test_phase2_rates_to_usage.py
+++ b/koku/masu/test/processor/ocp/test_phase2_rates_to_usage.py
@@ -92,7 +92,9 @@ class TestPriceListSwitch(MasuTestCase):
         with self._get_accessor() as accessor:
             infra = accessor.infrastructure_rates
             self.assertIsInstance(infra, dict)
-            self.assertGreater(len(infra), 0, "Expected at least one infrastructure rate")
+            self.assertGreater(
+                len(infra), 0, "Expected at least one infrastructure rate"
+            )
 
     # TC-05: supplementary_rates populated (BAC-2)
     def test_supplementary_rates_populated(self):
@@ -106,7 +108,9 @@ class TestPriceListSwitch(MasuTestCase):
         from cost_models.models import Rate
         from masu.database.cost_model_db_accessor import CostModelDBAccessor
 
-        with CostModelDBAccessor(self.schema, self.ocp_provider_uuid, price_list_effective_on=None) as accessor:
+        with CostModelDBAccessor(
+            self.schema, self.ocp_provider_uuid, price_list_effective_on=None
+        ) as accessor:
             if not accessor.cost_model:
                 self.skipTest("No cost model for OCP provider")
 
@@ -124,7 +128,9 @@ class TestPriceListSwitch(MasuTestCase):
             for (metric, cost_type), expected_sum in expected.items():
                 self.assertIn(metric, pl, f"Missing metric {metric}")
                 tiered = pl[metric]["tiered_rates"]
-                self.assertIn(cost_type, tiered, f"Missing cost_type {cost_type} for {metric}")
+                self.assertIn(
+                    cost_type, tiered, f"Missing cost_type {cost_type} for {metric}"
+                )
                 actual_sum = tiered[cost_type][0]["value"]
                 self.assertAlmostEqual(actual_sum, expected_sum, places=10)
 
@@ -133,7 +139,9 @@ class TestPriceListSwitch(MasuTestCase):
         from cost_models.models import Rate
         from masu.database.cost_model_db_accessor import CostModelDBAccessor
 
-        with CostModelDBAccessor(self.schema, self.ocp_provider_uuid, price_list_effective_on=None) as accessor:
+        with CostModelDBAccessor(
+            self.schema, self.ocp_provider_uuid, price_list_effective_on=None
+        ) as accessor:
             if not accessor.cost_model:
                 self.skipTest("No cost model for OCP provider")
 
@@ -154,7 +162,9 @@ class TestPriceListSwitch(MasuTestCase):
 
             pl = accessor.price_list
             for metric in tag_only_metrics:
-                self.assertNotIn(metric, pl, f"Tag-only metric {metric} should not be in price_list")
+                self.assertNotIn(
+                    metric, pl, f"Tag-only metric {metric} should not be in price_list"
+                )
 
     # TC-08: unknown provider returns {}
     def test_price_list_empty_for_unknown_provider(self):
@@ -176,14 +186,18 @@ class TestCostModelIdExtraction(MasuTestCase):
 
     # TC-10: cost_model_id populated when cost model exists
     def test_cost_model_id_populated(self):
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
         self.assertIsNotNone(updater._cost_model_id)
 
     # TC-11: cost_model_id None when no cost model
     @patch("masu.processor.ocp.ocp_cost_model_cost_updater.CostModelDBAccessor")
     def test_cost_model_id_none_when_no_cost_model(self, mock_accessor):
         _setup_no_cost_model_mock(mock_accessor)
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
         self.assertIsNone(updater._cost_model_id)
 
 
@@ -196,11 +210,15 @@ class TestSyncTestRateRows(MasuTestCase):
         from cost_models.models import PriceList
 
         with schema_context(self.schema):
-            cm = CostModel.objects.filter(costmodelmap__provider_uuid=self.ocp_provider_uuid).first()
+            cm = CostModel.objects.filter(
+                costmodelmap__provider_uuid=self.ocp_provider_uuid
+            ).first()
             if not cm:
                 self.skipTest("No cost model for OCP provider")
             pl_count = PriceList.objects.filter(cost_model_maps__cost_model=cm).count()
-            self.assertGreater(pl_count, 0, "sync_test_rate_rows should create at least one PriceList")
+            self.assertGreater(
+                pl_count, 0, "sync_test_rate_rows should create at least one PriceList"
+            )
 
     # TC-13: creates Rate rows matching JSON entries
     def test_sync_creates_rate_rows(self):
@@ -208,10 +226,14 @@ class TestSyncTestRateRows(MasuTestCase):
         from cost_models.models import Rate
 
         with schema_context(self.schema):
-            cm = CostModel.objects.filter(costmodelmap__provider_uuid=self.ocp_provider_uuid).first()
+            cm = CostModel.objects.filter(
+                costmodelmap__provider_uuid=self.ocp_provider_uuid
+            ).first()
             if not cm:
                 self.skipTest("No cost model for OCP provider")
-            rate_count = Rate.objects.filter(price_list__cost_model_maps__cost_model=cm).count()
+            rate_count = Rate.objects.filter(
+                price_list__cost_model_maps__cost_model=cm
+            ).count()
             json_rate_count = len(cm.rates) if isinstance(cm.rates, list) else 0
             self.assertEqual(
                 rate_count,
@@ -228,17 +250,23 @@ class TestSyncTestRateRows(MasuTestCase):
         from masu.database.cost_model_db_accessor import CostModelDBAccessor
 
         with schema_context(self.schema):
-            cm = CostModel.objects.filter(costmodelmap__provider_uuid=self.ocp_provider_uuid).first()
+            cm = CostModel.objects.filter(
+                costmodelmap__provider_uuid=self.ocp_provider_uuid
+            ).first()
             if not cm:
                 self.skipTest("No cost model for OCP provider")
 
-        with CostModelDBAccessor(self.schema, self.ocp_provider_uuid, price_list_effective_on=None) as accessor:
+        with CostModelDBAccessor(
+            self.schema, self.ocp_provider_uuid, price_list_effective_on=None
+        ) as accessor:
             pl_before = accessor.price_list
 
         with schema_context(self.schema):
             sync_test_rate_rows(cm)
 
-        with CostModelDBAccessor(self.schema, self.ocp_provider_uuid, price_list_effective_on=None) as accessor:
+        with CostModelDBAccessor(
+            self.schema, self.ocp_provider_uuid, price_list_effective_on=None
+        ) as accessor:
             pl_after = accessor.price_list
 
         self.assertEqual(
@@ -254,7 +282,9 @@ class TestSyncTestRateRows(MasuTestCase):
         from cost_models.models import Rate
 
         with schema_context(self.schema):
-            cm = CostModel.objects.filter(costmodelmap__provider_uuid=self.ocp_provider_uuid).first()
+            cm = CostModel.objects.filter(
+                costmodelmap__provider_uuid=self.ocp_provider_uuid
+            ).first()
             if not cm:
                 self.skipTest("No cost model for OCP provider")
             rate = Rate.objects.filter(
@@ -420,7 +450,9 @@ class TestPopulateUsageRatesToUsage(_ReportPeriodMixin, MasuTestCase):
         )
 
     # TC-22: executes INSERT SQL
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
+    )
     def test_populate_rtu_executes_insert_sql(self, mock_execute):
         with OCPReportDBAccessor(self.schema) as accessor:
             rp = self._get_report_period(accessor)
@@ -431,7 +463,9 @@ class TestPopulateUsageRatesToUsage(_ReportPeriodMixin, MasuTestCase):
         self.assertEqual(kwargs.get("operation"), "INSERT")
 
     # TC-23: cost_model_id included as string
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
+    )
     def test_populate_rtu_includes_cost_model_id(self, mock_execute):
         cost_model_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
         with OCPReportDBAccessor(self.schema) as accessor:
@@ -442,7 +476,9 @@ class TestPopulateUsageRatesToUsage(_ReportPeriodMixin, MasuTestCase):
         self.assertEqual(sql_params["cost_model_id"], cost_model_id)
 
     # TC-25: distribution is now read from cost_model table in SQL, not passed as param
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
+    )
     def test_populate_rtu_no_distribution_param(self, mock_execute):
         with OCPReportDBAccessor(self.schema) as accessor:
             rp = self._get_report_period(accessor)
@@ -452,7 +488,9 @@ class TestPopulateUsageRatesToUsage(_ReportPeriodMixin, MasuTestCase):
         self.assertNotIn("distribution", sql_params)
 
     # TC-25b: cluster_cost_per_hour NOT in sql_params (resolved via SQL JOIN)
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
+    )
     def test_populate_rtu_no_cluster_cost_per_hour_param(self, mock_execute):
         with OCPReportDBAccessor(self.schema) as accessor:
             rp = self._get_report_period(accessor)
@@ -462,7 +500,9 @@ class TestPopulateUsageRatesToUsage(_ReportPeriodMixin, MasuTestCase):
         self.assertNotIn("cluster_cost_per_hour", sql_params)
 
     # TC-25c: rate_type and per-metric params NOT in sql_params (single-pass reads from DB)
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
+    )
     def test_populate_rtu_no_rate_type_or_metric_params(self, mock_execute):
         with OCPReportDBAccessor(self.schema) as accessor:
             rp = self._get_report_period(accessor)
@@ -482,7 +522,9 @@ class TestAggregateRatesToDailySummary(_ReportPeriodMixin, MasuTestCase):
     """Test aggregate_rates_to_daily_summary accessor method (BAC-6)."""
 
     # TC-29: executes INSERT SQL
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
+    )
     def test_aggregate_rtu_executes_insert_sql(self, mock_execute):
         dh = DateHelper()
         with OCPReportDBAccessor(self.schema) as accessor:
@@ -498,7 +540,9 @@ class TestAggregateRatesToDailySummary(_ReportPeriodMixin, MasuTestCase):
         self.assertEqual(kwargs.get("operation"), "INSERT")
 
     # TC-30: params match window
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
+    )
     def test_aggregate_rtu_params_match_window(self, mock_execute):
         dh = DateHelper()
         with OCPReportDBAccessor(self.schema) as accessor:
@@ -521,7 +565,9 @@ class TestValidateRatesToUsage(_ReportPeriodMixin, MasuTestCase):
     """Test validate_rates_against_daily_summary accessor method (BAC-7)."""
 
     # TC-31: executes SELECT SQL
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
+    )
     def test_validate_rtu_executes_select_sql(self, mock_execute):
         dh = DateHelper()
         with OCPReportDBAccessor(self.schema) as accessor:
@@ -537,7 +583,9 @@ class TestValidateRatesToUsage(_ReportPeriodMixin, MasuTestCase):
         self.assertEqual(kwargs.get("operation"), "SELECT")
 
     # TC-32: params include report_period_id
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
+    )
     def test_validate_rtu_params_include_report_period(self, mock_execute):
         dh = DateHelper()
         with OCPReportDBAccessor(self.schema) as accessor:
@@ -655,7 +703,9 @@ class TestUpdaterOrchestration(_ReportPeriodMixin, MasuTestCase):
         mock_monthly,
         mock_dist,
     ):
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
         sr = self._make_summary_range()
         updater.update_summary_cost_model_costs(sr)
         mock_rtu.assert_called_once_with(sr.start_date, sr.end_date)
@@ -676,7 +726,9 @@ class TestUpdaterOrchestration(_ReportPeriodMixin, MasuTestCase):
         mock_monthly,
         mock_dist,
     ):
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
         sr = self._make_summary_range()
         updater.update_summary_cost_model_costs(sr)
         mock_agg.assert_called_once_with(sr.start_date, sr.end_date)
@@ -702,7 +754,9 @@ class TestUpdaterOrchestration(_ReportPeriodMixin, MasuTestCase):
         mock_agg.side_effect = lambda *a: call_order.append("agg")
         mock_dist.side_effect = lambda *a: call_order.append("dist")
 
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
         sr = self._make_summary_range()
         updater.update_summary_cost_model_costs(sr)
 
@@ -732,7 +786,9 @@ class TestUpdaterOrchestration(_ReportPeriodMixin, MasuTestCase):
         mock_agg.side_effect = lambda *a: call_order.append("agg")
         mock_dist.side_effect = lambda *a: call_order.append("dist")
 
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
         sr = self._make_summary_range()
         updater.update_summary_cost_model_costs(sr)
 
@@ -741,10 +797,14 @@ class TestUpdaterOrchestration(_ReportPeriodMixin, MasuTestCase):
         self.assertLess(call_order.index("agg"), call_order.index("dist"))
 
     # TC-53: single-pass INSERT (no rate_type loop)
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
+    )
     @patch.object(OCPCostModelCostUpdater, "_ensure_rates_to_usage_partitions")
     def test_rtu_insert_single_pass(self, mock_partitions, mock_execute):
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
         if not updater._cost_model_id:
             self.skipTest("No cost model for OCP provider")
         rp = self._get_report_period()
@@ -757,8 +817,12 @@ class TestUpdaterOrchestration(_ReportPeriodMixin, MasuTestCase):
 
         updater._update_usage_rates_to_usage(start_date, end_date)
 
-        insert_calls = [c for c in mock_execute.call_args_list if c[1].get("operation") == "INSERT"]
-        self.assertEqual(len(insert_calls), 1, "Single-pass: exactly one INSERT call expected")
+        insert_calls = [
+            c for c in mock_execute.call_args_list if c[1].get("operation") == "INSERT"
+        ]
+        self.assertEqual(
+            len(insert_calls), 1, "Single-pass: exactly one INSERT call expected"
+        )
         sql_params = insert_calls[0][0][2]
         self.assertIn("cost_model_id", sql_params)
         self.assertNotIn("cluster_cost_per_hour", sql_params)
@@ -779,7 +843,9 @@ class TestUpdaterOrchestration(_ReportPeriodMixin, MasuTestCase):
         mock_monthly,
         mock_dist,
     ):
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
         sr = self._make_summary_range()
         updater.update_summary_cost_model_costs(sr)
         mock_rtu.assert_not_called()
@@ -793,17 +859,25 @@ class TestPartitionWiring(MasuTestCase):
     # TC-45: calls _handle_partitions
     @patch.object(OCPCostModelCostUpdater, "_handle_partitions")
     def test_partition_wiring_calls_handle_partitions(self, mock_handle):
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
         dh = DateHelper()
-        updater._ensure_rates_to_usage_partitions(dh.this_month_start, dh.this_month_end)
+        updater._ensure_rates_to_usage_partitions(
+            dh.this_month_start, dh.this_month_end
+        )
         mock_handle.assert_called_once()
 
     # TC-46: correct table name
     @patch.object(OCPCostModelCostUpdater, "_handle_partitions")
     def test_partition_wiring_correct_table_name(self, mock_handle):
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
         dh = DateHelper()
-        updater._ensure_rates_to_usage_partitions(dh.this_month_start, dh.this_month_end)
+        updater._ensure_rates_to_usage_partitions(
+            dh.this_month_start, dh.this_month_end
+        )
         args, kwargs = mock_handle.call_args
         self.assertEqual(args[1], ["rates_to_usage"])
 
@@ -812,36 +886,58 @@ class TestSkipPaths(MasuTestCase):
     """Test skip paths when report period or cost_model_id is missing (BAC-10, BAC-12)."""
 
     # TC-47: RTU insert skips with log when no report period
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.report_periods_for_provider_uuid")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.report_periods_for_provider_uuid"
+    )
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
+    )
     @patch.object(OCPCostModelCostUpdater, "_ensure_rates_to_usage_partitions")
-    def test_rtu_insert_skips_no_report_period(self, mock_partitions, mock_execute, mock_rp):
+    def test_rtu_insert_skips_no_report_period(
+        self, mock_partitions, mock_execute, mock_rp
+    ):
         mock_rp.return_value = None
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
         dh = DateHelper()
         with self.assertLogs("masu.processor.ocp", level="INFO") as cm:
             updater._update_usage_rates_to_usage(dh.this_month_start, dh.this_month_end)
         mock_execute.assert_not_called()
-        self.assertTrue(any("skipping rates_to_usage insert" in msg for msg in cm.output))
+        self.assertTrue(
+            any("skipping rates_to_usage insert" in msg for msg in cm.output)
+        )
 
     # TC-48: RTU aggregate skips with log when no report period
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.report_periods_for_provider_uuid")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.report_periods_for_provider_uuid"
+    )
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
+    )
     def test_rtu_aggregate_skips_no_report_period(self, mock_execute, mock_rp):
         mock_rp.return_value = None
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
         dh = DateHelper()
         with self.assertLogs("masu.processor.ocp", level="INFO") as cm:
-            updater._aggregate_rates_to_daily_summary(dh.this_month_start, dh.this_month_end)
+            updater._aggregate_rates_to_daily_summary(
+                dh.this_month_start, dh.this_month_end
+            )
         mock_execute.assert_not_called()
-        self.assertTrue(any("skipping rates_to_usage aggregation" in msg for msg in cm.output))
+        self.assertTrue(
+            any("skipping rates_to_usage aggregation" in msg for msg in cm.output)
+        )
 
     # TC-49: RTU insert skips when no cost_model_id
     @patch.object(OCPCostModelCostUpdater, "_ensure_rates_to_usage_partitions")
     @patch("masu.processor.ocp.ocp_cost_model_cost_updater.CostModelDBAccessor")
     def test_rtu_insert_skips_no_cost_model_id(self, mock_accessor, mock_part):
         _setup_no_cost_model_mock(mock_accessor)
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
         self.assertIsNone(updater._cost_model_id)
 
         dh = DateHelper()
@@ -852,14 +948,18 @@ class TestSkipPaths(MasuTestCase):
     @patch("masu.processor.ocp.ocp_cost_model_cost_updater.CostModelDBAccessor")
     def test_rtu_aggregate_skips_no_cost_model_id(self, mock_accessor):
         _setup_no_cost_model_mock(mock_accessor)
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
         self.assertIsNone(updater._cost_model_id)
 
         dh = DateHelper()
         with patch(
             "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
         ) as mock_exec:
-            updater._aggregate_rates_to_daily_summary(dh.this_month_start, dh.this_month_end)
+            updater._aggregate_rates_to_daily_summary(
+                dh.this_month_start, dh.this_month_end
+            )
             mock_exec.assert_not_called()
 
 
@@ -871,7 +971,9 @@ class TestPurgeWiring(MasuTestCase):
     @patch("masu.processor.ocp.ocp_report_db_cleaner.cascade_delete")
     @patch("masu.processor.ocp.ocp_report_db_cleaner.PartitionedTable")
     @patch("masu.processor.ocp.ocp_report_db_cleaner.OCPReportDBAccessor")
-    def test_rates_to_usage_in_cleaner_base_list(self, mock_accessor_cls, mock_pt, mock_cascade, mock_delete):
+    def test_rates_to_usage_in_cleaner_base_list(
+        self, mock_accessor_cls, mock_pt, mock_cascade, mock_delete
+    ):
         """Verify partition cleanup includes rates_to_usage table."""
         from datetime import date as date_cls
         from unittest.mock import MagicMock
@@ -883,7 +985,9 @@ class TestPurgeWiring(MasuTestCase):
         mock_qs.__iter__ = MagicMock(return_value=iter([]))
         mock_qs.query = MagicMock()
         mock_accessor.get_report_periods_before_date.return_value = mock_qs
-        mock_accessor._table_map = {"line_item_daily_summary": "reporting_ocpusagelineitem_daily_summary"}
+        mock_accessor._table_map = {
+            "line_item_daily_summary": "reporting_ocpusagelineitem_daily_summary"
+        }
 
         cleaner = OCPReportDBCleaner(self.schema)
         cleaner.purge_expired_report_data_by_date(date_cls(2020, 1, 1))
@@ -927,7 +1031,9 @@ class TestRTUCostBreakdownAPI(_ReportPeriodMixin, MasuTestCase):
         from api.models import Provider
         from api.report.ocp.provider_map import OCPProviderMap
 
-        cls.provider_map = OCPProviderMap(Provider.PROVIDER_OCP, "costs", cls.schema_name)
+        cls.provider_map = OCPProviderMap(
+            Provider.PROVIDER_OCP, "costs", cls.schema_name
+        )
         cls.cost_term = (
             cls.provider_map.cloud_infrastructure_cost
             + cls.provider_map.markup_cost
@@ -942,7 +1048,9 @@ class TestRTUCostBreakdownAPI(_ReportPeriodMixin, MasuTestCase):
         return {
             "source_uuid": self.ocp_provider.uuid,
             "usage_start__gte": (
-                rp.report_period_start.date() if hasattr(rp.report_period_start, "date") else rp.report_period_start
+                rp.report_period_start.date()
+                if hasattr(rp.report_period_start, "date")
+                else rp.report_period_start
             ),
         }
 
@@ -963,7 +1071,9 @@ class TestRTUCostBreakdownAPI(_ReportPeriodMixin, MasuTestCase):
             dh = DateHelper()
             start_date = rp.report_period_start
             end_date = dh.month_end(start_date)
-            updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+            updater = OCPCostModelCostUpdater(
+                schema=self.schema, provider=self.ocp_provider
+            )
             if not updater._cost_model_id:
                 self.skipTest("No cost model for OCP provider")
             updater._load_rates(start_date)
@@ -977,7 +1087,9 @@ class TestRTUCostBreakdownAPI(_ReportPeriodMixin, MasuTestCase):
                     usage_start__gte=rp_filter["usage_start__gte"],
                 ).count()
 
-        self.assertGreater(count, 0, "RTU table should have rows for OCP-on-Prem provider")
+        self.assertGreater(
+            count, 0, "RTU table should have rows for OCP-on-Prem provider"
+        )
 
     # TC-E2E-02: RTU aggregated costs reconcile with daily summary
     def test_rtu_sums_match_daily_summary_cost_model_columns(self):
@@ -1002,7 +1114,9 @@ class TestRTUCostBreakdownAPI(_ReportPeriodMixin, MasuTestCase):
                 .values("metric_type")
                 .annotate(total=Sum("calculated_cost"))
             )
-            rtu_by_metric = {row["metric_type"]: row["total"] or Decimal(0) for row in rtu_agg}
+            rtu_by_metric = {
+                row["metric_type"]: row["total"] or Decimal(0) for row in rtu_agg
+            }
 
             ds_agg = OCPUsageLineItemDailySummary.objects.filter(
                 source_uuid=rp_filter["source_uuid"],
@@ -1066,7 +1180,9 @@ class TestRTUCostBreakdownAPI(_ReportPeriodMixin, MasuTestCase):
 
         with tenant_context(self.tenant):
             cost = (
-                OCPUsageLineItemDailySummary.objects.filter(usage_start__gte=self.dh.this_month_start.date())
+                OCPUsageLineItemDailySummary.objects.filter(
+                    usage_start__gte=self.dh.this_month_start.date()
+                )
                 .annotate(
                     infra_exchange_rate=Value(Decimal(1)),
                     exchange_rate=Value(Decimal(1)),
@@ -1076,7 +1192,13 @@ class TestRTUCostBreakdownAPI(_ReportPeriodMixin, MasuTestCase):
             )
             expected_total = cost if cost is not None else 0
 
-        total = data.get("meta", {}).get("total", {}).get("cost", {}).get("total", {}).get("value", 0)
+        total = (
+            data.get("meta", {})
+            .get("total", {})
+            .get("cost", {})
+            .get("total", {})
+            .get("value", 0)
+        )
         self.assertNotEqual(total, Decimal(0), "API should return non-zero cost total")
         self.assertAlmostEqual(total, expected_total, 6)
 
@@ -1116,14 +1238,18 @@ class TestRTUCostBreakdownAPI(_ReportPeriodMixin, MasuTestCase):
             if found_nonzero:
                 break
 
-        self.assertTrue(found_nonzero, "At least one project should have non-zero cost-model costs")
+        self.assertTrue(
+            found_nonzero, "At least one project should have non-zero cost-model costs"
+        )
 
 
 class TestRTURateResolution(_ReportPeriodMixin, MasuTestCase):
     """drift5-sql: Verify RTU rows resolve rate_id and custom_name from Rate table."""
 
     # TC-D5-01: SQL params include cost_model_id (regression guard)
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
+    )
     def test_populate_rtu_params_include_cost_model_id(self, mock_execute):
         """populate_usage_rates_to_usage passes cost_model_id in SQL params."""
         dh = DateHelper()
@@ -1219,7 +1345,9 @@ class TestRTURateResolution(_ReportPeriodMixin, MasuTestCase):
             ).count()
         if total == 0:
             self.skipTest("No RTU rows to check")
-        self.assertGreaterEqual(total, with_rate, "Total RTU rows should be >= rows with rate FK")
+        self.assertGreaterEqual(
+            total, with_rate, "Total RTU rows should be >= rows with rate FK"
+        )
 
     # TC-D5-05: RTU custom_name falls back to metric name when no Rate exists
     def test_rtu_custom_name_fallback(self):
@@ -1238,7 +1366,9 @@ class TestRTURateResolution(_ReportPeriodMixin, MasuTestCase):
                 rate__isnull=True,
             ).first()
         if not rtu_row:
-            self.skipTest("No RTU rows with NULL rate FK (all rows may have matching Rate)")
+            self.skipTest(
+                "No RTU rows with NULL rate FK (all rows may have matching Rate)"
+            )
         known_metrics = set(metric_constants.COST_MODEL_USAGE_RATES)
         metric_found = any(m in rtu_row.custom_name for m in known_metrics)
         self.assertTrue(
@@ -1289,12 +1419,16 @@ class TestOrchestrationOrder(_ReportPeriodMixin, MasuTestCase):
         mock_monthly.side_effect = lambda *a: call_order.append("monthly")
         mock_dist.side_effect = lambda *a: call_order.append("dist")
 
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
         sr = self._make_summary_range()
         updater.update_summary_cost_model_costs(sr)
 
         expected = ["rtu", "agg", "vm", "markup", "monthly", "dist"]
-        self.assertEqual(call_order, expected, f"R20: expected {expected}, got {call_order}")
+        self.assertEqual(
+            call_order, expected, f"R20: expected {expected}, got {call_order}"
+        )
         mock_usage.assert_not_called()
         mock_cleanup.assert_not_called()
 
@@ -1318,7 +1452,9 @@ class TestOrchestrationOrder(_ReportPeriodMixin, MasuTestCase):
         mock_agg.side_effect = lambda *a: call_order.append("agg")
         mock_markup.side_effect = lambda *a: call_order.append("markup")
 
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
         sr = self._make_summary_range()
         updater.update_summary_cost_model_costs(sr)
 
@@ -1346,7 +1482,9 @@ class TestOrchestrationOrder(_ReportPeriodMixin, MasuTestCase):
         mock_dist,
     ):
         """R20: When RTU is enabled but cost_model_id is None, cleanup must run instead of RTU+agg."""
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
         updater._cost_model_id = None
         sr = self._make_summary_range()
         updater.update_summary_cost_model_costs(sr)
@@ -1356,3 +1494,292 @@ class TestOrchestrationOrder(_ReportPeriodMixin, MasuTestCase):
         mock_agg.assert_not_called()
         mock_vm.assert_not_called()
         mock_usage.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# COST-7492 — Price List Validity Period Enforcement (blast-radius audit)
+# ---------------------------------------------------------------------------
+
+
+class TestPriceListValidityGuard(_ReportPeriodMixin, MasuTestCase):
+    """Verify the Python guard skips RTU when no price list covers the billing month."""
+
+    def _make_summary_range(self):
+        dh = DateHelper()
+        return SummaryRangeConfig(
+            schema=self.schema,
+            provider_uuid=self.ocp_provider_uuid,
+            start_date=dh.this_month_start,
+            end_date=dh.this_month_end,
+            cost_model_update=True,
+        )
+
+    # TC-7492-01: cleanup called when cost model exists but no effective PL
+    @_make_orchestration_patches(rtu_enabled=True)
+    def test_cleanup_when_no_effective_price_list(
+        self,
+        mock_ff,
+        mock_load,
+        mock_rtu,
+        mock_agg,
+        mock_vm,
+        mock_cleanup,
+        mock_usage,
+        mock_markup,
+        mock_monthly,
+        mock_dist,
+    ):
+        """When _load_rates finds no effective PL, RTU is skipped and stale rows cleaned."""
+        from datetime import date
+
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
+
+        def fake_load(start_date):
+            updater._infra_rates = {}
+            updater._supplementary_rates = {}
+            updater._tag_infra_rates = {}
+            updater._tag_supplementary_rates = {}
+            updater._tag_default_infra_rates = {}
+            updater._tag_default_supplementary_rates = {}
+            updater.metric_to_tag_params_map = {}
+            updater._price_list_effective_on = date(2026, 5, 1)
+
+        mock_load.side_effect = fake_load
+
+        sr = self._make_summary_range()
+        updater.update_summary_cost_model_costs(sr)
+
+        mock_cleanup.assert_called()
+        mock_rtu.assert_not_called()
+        mock_agg.assert_not_called()
+        mock_vm.assert_not_called()
+
+    # TC-7492-02: RTU still called when price_list_effective_on is None (feature flag disabled)
+    @_make_orchestration_patches(rtu_enabled=True)
+    def test_rtu_called_when_price_list_effective_on_is_none(
+        self,
+        mock_ff,
+        mock_load,
+        mock_rtu,
+        mock_agg,
+        mock_vm,
+        mock_cleanup,
+        mock_usage,
+        mock_markup,
+        mock_monthly,
+        mock_dist,
+    ):
+        """When _price_list_effective_on is None (feature flag disabled), RTU proceeds normally."""
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
+
+        def fake_load(start_date):
+            updater._infra_rates = {}
+            updater._supplementary_rates = {}
+            updater._tag_infra_rates = {}
+            updater._tag_supplementary_rates = {}
+            updater._tag_default_infra_rates = {}
+            updater._tag_default_supplementary_rates = {}
+            updater.metric_to_tag_params_map = {}
+            updater._price_list_effective_on = None
+
+        mock_load.side_effect = fake_load
+
+        sr = self._make_summary_range()
+        updater.update_summary_cost_model_costs(sr)
+
+        mock_rtu.assert_called_once()
+        mock_cleanup.assert_not_called()
+
+    # TC-7492-03: RTU called when effective PL found and rates are loaded
+    @_make_orchestration_patches(rtu_enabled=True)
+    def test_rtu_called_when_effective_pl_found(
+        self,
+        mock_ff,
+        mock_load,
+        mock_rtu,
+        mock_agg,
+        mock_vm,
+        mock_cleanup,
+        mock_usage,
+        mock_markup,
+        mock_monthly,
+        mock_dist,
+    ):
+        """When _load_rates finds an effective PL with rates, RTU proceeds."""
+        from datetime import date
+
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
+
+        def fake_load(start_date):
+            updater._infra_rates = {"cpu_core_usage_per_hour": 0.2}
+            updater._supplementary_rates = {}
+            updater._tag_infra_rates = {}
+            updater._tag_supplementary_rates = {}
+            updater._tag_default_infra_rates = {}
+            updater._tag_default_supplementary_rates = {}
+            updater.metric_to_tag_params_map = {}
+            updater._price_list_effective_on = date(2026, 4, 1)
+
+        mock_load.side_effect = fake_load
+
+        sr = self._make_summary_range()
+        updater.update_summary_cost_model_costs(sr)
+
+        mock_rtu.assert_called_once()
+        mock_cleanup.assert_not_called()
+
+    # TC-7492-04: _load_rates stores price_list_effective_on from accessor
+    def test_load_rates_stores_price_list_effective_on(self):
+        """_load_rates must propagate price_list_effective_on from the accessor."""
+        from datetime import date
+
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
+        self.assertIsNone(updater._price_list_effective_on)
+
+        test_date = date(2026, 4, 1)
+        updater._load_rates(test_date)
+
+        self.assertEqual(updater._price_list_effective_on, test_date)
+
+    # TC-7492-05: _load_rates stores None when feature flag disables date scoping
+    @patch(
+        "masu.database.cost_model_db_accessor.is_feature_flag_enabled_by_schema",
+        return_value=True,
+    )
+    def test_load_rates_stores_none_when_flag_disables_scoping(self, mock_ff):
+        """When DISABLE_PRICE_LIST flag is on, _price_list_effective_on should be None."""
+        from datetime import date
+
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
+        updater._load_rates(date(2026, 4, 1))
+
+        self.assertIsNone(updater._price_list_effective_on)
+
+    # TC-7492-06: tag cost paths skipped when no effective PL
+    @_make_orchestration_patches(rtu_enabled=True)
+    def test_tag_costs_skipped_when_no_effective_pl(
+        self,
+        mock_ff,
+        mock_load,
+        mock_rtu,
+        mock_agg,
+        mock_vm,
+        mock_cleanup,
+        mock_usage,
+        mock_markup,
+        mock_monthly,
+        mock_dist,
+    ):
+        """Tag-based cost paths must be skipped when no PL covers the month."""
+        from datetime import date
+
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
+
+        def fake_load(start_date):
+            updater._infra_rates = {}
+            updater._supplementary_rates = {}
+            updater._tag_infra_rates = {}
+            updater._tag_supplementary_rates = {}
+            updater._tag_default_infra_rates = {}
+            updater._tag_default_supplementary_rates = {}
+            updater.metric_to_tag_params_map = {}
+            updater._price_list_effective_on = date(2026, 5, 1)
+
+        mock_load.side_effect = fake_load
+
+        sr = self._make_summary_range()
+        with patch.object(
+            updater, "_delete_tag_usage_costs"
+        ) as mock_delete_tags, patch.object(
+            updater, "_update_tag_usage_costs"
+        ) as mock_tag_usage:
+            updater.update_summary_cost_model_costs(sr)
+            mock_tag_usage.assert_not_called()
+
+
+class TestTwoMonthOrchestration(_ReportPeriodMixin, MasuTestCase):
+    """Verify correct behavior across a two-month range where only one month has an effective PL."""
+
+    # TC-7492-07: two-month range — April RTU, May cleanup
+    def test_two_month_range_april_rtu_may_cleanup(self):
+        """Over April+May with an April-only PL, RTU runs for April and cleanup for May."""
+        from datetime import date
+        from datetime import datetime
+        from datetime import timezone
+
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
+        if not updater._cost_model_id:
+            self.skipTest("No cost model for OCP provider")
+
+        sr = SummaryRangeConfig(
+            schema=self.schema,
+            provider_uuid=self.ocp_provider_uuid,
+            start_date=datetime(2026, 4, 1, tzinfo=timezone.utc),
+            end_date=datetime(2026, 5, 31, tzinfo=timezone.utc),
+            cost_model_update=True,
+        )
+
+        call_log = []
+
+        def fake_load(start_date):
+            if hasattr(start_date, "date"):
+                d = start_date.date()
+            else:
+                d = start_date
+            if d.month == 4:
+                updater._infra_rates = {"cpu_core_usage_per_hour": 0.2}
+                updater._supplementary_rates = {"cpu_core_usage_per_hour": 0.2}
+            else:
+                updater._infra_rates = {}
+                updater._supplementary_rates = {}
+            updater._tag_infra_rates = {}
+            updater._tag_supplementary_rates = {}
+            updater._tag_default_infra_rates = {}
+            updater._tag_default_supplementary_rates = {}
+            updater.metric_to_tag_params_map = {}
+            updater._price_list_effective_on = d
+
+        with patch.object(updater, "_load_rates", side_effect=fake_load), patch.object(
+            updater, "_update_usage_rates_to_usage"
+        ) as mock_rtu, patch.object(
+            updater, "_aggregate_rates_to_daily_summary"
+        ) as mock_agg, patch.object(
+            updater, "_update_vm_usage_costs"
+        ) as mock_vm, patch.object(
+            updater, "_cleanup_stale_rtu_costs"
+        ) as mock_cleanup, patch.object(
+            updater, "_update_markup_cost"
+        ), patch.object(
+            updater, "_update_monthly_cost"
+        ), patch.object(
+            updater, "distribute_costs_and_update_ui_summary"
+        ), patch(
+            "masu.processor.ocp.ocp_cost_model_cost_updater.is_feature_flag_enabled_by_schema",
+            return_value=True,
+        ):
+            mock_rtu.side_effect = lambda s, e: call_log.append(("rtu", s))
+            mock_cleanup.side_effect = lambda s, e: call_log.append(("cleanup", s))
+
+            updater.update_summary_cost_model_costs(sr)
+
+        rtu_months = [d.month for action, d in call_log if action == "rtu"]
+        cleanup_months = [d.month for action, d in call_log if action == "cleanup"]
+
+        self.assertIn(4, rtu_months, "April should get RTU insert")
+        self.assertNotIn(5, rtu_months, "May should NOT get RTU insert")
+        self.assertIn(5, cleanup_months, "May should get cleanup")
+        self.assertNotIn(4, cleanup_months, "April should NOT get cleanup")

--- a/koku/masu/test/processor/ocp/test_phase2_rates_to_usage.py
+++ b/koku/masu/test/processor/ocp/test_phase2_rates_to_usage.py
@@ -92,9 +92,7 @@ class TestPriceListSwitch(MasuTestCase):
         with self._get_accessor() as accessor:
             infra = accessor.infrastructure_rates
             self.assertIsInstance(infra, dict)
-            self.assertGreater(
-                len(infra), 0, "Expected at least one infrastructure rate"
-            )
+            self.assertGreater(len(infra), 0, "Expected at least one infrastructure rate")
 
     # TC-05: supplementary_rates populated (BAC-2)
     def test_supplementary_rates_populated(self):
@@ -108,9 +106,7 @@ class TestPriceListSwitch(MasuTestCase):
         from cost_models.models import Rate
         from masu.database.cost_model_db_accessor import CostModelDBAccessor
 
-        with CostModelDBAccessor(
-            self.schema, self.ocp_provider_uuid, price_list_effective_on=None
-        ) as accessor:
+        with CostModelDBAccessor(self.schema, self.ocp_provider_uuid, price_list_effective_on=None) as accessor:
             if not accessor.cost_model:
                 self.skipTest("No cost model for OCP provider")
 
@@ -128,9 +124,7 @@ class TestPriceListSwitch(MasuTestCase):
             for (metric, cost_type), expected_sum in expected.items():
                 self.assertIn(metric, pl, f"Missing metric {metric}")
                 tiered = pl[metric]["tiered_rates"]
-                self.assertIn(
-                    cost_type, tiered, f"Missing cost_type {cost_type} for {metric}"
-                )
+                self.assertIn(cost_type, tiered, f"Missing cost_type {cost_type} for {metric}")
                 actual_sum = tiered[cost_type][0]["value"]
                 self.assertAlmostEqual(actual_sum, expected_sum, places=10)
 
@@ -139,9 +133,7 @@ class TestPriceListSwitch(MasuTestCase):
         from cost_models.models import Rate
         from masu.database.cost_model_db_accessor import CostModelDBAccessor
 
-        with CostModelDBAccessor(
-            self.schema, self.ocp_provider_uuid, price_list_effective_on=None
-        ) as accessor:
+        with CostModelDBAccessor(self.schema, self.ocp_provider_uuid, price_list_effective_on=None) as accessor:
             if not accessor.cost_model:
                 self.skipTest("No cost model for OCP provider")
 
@@ -162,9 +154,7 @@ class TestPriceListSwitch(MasuTestCase):
 
             pl = accessor.price_list
             for metric in tag_only_metrics:
-                self.assertNotIn(
-                    metric, pl, f"Tag-only metric {metric} should not be in price_list"
-                )
+                self.assertNotIn(metric, pl, f"Tag-only metric {metric} should not be in price_list")
 
     # TC-08: unknown provider returns {}
     def test_price_list_empty_for_unknown_provider(self):
@@ -186,18 +176,14 @@ class TestCostModelIdExtraction(MasuTestCase):
 
     # TC-10: cost_model_id populated when cost model exists
     def test_cost_model_id_populated(self):
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         self.assertIsNotNone(updater._cost_model_id)
 
     # TC-11: cost_model_id None when no cost model
     @patch("masu.processor.ocp.ocp_cost_model_cost_updater.CostModelDBAccessor")
     def test_cost_model_id_none_when_no_cost_model(self, mock_accessor):
         _setup_no_cost_model_mock(mock_accessor)
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         self.assertIsNone(updater._cost_model_id)
 
 
@@ -210,15 +196,11 @@ class TestSyncTestRateRows(MasuTestCase):
         from cost_models.models import PriceList
 
         with schema_context(self.schema):
-            cm = CostModel.objects.filter(
-                costmodelmap__provider_uuid=self.ocp_provider_uuid
-            ).first()
+            cm = CostModel.objects.filter(costmodelmap__provider_uuid=self.ocp_provider_uuid).first()
             if not cm:
                 self.skipTest("No cost model for OCP provider")
             pl_count = PriceList.objects.filter(cost_model_maps__cost_model=cm).count()
-            self.assertGreater(
-                pl_count, 0, "sync_test_rate_rows should create at least one PriceList"
-            )
+            self.assertGreater(pl_count, 0, "sync_test_rate_rows should create at least one PriceList")
 
     # TC-13: creates Rate rows matching JSON entries
     def test_sync_creates_rate_rows(self):
@@ -226,14 +208,10 @@ class TestSyncTestRateRows(MasuTestCase):
         from cost_models.models import Rate
 
         with schema_context(self.schema):
-            cm = CostModel.objects.filter(
-                costmodelmap__provider_uuid=self.ocp_provider_uuid
-            ).first()
+            cm = CostModel.objects.filter(costmodelmap__provider_uuid=self.ocp_provider_uuid).first()
             if not cm:
                 self.skipTest("No cost model for OCP provider")
-            rate_count = Rate.objects.filter(
-                price_list__cost_model_maps__cost_model=cm
-            ).count()
+            rate_count = Rate.objects.filter(price_list__cost_model_maps__cost_model=cm).count()
             json_rate_count = len(cm.rates) if isinstance(cm.rates, list) else 0
             self.assertEqual(
                 rate_count,
@@ -250,23 +228,17 @@ class TestSyncTestRateRows(MasuTestCase):
         from masu.database.cost_model_db_accessor import CostModelDBAccessor
 
         with schema_context(self.schema):
-            cm = CostModel.objects.filter(
-                costmodelmap__provider_uuid=self.ocp_provider_uuid
-            ).first()
+            cm = CostModel.objects.filter(costmodelmap__provider_uuid=self.ocp_provider_uuid).first()
             if not cm:
                 self.skipTest("No cost model for OCP provider")
 
-        with CostModelDBAccessor(
-            self.schema, self.ocp_provider_uuid, price_list_effective_on=None
-        ) as accessor:
+        with CostModelDBAccessor(self.schema, self.ocp_provider_uuid, price_list_effective_on=None) as accessor:
             pl_before = accessor.price_list
 
         with schema_context(self.schema):
             sync_test_rate_rows(cm)
 
-        with CostModelDBAccessor(
-            self.schema, self.ocp_provider_uuid, price_list_effective_on=None
-        ) as accessor:
+        with CostModelDBAccessor(self.schema, self.ocp_provider_uuid, price_list_effective_on=None) as accessor:
             pl_after = accessor.price_list
 
         self.assertEqual(
@@ -282,9 +254,7 @@ class TestSyncTestRateRows(MasuTestCase):
         from cost_models.models import Rate
 
         with schema_context(self.schema):
-            cm = CostModel.objects.filter(
-                costmodelmap__provider_uuid=self.ocp_provider_uuid
-            ).first()
+            cm = CostModel.objects.filter(costmodelmap__provider_uuid=self.ocp_provider_uuid).first()
             if not cm:
                 self.skipTest("No cost model for OCP provider")
             rate = Rate.objects.filter(
@@ -450,9 +420,7 @@ class TestPopulateUsageRatesToUsage(_ReportPeriodMixin, MasuTestCase):
         )
 
     # TC-22: executes INSERT SQL
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
     def test_populate_rtu_executes_insert_sql(self, mock_execute):
         with OCPReportDBAccessor(self.schema) as accessor:
             rp = self._get_report_period(accessor)
@@ -463,9 +431,7 @@ class TestPopulateUsageRatesToUsage(_ReportPeriodMixin, MasuTestCase):
         self.assertEqual(kwargs.get("operation"), "INSERT")
 
     # TC-23: cost_model_id included as string
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
     def test_populate_rtu_includes_cost_model_id(self, mock_execute):
         cost_model_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
         with OCPReportDBAccessor(self.schema) as accessor:
@@ -476,9 +442,7 @@ class TestPopulateUsageRatesToUsage(_ReportPeriodMixin, MasuTestCase):
         self.assertEqual(sql_params["cost_model_id"], cost_model_id)
 
     # TC-25: distribution is now read from cost_model table in SQL, not passed as param
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
     def test_populate_rtu_no_distribution_param(self, mock_execute):
         with OCPReportDBAccessor(self.schema) as accessor:
             rp = self._get_report_period(accessor)
@@ -488,9 +452,7 @@ class TestPopulateUsageRatesToUsage(_ReportPeriodMixin, MasuTestCase):
         self.assertNotIn("distribution", sql_params)
 
     # TC-25b: cluster_cost_per_hour NOT in sql_params (resolved via SQL JOIN)
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
     def test_populate_rtu_no_cluster_cost_per_hour_param(self, mock_execute):
         with OCPReportDBAccessor(self.schema) as accessor:
             rp = self._get_report_period(accessor)
@@ -500,9 +462,7 @@ class TestPopulateUsageRatesToUsage(_ReportPeriodMixin, MasuTestCase):
         self.assertNotIn("cluster_cost_per_hour", sql_params)
 
     # TC-25c: rate_type and per-metric params NOT in sql_params (single-pass reads from DB)
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
     def test_populate_rtu_no_rate_type_or_metric_params(self, mock_execute):
         with OCPReportDBAccessor(self.schema) as accessor:
             rp = self._get_report_period(accessor)
@@ -522,9 +482,7 @@ class TestAggregateRatesToDailySummary(_ReportPeriodMixin, MasuTestCase):
     """Test aggregate_rates_to_daily_summary accessor method (BAC-6)."""
 
     # TC-29: executes INSERT SQL
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
     def test_aggregate_rtu_executes_insert_sql(self, mock_execute):
         dh = DateHelper()
         with OCPReportDBAccessor(self.schema) as accessor:
@@ -540,9 +498,7 @@ class TestAggregateRatesToDailySummary(_ReportPeriodMixin, MasuTestCase):
         self.assertEqual(kwargs.get("operation"), "INSERT")
 
     # TC-30: params match window
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
     def test_aggregate_rtu_params_match_window(self, mock_execute):
         dh = DateHelper()
         with OCPReportDBAccessor(self.schema) as accessor:
@@ -565,9 +521,7 @@ class TestValidateRatesToUsage(_ReportPeriodMixin, MasuTestCase):
     """Test validate_rates_against_daily_summary accessor method (BAC-7)."""
 
     # TC-31: executes SELECT SQL
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
     def test_validate_rtu_executes_select_sql(self, mock_execute):
         dh = DateHelper()
         with OCPReportDBAccessor(self.schema) as accessor:
@@ -583,9 +537,7 @@ class TestValidateRatesToUsage(_ReportPeriodMixin, MasuTestCase):
         self.assertEqual(kwargs.get("operation"), "SELECT")
 
     # TC-32: params include report_period_id
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
     def test_validate_rtu_params_include_report_period(self, mock_execute):
         dh = DateHelper()
         with OCPReportDBAccessor(self.schema) as accessor:
@@ -703,9 +655,7 @@ class TestUpdaterOrchestration(_ReportPeriodMixin, MasuTestCase):
         mock_monthly,
         mock_dist,
     ):
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         sr = self._make_summary_range()
         updater.update_summary_cost_model_costs(sr)
         mock_rtu.assert_called_once_with(sr.start_date, sr.end_date)
@@ -726,9 +676,7 @@ class TestUpdaterOrchestration(_ReportPeriodMixin, MasuTestCase):
         mock_monthly,
         mock_dist,
     ):
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         sr = self._make_summary_range()
         updater.update_summary_cost_model_costs(sr)
         mock_agg.assert_called_once_with(sr.start_date, sr.end_date)
@@ -754,9 +702,7 @@ class TestUpdaterOrchestration(_ReportPeriodMixin, MasuTestCase):
         mock_agg.side_effect = lambda *a: call_order.append("agg")
         mock_dist.side_effect = lambda *a: call_order.append("dist")
 
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         sr = self._make_summary_range()
         updater.update_summary_cost_model_costs(sr)
 
@@ -786,9 +732,7 @@ class TestUpdaterOrchestration(_ReportPeriodMixin, MasuTestCase):
         mock_agg.side_effect = lambda *a: call_order.append("agg")
         mock_dist.side_effect = lambda *a: call_order.append("dist")
 
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         sr = self._make_summary_range()
         updater.update_summary_cost_model_costs(sr)
 
@@ -797,14 +741,10 @@ class TestUpdaterOrchestration(_ReportPeriodMixin, MasuTestCase):
         self.assertLess(call_order.index("agg"), call_order.index("dist"))
 
     # TC-53: single-pass INSERT (no rate_type loop)
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
     @patch.object(OCPCostModelCostUpdater, "_ensure_rates_to_usage_partitions")
     def test_rtu_insert_single_pass(self, mock_partitions, mock_execute):
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         if not updater._cost_model_id:
             self.skipTest("No cost model for OCP provider")
         rp = self._get_report_period()
@@ -817,12 +757,8 @@ class TestUpdaterOrchestration(_ReportPeriodMixin, MasuTestCase):
 
         updater._update_usage_rates_to_usage(start_date, end_date)
 
-        insert_calls = [
-            c for c in mock_execute.call_args_list if c[1].get("operation") == "INSERT"
-        ]
-        self.assertEqual(
-            len(insert_calls), 1, "Single-pass: exactly one INSERT call expected"
-        )
+        insert_calls = [c for c in mock_execute.call_args_list if c[1].get("operation") == "INSERT"]
+        self.assertEqual(len(insert_calls), 1, "Single-pass: exactly one INSERT call expected")
         sql_params = insert_calls[0][0][2]
         self.assertIn("cost_model_id", sql_params)
         self.assertNotIn("cluster_cost_per_hour", sql_params)
@@ -843,9 +779,7 @@ class TestUpdaterOrchestration(_ReportPeriodMixin, MasuTestCase):
         mock_monthly,
         mock_dist,
     ):
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         sr = self._make_summary_range()
         updater.update_summary_cost_model_costs(sr)
         mock_rtu.assert_not_called()
@@ -859,25 +793,17 @@ class TestPartitionWiring(MasuTestCase):
     # TC-45: calls _handle_partitions
     @patch.object(OCPCostModelCostUpdater, "_handle_partitions")
     def test_partition_wiring_calls_handle_partitions(self, mock_handle):
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         dh = DateHelper()
-        updater._ensure_rates_to_usage_partitions(
-            dh.this_month_start, dh.this_month_end
-        )
+        updater._ensure_rates_to_usage_partitions(dh.this_month_start, dh.this_month_end)
         mock_handle.assert_called_once()
 
     # TC-46: correct table name
     @patch.object(OCPCostModelCostUpdater, "_handle_partitions")
     def test_partition_wiring_correct_table_name(self, mock_handle):
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         dh = DateHelper()
-        updater._ensure_rates_to_usage_partitions(
-            dh.this_month_start, dh.this_month_end
-        )
+        updater._ensure_rates_to_usage_partitions(dh.this_month_start, dh.this_month_end)
         args, kwargs = mock_handle.call_args
         self.assertEqual(args[1], ["rates_to_usage"])
 
@@ -886,58 +812,36 @@ class TestSkipPaths(MasuTestCase):
     """Test skip paths when report period or cost_model_id is missing (BAC-10, BAC-12)."""
 
     # TC-47: RTU insert skips with log when no report period
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.report_periods_for_provider_uuid"
-    )
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.report_periods_for_provider_uuid")
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
     @patch.object(OCPCostModelCostUpdater, "_ensure_rates_to_usage_partitions")
-    def test_rtu_insert_skips_no_report_period(
-        self, mock_partitions, mock_execute, mock_rp
-    ):
+    def test_rtu_insert_skips_no_report_period(self, mock_partitions, mock_execute, mock_rp):
         mock_rp.return_value = None
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         dh = DateHelper()
         with self.assertLogs("masu.processor.ocp", level="INFO") as cm:
             updater._update_usage_rates_to_usage(dh.this_month_start, dh.this_month_end)
         mock_execute.assert_not_called()
-        self.assertTrue(
-            any("skipping rates_to_usage insert" in msg for msg in cm.output)
-        )
+        self.assertTrue(any("skipping rates_to_usage insert" in msg for msg in cm.output))
 
     # TC-48: RTU aggregate skips with log when no report period
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.report_periods_for_provider_uuid"
-    )
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.report_periods_for_provider_uuid")
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
     def test_rtu_aggregate_skips_no_report_period(self, mock_execute, mock_rp):
         mock_rp.return_value = None
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         dh = DateHelper()
         with self.assertLogs("masu.processor.ocp", level="INFO") as cm:
-            updater._aggregate_rates_to_daily_summary(
-                dh.this_month_start, dh.this_month_end
-            )
+            updater._aggregate_rates_to_daily_summary(dh.this_month_start, dh.this_month_end)
         mock_execute.assert_not_called()
-        self.assertTrue(
-            any("skipping rates_to_usage aggregation" in msg for msg in cm.output)
-        )
+        self.assertTrue(any("skipping rates_to_usage aggregation" in msg for msg in cm.output))
 
     # TC-49: RTU insert skips when no cost_model_id
     @patch.object(OCPCostModelCostUpdater, "_ensure_rates_to_usage_partitions")
     @patch("masu.processor.ocp.ocp_cost_model_cost_updater.CostModelDBAccessor")
     def test_rtu_insert_skips_no_cost_model_id(self, mock_accessor, mock_part):
         _setup_no_cost_model_mock(mock_accessor)
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         self.assertIsNone(updater._cost_model_id)
 
         dh = DateHelper()
@@ -948,18 +852,14 @@ class TestSkipPaths(MasuTestCase):
     @patch("masu.processor.ocp.ocp_cost_model_cost_updater.CostModelDBAccessor")
     def test_rtu_aggregate_skips_no_cost_model_id(self, mock_accessor):
         _setup_no_cost_model_mock(mock_accessor)
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         self.assertIsNone(updater._cost_model_id)
 
         dh = DateHelper()
         with patch(
             "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
         ) as mock_exec:
-            updater._aggregate_rates_to_daily_summary(
-                dh.this_month_start, dh.this_month_end
-            )
+            updater._aggregate_rates_to_daily_summary(dh.this_month_start, dh.this_month_end)
             mock_exec.assert_not_called()
 
 
@@ -971,9 +871,7 @@ class TestPurgeWiring(MasuTestCase):
     @patch("masu.processor.ocp.ocp_report_db_cleaner.cascade_delete")
     @patch("masu.processor.ocp.ocp_report_db_cleaner.PartitionedTable")
     @patch("masu.processor.ocp.ocp_report_db_cleaner.OCPReportDBAccessor")
-    def test_rates_to_usage_in_cleaner_base_list(
-        self, mock_accessor_cls, mock_pt, mock_cascade, mock_delete
-    ):
+    def test_rates_to_usage_in_cleaner_base_list(self, mock_accessor_cls, mock_pt, mock_cascade, mock_delete):
         """Verify partition cleanup includes rates_to_usage table."""
         from datetime import date as date_cls
         from unittest.mock import MagicMock
@@ -985,9 +883,7 @@ class TestPurgeWiring(MasuTestCase):
         mock_qs.__iter__ = MagicMock(return_value=iter([]))
         mock_qs.query = MagicMock()
         mock_accessor.get_report_periods_before_date.return_value = mock_qs
-        mock_accessor._table_map = {
-            "line_item_daily_summary": "reporting_ocpusagelineitem_daily_summary"
-        }
+        mock_accessor._table_map = {"line_item_daily_summary": "reporting_ocpusagelineitem_daily_summary"}
 
         cleaner = OCPReportDBCleaner(self.schema)
         cleaner.purge_expired_report_data_by_date(date_cls(2020, 1, 1))
@@ -1031,9 +927,7 @@ class TestRTUCostBreakdownAPI(_ReportPeriodMixin, MasuTestCase):
         from api.models import Provider
         from api.report.ocp.provider_map import OCPProviderMap
 
-        cls.provider_map = OCPProviderMap(
-            Provider.PROVIDER_OCP, "costs", cls.schema_name
-        )
+        cls.provider_map = OCPProviderMap(Provider.PROVIDER_OCP, "costs", cls.schema_name)
         cls.cost_term = (
             cls.provider_map.cloud_infrastructure_cost
             + cls.provider_map.markup_cost
@@ -1048,9 +942,7 @@ class TestRTUCostBreakdownAPI(_ReportPeriodMixin, MasuTestCase):
         return {
             "source_uuid": self.ocp_provider.uuid,
             "usage_start__gte": (
-                rp.report_period_start.date()
-                if hasattr(rp.report_period_start, "date")
-                else rp.report_period_start
+                rp.report_period_start.date() if hasattr(rp.report_period_start, "date") else rp.report_period_start
             ),
         }
 
@@ -1071,9 +963,7 @@ class TestRTUCostBreakdownAPI(_ReportPeriodMixin, MasuTestCase):
             dh = DateHelper()
             start_date = rp.report_period_start
             end_date = dh.month_end(start_date)
-            updater = OCPCostModelCostUpdater(
-                schema=self.schema, provider=self.ocp_provider
-            )
+            updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
             if not updater._cost_model_id:
                 self.skipTest("No cost model for OCP provider")
             updater._load_rates(start_date)
@@ -1087,9 +977,7 @@ class TestRTUCostBreakdownAPI(_ReportPeriodMixin, MasuTestCase):
                     usage_start__gte=rp_filter["usage_start__gte"],
                 ).count()
 
-        self.assertGreater(
-            count, 0, "RTU table should have rows for OCP-on-Prem provider"
-        )
+        self.assertGreater(count, 0, "RTU table should have rows for OCP-on-Prem provider")
 
     # TC-E2E-02: RTU aggregated costs reconcile with daily summary
     def test_rtu_sums_match_daily_summary_cost_model_columns(self):
@@ -1114,9 +1002,7 @@ class TestRTUCostBreakdownAPI(_ReportPeriodMixin, MasuTestCase):
                 .values("metric_type")
                 .annotate(total=Sum("calculated_cost"))
             )
-            rtu_by_metric = {
-                row["metric_type"]: row["total"] or Decimal(0) for row in rtu_agg
-            }
+            rtu_by_metric = {row["metric_type"]: row["total"] or Decimal(0) for row in rtu_agg}
 
             ds_agg = OCPUsageLineItemDailySummary.objects.filter(
                 source_uuid=rp_filter["source_uuid"],
@@ -1180,9 +1066,7 @@ class TestRTUCostBreakdownAPI(_ReportPeriodMixin, MasuTestCase):
 
         with tenant_context(self.tenant):
             cost = (
-                OCPUsageLineItemDailySummary.objects.filter(
-                    usage_start__gte=self.dh.this_month_start.date()
-                )
+                OCPUsageLineItemDailySummary.objects.filter(usage_start__gte=self.dh.this_month_start.date())
                 .annotate(
                     infra_exchange_rate=Value(Decimal(1)),
                     exchange_rate=Value(Decimal(1)),
@@ -1192,13 +1076,7 @@ class TestRTUCostBreakdownAPI(_ReportPeriodMixin, MasuTestCase):
             )
             expected_total = cost if cost is not None else 0
 
-        total = (
-            data.get("meta", {})
-            .get("total", {})
-            .get("cost", {})
-            .get("total", {})
-            .get("value", 0)
-        )
+        total = data.get("meta", {}).get("total", {}).get("cost", {}).get("total", {}).get("value", 0)
         self.assertNotEqual(total, Decimal(0), "API should return non-zero cost total")
         self.assertAlmostEqual(total, expected_total, 6)
 
@@ -1238,18 +1116,14 @@ class TestRTUCostBreakdownAPI(_ReportPeriodMixin, MasuTestCase):
             if found_nonzero:
                 break
 
-        self.assertTrue(
-            found_nonzero, "At least one project should have non-zero cost-model costs"
-        )
+        self.assertTrue(found_nonzero, "At least one project should have non-zero cost-model costs")
 
 
 class TestRTURateResolution(_ReportPeriodMixin, MasuTestCase):
     """drift5-sql: Verify RTU rows resolve rate_id and custom_name from Rate table."""
 
     # TC-D5-01: SQL params include cost_model_id (regression guard)
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
     def test_populate_rtu_params_include_cost_model_id(self, mock_execute):
         """populate_usage_rates_to_usage passes cost_model_id in SQL params."""
         dh = DateHelper()
@@ -1345,9 +1219,7 @@ class TestRTURateResolution(_ReportPeriodMixin, MasuTestCase):
             ).count()
         if total == 0:
             self.skipTest("No RTU rows to check")
-        self.assertGreaterEqual(
-            total, with_rate, "Total RTU rows should be >= rows with rate FK"
-        )
+        self.assertGreaterEqual(total, with_rate, "Total RTU rows should be >= rows with rate FK")
 
     # TC-D5-05: RTU custom_name falls back to metric name when no Rate exists
     def test_rtu_custom_name_fallback(self):
@@ -1366,9 +1238,7 @@ class TestRTURateResolution(_ReportPeriodMixin, MasuTestCase):
                 rate__isnull=True,
             ).first()
         if not rtu_row:
-            self.skipTest(
-                "No RTU rows with NULL rate FK (all rows may have matching Rate)"
-            )
+            self.skipTest("No RTU rows with NULL rate FK (all rows may have matching Rate)")
         known_metrics = set(metric_constants.COST_MODEL_USAGE_RATES)
         metric_found = any(m in rtu_row.custom_name for m in known_metrics)
         self.assertTrue(
@@ -1419,16 +1289,12 @@ class TestOrchestrationOrder(_ReportPeriodMixin, MasuTestCase):
         mock_monthly.side_effect = lambda *a: call_order.append("monthly")
         mock_dist.side_effect = lambda *a: call_order.append("dist")
 
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         sr = self._make_summary_range()
         updater.update_summary_cost_model_costs(sr)
 
         expected = ["rtu", "agg", "vm", "markup", "monthly", "dist"]
-        self.assertEqual(
-            call_order, expected, f"R20: expected {expected}, got {call_order}"
-        )
+        self.assertEqual(call_order, expected, f"R20: expected {expected}, got {call_order}")
         mock_usage.assert_not_called()
         mock_cleanup.assert_not_called()
 
@@ -1452,9 +1318,7 @@ class TestOrchestrationOrder(_ReportPeriodMixin, MasuTestCase):
         mock_agg.side_effect = lambda *a: call_order.append("agg")
         mock_markup.side_effect = lambda *a: call_order.append("markup")
 
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         sr = self._make_summary_range()
         updater.update_summary_cost_model_costs(sr)
 
@@ -1482,9 +1346,7 @@ class TestOrchestrationOrder(_ReportPeriodMixin, MasuTestCase):
         mock_dist,
     ):
         """R20: When RTU is enabled but cost_model_id is None, cleanup must run instead of RTU+agg."""
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         updater._cost_model_id = None
         sr = self._make_summary_range()
         updater.update_summary_cost_model_costs(sr)
@@ -1532,9 +1394,7 @@ class TestPriceListValidityGuard(_ReportPeriodMixin, MasuTestCase):
         """When _load_rates finds no effective PL, RTU is skipped and stale rows cleaned."""
         from datetime import date
 
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
 
         def fake_load(start_date):
             updater._infra_rates = {}
@@ -1572,9 +1432,7 @@ class TestPriceListValidityGuard(_ReportPeriodMixin, MasuTestCase):
         mock_dist,
     ):
         """When _price_list_effective_on is None (feature flag disabled), RTU proceeds normally."""
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
 
         def fake_load(start_date):
             updater._infra_rates = {}
@@ -1612,9 +1470,7 @@ class TestPriceListValidityGuard(_ReportPeriodMixin, MasuTestCase):
         """When _load_rates finds an effective PL with rates, RTU proceeds."""
         from datetime import date
 
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
 
         def fake_load(start_date):
             updater._infra_rates = {"cpu_core_usage_per_hour": 0.2}
@@ -1639,9 +1495,7 @@ class TestPriceListValidityGuard(_ReportPeriodMixin, MasuTestCase):
         """_load_rates must propagate price_list_effective_on from the accessor."""
         from datetime import date
 
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         self.assertIsNone(updater._price_list_effective_on)
 
         test_date = date(2026, 4, 1)
@@ -1658,9 +1512,7 @@ class TestPriceListValidityGuard(_ReportPeriodMixin, MasuTestCase):
         """When DISABLE_PRICE_LIST flag is on, _price_list_effective_on should be None."""
         from datetime import date
 
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         updater._load_rates(date(2026, 4, 1))
 
         self.assertIsNone(updater._price_list_effective_on)
@@ -1683,9 +1535,7 @@ class TestPriceListValidityGuard(_ReportPeriodMixin, MasuTestCase):
         """Tag-based cost paths must be skipped when no PL covers the month."""
         from datetime import date
 
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
 
         def fake_load(start_date):
             updater._infra_rates = {}
@@ -1700,9 +1550,7 @@ class TestPriceListValidityGuard(_ReportPeriodMixin, MasuTestCase):
         mock_load.side_effect = fake_load
 
         sr = self._make_summary_range()
-        with patch.object(
-            updater, "_delete_tag_usage_costs"
-        ) as mock_delete_tags, patch.object(
+        with patch.object(updater, "_delete_tag_usage_costs"), patch.object(
             updater, "_update_tag_usage_costs"
         ) as mock_tag_usage:
             updater.update_summary_cost_model_costs(sr)
@@ -1715,13 +1563,10 @@ class TestTwoMonthOrchestration(_ReportPeriodMixin, MasuTestCase):
     # TC-7492-07: two-month range — April RTU, May cleanup
     def test_two_month_range_april_rtu_may_cleanup(self):
         """Over April+May with an April-only PL, RTU runs for April and cleanup for May."""
-        from datetime import date
         from datetime import datetime
         from datetime import timezone
 
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         if not updater._cost_model_id:
             self.skipTest("No cost model for OCP provider")
 
@@ -1755,11 +1600,9 @@ class TestTwoMonthOrchestration(_ReportPeriodMixin, MasuTestCase):
 
         with patch.object(updater, "_load_rates", side_effect=fake_load), patch.object(
             updater, "_update_usage_rates_to_usage"
-        ) as mock_rtu, patch.object(
-            updater, "_aggregate_rates_to_daily_summary"
-        ) as mock_agg, patch.object(
+        ) as mock_rtu, patch.object(updater, "_aggregate_rates_to_daily_summary"), patch.object(
             updater, "_update_vm_usage_costs"
-        ) as mock_vm, patch.object(
+        ), patch.object(
             updater, "_cleanup_stale_rtu_costs"
         ) as mock_cleanup, patch.object(
             updater, "_update_markup_cost"


### PR DESCRIPTION
## Summary

- Fixes cost calculation ignoring price list validity periods (effective_start_date / effective_end_date)
- The `rate_info_map` property (introduced in Phase 2, commit df40716c0) queried the Rate table without date filtering, causing costs to be applied for months outside the price list's validity period
- Scopes `rate_info_map` to the effective price list when `price_list_effective_on` is set, matching the resolution used by `effective_rates`
- Extracts `_effective_price_list` as a shared `@cached_property` to avoid duplicate `get_effective_price_list` DB calls

Cherry-picked from Phase 3 branch (COST-7249/phase3-sql-migration, commit c918362a7).

## Test plan

- [x] Unit tests: rate_info_map with no price_list_effective_on (fallback), scoped to effective price list (correct filtering), and empty when no price list covers the date
- [x] Verify with Daniel's IQE reproducer: `test_api_ocp_source_raw_price_list_intervals` -- May data should show zero costs when price list validity covers April only

Fixes: https://issues.redhat.com/browse/COST-7492

Made with [Cursor](https://cursor.com)