### PR TITLE
[COST-7504] Fix version bump on metadata-only price list updates

### DIFF
--- a/koku/cost_models/serializers.py
+++ b/koku/cost_models/serializers.py
@@ -362,11 +362,14 @@ class RateSerializer(serializers.Serializer):
         """Convert decimals and ensure usage dict structure on a single tiered rate."""
         RateSerializer._convert_to_decimal(rate)
         if not rate.get("usage"):
-            rate["usage"] = {
-                "usage_start": rate.pop("usage_start", None),
-                "usage_end": rate.pop("usage_end", None),
-                "unit": rate.get("unit"),
-            }
+            usage_start = rate.pop("usage_start", None)
+            usage_end = rate.pop("usage_end", None)
+            if usage_start is not None or usage_end is not None:
+                rate["usage"] = {
+                    "usage_start": usage_start,
+                    "usage_end": usage_end,
+                    "unit": rate.get("unit"),
+                }
 
     def to_representation(self, rate_obj):
         """Create external representation of a rate."""

--- a/koku/cost_models/test/test_price_list_view.py
+++ b/koku/cost_models/test/test_price_list_view.py
@@ -246,6 +246,16 @@ class PriceListViewTests(IamTestCase):
         self.assertEqual(resp.data["version"], 1)
         return resp
 
+    def test_normalize_tiered_rate_creates_usage_when_values_provided(self):
+        """Test that usage dict is created when usage_start/usage_end have real values."""
+        from cost_models.serializers import RateSerializer
+
+        rate = {"value": "1.00", "unit": "USD", "usage_start": "0", "usage_end": "100"}
+        RateSerializer._normalize_tiered_rate(rate)
+        self.assertIn("usage", rate)
+        self.assertNotIn("usage_start", rate)
+        self.assertNotIn("usage_end", rate)
+
     def test_update_metadata_does_not_increment_version(self):
         """Test that metadata-only updates do not increment version."""
         create_response = self._create_price_list_no_usage()

--- a/koku/cost_models/test/test_price_list_view.py
+++ b/koku/cost_models/test/test_price_list_view.py
@@ -222,9 +222,33 @@ class PriceListViewTests(IamTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["version"], 2)
 
+    def _create_price_list_no_usage(self):
+        """Helper: create a price list without usage in tiered_rates (matches real client behavior)."""
+        url = reverse("price-lists-list")
+        post_data = {
+            "rates": [
+                {
+                    "cost_type": "Infrastructure",
+                    "custom_name": "a test",
+                    "description": "",
+                    "metric": {"name": "cpu_core_effective_usage_per_hour"},
+                    "tiered_rates": [{"unit": "USD", "value": 1}],
+                }
+            ],
+            "currency": "USD",
+            "description": "",
+            "effective_end_date": "2026-06-30",
+            "effective_start_date": "2026-05-01",
+            "name": "pedro_test",
+        }
+        resp = self.client.post(url, data=post_data, format="json", **self.headers)
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(resp.data["version"], 1)
+        return resp
+
     def test_update_metadata_does_not_increment_version(self):
         """Test that metadata-only updates do not increment version."""
-        create_response = self._create_price_list()
+        create_response = self._create_price_list_no_usage()
         pl_uuid = create_response.data["uuid"]
         self.assertEqual(create_response.data["version"], 1)
 


### PR DESCRIPTION
_normalize_tiered_rate was injecting an empty usage dict into API responses even when no usage values existed. When the client echoed the response back on PUT, the comparison detected the usage dict as a rate change and incorrectly incremented the version.

## Jira Ticket

[COST-####](https://issues.redhat.com/browse/COST-####)

## Description

This change will ...

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Release Notes
- [ ] proposed release note

```markdown
* [COST-####](https://issues.redhat.com/browse/COST-####) Fix some things
```
