### PR TITLE
fix unit tests

### DIFF
--- a/.cursor/commands/create-pr-testing-instructions.md
+++ b/.cursor/commands/create-pr-testing-instructions.md
@@ -8,7 +8,7 @@ Use this command when preparing a PR description or a `pr-testing.md` file. If a
 
 ## Output Template
 
-Use this exact structure and headings:
+Use this exact structure and headings. **Deliver the completed text inside one `markdown` fenced code block** so the user can copy it into the PR in one step.
 
 ````
 ## Jira Ticket
@@ -34,6 +34,8 @@ This change will ...
 * [COST-####](https://issues.redhat.com/browse/COST-####) Fix some things
 ```
 ````
+
+**Copy-paste:** Wrap the filled-in sections in a single outer ` ```markdown ` … ` ``` ` block for one-step copy. In **Testing**, use normal fenced snippets (` ```bash `, ` ```shell `, etc.) for commands, `curl`, and tox. GitHub PR descriptions render these correctly when pasted.
 
 ## Jira Optional Handling
 

--- a/koku/masu/test/external/downloader/aws/test_aws_report_downloader.py
+++ b/koku/masu/test/external/downloader/aws/test_aws_report_downloader.py
@@ -703,7 +703,14 @@ class AWSReportDownloaderTest(MasuTestCase):
             ),
         ):
             daily_file_names, date_range = create_daily_archives(
-                "trace_id", "account", self.aws_provider_uuid, temp_path, file_name, manifest_id, start_date, self.daily_archives_context
+                "trace_id",
+                "account",
+                self.aws_provider_uuid,
+                temp_path,
+                file_name,
+                manifest_id,
+                start_date,
+                self.daily_archives_context,
             )
             expected_date_range = {"start": "2023-06-01", "end": "2023-06-01"}
             mock_copy.assert_called()
@@ -738,7 +745,14 @@ class AWSReportDownloaderTest(MasuTestCase):
             ),
         ):
             daily_file_names, date_range = create_daily_archives(
-                "trace_id", "account", self.aws_provider_uuid, temp_path, file_name, manifest_id, start_date, self.daily_archives_context
+                "trace_id",
+                "account",
+                self.aws_provider_uuid,
+                temp_path,
+                file_name,
+                manifest_id,
+                start_date,
+                self.daily_archives_context,
             )
 
         for daily_file in daily_file_names:
@@ -766,7 +780,14 @@ class AWSReportDownloaderTest(MasuTestCase):
 
         start_date = self.dh.this_month_start.replace(year=2023, month=9).date()
         daily_file_names, date_range = create_daily_archives(
-            "trace_id", "account", self.aws_provider_uuid, temp_path, file_name, manifest_id, start_date, self.daily_archives_context
+            "trace_id",
+            "account",
+            self.aws_provider_uuid,
+            temp_path,
+            file_name,
+            manifest_id,
+            start_date,
+            self.daily_archives_context,
         )
         self.assertEqual(date_range, {})
         self.assertEqual(daily_file_names, [])
@@ -785,7 +806,14 @@ class AWSReportDownloaderTest(MasuTestCase):
         shutil.copy2(file_path, temp_path)
         start_date = self.dh.this_month_start.replace(year=2023, month=6).date()
         daily_file_names, date_range = create_daily_archives(
-            "trace_id", "account", self.aws_provider_uuid, temp_path, file_name, manifest_id, start_date, self.daily_archives_context
+            "trace_id",
+            "account",
+            self.aws_provider_uuid,
+            temp_path,
+            file_name,
+            manifest_id,
+            start_date,
+            self.daily_archives_context,
         )
         self.assertEqual(date_range, {})
         self.assertIsInstance(daily_file_names, list)
@@ -816,7 +844,14 @@ class AWSReportDownloaderTest(MasuTestCase):
             ),
         ):
             daily_file_names, date_range = create_daily_archives(
-                "trace_id", "account", self.aws_provider_uuid, temp_path, file_name, manifest_id, start_date, self.daily_archives_context
+                "trace_id",
+                "account",
+                self.aws_provider_uuid,
+                temp_path,
+                file_name,
+                manifest_id,
+                start_date,
+                self.daily_archives_context,
             )
             expected_date_range = {"start": "2022-07-01", "end": "2022-07-01"}
             mock_copy.assert_called()

--- a/koku/masu/test/external/downloader/aws/test_aws_report_downloader.py
+++ b/koku/masu/test/external/downloader/aws/test_aws_report_downloader.py
@@ -207,6 +207,11 @@ class AWSReportDownloaderTest(MasuTestCase):
         )
         self.aws_manifest = CostUsageReportManifest.objects.filter(provider_id=self.aws_provider_uuid).first()
         self.aws_manifest_id = self.aws_manifest.id
+        self.daily_archives_context = {
+            "account": "account",
+            "provider_type": Provider.PROVIDER_AWS_LOCAL,
+            "provider_uuid": self.aws_provider_uuid,
+        }
 
     def tearDown(self):
         """Remove test generated data."""
@@ -687,12 +692,18 @@ class AWSReportDownloaderTest(MasuTestCase):
             f"{temp_dir}/2023-06-01_manifestid-{manifest_id}_basefile-{file}_batch-0.csv",
         ]
         start_date = self.dh.this_month_start.replace(year=2023, month=6).date()
-        with patch(
-            "masu.database.report_manifest_db_accessor.ReportManifestDBAccessor.set_manifest_daily_start_date",
-            return_value=start_date,
+        with (
+            patch(
+                "masu.external.downloader.aws.aws_report_downloader.utils.get_or_clear_daily_s3_by_date",
+                return_value=start_date,
+            ),
+            patch(
+                "masu.database.report_manifest_db_accessor.ReportManifestDBAccessor.set_manifest_daily_start_date",
+                return_value=start_date,
+            ),
         ):
             daily_file_names, date_range = create_daily_archives(
-                "trace_id", "account", self.aws_provider_uuid, temp_path, file_name, manifest_id, start_date, {}
+                "trace_id", "account", self.aws_provider_uuid, temp_path, file_name, manifest_id, start_date, self.daily_archives_context
             )
             expected_date_range = {"start": "2023-06-01", "end": "2023-06-01"}
             mock_copy.assert_called()
@@ -716,12 +727,18 @@ class AWSReportDownloaderTest(MasuTestCase):
         shutil.copy2(file_path, temp_path)
         start_date = self.dh.this_month_start.replace(year=2023, month=6).date()
 
-        with patch(
-            "masu.database.report_manifest_db_accessor.ReportManifestDBAccessor.set_manifest_daily_start_date",
-            return_value=start_date,
+        with (
+            patch(
+                "masu.external.downloader.aws.aws_report_downloader.utils.get_or_clear_daily_s3_by_date",
+                return_value=start_date,
+            ),
+            patch(
+                "masu.database.report_manifest_db_accessor.ReportManifestDBAccessor.set_manifest_daily_start_date",
+                return_value=start_date,
+            ),
         ):
             daily_file_names, date_range = create_daily_archives(
-                "trace_id", "account", self.aws_provider_uuid, temp_path, file_name, manifest_id, start_date, {}
+                "trace_id", "account", self.aws_provider_uuid, temp_path, file_name, manifest_id, start_date, self.daily_archives_context
             )
 
         for daily_file in daily_file_names:
@@ -749,7 +766,7 @@ class AWSReportDownloaderTest(MasuTestCase):
 
         start_date = self.dh.this_month_start.replace(year=2023, month=9).date()
         daily_file_names, date_range = create_daily_archives(
-            "trace_id", "account", self.aws_provider_uuid, temp_path, file_name, manifest_id, start_date, {}
+            "trace_id", "account", self.aws_provider_uuid, temp_path, file_name, manifest_id, start_date, self.daily_archives_context
         )
         self.assertEqual(date_range, {})
         self.assertEqual(daily_file_names, [])
@@ -768,7 +785,7 @@ class AWSReportDownloaderTest(MasuTestCase):
         shutil.copy2(file_path, temp_path)
         start_date = self.dh.this_month_start.replace(year=2023, month=6).date()
         daily_file_names, date_range = create_daily_archives(
-            "trace_id", "account", self.aws_provider_uuid, temp_path, file_name, manifest_id, start_date, {}
+            "trace_id", "account", self.aws_provider_uuid, temp_path, file_name, manifest_id, start_date, self.daily_archives_context
         )
         self.assertEqual(date_range, {})
         self.assertIsInstance(daily_file_names, list)
@@ -788,12 +805,18 @@ class AWSReportDownloaderTest(MasuTestCase):
             f"{temp_dir}/2022-07-01_manifestid-{manifest_id}_basefile-{file}_batch-0.csv",
         ]
         start_date = self.dh.this_month_start.replace(year=2022, month=7).date()
-        with patch(
-            "masu.database.report_manifest_db_accessor.ReportManifestDBAccessor.set_manifest_daily_start_date",
-            return_value=start_date,
+        with (
+            patch(
+                "masu.external.downloader.aws.aws_report_downloader.utils.get_or_clear_daily_s3_by_date",
+                return_value=start_date,
+            ),
+            patch(
+                "masu.database.report_manifest_db_accessor.ReportManifestDBAccessor.set_manifest_daily_start_date",
+                return_value=start_date,
+            ),
         ):
             daily_file_names, date_range = create_daily_archives(
-                "trace_id", "account", self.aws_provider_uuid, temp_path, file_name, manifest_id, start_date, {}
+                "trace_id", "account", self.aws_provider_uuid, temp_path, file_name, manifest_id, start_date, self.daily_archives_context
             )
             expected_date_range = {"start": "2022-07-01", "end": "2022-07-01"}
             mock_copy.assert_called()


### PR DESCRIPTION
## Jira Ticket

None

## Description

This change will fix AWS `create_daily_archives` unit tests that fail when the current calendar month matches the test CSV month. Tests passed an empty `{}` context while production supplies `account` and `provider_type` via `ReportDownloader`; that led to `clear_s3_files` raising `AttributeError` on `provider_type.strip("-local")`.


## Testing

1. Checkout branch.
2. Run the affected unit tests:
   ```bash
   pipenv run tox -e py311 -- masu.test.external.downloader.aws.test_aws_report_downloader.AWSReportDownloaderTest.test_create_daily_archives masu.test.external.downloader.aws.test_aws_report_downloader.AWSReportDownloaderTest.test_create_daily_archives_check_leading_zeros masu.test.external.downloader.aws.test_aws_report_downloader.AWSReportDownloaderTest.test_create_daily_archives_alt_columns masu.test.external.downloader.aws.test_aws_report_downloader.AWSReportDownloaderTest.test_create_daily_archives_dates_out_of_range masu.test.external.downloader.aws.test_aws_report_downloader.AWSReportDownloaderTest.test_create_daily_archives_empty_frame