### PR TITLE
[COST-7249] Phase 4 PR 2: Per-rate distribution SQL files

### DIFF
--- a/koku/masu/database/self_hosted_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
+++ b/koku/masu/database/self_hosted_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
@@ -1,0 +1,94 @@
+-- Per-rate GPU unallocated cost distribution via rates_to_usage (self-hosted).
+-- Reads per-rate GPU costs from RTU (GPU unallocated namespace), distributes
+-- proportionally by MIG-aware slice-hours, writes distributed rows back to RTU
+-- with monthly_cost_type = 'gpu_distributed'.
+INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
+    uuid, report_period_id, source_uuid, usage_start, usage_end,
+    cluster_id, cluster_alias, namespace, node,
+    custom_name, metric_type, cost_model_rate_type,
+    monthly_cost_type, distributed_cost
+)
+WITH gpu_rtu_cost AS (
+    SELECT
+        rtu.usage_start,
+        rtu.source_uuid,
+        rtu.cluster_id,
+        rtu.cluster_alias,
+        rtu.report_period_id,
+        rtu.node,
+        rtu.custom_name,
+        rtu.metric_type,
+        rtu.cost_model_rate_type,
+        SUM(COALESCE(rtu.calculated_cost, 0)) AS rate_cost
+    FROM {{schema | sqlsafe}}.rates_to_usage rtu
+    WHERE rtu.usage_start >= DATE({{start_date}})
+        AND rtu.usage_start <= DATE({{end_date}})
+        AND rtu.source_uuid = {{source_uuid}}::uuid
+        AND rtu.namespace = 'GPU unallocated'
+        AND rtu.monthly_cost_type IS NULL
+    GROUP BY rtu.usage_start, rtu.source_uuid, rtu.cluster_id, rtu.cluster_alias,
+             rtu.report_period_id, rtu.node,
+             rtu.custom_name, rtu.metric_type, rtu.cost_model_rate_type
+),
+gpu_model_map AS (
+    SELECT
+        node,
+        all_labels->>'gpu-model' AS gpu_model,
+        usage_start
+    FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary
+    WHERE namespace = 'GPU unallocated'
+      AND usage_start >= DATE({{start_date}})
+      AND usage_start <= DATE({{end_date}})
+      AND source_uuid = {{source_uuid}}::uuid
+    GROUP BY node, all_labels->>'gpu-model', usage_start
+),
+namespace_usage_information AS (
+    SELECT gpu_model_name,
+        gpu_usage.namespace,
+        gpu_usage.node,
+        SUM(gpu_pod_uptime * COALESCE(gpu_usage.mig_slice_count, 1)) AS pod_usage_slice_hours,
+        gpu_usage.usage_start
+    FROM {{schema | sqlsafe}}.openshift_gpu_usage_line_items_daily AS gpu_usage
+    WHERE source = {{source_uuid}}
+      AND year = {{year}}
+      AND month = {{month}}
+      AND gpu_usage.usage_start >= DATE({{start_date}})
+      AND gpu_usage.usage_start <= DATE({{end_date}})
+    GROUP BY gpu_model_name, gpu_usage.node, namespace, gpu_usage.usage_start
+),
+total_usage AS (
+    SELECT node, gpu_model_name, usage_start,
+           SUM(pod_usage_slice_hours) AS total_slice_hours
+    FROM namespace_usage_information
+    GROUP BY node, gpu_model_name, usage_start
+)
+SELECT
+    uuid_generate_v4(),
+    MAX(gc.report_period_id),
+    gc.source_uuid,
+    nsp.usage_start,
+    nsp.usage_start,
+    MAX(gc.cluster_id),
+    MAX(gc.cluster_alias),
+    nsp.namespace,
+    nsp.node,
+    gc.custom_name,
+    gc.metric_type,
+    gc.cost_model_rate_type,
+    {{cost_model_rate_type}},
+    MAX(nsp.pod_usage_slice_hours / NULLIF(tu.total_slice_hours, 0) * gc.rate_cost)
+FROM gpu_rtu_cost gc
+JOIN gpu_model_map gm
+    ON gm.node = gc.node AND gm.usage_start = gc.usage_start
+JOIN namespace_usage_information nsp
+    ON nsp.node = gc.node
+    AND nsp.gpu_model_name = gm.gpu_model
+    AND nsp.usage_start = gc.usage_start
+JOIN total_usage tu
+    ON tu.node = nsp.node
+    AND tu.gpu_model_name = nsp.gpu_model_name
+    AND tu.usage_start = nsp.usage_start
+GROUP BY nsp.usage_start, nsp.node, nsp.namespace,
+         gc.source_uuid, gc.custom_name, gc.metric_type, gc.cost_model_rate_type
+HAVING MAX(nsp.pod_usage_slice_hours / NULLIF(tu.total_slice_hours, 0) * gc.rate_cost) != 0
+RETURNING 1;

--- a/koku/masu/database/self_hosted_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
+++ b/koku/masu/database/self_hosted_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
@@ -75,7 +75,7 @@ SELECT
     gc.custom_name,
     gc.metric_type,
     gc.cost_model_rate_type,
-    {{cost_model_rate_type}},
+    {{distribution_tag}},
     MAX(nsp.pod_usage_slice_hours / NULLIF(tu.total_slice_hours, 0) * gc.rate_cost)
 FROM gpu_rtu_cost gc
 JOIN gpu_model_map gm

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/delete_distributed_rates_to_usage.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/delete_distributed_rates_to_usage.sql
@@ -1,0 +1,8 @@
+-- Delete distributed rows from rates_to_usage before re-inserting.
+-- Mirrors delete_monthly_cost_model_rate_type.sql but targets RTU.
+DELETE FROM {{schema | sqlsafe}}.rates_to_usage AS rtu
+WHERE rtu.usage_start >= {{start_date}}::date
+    AND rtu.usage_start <= {{end_date}}::date
+    AND rtu.report_period_id = {{report_period_id}}
+    AND rtu.monthly_cost_type = {{cost_model_rate_type}}
+;

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/delete_distributed_rates_to_usage.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/delete_distributed_rates_to_usage.sql
@@ -4,5 +4,5 @@ DELETE FROM {{schema | sqlsafe}}.rates_to_usage AS rtu
 WHERE rtu.usage_start >= {{start_date}}::date
     AND rtu.usage_start <= {{end_date}}::date
     AND rtu.report_period_id = {{report_period_id}}
-    AND rtu.monthly_cost_type = {{cost_model_rate_type}}
+    AND rtu.monthly_cost_type = {{distribution_tag}}
 ;

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_platform_cost_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_platform_cost_per_rate.sql
@@ -1,0 +1,113 @@
+-- Per-rate platform cost distribution via rates_to_usage.
+-- Reads per-rate costs from RTU (Platform category), distributes
+-- proportionally to non-Platform namespaces by CPU/memory hours,
+-- writes distributed rows back to RTU with monthly_cost_type = 'platform_distributed'.
+WITH platform_rtu_cost AS (
+    SELECT
+        rtu.usage_start,
+        rtu.source_uuid,
+        rtu.cluster_id,
+        rtu.custom_name,
+        rtu.metric_type,
+        rtu.cost_model_rate_type,
+        SUM(COALESCE(rtu.calculated_cost, 0)) AS rate_cost
+    FROM {{schema | sqlsafe}}.rates_to_usage rtu
+    JOIN {{schema | sqlsafe}}.reporting_ocp_cost_category cat
+        ON rtu.cost_category_id = cat.id
+    WHERE rtu.usage_start >= {{start_date}}::date
+        AND rtu.usage_start <= {{end_date}}::date
+        AND rtu.report_period_id = {{report_period_id}}
+        AND rtu.source_uuid = {{source_uuid}}::uuid
+        AND cat.name = 'Platform'
+        AND rtu.monthly_cost_type IS NULL
+    GROUP BY rtu.usage_start, rtu.source_uuid, rtu.cluster_id,
+             rtu.custom_name, rtu.metric_type, rtu.cost_model_rate_type
+),
+denominator AS (
+    SELECT
+        lids.usage_start,
+        lids.cluster_id,
+        SUM(lids.pod_effective_usage_cpu_core_hours) AS usage_cpu_sum,
+        SUM(lids.pod_effective_usage_memory_gigabyte_hours) AS usage_memory_sum
+    FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
+    LEFT JOIN {{schema | sqlsafe}}.reporting_ocp_cost_category cat
+        ON lids.cost_category_id = cat.id
+    WHERE lids.usage_start >= {{start_date}}::date
+        AND lids.usage_start <= {{end_date}}::date
+        AND lids.report_period_id = {{report_period_id}}
+        AND lids.namespace != 'Worker unallocated'
+        AND lids.namespace != 'Storage unattributed'
+        AND lids.namespace != 'Network unattributed'
+        AND (lids.cost_category_id IS NULL OR cat.name != 'Platform')
+        AND lids.data_source = 'Pod'
+    GROUP BY lids.usage_start, lids.cluster_id
+),
+namespace_usage AS (
+    SELECT
+        lids.usage_start,
+        lids.cluster_id,
+        lids.namespace,
+        lids.node,
+        MAX(lids.report_period_id) AS report_period_id,
+        MAX(lids.cluster_alias) AS cluster_alias,
+        MAX(lids.cost_category_id) AS cost_category_id,
+        SUM(lids.pod_effective_usage_cpu_core_hours) AS ns_cpu,
+        SUM(lids.pod_effective_usage_memory_gigabyte_hours) AS ns_memory
+    FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
+    LEFT JOIN {{schema | sqlsafe}}.reporting_ocp_cost_category cat
+        ON lids.cost_category_id = cat.id
+    WHERE lids.usage_start >= {{start_date}}::date
+        AND lids.usage_start <= {{end_date}}::date
+        AND lids.report_period_id = {{report_period_id}}
+        AND lids.namespace IS NOT NULL
+        AND lids.namespace != 'Worker unallocated'
+        AND lids.namespace != 'Storage unattributed'
+        AND lids.namespace != 'Network unattributed'
+        AND (lids.cost_category_id IS NULL OR cat.name != 'Platform')
+        AND lids.data_source = 'Pod'
+    GROUP BY lids.usage_start, lids.cluster_id, lids.namespace, lids.node
+)
+INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
+    uuid, report_period_id, source_uuid, usage_start, usage_end,
+    cluster_id, cluster_alias, namespace, node,
+    cost_category_id, custom_name, metric_type, cost_model_rate_type,
+    monthly_cost_type, distributed_cost
+)
+SELECT
+    uuid_generate_v4(),
+    nu.report_period_id,
+    pc.source_uuid,
+    nu.usage_start,
+    nu.usage_start,
+    nu.cluster_id,
+    nu.cluster_alias,
+    nu.namespace,
+    nu.node,
+    nu.cost_category_id,
+    pc.custom_name,
+    pc.metric_type,
+    pc.cost_model_rate_type,
+    {{cost_model_rate_type}},
+    CASE WHEN {{distribution}} = 'cpu' THEN
+        CASE WHEN d.usage_cpu_sum <= 0 THEN 0
+             ELSE (nu.ns_cpu / d.usage_cpu_sum) * pc.rate_cost
+        END
+    ELSE
+        CASE WHEN d.usage_memory_sum <= 0 THEN 0
+             ELSE (nu.ns_memory / d.usage_memory_sum) * pc.rate_cost
+        END
+    END
+FROM platform_rtu_cost pc
+JOIN denominator d
+    ON d.usage_start = pc.usage_start AND d.cluster_id = pc.cluster_id
+JOIN namespace_usage nu
+    ON nu.usage_start = pc.usage_start AND nu.cluster_id = pc.cluster_id
+WHERE CASE WHEN {{distribution}} = 'cpu' THEN
+          CASE WHEN d.usage_cpu_sum <= 0 THEN 0
+               ELSE (nu.ns_cpu / d.usage_cpu_sum) * pc.rate_cost
+          END
+      ELSE
+          CASE WHEN d.usage_memory_sum <= 0 THEN 0
+               ELSE (nu.ns_memory / d.usage_memory_sum) * pc.rate_cost
+          END
+      END != 0;

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_platform_cost_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_platform_cost_per_rate.sql
@@ -87,7 +87,7 @@ SELECT
     pc.custom_name,
     pc.metric_type,
     pc.cost_model_rate_type,
-    {{cost_model_rate_type}},
+    {{distribution_tag}},
     CASE WHEN {{distribution}} = 'cpu' THEN
         CASE WHEN d.usage_cpu_sum <= 0 THEN 0
              ELSE (nu.ns_cpu / d.usage_cpu_sum) * pc.rate_cost

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_network_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_network_per_rate.sql
@@ -83,7 +83,7 @@ SELECT
     nc.custom_name,
     nc.metric_type,
     nc.cost_model_rate_type,
-    {{cost_model_rate_type}},
+    {{distribution_tag}},
     CASE WHEN {{distribution}} = 'cpu' THEN
         CASE WHEN d.usage_cpu_sum <= 0 THEN 0
              ELSE (nu.ns_cpu / d.usage_cpu_sum) * nc.rate_cost

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_network_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_network_per_rate.sql
@@ -1,0 +1,109 @@
+-- Per-rate unattributed network cost distribution via rates_to_usage.
+-- Reads per-rate costs from RTU (Network unattributed namespace), distributes
+-- proportionally to non-Network namespaces by CPU/memory hours (cross-cluster, daily),
+-- writes distributed rows back to RTU with monthly_cost_type = 'unattributed_network'.
+WITH network_rtu_cost AS (
+    SELECT
+        rtu.usage_start,
+        rtu.source_uuid,
+        rtu.cluster_id,
+        rtu.custom_name,
+        rtu.metric_type,
+        rtu.cost_model_rate_type,
+        SUM(COALESCE(rtu.calculated_cost, 0)) AS rate_cost
+    FROM {{schema | sqlsafe}}.rates_to_usage rtu
+    WHERE rtu.usage_start >= {{start_date}}::date
+        AND rtu.usage_start <= {{end_date}}::date
+        AND rtu.report_period_id = {{report_period_id}}
+        AND rtu.source_uuid = {{source_uuid}}::uuid
+        AND rtu.namespace = 'Network unattributed'
+        AND rtu.monthly_cost_type IS NULL
+    GROUP BY rtu.usage_start, rtu.source_uuid, rtu.cluster_id,
+             rtu.custom_name, rtu.metric_type, rtu.cost_model_rate_type
+),
+denominator AS (
+    SELECT
+        lids.usage_start,
+        lids.cluster_id,
+        SUM(lids.pod_effective_usage_cpu_core_hours) AS usage_cpu_sum,
+        SUM(lids.pod_effective_usage_memory_gigabyte_hours) AS usage_memory_sum
+    FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
+    LEFT JOIN {{schema | sqlsafe}}.reporting_ocp_cost_category cat
+        ON lids.cost_category_id = cat.id
+    WHERE lids.usage_start >= {{start_date}}::date
+        AND lids.usage_start <= {{end_date}}::date
+        AND lids.report_period_id = {{report_period_id}}
+        AND lids.namespace != 'Storage unattributed'
+        AND lids.namespace != 'Network unattributed'
+        AND lids.namespace != 'Worker unallocated'
+        AND (lids.cost_category_id IS NULL OR cat.name != 'Platform')
+    GROUP BY lids.usage_start, lids.cluster_id
+),
+namespace_usage AS (
+    SELECT
+        lids.usage_start,
+        lids.cluster_id,
+        lids.namespace,
+        lids.node,
+        MAX(lids.report_period_id) AS report_period_id,
+        MAX(lids.cluster_alias) AS cluster_alias,
+        MAX(lids.cost_category_id) AS cost_category_id,
+        SUM(lids.pod_effective_usage_cpu_core_hours) AS ns_cpu,
+        SUM(lids.pod_effective_usage_memory_gigabyte_hours) AS ns_memory
+    FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
+    LEFT JOIN {{schema | sqlsafe}}.reporting_ocp_cost_category cat
+        ON lids.cost_category_id = cat.id
+    WHERE lids.usage_start >= {{start_date}}::date
+        AND lids.usage_start <= {{end_date}}::date
+        AND lids.report_period_id = {{report_period_id}}
+        AND lids.namespace IS NOT NULL
+        AND lids.namespace != 'Storage unattributed'
+        AND lids.namespace != 'Network unattributed'
+        AND lids.namespace != 'Worker unallocated'
+        AND (lids.cost_category_id IS NULL OR cat.name != 'Platform')
+    GROUP BY lids.usage_start, lids.cluster_id, lids.namespace, lids.node
+)
+INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
+    uuid, report_period_id, source_uuid, usage_start, usage_end,
+    cluster_id, cluster_alias, namespace, node,
+    cost_category_id, custom_name, metric_type, cost_model_rate_type,
+    monthly_cost_type, distributed_cost
+)
+SELECT
+    uuid_generate_v4(),
+    nu.report_period_id,
+    nc.source_uuid,
+    nu.usage_start,
+    nu.usage_start,
+    nu.cluster_id,
+    nu.cluster_alias,
+    nu.namespace,
+    nu.node,
+    nu.cost_category_id,
+    nc.custom_name,
+    nc.metric_type,
+    nc.cost_model_rate_type,
+    {{cost_model_rate_type}},
+    CASE WHEN {{distribution}} = 'cpu' THEN
+        CASE WHEN d.usage_cpu_sum <= 0 THEN 0
+             ELSE (nu.ns_cpu / d.usage_cpu_sum) * nc.rate_cost
+        END
+    ELSE
+        CASE WHEN d.usage_memory_sum <= 0 THEN 0
+             ELSE (nu.ns_memory / d.usage_memory_sum) * nc.rate_cost
+        END
+    END
+FROM network_rtu_cost nc
+JOIN denominator d
+    ON d.usage_start = nc.usage_start AND d.cluster_id = nc.cluster_id
+JOIN namespace_usage nu
+    ON nu.usage_start = nc.usage_start AND nu.cluster_id = nc.cluster_id
+WHERE CASE WHEN {{distribution}} = 'cpu' THEN
+          CASE WHEN d.usage_cpu_sum <= 0 THEN 0
+               ELSE (nu.ns_cpu / d.usage_cpu_sum) * nc.rate_cost
+          END
+      ELSE
+          CASE WHEN d.usage_memory_sum <= 0 THEN 0
+               ELSE (nu.ns_memory / d.usage_memory_sum) * nc.rate_cost
+          END
+      END != 0;

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_storage_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_storage_per_rate.sql
@@ -1,0 +1,109 @@
+-- Per-rate unattributed storage cost distribution via rates_to_usage.
+-- Reads per-rate costs from RTU (Storage unattributed namespace), distributes
+-- proportionally to non-Storage namespaces by CPU/memory hours (cross-cluster, daily),
+-- writes distributed rows back to RTU with monthly_cost_type = 'unattributed_storage'.
+WITH storage_rtu_cost AS (
+    SELECT
+        rtu.usage_start,
+        rtu.source_uuid,
+        rtu.cluster_id,
+        rtu.custom_name,
+        rtu.metric_type,
+        rtu.cost_model_rate_type,
+        SUM(COALESCE(rtu.calculated_cost, 0)) AS rate_cost
+    FROM {{schema | sqlsafe}}.rates_to_usage rtu
+    WHERE rtu.usage_start >= {{start_date}}::date
+        AND rtu.usage_start <= {{end_date}}::date
+        AND rtu.report_period_id = {{report_period_id}}
+        AND rtu.source_uuid = {{source_uuid}}::uuid
+        AND rtu.namespace = 'Storage unattributed'
+        AND rtu.monthly_cost_type IS NULL
+    GROUP BY rtu.usage_start, rtu.source_uuid, rtu.cluster_id,
+             rtu.custom_name, rtu.metric_type, rtu.cost_model_rate_type
+),
+denominator AS (
+    SELECT
+        lids.usage_start,
+        lids.cluster_id,
+        SUM(lids.pod_effective_usage_cpu_core_hours) AS usage_cpu_sum,
+        SUM(lids.pod_effective_usage_memory_gigabyte_hours) AS usage_memory_sum
+    FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
+    LEFT JOIN {{schema | sqlsafe}}.reporting_ocp_cost_category cat
+        ON lids.cost_category_id = cat.id
+    WHERE lids.usage_start >= {{start_date}}::date
+        AND lids.usage_start <= {{end_date}}::date
+        AND lids.report_period_id = {{report_period_id}}
+        AND lids.namespace != 'Storage unattributed'
+        AND lids.namespace != 'Network unattributed'
+        AND lids.namespace != 'Worker unallocated'
+        AND (lids.cost_category_id IS NULL OR cat.name != 'Platform')
+    GROUP BY lids.usage_start, lids.cluster_id
+),
+namespace_usage AS (
+    SELECT
+        lids.usage_start,
+        lids.cluster_id,
+        lids.namespace,
+        lids.node,
+        MAX(lids.report_period_id) AS report_period_id,
+        MAX(lids.cluster_alias) AS cluster_alias,
+        MAX(lids.cost_category_id) AS cost_category_id,
+        SUM(lids.pod_effective_usage_cpu_core_hours) AS ns_cpu,
+        SUM(lids.pod_effective_usage_memory_gigabyte_hours) AS ns_memory
+    FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
+    LEFT JOIN {{schema | sqlsafe}}.reporting_ocp_cost_category cat
+        ON lids.cost_category_id = cat.id
+    WHERE lids.usage_start >= {{start_date}}::date
+        AND lids.usage_start <= {{end_date}}::date
+        AND lids.report_period_id = {{report_period_id}}
+        AND lids.namespace IS NOT NULL
+        AND lids.namespace != 'Storage unattributed'
+        AND lids.namespace != 'Network unattributed'
+        AND lids.namespace != 'Worker unallocated'
+        AND (lids.cost_category_id IS NULL OR cat.name != 'Platform')
+    GROUP BY lids.usage_start, lids.cluster_id, lids.namespace, lids.node
+)
+INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
+    uuid, report_period_id, source_uuid, usage_start, usage_end,
+    cluster_id, cluster_alias, namespace, node,
+    cost_category_id, custom_name, metric_type, cost_model_rate_type,
+    monthly_cost_type, distributed_cost
+)
+SELECT
+    uuid_generate_v4(),
+    nu.report_period_id,
+    sc.source_uuid,
+    nu.usage_start,
+    nu.usage_start,
+    nu.cluster_id,
+    nu.cluster_alias,
+    nu.namespace,
+    nu.node,
+    nu.cost_category_id,
+    sc.custom_name,
+    sc.metric_type,
+    sc.cost_model_rate_type,
+    {{cost_model_rate_type}},
+    CASE WHEN {{distribution}} = 'cpu' THEN
+        CASE WHEN d.usage_cpu_sum <= 0 THEN 0
+             ELSE (nu.ns_cpu / d.usage_cpu_sum) * sc.rate_cost
+        END
+    ELSE
+        CASE WHEN d.usage_memory_sum <= 0 THEN 0
+             ELSE (nu.ns_memory / d.usage_memory_sum) * sc.rate_cost
+        END
+    END
+FROM storage_rtu_cost sc
+JOIN denominator d
+    ON d.usage_start = sc.usage_start AND d.cluster_id = sc.cluster_id
+JOIN namespace_usage nu
+    ON nu.usage_start = sc.usage_start AND nu.cluster_id = sc.cluster_id
+WHERE CASE WHEN {{distribution}} = 'cpu' THEN
+          CASE WHEN d.usage_cpu_sum <= 0 THEN 0
+               ELSE (nu.ns_cpu / d.usage_cpu_sum) * sc.rate_cost
+          END
+      ELSE
+          CASE WHEN d.usage_memory_sum <= 0 THEN 0
+               ELSE (nu.ns_memory / d.usage_memory_sum) * sc.rate_cost
+          END
+      END != 0;

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_storage_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_storage_per_rate.sql
@@ -83,7 +83,7 @@ SELECT
     sc.custom_name,
     sc.metric_type,
     sc.cost_model_rate_type,
-    {{cost_model_rate_type}},
+    {{distribution_tag}},
     CASE WHEN {{distribution}} = 'cpu' THEN
         CASE WHEN d.usage_cpu_sum <= 0 THEN 0
              ELSE (nu.ns_cpu / d.usage_cpu_sum) * sc.rate_cost

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_worker_cost_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_worker_cost_per_rate.sql
@@ -1,0 +1,111 @@
+-- Per-rate worker unallocated cost distribution via rates_to_usage.
+-- Reads per-rate costs from RTU (Worker unallocated namespace), distributes
+-- proportionally to non-Worker namespaces by CPU/memory hours (Pod data_source),
+-- writes distributed rows back to RTU with monthly_cost_type = 'worker_distributed'.
+WITH worker_rtu_cost AS (
+    SELECT
+        rtu.usage_start,
+        rtu.source_uuid,
+        rtu.cluster_id,
+        rtu.custom_name,
+        rtu.metric_type,
+        rtu.cost_model_rate_type,
+        SUM(COALESCE(rtu.calculated_cost, 0)) AS rate_cost
+    FROM {{schema | sqlsafe}}.rates_to_usage rtu
+    WHERE rtu.usage_start >= {{start_date}}::date
+        AND rtu.usage_start <= {{end_date}}::date
+        AND rtu.report_period_id = {{report_period_id}}
+        AND rtu.source_uuid = {{source_uuid}}::uuid
+        AND rtu.namespace = 'Worker unallocated'
+        AND rtu.monthly_cost_type IS NULL
+    GROUP BY rtu.usage_start, rtu.source_uuid, rtu.cluster_id,
+             rtu.custom_name, rtu.metric_type, rtu.cost_model_rate_type
+),
+denominator AS (
+    SELECT
+        lids.usage_start,
+        lids.cluster_id,
+        SUM(lids.pod_effective_usage_cpu_core_hours) AS usage_cpu_sum,
+        SUM(lids.pod_effective_usage_memory_gigabyte_hours) AS usage_memory_sum
+    FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
+    LEFT JOIN {{schema | sqlsafe}}.reporting_ocp_cost_category cat
+        ON lids.cost_category_id = cat.id
+    WHERE lids.usage_start >= {{start_date}}::date
+        AND lids.usage_start <= {{end_date}}::date
+        AND lids.report_period_id = {{report_period_id}}
+        AND lids.namespace != 'Worker unallocated'
+        AND lids.namespace != 'Storage unattributed'
+        AND lids.namespace != 'Network unattributed'
+        AND (lids.cost_category_id IS NULL OR cat.name != 'Platform')
+        AND lids.data_source = 'Pod'
+    GROUP BY lids.usage_start, lids.cluster_id
+),
+namespace_usage AS (
+    SELECT
+        lids.usage_start,
+        lids.cluster_id,
+        lids.namespace,
+        lids.node,
+        MAX(lids.report_period_id) AS report_period_id,
+        MAX(lids.cluster_alias) AS cluster_alias,
+        MAX(lids.cost_category_id) AS cost_category_id,
+        SUM(lids.pod_effective_usage_cpu_core_hours) AS ns_cpu,
+        SUM(lids.pod_effective_usage_memory_gigabyte_hours) AS ns_memory
+    FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
+    LEFT JOIN {{schema | sqlsafe}}.reporting_ocp_cost_category cat
+        ON lids.cost_category_id = cat.id
+    WHERE lids.usage_start >= {{start_date}}::date
+        AND lids.usage_start <= {{end_date}}::date
+        AND lids.report_period_id = {{report_period_id}}
+        AND lids.namespace IS NOT NULL
+        AND lids.namespace != 'Worker unallocated'
+        AND lids.namespace != 'Storage unattributed'
+        AND lids.namespace != 'Network unattributed'
+        AND (lids.cost_category_id IS NULL OR cat.name != 'Platform')
+        AND lids.data_source = 'Pod'
+    GROUP BY lids.usage_start, lids.cluster_id, lids.namespace, lids.node
+)
+INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
+    uuid, report_period_id, source_uuid, usage_start, usage_end,
+    cluster_id, cluster_alias, namespace, node,
+    cost_category_id, custom_name, metric_type, cost_model_rate_type,
+    monthly_cost_type, distributed_cost
+)
+SELECT
+    uuid_generate_v4(),
+    nu.report_period_id,
+    wc.source_uuid,
+    nu.usage_start,
+    nu.usage_start,
+    nu.cluster_id,
+    nu.cluster_alias,
+    nu.namespace,
+    nu.node,
+    nu.cost_category_id,
+    wc.custom_name,
+    wc.metric_type,
+    wc.cost_model_rate_type,
+    {{cost_model_rate_type}},
+    CASE WHEN {{distribution}} = 'cpu' THEN
+        CASE WHEN d.usage_cpu_sum <= 0 THEN 0
+             ELSE (nu.ns_cpu / d.usage_cpu_sum) * wc.rate_cost
+        END
+    ELSE
+        CASE WHEN d.usage_memory_sum <= 0 THEN 0
+             ELSE (nu.ns_memory / d.usage_memory_sum) * wc.rate_cost
+        END
+    END
+FROM worker_rtu_cost wc
+JOIN denominator d
+    ON d.usage_start = wc.usage_start AND d.cluster_id = wc.cluster_id
+JOIN namespace_usage nu
+    ON nu.usage_start = wc.usage_start AND nu.cluster_id = wc.cluster_id
+WHERE CASE WHEN {{distribution}} = 'cpu' THEN
+          CASE WHEN d.usage_cpu_sum <= 0 THEN 0
+               ELSE (nu.ns_cpu / d.usage_cpu_sum) * wc.rate_cost
+          END
+      ELSE
+          CASE WHEN d.usage_memory_sum <= 0 THEN 0
+               ELSE (nu.ns_memory / d.usage_memory_sum) * wc.rate_cost
+          END
+      END != 0;

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_worker_cost_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_worker_cost_per_rate.sql
@@ -85,7 +85,7 @@ SELECT
     wc.custom_name,
     wc.metric_type,
     wc.cost_model_rate_type,
-    {{cost_model_rate_type}},
+    {{distribution_tag}},
     CASE WHEN {{distribution}} = 'cpu' THEN
         CASE WHEN d.usage_cpu_sum <= 0 THEN 0
              ELSE (nu.ns_cpu / d.usage_cpu_sum) * wc.rate_cost

--- a/koku/masu/database/sql/openshift/cost_model/usage_rates/aggregate_rates_to_daily_summary.sql
+++ b/koku/masu/database/sql/openshift/cost_model/usage_rates/aggregate_rates_to_daily_summary.sql
@@ -145,6 +145,7 @@ INSERT INTO {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary (
     cost_category_id, cost_model_rate_type,
     cost_model_cpu_cost, cost_model_memory_cost, cost_model_volume_cost,
     cost_model_gpu_cost,
+    distributed_cost,
     monthly_cost_type
 )
 SELECT
@@ -168,6 +169,7 @@ SELECT
     SUM(CASE WHEN rtu.metric_type = 'memory'  THEN rtu.calculated_cost ELSE 0 END),
     SUM(CASE WHEN rtu.metric_type = 'storage' THEN rtu.calculated_cost ELSE 0 END),
     SUM(CASE WHEN rtu.metric_type = 'gpu'     THEN rtu.calculated_cost ELSE 0 END),
+    SUM(COALESCE(rtu.distributed_cost, 0)),
     rtu.monthly_cost_type
 FROM {{schema | sqlsafe}}.rates_to_usage rtu
 WHERE rtu.usage_start >= {{start_date}}

--- a/koku/masu/database/trino_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
+++ b/koku/masu/database/trino_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
@@ -75,7 +75,7 @@ SELECT
     gc.custom_name,
     gc.metric_type,
     gc.cost_model_rate_type,
-    {{cost_model_rate_type}},
+    {{distribution_tag}},
     MAX(nsp.pod_usage_slice_hours / NULLIF(tu.total_slice_hours, 0) * gc.rate_cost)
 FROM gpu_rtu_cost gc
 JOIN gpu_model_map gm

--- a/koku/masu/database/trino_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
+++ b/koku/masu/database/trino_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
@@ -1,0 +1,93 @@
+-- Per-rate GPU unallocated cost distribution via rates_to_usage (Trino/SaaS).
+-- Reads per-rate GPU costs from RTU (GPU unallocated namespace), distributes
+-- proportionally by MIG-aware slice-hours, writes distributed rows back to RTU
+-- with monthly_cost_type = 'gpu_distributed'.
+INSERT INTO postgres.{{schema | sqlsafe}}.rates_to_usage (
+    uuid, report_period_id, source_uuid, usage_start, usage_end,
+    cluster_id, cluster_alias, namespace, node,
+    custom_name, metric_type, cost_model_rate_type,
+    monthly_cost_type, distributed_cost
+)
+WITH gpu_rtu_cost AS (
+    SELECT
+        rtu.usage_start,
+        rtu.source_uuid,
+        rtu.cluster_id,
+        rtu.cluster_alias,
+        rtu.report_period_id,
+        rtu.node,
+        rtu.custom_name,
+        rtu.metric_type,
+        rtu.cost_model_rate_type,
+        SUM(COALESCE(rtu.calculated_cost, 0)) AS rate_cost
+    FROM postgres.{{schema | sqlsafe}}.rates_to_usage rtu
+    WHERE rtu.usage_start >= DATE({{start_date}})
+        AND rtu.usage_start <= DATE({{end_date}})
+        AND rtu.source_uuid = CAST({{source_uuid}} AS UUID)
+        AND rtu.namespace = 'GPU unallocated'
+        AND rtu.monthly_cost_type IS NULL
+    GROUP BY rtu.usage_start, rtu.source_uuid, rtu.cluster_id, rtu.cluster_alias,
+             rtu.report_period_id, rtu.node,
+             rtu.custom_name, rtu.metric_type, rtu.cost_model_rate_type
+),
+gpu_model_map AS (
+    SELECT
+        node,
+        json_extract_scalar(all_labels, '$["gpu-model"]') AS gpu_model,
+        usage_start
+    FROM postgres.{{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary
+    WHERE namespace = 'GPU unallocated'
+      AND usage_start >= DATE({{start_date}})
+      AND usage_start <= DATE({{end_date}})
+      AND source_uuid = CAST({{source_uuid}} AS UUID)
+    GROUP BY node, json_extract_scalar(all_labels, '$["gpu-model"]'), usage_start
+),
+namespace_usage_information AS (
+    SELECT gpu_model_name,
+        gpu_usage.namespace,
+        gpu_usage.node,
+        SUM(gpu_pod_uptime * COALESCE(gpu_usage.mig_slice_count, 1)) AS pod_usage_slice_hours,
+        DATE(interval_start) AS usage_start
+    FROM hive.{{schema | sqlsafe}}.openshift_gpu_usage_line_items_daily AS gpu_usage
+    WHERE source = {{source_uuid}}
+      AND year = {{year}}
+      AND month = {{month}}
+      AND DATE(interval_start) >= DATE({{start_date}})
+      AND DATE(interval_start) <= DATE({{end_date}})
+    GROUP BY gpu_model_name, gpu_usage.node, namespace, DATE(interval_start)
+),
+total_usage AS (
+    SELECT node, gpu_model_name, usage_start,
+           SUM(pod_usage_slice_hours) AS total_slice_hours
+    FROM namespace_usage_information
+    GROUP BY node, gpu_model_name, usage_start
+)
+SELECT
+    uuid(),
+    MAX(gc.report_period_id),
+    gc.source_uuid,
+    nsp.usage_start,
+    nsp.usage_start,
+    MAX(gc.cluster_id),
+    MAX(gc.cluster_alias),
+    nsp.namespace,
+    nsp.node,
+    gc.custom_name,
+    gc.metric_type,
+    gc.cost_model_rate_type,
+    {{cost_model_rate_type}},
+    MAX(nsp.pod_usage_slice_hours / NULLIF(tu.total_slice_hours, 0) * gc.rate_cost)
+FROM gpu_rtu_cost gc
+JOIN gpu_model_map gm
+    ON gm.node = gc.node AND gm.usage_start = gc.usage_start
+JOIN namespace_usage_information nsp
+    ON nsp.node = gc.node
+    AND nsp.gpu_model_name = gm.gpu_model
+    AND nsp.usage_start = gc.usage_start
+JOIN total_usage tu
+    ON tu.node = nsp.node
+    AND tu.gpu_model_name = nsp.gpu_model_name
+    AND tu.usage_start = nsp.usage_start
+GROUP BY nsp.usage_start, nsp.node, nsp.namespace,
+         gc.source_uuid, gc.custom_name, gc.metric_type, gc.cost_model_rate_type
+HAVING MAX(nsp.pod_usage_slice_hours / NULLIF(tu.total_slice_hours, 0) * gc.rate_cost) != 0;


### PR DESCRIPTION
## Summary

- Add 5 per-rate distribution SQL files that read costs from `rates_to_usage` and write distributed rows back to `rates_to_usage` (platform, worker, storage, network, GPU)
- Add RTU DELETE SQL (`delete_distributed_rates_to_usage.sql`) for idempotent re-execution
- Fix aggregation Block 2 in `aggregate_rates_to_daily_summary.sql` to include `distributed_cost` in INSERT + SELECT (mirrors Block 1)
- GPU per-rate variant in both `self_hosted_sql/` and `trino_sql/` paths

## Context

This is **PR 2 of 5** for COST-7249 Phase 4. This PR contains only SQL files -- no Python changes. The new SQL files are inert on disk until PR 3 wires `DistributionConfig` to reference them.

**PR sequence:**
1. PR 1 -- DDL migration ([#6098](https://github.com/project-koku/koku/pull/6098))
2. **This PR** -- Per-rate distribution SQL files (no Python)
3. PR 3 -- Orchestration rewire + tests
4. PR 4 -- Breakdown population SQL + `UI_SUMMARY_TABLES` registration
5. PR 5 -- API surface (serializers, view, URL)

## What is NOT in this PR

- No Python changes (`DistributionConfig` still points to legacy SQL files)
- No orchestration changes
- Legacy `distribute_cost/*.sql` files preserved (R18 rollback safety)

## Key design: per-rate vs legacy

| Aspect | Legacy SQL | Per-rate SQL (this PR) |
|--------|-----------|----------------------|
| Read source | `reporting_ocpusagelineitem_daily_summary` | `rates_to_usage` |
| Write target | `reporting_ocpusagelineitem_daily_summary` | `rates_to_usage` |
| Cost identity | Aggregated (lost per-rate detail) | Per-rate (`custom_name`, `metric_type`, `cost_model_rate_type`) |
| Distribution column | `distributed_cost` | `distributed_cost` + `monthly_cost_type` |

## Test plan

- [ ] SQL syntax validates (all files are Jinja2 templates, verified by template parsing)
- [ ] No runtime behavior change (files are inert until PR 3)
- [ ] Existing tests pass (no code changes)
- [ ] Code review: verify CTE patterns match legacy for cost conservation


Made with [Cursor](https://cursor.com)