### PR TITLE
group github actions into single pr

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,16 @@
     "packageRules": [
         {
             "matchManagers": [
+                "github-actions"
+            ],
+            "groupName": "ci-dependencies",
+            "groupSlug": "ci-dependencies",
+            "addLabels": [
+                "ok-to-skip-smokes"
+            ]
+        },
+        {
+            "matchManagers": [
                 "pipenv"
             ],
             "matchUpdateTypes": [


### PR DESCRIPTION
## Jira Ticket

None

## Description

This change configures Renovate to group all GitHub Actions dependency updates into a single PR instead of creating individual PRs for each action (e.g., `actions/checkout`, `codecov/codecov-action`, `step-security/harden-runner`).


## Release Notes
- [ ] Group GitHub Actions dependency updates into a single Renovate PR
