### PR TITLE
[COST-7465] - Change tag based rate description to optional

### DIFF
--- a/koku/cost_models/serializers.py
+++ b/koku/cost_models/serializers.py
@@ -136,7 +136,7 @@ class TagRateValueSerializer(serializers.Serializer):
     unit = serializers.ChoiceField(choices=CURRENCY_CHOICES)
     usage = serializers.DictField(required=False)
     value = serializers.DecimalField(required=False, max_digits=19, decimal_places=10)
-    description = serializers.CharField(allow_blank=True, max_length=500)
+    description = serializers.CharField(allow_blank=True, max_length=500, required=False)
     default = serializers.BooleanField()
 
     def validate_value(self, value):


### PR DESCRIPTION
## Jira Ticket

[COST-7465](https://issues.redhat.com/browse/COST-7465)

## Description

This change will add required=False to tag based rate descriptions. This description should have always been optional.

## Testing

1. Checkout Branch
2. Restart Koku
3. Create a new price list rate without a description. `curl -s -X POST   -H "x-rh-identity: $IDENTITY"   -H "Content-Type: application/json"   -d '{
    "name": "tag-rate-no-description-repro",
    "currency": "USD",
    "effective_start_date": "2026-05-01",
    "effective_end_date": "2026-06-30",
    "rates": [
      {
        "metric": {"name": "cpu_core_usage_per_hour"},
        "cost_type": "Supplementary",
        "tag_rates": {
          "tag_key": "app",
          "tag_values": [
            {
              "tag_value": "web",
              "value": "0.5",
              "unit": "USD",
              "default": false
            }
          ]
        }
      }
    ]
  }'   http://localhost:8000/api/cost-management/v1/price-lists/ | python3 -m json.tool`
4. See no 400 error.
5. Try the same thing on main and see 400 error.

## Release Notes
- [ ] proposed release note

```markdown
* [COST-7465](https://issues.redhat.com/browse/COST-7465) Make description optional for tag based rates
```
