### PR TITLE
[COST-7538] Disable price lists by default in on-prem mode

### DIFF
--- a/koku/koku/feature_flags.py
+++ b/koku/koku/feature_flags.py
@@ -33,6 +33,7 @@ class MockUnleashClient:
         "cost-management.backend.ocp_gpu_cost_model": True,
         "cost-management.backend.disable-ingress-rate-limit": True,
         "cost-management.backend.override_customer_group_by_limit": False,
+        "cost-management.backend.disable_price_list": True,
     }
 
     def __init__(self, app_name, environment, instance_id, **kwargs):


### PR DESCRIPTION
Add disable_price_list flag to ONPREM_FLAG_DEFAULTS with value True so price list date filtering is bypassed in on-prem deployments where Unleash is not available.

## Jira Ticket

[COST-####](https://issues.redhat.com/browse/COST-####)

## Description

This change will ...

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Release Notes
- [ ] proposed release note

```markdown
* [COST-####](https://issues.redhat.com/browse/COST-####) Fix some things
```
