### PR TITLE
[COST-7249] Phase 4 PR 3: Orchestration rewire + per-rate distribution

### DIFF
--- a/koku/masu/celery/tasks.py
+++ b/koku/masu/celery/tasks.py
@@ -245,6 +245,15 @@ def delete_archived_data(schema_name, provider_type, provider_uuid):  # noqa: C9
             for table, partition_column in TRINO_MANAGED_TABLES.items():
                 accessor.delete_hive_partitions_by_source(table, partition_column, provider_uuid)
 
+        # rates_to_usage is a PostgreSQL table in both modes and uses a bare
+        # UUIDField for source_uuid (no FK cascade), so clean it up explicitly.
+        from reporting.provider.ocp.models import RatesToUsage
+
+        with schema_context(schema_name):
+            deleted, _ = RatesToUsage.objects.filter(source_uuid=provider_uuid).delete()
+            if deleted:
+                LOG.info("Deleted %d rates_to_usage rows for provider %s", deleted, provider_uuid)
+
 
 # This task will process the autovacuum tuning as a background process
 @celery_app.task(name="masu.celery.tasks.autovacuum_tune_schemas", queue=DEFAULT)

--- a/koku/masu/database/ocp_report_db_accessor.py
+++ b/koku/masu/database/ocp_report_db_accessor.py
@@ -96,14 +96,18 @@ class OCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
             if isinstance(start_date, str):
                 start_date = parse(start_date)
             report_date = start_date.replace(day=1)
-            report_periods = report_periods.filter(report_period_start=report_date).first()
+            report_periods = report_periods.filter(
+                report_period_start=report_date
+            ).first()
         return report_periods
 
     def get_report_periods_before_date(self, date):
         """Get the report periods with report period before provided date."""
         return OCPUsageReportPeriod.objects.filter(report_period_start__lte=date)
 
-    def populate_ui_summary_tables(self, summary_range: SummaryRangeConfig, source_uuid, tables=UI_SUMMARY_TABLES):
+    def populate_ui_summary_tables(
+        self, summary_range: SummaryRangeConfig, source_uuid, tables=UI_SUMMARY_TABLES
+    ):
         """Populate our UI summary tables (formerly materialized views)."""
         sql_params = {
             "start_date": summary_range.start_date,
@@ -112,9 +116,13 @@ class OCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
             "source_uuid": source_uuid,
         }
         for table_name in tables:
-            sql = pkgutil.get_data("masu.database", f"sql/openshift/ui_summary/{table_name}.sql")
+            sql = pkgutil.get_data(
+                "masu.database", f"sql/openshift/ui_summary/{table_name}.sql"
+            )
             sql = sql.decode("utf-8")
-            self._prepare_and_execute_raw_sql_query(table_name, sql, sql_params, operation="DELETE/INSERT")
+            self._prepare_and_execute_raw_sql_query(
+                table_name, sql, sql_params, operation="DELETE/INSERT"
+            )
 
         # Trino Queries:
         start_date = DateHelper().parse_to_date(sql_params["start_date"])
@@ -122,7 +130,10 @@ class OCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
         sql_params["month"] = start_date.strftime("%m")
 
         self._populate_gpu_ui_summary_table_with_usage_only(sql_params)
-        if summary_range.summarize_previous_month and not summary_range.is_current_month:
+        if (
+            summary_range.summarize_previous_month
+            and not summary_range.is_current_month
+        ):
             # Don't resummarize virtualization UI table if we are summarizing previous month
             return
         self._populate_virtualization_ui_summary_table(sql_params)
@@ -143,7 +154,9 @@ class OCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
             from reporting.provider.ocp.self_hosted_models import OCPGPUUsageLineItem
 
             with schema_context(self.schema):
-                gpu_data_exists = OCPGPUUsageLineItem.objects.filter(source=source_uuid).exists()
+                gpu_data_exists = OCPGPUUsageLineItem.objects.filter(
+                    source=source_uuid
+                ).exists()
             if not gpu_data_exists:
                 return
         else:
@@ -166,10 +179,14 @@ class OCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
         cost_model_accessor = CostModelDBAccessor(
             self.schema,
             sql_params.get("source_uuid"),
-            price_list_effective_on=DateHelper().parse_to_date(sql_params.get("start_date")),
+            price_list_effective_on=DateHelper().parse_to_date(
+                sql_params.get("start_date")
+            ),
         )
         # Check to see if the cost model is set up to give cost
-        if cost_model_accessor.metric_to_tag_params_map.get(metric_constants.OCP_GPU_MONTH):
+        if cost_model_accessor.metric_to_tag_params_map.get(
+            metric_constants.OCP_GPU_MONTH
+        ):
             return
 
         cluster_id = get_cluster_id_from_provider(sql_params.get("source_uuid"))
@@ -201,9 +218,13 @@ class OCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
             )
         else:
             # SaaS: execute via Trino
-            self._execute_trino_multipart_sql_query(populate_gpu_usage_info, bind_params=sql_params)
+            self._execute_trino_multipart_sql_query(
+                populate_gpu_usage_info, bind_params=sql_params
+            )
 
-    def _reporting_period_has_gpu_data(self, source_uuid: uuid.UUID, start_date) -> bool:
+    def _reporting_period_has_gpu_data(
+        self, source_uuid: uuid.UUID, start_date
+    ) -> bool:
         """
         Return True if the cluster/source has GPU data for the given reporting period.
 
@@ -270,7 +291,9 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             return
         # create the temp table
         sql_params["uuid"] = str(uuid4().hex)
-        create_temp_table_sql = pkgutil.get_data("masu.database", "sql/openshift/create_virtualization_tmp_table.sql")
+        create_temp_table_sql = pkgutil.get_data(
+            "masu.database", "sql/openshift/create_virtualization_tmp_table.sql"
+        )
         create_temp_table_sql = create_temp_table_sql.decode("utf-8")
         self._prepare_and_execute_raw_sql_query(
             "create temp virtualization table",
@@ -299,13 +322,21 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             f"{self.get_sql_folder_name()}/openshift/{population_temp_table_file}",
         )
         populate_temp_table_sql = populate_temp_table_sql.decode("utf8")
-        self._execute_trino_multipart_sql_query(populate_temp_table_sql, bind_params=sql_params)
+        self._execute_trino_multipart_sql_query(
+            populate_temp_table_sql, bind_params=sql_params
+        )
         # populate vm UI table
-        sql = pkgutil.get_data("masu.database", f"sql/openshift/ui_summary/{VM_UI_SUMMARY_TABLE}.sql")
+        sql = pkgutil.get_data(
+            "masu.database", f"sql/openshift/ui_summary/{VM_UI_SUMMARY_TABLE}.sql"
+        )
         sql = sql.decode("utf-8")
-        self._prepare_and_execute_raw_sql_query(VM_UI_SUMMARY_TABLE, sql, sql_params, operation="DELETE/INSERT")
+        self._prepare_and_execute_raw_sql_query(
+            VM_UI_SUMMARY_TABLE, sql, sql_params, operation="DELETE/INSERT"
+        )
 
-    def update_line_item_daily_summary_with_tag_mapping(self, start_date, end_date, report_period_ids=None):
+    def update_line_item_daily_summary_with_tag_mapping(
+        self, start_date, end_date, report_period_ids=None
+    ):
         """Maps child keys to parent key.
         Args:
             start_date (datetime.date) The date to start mapping keys
@@ -316,11 +347,15 @@ AND (month = {{month_no_zero}} OR month = {{month}})
         """
         with schema_context(self.schema):
             # Early return check to see if they have any tag mappings set.
-            if not TagMapping.objects.filter(child__provider_type=Provider.PROVIDER_OCP).exists():
+            if not TagMapping.objects.filter(
+                child__provider_type=Provider.PROVIDER_OCP
+            ).exists():
                 LOG.debug("No tag mappings for OCP.")
                 return
         table_name = self._table_map["line_item_daily_summary"]
-        sql = pkgutil.get_data("masu.database", "sql/openshift/ocp_tag_mapping_update_daily_summary.sql")
+        sql = pkgutil.get_data(
+            "masu.database", "sql/openshift/ocp_tag_mapping_update_daily_summary.sql"
+        )
         sql = sql.decode("utf-8")
         sql_params = {
             "start_date": start_date,
@@ -330,7 +365,9 @@ AND (month = {{month_no_zero}} OR month = {{month}})
         }
         self._prepare_and_execute_raw_sql_query(table_name, sql, sql_params)
 
-    def get_ocp_infrastructure_map_trino(self, start_date, end_date, **kwargs):  # noqa: C901
+    def get_ocp_infrastructure_map_trino(
+        self, start_date, end_date, **kwargs
+    ):  # noqa: C901
         """Get the OCP on infrastructure map.
 
         Args:
@@ -352,7 +389,9 @@ AND (month = {{month_no_zero}} OR month = {{month}})
         check_azure = False
         check_gcp = False
 
-        if not self.table_exists_trino(TRINO_LINE_ITEM_TABLE_DAILY_MAP.get("pod_usage")):
+        if not self.table_exists_trino(
+            TRINO_LINE_ITEM_TABLE_DAILY_MAP.get("pod_usage")
+        ):
             return {}
         if aws_provider_uuid or ocp_provider_uuid:
             check_aws = self.table_exists_trino(AWS_TRINO_LINE_ITEM_DAILY_TABLE)
@@ -457,7 +496,9 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             "table": table,
         }
         LOG.info(log_json(msg="deleting Hive partitions by source", context=ctx))
-        sql = get_report_db_accessor().get_delete_by_source_sql(self.schema, table, partition_column, provider_uuid)
+        sql = get_report_db_accessor().get_delete_by_source_sql(
+            self.schema, table, partition_column, provider_uuid
+        )
         self._execute_trino_raw_sql_query(
             sql,
             log_ref=f"delete_hive_partitions_by_source for {provider_uuid}",
@@ -484,9 +525,13 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             for model in get_self_hosted_models():
                 # Staging table uses source_uuid, line item tables use source
                 if model == OCPUsageLineItemDailySummaryStaging:
-                    deleted_count, _ = model.objects.filter(source_uuid=provider_uuid_str).delete()
+                    deleted_count, _ = model.objects.filter(
+                        source_uuid=provider_uuid_str
+                    ).delete()
                 else:
-                    deleted_count, _ = model.objects.filter(source=provider_uuid_str).delete()
+                    deleted_count, _ = model.objects.filter(
+                        source=provider_uuid_str
+                    ).delete()
 
                 if deleted_count:
                     LOG.info(
@@ -523,7 +568,9 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             source_column=source_column,
             expired_date=date_str,
         )
-        return self._execute_trino_raw_sql_query(sql, log_ref="finding expired partitions")
+        return self._execute_trino_raw_sql_query(
+            sql, log_ref="finding expired partitions"
+        )
 
     def populate_line_item_daily_summary_table_trino(
         self, start_date, end_date, report_period_id, cluster_id, cluster_alias, source
@@ -546,7 +593,9 @@ AND (month = {{month_no_zero}} OR month = {{month}})
         start_date = DateHelper().parse_to_date(start_date)
         end_date = DateHelper().parse_to_date(end_date)
 
-        storage_exists = trino_table_exists(self.schema, "openshift_storage_usage_line_items_daily")
+        storage_exists = trino_table_exists(
+            self.schema, "openshift_storage_usage_line_items_daily"
+        )
 
         year = start_date.strftime("%Y")
         month = start_date.strftime("%m")
@@ -612,7 +661,9 @@ AND (month = {{month_no_zero}} OR month = {{month}})
         )
         LOG.info(log_json(msg=f"finished updating {table_name}", context=ctx))
 
-    def populate_volume_label_summary_table(self, report_period_ids, start_date, end_date):
+    def populate_volume_label_summary_table(
+        self, report_period_ids, start_date, end_date
+    ):
         """Populate the OCP volume label summary table."""
         table_name = self._table_map["volume_label_summary"]
 
@@ -758,7 +809,9 @@ AND (month = {{month_no_zero}} OR month = {{month}})
                     sql_params["start_date"] = summary_range.start_of_month
                     sql_params["end_date"] = summary_range.end_of_month
 
-            report_period = self.report_periods_for_provider_uuid(provider_uuid, sql_params["start_date"])
+            report_period = self.report_periods_for_provider_uuid(
+                provider_uuid, sql_params["start_date"]
+            )
             if not report_period:
                 msg = f"no report period for OCP provider, skipping {cost_model_key} distribution update"
                 context = {
@@ -772,12 +825,17 @@ AND (month = {{month_no_zero}} OR month = {{month}})
 
             self._delete_monthly_cost_model_rate_type_data(sql_params, cost_model_key)
             self._delete_distributed_rtu_rows(sql_params, cost_model_key)
-            populate = distribution_info.get(cost_model_key, config.distribute_by_default)
+            populate = distribution_info.get(
+                cost_model_key, config.distribute_by_default
+            )
             if not populate:
                 continue
             # Gate: skip GPU distribution if cluster has no GPU data for the period
-            if cost_model_key == metric_constants.GPU_UNALLOCATED and not self._reporting_period_has_gpu_data(
-                provider_uuid, sql_params["start_date"]
+            if (
+                cost_model_key == metric_constants.GPU_UNALLOCATED
+                and not self._reporting_period_has_gpu_data(
+                    provider_uuid, sql_params["start_date"]
+                )
             ):
                 msg = "Skipping GPU full-month summary: no GPU data for cluster"
                 LOG.info(
@@ -790,8 +848,13 @@ AND (month = {{month_no_zero}} OR month = {{month}})
                     )
                 )
                 continue
-            sql_params["distribution"] = distribution_info.get("distribution_type", DEFAULT_DISTRIBUTION_TYPE)
-            if cost_model_key in (metric_constants.NETWORK_UNATTRIBUTED, metric_constants.STORAGE_UNATTRIBUTED):
+            sql_params["distribution"] = distribution_info.get(
+                "distribution_type", DEFAULT_DISTRIBUTION_TYPE
+            )
+            if cost_model_key in (
+                metric_constants.NETWORK_UNATTRIBUTED,
+                metric_constants.STORAGE_UNATTRIBUTED,
+            ):
                 sql_params["infra_to_cm_rate"] = float(infra_to_cm_rate)
                 sql_params["cost_model_currency"] = cost_model_currency
             sql = pkgutil.get_data("masu.database", config.get_full_path())
@@ -802,7 +865,9 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             # Execute using appropriate query engine
             if config.is_trino:
                 # Check if required table exists before executing Trino query
-                if config.has_table_requirement and not config.table_exists(self.schema):
+                if config.has_table_requirement and not config.table_exists(
+                    self.schema
+                ):
                     msg = (
                         f"Skipping {cost_model_key} distribution - "
                         f"required table '{config.required_table}' does not exist"
@@ -822,7 +887,9 @@ AND (month = {{month_no_zero}} OR month = {{month}})
                 sql_params["month"] = start_date_parsed.strftime("%m")
                 self._execute_trino_multipart_sql_query(sql, bind_params=sql_params)
             else:
-                self._prepare_and_execute_raw_sql_query(table_name, sql, sql_params, operation=f"INSERT: {log_msg}")
+                self._prepare_and_execute_raw_sql_query(
+                    table_name, sql, sql_params, operation=f"INSERT: {log_msg}"
+                )
 
         return summary_range
 
@@ -832,7 +899,9 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             "sql/openshift/cost_model/delete_monthly_cost_model_rate_type.sql",
         )
         delete_sql = delete_sql.decode("utf-8")
-        LOG.info(log_json(msg=f"removing {cost_model_key} distribution", context=sql_params))
+        LOG.info(
+            log_json(msg=f"removing {cost_model_key} distribution", context=sql_params)
+        )
         self._prepare_and_execute_raw_sql_query(
             self._table_map["line_item_daily_summary"],
             delete_sql,
@@ -847,7 +916,12 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             "sql/openshift/cost_model/distribute_cost/delete_distributed_rates_to_usage.sql",
         )
         delete_sql = delete_sql.decode("utf-8")
-        LOG.info(log_json(msg=f"removing {cost_model_key} RTU distribution rows", context=sql_params))
+        LOG.info(
+            log_json(
+                msg=f"removing {cost_model_key} RTU distribution rows",
+                context=sql_params,
+            )
+        )
         self._prepare_and_execute_raw_sql_query(
             "rates_to_usage",
             delete_sql,
@@ -856,7 +930,9 @@ AND (month = {{month_no_zero}} OR month = {{month}})
         )
 
     def _delete_monthly_cost_model_data(self, sql_params, ctx):
-        delete_sql = pkgutil.get_data("masu.database", "sql/openshift/cost_model/delete_monthly_cost.sql")
+        delete_sql = pkgutil.get_data(
+            "masu.database", "sql/openshift/cost_model/delete_monthly_cost.sql"
+        )
         delete_sql = delete_sql.decode("utf-8")
         if sql_params.get("rate_type"):
             LOG.info(log_json(msg="removing monthly costs", context=ctx))
@@ -870,7 +946,9 @@ AND (month = {{month_no_zero}} OR month = {{month}})
         )
 
     @staticmethod
-    def _get_routing_metric_type(cost_type=None, distribution=None, usage_type=None, metric_name=None):
+    def _get_routing_metric_type(
+        cost_type=None, distribution=None, usage_type=None, metric_name=None
+    ):
         """Map cost parameters to the aggregation routing bucket.
 
         The aggregation SQL routes ``calculated_cost`` into daily-summary
@@ -927,7 +1005,9 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             distribution: Choice of monthly distribution ex. memory
             provider_uuid (str): The str of the provider UUID
         """
-        if cost_type == "OCP_VM_CORE" and not trino_table_exists(self.schema, "openshift_vm_usage_line_items"):
+        if cost_type == "OCP_VM_CORE" and not trino_table_exists(
+            self.schema, "openshift_vm_usage_line_items"
+        ):
             return
         cost_type_file_mapping = {
             "Node": "sql/openshift/cost_model/monthly_cost_cluster_and_node.sql",
@@ -939,7 +1019,9 @@ AND (month = {{month_no_zero}} OR month = {{month}})
         }
         cost_type_file = cost_type_file_mapping.get(cost_type)
         if not cost_type_file:
-            LOG.warning(f"Invalid cost_type: {cost_type} for OCP provider. Skipping populate_monthly_cost_sql update")
+            LOG.warning(
+                f"Invalid cost_type: {cost_type} for OCP provider. Skipping populate_monthly_cost_sql update"
+            )
             return
 
         table_name = self._table_map["line_item_daily_summary"]
@@ -990,7 +1072,9 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             "cost_model_id": cost_model_id,
             "rate_uuid": rate_uuid,
             "custom_name": custom_name or cost_type,
-            "metric_type": self._get_routing_metric_type(cost_type=cost_type, distribution=distribution),
+            "metric_type": self._get_routing_metric_type(
+                cost_type=cost_type, distribution=distribution
+            ),
         }
         insert_sql = pkgutil.get_data("masu.database", cost_type_file)
         insert_sql = insert_sql.decode("utf-8")
@@ -1001,7 +1085,9 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             sql_params["month"] = start_date.strftime("%m")
             self._execute_trino_multipart_sql_query(insert_sql, bind_params=sql_params)
         else:
-            self._prepare_and_execute_raw_sql_query(table_name, insert_sql, sql_params, operation="INSERT")
+            self._prepare_and_execute_raw_sql_query(
+                table_name, insert_sql, sql_params, operation="INSERT"
+            )
 
     def populate_tag_cost_sql(
         self,
@@ -1046,7 +1132,9 @@ AND (month = {{month_no_zero}} OR month = {{month}})
         labels = case_dict.get("labels")
 
         if "Node" in cost_type:
-            sql = pkgutil.get_data("masu.database", "sql/openshift/cost_model/node_cost_by_tag.sql")
+            sql = pkgutil.get_data(
+                "masu.database", "sql/openshift/cost_model/node_cost_by_tag.sql"
+            )
         elif cost_type == "PVC":
             sql = pkgutil.get_data(
                 "masu.database",
@@ -1071,17 +1159,23 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             "cost_model_id": cost_model_id,
             "rate_uuid": rate_uuid,
             "custom_name": custom_name or cost_type,
-            "metric_type": self._get_routing_metric_type(cost_type=cost_type, distribution=distribution),
+            "metric_type": self._get_routing_metric_type(
+                cost_type=cost_type, distribution=distribution
+            ),
         }
 
         if case_dict.get("unallocated"):
-            unallocated_cpu_case, unallocated_memory_case, unallocated_volume_case = case_dict.get("unallocated")
+            unallocated_cpu_case, unallocated_memory_case, unallocated_volume_case = (
+                case_dict.get("unallocated")
+            )
             sql_params["unallocated_cost_model_cpu_cost"] = unallocated_cpu_case
             sql_params["unallocated_cost_model_memory_cost"] = unallocated_memory_case
             sql_params["unallocated_cost_model_volume_cost"] = unallocated_volume_case
 
         LOG.info(log_json(msg="populating tag costs", context=ctx))
-        self._prepare_and_execute_raw_sql_query(table_name, sql, sql_params, operation="INSERT")
+        self._prepare_and_execute_raw_sql_query(
+            table_name, sql, sql_params, operation="INSERT"
+        )
 
     def populate_vm_usage_costs(
         self,
@@ -1096,7 +1190,9 @@ AND (month = {{month_no_zero}} OR month = {{month}})
     ):
         if not vm_usage_rates:
             return
-        vm_table_exists = trino_table_exists(self.schema, "openshift_vm_usage_line_items")
+        vm_table_exists = trino_table_exists(
+            self.schema, "openshift_vm_usage_line_items"
+        )
         rate_info_map = rate_info_map or {}
         vm_usage_metadata = {
             metric_constants.OCP_VM_HOUR: {
@@ -1132,7 +1228,9 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             if metric_params := metadata.get("metric_params"):
                 context_params.update(metric_params)
             sql_params = param_builder.build_parameters(context_params=context_params)
-            sql = pkgutil.get_data("masu.database", metadata["file_path"]).decode("utf-8")
+            sql = pkgutil.get_data("masu.database", metadata["file_path"]).decode(
+                "utf-8"
+            )
             LOG.info(log_json(msg=metadata["log_msg"], context=sql_params))
             self._execute_trino_multipart_sql_query(sql, bind_params=sql_params)
 
@@ -1172,7 +1270,9 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             # We cleared out existing data, but there is no new to calculate.
             return
 
-        sql = pkgutil.get_data("masu.database", "sql/openshift/cost_model/usage_costs.sql")
+        sql = pkgutil.get_data(
+            "masu.database", "sql/openshift/cost_model/usage_costs.sql"
+        )
 
         sql = sql.decode("utf-8")
         sql_params = {
@@ -1188,9 +1288,13 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             sql_params[metric] = rates.get(metric, 0)
 
         LOG.info(log_json(msg=f"populating {rate_type} usage costs", context=ctx))
-        self._prepare_and_execute_raw_sql_query(table_name, sql, sql_params, operation="INSERT")
+        self._prepare_and_execute_raw_sql_query(
+            table_name, sql, sql_params, operation="INSERT"
+        )
 
-    def populate_usage_rates_to_usage(self, start_date, end_date, provider_uuid, report_period_id, cost_model_id):
+    def populate_usage_rates_to_usage(
+        self, start_date, end_date, provider_uuid, report_period_id, cost_model_id
+    ):
         """Delete stale rows and insert per-rate cost rows into rates_to_usage (single-pass).
 
         All rate values (including cluster_cost_per_hour) are read from
@@ -1212,10 +1316,16 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             "cost_model_id": cost_model_id,
         }
 
-        LOG.info(log_json(msg="populating rates_to_usage (single-pass)", context=sql_params))
-        self._prepare_and_execute_raw_sql_query("rates_to_usage", sql, sql_params, operation="INSERT")
+        LOG.info(
+            log_json(msg="populating rates_to_usage (single-pass)", context=sql_params)
+        )
+        self._prepare_and_execute_raw_sql_query(
+            "rates_to_usage", sql, sql_params, operation="INSERT"
+        )
 
-    def populate_markup_rates_to_usage(self, start_date, end_date, source_uuid, cluster_id, cost_model_id):
+    def populate_markup_rates_to_usage(
+        self, start_date, end_date, source_uuid, cluster_id, cost_model_id
+    ):
         """Write markup costs as RatesToUsage rows with metric_type='markup'.
 
         Reads from infrastructure_markup_cost on daily summary (set by
@@ -1237,10 +1347,17 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             "cost_model_id": cost_model_id,
         }
         LOG.info(log_json(msg="populating markup rates_to_usage", context=sql_params))
-        self._prepare_and_execute_raw_sql_query("rates_to_usage", sql, sql_params, operation="INSERT")
+        self._prepare_and_execute_raw_sql_query(
+            "rates_to_usage", sql, sql_params, operation="INSERT"
+        )
 
     def aggregate_rates_to_daily_summary(
-        self, start_date, end_date, source_uuid, report_period_id, cost_model_currency="USD"
+        self,
+        start_date,
+        end_date,
+        source_uuid,
+        report_period_id,
+        cost_model_currency="USD",
     ):
         """Aggregate RatesToUsage rows into daily summary cost columns."""
 
@@ -1258,10 +1375,18 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             "report_period_id": report_period_id,
             "cost_model_currency": cost_model_currency,
         }
-        LOG.info(log_json(msg="aggregating rates_to_usage → daily summary", context=sql_params))
-        self._prepare_and_execute_raw_sql_query(table_name, sql, sql_params, operation="INSERT")
+        LOG.info(
+            log_json(
+                msg="aggregating rates_to_usage → daily summary", context=sql_params
+            )
+        )
+        self._prepare_and_execute_raw_sql_query(
+            table_name, sql, sql_params, operation="INSERT"
+        )
 
-    def validate_rates_against_daily_summary(self, start_date, end_date, source_uuid, report_period_id):
+    def validate_rates_against_daily_summary(
+        self, start_date, end_date, source_uuid, report_period_id
+    ):
         """CI-only: return diff rows between RTU aggregates and daily summary. Empty = correct."""
         sql = pkgutil.get_data(
             "masu.database",
@@ -1298,8 +1423,12 @@ AND (month = {{month_no_zero}} OR month = {{month}})
 
         Called once per (metric, tag_key, tag_value) combination.
         """
-        infrastructure_rates = filter_dictionary(infrastructure_rates, metric_constants.USAGE_METRIC_MAP.keys())
-        supplementary_rates = filter_dictionary(supplementary_rates, metric_constants.USAGE_METRIC_MAP.keys())
+        infrastructure_rates = filter_dictionary(
+            infrastructure_rates, metric_constants.USAGE_METRIC_MAP.keys()
+        )
+        supplementary_rates = filter_dictionary(
+            supplementary_rates, metric_constants.USAGE_METRIC_MAP.keys()
+        )
         rate_types = [
             {
                 "rates": infrastructure_rates,
@@ -1329,7 +1458,9 @@ AND (month = {{month_no_zero}} OR month = {{month}})
                 table_name = self._table_map["line_item_daily_summary"]
                 rate_info = rate_info_map.get((metric, cost_type_label, ""), {})
                 for tag_key in tags:
-                    tag_rate_info = rate_info_map.get((metric, cost_type_label, tag_key), rate_info)
+                    tag_rate_info = rate_info_map.get(
+                        (metric, cost_type_label, tag_key), rate_info
+                    )
                     tag_vals = tags.get(tag_key, {})
                     value_names = list(tag_vals.keys())
                     for val_name in value_names:
@@ -1354,8 +1485,14 @@ AND (month = {{month_no_zero}} OR month = {{month}})
                             "report_period_id": report_period_id,
                         }
                         ctx = self.extract_context_from_sql_params(sql_params)
-                        LOG.info(log_json(msg="running populate_tag_usage_costs SQL", context=ctx))
-                        self._prepare_and_execute_raw_sql_query(table_name, sql, sql_params)
+                        LOG.info(
+                            log_json(
+                                msg="running populate_tag_usage_costs SQL", context=ctx
+                            )
+                        )
+                        self._prepare_and_execute_raw_sql_query(
+                            table_name, sql, sql_params
+                        )
 
     def populate_tag_usage_default_costs(  # noqa: C901
         self,
@@ -1370,8 +1507,12 @@ AND (month = {{month_no_zero}} OR month = {{month}})
         report_period_id=None,
     ):
         """Insert per-rate default tag-based usage costs into rates_to_usage."""
-        infrastructure_rates = filter_dictionary(infrastructure_rates, metric_constants.USAGE_METRIC_MAP.keys())
-        supplementary_rates = filter_dictionary(supplementary_rates, metric_constants.USAGE_METRIC_MAP.keys())
+        infrastructure_rates = filter_dictionary(
+            infrastructure_rates, metric_constants.USAGE_METRIC_MAP.keys()
+        )
+        supplementary_rates = filter_dictionary(
+            supplementary_rates, metric_constants.USAGE_METRIC_MAP.keys()
+        )
         rate_types = [
             {
                 "rates": infrastructure_rates,
@@ -1411,7 +1552,9 @@ AND (month = {{month_no_zero}} OR month = {{month}})
                     for value_to_skip in value_names:
                         key_value_pair.append(json.dumps({tag_key: value_to_skip}))
                     json.dumps(key_value_pair)
-                    tag_rate_info = rate_info_map.get((metric, cost_type_label, tag_key), rate_info)
+                    tag_rate_info = rate_info_map.get(
+                        (metric, cost_type_label, tag_key), rate_info
+                    )
                     sql = pkgutil.get_data("masu.database", sql_file)
                     sql = sql.decode("utf-8")
                     sql_params = {
@@ -1440,7 +1583,9 @@ AND (month = {{month_no_zero}} OR month = {{month}})
                     )
                     self._prepare_and_execute_raw_sql_query(table_name, sql, sql_params)
 
-    def populate_openshift_cluster_information_tables(self, provider, cluster_id, cluster_alias, start_date, end_date):
+    def populate_openshift_cluster_information_tables(
+        self, provider, cluster_id, cluster_alias, start_date, end_date
+    ):
         """Populate the cluster, node, PVC, and project tables for the cluster."""
         cluster_table = self.populate_cluster_table(provider, cluster_id, cluster_alias)
 
@@ -1484,7 +1629,9 @@ AND (month = {{month_no_zero}} OR month = {{month}})
         elif cluster.cluster_alias != cluster_alias:
             cluster.cluster_alias = cluster_alias
             cluster.save()
-            msg = "updated cluster entry with new cluster alias in reporting_ocp_clusters"
+            msg = (
+                "updated cluster entry with new cluster alias in reporting_ocp_clusters"
+            )
 
         LOG.info(
             log_json(
@@ -1566,7 +1713,9 @@ AND (month = {{month_no_zero}} OR month = {{month}})
 
                 except IntegrityError as e:
                     LOG.warning(
-                        log_json(msg="IntegrityError raised when creating pvc", pvc=pvc),
+                        log_json(
+                            msg="IntegrityError raised when creating pvc", pvc=pvc
+                        ),
                         exc_info=e,
                     )
 
@@ -1601,11 +1750,15 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             "end": end_date,
             "provider_uuid": source_uuid,
         }
-        return self._execute_trino_raw_sql_query(sql, context=context, log_ref="get_nodes_trino")
+        return self._execute_trino_raw_sql_query(
+            sql, context=context, log_ref="get_nodes_trino"
+        )
 
     def get_pvcs_trino(self, source_uuid, start_date, end_date):
         """Get the nodes from an OpenShift cluster."""
-        if not trino_table_exists(self.schema, "openshift_storage_usage_line_items_daily"):
+        if not trino_table_exists(
+            self.schema, "openshift_storage_usage_line_items_daily"
+        ):
             return []
         sql = get_report_db_accessor().get_pvcs_query_sql(
             schema_name=self.schema,
@@ -1621,7 +1774,9 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             "end": end_date,
             "provider_uuid": source_uuid,
         }
-        return self._execute_trino_raw_sql_query(sql, context=context, log_ref="get_pvcs_trino")
+        return self._execute_trino_raw_sql_query(
+            sql, context=context, log_ref="get_pvcs_trino"
+        )
 
     def get_projects_trino(self, source_uuid, start_date, end_date):
         """Get the nodes from an OpenShift cluster."""
@@ -1639,7 +1794,9 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             "end": end_date,
             "provider_uuid": source_uuid,
         }
-        projects = self._execute_trino_raw_sql_query(sql, context=context, log_ref="get_projects_trino")
+        projects = self._execute_trino_raw_sql_query(
+            sql, context=context, log_ref="get_projects_trino"
+        )
 
         return [project[0] for project in projects]
 
@@ -1650,7 +1807,9 @@ AND (month = {{month_no_zero}} OR month = {{month}})
     def get_nodes_for_cluster(self, cluster_pk):
         """Get all nodes for an OCP cluster."""
         nodes = (
-            OCPNode.objects.filter(cluster_id=cluster_pk).exclude(node__exact="").values_list("node", "resource_id")
+            OCPNode.objects.filter(cluster_id=cluster_pk)
+            .exclude(node__exact="")
+            .values_list("node", "resource_id")
         )
         nodes = [(node[0], node[1]) for node in nodes]
         return nodes
@@ -1660,14 +1819,18 @@ AND (month = {{month_no_zero}} OR month = {{month}})
         pvcs = (
             OCPPVC.objects.filter(cluster_id=cluster_pk)
             .exclude(persistent_volume__exact="")
-            .values_list("persistent_volume", "persistent_volume_claim", "csi_volume_handle")
+            .values_list(
+                "persistent_volume", "persistent_volume_claim", "csi_volume_handle"
+            )
         )
         pvcs = [(pvc[0], pvc[1], pvc[2]) for pvc in pvcs]
         return pvcs
 
     def get_projects_for_cluster(self, cluster_pk):
         """Get all nodes for an OCP cluster."""
-        projects = OCPProject.objects.filter(cluster_id=cluster_pk).values_list("project")
+        projects = OCPProject.objects.filter(cluster_id=cluster_pk).values_list(
+            "project"
+        )
         projects = [project[0] for project in projects]
         return projects
 
@@ -1688,14 +1851,18 @@ AND (month = {{month_no_zero}} OR month = {{month}})
                     "resource_ids": [node[1] for node in nodes_tuple],
                     "persistent_volumes": [pvc[0] for pvc in pvc_tuple],
                     "persistent_volume_claims": [pvc[1] for pvc in pvc_tuple],
-                    "csi_volume_handle": [pvc[2] for pvc in pvc_tuple if pvc[2] is not None],
+                    "csi_volume_handle": [
+                        pvc[2] for pvc in pvc_tuple if pvc[2] is not None
+                    ],
                     "projects": [project for project in project_tuple],
                 }
             )
 
         return topology_list
 
-    def get_filtered_openshift_topology_for_multiple_providers(self, provider_uuids, start_date, end_date):
+    def get_filtered_openshift_topology_for_multiple_providers(
+        self, provider_uuids, start_date, end_date
+    ):
         """Return a dictionary with 1 or more Clusters topology."""
         topology_list = []
         for provider_uuid in provider_uuids:
@@ -1715,7 +1882,9 @@ AND (month = {{month_no_zero}} OR month = {{month}})
 
         return topology_list
 
-    def delete_infrastructure_raw_cost_from_daily_summary(self, provider_uuid, report_period_id, start_date, end_date):
+    def delete_infrastructure_raw_cost_from_daily_summary(
+        self, provider_uuid, report_period_id, start_date, end_date
+    ):
         table_name = OCP_REPORT_TABLE_MAP["line_item_daily_summary"]
         ctx = {
             "schema": self.schema,
@@ -1725,7 +1894,11 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             "table_name": table_name,
             "report_period_id": report_period_id,
         }
-        LOG.info(log_json(msg="removing infrastructure raw cast from daily summary", context=ctx))
+        LOG.info(
+            log_json(
+                msg="removing infrastructure raw cast from daily summary", context=ctx
+            )
+        )
         sql = f"""
             DELETE FROM {self.schema}.reporting_ocpusagelineitem_daily_summary
             WHERE usage_start >= '{start_date}'::date
@@ -1772,7 +1945,9 @@ AND (month = {{month_no_zero}} OR month = {{month}})
                 **sql_params,
             )
         )
-        script_file_name = f"reporting_ocpallcostlineitem_project_daily_summary_{platform.lower()}.sql"
+        script_file_name = (
+            f"reporting_ocpallcostlineitem_project_daily_summary_{platform.lower()}.sql"
+        )
         script_file_path = f"{self.OCP_ON_ALL_SQL_PATH}{script_file_name}"
         self._execute_processing_script("masu.database", script_file_path, sql_params)
 
@@ -1783,15 +1958,23 @@ AND (month = {{month_no_zero}} OR month = {{month}})
                 **sql_params,
             )
         )
-        script_file_name = f"reporting_ocpallcostlineitem_daily_summary_{platform.lower()}.sql"
+        script_file_name = (
+            f"reporting_ocpallcostlineitem_daily_summary_{platform.lower()}.sql"
+        )
         script_file_path = f"{self.OCP_ON_ALL_SQL_PATH}{script_file_name}"
         self._execute_processing_script("masu.database", script_file_path, sql_params)
 
     def populate_ocp_on_all_ui_summary_tables(self, sql_params):
         for perspective in OCP_ON_ALL_PERSPECTIVES:
-            LOG.info(log_json(msg=f"populating {perspective._meta.db_table}", **sql_params))
-            script_file_path = f"{self.OCP_ON_ALL_SQL_PATH}{perspective._meta.db_table}.sql"
-            self._execute_processing_script("masu.database", script_file_path, sql_params)
+            LOG.info(
+                log_json(msg=f"populating {perspective._meta.db_table}", **sql_params)
+            )
+            script_file_path = (
+                f"{self.OCP_ON_ALL_SQL_PATH}{perspective._meta.db_table}.sql"
+            )
+            self._execute_processing_script(
+                "masu.database", script_file_path, sql_params
+            )
 
     def get_max_min_timestamp_from_parquet(self, source_uuid, start_date, end_date):
         """Get the max and min timestamps for parquet data given a date range"""
@@ -1813,8 +1996,16 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             sql, context=context, log_ref="get_max_min_timestamp_from_parquet"
         )
         minim, maxim = timestamps[0]
-        minim = parse(str(minim)) if minim else datetime.datetime(start_date.year, start_date.month, start_date.day)
-        maxim = parse(str(maxim)) if maxim else datetime.datetime(end_date.year, end_date.month, end_date.day)
+        minim = (
+            parse(str(minim))
+            if minim
+            else datetime.datetime(start_date.year, start_date.month, start_date.day)
+        )
+        maxim = (
+            parse(str(maxim))
+            if maxim
+            else datetime.datetime(end_date.year, end_date.month, end_date.day)
+        )
         return minim, maxim
 
     def populate_tag_based_costs(  # noqa: C901
@@ -1840,8 +2031,12 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             "amortized_denominator": DateHelper().days_in_month(start_date),
             "cost_type": "Tag",
         }
-        vm_table_exists = trino_table_exists(self.schema, "openshift_vm_usage_line_items")
-        gpu_table_exists = trino_table_exists(self.schema, "openshift_gpu_usage_line_items_daily")
+        vm_table_exists = trino_table_exists(
+            self.schema, "openshift_vm_usage_line_items"
+        )
+        gpu_table_exists = trino_table_exists(
+            self.schema, "openshift_gpu_usage_line_items_daily"
+        )
         requires_vm_table = [
             metric_constants.OCP_VM_CORE_HOUR,
             metric_constants.OCP_VM_CORE_MONTH,
@@ -1926,12 +2121,20 @@ AND (month = {{month_no_zero}} OR month = {{month}})
                 context_params["cost_model_id"] = cost_model_id
                 context_params["rate_uuid"] = rate_info.get("rate_uuid")
                 context_params["custom_name"] = rate_info.get("custom_name", name)
-                context_params["metric_type"] = self._get_routing_metric_type(metric_name=name)
-                final_sql_params = param_builder.build_parameters(context_params=context_params)
-                sql = pkgutil.get_data("masu.database", metadata["file_path"]).decode("utf-8")
+                context_params["metric_type"] = self._get_routing_metric_type(
+                    metric_name=name
+                )
+                final_sql_params = param_builder.build_parameters(
+                    context_params=context_params
+                )
+                sql = pkgutil.get_data("masu.database", metadata["file_path"]).decode(
+                    "utf-8"
+                )
                 LOG.info(log_json(msg=metadata["log_msg"], context=context_params))
                 if self.get_sql_folder_name() in metadata["file_path"]:
-                    self._execute_trino_multipart_sql_query(sql, bind_params=final_sql_params)
+                    self._execute_trino_multipart_sql_query(
+                        sql, bind_params=final_sql_params
+                    )
                 else:
                     self._prepare_and_execute_raw_sql_query(
                         self._table_map["line_item_daily_summary"],

--- a/koku/masu/database/ocp_report_db_accessor.py
+++ b/koku/masu/database/ocp_report_db_accessor.py
@@ -676,25 +676,25 @@ AND (month = {{month_no_zero}} OR month = {{month}})
 
         distribution_configs = {
             metric_constants.PLATFORM_COST: DistributionConfig(
-                sql_file="distribute_platform_cost.sql",
+                sql_file="distribute_platform_cost_per_rate.sql",
                 cost_model_rate_type="platform_distributed",
             ),
             metric_constants.WORKER_UNALLOCATED: DistributionConfig(
-                sql_file="distribute_worker_cost.sql",
+                sql_file="distribute_worker_cost_per_rate.sql",
                 cost_model_rate_type="worker_distributed",
             ),
             metric_constants.STORAGE_UNATTRIBUTED: DistributionConfig(
-                sql_file="distribute_unattributed_storage_cost.sql",
+                sql_file="distribute_unattributed_storage_per_rate.sql",
                 cost_model_rate_type="unattributed_storage",
-                distribute_by_default=True,  # Distributed without cost model
+                distribute_by_default=True,
             ),
             metric_constants.NETWORK_UNATTRIBUTED: DistributionConfig(
-                sql_file="distribute_unattributed_network_cost.sql",
+                sql_file="distribute_unattributed_network_per_rate.sql",
                 cost_model_rate_type="unattributed_network",
-                distribute_by_default=True,  # Distributed without cost model
+                distribute_by_default=True,
             ),
             metric_constants.GPU_UNALLOCATED: DistributionConfig(
-                sql_file="distribute_unallocated_gpu_cost.sql",
+                sql_file="distribute_unallocated_gpu_per_rate.sql",
                 cost_model_rate_type="gpu_distributed",
                 query_type="trino",
                 required_table="openshift_gpu_usage_line_items_daily",
@@ -766,6 +766,7 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             sql_params["report_period_id"] = report_period.id
 
             self._delete_monthly_cost_model_rate_type_data(sql_params, cost_model_key)
+            self._delete_distributed_rtu_rows(sql_params, cost_model_key)
             populate = distribution_info.get(cost_model_key, config.distribute_by_default)
             if not populate:
                 continue
@@ -826,6 +827,21 @@ AND (month = {{month_no_zero}} OR month = {{month}})
         LOG.info(log_json(msg=f"removing {cost_model_key} distribution", context=sql_params))
         self._prepare_and_execute_raw_sql_query(
             self._table_map["line_item_daily_summary"],
+            delete_sql,
+            sql_params,
+            operation="DELETE",
+        )
+
+    def _delete_distributed_rtu_rows(self, sql_params, cost_model_key):
+        """Delete distributed rows from rates_to_usage before re-inserting."""
+        delete_sql = pkgutil.get_data(
+            "masu.database",
+            "sql/openshift/cost_model/distribute_cost/delete_distributed_rates_to_usage.sql",
+        )
+        delete_sql = delete_sql.decode("utf-8")
+        LOG.info(log_json(msg=f"removing {cost_model_key} RTU distribution rows", context=sql_params))
+        self._prepare_and_execute_raw_sql_query(
+            "rates_to_usage",
             delete_sql,
             sql_params,
             operation="DELETE",

--- a/koku/masu/database/ocp_report_db_accessor.py
+++ b/koku/masu/database/ocp_report_db_accessor.py
@@ -96,18 +96,14 @@ class OCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
             if isinstance(start_date, str):
                 start_date = parse(start_date)
             report_date = start_date.replace(day=1)
-            report_periods = report_periods.filter(
-                report_period_start=report_date
-            ).first()
+            report_periods = report_periods.filter(report_period_start=report_date).first()
         return report_periods
 
     def get_report_periods_before_date(self, date):
         """Get the report periods with report period before provided date."""
         return OCPUsageReportPeriod.objects.filter(report_period_start__lte=date)
 
-    def populate_ui_summary_tables(
-        self, summary_range: SummaryRangeConfig, source_uuid, tables=UI_SUMMARY_TABLES
-    ):
+    def populate_ui_summary_tables(self, summary_range: SummaryRangeConfig, source_uuid, tables=UI_SUMMARY_TABLES):
         """Populate our UI summary tables (formerly materialized views)."""
         sql_params = {
             "start_date": summary_range.start_date,
@@ -116,13 +112,9 @@ class OCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
             "source_uuid": source_uuid,
         }
         for table_name in tables:
-            sql = pkgutil.get_data(
-                "masu.database", f"sql/openshift/ui_summary/{table_name}.sql"
-            )
+            sql = pkgutil.get_data("masu.database", f"sql/openshift/ui_summary/{table_name}.sql")
             sql = sql.decode("utf-8")
-            self._prepare_and_execute_raw_sql_query(
-                table_name, sql, sql_params, operation="DELETE/INSERT"
-            )
+            self._prepare_and_execute_raw_sql_query(table_name, sql, sql_params, operation="DELETE/INSERT")
 
         # Trino Queries:
         start_date = DateHelper().parse_to_date(sql_params["start_date"])
@@ -130,10 +122,7 @@ class OCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
         sql_params["month"] = start_date.strftime("%m")
 
         self._populate_gpu_ui_summary_table_with_usage_only(sql_params)
-        if (
-            summary_range.summarize_previous_month
-            and not summary_range.is_current_month
-        ):
+        if summary_range.summarize_previous_month and not summary_range.is_current_month:
             # Don't resummarize virtualization UI table if we are summarizing previous month
             return
         self._populate_virtualization_ui_summary_table(sql_params)
@@ -154,9 +143,7 @@ class OCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
             from reporting.provider.ocp.self_hosted_models import OCPGPUUsageLineItem
 
             with schema_context(self.schema):
-                gpu_data_exists = OCPGPUUsageLineItem.objects.filter(
-                    source=source_uuid
-                ).exists()
+                gpu_data_exists = OCPGPUUsageLineItem.objects.filter(source=source_uuid).exists()
             if not gpu_data_exists:
                 return
         else:
@@ -179,14 +166,10 @@ class OCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
         cost_model_accessor = CostModelDBAccessor(
             self.schema,
             sql_params.get("source_uuid"),
-            price_list_effective_on=DateHelper().parse_to_date(
-                sql_params.get("start_date")
-            ),
+            price_list_effective_on=DateHelper().parse_to_date(sql_params.get("start_date")),
         )
         # Check to see if the cost model is set up to give cost
-        if cost_model_accessor.metric_to_tag_params_map.get(
-            metric_constants.OCP_GPU_MONTH
-        ):
+        if cost_model_accessor.metric_to_tag_params_map.get(metric_constants.OCP_GPU_MONTH):
             return
 
         cluster_id = get_cluster_id_from_provider(sql_params.get("source_uuid"))
@@ -218,13 +201,9 @@ class OCPReportDBAccessor(SQLScriptAtomicExecutorMixin, ReportDBAccessorBase):
             )
         else:
             # SaaS: execute via Trino
-            self._execute_trino_multipart_sql_query(
-                populate_gpu_usage_info, bind_params=sql_params
-            )
+            self._execute_trino_multipart_sql_query(populate_gpu_usage_info, bind_params=sql_params)
 
-    def _reporting_period_has_gpu_data(
-        self, source_uuid: uuid.UUID, start_date
-    ) -> bool:
+    def _reporting_period_has_gpu_data(self, source_uuid: uuid.UUID, start_date) -> bool:
         """
         Return True if the cluster/source has GPU data for the given reporting period.
 
@@ -291,9 +270,7 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             return
         # create the temp table
         sql_params["uuid"] = str(uuid4().hex)
-        create_temp_table_sql = pkgutil.get_data(
-            "masu.database", "sql/openshift/create_virtualization_tmp_table.sql"
-        )
+        create_temp_table_sql = pkgutil.get_data("masu.database", "sql/openshift/create_virtualization_tmp_table.sql")
         create_temp_table_sql = create_temp_table_sql.decode("utf-8")
         self._prepare_and_execute_raw_sql_query(
             "create temp virtualization table",
@@ -322,21 +299,13 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             f"{self.get_sql_folder_name()}/openshift/{population_temp_table_file}",
         )
         populate_temp_table_sql = populate_temp_table_sql.decode("utf8")
-        self._execute_trino_multipart_sql_query(
-            populate_temp_table_sql, bind_params=sql_params
-        )
+        self._execute_trino_multipart_sql_query(populate_temp_table_sql, bind_params=sql_params)
         # populate vm UI table
-        sql = pkgutil.get_data(
-            "masu.database", f"sql/openshift/ui_summary/{VM_UI_SUMMARY_TABLE}.sql"
-        )
+        sql = pkgutil.get_data("masu.database", f"sql/openshift/ui_summary/{VM_UI_SUMMARY_TABLE}.sql")
         sql = sql.decode("utf-8")
-        self._prepare_and_execute_raw_sql_query(
-            VM_UI_SUMMARY_TABLE, sql, sql_params, operation="DELETE/INSERT"
-        )
+        self._prepare_and_execute_raw_sql_query(VM_UI_SUMMARY_TABLE, sql, sql_params, operation="DELETE/INSERT")
 
-    def update_line_item_daily_summary_with_tag_mapping(
-        self, start_date, end_date, report_period_ids=None
-    ):
+    def update_line_item_daily_summary_with_tag_mapping(self, start_date, end_date, report_period_ids=None):
         """Maps child keys to parent key.
         Args:
             start_date (datetime.date) The date to start mapping keys
@@ -347,15 +316,11 @@ AND (month = {{month_no_zero}} OR month = {{month}})
         """
         with schema_context(self.schema):
             # Early return check to see if they have any tag mappings set.
-            if not TagMapping.objects.filter(
-                child__provider_type=Provider.PROVIDER_OCP
-            ).exists():
+            if not TagMapping.objects.filter(child__provider_type=Provider.PROVIDER_OCP).exists():
                 LOG.debug("No tag mappings for OCP.")
                 return
         table_name = self._table_map["line_item_daily_summary"]
-        sql = pkgutil.get_data(
-            "masu.database", "sql/openshift/ocp_tag_mapping_update_daily_summary.sql"
-        )
+        sql = pkgutil.get_data("masu.database", "sql/openshift/ocp_tag_mapping_update_daily_summary.sql")
         sql = sql.decode("utf-8")
         sql_params = {
             "start_date": start_date,
@@ -365,9 +330,7 @@ AND (month = {{month_no_zero}} OR month = {{month}})
         }
         self._prepare_and_execute_raw_sql_query(table_name, sql, sql_params)
 
-    def get_ocp_infrastructure_map_trino(
-        self, start_date, end_date, **kwargs
-    ):  # noqa: C901
+    def get_ocp_infrastructure_map_trino(self, start_date, end_date, **kwargs):  # noqa: C901
         """Get the OCP on infrastructure map.
 
         Args:
@@ -389,9 +352,7 @@ AND (month = {{month_no_zero}} OR month = {{month}})
         check_azure = False
         check_gcp = False
 
-        if not self.table_exists_trino(
-            TRINO_LINE_ITEM_TABLE_DAILY_MAP.get("pod_usage")
-        ):
+        if not self.table_exists_trino(TRINO_LINE_ITEM_TABLE_DAILY_MAP.get("pod_usage")):
             return {}
         if aws_provider_uuid or ocp_provider_uuid:
             check_aws = self.table_exists_trino(AWS_TRINO_LINE_ITEM_DAILY_TABLE)
@@ -496,9 +457,7 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             "table": table,
         }
         LOG.info(log_json(msg="deleting Hive partitions by source", context=ctx))
-        sql = get_report_db_accessor().get_delete_by_source_sql(
-            self.schema, table, partition_column, provider_uuid
-        )
+        sql = get_report_db_accessor().get_delete_by_source_sql(self.schema, table, partition_column, provider_uuid)
         self._execute_trino_raw_sql_query(
             sql,
             log_ref=f"delete_hive_partitions_by_source for {provider_uuid}",
@@ -525,13 +484,9 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             for model in get_self_hosted_models():
                 # Staging table uses source_uuid, line item tables use source
                 if model == OCPUsageLineItemDailySummaryStaging:
-                    deleted_count, _ = model.objects.filter(
-                        source_uuid=provider_uuid_str
-                    ).delete()
+                    deleted_count, _ = model.objects.filter(source_uuid=provider_uuid_str).delete()
                 else:
-                    deleted_count, _ = model.objects.filter(
-                        source=provider_uuid_str
-                    ).delete()
+                    deleted_count, _ = model.objects.filter(source=provider_uuid_str).delete()
 
                 if deleted_count:
                     LOG.info(
@@ -568,9 +523,7 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             source_column=source_column,
             expired_date=date_str,
         )
-        return self._execute_trino_raw_sql_query(
-            sql, log_ref="finding expired partitions"
-        )
+        return self._execute_trino_raw_sql_query(sql, log_ref="finding expired partitions")
 
     def populate_line_item_daily_summary_table_trino(
         self, start_date, end_date, report_period_id, cluster_id, cluster_alias, source
@@ -593,9 +546,7 @@ AND (month = {{month_no_zero}} OR month = {{month}})
         start_date = DateHelper().parse_to_date(start_date)
         end_date = DateHelper().parse_to_date(end_date)
 
-        storage_exists = trino_table_exists(
-            self.schema, "openshift_storage_usage_line_items_daily"
-        )
+        storage_exists = trino_table_exists(self.schema, "openshift_storage_usage_line_items_daily")
 
         year = start_date.strftime("%Y")
         month = start_date.strftime("%m")
@@ -661,9 +612,7 @@ AND (month = {{month_no_zero}} OR month = {{month}})
         )
         LOG.info(log_json(msg=f"finished updating {table_name}", context=ctx))
 
-    def populate_volume_label_summary_table(
-        self, report_period_ids, start_date, end_date
-    ):
+    def populate_volume_label_summary_table(self, report_period_ids, start_date, end_date):
         """Populate the OCP volume label summary table."""
         table_name = self._table_map["volume_label_summary"]
 
@@ -809,9 +758,7 @@ AND (month = {{month_no_zero}} OR month = {{month}})
                     sql_params["start_date"] = summary_range.start_of_month
                     sql_params["end_date"] = summary_range.end_of_month
 
-            report_period = self.report_periods_for_provider_uuid(
-                provider_uuid, sql_params["start_date"]
-            )
+            report_period = self.report_periods_for_provider_uuid(provider_uuid, sql_params["start_date"])
             if not report_period:
                 msg = f"no report period for OCP provider, skipping {cost_model_key} distribution update"
                 context = {
@@ -825,17 +772,12 @@ AND (month = {{month_no_zero}} OR month = {{month}})
 
             self._delete_monthly_cost_model_rate_type_data(sql_params, cost_model_key)
             self._delete_distributed_rtu_rows(sql_params, cost_model_key)
-            populate = distribution_info.get(
-                cost_model_key, config.distribute_by_default
-            )
+            populate = distribution_info.get(cost_model_key, config.distribute_by_default)
             if not populate:
                 continue
             # Gate: skip GPU distribution if cluster has no GPU data for the period
-            if (
-                cost_model_key == metric_constants.GPU_UNALLOCATED
-                and not self._reporting_period_has_gpu_data(
-                    provider_uuid, sql_params["start_date"]
-                )
+            if cost_model_key == metric_constants.GPU_UNALLOCATED and not self._reporting_period_has_gpu_data(
+                provider_uuid, sql_params["start_date"]
             ):
                 msg = "Skipping GPU full-month summary: no GPU data for cluster"
                 LOG.info(
@@ -848,9 +790,7 @@ AND (month = {{month_no_zero}} OR month = {{month}})
                     )
                 )
                 continue
-            sql_params["distribution"] = distribution_info.get(
-                "distribution_type", DEFAULT_DISTRIBUTION_TYPE
-            )
+            sql_params["distribution"] = distribution_info.get("distribution_type", DEFAULT_DISTRIBUTION_TYPE)
             if cost_model_key in (
                 metric_constants.NETWORK_UNATTRIBUTED,
                 metric_constants.STORAGE_UNATTRIBUTED,
@@ -865,9 +805,7 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             # Execute using appropriate query engine
             if config.is_trino:
                 # Check if required table exists before executing Trino query
-                if config.has_table_requirement and not config.table_exists(
-                    self.schema
-                ):
+                if config.has_table_requirement and not config.table_exists(self.schema):
                     msg = (
                         f"Skipping {cost_model_key} distribution - "
                         f"required table '{config.required_table}' does not exist"
@@ -887,9 +825,7 @@ AND (month = {{month_no_zero}} OR month = {{month}})
                 sql_params["month"] = start_date_parsed.strftime("%m")
                 self._execute_trino_multipart_sql_query(sql, bind_params=sql_params)
             else:
-                self._prepare_and_execute_raw_sql_query(
-                    table_name, sql, sql_params, operation=f"INSERT: {log_msg}"
-                )
+                self._prepare_and_execute_raw_sql_query(table_name, sql, sql_params, operation=f"INSERT: {log_msg}")
 
         return summary_range
 
@@ -899,9 +835,7 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             "sql/openshift/cost_model/delete_monthly_cost_model_rate_type.sql",
         )
         delete_sql = delete_sql.decode("utf-8")
-        LOG.info(
-            log_json(msg=f"removing {cost_model_key} distribution", context=sql_params)
-        )
+        LOG.info(log_json(msg=f"removing {cost_model_key} distribution", context=sql_params))
         self._prepare_and_execute_raw_sql_query(
             self._table_map["line_item_daily_summary"],
             delete_sql,
@@ -930,9 +864,7 @@ AND (month = {{month_no_zero}} OR month = {{month}})
         )
 
     def _delete_monthly_cost_model_data(self, sql_params, ctx):
-        delete_sql = pkgutil.get_data(
-            "masu.database", "sql/openshift/cost_model/delete_monthly_cost.sql"
-        )
+        delete_sql = pkgutil.get_data("masu.database", "sql/openshift/cost_model/delete_monthly_cost.sql")
         delete_sql = delete_sql.decode("utf-8")
         if sql_params.get("rate_type"):
             LOG.info(log_json(msg="removing monthly costs", context=ctx))
@@ -946,9 +878,7 @@ AND (month = {{month_no_zero}} OR month = {{month}})
         )
 
     @staticmethod
-    def _get_routing_metric_type(
-        cost_type=None, distribution=None, usage_type=None, metric_name=None
-    ):
+    def _get_routing_metric_type(cost_type=None, distribution=None, usage_type=None, metric_name=None):
         """Map cost parameters to the aggregation routing bucket.
 
         The aggregation SQL routes ``calculated_cost`` into daily-summary
@@ -1005,9 +935,7 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             distribution: Choice of monthly distribution ex. memory
             provider_uuid (str): The str of the provider UUID
         """
-        if cost_type == "OCP_VM_CORE" and not trino_table_exists(
-            self.schema, "openshift_vm_usage_line_items"
-        ):
+        if cost_type == "OCP_VM_CORE" and not trino_table_exists(self.schema, "openshift_vm_usage_line_items"):
             return
         cost_type_file_mapping = {
             "Node": "sql/openshift/cost_model/monthly_cost_cluster_and_node.sql",
@@ -1019,9 +947,7 @@ AND (month = {{month_no_zero}} OR month = {{month}})
         }
         cost_type_file = cost_type_file_mapping.get(cost_type)
         if not cost_type_file:
-            LOG.warning(
-                f"Invalid cost_type: {cost_type} for OCP provider. Skipping populate_monthly_cost_sql update"
-            )
+            LOG.warning(f"Invalid cost_type: {cost_type} for OCP provider. Skipping populate_monthly_cost_sql update")
             return
 
         table_name = self._table_map["line_item_daily_summary"]
@@ -1072,9 +998,7 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             "cost_model_id": cost_model_id,
             "rate_uuid": rate_uuid,
             "custom_name": custom_name or cost_type,
-            "metric_type": self._get_routing_metric_type(
-                cost_type=cost_type, distribution=distribution
-            ),
+            "metric_type": self._get_routing_metric_type(cost_type=cost_type, distribution=distribution),
         }
         insert_sql = pkgutil.get_data("masu.database", cost_type_file)
         insert_sql = insert_sql.decode("utf-8")
@@ -1085,9 +1009,7 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             sql_params["month"] = start_date.strftime("%m")
             self._execute_trino_multipart_sql_query(insert_sql, bind_params=sql_params)
         else:
-            self._prepare_and_execute_raw_sql_query(
-                table_name, insert_sql, sql_params, operation="INSERT"
-            )
+            self._prepare_and_execute_raw_sql_query(table_name, insert_sql, sql_params, operation="INSERT")
 
     def populate_tag_cost_sql(
         self,
@@ -1132,9 +1054,7 @@ AND (month = {{month_no_zero}} OR month = {{month}})
         labels = case_dict.get("labels")
 
         if "Node" in cost_type:
-            sql = pkgutil.get_data(
-                "masu.database", "sql/openshift/cost_model/node_cost_by_tag.sql"
-            )
+            sql = pkgutil.get_data("masu.database", "sql/openshift/cost_model/node_cost_by_tag.sql")
         elif cost_type == "PVC":
             sql = pkgutil.get_data(
                 "masu.database",
@@ -1159,23 +1079,17 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             "cost_model_id": cost_model_id,
             "rate_uuid": rate_uuid,
             "custom_name": custom_name or cost_type,
-            "metric_type": self._get_routing_metric_type(
-                cost_type=cost_type, distribution=distribution
-            ),
+            "metric_type": self._get_routing_metric_type(cost_type=cost_type, distribution=distribution),
         }
 
         if case_dict.get("unallocated"):
-            unallocated_cpu_case, unallocated_memory_case, unallocated_volume_case = (
-                case_dict.get("unallocated")
-            )
+            unallocated_cpu_case, unallocated_memory_case, unallocated_volume_case = case_dict.get("unallocated")
             sql_params["unallocated_cost_model_cpu_cost"] = unallocated_cpu_case
             sql_params["unallocated_cost_model_memory_cost"] = unallocated_memory_case
             sql_params["unallocated_cost_model_volume_cost"] = unallocated_volume_case
 
         LOG.info(log_json(msg="populating tag costs", context=ctx))
-        self._prepare_and_execute_raw_sql_query(
-            table_name, sql, sql_params, operation="INSERT"
-        )
+        self._prepare_and_execute_raw_sql_query(table_name, sql, sql_params, operation="INSERT")
 
     def populate_vm_usage_costs(
         self,
@@ -1190,9 +1104,7 @@ AND (month = {{month_no_zero}} OR month = {{month}})
     ):
         if not vm_usage_rates:
             return
-        vm_table_exists = trino_table_exists(
-            self.schema, "openshift_vm_usage_line_items"
-        )
+        vm_table_exists = trino_table_exists(self.schema, "openshift_vm_usage_line_items")
         rate_info_map = rate_info_map or {}
         vm_usage_metadata = {
             metric_constants.OCP_VM_HOUR: {
@@ -1228,9 +1140,7 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             if metric_params := metadata.get("metric_params"):
                 context_params.update(metric_params)
             sql_params = param_builder.build_parameters(context_params=context_params)
-            sql = pkgutil.get_data("masu.database", metadata["file_path"]).decode(
-                "utf-8"
-            )
+            sql = pkgutil.get_data("masu.database", metadata["file_path"]).decode("utf-8")
             LOG.info(log_json(msg=metadata["log_msg"], context=sql_params))
             self._execute_trino_multipart_sql_query(sql, bind_params=sql_params)
 
@@ -1270,9 +1180,7 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             # We cleared out existing data, but there is no new to calculate.
             return
 
-        sql = pkgutil.get_data(
-            "masu.database", "sql/openshift/cost_model/usage_costs.sql"
-        )
+        sql = pkgutil.get_data("masu.database", "sql/openshift/cost_model/usage_costs.sql")
 
         sql = sql.decode("utf-8")
         sql_params = {
@@ -1288,13 +1196,9 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             sql_params[metric] = rates.get(metric, 0)
 
         LOG.info(log_json(msg=f"populating {rate_type} usage costs", context=ctx))
-        self._prepare_and_execute_raw_sql_query(
-            table_name, sql, sql_params, operation="INSERT"
-        )
+        self._prepare_and_execute_raw_sql_query(table_name, sql, sql_params, operation="INSERT")
 
-    def populate_usage_rates_to_usage(
-        self, start_date, end_date, provider_uuid, report_period_id, cost_model_id
-    ):
+    def populate_usage_rates_to_usage(self, start_date, end_date, provider_uuid, report_period_id, cost_model_id):
         """Delete stale rows and insert per-rate cost rows into rates_to_usage (single-pass).
 
         All rate values (including cluster_cost_per_hour) are read from
@@ -1316,16 +1220,10 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             "cost_model_id": cost_model_id,
         }
 
-        LOG.info(
-            log_json(msg="populating rates_to_usage (single-pass)", context=sql_params)
-        )
-        self._prepare_and_execute_raw_sql_query(
-            "rates_to_usage", sql, sql_params, operation="INSERT"
-        )
+        LOG.info(log_json(msg="populating rates_to_usage (single-pass)", context=sql_params))
+        self._prepare_and_execute_raw_sql_query("rates_to_usage", sql, sql_params, operation="INSERT")
 
-    def populate_markup_rates_to_usage(
-        self, start_date, end_date, source_uuid, cluster_id, cost_model_id
-    ):
+    def populate_markup_rates_to_usage(self, start_date, end_date, source_uuid, cluster_id, cost_model_id):
         """Write markup costs as RatesToUsage rows with metric_type='markup'.
 
         Reads from infrastructure_markup_cost on daily summary (set by
@@ -1347,9 +1245,7 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             "cost_model_id": cost_model_id,
         }
         LOG.info(log_json(msg="populating markup rates_to_usage", context=sql_params))
-        self._prepare_and_execute_raw_sql_query(
-            "rates_to_usage", sql, sql_params, operation="INSERT"
-        )
+        self._prepare_and_execute_raw_sql_query("rates_to_usage", sql, sql_params, operation="INSERT")
 
     def aggregate_rates_to_daily_summary(
         self,
@@ -1375,18 +1271,10 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             "report_period_id": report_period_id,
             "cost_model_currency": cost_model_currency,
         }
-        LOG.info(
-            log_json(
-                msg="aggregating rates_to_usage → daily summary", context=sql_params
-            )
-        )
-        self._prepare_and_execute_raw_sql_query(
-            table_name, sql, sql_params, operation="INSERT"
-        )
+        LOG.info(log_json(msg="aggregating rates_to_usage → daily summary", context=sql_params))
+        self._prepare_and_execute_raw_sql_query(table_name, sql, sql_params, operation="INSERT")
 
-    def validate_rates_against_daily_summary(
-        self, start_date, end_date, source_uuid, report_period_id
-    ):
+    def validate_rates_against_daily_summary(self, start_date, end_date, source_uuid, report_period_id):
         """CI-only: return diff rows between RTU aggregates and daily summary. Empty = correct."""
         sql = pkgutil.get_data(
             "masu.database",
@@ -1423,12 +1311,8 @@ AND (month = {{month_no_zero}} OR month = {{month}})
 
         Called once per (metric, tag_key, tag_value) combination.
         """
-        infrastructure_rates = filter_dictionary(
-            infrastructure_rates, metric_constants.USAGE_METRIC_MAP.keys()
-        )
-        supplementary_rates = filter_dictionary(
-            supplementary_rates, metric_constants.USAGE_METRIC_MAP.keys()
-        )
+        infrastructure_rates = filter_dictionary(infrastructure_rates, metric_constants.USAGE_METRIC_MAP.keys())
+        supplementary_rates = filter_dictionary(supplementary_rates, metric_constants.USAGE_METRIC_MAP.keys())
         rate_types = [
             {
                 "rates": infrastructure_rates,
@@ -1458,9 +1342,7 @@ AND (month = {{month_no_zero}} OR month = {{month}})
                 table_name = self._table_map["line_item_daily_summary"]
                 rate_info = rate_info_map.get((metric, cost_type_label, ""), {})
                 for tag_key in tags:
-                    tag_rate_info = rate_info_map.get(
-                        (metric, cost_type_label, tag_key), rate_info
-                    )
+                    tag_rate_info = rate_info_map.get((metric, cost_type_label, tag_key), rate_info)
                     tag_vals = tags.get(tag_key, {})
                     value_names = list(tag_vals.keys())
                     for val_name in value_names:
@@ -1485,14 +1367,8 @@ AND (month = {{month_no_zero}} OR month = {{month}})
                             "report_period_id": report_period_id,
                         }
                         ctx = self.extract_context_from_sql_params(sql_params)
-                        LOG.info(
-                            log_json(
-                                msg="running populate_tag_usage_costs SQL", context=ctx
-                            )
-                        )
-                        self._prepare_and_execute_raw_sql_query(
-                            table_name, sql, sql_params
-                        )
+                        LOG.info(log_json(msg="running populate_tag_usage_costs SQL", context=ctx))
+                        self._prepare_and_execute_raw_sql_query(table_name, sql, sql_params)
 
     def populate_tag_usage_default_costs(  # noqa: C901
         self,
@@ -1507,12 +1383,8 @@ AND (month = {{month_no_zero}} OR month = {{month}})
         report_period_id=None,
     ):
         """Insert per-rate default tag-based usage costs into rates_to_usage."""
-        infrastructure_rates = filter_dictionary(
-            infrastructure_rates, metric_constants.USAGE_METRIC_MAP.keys()
-        )
-        supplementary_rates = filter_dictionary(
-            supplementary_rates, metric_constants.USAGE_METRIC_MAP.keys()
-        )
+        infrastructure_rates = filter_dictionary(infrastructure_rates, metric_constants.USAGE_METRIC_MAP.keys())
+        supplementary_rates = filter_dictionary(supplementary_rates, metric_constants.USAGE_METRIC_MAP.keys())
         rate_types = [
             {
                 "rates": infrastructure_rates,
@@ -1552,9 +1424,7 @@ AND (month = {{month_no_zero}} OR month = {{month}})
                     for value_to_skip in value_names:
                         key_value_pair.append(json.dumps({tag_key: value_to_skip}))
                     json.dumps(key_value_pair)
-                    tag_rate_info = rate_info_map.get(
-                        (metric, cost_type_label, tag_key), rate_info
-                    )
+                    tag_rate_info = rate_info_map.get((metric, cost_type_label, tag_key), rate_info)
                     sql = pkgutil.get_data("masu.database", sql_file)
                     sql = sql.decode("utf-8")
                     sql_params = {
@@ -1583,9 +1453,7 @@ AND (month = {{month_no_zero}} OR month = {{month}})
                     )
                     self._prepare_and_execute_raw_sql_query(table_name, sql, sql_params)
 
-    def populate_openshift_cluster_information_tables(
-        self, provider, cluster_id, cluster_alias, start_date, end_date
-    ):
+    def populate_openshift_cluster_information_tables(self, provider, cluster_id, cluster_alias, start_date, end_date):
         """Populate the cluster, node, PVC, and project tables for the cluster."""
         cluster_table = self.populate_cluster_table(provider, cluster_id, cluster_alias)
 
@@ -1629,9 +1497,7 @@ AND (month = {{month_no_zero}} OR month = {{month}})
         elif cluster.cluster_alias != cluster_alias:
             cluster.cluster_alias = cluster_alias
             cluster.save()
-            msg = (
-                "updated cluster entry with new cluster alias in reporting_ocp_clusters"
-            )
+            msg = "updated cluster entry with new cluster alias in reporting_ocp_clusters"
 
         LOG.info(
             log_json(
@@ -1713,9 +1579,7 @@ AND (month = {{month_no_zero}} OR month = {{month}})
 
                 except IntegrityError as e:
                     LOG.warning(
-                        log_json(
-                            msg="IntegrityError raised when creating pvc", pvc=pvc
-                        ),
+                        log_json(msg="IntegrityError raised when creating pvc", pvc=pvc),
                         exc_info=e,
                     )
 
@@ -1750,15 +1614,11 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             "end": end_date,
             "provider_uuid": source_uuid,
         }
-        return self._execute_trino_raw_sql_query(
-            sql, context=context, log_ref="get_nodes_trino"
-        )
+        return self._execute_trino_raw_sql_query(sql, context=context, log_ref="get_nodes_trino")
 
     def get_pvcs_trino(self, source_uuid, start_date, end_date):
         """Get the nodes from an OpenShift cluster."""
-        if not trino_table_exists(
-            self.schema, "openshift_storage_usage_line_items_daily"
-        ):
+        if not trino_table_exists(self.schema, "openshift_storage_usage_line_items_daily"):
             return []
         sql = get_report_db_accessor().get_pvcs_query_sql(
             schema_name=self.schema,
@@ -1774,9 +1634,7 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             "end": end_date,
             "provider_uuid": source_uuid,
         }
-        return self._execute_trino_raw_sql_query(
-            sql, context=context, log_ref="get_pvcs_trino"
-        )
+        return self._execute_trino_raw_sql_query(sql, context=context, log_ref="get_pvcs_trino")
 
     def get_projects_trino(self, source_uuid, start_date, end_date):
         """Get the nodes from an OpenShift cluster."""
@@ -1794,9 +1652,7 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             "end": end_date,
             "provider_uuid": source_uuid,
         }
-        projects = self._execute_trino_raw_sql_query(
-            sql, context=context, log_ref="get_projects_trino"
-        )
+        projects = self._execute_trino_raw_sql_query(sql, context=context, log_ref="get_projects_trino")
 
         return [project[0] for project in projects]
 
@@ -1807,9 +1663,7 @@ AND (month = {{month_no_zero}} OR month = {{month}})
     def get_nodes_for_cluster(self, cluster_pk):
         """Get all nodes for an OCP cluster."""
         nodes = (
-            OCPNode.objects.filter(cluster_id=cluster_pk)
-            .exclude(node__exact="")
-            .values_list("node", "resource_id")
+            OCPNode.objects.filter(cluster_id=cluster_pk).exclude(node__exact="").values_list("node", "resource_id")
         )
         nodes = [(node[0], node[1]) for node in nodes]
         return nodes
@@ -1819,18 +1673,14 @@ AND (month = {{month_no_zero}} OR month = {{month}})
         pvcs = (
             OCPPVC.objects.filter(cluster_id=cluster_pk)
             .exclude(persistent_volume__exact="")
-            .values_list(
-                "persistent_volume", "persistent_volume_claim", "csi_volume_handle"
-            )
+            .values_list("persistent_volume", "persistent_volume_claim", "csi_volume_handle")
         )
         pvcs = [(pvc[0], pvc[1], pvc[2]) for pvc in pvcs]
         return pvcs
 
     def get_projects_for_cluster(self, cluster_pk):
         """Get all nodes for an OCP cluster."""
-        projects = OCPProject.objects.filter(cluster_id=cluster_pk).values_list(
-            "project"
-        )
+        projects = OCPProject.objects.filter(cluster_id=cluster_pk).values_list("project")
         projects = [project[0] for project in projects]
         return projects
 
@@ -1851,18 +1701,14 @@ AND (month = {{month_no_zero}} OR month = {{month}})
                     "resource_ids": [node[1] for node in nodes_tuple],
                     "persistent_volumes": [pvc[0] for pvc in pvc_tuple],
                     "persistent_volume_claims": [pvc[1] for pvc in pvc_tuple],
-                    "csi_volume_handle": [
-                        pvc[2] for pvc in pvc_tuple if pvc[2] is not None
-                    ],
+                    "csi_volume_handle": [pvc[2] for pvc in pvc_tuple if pvc[2] is not None],
                     "projects": [project for project in project_tuple],
                 }
             )
 
         return topology_list
 
-    def get_filtered_openshift_topology_for_multiple_providers(
-        self, provider_uuids, start_date, end_date
-    ):
+    def get_filtered_openshift_topology_for_multiple_providers(self, provider_uuids, start_date, end_date):
         """Return a dictionary with 1 or more Clusters topology."""
         topology_list = []
         for provider_uuid in provider_uuids:
@@ -1882,9 +1728,7 @@ AND (month = {{month_no_zero}} OR month = {{month}})
 
         return topology_list
 
-    def delete_infrastructure_raw_cost_from_daily_summary(
-        self, provider_uuid, report_period_id, start_date, end_date
-    ):
+    def delete_infrastructure_raw_cost_from_daily_summary(self, provider_uuid, report_period_id, start_date, end_date):
         table_name = OCP_REPORT_TABLE_MAP["line_item_daily_summary"]
         ctx = {
             "schema": self.schema,
@@ -1894,11 +1738,7 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             "table_name": table_name,
             "report_period_id": report_period_id,
         }
-        LOG.info(
-            log_json(
-                msg="removing infrastructure raw cast from daily summary", context=ctx
-            )
-        )
+        LOG.info(log_json(msg="removing infrastructure raw cast from daily summary", context=ctx))
         sql = f"""
             DELETE FROM {self.schema}.reporting_ocpusagelineitem_daily_summary
             WHERE usage_start >= '{start_date}'::date
@@ -1945,9 +1785,7 @@ AND (month = {{month_no_zero}} OR month = {{month}})
                 **sql_params,
             )
         )
-        script_file_name = (
-            f"reporting_ocpallcostlineitem_project_daily_summary_{platform.lower()}.sql"
-        )
+        script_file_name = f"reporting_ocpallcostlineitem_project_daily_summary_{platform.lower()}.sql"
         script_file_path = f"{self.OCP_ON_ALL_SQL_PATH}{script_file_name}"
         self._execute_processing_script("masu.database", script_file_path, sql_params)
 
@@ -1958,23 +1796,15 @@ AND (month = {{month_no_zero}} OR month = {{month}})
                 **sql_params,
             )
         )
-        script_file_name = (
-            f"reporting_ocpallcostlineitem_daily_summary_{platform.lower()}.sql"
-        )
+        script_file_name = f"reporting_ocpallcostlineitem_daily_summary_{platform.lower()}.sql"
         script_file_path = f"{self.OCP_ON_ALL_SQL_PATH}{script_file_name}"
         self._execute_processing_script("masu.database", script_file_path, sql_params)
 
     def populate_ocp_on_all_ui_summary_tables(self, sql_params):
         for perspective in OCP_ON_ALL_PERSPECTIVES:
-            LOG.info(
-                log_json(msg=f"populating {perspective._meta.db_table}", **sql_params)
-            )
-            script_file_path = (
-                f"{self.OCP_ON_ALL_SQL_PATH}{perspective._meta.db_table}.sql"
-            )
-            self._execute_processing_script(
-                "masu.database", script_file_path, sql_params
-            )
+            LOG.info(log_json(msg=f"populating {perspective._meta.db_table}", **sql_params))
+            script_file_path = f"{self.OCP_ON_ALL_SQL_PATH}{perspective._meta.db_table}.sql"
+            self._execute_processing_script("masu.database", script_file_path, sql_params)
 
     def get_max_min_timestamp_from_parquet(self, source_uuid, start_date, end_date):
         """Get the max and min timestamps for parquet data given a date range"""
@@ -1996,16 +1826,8 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             sql, context=context, log_ref="get_max_min_timestamp_from_parquet"
         )
         minim, maxim = timestamps[0]
-        minim = (
-            parse(str(minim))
-            if minim
-            else datetime.datetime(start_date.year, start_date.month, start_date.day)
-        )
-        maxim = (
-            parse(str(maxim))
-            if maxim
-            else datetime.datetime(end_date.year, end_date.month, end_date.day)
-        )
+        minim = parse(str(minim)) if minim else datetime.datetime(start_date.year, start_date.month, start_date.day)
+        maxim = parse(str(maxim)) if maxim else datetime.datetime(end_date.year, end_date.month, end_date.day)
         return minim, maxim
 
     def populate_tag_based_costs(  # noqa: C901
@@ -2031,12 +1853,8 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             "amortized_denominator": DateHelper().days_in_month(start_date),
             "cost_type": "Tag",
         }
-        vm_table_exists = trino_table_exists(
-            self.schema, "openshift_vm_usage_line_items"
-        )
-        gpu_table_exists = trino_table_exists(
-            self.schema, "openshift_gpu_usage_line_items_daily"
-        )
+        vm_table_exists = trino_table_exists(self.schema, "openshift_vm_usage_line_items")
+        gpu_table_exists = trino_table_exists(self.schema, "openshift_gpu_usage_line_items_daily")
         requires_vm_table = [
             metric_constants.OCP_VM_CORE_HOUR,
             metric_constants.OCP_VM_CORE_MONTH,
@@ -2121,20 +1939,12 @@ AND (month = {{month_no_zero}} OR month = {{month}})
                 context_params["cost_model_id"] = cost_model_id
                 context_params["rate_uuid"] = rate_info.get("rate_uuid")
                 context_params["custom_name"] = rate_info.get("custom_name", name)
-                context_params["metric_type"] = self._get_routing_metric_type(
-                    metric_name=name
-                )
-                final_sql_params = param_builder.build_parameters(
-                    context_params=context_params
-                )
-                sql = pkgutil.get_data("masu.database", metadata["file_path"]).decode(
-                    "utf-8"
-                )
+                context_params["metric_type"] = self._get_routing_metric_type(metric_name=name)
+                final_sql_params = param_builder.build_parameters(context_params=context_params)
+                sql = pkgutil.get_data("masu.database", metadata["file_path"]).decode("utf-8")
                 LOG.info(log_json(msg=metadata["log_msg"], context=context_params))
                 if self.get_sql_folder_name() in metadata["file_path"]:
-                    self._execute_trino_multipart_sql_query(
-                        sql, bind_params=final_sql_params
-                    )
+                    self._execute_trino_multipart_sql_query(sql, bind_params=final_sql_params)
                 else:
                     self._prepare_and_execute_raw_sql_query(
                         self._table_map["line_item_daily_summary"],

--- a/koku/masu/database/ocp_report_db_accessor.py
+++ b/koku/masu/database/ocp_report_db_accessor.py
@@ -10,6 +10,7 @@ import logging
 import os
 import pkgutil
 import uuid
+from decimal import Decimal
 from uuid import uuid4
 
 from dateutil.parser import parse
@@ -663,6 +664,8 @@ AND (month = {{month_no_zero}} OR month = {{month}})
         summary_range: SummaryRangeConfig,
         provider_uuid: uuid.UUID,
         distribution_info: dict,
+        infra_to_cm_rate: Decimal = Decimal(1),
+        cost_model_currency: str = "USD",
     ) -> SummaryRangeConfig:
         """
         Populate the distribution cost model options.
@@ -672,6 +675,8 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             end_date (datetime, str): The end_date to calculate monthly_cost.
             distribution: Choice of monthly distribution ex. memory
             provider_uuid (str): The str of the provider UUID
+            infra_to_cm_rate: Exchange rate from infra raw_currency to cost_model_currency.
+            cost_model_currency: The cost model's currency code.
         """
 
         distribution_configs = {
@@ -786,6 +791,9 @@ AND (month = {{month_no_zero}} OR month = {{month}})
                 )
                 continue
             sql_params["distribution"] = distribution_info.get("distribution_type", DEFAULT_DISTRIBUTION_TYPE)
+            if cost_model_key in (metric_constants.NETWORK_UNATTRIBUTED, metric_constants.STORAGE_UNATTRIBUTED):
+                sql_params["infra_to_cm_rate"] = float(infra_to_cm_rate)
+                sql_params["cost_model_currency"] = cost_model_currency
             sql = pkgutil.get_data("masu.database", config.get_full_path())
             sql = sql.decode("utf-8")
             log_msg = f"distributing {cost_model_key}"
@@ -1231,7 +1239,9 @@ AND (month = {{month_no_zero}} OR month = {{month}})
         LOG.info(log_json(msg="populating markup rates_to_usage", context=sql_params))
         self._prepare_and_execute_raw_sql_query("rates_to_usage", sql, sql_params, operation="INSERT")
 
-    def aggregate_rates_to_daily_summary(self, start_date, end_date, source_uuid, report_period_id):
+    def aggregate_rates_to_daily_summary(
+        self, start_date, end_date, source_uuid, report_period_id, cost_model_currency="USD"
+    ):
         """Aggregate RatesToUsage rows into daily summary cost columns."""
 
         table_name = self._table_map["line_item_daily_summary"]
@@ -1246,6 +1256,7 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             "end_date": end_date,
             "source_uuid": source_uuid,
             "report_period_id": report_period_id,
+            "cost_model_currency": cost_model_currency,
         }
         LOG.info(log_json(msg="aggregating rates_to_usage → daily summary", context=sql_params))
         self._prepare_and_execute_raw_sql_query(table_name, sql, sql_params, operation="INSERT")

--- a/koku/masu/database/ocp_report_db_accessor.py
+++ b/koku/masu/database/ocp_report_db_accessor.py
@@ -666,6 +666,7 @@ AND (month = {{month_no_zero}} OR month = {{month}})
         distribution_info: dict,
         infra_to_cm_rate: Decimal = Decimal(1),
         cost_model_currency: str = "USD",
+        cost_model_id=None,
     ) -> SummaryRangeConfig:
         """
         Populate the distribution cost model options.
@@ -716,6 +717,7 @@ AND (month = {{month_no_zero}} OR month = {{month}})
                 "schema": self.schema,
                 "source_uuid": provider_uuid,
                 "cost_model_rate_type": config.cost_model_rate_type,
+                "cost_model_id": cost_model_id,
             }
             # Handle distributions that require full month data
             if config.requires_full_month:

--- a/koku/masu/database/self_hosted_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
+++ b/koku/masu/database/self_hosted_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
@@ -93,6 +93,8 @@ GROUP BY nsp.usage_start, nsp.node, nsp.namespace,
 HAVING MAX(nsp.pod_usage_slice_hours / NULLIF(tu.total_slice_hours, 0) * gc.rate_cost) != 0;
 
 -- Negate source: offset GPU unallocated costs so the net distributed total is zero.
+-- Must negate cost-model costs (from RTU) AND infrastructure/markup costs (from
+-- daily_summary) so the API's cost_total + gpu_distributed sums to zero.
 INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
     uuid, report_period_id, source_uuid, usage_start, usage_end,
     cluster_id, cluster_alias, namespace,
@@ -101,23 +103,49 @@ INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
 )
 SELECT
     uuid_generate_v4(),
-    rtu.report_period_id,
-    rtu.source_uuid,
-    rtu.usage_start,
-    rtu.usage_start,
-    rtu.cluster_id,
-    MAX(rtu.cluster_alias),
+    rtu_agg.report_period_id,
+    rtu_agg.source_uuid,
+    rtu_agg.usage_start,
+    rtu_agg.usage_start,
+    rtu_agg.cluster_id,
+    rtu_agg.cluster_alias,
     'GPU unallocated',
     '', '',
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
-    -SUM(COALESCE(rtu.calculated_cost, 0))
-FROM {{schema | sqlsafe}}.rates_to_usage rtu
-WHERE rtu.usage_start >= DATE({{start_date}})
-    AND rtu.usage_start <= DATE({{end_date}})
-    AND rtu.source_uuid = {{source_uuid}}::uuid
-    AND rtu.namespace = 'GPU unallocated'
-    AND rtu.monthly_cost_type IS NULL
-GROUP BY rtu.report_period_id, rtu.source_uuid, rtu.usage_start,
-         rtu.cluster_id
-HAVING SUM(COALESCE(rtu.calculated_cost, 0)) != 0;
+    -(rtu_agg.cost_model_total + COALESCE(infra_agg.infra_total, 0))
+FROM (
+    SELECT
+        rtu.report_period_id,
+        rtu.source_uuid,
+        rtu.usage_start,
+        rtu.cluster_id,
+        MAX(rtu.cluster_alias) AS cluster_alias,
+        SUM(COALESCE(rtu.calculated_cost, 0)) AS cost_model_total
+    FROM {{schema | sqlsafe}}.rates_to_usage rtu
+    WHERE rtu.usage_start >= DATE({{start_date}})
+        AND rtu.usage_start <= DATE({{end_date}})
+        AND rtu.source_uuid = {{source_uuid}}::uuid
+        AND rtu.namespace = 'GPU unallocated'
+        AND rtu.monthly_cost_type IS NULL
+    GROUP BY rtu.report_period_id, rtu.source_uuid, rtu.usage_start,
+             rtu.cluster_id
+    HAVING SUM(COALESCE(rtu.calculated_cost, 0)) != 0
+) rtu_agg
+LEFT JOIN (
+    SELECT
+        lids.usage_start,
+        lids.cluster_id,
+        SUM(
+            COALESCE(lids.infrastructure_raw_cost, 0) +
+            COALESCE(lids.infrastructure_markup_cost, 0)
+        ) AS infra_total
+    FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
+    WHERE lids.usage_start >= DATE({{start_date}})
+        AND lids.usage_start <= DATE({{end_date}})
+        AND lids.namespace = 'GPU unallocated'
+        AND lids.cost_model_rate_type IS NULL
+    GROUP BY lids.usage_start, lids.cluster_id
+) infra_agg
+    ON rtu_agg.usage_start = infra_agg.usage_start
+    AND rtu_agg.cluster_id = infra_agg.cluster_id;

--- a/koku/masu/database/self_hosted_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
+++ b/koku/masu/database/self_hosted_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
@@ -1,0 +1,94 @@
+-- Per-rate GPU unallocated cost distribution via rates_to_usage (self-hosted).
+-- Reads per-rate GPU costs from RTU (GPU unallocated namespace), distributes
+-- proportionally by MIG-aware slice-hours, writes distributed rows back to RTU
+-- with monthly_cost_type = 'gpu_distributed'.
+INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
+    uuid, report_period_id, source_uuid, usage_start, usage_end,
+    cluster_id, cluster_alias, namespace, node,
+    custom_name, metric_type, cost_model_rate_type,
+    monthly_cost_type, distributed_cost
+)
+WITH gpu_rtu_cost AS (
+    SELECT
+        rtu.usage_start,
+        rtu.source_uuid,
+        rtu.cluster_id,
+        rtu.cluster_alias,
+        rtu.report_period_id,
+        rtu.node,
+        rtu.custom_name,
+        rtu.metric_type,
+        rtu.cost_model_rate_type,
+        SUM(COALESCE(rtu.calculated_cost, 0)) AS rate_cost
+    FROM {{schema | sqlsafe}}.rates_to_usage rtu
+    WHERE rtu.usage_start >= DATE({{start_date}})
+        AND rtu.usage_start <= DATE({{end_date}})
+        AND rtu.source_uuid = {{source_uuid}}::uuid
+        AND rtu.namespace = 'GPU unallocated'
+        AND rtu.monthly_cost_type IS NULL
+    GROUP BY rtu.usage_start, rtu.source_uuid, rtu.cluster_id, rtu.cluster_alias,
+             rtu.report_period_id, rtu.node,
+             rtu.custom_name, rtu.metric_type, rtu.cost_model_rate_type
+),
+gpu_model_map AS (
+    SELECT
+        node,
+        all_labels->>'gpu-model' AS gpu_model,
+        usage_start
+    FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary
+    WHERE namespace = 'GPU unallocated'
+      AND usage_start >= DATE({{start_date}})
+      AND usage_start <= DATE({{end_date}})
+      AND source_uuid = {{source_uuid}}::uuid
+    GROUP BY node, all_labels->>'gpu-model', usage_start
+),
+namespace_usage_information AS (
+    SELECT gpu_model_name,
+        gpu_usage.namespace,
+        gpu_usage.node,
+        SUM(gpu_pod_uptime * COALESCE(gpu_usage.mig_slice_count, 1)) AS pod_usage_slice_hours,
+        gpu_usage.usage_start
+    FROM {{schema | sqlsafe}}.openshift_gpu_usage_line_items_daily AS gpu_usage
+    WHERE source = {{source_uuid}}
+      AND year = {{year}}
+      AND month = {{month}}
+      AND gpu_usage.usage_start >= DATE({{start_date}})
+      AND gpu_usage.usage_start <= DATE({{end_date}})
+    GROUP BY gpu_model_name, gpu_usage.node, namespace, gpu_usage.usage_start
+),
+total_usage AS (
+    SELECT node, gpu_model_name, usage_start,
+           SUM(pod_usage_slice_hours) AS total_slice_hours
+    FROM namespace_usage_information
+    GROUP BY node, gpu_model_name, usage_start
+)
+SELECT
+    uuid_generate_v4(),
+    MAX(gc.report_period_id),
+    gc.source_uuid,
+    nsp.usage_start,
+    nsp.usage_start,
+    MAX(gc.cluster_id),
+    MAX(gc.cluster_alias),
+    nsp.namespace,
+    nsp.node,
+    gc.custom_name,
+    gc.metric_type,
+    gc.cost_model_rate_type,
+    {{cost_model_rate_type}},
+    MAX(nsp.pod_usage_slice_hours / NULLIF(tu.total_slice_hours, 0) * gc.rate_cost)
+FROM gpu_rtu_cost gc
+JOIN gpu_model_map gm
+    ON gm.node = gc.node AND gm.usage_start = gc.usage_start
+JOIN namespace_usage_information nsp
+    ON nsp.node = gc.node
+    AND nsp.gpu_model_name = gm.gpu_model
+    AND nsp.usage_start = gc.usage_start
+JOIN total_usage tu
+    ON tu.node = nsp.node
+    AND tu.gpu_model_name = nsp.gpu_model_name
+    AND tu.usage_start = nsp.usage_start
+GROUP BY nsp.usage_start, nsp.node, nsp.namespace,
+         gc.source_uuid, gc.custom_name, gc.metric_type, gc.cost_model_rate_type
+HAVING MAX(nsp.pod_usage_slice_hours / NULLIF(tu.total_slice_hours, 0) * gc.rate_cost) != 0
+RETURNING 1;

--- a/koku/masu/database/self_hosted_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
+++ b/koku/masu/database/self_hosted_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
@@ -75,7 +75,7 @@ SELECT
     gc.custom_name,
     gc.metric_type,
     gc.cost_model_rate_type,
-    {{cost_model_rate_type}},
+    {{distribution_tag}},
     MAX(nsp.pod_usage_slice_hours / NULLIF(tu.total_slice_hours, 0) * gc.rate_cost)
 FROM gpu_rtu_cost gc
 JOIN gpu_model_map gm

--- a/koku/masu/database/self_hosted_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
+++ b/koku/masu/database/self_hosted_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
@@ -95,60 +95,34 @@ GROUP BY nsp.usage_start, nsp.node, nsp.namespace,
          gc.source_uuid, gc.custom_name, gc.metric_type, gc.cost_model_rate_type
 HAVING MAX(nsp.pod_usage_slice_hours / NULLIF(tu.total_slice_hours, 0) * gc.rate_cost) != 0;
 
--- Negate source: offset GPU unallocated costs so the net distributed total is zero.
--- Must negate cost-model costs (from RTU) AND infrastructure/markup costs (from
--- daily_summary) so the API's cost_total + gpu_distributed sums to zero.
+-- Negate source: derive negation from the distributed output rows just inserted.
+-- Sums distributed_cost of gpu_distributed rows and inserts exact negative,
+-- guaranteeing algebraic zero-sum.
 INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
     uuid, report_period_id, source_uuid, usage_start, usage_end,
-    cluster_id, cluster_alias, namespace,
+    cluster_id, cluster_alias, namespace, node,
     custom_name, metric_type, cost_model_rate_type,
     monthly_cost_type, distributed_cost
 )
 SELECT
     uuid_generate_v4(),
-    rtu_agg.report_period_id,
-    rtu_agg.source_uuid,
-    rtu_agg.usage_start,
-    rtu_agg.usage_start,
-    rtu_agg.cluster_id,
-    rtu_agg.cluster_alias,
+    MAX(rtu.report_period_id),
+    rtu.source_uuid,
+    rtu.usage_start,
+    rtu.usage_start,
+    rtu.cluster_id,
+    MAX(rtu.cluster_alias),
     'GPU unallocated',
+    rtu.node,
     '', '',
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
-    -(rtu_agg.cost_model_total + COALESCE(infra_agg.infra_total, 0))
-FROM (
-    SELECT
-        rtu.report_period_id,
-        rtu.source_uuid,
-        rtu.usage_start,
-        rtu.cluster_id,
-        MAX(rtu.cluster_alias) AS cluster_alias,
-        SUM(COALESCE(rtu.calculated_cost, 0)) AS cost_model_total
-    FROM {{schema | sqlsafe}}.rates_to_usage rtu
-    WHERE rtu.usage_start >= DATE({{start_date}})
-        AND rtu.usage_start <= DATE({{end_date}})
-        AND rtu.source_uuid = {{source_uuid}}::uuid
-        AND rtu.namespace = 'GPU unallocated'
-        AND rtu.monthly_cost_type IS NULL
-    GROUP BY rtu.report_period_id, rtu.source_uuid, rtu.usage_start,
-             rtu.cluster_id
-    HAVING SUM(COALESCE(rtu.calculated_cost, 0)) != 0
-) rtu_agg
-LEFT JOIN (
-    SELECT
-        lids.usage_start,
-        lids.cluster_id,
-        SUM(
-            COALESCE(lids.infrastructure_raw_cost, 0) +
-            COALESCE(lids.infrastructure_markup_cost, 0)
-        ) AS infra_total
-    FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
-    WHERE lids.usage_start >= DATE({{start_date}})
-        AND lids.usage_start <= DATE({{end_date}})
-        AND lids.namespace = 'GPU unallocated'
-        AND lids.cost_model_rate_type IS NULL
-    GROUP BY lids.usage_start, lids.cluster_id
-) infra_agg
-    ON rtu_agg.usage_start = infra_agg.usage_start
-    AND rtu_agg.cluster_id = infra_agg.cluster_id;
+    -SUM(rtu.distributed_cost)
+FROM {{schema | sqlsafe}}.rates_to_usage rtu
+WHERE rtu.usage_start >= DATE({{start_date}})
+    AND rtu.usage_start <= DATE({{end_date}})
+    AND rtu.source_uuid = {{source_uuid}}::uuid
+    AND rtu.monthly_cost_type = {{cost_model_rate_type}}
+    AND rtu.namespace != 'GPU unallocated'
+GROUP BY rtu.source_uuid, rtu.usage_start, rtu.cluster_id, rtu.node
+HAVING SUM(rtu.distributed_cost) != 0;

--- a/koku/masu/database/self_hosted_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
+++ b/koku/masu/database/self_hosted_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
@@ -81,7 +81,7 @@ SELECT
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
     MAX(nsp.pod_usage_slice_hours / NULLIF(tu.total_slice_hours, 0) * gc.rate_cost),
-    {{cost_model_id}}
+    {{cost_model_id}}::uuid
 FROM gpu_rtu_cost gc
 JOIN gpu_model_map gm
     ON gm.node = gc.node AND gm.usage_start = gc.usage_start
@@ -120,7 +120,7 @@ SELECT
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
     -SUM(rtu.distributed_cost),
-    {{cost_model_id}}
+    {{cost_model_id}}::uuid
 FROM {{schema | sqlsafe}}.rates_to_usage rtu
 WHERE rtu.usage_start >= DATE({{start_date}})
     AND rtu.usage_start <= DATE({{end_date}})

--- a/koku/masu/database/self_hosted_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
+++ b/koku/masu/database/self_hosted_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
@@ -74,7 +74,7 @@ SELECT
     nsp.node,
     gc.custom_name,
     gc.metric_type,
-    gc.cost_model_rate_type,
+    {{cost_model_rate_type}},
     {{cost_model_rate_type}},
     MAX(nsp.pod_usage_slice_hours / NULLIF(tu.total_slice_hours, 0) * gc.rate_cost)
 FROM gpu_rtu_cost gc
@@ -90,5 +90,33 @@ JOIN total_usage tu
     AND tu.usage_start = nsp.usage_start
 GROUP BY nsp.usage_start, nsp.node, nsp.namespace,
          gc.source_uuid, gc.custom_name, gc.metric_type, gc.cost_model_rate_type
-HAVING MAX(nsp.pod_usage_slice_hours / NULLIF(tu.total_slice_hours, 0) * gc.rate_cost) != 0
-RETURNING 1;
+HAVING MAX(nsp.pod_usage_slice_hours / NULLIF(tu.total_slice_hours, 0) * gc.rate_cost) != 0;
+
+-- Negate source: offset GPU unallocated costs so the net distributed total is zero.
+INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
+    uuid, report_period_id, source_uuid, usage_start, usage_end,
+    cluster_id, cluster_alias, namespace,
+    cost_model_rate_type,
+    monthly_cost_type, distributed_cost
+)
+SELECT
+    uuid_generate_v4(),
+    rtu.report_period_id,
+    rtu.source_uuid,
+    rtu.usage_start,
+    rtu.usage_start,
+    rtu.cluster_id,
+    MAX(rtu.cluster_alias),
+    'GPU unallocated',
+    {{cost_model_rate_type}},
+    {{cost_model_rate_type}},
+    -SUM(COALESCE(rtu.calculated_cost, 0))
+FROM {{schema | sqlsafe}}.rates_to_usage rtu
+WHERE rtu.usage_start >= DATE({{start_date}})
+    AND rtu.usage_start <= DATE({{end_date}})
+    AND rtu.source_uuid = {{source_uuid}}::uuid
+    AND rtu.namespace = 'GPU unallocated'
+    AND rtu.monthly_cost_type IS NULL
+GROUP BY rtu.report_period_id, rtu.source_uuid, rtu.usage_start,
+         rtu.cluster_id
+HAVING SUM(COALESCE(rtu.calculated_cost, 0)) != 0;

--- a/koku/masu/database/self_hosted_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
+++ b/koku/masu/database/self_hosted_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
@@ -96,7 +96,7 @@ HAVING MAX(nsp.pod_usage_slice_hours / NULLIF(tu.total_slice_hours, 0) * gc.rate
 INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
     uuid, report_period_id, source_uuid, usage_start, usage_end,
     cluster_id, cluster_alias, namespace,
-    custom_name, cost_model_rate_type,
+    custom_name, metric_type, cost_model_rate_type,
     monthly_cost_type, distributed_cost
 )
 SELECT
@@ -108,7 +108,7 @@ SELECT
     rtu.cluster_id,
     MAX(rtu.cluster_alias),
     'GPU unallocated',
-    '',
+    '', '',
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
     -SUM(COALESCE(rtu.calculated_cost, 0))

--- a/koku/masu/database/self_hosted_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
+++ b/koku/masu/database/self_hosted_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
@@ -38,11 +38,12 @@ gpu_model_map AS (
         node,
         all_labels->>'gpu-model' AS gpu_model,
         usage_start
-    FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary
+    FROM {{schema | sqlsafe}}.rates_to_usage
     WHERE namespace = 'GPU unallocated'
       AND usage_start >= DATE({{start_date}})
       AND usage_start <= DATE({{end_date}})
       AND source_uuid = {{source_uuid}}::uuid
+      AND metric_type = 'gpu'
     GROUP BY node, all_labels->>'gpu-model', usage_start
 ),
 namespace_usage_information AS (

--- a/koku/masu/database/self_hosted_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
+++ b/koku/masu/database/self_hosted_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
@@ -25,7 +25,10 @@ WITH gpu_rtu_cost AS (
         AND rtu.usage_start <= DATE({{end_date}})
         AND rtu.source_uuid = {{source_uuid}}::uuid
         AND rtu.namespace = 'GPU unallocated'
-        AND rtu.monthly_cost_type IS NULL
+        AND (rtu.monthly_cost_type IS NULL OR rtu.monthly_cost_type NOT IN (
+            'worker_distributed', 'platform_distributed', 'gpu_distributed',
+            'unattributed_storage', 'unattributed_network'
+        ))
     GROUP BY rtu.usage_start, rtu.source_uuid, rtu.cluster_id, rtu.cluster_alias,
              rtu.report_period_id, rtu.node,
              rtu.custom_name, rtu.metric_type, rtu.cost_model_rate_type

--- a/koku/masu/database/self_hosted_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
+++ b/koku/masu/database/self_hosted_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
@@ -75,7 +75,7 @@ SELECT
     gc.custom_name,
     gc.metric_type,
     gc.cost_model_rate_type,
-    {{distribution_tag}},
+    {{cost_model_rate_type}},
     MAX(nsp.pod_usage_slice_hours / NULLIF(tu.total_slice_hours, 0) * gc.rate_cost)
 FROM gpu_rtu_cost gc
 JOIN gpu_model_map gm

--- a/koku/masu/database/self_hosted_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
+++ b/koku/masu/database/self_hosted_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
@@ -6,7 +6,7 @@ INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
     uuid, report_period_id, source_uuid, usage_start, usage_end,
     cluster_id, cluster_alias, namespace, node,
     custom_name, metric_type, cost_model_rate_type,
-    monthly_cost_type, distributed_cost
+    monthly_cost_type, distributed_cost, cost_model_id
 )
 WITH gpu_rtu_cost AS (
     SELECT
@@ -80,7 +80,8 @@ SELECT
     gc.metric_type,
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
-    MAX(nsp.pod_usage_slice_hours / NULLIF(tu.total_slice_hours, 0) * gc.rate_cost)
+    MAX(nsp.pod_usage_slice_hours / NULLIF(tu.total_slice_hours, 0) * gc.rate_cost),
+    {{cost_model_id}}
 FROM gpu_rtu_cost gc
 JOIN gpu_model_map gm
     ON gm.node = gc.node AND gm.usage_start = gc.usage_start
@@ -103,7 +104,7 @@ INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
     uuid, report_period_id, source_uuid, usage_start, usage_end,
     cluster_id, cluster_alias, namespace, node,
     custom_name, metric_type, cost_model_rate_type,
-    monthly_cost_type, distributed_cost
+    monthly_cost_type, distributed_cost, cost_model_id
 )
 SELECT
     uuid_generate_v4(),
@@ -118,7 +119,8 @@ SELECT
     '', '',
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
-    -SUM(rtu.distributed_cost)
+    -SUM(rtu.distributed_cost),
+    {{cost_model_id}}
 FROM {{schema | sqlsafe}}.rates_to_usage rtu
 WHERE rtu.usage_start >= DATE({{start_date}})
     AND rtu.usage_start <= DATE({{end_date}})

--- a/koku/masu/database/self_hosted_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
+++ b/koku/masu/database/self_hosted_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
@@ -72,7 +72,7 @@ SELECT
     MAX(gc.cluster_alias),
     nsp.namespace,
     nsp.node,
-    gc.custom_name,
+    COALESCE(gc.custom_name, ''),
     gc.metric_type,
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
@@ -96,7 +96,7 @@ HAVING MAX(nsp.pod_usage_slice_hours / NULLIF(tu.total_slice_hours, 0) * gc.rate
 INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
     uuid, report_period_id, source_uuid, usage_start, usage_end,
     cluster_id, cluster_alias, namespace,
-    cost_model_rate_type,
+    custom_name, cost_model_rate_type,
     monthly_cost_type, distributed_cost
 )
 SELECT
@@ -108,6 +108,7 @@ SELECT
     rtu.cluster_id,
     MAX(rtu.cluster_alias),
     'GPU unallocated',
+    '',
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
     -SUM(COALESCE(rtu.calculated_cost, 0))

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/delete_distributed_rates_to_usage.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/delete_distributed_rates_to_usage.sql
@@ -4,5 +4,5 @@ DELETE FROM {{schema | sqlsafe}}.rates_to_usage AS rtu
 WHERE rtu.usage_start >= {{start_date}}::date
     AND rtu.usage_start <= {{end_date}}::date
     AND rtu.report_period_id = {{report_period_id}}
-    AND rtu.monthly_cost_type = {{distribution_tag}}
+    AND rtu.monthly_cost_type = {{cost_model_rate_type}}
 ;

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/delete_distributed_rates_to_usage.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/delete_distributed_rates_to_usage.sql
@@ -1,0 +1,8 @@
+-- Delete distributed rows from rates_to_usage before re-inserting.
+-- Mirrors delete_monthly_cost_model_rate_type.sql but targets RTU.
+DELETE FROM {{schema | sqlsafe}}.rates_to_usage AS rtu
+WHERE rtu.usage_start >= {{start_date}}::date
+    AND rtu.usage_start <= {{end_date}}::date
+    AND rtu.report_period_id = {{report_period_id}}
+    AND rtu.monthly_cost_type = {{cost_model_rate_type}}
+;

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/delete_distributed_rates_to_usage.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/delete_distributed_rates_to_usage.sql
@@ -4,5 +4,5 @@ DELETE FROM {{schema | sqlsafe}}.rates_to_usage AS rtu
 WHERE rtu.usage_start >= {{start_date}}::date
     AND rtu.usage_start <= {{end_date}}::date
     AND rtu.report_period_id = {{report_period_id}}
-    AND rtu.monthly_cost_type = {{cost_model_rate_type}}
+    AND rtu.monthly_cost_type = {{distribution_tag}}
 ;

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_platform_cost_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_platform_cost_per_rate.sql
@@ -84,7 +84,7 @@ SELECT
     nu.namespace,
     nu.node,
     nu.cost_category_id,
-    pc.custom_name,
+    COALESCE(pc.custom_name, ''),
     pc.metric_type,
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
@@ -116,7 +116,7 @@ WHERE CASE WHEN {{distribution}} = 'cpu' THEN
 INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
     uuid, report_period_id, source_uuid, usage_start, usage_end,
     cluster_id, cluster_alias, namespace,
-    cost_category_id, cost_model_rate_type,
+    cost_category_id, custom_name, cost_model_rate_type,
     monthly_cost_type, distributed_cost
 )
 SELECT
@@ -129,6 +129,7 @@ SELECT
     MAX(rtu.cluster_alias),
     rtu.namespace,
     MAX(rtu.cost_category_id),
+    '',
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
     -SUM(COALESCE(rtu.calculated_cost, 0))

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_platform_cost_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_platform_cost_per_rate.sql
@@ -87,7 +87,7 @@ SELECT
     pc.custom_name,
     pc.metric_type,
     pc.cost_model_rate_type,
-    {{distribution_tag}},
+    {{cost_model_rate_type}},
     CASE WHEN {{distribution}} = 'cpu' THEN
         CASE WHEN d.usage_cpu_sum <= 0 THEN 0
              ELSE (nu.ns_cpu / d.usage_cpu_sum) * pc.rate_cost

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_platform_cost_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_platform_cost_per_rate.sql
@@ -2,6 +2,10 @@
 -- Reads per-rate costs from RTU (Platform category), distributes
 -- proportionally to non-Platform namespaces by CPU/memory hours,
 -- writes distributed rows back to RTU with monthly_cost_type = 'platform_distributed'.
+--
+-- Infrastructure costs (OCP-on-cloud matching) live in daily_summary, not RTU.
+-- They are distributed proportionally across rates via a scaling factor so
+-- Platform namespaces fully zero out (infra + cost_model = 0).
 WITH platform_rtu_cost AS (
     SELECT
         rtu.usage_start,
@@ -25,6 +29,32 @@ WITH platform_rtu_cost AS (
         ))
     GROUP BY rtu.usage_start, rtu.source_uuid, rtu.cluster_id,
              rtu.custom_name, rtu.metric_type, rtu.cost_model_rate_type
+),
+platform_infra AS (
+    SELECT
+        lids.usage_start,
+        lids.cluster_id,
+        SUM(
+            COALESCE(lids.infrastructure_raw_cost, 0) +
+            COALESCE(lids.infrastructure_markup_cost, 0)
+        ) AS infra_total
+    FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
+    JOIN {{schema | sqlsafe}}.reporting_ocp_cost_category cat
+        ON lids.cost_category_id = cat.id
+    WHERE lids.usage_start >= {{start_date}}::date
+        AND lids.usage_start <= {{end_date}}::date
+        AND lids.report_period_id = {{report_period_id}}
+        AND cat.name = 'Platform'
+        AND lids.cost_model_rate_type IS NULL
+    GROUP BY lids.usage_start, lids.cluster_id
+),
+platform_total_rate AS (
+    SELECT
+        usage_start,
+        cluster_id,
+        SUM(rate_cost) AS total_rate_cost
+    FROM platform_rtu_cost
+    GROUP BY usage_start, cluster_id
 ),
 denominator AS (
     SELECT
@@ -94,10 +124,16 @@ SELECT
     CASE WHEN {{distribution}} = 'cpu' THEN
         CASE WHEN d.usage_cpu_sum <= 0 THEN 0
              ELSE (nu.ns_cpu / d.usage_cpu_sum) * pc.rate_cost
+                  * CASE WHEN pt.total_rate_cost > 0
+                         THEN (pt.total_rate_cost + COALESCE(pi.infra_total, 0)) / pt.total_rate_cost
+                         ELSE 1 END
         END
     ELSE
         CASE WHEN d.usage_memory_sum <= 0 THEN 0
              ELSE (nu.ns_memory / d.usage_memory_sum) * pc.rate_cost
+                  * CASE WHEN pt.total_rate_cost > 0
+                         THEN (pt.total_rate_cost + COALESCE(pi.infra_total, 0)) / pt.total_rate_cost
+                         ELSE 1 END
         END
     END
 FROM platform_rtu_cost pc
@@ -105,19 +141,29 @@ JOIN denominator d
     ON d.usage_start = pc.usage_start AND d.cluster_id = pc.cluster_id
 JOIN namespace_usage nu
     ON nu.usage_start = pc.usage_start AND nu.cluster_id = pc.cluster_id
+LEFT JOIN platform_infra pi
+    ON pi.usage_start = pc.usage_start AND pi.cluster_id = pc.cluster_id
+LEFT JOIN platform_total_rate pt
+    ON pt.usage_start = pc.usage_start AND pt.cluster_id = pc.cluster_id
 WHERE CASE WHEN {{distribution}} = 'cpu' THEN
           CASE WHEN d.usage_cpu_sum <= 0 THEN 0
                ELSE (nu.ns_cpu / d.usage_cpu_sum) * pc.rate_cost
+                    * CASE WHEN pt.total_rate_cost > 0
+                           THEN (pt.total_rate_cost + COALESCE(pi.infra_total, 0)) / pt.total_rate_cost
+                           ELSE 1 END
           END
       ELSE
           CASE WHEN d.usage_memory_sum <= 0 THEN 0
                ELSE (nu.ns_memory / d.usage_memory_sum) * pc.rate_cost
+                    * CASE WHEN pt.total_rate_cost > 0
+                           THEN (pt.total_rate_cost + COALESCE(pi.infra_total, 0)) / pt.total_rate_cost
+                           ELSE 1 END
           END
       END != 0;
 
--- Negate source: derive negation from the distributed output rows just inserted.
--- Sums distributed_cost of platform_distributed rows and inserts exact negative
--- per source namespace, guaranteeing algebraic zero-sum.
+-- Negate source: for each Platform namespace, negate its cost-model total plus
+-- infrastructure costs from daily_summary. This ensures each Platform namespace
+-- fully zeroes out in the API's cost.total computation.
 INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
     uuid, report_period_id, source_uuid, usage_start, usage_end,
     cluster_id, cluster_alias, namespace,
@@ -137,7 +183,7 @@ SELECT
     '', '',
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
-    -rtu_agg.cost_model_total
+    -(rtu_agg.cost_model_total + COALESCE(pi_ns.infra_total, 0))
 FROM (
     SELECT
         rtu.report_period_id,
@@ -162,12 +208,34 @@ FROM (
         ))
     GROUP BY rtu.report_period_id, rtu.source_uuid, rtu.usage_start,
              rtu.cluster_id, rtu.namespace
-    HAVING SUM(COALESCE(rtu.calculated_cost, 0)) != 0
 ) rtu_agg
+LEFT JOIN (
+    SELECT
+        lids.usage_start,
+        lids.cluster_id,
+        lids.namespace,
+        SUM(
+            COALESCE(lids.infrastructure_raw_cost, 0) +
+            COALESCE(lids.infrastructure_markup_cost, 0)
+        ) AS infra_total
+    FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
+    JOIN {{schema | sqlsafe}}.reporting_ocp_cost_category cat
+        ON lids.cost_category_id = cat.id
+    WHERE lids.usage_start >= {{start_date}}::date
+        AND lids.usage_start <= {{end_date}}::date
+        AND lids.report_period_id = {{report_period_id}}
+        AND cat.name = 'Platform'
+        AND lids.cost_model_rate_type IS NULL
+    GROUP BY lids.usage_start, lids.cluster_id, lids.namespace
+) pi_ns
+    ON pi_ns.usage_start = rtu_agg.usage_start
+    AND pi_ns.cluster_id = rtu_agg.cluster_id
+    AND pi_ns.namespace = rtu_agg.namespace
 WHERE EXISTS (
     SELECT 1 FROM {{schema | sqlsafe}}.rates_to_usage dist
     WHERE dist.monthly_cost_type = {{cost_model_rate_type}}
     AND dist.source_uuid = rtu_agg.source_uuid
     AND dist.usage_start = rtu_agg.usage_start
     AND dist.cluster_id = rtu_agg.cluster_id
-);
+)
+AND (rtu_agg.cost_model_total + COALESCE(pi_ns.infra_total, 0)) != 0;

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_platform_cost_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_platform_cost_per_rate.sql
@@ -113,6 +113,8 @@ WHERE CASE WHEN {{distribution}} = 'cpu' THEN
       END != 0;
 
 -- Negate source: offset Platform-category namespace costs so the net distributed total is zero.
+-- Must negate cost-model costs (from RTU) AND infrastructure/markup costs (from
+-- daily_summary) so the API's cost_total + platform_distributed sums to zero.
 INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
     uuid, report_period_id, source_uuid, usage_start, usage_end,
     cluster_id, cluster_alias, namespace,
@@ -121,27 +123,60 @@ INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
 )
 SELECT
     uuid_generate_v4(),
-    rtu.report_period_id,
-    rtu.source_uuid,
-    rtu.usage_start,
-    rtu.usage_start,
-    rtu.cluster_id,
-    MAX(rtu.cluster_alias),
-    rtu.namespace,
-    MAX(rtu.cost_category_id),
+    rtu_agg.report_period_id,
+    rtu_agg.source_uuid,
+    rtu_agg.usage_start,
+    rtu_agg.usage_start,
+    rtu_agg.cluster_id,
+    rtu_agg.cluster_alias,
+    rtu_agg.namespace,
+    rtu_agg.cost_category_id,
     '', '',
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
-    -SUM(COALESCE(rtu.calculated_cost, 0))
-FROM {{schema | sqlsafe}}.rates_to_usage rtu
-JOIN {{schema | sqlsafe}}.reporting_ocp_cost_category cat
-    ON rtu.cost_category_id = cat.id
-WHERE rtu.usage_start >= {{start_date}}::date
-    AND rtu.usage_start <= {{end_date}}::date
-    AND rtu.report_period_id = {{report_period_id}}
-    AND rtu.source_uuid = {{source_uuid}}::uuid
-    AND cat.name = 'Platform'
-    AND rtu.monthly_cost_type IS NULL
-GROUP BY rtu.report_period_id, rtu.source_uuid, rtu.usage_start,
-         rtu.cluster_id, rtu.namespace
-HAVING SUM(COALESCE(rtu.calculated_cost, 0)) != 0;
+    -(rtu_agg.cost_model_total + COALESCE(infra_agg.infra_total, 0))
+FROM (
+    SELECT
+        rtu.report_period_id,
+        rtu.source_uuid,
+        rtu.usage_start,
+        rtu.cluster_id,
+        rtu.namespace,
+        MAX(rtu.cluster_alias) AS cluster_alias,
+        MAX(rtu.cost_category_id) AS cost_category_id,
+        SUM(COALESCE(rtu.calculated_cost, 0)) AS cost_model_total
+    FROM {{schema | sqlsafe}}.rates_to_usage rtu
+    JOIN {{schema | sqlsafe}}.reporting_ocp_cost_category cat
+        ON rtu.cost_category_id = cat.id
+    WHERE rtu.usage_start >= {{start_date}}::date
+        AND rtu.usage_start <= {{end_date}}::date
+        AND rtu.report_period_id = {{report_period_id}}
+        AND rtu.source_uuid = {{source_uuid}}::uuid
+        AND cat.name = 'Platform'
+        AND rtu.monthly_cost_type IS NULL
+    GROUP BY rtu.report_period_id, rtu.source_uuid, rtu.usage_start,
+             rtu.cluster_id, rtu.namespace
+    HAVING SUM(COALESCE(rtu.calculated_cost, 0)) != 0
+) rtu_agg
+LEFT JOIN (
+    SELECT
+        lids.namespace,
+        lids.usage_start,
+        lids.cluster_id,
+        SUM(
+            COALESCE(lids.infrastructure_raw_cost, 0) +
+            COALESCE(lids.infrastructure_markup_cost, 0)
+        ) AS infra_total
+    FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
+    JOIN {{schema | sqlsafe}}.reporting_ocp_cost_category cat
+        ON lids.cost_category_id = cat.id
+    WHERE lids.usage_start >= {{start_date}}::date
+        AND lids.usage_start <= {{end_date}}::date
+        AND lids.report_period_id = {{report_period_id}}
+        AND cat.name = 'Platform'
+        AND lids.cost_model_rate_type IS NULL
+    GROUP BY lids.namespace, lids.usage_start, lids.cluster_id
+) infra_agg
+    ON rtu_agg.namespace = infra_agg.namespace
+    AND rtu_agg.usage_start = infra_agg.usage_start
+    AND rtu_agg.cluster_id = infra_agg.cluster_id;

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_platform_cost_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_platform_cost_per_rate.sql
@@ -1,0 +1,113 @@
+-- Per-rate platform cost distribution via rates_to_usage.
+-- Reads per-rate costs from RTU (Platform category), distributes
+-- proportionally to non-Platform namespaces by CPU/memory hours,
+-- writes distributed rows back to RTU with monthly_cost_type = 'platform_distributed'.
+WITH platform_rtu_cost AS (
+    SELECT
+        rtu.usage_start,
+        rtu.source_uuid,
+        rtu.cluster_id,
+        rtu.custom_name,
+        rtu.metric_type,
+        rtu.cost_model_rate_type,
+        SUM(COALESCE(rtu.calculated_cost, 0)) AS rate_cost
+    FROM {{schema | sqlsafe}}.rates_to_usage rtu
+    JOIN {{schema | sqlsafe}}.reporting_ocp_cost_category cat
+        ON rtu.cost_category_id = cat.id
+    WHERE rtu.usage_start >= {{start_date}}::date
+        AND rtu.usage_start <= {{end_date}}::date
+        AND rtu.report_period_id = {{report_period_id}}
+        AND rtu.source_uuid = {{source_uuid}}::uuid
+        AND cat.name = 'Platform'
+        AND rtu.monthly_cost_type IS NULL
+    GROUP BY rtu.usage_start, rtu.source_uuid, rtu.cluster_id,
+             rtu.custom_name, rtu.metric_type, rtu.cost_model_rate_type
+),
+denominator AS (
+    SELECT
+        lids.usage_start,
+        lids.cluster_id,
+        SUM(lids.pod_effective_usage_cpu_core_hours) AS usage_cpu_sum,
+        SUM(lids.pod_effective_usage_memory_gigabyte_hours) AS usage_memory_sum
+    FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
+    LEFT JOIN {{schema | sqlsafe}}.reporting_ocp_cost_category cat
+        ON lids.cost_category_id = cat.id
+    WHERE lids.usage_start >= {{start_date}}::date
+        AND lids.usage_start <= {{end_date}}::date
+        AND lids.report_period_id = {{report_period_id}}
+        AND lids.namespace != 'Worker unallocated'
+        AND lids.namespace != 'Storage unattributed'
+        AND lids.namespace != 'Network unattributed'
+        AND (lids.cost_category_id IS NULL OR cat.name != 'Platform')
+        AND lids.data_source = 'Pod'
+    GROUP BY lids.usage_start, lids.cluster_id
+),
+namespace_usage AS (
+    SELECT
+        lids.usage_start,
+        lids.cluster_id,
+        lids.namespace,
+        lids.node,
+        MAX(lids.report_period_id) AS report_period_id,
+        MAX(lids.cluster_alias) AS cluster_alias,
+        MAX(lids.cost_category_id) AS cost_category_id,
+        SUM(lids.pod_effective_usage_cpu_core_hours) AS ns_cpu,
+        SUM(lids.pod_effective_usage_memory_gigabyte_hours) AS ns_memory
+    FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
+    LEFT JOIN {{schema | sqlsafe}}.reporting_ocp_cost_category cat
+        ON lids.cost_category_id = cat.id
+    WHERE lids.usage_start >= {{start_date}}::date
+        AND lids.usage_start <= {{end_date}}::date
+        AND lids.report_period_id = {{report_period_id}}
+        AND lids.namespace IS NOT NULL
+        AND lids.namespace != 'Worker unallocated'
+        AND lids.namespace != 'Storage unattributed'
+        AND lids.namespace != 'Network unattributed'
+        AND (lids.cost_category_id IS NULL OR cat.name != 'Platform')
+        AND lids.data_source = 'Pod'
+    GROUP BY lids.usage_start, lids.cluster_id, lids.namespace, lids.node
+)
+INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
+    uuid, report_period_id, source_uuid, usage_start, usage_end,
+    cluster_id, cluster_alias, namespace, node,
+    cost_category_id, custom_name, metric_type, cost_model_rate_type,
+    monthly_cost_type, distributed_cost
+)
+SELECT
+    uuid_generate_v4(),
+    nu.report_period_id,
+    pc.source_uuid,
+    nu.usage_start,
+    nu.usage_start,
+    nu.cluster_id,
+    nu.cluster_alias,
+    nu.namespace,
+    nu.node,
+    nu.cost_category_id,
+    pc.custom_name,
+    pc.metric_type,
+    pc.cost_model_rate_type,
+    {{cost_model_rate_type}},
+    CASE WHEN {{distribution}} = 'cpu' THEN
+        CASE WHEN d.usage_cpu_sum <= 0 THEN 0
+             ELSE (nu.ns_cpu / d.usage_cpu_sum) * pc.rate_cost
+        END
+    ELSE
+        CASE WHEN d.usage_memory_sum <= 0 THEN 0
+             ELSE (nu.ns_memory / d.usage_memory_sum) * pc.rate_cost
+        END
+    END
+FROM platform_rtu_cost pc
+JOIN denominator d
+    ON d.usage_start = pc.usage_start AND d.cluster_id = pc.cluster_id
+JOIN namespace_usage nu
+    ON nu.usage_start = pc.usage_start AND nu.cluster_id = pc.cluster_id
+WHERE CASE WHEN {{distribution}} = 'cpu' THEN
+          CASE WHEN d.usage_cpu_sum <= 0 THEN 0
+               ELSE (nu.ns_cpu / d.usage_cpu_sum) * pc.rate_cost
+          END
+      ELSE
+          CASE WHEN d.usage_memory_sum <= 0 THEN 0
+               ELSE (nu.ns_memory / d.usage_memory_sum) * pc.rate_cost
+          END
+      END != 0;

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_platform_cost_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_platform_cost_per_rate.sql
@@ -116,7 +116,7 @@ WHERE CASE WHEN {{distribution}} = 'cpu' THEN
 INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
     uuid, report_period_id, source_uuid, usage_start, usage_end,
     cluster_id, cluster_alias, namespace,
-    cost_category_id, custom_name, cost_model_rate_type,
+    cost_category_id, custom_name, metric_type, cost_model_rate_type,
     monthly_cost_type, distributed_cost
 )
 SELECT
@@ -129,7 +129,7 @@ SELECT
     MAX(rtu.cluster_alias),
     rtu.namespace,
     MAX(rtu.cost_category_id),
-    '',
+    '', '',
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
     -SUM(COALESCE(rtu.calculated_cost, 0))

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_platform_cost_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_platform_cost_per_rate.sql
@@ -115,9 +115,9 @@ WHERE CASE WHEN {{distribution}} = 'cpu' THEN
           END
       END != 0;
 
--- Negate source: offset Platform-category namespace costs so the net distributed total is zero.
--- Must negate cost-model costs (from RTU) AND infrastructure/markup costs (from
--- daily_summary) so the API's cost_total + platform_distributed sums to zero.
+-- Negate source: derive negation from the distributed output rows just inserted.
+-- Sums distributed_cost of platform_distributed rows and inserts exact negative
+-- per source namespace, guaranteeing algebraic zero-sum.
 INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
     uuid, report_period_id, source_uuid, usage_start, usage_end,
     cluster_id, cluster_alias, namespace,
@@ -137,7 +137,7 @@ SELECT
     '', '',
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
-    -(rtu_agg.cost_model_total + COALESCE(infra_agg.infra_total, 0))
+    -rtu_agg.cost_model_total
 FROM (
     SELECT
         rtu.report_period_id,
@@ -156,30 +156,18 @@ FROM (
         AND rtu.report_period_id = {{report_period_id}}
         AND rtu.source_uuid = {{source_uuid}}::uuid
         AND cat.name = 'Platform'
-        AND rtu.monthly_cost_type IS NULL
+        AND (rtu.monthly_cost_type IS NULL OR rtu.monthly_cost_type NOT IN (
+            'worker_distributed', 'platform_distributed', 'gpu_distributed',
+            'unattributed_storage', 'unattributed_network'
+        ))
     GROUP BY rtu.report_period_id, rtu.source_uuid, rtu.usage_start,
              rtu.cluster_id, rtu.namespace
     HAVING SUM(COALESCE(rtu.calculated_cost, 0)) != 0
 ) rtu_agg
-LEFT JOIN (
-    SELECT
-        lids.namespace,
-        lids.usage_start,
-        lids.cluster_id,
-        SUM(
-            COALESCE(lids.infrastructure_raw_cost, 0) +
-            COALESCE(lids.infrastructure_markup_cost, 0)
-        ) AS infra_total
-    FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
-    JOIN {{schema | sqlsafe}}.reporting_ocp_cost_category cat
-        ON lids.cost_category_id = cat.id
-    WHERE lids.usage_start >= {{start_date}}::date
-        AND lids.usage_start <= {{end_date}}::date
-        AND lids.report_period_id = {{report_period_id}}
-        AND cat.name = 'Platform'
-        AND lids.cost_model_rate_type IS NULL
-    GROUP BY lids.namespace, lids.usage_start, lids.cluster_id
-) infra_agg
-    ON rtu_agg.namespace = infra_agg.namespace
-    AND rtu_agg.usage_start = infra_agg.usage_start
-    AND rtu_agg.cluster_id = infra_agg.cluster_id;
+WHERE EXISTS (
+    SELECT 1 FROM {{schema | sqlsafe}}.rates_to_usage dist
+    WHERE dist.monthly_cost_type = {{cost_model_rate_type}}
+    AND dist.source_uuid = rtu_agg.source_uuid
+    AND dist.usage_start = rtu_agg.usage_start
+    AND dist.cluster_id = rtu_agg.cluster_id
+);

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_platform_cost_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_platform_cost_per_rate.sql
@@ -104,7 +104,7 @@ INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
     uuid, report_period_id, source_uuid, usage_start, usage_end,
     cluster_id, cluster_alias, namespace, node,
     cost_category_id, custom_name, metric_type, cost_model_rate_type,
-    monthly_cost_type, distributed_cost
+    monthly_cost_type, distributed_cost, cost_model_id
 )
 SELECT
     uuid_generate_v4(),
@@ -135,7 +135,8 @@ SELECT
                          THEN (pt.total_rate_cost + COALESCE(pi.infra_total, 0)) / pt.total_rate_cost
                          ELSE 1 END
         END
-    END
+    END,
+    {{cost_model_id}}
 FROM platform_rtu_cost pc
 JOIN denominator d
     ON d.usage_start = pc.usage_start AND d.cluster_id = pc.cluster_id
@@ -168,7 +169,7 @@ INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
     uuid, report_period_id, source_uuid, usage_start, usage_end,
     cluster_id, cluster_alias, namespace, node,
     cost_category_id, custom_name, metric_type, cost_model_rate_type,
-    monthly_cost_type, distributed_cost
+    monthly_cost_type, distributed_cost, cost_model_id
 )
 SELECT
     uuid_generate_v4(),
@@ -184,7 +185,8 @@ SELECT
     '', '',
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
-    -(rtu_agg.cost_model_total + COALESCE(pi_ns.infra_total, 0))
+    -(rtu_agg.cost_model_total + COALESCE(pi_ns.infra_total, 0)),
+    {{cost_model_id}}
 FROM (
     SELECT
         rtu.report_period_id,

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_platform_cost_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_platform_cost_per_rate.sql
@@ -87,7 +87,7 @@ SELECT
     pc.custom_name,
     pc.metric_type,
     pc.cost_model_rate_type,
-    {{cost_model_rate_type}},
+    {{distribution_tag}},
     CASE WHEN {{distribution}} = 'cpu' THEN
         CASE WHEN d.usage_cpu_sum <= 0 THEN 0
              ELSE (nu.ns_cpu / d.usage_cpu_sum) * pc.rate_cost

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_platform_cost_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_platform_cost_per_rate.sql
@@ -136,7 +136,7 @@ SELECT
                          ELSE 1 END
         END
     END,
-    {{cost_model_id}}
+    {{cost_model_id}}::uuid
 FROM platform_rtu_cost pc
 JOIN denominator d
     ON d.usage_start = pc.usage_start AND d.cluster_id = pc.cluster_id
@@ -186,7 +186,7 @@ SELECT
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
     -(rtu_agg.cost_model_total + COALESCE(pi_ns.infra_total, 0)),
-    {{cost_model_id}}
+    {{cost_model_id}}::uuid
 FROM (
     SELECT
         rtu.report_period_id,

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_platform_cost_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_platform_cost_per_rate.sql
@@ -161,12 +161,12 @@ WHERE CASE WHEN {{distribution}} = 'cpu' THEN
           END
       END != 0;
 
--- Negate source: for each Platform namespace, negate its cost-model total plus
--- infrastructure costs from daily_summary. This ensures each Platform namespace
--- fully zeroes out in the API's cost.total computation.
+-- Negate source: per-node negation for each Platform namespace.
+-- Includes infrastructure costs from daily_summary. Per-node granularity
+-- avoids NULL node ("No-node") entries in the API.
 INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
     uuid, report_period_id, source_uuid, usage_start, usage_end,
-    cluster_id, cluster_alias, namespace,
+    cluster_id, cluster_alias, namespace, node,
     cost_category_id, custom_name, metric_type, cost_model_rate_type,
     monthly_cost_type, distributed_cost
 )
@@ -179,6 +179,7 @@ SELECT
     rtu_agg.cluster_id,
     rtu_agg.cluster_alias,
     rtu_agg.namespace,
+    rtu_agg.node,
     rtu_agg.cost_category_id,
     '', '',
     {{cost_model_rate_type}},
@@ -191,6 +192,7 @@ FROM (
         rtu.usage_start,
         rtu.cluster_id,
         rtu.namespace,
+        rtu.node,
         MAX(rtu.cluster_alias) AS cluster_alias,
         MAX(rtu.cost_category_id) AS cost_category_id,
         SUM(COALESCE(rtu.calculated_cost, 0)) AS cost_model_total
@@ -207,13 +209,14 @@ FROM (
             'unattributed_storage', 'unattributed_network'
         ))
     GROUP BY rtu.report_period_id, rtu.source_uuid, rtu.usage_start,
-             rtu.cluster_id, rtu.namespace
+             rtu.cluster_id, rtu.namespace, rtu.node
 ) rtu_agg
 LEFT JOIN (
     SELECT
         lids.usage_start,
         lids.cluster_id,
         lids.namespace,
+        lids.node,
         SUM(
             COALESCE(lids.infrastructure_raw_cost, 0) +
             COALESCE(lids.infrastructure_markup_cost, 0)
@@ -226,11 +229,12 @@ LEFT JOIN (
         AND lids.report_period_id = {{report_period_id}}
         AND cat.name = 'Platform'
         AND lids.cost_model_rate_type IS NULL
-    GROUP BY lids.usage_start, lids.cluster_id, lids.namespace
+    GROUP BY lids.usage_start, lids.cluster_id, lids.namespace, lids.node
 ) pi_ns
     ON pi_ns.usage_start = rtu_agg.usage_start
     AND pi_ns.cluster_id = rtu_agg.cluster_id
     AND pi_ns.namespace = rtu_agg.namespace
+    AND pi_ns.node IS NOT DISTINCT FROM rtu_agg.node
 WHERE EXISTS (
     SELECT 1 FROM {{schema | sqlsafe}}.rates_to_usage dist
     WHERE dist.monthly_cost_type = {{cost_model_rate_type}}

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_platform_cost_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_platform_cost_per_rate.sql
@@ -86,7 +86,7 @@ SELECT
     nu.cost_category_id,
     pc.custom_name,
     pc.metric_type,
-    pc.cost_model_rate_type,
+    {{cost_model_rate_type}},
     {{cost_model_rate_type}},
     CASE WHEN {{distribution}} = 'cpu' THEN
         CASE WHEN d.usage_cpu_sum <= 0 THEN 0
@@ -111,3 +111,36 @@ WHERE CASE WHEN {{distribution}} = 'cpu' THEN
                ELSE (nu.ns_memory / d.usage_memory_sum) * pc.rate_cost
           END
       END != 0;
+
+-- Negate source: offset Platform-category namespace costs so the net distributed total is zero.
+INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
+    uuid, report_period_id, source_uuid, usage_start, usage_end,
+    cluster_id, cluster_alias, namespace,
+    cost_category_id, cost_model_rate_type,
+    monthly_cost_type, distributed_cost
+)
+SELECT
+    uuid_generate_v4(),
+    rtu.report_period_id,
+    rtu.source_uuid,
+    rtu.usage_start,
+    rtu.usage_start,
+    rtu.cluster_id,
+    MAX(rtu.cluster_alias),
+    rtu.namespace,
+    MAX(rtu.cost_category_id),
+    {{cost_model_rate_type}},
+    {{cost_model_rate_type}},
+    -SUM(COALESCE(rtu.calculated_cost, 0))
+FROM {{schema | sqlsafe}}.rates_to_usage rtu
+JOIN {{schema | sqlsafe}}.reporting_ocp_cost_category cat
+    ON rtu.cost_category_id = cat.id
+WHERE rtu.usage_start >= {{start_date}}::date
+    AND rtu.usage_start <= {{end_date}}::date
+    AND rtu.report_period_id = {{report_period_id}}
+    AND rtu.source_uuid = {{source_uuid}}::uuid
+    AND cat.name = 'Platform'
+    AND rtu.monthly_cost_type IS NULL
+GROUP BY rtu.report_period_id, rtu.source_uuid, rtu.usage_start,
+         rtu.cluster_id, rtu.namespace
+HAVING SUM(COALESCE(rtu.calculated_cost, 0)) != 0;

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_platform_cost_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_platform_cost_per_rate.sql
@@ -19,7 +19,10 @@ WITH platform_rtu_cost AS (
         AND rtu.report_period_id = {{report_period_id}}
         AND rtu.source_uuid = {{source_uuid}}::uuid
         AND cat.name = 'Platform'
-        AND rtu.monthly_cost_type IS NULL
+        AND (rtu.monthly_cost_type IS NULL OR rtu.monthly_cost_type NOT IN (
+            'worker_distributed', 'platform_distributed', 'gpu_distributed',
+            'unattributed_storage', 'unattributed_network'
+        ))
     GROUP BY rtu.usage_start, rtu.source_uuid, rtu.cluster_id,
              rtu.custom_name, rtu.metric_type, rtu.cost_model_rate_type
 ),

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_network_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_network_per_rate.sql
@@ -153,7 +153,54 @@ WHERE CASE WHEN {{distribution}} = 'cpu' THEN
                            THEN (nt.total_rate_cost + COALESCE(ni.infra_total, 0)) / nt.total_rate_cost
                            ELSE 1 END
           END
-      END != 0;
+      END != 0
+
+UNION ALL
+
+-- Infra-only fallback: when cost model rates produce zero costs for Network
+-- unattributed (no pod usage in that namespace), distribute infrastructure
+-- costs directly. Guards: total_rate_cost IS NULL (no RTU rows) or <= 0.
+SELECT
+    uuid_generate_v4(),
+    nu.report_period_id,
+    {{source_uuid}}::uuid,
+    nu.usage_start,
+    nu.usage_start,
+    nu.cluster_id,
+    nu.cluster_alias,
+    nu.namespace,
+    nu.node,
+    nu.cost_category_id,
+    '', '',
+    {{cost_model_rate_type}},
+    {{cost_model_rate_type}},
+    CASE WHEN {{distribution}} = 'cpu' THEN
+        CASE WHEN d.usage_cpu_sum <= 0 THEN 0
+             ELSE (nu.ns_cpu / d.usage_cpu_sum) * ni.infra_total
+        END
+    ELSE
+        CASE WHEN d.usage_memory_sum <= 0 THEN 0
+             ELSE (nu.ns_memory / d.usage_memory_sum) * ni.infra_total
+        END
+    END
+FROM network_infra ni
+JOIN denominator d
+    ON d.usage_start = ni.usage_start AND d.cluster_id = ni.cluster_id
+JOIN namespace_usage nu
+    ON nu.usage_start = ni.usage_start AND nu.cluster_id = ni.cluster_id
+LEFT JOIN network_total_rate nt
+    ON nt.usage_start = ni.usage_start AND nt.cluster_id = ni.cluster_id
+WHERE (nt.total_rate_cost IS NULL OR nt.total_rate_cost <= 0)
+AND ni.infra_total != 0
+AND CASE WHEN {{distribution}} = 'cpu' THEN
+        CASE WHEN d.usage_cpu_sum <= 0 THEN 0
+             ELSE (nu.ns_cpu / d.usage_cpu_sum) * ni.infra_total
+        END
+    ELSE
+        CASE WHEN d.usage_memory_sum <= 0 THEN 0
+             ELSE (nu.ns_memory / d.usage_memory_sum) * ni.infra_total
+        END
+    END != 0;
 
 -- Negate source: per-node negation of Network unattributed costs.
 -- Includes infrastructure costs from daily_summary. Per-node granularity
@@ -225,4 +272,54 @@ WHERE EXISTS (
     AND dist.usage_start = src.usage_start
     AND dist.cluster_id = src.cluster_id
 )
-AND (src.cost_model_total + COALESCE(infra.infra_total, 0)) != 0;
+AND (src.cost_model_total + COALESCE(infra.infra_total, 0)) != 0
+
+UNION ALL
+
+-- Infra-only fallback negation: negate per-node infrastructure costs when
+-- no cost model RTU rows exist for Network unattributed (markup-only cost model).
+SELECT
+    uuid_generate_v4(),
+    MAX(lids.report_period_id),
+    {{source_uuid}}::uuid,
+    lids.usage_start,
+    lids.usage_start,
+    lids.cluster_id,
+    MAX(lids.cluster_alias),
+    'Network unattributed',
+    lids.node,
+    '', '',
+    {{cost_model_rate_type}},
+    {{cost_model_rate_type}},
+    -SUM(
+        COALESCE(lids.infrastructure_raw_cost, 0) +
+        COALESCE(lids.infrastructure_markup_cost, 0)
+    )
+FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
+WHERE lids.usage_start >= {{start_date}}::date
+    AND lids.usage_start <= {{end_date}}::date
+    AND lids.report_period_id = {{report_period_id}}
+    AND lids.namespace = 'Network unattributed'
+    AND lids.cost_model_rate_type IS NULL
+AND NOT EXISTS (
+    SELECT 1 FROM {{schema | sqlsafe}}.rates_to_usage rtu
+    WHERE rtu.usage_start = lids.usage_start
+        AND rtu.source_uuid = {{source_uuid}}::uuid
+        AND rtu.namespace = 'Network unattributed'
+        AND (rtu.monthly_cost_type IS NULL OR rtu.monthly_cost_type NOT IN (
+            'worker_distributed', 'platform_distributed', 'gpu_distributed',
+            'unattributed_storage', 'unattributed_network'
+        ))
+)
+AND EXISTS (
+    SELECT 1 FROM {{schema | sqlsafe}}.rates_to_usage dist
+    WHERE dist.monthly_cost_type = {{cost_model_rate_type}}
+    AND dist.source_uuid = {{source_uuid}}::uuid
+    AND dist.usage_start = lids.usage_start
+    AND dist.cluster_id = lids.cluster_id
+)
+GROUP BY lids.usage_start, lids.cluster_id, lids.node
+HAVING SUM(
+    COALESCE(lids.infrastructure_raw_cost, 0) +
+    COALESCE(lids.infrastructure_markup_cost, 0)
+) != 0;

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_network_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_network_per_rate.sql
@@ -109,6 +109,8 @@ WHERE CASE WHEN {{distribution}} = 'cpu' THEN
       END != 0;
 
 -- Negate source: offset Network unattributed costs so the net distributed total is zero.
+-- Must negate cost-model costs (from RTU) AND infrastructure/markup costs (from
+-- daily_summary) so the API's cost_total + unattributed_network sums to zero.
 INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
     uuid, report_period_id, source_uuid, usage_start, usage_end,
     cluster_id, cluster_alias, namespace,
@@ -117,24 +119,51 @@ INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
 )
 SELECT
     uuid_generate_v4(),
-    rtu.report_period_id,
-    rtu.source_uuid,
-    rtu.usage_start,
-    rtu.usage_start,
-    rtu.cluster_id,
-    MAX(rtu.cluster_alias),
+    rtu_agg.report_period_id,
+    rtu_agg.source_uuid,
+    rtu_agg.usage_start,
+    rtu_agg.usage_start,
+    rtu_agg.cluster_id,
+    rtu_agg.cluster_alias,
     'Network unattributed',
     '', '',
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
-    -SUM(COALESCE(rtu.calculated_cost, 0))
-FROM {{schema | sqlsafe}}.rates_to_usage rtu
-WHERE rtu.usage_start >= {{start_date}}::date
-    AND rtu.usage_start <= {{end_date}}::date
-    AND rtu.report_period_id = {{report_period_id}}
-    AND rtu.source_uuid = {{source_uuid}}::uuid
-    AND rtu.namespace = 'Network unattributed'
-    AND rtu.monthly_cost_type IS NULL
-GROUP BY rtu.report_period_id, rtu.source_uuid, rtu.usage_start,
-         rtu.cluster_id
-HAVING SUM(COALESCE(rtu.calculated_cost, 0)) != 0;
+    -(rtu_agg.cost_model_total + COALESCE(infra_agg.infra_total, 0))
+FROM (
+    SELECT
+        rtu.report_period_id,
+        rtu.source_uuid,
+        rtu.usage_start,
+        rtu.cluster_id,
+        MAX(rtu.cluster_alias) AS cluster_alias,
+        SUM(COALESCE(rtu.calculated_cost, 0)) AS cost_model_total
+    FROM {{schema | sqlsafe}}.rates_to_usage rtu
+    WHERE rtu.usage_start >= {{start_date}}::date
+        AND rtu.usage_start <= {{end_date}}::date
+        AND rtu.report_period_id = {{report_period_id}}
+        AND rtu.source_uuid = {{source_uuid}}::uuid
+        AND rtu.namespace = 'Network unattributed'
+        AND rtu.monthly_cost_type IS NULL
+    GROUP BY rtu.report_period_id, rtu.source_uuid, rtu.usage_start,
+             rtu.cluster_id
+    HAVING SUM(COALESCE(rtu.calculated_cost, 0)) != 0
+) rtu_agg
+LEFT JOIN (
+    SELECT
+        lids.usage_start,
+        lids.cluster_id,
+        SUM(
+            COALESCE(lids.infrastructure_raw_cost, 0) +
+            COALESCE(lids.infrastructure_markup_cost, 0)
+        ) AS infra_total
+    FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
+    WHERE lids.usage_start >= {{start_date}}::date
+        AND lids.usage_start <= {{end_date}}::date
+        AND lids.report_period_id = {{report_period_id}}
+        AND lids.namespace = 'Network unattributed'
+        AND lids.cost_model_rate_type IS NULL
+    GROUP BY lids.usage_start, lids.cluster_id
+) infra_agg
+    ON rtu_agg.usage_start = infra_agg.usage_start
+    AND rtu_agg.cluster_id = infra_agg.cluster_id;

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_network_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_network_per_rate.sql
@@ -83,7 +83,7 @@ SELECT
     nc.custom_name,
     nc.metric_type,
     nc.cost_model_rate_type,
-    {{cost_model_rate_type}},
+    {{distribution_tag}},
     CASE WHEN {{distribution}} = 'cpu' THEN
         CASE WHEN d.usage_cpu_sum <= 0 THEN 0
              ELSE (nu.ns_cpu / d.usage_cpu_sum) * nc.rate_cost

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_network_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_network_per_rate.sql
@@ -112,7 +112,7 @@ WHERE CASE WHEN {{distribution}} = 'cpu' THEN
 INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
     uuid, report_period_id, source_uuid, usage_start, usage_end,
     cluster_id, cluster_alias, namespace,
-    custom_name, cost_model_rate_type,
+    custom_name, metric_type, cost_model_rate_type,
     monthly_cost_type, distributed_cost
 )
 SELECT
@@ -124,7 +124,7 @@ SELECT
     rtu.cluster_id,
     MAX(rtu.cluster_alias),
     'Network unattributed',
-    '',
+    '', '',
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
     -SUM(COALESCE(rtu.calculated_cost, 0))

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_network_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_network_per_rate.sql
@@ -80,7 +80,7 @@ SELECT
     nu.namespace,
     nu.node,
     nu.cost_category_id,
-    nc.custom_name,
+    COALESCE(nc.custom_name, ''),
     nc.metric_type,
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
@@ -112,7 +112,7 @@ WHERE CASE WHEN {{distribution}} = 'cpu' THEN
 INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
     uuid, report_period_id, source_uuid, usage_start, usage_end,
     cluster_id, cluster_alias, namespace,
-    cost_model_rate_type,
+    custom_name, cost_model_rate_type,
     monthly_cost_type, distributed_cost
 )
 SELECT
@@ -124,6 +124,7 @@ SELECT
     rtu.cluster_id,
     MAX(rtu.cluster_alias),
     'Network unattributed',
+    '',
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
     -SUM(COALESCE(rtu.calculated_cost, 0))

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_network_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_network_per_rate.sql
@@ -82,7 +82,7 @@ SELECT
     nu.cost_category_id,
     nc.custom_name,
     nc.metric_type,
-    nc.cost_model_rate_type,
+    {{cost_model_rate_type}},
     {{cost_model_rate_type}},
     CASE WHEN {{distribution}} = 'cpu' THEN
         CASE WHEN d.usage_cpu_sum <= 0 THEN 0
@@ -107,3 +107,33 @@ WHERE CASE WHEN {{distribution}} = 'cpu' THEN
                ELSE (nu.ns_memory / d.usage_memory_sum) * nc.rate_cost
           END
       END != 0;
+
+-- Negate source: offset Network unattributed costs so the net distributed total is zero.
+INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
+    uuid, report_period_id, source_uuid, usage_start, usage_end,
+    cluster_id, cluster_alias, namespace,
+    cost_model_rate_type,
+    monthly_cost_type, distributed_cost
+)
+SELECT
+    uuid_generate_v4(),
+    rtu.report_period_id,
+    rtu.source_uuid,
+    rtu.usage_start,
+    rtu.usage_start,
+    rtu.cluster_id,
+    MAX(rtu.cluster_alias),
+    'Network unattributed',
+    {{cost_model_rate_type}},
+    {{cost_model_rate_type}},
+    -SUM(COALESCE(rtu.calculated_cost, 0))
+FROM {{schema | sqlsafe}}.rates_to_usage rtu
+WHERE rtu.usage_start >= {{start_date}}::date
+    AND rtu.usage_start <= {{end_date}}::date
+    AND rtu.report_period_id = {{report_period_id}}
+    AND rtu.source_uuid = {{source_uuid}}::uuid
+    AND rtu.namespace = 'Network unattributed'
+    AND rtu.monthly_cost_type IS NULL
+GROUP BY rtu.report_period_id, rtu.source_uuid, rtu.usage_start,
+         rtu.cluster_id
+HAVING SUM(COALESCE(rtu.calculated_cost, 0)) != 0;

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_network_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_network_per_rate.sql
@@ -1,0 +1,109 @@
+-- Per-rate unattributed network cost distribution via rates_to_usage.
+-- Reads per-rate costs from RTU (Network unattributed namespace), distributes
+-- proportionally to non-Network namespaces by CPU/memory hours (cross-cluster, daily),
+-- writes distributed rows back to RTU with monthly_cost_type = 'unattributed_network'.
+WITH network_rtu_cost AS (
+    SELECT
+        rtu.usage_start,
+        rtu.source_uuid,
+        rtu.cluster_id,
+        rtu.custom_name,
+        rtu.metric_type,
+        rtu.cost_model_rate_type,
+        SUM(COALESCE(rtu.calculated_cost, 0)) AS rate_cost
+    FROM {{schema | sqlsafe}}.rates_to_usage rtu
+    WHERE rtu.usage_start >= {{start_date}}::date
+        AND rtu.usage_start <= {{end_date}}::date
+        AND rtu.report_period_id = {{report_period_id}}
+        AND rtu.source_uuid = {{source_uuid}}::uuid
+        AND rtu.namespace = 'Network unattributed'
+        AND rtu.monthly_cost_type IS NULL
+    GROUP BY rtu.usage_start, rtu.source_uuid, rtu.cluster_id,
+             rtu.custom_name, rtu.metric_type, rtu.cost_model_rate_type
+),
+denominator AS (
+    SELECT
+        lids.usage_start,
+        lids.cluster_id,
+        SUM(lids.pod_effective_usage_cpu_core_hours) AS usage_cpu_sum,
+        SUM(lids.pod_effective_usage_memory_gigabyte_hours) AS usage_memory_sum
+    FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
+    LEFT JOIN {{schema | sqlsafe}}.reporting_ocp_cost_category cat
+        ON lids.cost_category_id = cat.id
+    WHERE lids.usage_start >= {{start_date}}::date
+        AND lids.usage_start <= {{end_date}}::date
+        AND lids.report_period_id = {{report_period_id}}
+        AND lids.namespace != 'Storage unattributed'
+        AND lids.namespace != 'Network unattributed'
+        AND lids.namespace != 'Worker unallocated'
+        AND (lids.cost_category_id IS NULL OR cat.name != 'Platform')
+    GROUP BY lids.usage_start, lids.cluster_id
+),
+namespace_usage AS (
+    SELECT
+        lids.usage_start,
+        lids.cluster_id,
+        lids.namespace,
+        lids.node,
+        MAX(lids.report_period_id) AS report_period_id,
+        MAX(lids.cluster_alias) AS cluster_alias,
+        MAX(lids.cost_category_id) AS cost_category_id,
+        SUM(lids.pod_effective_usage_cpu_core_hours) AS ns_cpu,
+        SUM(lids.pod_effective_usage_memory_gigabyte_hours) AS ns_memory
+    FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
+    LEFT JOIN {{schema | sqlsafe}}.reporting_ocp_cost_category cat
+        ON lids.cost_category_id = cat.id
+    WHERE lids.usage_start >= {{start_date}}::date
+        AND lids.usage_start <= {{end_date}}::date
+        AND lids.report_period_id = {{report_period_id}}
+        AND lids.namespace IS NOT NULL
+        AND lids.namespace != 'Storage unattributed'
+        AND lids.namespace != 'Network unattributed'
+        AND lids.namespace != 'Worker unallocated'
+        AND (lids.cost_category_id IS NULL OR cat.name != 'Platform')
+    GROUP BY lids.usage_start, lids.cluster_id, lids.namespace, lids.node
+)
+INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
+    uuid, report_period_id, source_uuid, usage_start, usage_end,
+    cluster_id, cluster_alias, namespace, node,
+    cost_category_id, custom_name, metric_type, cost_model_rate_type,
+    monthly_cost_type, distributed_cost
+)
+SELECT
+    uuid_generate_v4(),
+    nu.report_period_id,
+    nc.source_uuid,
+    nu.usage_start,
+    nu.usage_start,
+    nu.cluster_id,
+    nu.cluster_alias,
+    nu.namespace,
+    nu.node,
+    nu.cost_category_id,
+    nc.custom_name,
+    nc.metric_type,
+    nc.cost_model_rate_type,
+    {{cost_model_rate_type}},
+    CASE WHEN {{distribution}} = 'cpu' THEN
+        CASE WHEN d.usage_cpu_sum <= 0 THEN 0
+             ELSE (nu.ns_cpu / d.usage_cpu_sum) * nc.rate_cost
+        END
+    ELSE
+        CASE WHEN d.usage_memory_sum <= 0 THEN 0
+             ELSE (nu.ns_memory / d.usage_memory_sum) * nc.rate_cost
+        END
+    END
+FROM network_rtu_cost nc
+JOIN denominator d
+    ON d.usage_start = nc.usage_start AND d.cluster_id = nc.cluster_id
+JOIN namespace_usage nu
+    ON nu.usage_start = nc.usage_start AND nu.cluster_id = nc.cluster_id
+WHERE CASE WHEN {{distribution}} = 'cpu' THEN
+          CASE WHEN d.usage_cpu_sum <= 0 THEN 0
+               ELSE (nu.ns_cpu / d.usage_cpu_sum) * nc.rate_cost
+          END
+      ELSE
+          CASE WHEN d.usage_memory_sum <= 0 THEN 0
+               ELSE (nu.ns_memory / d.usage_memory_sum) * nc.rate_cost
+          END
+      END != 0;

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_network_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_network_per_rate.sql
@@ -102,7 +102,7 @@ INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
     uuid, report_period_id, source_uuid, usage_start, usage_end,
     cluster_id, cluster_alias, namespace, node,
     cost_category_id, custom_name, metric_type, cost_model_rate_type,
-    monthly_cost_type, distributed_cost
+    monthly_cost_type, distributed_cost, cost_model_id
 )
 SELECT
     uuid_generate_v4(),
@@ -133,7 +133,8 @@ SELECT
                          THEN (nt.total_rate_cost + COALESCE(ni.infra_total, 0)) / nt.total_rate_cost
                          ELSE 1 END
         END
-    END
+    END,
+    {{cost_model_id}}
 FROM network_rtu_cost nc
 JOIN denominator d
     ON d.usage_start = nc.usage_start AND d.cluster_id = nc.cluster_id
@@ -186,7 +187,8 @@ SELECT
         CASE WHEN d.usage_memory_sum <= 0 THEN 0
              ELSE (nu.ns_memory / d.usage_memory_sum) * ni.infra_total
         END
-    END
+    END,
+    {{cost_model_id}}
 FROM network_infra ni
 JOIN denominator d
     ON d.usage_start = ni.usage_start AND d.cluster_id = ni.cluster_id
@@ -213,7 +215,7 @@ INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
     uuid, report_period_id, source_uuid, usage_start, usage_end,
     cluster_id, cluster_alias, namespace, node,
     custom_name, metric_type, cost_model_rate_type,
-    monthly_cost_type, distributed_cost
+    monthly_cost_type, distributed_cost, cost_model_id
 )
 SELECT
     uuid_generate_v4(),
@@ -228,7 +230,8 @@ SELECT
     '', '',
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
-    -(src.cost_model_total + COALESCE(infra.infra_total, 0))
+    -(src.cost_model_total + COALESCE(infra.infra_total, 0)),
+    {{cost_model_id}}
 FROM (
     SELECT
         MAX(rtu.report_period_id) AS report_period_id,
@@ -293,7 +296,8 @@ SELECT
     -SUM(
         COALESCE(lids.infrastructure_raw_cost, 0) +
         COALESCE(lids.infrastructure_markup_cost, 0)
-    ) * {{infra_to_cm_rate}}
+    ) * {{infra_to_cm_rate}},
+    {{cost_model_id}}
 FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
 WHERE lids.usage_start >= {{start_date}}::date
     AND lids.usage_start <= {{end_date}}::date

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_network_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_network_per_rate.sql
@@ -134,7 +134,7 @@ SELECT
                          ELSE 1 END
         END
     END,
-    {{cost_model_id}}
+    {{cost_model_id}}::uuid
 FROM network_rtu_cost nc
 JOIN denominator d
     ON d.usage_start = nc.usage_start AND d.cluster_id = nc.cluster_id
@@ -188,7 +188,7 @@ SELECT
              ELSE (nu.ns_memory / d.usage_memory_sum) * ni.infra_total
         END
     END,
-    {{cost_model_id}}
+    {{cost_model_id}}::uuid
 FROM network_infra ni
 JOIN denominator d
     ON d.usage_start = ni.usage_start AND d.cluster_id = ni.cluster_id
@@ -231,7 +231,7 @@ SELECT
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
     -(src.cost_model_total + COALESCE(infra.infra_total, 0)),
-    {{cost_model_id}}
+    {{cost_model_id}}::uuid
 FROM (
     SELECT
         MAX(rtu.report_period_id) AS report_period_id,
@@ -297,7 +297,7 @@ SELECT
         COALESCE(lids.infrastructure_raw_cost, 0) +
         COALESCE(lids.infrastructure_markup_cost, 0)
     ) * {{infra_to_cm_rate}},
-    {{cost_model_id}}
+    {{cost_model_id}}::uuid
 FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
 WHERE lids.usage_start >= {{start_date}}::date
     AND lids.usage_start <= {{end_date}}::date

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_network_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_network_per_rate.sql
@@ -111,9 +111,9 @@ WHERE CASE WHEN {{distribution}} = 'cpu' THEN
           END
       END != 0;
 
--- Negate source: offset Network unattributed costs so the net distributed total is zero.
--- Must negate cost-model costs (from RTU) AND infrastructure/markup costs (from
--- daily_summary) so the API's cost_total + unattributed_network sums to zero.
+-- Negate source: derive negation from the distributed output rows just inserted.
+-- Sums distributed_cost of unattributed_network rows and inserts exact negative,
+-- guaranteeing algebraic zero-sum.
 INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
     uuid, report_period_id, source_uuid, usage_start, usage_end,
     cluster_id, cluster_alias, namespace,
@@ -122,51 +122,22 @@ INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
 )
 SELECT
     uuid_generate_v4(),
-    rtu_agg.report_period_id,
-    rtu_agg.source_uuid,
-    rtu_agg.usage_start,
-    rtu_agg.usage_start,
-    rtu_agg.cluster_id,
-    rtu_agg.cluster_alias,
+    MAX(rtu.report_period_id),
+    rtu.source_uuid,
+    rtu.usage_start,
+    rtu.usage_start,
+    rtu.cluster_id,
+    MAX(rtu.cluster_alias),
     'Network unattributed',
     '', '',
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
-    -(rtu_agg.cost_model_total + COALESCE(infra_agg.infra_total, 0))
-FROM (
-    SELECT
-        rtu.report_period_id,
-        rtu.source_uuid,
-        rtu.usage_start,
-        rtu.cluster_id,
-        MAX(rtu.cluster_alias) AS cluster_alias,
-        SUM(COALESCE(rtu.calculated_cost, 0)) AS cost_model_total
-    FROM {{schema | sqlsafe}}.rates_to_usage rtu
-    WHERE rtu.usage_start >= {{start_date}}::date
-        AND rtu.usage_start <= {{end_date}}::date
-        AND rtu.report_period_id = {{report_period_id}}
-        AND rtu.source_uuid = {{source_uuid}}::uuid
-        AND rtu.namespace = 'Network unattributed'
-        AND rtu.monthly_cost_type IS NULL
-    GROUP BY rtu.report_period_id, rtu.source_uuid, rtu.usage_start,
-             rtu.cluster_id
-    HAVING SUM(COALESCE(rtu.calculated_cost, 0)) != 0
-) rtu_agg
-LEFT JOIN (
-    SELECT
-        lids.usage_start,
-        lids.cluster_id,
-        SUM(
-            COALESCE(lids.infrastructure_raw_cost, 0) +
-            COALESCE(lids.infrastructure_markup_cost, 0)
-        ) AS infra_total
-    FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
-    WHERE lids.usage_start >= {{start_date}}::date
-        AND lids.usage_start <= {{end_date}}::date
-        AND lids.report_period_id = {{report_period_id}}
-        AND lids.namespace = 'Network unattributed'
-        AND lids.cost_model_rate_type IS NULL
-    GROUP BY lids.usage_start, lids.cluster_id
-) infra_agg
-    ON rtu_agg.usage_start = infra_agg.usage_start
-    AND rtu_agg.cluster_id = infra_agg.cluster_id;
+    -SUM(rtu.distributed_cost)
+FROM {{schema | sqlsafe}}.rates_to_usage rtu
+WHERE rtu.usage_start >= {{start_date}}::date
+    AND rtu.usage_start <= {{end_date}}::date
+    AND rtu.source_uuid = {{source_uuid}}::uuid
+    AND rtu.monthly_cost_type = {{cost_model_rate_type}}
+    AND rtu.namespace != 'Network unattributed'
+GROUP BY rtu.source_uuid, rtu.usage_start, rtu.cluster_id
+HAVING SUM(rtu.distributed_cost) != 0;

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_network_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_network_per_rate.sql
@@ -2,6 +2,10 @@
 -- Reads per-rate costs from RTU (Network unattributed namespace), distributes
 -- proportionally to non-Network namespaces by CPU/memory hours (cross-cluster, daily),
 -- writes distributed rows back to RTU with monthly_cost_type = 'unattributed_network'.
+--
+-- Infrastructure costs (OCP-on-cloud matching) live in daily_summary, not RTU.
+-- They are distributed proportionally across rates via a scaling factor so the
+-- Network unattributed namespace fully zeroes out (infra + cost_model = 0).
 WITH network_rtu_cost AS (
     SELECT
         rtu.usage_start,
@@ -23,6 +27,30 @@ WITH network_rtu_cost AS (
         ))
     GROUP BY rtu.usage_start, rtu.source_uuid, rtu.cluster_id,
              rtu.custom_name, rtu.metric_type, rtu.cost_model_rate_type
+),
+network_infra AS (
+    SELECT
+        lids.usage_start,
+        lids.cluster_id,
+        SUM(
+            COALESCE(lids.infrastructure_raw_cost, 0) +
+            COALESCE(lids.infrastructure_markup_cost, 0)
+        ) AS infra_total
+    FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
+    WHERE lids.usage_start >= {{start_date}}::date
+        AND lids.usage_start <= {{end_date}}::date
+        AND lids.report_period_id = {{report_period_id}}
+        AND lids.namespace = 'Network unattributed'
+        AND lids.cost_model_rate_type IS NULL
+    GROUP BY lids.usage_start, lids.cluster_id
+),
+network_total_rate AS (
+    SELECT
+        usage_start,
+        cluster_id,
+        SUM(rate_cost) AS total_rate_cost
+    FROM network_rtu_cost
+    GROUP BY usage_start, cluster_id
 ),
 denominator AS (
     SELECT
@@ -90,10 +118,16 @@ SELECT
     CASE WHEN {{distribution}} = 'cpu' THEN
         CASE WHEN d.usage_cpu_sum <= 0 THEN 0
              ELSE (nu.ns_cpu / d.usage_cpu_sum) * nc.rate_cost
+                  * CASE WHEN nt.total_rate_cost > 0
+                         THEN (nt.total_rate_cost + COALESCE(ni.infra_total, 0)) / nt.total_rate_cost
+                         ELSE 1 END
         END
     ELSE
         CASE WHEN d.usage_memory_sum <= 0 THEN 0
              ELSE (nu.ns_memory / d.usage_memory_sum) * nc.rate_cost
+                  * CASE WHEN nt.total_rate_cost > 0
+                         THEN (nt.total_rate_cost + COALESCE(ni.infra_total, 0)) / nt.total_rate_cost
+                         ELSE 1 END
         END
     END
 FROM network_rtu_cost nc
@@ -101,19 +135,29 @@ JOIN denominator d
     ON d.usage_start = nc.usage_start AND d.cluster_id = nc.cluster_id
 JOIN namespace_usage nu
     ON nu.usage_start = nc.usage_start AND nu.cluster_id = nc.cluster_id
+LEFT JOIN network_infra ni
+    ON ni.usage_start = nc.usage_start AND ni.cluster_id = nc.cluster_id
+LEFT JOIN network_total_rate nt
+    ON nt.usage_start = nc.usage_start AND nt.cluster_id = nc.cluster_id
 WHERE CASE WHEN {{distribution}} = 'cpu' THEN
           CASE WHEN d.usage_cpu_sum <= 0 THEN 0
                ELSE (nu.ns_cpu / d.usage_cpu_sum) * nc.rate_cost
+                    * CASE WHEN nt.total_rate_cost > 0
+                           THEN (nt.total_rate_cost + COALESCE(ni.infra_total, 0)) / nt.total_rate_cost
+                           ELSE 1 END
           END
       ELSE
           CASE WHEN d.usage_memory_sum <= 0 THEN 0
                ELSE (nu.ns_memory / d.usage_memory_sum) * nc.rate_cost
+                    * CASE WHEN nt.total_rate_cost > 0
+                           THEN (nt.total_rate_cost + COALESCE(ni.infra_total, 0)) / nt.total_rate_cost
+                           ELSE 1 END
           END
       END != 0;
 
 -- Negate source: derive negation from the distributed output rows just inserted.
--- Sums distributed_cost of unattributed_network rows and inserts exact negative,
--- guaranteeing algebraic zero-sum.
+-- Because the distribution above includes infrastructure costs via scaling,
+-- the derived sum automatically covers both cost-model and infrastructure.
 INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
     uuid, report_period_id, source_uuid, usage_start, usage_end,
     cluster_id, cluster_alias, namespace,

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_network_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_network_per_rate.sql
@@ -269,19 +269,14 @@ LEFT JOIN (
     ON src.usage_start = infra.usage_start
     AND src.cluster_id = infra.cluster_id
     AND src.node IS NOT DISTINCT FROM infra.node
-WHERE EXISTS (
-    SELECT 1 FROM {{schema | sqlsafe}}.rates_to_usage dist
-    WHERE dist.monthly_cost_type = {{cost_model_rate_type}}
-    AND dist.source_uuid = src.source_uuid
-    AND dist.usage_start = src.usage_start
-    AND dist.cluster_id = src.cluster_id
-)
-AND (src.cost_model_total + COALESCE(infra.infra_total, 0)) != 0
+WHERE (src.cost_model_total + COALESCE(infra.infra_total, 0)) != 0
 
 UNION ALL
 
 -- Infra-only fallback negation: negate per-node infrastructure costs when
 -- no cost model RTU rows exist for Network unattributed (markup-only cost model).
+-- No distribution-row guard needed: this SQL only runs when distribution is
+-- enabled in the cost model (checked by populate_distributed_cost_sql).
 SELECT
     uuid_generate_v4(),
     MAX(lids.report_period_id),
@@ -314,13 +309,6 @@ AND NOT EXISTS (
             'worker_distributed', 'platform_distributed', 'gpu_distributed',
             'unattributed_storage', 'unattributed_network'
         ))
-)
-AND EXISTS (
-    SELECT 1 FROM {{schema | sqlsafe}}.rates_to_usage dist
-    WHERE dist.monthly_cost_type = {{cost_model_rate_type}}
-    AND dist.source_uuid = {{source_uuid}}::uuid
-    AND dist.usage_start = lids.usage_start
-    AND dist.cluster_id = lids.cluster_id
 )
 GROUP BY lids.usage_start, lids.cluster_id, lids.node
 HAVING SUM(

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_network_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_network_per_rate.sql
@@ -83,7 +83,7 @@ SELECT
     nc.custom_name,
     nc.metric_type,
     nc.cost_model_rate_type,
-    {{distribution_tag}},
+    {{cost_model_rate_type}},
     CASE WHEN {{distribution}} = 'cpu' THEN
         CASE WHEN d.usage_cpu_sum <= 0 THEN 0
              ELSE (nu.ns_cpu / d.usage_cpu_sum) * nc.rate_cost

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_network_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_network_per_rate.sql
@@ -155,33 +155,74 @@ WHERE CASE WHEN {{distribution}} = 'cpu' THEN
           END
       END != 0;
 
--- Negate source: derive negation from the distributed output rows just inserted.
--- Because the distribution above includes infrastructure costs via scaling,
--- the derived sum automatically covers both cost-model and infrastructure.
+-- Negate source: per-node negation of Network unattributed costs.
+-- Includes infrastructure costs from daily_summary. Per-node granularity
+-- avoids NULL node ("No-node") entries in the API.
 INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
     uuid, report_period_id, source_uuid, usage_start, usage_end,
-    cluster_id, cluster_alias, namespace,
+    cluster_id, cluster_alias, namespace, node,
     custom_name, metric_type, cost_model_rate_type,
     monthly_cost_type, distributed_cost
 )
 SELECT
     uuid_generate_v4(),
-    MAX(rtu.report_period_id),
-    rtu.source_uuid,
-    rtu.usage_start,
-    rtu.usage_start,
-    rtu.cluster_id,
-    MAX(rtu.cluster_alias),
+    src.report_period_id,
+    src.source_uuid,
+    src.usage_start,
+    src.usage_start,
+    src.cluster_id,
+    src.cluster_alias,
     'Network unattributed',
+    src.node,
     '', '',
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
-    -SUM(rtu.distributed_cost)
-FROM {{schema | sqlsafe}}.rates_to_usage rtu
-WHERE rtu.usage_start >= {{start_date}}::date
-    AND rtu.usage_start <= {{end_date}}::date
-    AND rtu.source_uuid = {{source_uuid}}::uuid
-    AND rtu.monthly_cost_type = {{cost_model_rate_type}}
-    AND rtu.namespace != 'Network unattributed'
-GROUP BY rtu.source_uuid, rtu.usage_start, rtu.cluster_id
-HAVING SUM(rtu.distributed_cost) != 0;
+    -(src.cost_model_total + COALESCE(infra.infra_total, 0))
+FROM (
+    SELECT
+        MAX(rtu.report_period_id) AS report_period_id,
+        rtu.source_uuid,
+        rtu.usage_start,
+        rtu.cluster_id,
+        rtu.node,
+        MAX(rtu.cluster_alias) AS cluster_alias,
+        SUM(COALESCE(rtu.calculated_cost, 0)) AS cost_model_total
+    FROM {{schema | sqlsafe}}.rates_to_usage rtu
+    WHERE rtu.usage_start >= {{start_date}}::date
+        AND rtu.usage_start <= {{end_date}}::date
+        AND rtu.source_uuid = {{source_uuid}}::uuid
+        AND rtu.namespace = 'Network unattributed'
+        AND (rtu.monthly_cost_type IS NULL OR rtu.monthly_cost_type NOT IN (
+            'worker_distributed', 'platform_distributed', 'gpu_distributed',
+            'unattributed_storage', 'unattributed_network'
+        ))
+    GROUP BY rtu.source_uuid, rtu.usage_start, rtu.cluster_id, rtu.node
+) src
+LEFT JOIN (
+    SELECT
+        lids.usage_start,
+        lids.cluster_id,
+        lids.node,
+        SUM(
+            COALESCE(lids.infrastructure_raw_cost, 0) +
+            COALESCE(lids.infrastructure_markup_cost, 0)
+        ) AS infra_total
+    FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
+    WHERE lids.usage_start >= {{start_date}}::date
+        AND lids.usage_start <= {{end_date}}::date
+        AND lids.report_period_id = {{report_period_id}}
+        AND lids.namespace = 'Network unattributed'
+        AND lids.cost_model_rate_type IS NULL
+    GROUP BY lids.usage_start, lids.cluster_id, lids.node
+) infra
+    ON src.usage_start = infra.usage_start
+    AND src.cluster_id = infra.cluster_id
+    AND src.node IS NOT DISTINCT FROM infra.node
+WHERE EXISTS (
+    SELECT 1 FROM {{schema | sqlsafe}}.rates_to_usage dist
+    WHERE dist.monthly_cost_type = {{cost_model_rate_type}}
+    AND dist.source_uuid = src.source_uuid
+    AND dist.usage_start = src.usage_start
+    AND dist.cluster_id = src.cluster_id
+)
+AND (src.cost_model_total + COALESCE(infra.infra_total, 0)) != 0;

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_network_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_network_per_rate.sql
@@ -17,7 +17,10 @@ WITH network_rtu_cost AS (
         AND rtu.report_period_id = {{report_period_id}}
         AND rtu.source_uuid = {{source_uuid}}::uuid
         AND rtu.namespace = 'Network unattributed'
-        AND rtu.monthly_cost_type IS NULL
+        AND (rtu.monthly_cost_type IS NULL OR rtu.monthly_cost_type NOT IN (
+            'worker_distributed', 'platform_distributed', 'gpu_distributed',
+            'unattributed_storage', 'unattributed_network'
+        ))
     GROUP BY rtu.usage_start, rtu.source_uuid, rtu.cluster_id,
              rtu.custom_name, rtu.metric_type, rtu.cost_model_rate_type
 ),

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_network_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_network_per_rate.sql
@@ -4,8 +4,12 @@
 -- writes distributed rows back to RTU with monthly_cost_type = 'unattributed_network'.
 --
 -- Infrastructure costs (OCP-on-cloud matching) live in daily_summary, not RTU.
--- They are distributed proportionally across rates via a scaling factor so the
--- Network unattributed namespace fully zeroes out (infra + cost_model = 0).
+-- They are converted from raw_currency to cost_model_currency using
+-- infra_to_cm_rate before inclusion, so distributed_cost is denominated
+-- entirely in the cost model's currency.  The API's infra_exchange_rate
+-- annotation converts from cost_model_currency to the user's requested currency.
+--
+-- Parameters (additional): infra_to_cm_rate, cost_model_currency
 WITH network_rtu_cost AS (
     SELECT
         rtu.usage_start,
@@ -35,7 +39,7 @@ network_infra AS (
         SUM(
             COALESCE(lids.infrastructure_raw_cost, 0) +
             COALESCE(lids.infrastructure_markup_cost, 0)
-        ) AS infra_total
+        ) * {{infra_to_cm_rate}} AS infra_total
     FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
     WHERE lids.usage_start >= {{start_date}}::date
         AND lids.usage_start <= {{end_date}}::date
@@ -253,7 +257,7 @@ LEFT JOIN (
         SUM(
             COALESCE(lids.infrastructure_raw_cost, 0) +
             COALESCE(lids.infrastructure_markup_cost, 0)
-        ) AS infra_total
+        ) * {{infra_to_cm_rate}} AS infra_total
     FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
     WHERE lids.usage_start >= {{start_date}}::date
         AND lids.usage_start <= {{end_date}}::date
@@ -294,7 +298,7 @@ SELECT
     -SUM(
         COALESCE(lids.infrastructure_raw_cost, 0) +
         COALESCE(lids.infrastructure_markup_cost, 0)
-    )
+    ) * {{infra_to_cm_rate}}
 FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
 WHERE lids.usage_start >= {{start_date}}::date
     AND lids.usage_start <= {{end_date}}::date

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_storage_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_storage_per_rate.sql
@@ -133,7 +133,7 @@ SELECT
                          ELSE 1 END
         END
     END,
-    {{cost_model_id}}
+    {{cost_model_id}}::uuid
 FROM storage_rtu_cost sc
 JOIN denominator d
     ON d.usage_start = sc.usage_start AND d.cluster_id = sc.cluster_id
@@ -187,7 +187,7 @@ SELECT
              ELSE (nu.ns_memory / d.usage_memory_sum) * si.infra_total
         END
     END,
-    {{cost_model_id}}
+    {{cost_model_id}}::uuid
 FROM storage_infra si
 JOIN denominator d
     ON d.usage_start = si.usage_start AND d.cluster_id = si.cluster_id
@@ -230,7 +230,7 @@ SELECT
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
     -(src.cost_model_total + COALESCE(infra.infra_total, 0)),
-    {{cost_model_id}}
+    {{cost_model_id}}::uuid
 FROM (
     SELECT
         MAX(rtu.report_period_id) AS report_period_id,
@@ -296,7 +296,7 @@ SELECT
         COALESCE(lids.infrastructure_raw_cost, 0) +
         COALESCE(lids.infrastructure_markup_cost, 0)
     ) * {{infra_to_cm_rate}},
-    {{cost_model_id}}
+    {{cost_model_id}}::uuid
 FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
 WHERE lids.usage_start >= {{start_date}}::date
     AND lids.usage_start <= {{end_date}}::date

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_storage_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_storage_per_rate.sql
@@ -82,7 +82,7 @@ SELECT
     nu.cost_category_id,
     sc.custom_name,
     sc.metric_type,
-    sc.cost_model_rate_type,
+    {{cost_model_rate_type}},
     {{cost_model_rate_type}},
     CASE WHEN {{distribution}} = 'cpu' THEN
         CASE WHEN d.usage_cpu_sum <= 0 THEN 0
@@ -107,3 +107,33 @@ WHERE CASE WHEN {{distribution}} = 'cpu' THEN
                ELSE (nu.ns_memory / d.usage_memory_sum) * sc.rate_cost
           END
       END != 0;
+
+-- Negate source: offset Storage unattributed costs so the net distributed total is zero.
+INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
+    uuid, report_period_id, source_uuid, usage_start, usage_end,
+    cluster_id, cluster_alias, namespace,
+    cost_model_rate_type,
+    monthly_cost_type, distributed_cost
+)
+SELECT
+    uuid_generate_v4(),
+    rtu.report_period_id,
+    rtu.source_uuid,
+    rtu.usage_start,
+    rtu.usage_start,
+    rtu.cluster_id,
+    MAX(rtu.cluster_alias),
+    'Storage unattributed',
+    {{cost_model_rate_type}},
+    {{cost_model_rate_type}},
+    -SUM(COALESCE(rtu.calculated_cost, 0))
+FROM {{schema | sqlsafe}}.rates_to_usage rtu
+WHERE rtu.usage_start >= {{start_date}}::date
+    AND rtu.usage_start <= {{end_date}}::date
+    AND rtu.report_period_id = {{report_period_id}}
+    AND rtu.source_uuid = {{source_uuid}}::uuid
+    AND rtu.namespace = 'Storage unattributed'
+    AND rtu.monthly_cost_type IS NULL
+GROUP BY rtu.report_period_id, rtu.source_uuid, rtu.usage_start,
+         rtu.cluster_id
+HAVING SUM(COALESCE(rtu.calculated_cost, 0)) != 0;

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_storage_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_storage_per_rate.sql
@@ -1,0 +1,109 @@
+-- Per-rate unattributed storage cost distribution via rates_to_usage.
+-- Reads per-rate costs from RTU (Storage unattributed namespace), distributes
+-- proportionally to non-Storage namespaces by CPU/memory hours (cross-cluster, daily),
+-- writes distributed rows back to RTU with monthly_cost_type = 'unattributed_storage'.
+WITH storage_rtu_cost AS (
+    SELECT
+        rtu.usage_start,
+        rtu.source_uuid,
+        rtu.cluster_id,
+        rtu.custom_name,
+        rtu.metric_type,
+        rtu.cost_model_rate_type,
+        SUM(COALESCE(rtu.calculated_cost, 0)) AS rate_cost
+    FROM {{schema | sqlsafe}}.rates_to_usage rtu
+    WHERE rtu.usage_start >= {{start_date}}::date
+        AND rtu.usage_start <= {{end_date}}::date
+        AND rtu.report_period_id = {{report_period_id}}
+        AND rtu.source_uuid = {{source_uuid}}::uuid
+        AND rtu.namespace = 'Storage unattributed'
+        AND rtu.monthly_cost_type IS NULL
+    GROUP BY rtu.usage_start, rtu.source_uuid, rtu.cluster_id,
+             rtu.custom_name, rtu.metric_type, rtu.cost_model_rate_type
+),
+denominator AS (
+    SELECT
+        lids.usage_start,
+        lids.cluster_id,
+        SUM(lids.pod_effective_usage_cpu_core_hours) AS usage_cpu_sum,
+        SUM(lids.pod_effective_usage_memory_gigabyte_hours) AS usage_memory_sum
+    FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
+    LEFT JOIN {{schema | sqlsafe}}.reporting_ocp_cost_category cat
+        ON lids.cost_category_id = cat.id
+    WHERE lids.usage_start >= {{start_date}}::date
+        AND lids.usage_start <= {{end_date}}::date
+        AND lids.report_period_id = {{report_period_id}}
+        AND lids.namespace != 'Storage unattributed'
+        AND lids.namespace != 'Network unattributed'
+        AND lids.namespace != 'Worker unallocated'
+        AND (lids.cost_category_id IS NULL OR cat.name != 'Platform')
+    GROUP BY lids.usage_start, lids.cluster_id
+),
+namespace_usage AS (
+    SELECT
+        lids.usage_start,
+        lids.cluster_id,
+        lids.namespace,
+        lids.node,
+        MAX(lids.report_period_id) AS report_period_id,
+        MAX(lids.cluster_alias) AS cluster_alias,
+        MAX(lids.cost_category_id) AS cost_category_id,
+        SUM(lids.pod_effective_usage_cpu_core_hours) AS ns_cpu,
+        SUM(lids.pod_effective_usage_memory_gigabyte_hours) AS ns_memory
+    FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
+    LEFT JOIN {{schema | sqlsafe}}.reporting_ocp_cost_category cat
+        ON lids.cost_category_id = cat.id
+    WHERE lids.usage_start >= {{start_date}}::date
+        AND lids.usage_start <= {{end_date}}::date
+        AND lids.report_period_id = {{report_period_id}}
+        AND lids.namespace IS NOT NULL
+        AND lids.namespace != 'Storage unattributed'
+        AND lids.namespace != 'Network unattributed'
+        AND lids.namespace != 'Worker unallocated'
+        AND (lids.cost_category_id IS NULL OR cat.name != 'Platform')
+    GROUP BY lids.usage_start, lids.cluster_id, lids.namespace, lids.node
+)
+INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
+    uuid, report_period_id, source_uuid, usage_start, usage_end,
+    cluster_id, cluster_alias, namespace, node,
+    cost_category_id, custom_name, metric_type, cost_model_rate_type,
+    monthly_cost_type, distributed_cost
+)
+SELECT
+    uuid_generate_v4(),
+    nu.report_period_id,
+    sc.source_uuid,
+    nu.usage_start,
+    nu.usage_start,
+    nu.cluster_id,
+    nu.cluster_alias,
+    nu.namespace,
+    nu.node,
+    nu.cost_category_id,
+    sc.custom_name,
+    sc.metric_type,
+    sc.cost_model_rate_type,
+    {{cost_model_rate_type}},
+    CASE WHEN {{distribution}} = 'cpu' THEN
+        CASE WHEN d.usage_cpu_sum <= 0 THEN 0
+             ELSE (nu.ns_cpu / d.usage_cpu_sum) * sc.rate_cost
+        END
+    ELSE
+        CASE WHEN d.usage_memory_sum <= 0 THEN 0
+             ELSE (nu.ns_memory / d.usage_memory_sum) * sc.rate_cost
+        END
+    END
+FROM storage_rtu_cost sc
+JOIN denominator d
+    ON d.usage_start = sc.usage_start AND d.cluster_id = sc.cluster_id
+JOIN namespace_usage nu
+    ON nu.usage_start = sc.usage_start AND nu.cluster_id = sc.cluster_id
+WHERE CASE WHEN {{distribution}} = 'cpu' THEN
+          CASE WHEN d.usage_cpu_sum <= 0 THEN 0
+               ELSE (nu.ns_cpu / d.usage_cpu_sum) * sc.rate_cost
+          END
+      ELSE
+          CASE WHEN d.usage_memory_sum <= 0 THEN 0
+               ELSE (nu.ns_memory / d.usage_memory_sum) * sc.rate_cost
+          END
+      END != 0;

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_storage_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_storage_per_rate.sql
@@ -111,9 +111,9 @@ WHERE CASE WHEN {{distribution}} = 'cpu' THEN
           END
       END != 0;
 
--- Negate source: offset Storage unattributed costs so the net distributed total is zero.
--- Must negate cost-model costs (from RTU) AND infrastructure/markup costs (from
--- daily_summary) so the API's cost_total + unattributed_storage sums to zero.
+-- Negate source: derive negation from the distributed output rows just inserted.
+-- Sums distributed_cost of unattributed_storage rows and inserts exact negative,
+-- guaranteeing algebraic zero-sum.
 INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
     uuid, report_period_id, source_uuid, usage_start, usage_end,
     cluster_id, cluster_alias, namespace,
@@ -122,51 +122,22 @@ INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
 )
 SELECT
     uuid_generate_v4(),
-    rtu_agg.report_period_id,
-    rtu_agg.source_uuid,
-    rtu_agg.usage_start,
-    rtu_agg.usage_start,
-    rtu_agg.cluster_id,
-    rtu_agg.cluster_alias,
+    MAX(rtu.report_period_id),
+    rtu.source_uuid,
+    rtu.usage_start,
+    rtu.usage_start,
+    rtu.cluster_id,
+    MAX(rtu.cluster_alias),
     'Storage unattributed',
     '', '',
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
-    -(rtu_agg.cost_model_total + COALESCE(infra_agg.infra_total, 0))
-FROM (
-    SELECT
-        rtu.report_period_id,
-        rtu.source_uuid,
-        rtu.usage_start,
-        rtu.cluster_id,
-        MAX(rtu.cluster_alias) AS cluster_alias,
-        SUM(COALESCE(rtu.calculated_cost, 0)) AS cost_model_total
-    FROM {{schema | sqlsafe}}.rates_to_usage rtu
-    WHERE rtu.usage_start >= {{start_date}}::date
-        AND rtu.usage_start <= {{end_date}}::date
-        AND rtu.report_period_id = {{report_period_id}}
-        AND rtu.source_uuid = {{source_uuid}}::uuid
-        AND rtu.namespace = 'Storage unattributed'
-        AND rtu.monthly_cost_type IS NULL
-    GROUP BY rtu.report_period_id, rtu.source_uuid, rtu.usage_start,
-             rtu.cluster_id
-    HAVING SUM(COALESCE(rtu.calculated_cost, 0)) != 0
-) rtu_agg
-LEFT JOIN (
-    SELECT
-        lids.usage_start,
-        lids.cluster_id,
-        SUM(
-            COALESCE(lids.infrastructure_raw_cost, 0) +
-            COALESCE(lids.infrastructure_markup_cost, 0)
-        ) AS infra_total
-    FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
-    WHERE lids.usage_start >= {{start_date}}::date
-        AND lids.usage_start <= {{end_date}}::date
-        AND lids.report_period_id = {{report_period_id}}
-        AND lids.namespace = 'Storage unattributed'
-        AND lids.cost_model_rate_type IS NULL
-    GROUP BY lids.usage_start, lids.cluster_id
-) infra_agg
-    ON rtu_agg.usage_start = infra_agg.usage_start
-    AND rtu_agg.cluster_id = infra_agg.cluster_id;
+    -SUM(rtu.distributed_cost)
+FROM {{schema | sqlsafe}}.rates_to_usage rtu
+WHERE rtu.usage_start >= {{start_date}}::date
+    AND rtu.usage_start <= {{end_date}}::date
+    AND rtu.source_uuid = {{source_uuid}}::uuid
+    AND rtu.monthly_cost_type = {{cost_model_rate_type}}
+    AND rtu.namespace != 'Storage unattributed'
+GROUP BY rtu.source_uuid, rtu.usage_start, rtu.cluster_id
+HAVING SUM(rtu.distributed_cost) != 0;

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_storage_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_storage_per_rate.sql
@@ -83,7 +83,7 @@ SELECT
     sc.custom_name,
     sc.metric_type,
     sc.cost_model_rate_type,
-    {{distribution_tag}},
+    {{cost_model_rate_type}},
     CASE WHEN {{distribution}} = 'cpu' THEN
         CASE WHEN d.usage_cpu_sum <= 0 THEN 0
              ELSE (nu.ns_cpu / d.usage_cpu_sum) * sc.rate_cost

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_storage_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_storage_per_rate.sql
@@ -109,6 +109,8 @@ WHERE CASE WHEN {{distribution}} = 'cpu' THEN
       END != 0;
 
 -- Negate source: offset Storage unattributed costs so the net distributed total is zero.
+-- Must negate cost-model costs (from RTU) AND infrastructure/markup costs (from
+-- daily_summary) so the API's cost_total + unattributed_storage sums to zero.
 INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
     uuid, report_period_id, source_uuid, usage_start, usage_end,
     cluster_id, cluster_alias, namespace,
@@ -117,24 +119,51 @@ INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
 )
 SELECT
     uuid_generate_v4(),
-    rtu.report_period_id,
-    rtu.source_uuid,
-    rtu.usage_start,
-    rtu.usage_start,
-    rtu.cluster_id,
-    MAX(rtu.cluster_alias),
+    rtu_agg.report_period_id,
+    rtu_agg.source_uuid,
+    rtu_agg.usage_start,
+    rtu_agg.usage_start,
+    rtu_agg.cluster_id,
+    rtu_agg.cluster_alias,
     'Storage unattributed',
     '', '',
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
-    -SUM(COALESCE(rtu.calculated_cost, 0))
-FROM {{schema | sqlsafe}}.rates_to_usage rtu
-WHERE rtu.usage_start >= {{start_date}}::date
-    AND rtu.usage_start <= {{end_date}}::date
-    AND rtu.report_period_id = {{report_period_id}}
-    AND rtu.source_uuid = {{source_uuid}}::uuid
-    AND rtu.namespace = 'Storage unattributed'
-    AND rtu.monthly_cost_type IS NULL
-GROUP BY rtu.report_period_id, rtu.source_uuid, rtu.usage_start,
-         rtu.cluster_id
-HAVING SUM(COALESCE(rtu.calculated_cost, 0)) != 0;
+    -(rtu_agg.cost_model_total + COALESCE(infra_agg.infra_total, 0))
+FROM (
+    SELECT
+        rtu.report_period_id,
+        rtu.source_uuid,
+        rtu.usage_start,
+        rtu.cluster_id,
+        MAX(rtu.cluster_alias) AS cluster_alias,
+        SUM(COALESCE(rtu.calculated_cost, 0)) AS cost_model_total
+    FROM {{schema | sqlsafe}}.rates_to_usage rtu
+    WHERE rtu.usage_start >= {{start_date}}::date
+        AND rtu.usage_start <= {{end_date}}::date
+        AND rtu.report_period_id = {{report_period_id}}
+        AND rtu.source_uuid = {{source_uuid}}::uuid
+        AND rtu.namespace = 'Storage unattributed'
+        AND rtu.monthly_cost_type IS NULL
+    GROUP BY rtu.report_period_id, rtu.source_uuid, rtu.usage_start,
+             rtu.cluster_id
+    HAVING SUM(COALESCE(rtu.calculated_cost, 0)) != 0
+) rtu_agg
+LEFT JOIN (
+    SELECT
+        lids.usage_start,
+        lids.cluster_id,
+        SUM(
+            COALESCE(lids.infrastructure_raw_cost, 0) +
+            COALESCE(lids.infrastructure_markup_cost, 0)
+        ) AS infra_total
+    FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
+    WHERE lids.usage_start >= {{start_date}}::date
+        AND lids.usage_start <= {{end_date}}::date
+        AND lids.report_period_id = {{report_period_id}}
+        AND lids.namespace = 'Storage unattributed'
+        AND lids.cost_model_rate_type IS NULL
+    GROUP BY lids.usage_start, lids.cluster_id
+) infra_agg
+    ON rtu_agg.usage_start = infra_agg.usage_start
+    AND rtu_agg.cluster_id = infra_agg.cluster_id;

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_storage_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_storage_per_rate.sql
@@ -112,7 +112,7 @@ WHERE CASE WHEN {{distribution}} = 'cpu' THEN
 INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
     uuid, report_period_id, source_uuid, usage_start, usage_end,
     cluster_id, cluster_alias, namespace,
-    custom_name, cost_model_rate_type,
+    custom_name, metric_type, cost_model_rate_type,
     monthly_cost_type, distributed_cost
 )
 SELECT
@@ -124,7 +124,7 @@ SELECT
     rtu.cluster_id,
     MAX(rtu.cluster_alias),
     'Storage unattributed',
-    '',
+    '', '',
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
     -SUM(COALESCE(rtu.calculated_cost, 0))

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_storage_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_storage_per_rate.sql
@@ -4,8 +4,11 @@
 -- writes distributed rows back to RTU with monthly_cost_type = 'unattributed_storage'.
 --
 -- Infrastructure costs (OCP-on-cloud matching) live in daily_summary, not RTU.
--- They are distributed proportionally across rates via a scaling factor so the
--- Storage unattributed namespace fully zeroes out (infra + cost_model = 0).
+-- They are converted from raw_currency to cost_model_currency using
+-- infra_to_cm_rate before inclusion, so distributed_cost is denominated
+-- entirely in the cost model's currency.
+--
+-- Parameters (additional): infra_to_cm_rate, cost_model_currency
 WITH storage_rtu_cost AS (
     SELECT
         rtu.usage_start,
@@ -35,7 +38,7 @@ storage_infra AS (
         SUM(
             COALESCE(lids.infrastructure_raw_cost, 0) +
             COALESCE(lids.infrastructure_markup_cost, 0)
-        ) AS infra_total
+        ) * {{infra_to_cm_rate}} AS infra_total
     FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
     WHERE lids.usage_start >= {{start_date}}::date
         AND lids.usage_start <= {{end_date}}::date
@@ -253,7 +256,7 @@ LEFT JOIN (
         SUM(
             COALESCE(lids.infrastructure_raw_cost, 0) +
             COALESCE(lids.infrastructure_markup_cost, 0)
-        ) AS infra_total
+        ) * {{infra_to_cm_rate}} AS infra_total
     FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
     WHERE lids.usage_start >= {{start_date}}::date
         AND lids.usage_start <= {{end_date}}::date
@@ -294,7 +297,7 @@ SELECT
     -SUM(
         COALESCE(lids.infrastructure_raw_cost, 0) +
         COALESCE(lids.infrastructure_markup_cost, 0)
-    )
+    ) * {{infra_to_cm_rate}}
 FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
 WHERE lids.usage_start >= {{start_date}}::date
     AND lids.usage_start <= {{end_date}}::date

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_storage_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_storage_per_rate.sql
@@ -83,7 +83,7 @@ SELECT
     sc.custom_name,
     sc.metric_type,
     sc.cost_model_rate_type,
-    {{cost_model_rate_type}},
+    {{distribution_tag}},
     CASE WHEN {{distribution}} = 'cpu' THEN
         CASE WHEN d.usage_cpu_sum <= 0 THEN 0
              ELSE (nu.ns_cpu / d.usage_cpu_sum) * sc.rate_cost

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_storage_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_storage_per_rate.sql
@@ -17,7 +17,10 @@ WITH storage_rtu_cost AS (
         AND rtu.report_period_id = {{report_period_id}}
         AND rtu.source_uuid = {{source_uuid}}::uuid
         AND rtu.namespace = 'Storage unattributed'
-        AND rtu.monthly_cost_type IS NULL
+        AND (rtu.monthly_cost_type IS NULL OR rtu.monthly_cost_type NOT IN (
+            'worker_distributed', 'platform_distributed', 'gpu_distributed',
+            'unattributed_storage', 'unattributed_network'
+        ))
     GROUP BY rtu.usage_start, rtu.source_uuid, rtu.cluster_id,
              rtu.custom_name, rtu.metric_type, rtu.cost_model_rate_type
 ),

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_storage_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_storage_per_rate.sql
@@ -268,19 +268,14 @@ LEFT JOIN (
     ON src.usage_start = infra.usage_start
     AND src.cluster_id = infra.cluster_id
     AND src.node IS NOT DISTINCT FROM infra.node
-WHERE EXISTS (
-    SELECT 1 FROM {{schema | sqlsafe}}.rates_to_usage dist
-    WHERE dist.monthly_cost_type = {{cost_model_rate_type}}
-    AND dist.source_uuid = src.source_uuid
-    AND dist.usage_start = src.usage_start
-    AND dist.cluster_id = src.cluster_id
-)
-AND (src.cost_model_total + COALESCE(infra.infra_total, 0)) != 0
+WHERE (src.cost_model_total + COALESCE(infra.infra_total, 0)) != 0
 
 UNION ALL
 
 -- Infra-only fallback negation: negate per-node infrastructure costs when
 -- no cost model RTU rows exist for Storage unattributed (markup-only cost model).
+-- No distribution-row guard needed: this SQL only runs when distribution is
+-- enabled in the cost model (checked by populate_distributed_cost_sql).
 SELECT
     uuid_generate_v4(),
     MAX(lids.report_period_id),
@@ -313,13 +308,6 @@ AND NOT EXISTS (
             'worker_distributed', 'platform_distributed', 'gpu_distributed',
             'unattributed_storage', 'unattributed_network'
         ))
-)
-AND EXISTS (
-    SELECT 1 FROM {{schema | sqlsafe}}.rates_to_usage dist
-    WHERE dist.monthly_cost_type = {{cost_model_rate_type}}
-    AND dist.source_uuid = {{source_uuid}}::uuid
-    AND dist.usage_start = lids.usage_start
-    AND dist.cluster_id = lids.cluster_id
 )
 GROUP BY lids.usage_start, lids.cluster_id, lids.node
 HAVING SUM(

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_storage_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_storage_per_rate.sql
@@ -155,33 +155,74 @@ WHERE CASE WHEN {{distribution}} = 'cpu' THEN
           END
       END != 0;
 
--- Negate source: derive negation from the distributed output rows just inserted.
--- Because the distribution above includes infrastructure costs via scaling,
--- the derived sum automatically covers both cost-model and infrastructure.
+-- Negate source: per-node negation of Storage unattributed costs.
+-- Includes infrastructure costs from daily_summary. Per-node granularity
+-- avoids NULL node ("No-node") entries in the API.
 INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
     uuid, report_period_id, source_uuid, usage_start, usage_end,
-    cluster_id, cluster_alias, namespace,
+    cluster_id, cluster_alias, namespace, node,
     custom_name, metric_type, cost_model_rate_type,
     monthly_cost_type, distributed_cost
 )
 SELECT
     uuid_generate_v4(),
-    MAX(rtu.report_period_id),
-    rtu.source_uuid,
-    rtu.usage_start,
-    rtu.usage_start,
-    rtu.cluster_id,
-    MAX(rtu.cluster_alias),
+    src.report_period_id,
+    src.source_uuid,
+    src.usage_start,
+    src.usage_start,
+    src.cluster_id,
+    src.cluster_alias,
     'Storage unattributed',
+    src.node,
     '', '',
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
-    -SUM(rtu.distributed_cost)
-FROM {{schema | sqlsafe}}.rates_to_usage rtu
-WHERE rtu.usage_start >= {{start_date}}::date
-    AND rtu.usage_start <= {{end_date}}::date
-    AND rtu.source_uuid = {{source_uuid}}::uuid
-    AND rtu.monthly_cost_type = {{cost_model_rate_type}}
-    AND rtu.namespace != 'Storage unattributed'
-GROUP BY rtu.source_uuid, rtu.usage_start, rtu.cluster_id
-HAVING SUM(rtu.distributed_cost) != 0;
+    -(src.cost_model_total + COALESCE(infra.infra_total, 0))
+FROM (
+    SELECT
+        MAX(rtu.report_period_id) AS report_period_id,
+        rtu.source_uuid,
+        rtu.usage_start,
+        rtu.cluster_id,
+        rtu.node,
+        MAX(rtu.cluster_alias) AS cluster_alias,
+        SUM(COALESCE(rtu.calculated_cost, 0)) AS cost_model_total
+    FROM {{schema | sqlsafe}}.rates_to_usage rtu
+    WHERE rtu.usage_start >= {{start_date}}::date
+        AND rtu.usage_start <= {{end_date}}::date
+        AND rtu.source_uuid = {{source_uuid}}::uuid
+        AND rtu.namespace = 'Storage unattributed'
+        AND (rtu.monthly_cost_type IS NULL OR rtu.monthly_cost_type NOT IN (
+            'worker_distributed', 'platform_distributed', 'gpu_distributed',
+            'unattributed_storage', 'unattributed_network'
+        ))
+    GROUP BY rtu.source_uuid, rtu.usage_start, rtu.cluster_id, rtu.node
+) src
+LEFT JOIN (
+    SELECT
+        lids.usage_start,
+        lids.cluster_id,
+        lids.node,
+        SUM(
+            COALESCE(lids.infrastructure_raw_cost, 0) +
+            COALESCE(lids.infrastructure_markup_cost, 0)
+        ) AS infra_total
+    FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
+    WHERE lids.usage_start >= {{start_date}}::date
+        AND lids.usage_start <= {{end_date}}::date
+        AND lids.report_period_id = {{report_period_id}}
+        AND lids.namespace = 'Storage unattributed'
+        AND lids.cost_model_rate_type IS NULL
+    GROUP BY lids.usage_start, lids.cluster_id, lids.node
+) infra
+    ON src.usage_start = infra.usage_start
+    AND src.cluster_id = infra.cluster_id
+    AND src.node IS NOT DISTINCT FROM infra.node
+WHERE EXISTS (
+    SELECT 1 FROM {{schema | sqlsafe}}.rates_to_usage dist
+    WHERE dist.monthly_cost_type = {{cost_model_rate_type}}
+    AND dist.source_uuid = src.source_uuid
+    AND dist.usage_start = src.usage_start
+    AND dist.cluster_id = src.cluster_id
+)
+AND (src.cost_model_total + COALESCE(infra.infra_total, 0)) != 0;

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_storage_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_storage_per_rate.sql
@@ -80,7 +80,7 @@ SELECT
     nu.namespace,
     nu.node,
     nu.cost_category_id,
-    sc.custom_name,
+    COALESCE(sc.custom_name, ''),
     sc.metric_type,
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
@@ -112,7 +112,7 @@ WHERE CASE WHEN {{distribution}} = 'cpu' THEN
 INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
     uuid, report_period_id, source_uuid, usage_start, usage_end,
     cluster_id, cluster_alias, namespace,
-    cost_model_rate_type,
+    custom_name, cost_model_rate_type,
     monthly_cost_type, distributed_cost
 )
 SELECT
@@ -124,6 +124,7 @@ SELECT
     rtu.cluster_id,
     MAX(rtu.cluster_alias),
     'Storage unattributed',
+    '',
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
     -SUM(COALESCE(rtu.calculated_cost, 0))

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_storage_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_storage_per_rate.sql
@@ -101,7 +101,7 @@ INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
     uuid, report_period_id, source_uuid, usage_start, usage_end,
     cluster_id, cluster_alias, namespace, node,
     cost_category_id, custom_name, metric_type, cost_model_rate_type,
-    monthly_cost_type, distributed_cost
+    monthly_cost_type, distributed_cost, cost_model_id
 )
 SELECT
     uuid_generate_v4(),
@@ -132,7 +132,8 @@ SELECT
                          THEN (st.total_rate_cost + COALESCE(si.infra_total, 0)) / st.total_rate_cost
                          ELSE 1 END
         END
-    END
+    END,
+    {{cost_model_id}}
 FROM storage_rtu_cost sc
 JOIN denominator d
     ON d.usage_start = sc.usage_start AND d.cluster_id = sc.cluster_id
@@ -185,7 +186,8 @@ SELECT
         CASE WHEN d.usage_memory_sum <= 0 THEN 0
              ELSE (nu.ns_memory / d.usage_memory_sum) * si.infra_total
         END
-    END
+    END,
+    {{cost_model_id}}
 FROM storage_infra si
 JOIN denominator d
     ON d.usage_start = si.usage_start AND d.cluster_id = si.cluster_id
@@ -212,7 +214,7 @@ INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
     uuid, report_period_id, source_uuid, usage_start, usage_end,
     cluster_id, cluster_alias, namespace, node,
     custom_name, metric_type, cost_model_rate_type,
-    monthly_cost_type, distributed_cost
+    monthly_cost_type, distributed_cost, cost_model_id
 )
 SELECT
     uuid_generate_v4(),
@@ -227,7 +229,8 @@ SELECT
     '', '',
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
-    -(src.cost_model_total + COALESCE(infra.infra_total, 0))
+    -(src.cost_model_total + COALESCE(infra.infra_total, 0)),
+    {{cost_model_id}}
 FROM (
     SELECT
         MAX(rtu.report_period_id) AS report_period_id,
@@ -292,7 +295,8 @@ SELECT
     -SUM(
         COALESCE(lids.infrastructure_raw_cost, 0) +
         COALESCE(lids.infrastructure_markup_cost, 0)
-    ) * {{infra_to_cm_rate}}
+    ) * {{infra_to_cm_rate}},
+    {{cost_model_id}}
 FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
 WHERE lids.usage_start >= {{start_date}}::date
     AND lids.usage_start <= {{end_date}}::date

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_storage_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_storage_per_rate.sql
@@ -153,7 +153,54 @@ WHERE CASE WHEN {{distribution}} = 'cpu' THEN
                            THEN (st.total_rate_cost + COALESCE(si.infra_total, 0)) / st.total_rate_cost
                            ELSE 1 END
           END
-      END != 0;
+      END != 0
+
+UNION ALL
+
+-- Infra-only fallback: when cost model rates produce zero costs for Storage
+-- unattributed (no pod usage in that namespace), distribute infrastructure
+-- costs directly. Guards: total_rate_cost IS NULL (no RTU rows) or <= 0.
+SELECT
+    uuid_generate_v4(),
+    nu.report_period_id,
+    {{source_uuid}}::uuid,
+    nu.usage_start,
+    nu.usage_start,
+    nu.cluster_id,
+    nu.cluster_alias,
+    nu.namespace,
+    nu.node,
+    nu.cost_category_id,
+    '', '',
+    {{cost_model_rate_type}},
+    {{cost_model_rate_type}},
+    CASE WHEN {{distribution}} = 'cpu' THEN
+        CASE WHEN d.usage_cpu_sum <= 0 THEN 0
+             ELSE (nu.ns_cpu / d.usage_cpu_sum) * si.infra_total
+        END
+    ELSE
+        CASE WHEN d.usage_memory_sum <= 0 THEN 0
+             ELSE (nu.ns_memory / d.usage_memory_sum) * si.infra_total
+        END
+    END
+FROM storage_infra si
+JOIN denominator d
+    ON d.usage_start = si.usage_start AND d.cluster_id = si.cluster_id
+JOIN namespace_usage nu
+    ON nu.usage_start = si.usage_start AND nu.cluster_id = si.cluster_id
+LEFT JOIN storage_total_rate st
+    ON st.usage_start = si.usage_start AND st.cluster_id = si.cluster_id
+WHERE (st.total_rate_cost IS NULL OR st.total_rate_cost <= 0)
+AND si.infra_total != 0
+AND CASE WHEN {{distribution}} = 'cpu' THEN
+        CASE WHEN d.usage_cpu_sum <= 0 THEN 0
+             ELSE (nu.ns_cpu / d.usage_cpu_sum) * si.infra_total
+        END
+    ELSE
+        CASE WHEN d.usage_memory_sum <= 0 THEN 0
+             ELSE (nu.ns_memory / d.usage_memory_sum) * si.infra_total
+        END
+    END != 0;
 
 -- Negate source: per-node negation of Storage unattributed costs.
 -- Includes infrastructure costs from daily_summary. Per-node granularity
@@ -225,4 +272,54 @@ WHERE EXISTS (
     AND dist.usage_start = src.usage_start
     AND dist.cluster_id = src.cluster_id
 )
-AND (src.cost_model_total + COALESCE(infra.infra_total, 0)) != 0;
+AND (src.cost_model_total + COALESCE(infra.infra_total, 0)) != 0
+
+UNION ALL
+
+-- Infra-only fallback negation: negate per-node infrastructure costs when
+-- no cost model RTU rows exist for Storage unattributed (markup-only cost model).
+SELECT
+    uuid_generate_v4(),
+    MAX(lids.report_period_id),
+    {{source_uuid}}::uuid,
+    lids.usage_start,
+    lids.usage_start,
+    lids.cluster_id,
+    MAX(lids.cluster_alias),
+    'Storage unattributed',
+    lids.node,
+    '', '',
+    {{cost_model_rate_type}},
+    {{cost_model_rate_type}},
+    -SUM(
+        COALESCE(lids.infrastructure_raw_cost, 0) +
+        COALESCE(lids.infrastructure_markup_cost, 0)
+    )
+FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
+WHERE lids.usage_start >= {{start_date}}::date
+    AND lids.usage_start <= {{end_date}}::date
+    AND lids.report_period_id = {{report_period_id}}
+    AND lids.namespace = 'Storage unattributed'
+    AND lids.cost_model_rate_type IS NULL
+AND NOT EXISTS (
+    SELECT 1 FROM {{schema | sqlsafe}}.rates_to_usage rtu
+    WHERE rtu.usage_start = lids.usage_start
+        AND rtu.source_uuid = {{source_uuid}}::uuid
+        AND rtu.namespace = 'Storage unattributed'
+        AND (rtu.monthly_cost_type IS NULL OR rtu.monthly_cost_type NOT IN (
+            'worker_distributed', 'platform_distributed', 'gpu_distributed',
+            'unattributed_storage', 'unattributed_network'
+        ))
+)
+AND EXISTS (
+    SELECT 1 FROM {{schema | sqlsafe}}.rates_to_usage dist
+    WHERE dist.monthly_cost_type = {{cost_model_rate_type}}
+    AND dist.source_uuid = {{source_uuid}}::uuid
+    AND dist.usage_start = lids.usage_start
+    AND dist.cluster_id = lids.cluster_id
+)
+GROUP BY lids.usage_start, lids.cluster_id, lids.node
+HAVING SUM(
+    COALESCE(lids.infrastructure_raw_cost, 0) +
+    COALESCE(lids.infrastructure_markup_cost, 0)
+) != 0;

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_storage_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_unattributed_storage_per_rate.sql
@@ -2,6 +2,10 @@
 -- Reads per-rate costs from RTU (Storage unattributed namespace), distributes
 -- proportionally to non-Storage namespaces by CPU/memory hours (cross-cluster, daily),
 -- writes distributed rows back to RTU with monthly_cost_type = 'unattributed_storage'.
+--
+-- Infrastructure costs (OCP-on-cloud matching) live in daily_summary, not RTU.
+-- They are distributed proportionally across rates via a scaling factor so the
+-- Storage unattributed namespace fully zeroes out (infra + cost_model = 0).
 WITH storage_rtu_cost AS (
     SELECT
         rtu.usage_start,
@@ -23,6 +27,30 @@ WITH storage_rtu_cost AS (
         ))
     GROUP BY rtu.usage_start, rtu.source_uuid, rtu.cluster_id,
              rtu.custom_name, rtu.metric_type, rtu.cost_model_rate_type
+),
+storage_infra AS (
+    SELECT
+        lids.usage_start,
+        lids.cluster_id,
+        SUM(
+            COALESCE(lids.infrastructure_raw_cost, 0) +
+            COALESCE(lids.infrastructure_markup_cost, 0)
+        ) AS infra_total
+    FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
+    WHERE lids.usage_start >= {{start_date}}::date
+        AND lids.usage_start <= {{end_date}}::date
+        AND lids.report_period_id = {{report_period_id}}
+        AND lids.namespace = 'Storage unattributed'
+        AND lids.cost_model_rate_type IS NULL
+    GROUP BY lids.usage_start, lids.cluster_id
+),
+storage_total_rate AS (
+    SELECT
+        usage_start,
+        cluster_id,
+        SUM(rate_cost) AS total_rate_cost
+    FROM storage_rtu_cost
+    GROUP BY usage_start, cluster_id
 ),
 denominator AS (
     SELECT
@@ -90,10 +118,16 @@ SELECT
     CASE WHEN {{distribution}} = 'cpu' THEN
         CASE WHEN d.usage_cpu_sum <= 0 THEN 0
              ELSE (nu.ns_cpu / d.usage_cpu_sum) * sc.rate_cost
+                  * CASE WHEN st.total_rate_cost > 0
+                         THEN (st.total_rate_cost + COALESCE(si.infra_total, 0)) / st.total_rate_cost
+                         ELSE 1 END
         END
     ELSE
         CASE WHEN d.usage_memory_sum <= 0 THEN 0
              ELSE (nu.ns_memory / d.usage_memory_sum) * sc.rate_cost
+                  * CASE WHEN st.total_rate_cost > 0
+                         THEN (st.total_rate_cost + COALESCE(si.infra_total, 0)) / st.total_rate_cost
+                         ELSE 1 END
         END
     END
 FROM storage_rtu_cost sc
@@ -101,19 +135,29 @@ JOIN denominator d
     ON d.usage_start = sc.usage_start AND d.cluster_id = sc.cluster_id
 JOIN namespace_usage nu
     ON nu.usage_start = sc.usage_start AND nu.cluster_id = sc.cluster_id
+LEFT JOIN storage_infra si
+    ON si.usage_start = sc.usage_start AND si.cluster_id = sc.cluster_id
+LEFT JOIN storage_total_rate st
+    ON st.usage_start = sc.usage_start AND st.cluster_id = sc.cluster_id
 WHERE CASE WHEN {{distribution}} = 'cpu' THEN
           CASE WHEN d.usage_cpu_sum <= 0 THEN 0
                ELSE (nu.ns_cpu / d.usage_cpu_sum) * sc.rate_cost
+                    * CASE WHEN st.total_rate_cost > 0
+                           THEN (st.total_rate_cost + COALESCE(si.infra_total, 0)) / st.total_rate_cost
+                           ELSE 1 END
           END
       ELSE
           CASE WHEN d.usage_memory_sum <= 0 THEN 0
                ELSE (nu.ns_memory / d.usage_memory_sum) * sc.rate_cost
+                    * CASE WHEN st.total_rate_cost > 0
+                           THEN (st.total_rate_cost + COALESCE(si.infra_total, 0)) / st.total_rate_cost
+                           ELSE 1 END
           END
       END != 0;
 
 -- Negate source: derive negation from the distributed output rows just inserted.
--- Sums distributed_cost of unattributed_storage rows and inserts exact negative,
--- guaranteeing algebraic zero-sum.
+-- Because the distribution above includes infrastructure costs via scaling,
+-- the derived sum automatically covers both cost-model and infrastructure.
 INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
     uuid, report_period_id, source_uuid, usage_start, usage_end,
     cluster_id, cluster_alias, namespace,

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_worker_cost_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_worker_cost_per_rate.sql
@@ -100,7 +100,7 @@ INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
     uuid, report_period_id, source_uuid, usage_start, usage_end,
     cluster_id, cluster_alias, namespace, node,
     cost_category_id, custom_name, metric_type, cost_model_rate_type,
-    monthly_cost_type, distributed_cost
+    monthly_cost_type, distributed_cost, cost_model_id
 )
 SELECT
     uuid_generate_v4(),
@@ -131,7 +131,8 @@ SELECT
                          THEN (wt.total_rate_cost + COALESCE(wi.infra_total, 0)) / wt.total_rate_cost
                          ELSE 1 END
         END
-    END
+    END,
+    {{cost_model_id}}
 FROM worker_rtu_cost wc
 JOIN denominator d
     ON d.usage_start = wc.usage_start AND d.cluster_id = wc.cluster_id
@@ -165,7 +166,7 @@ INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
     uuid, report_period_id, source_uuid, usage_start, usage_end,
     cluster_id, cluster_alias, namespace, node,
     custom_name, metric_type, cost_model_rate_type,
-    monthly_cost_type, distributed_cost
+    monthly_cost_type, distributed_cost, cost_model_id
 )
 SELECT
     uuid_generate_v4(),
@@ -180,7 +181,8 @@ SELECT
     '', '',
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
-    -(src.cost_model_total + COALESCE(infra.infra_total, 0))
+    -(src.cost_model_total + COALESCE(infra.infra_total, 0)),
+    {{cost_model_id}}
 FROM (
     SELECT
         MAX(rtu.report_period_id) AS report_period_id,

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_worker_cost_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_worker_cost_per_rate.sql
@@ -114,7 +114,7 @@ WHERE CASE WHEN {{distribution}} = 'cpu' THEN
 INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
     uuid, report_period_id, source_uuid, usage_start, usage_end,
     cluster_id, cluster_alias, namespace,
-    custom_name, cost_model_rate_type,
+    custom_name, metric_type, cost_model_rate_type,
     monthly_cost_type, distributed_cost
 )
 SELECT
@@ -126,7 +126,7 @@ SELECT
     rtu.cluster_id,
     MAX(rtu.cluster_alias),
     'Worker unallocated',
-    '',
+    '', '',
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
     -SUM(COALESCE(rtu.calculated_cost, 0))

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_worker_cost_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_worker_cost_per_rate.sql
@@ -82,7 +82,7 @@ SELECT
     nu.namespace,
     nu.node,
     nu.cost_category_id,
-    wc.custom_name,
+    COALESCE(wc.custom_name, ''),
     wc.metric_type,
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
@@ -114,7 +114,7 @@ WHERE CASE WHEN {{distribution}} = 'cpu' THEN
 INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
     uuid, report_period_id, source_uuid, usage_start, usage_end,
     cluster_id, cluster_alias, namespace,
-    cost_model_rate_type,
+    custom_name, cost_model_rate_type,
     monthly_cost_type, distributed_cost
 )
 SELECT
@@ -126,6 +126,7 @@ SELECT
     rtu.cluster_id,
     MAX(rtu.cluster_alias),
     'Worker unallocated',
+    '',
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
     -SUM(COALESCE(rtu.calculated_cost, 0))

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_worker_cost_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_worker_cost_per_rate.sql
@@ -111,6 +111,8 @@ WHERE CASE WHEN {{distribution}} = 'cpu' THEN
       END != 0;
 
 -- Negate source: offset Worker unallocated costs so the net distributed total is zero.
+-- Must negate cost-model costs (from RTU) AND infrastructure/markup costs (from
+-- daily_summary) so the API's cost_total + worker_distributed sums to zero.
 INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
     uuid, report_period_id, source_uuid, usage_start, usage_end,
     cluster_id, cluster_alias, namespace,
@@ -119,24 +121,51 @@ INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
 )
 SELECT
     uuid_generate_v4(),
-    rtu.report_period_id,
-    rtu.source_uuid,
-    rtu.usage_start,
-    rtu.usage_start,
-    rtu.cluster_id,
-    MAX(rtu.cluster_alias),
+    rtu_agg.report_period_id,
+    rtu_agg.source_uuid,
+    rtu_agg.usage_start,
+    rtu_agg.usage_start,
+    rtu_agg.cluster_id,
+    rtu_agg.cluster_alias,
     'Worker unallocated',
     '', '',
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
-    -SUM(COALESCE(rtu.calculated_cost, 0))
-FROM {{schema | sqlsafe}}.rates_to_usage rtu
-WHERE rtu.usage_start >= {{start_date}}::date
-    AND rtu.usage_start <= {{end_date}}::date
-    AND rtu.report_period_id = {{report_period_id}}
-    AND rtu.source_uuid = {{source_uuid}}::uuid
-    AND rtu.namespace = 'Worker unallocated'
-    AND rtu.monthly_cost_type IS NULL
-GROUP BY rtu.report_period_id, rtu.source_uuid, rtu.usage_start,
-         rtu.cluster_id
-HAVING SUM(COALESCE(rtu.calculated_cost, 0)) != 0;
+    -(rtu_agg.cost_model_total + COALESCE(infra_agg.infra_total, 0))
+FROM (
+    SELECT
+        rtu.report_period_id,
+        rtu.source_uuid,
+        rtu.usage_start,
+        rtu.cluster_id,
+        MAX(rtu.cluster_alias) AS cluster_alias,
+        SUM(COALESCE(rtu.calculated_cost, 0)) AS cost_model_total
+    FROM {{schema | sqlsafe}}.rates_to_usage rtu
+    WHERE rtu.usage_start >= {{start_date}}::date
+        AND rtu.usage_start <= {{end_date}}::date
+        AND rtu.report_period_id = {{report_period_id}}
+        AND rtu.source_uuid = {{source_uuid}}::uuid
+        AND rtu.namespace = 'Worker unallocated'
+        AND rtu.monthly_cost_type IS NULL
+    GROUP BY rtu.report_period_id, rtu.source_uuid, rtu.usage_start,
+             rtu.cluster_id
+    HAVING SUM(COALESCE(rtu.calculated_cost, 0)) != 0
+) rtu_agg
+LEFT JOIN (
+    SELECT
+        lids.usage_start,
+        lids.cluster_id,
+        SUM(
+            COALESCE(lids.infrastructure_raw_cost, 0) +
+            COALESCE(lids.infrastructure_markup_cost, 0)
+        ) AS infra_total
+    FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
+    WHERE lids.usage_start >= {{start_date}}::date
+        AND lids.usage_start <= {{end_date}}::date
+        AND lids.report_period_id = {{report_period_id}}
+        AND lids.namespace = 'Worker unallocated'
+        AND lids.cost_model_rate_type IS NULL
+    GROUP BY lids.usage_start, lids.cluster_id
+) infra_agg
+    ON rtu_agg.usage_start = infra_agg.usage_start
+    AND rtu_agg.cluster_id = infra_agg.cluster_id;

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_worker_cost_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_worker_cost_per_rate.sql
@@ -132,7 +132,7 @@ SELECT
                          ELSE 1 END
         END
     END,
-    {{cost_model_id}}
+    {{cost_model_id}}::uuid
 FROM worker_rtu_cost wc
 JOIN denominator d
     ON d.usage_start = wc.usage_start AND d.cluster_id = wc.cluster_id
@@ -182,7 +182,7 @@ SELECT
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
     -(src.cost_model_total + COALESCE(infra.infra_total, 0)),
-    {{cost_model_id}}
+    {{cost_model_id}}::uuid
 FROM (
     SELECT
         MAX(rtu.report_period_id) AS report_period_id,

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_worker_cost_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_worker_cost_per_rate.sql
@@ -85,7 +85,7 @@ SELECT
     wc.custom_name,
     wc.metric_type,
     wc.cost_model_rate_type,
-    {{distribution_tag}},
+    {{cost_model_rate_type}},
     CASE WHEN {{distribution}} = 'cpu' THEN
         CASE WHEN d.usage_cpu_sum <= 0 THEN 0
              ELSE (nu.ns_cpu / d.usage_cpu_sum) * wc.rate_cost

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_worker_cost_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_worker_cost_per_rate.sql
@@ -2,6 +2,10 @@
 -- Reads per-rate costs from RTU (Worker unallocated namespace), distributes
 -- proportionally to non-Worker namespaces by CPU/memory hours (Pod data_source),
 -- writes distributed rows back to RTU with monthly_cost_type = 'worker_distributed'.
+--
+-- Infrastructure costs (OCP-on-cloud matching) live in daily_summary, not RTU.
+-- They are distributed proportionally across rates via a scaling factor so the
+-- Worker unallocated namespace fully zeroes out (infra + cost_model = 0).
 WITH worker_rtu_cost AS (
     SELECT
         rtu.usage_start,
@@ -23,6 +27,30 @@ WITH worker_rtu_cost AS (
         ))
     GROUP BY rtu.usage_start, rtu.source_uuid, rtu.cluster_id,
              rtu.custom_name, rtu.metric_type, rtu.cost_model_rate_type
+),
+worker_infra AS (
+    SELECT
+        lids.usage_start,
+        lids.cluster_id,
+        SUM(
+            COALESCE(lids.infrastructure_raw_cost, 0) +
+            COALESCE(lids.infrastructure_markup_cost, 0)
+        ) AS infra_total
+    FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
+    WHERE lids.usage_start >= {{start_date}}::date
+        AND lids.usage_start <= {{end_date}}::date
+        AND lids.report_period_id = {{report_period_id}}
+        AND lids.namespace = 'Worker unallocated'
+        AND lids.cost_model_rate_type IS NULL
+    GROUP BY lids.usage_start, lids.cluster_id
+),
+worker_total_rate AS (
+    SELECT
+        usage_start,
+        cluster_id,
+        SUM(rate_cost) AS total_rate_cost
+    FROM worker_rtu_cost
+    GROUP BY usage_start, cluster_id
 ),
 denominator AS (
     SELECT
@@ -92,10 +120,16 @@ SELECT
     CASE WHEN {{distribution}} = 'cpu' THEN
         CASE WHEN d.usage_cpu_sum <= 0 THEN 0
              ELSE (nu.ns_cpu / d.usage_cpu_sum) * wc.rate_cost
+                  * CASE WHEN wt.total_rate_cost > 0
+                         THEN (wt.total_rate_cost + COALESCE(wi.infra_total, 0)) / wt.total_rate_cost
+                         ELSE 1 END
         END
     ELSE
         CASE WHEN d.usage_memory_sum <= 0 THEN 0
              ELSE (nu.ns_memory / d.usage_memory_sum) * wc.rate_cost
+                  * CASE WHEN wt.total_rate_cost > 0
+                         THEN (wt.total_rate_cost + COALESCE(wi.infra_total, 0)) / wt.total_rate_cost
+                         ELSE 1 END
         END
     END
 FROM worker_rtu_cost wc
@@ -103,19 +137,31 @@ JOIN denominator d
     ON d.usage_start = wc.usage_start AND d.cluster_id = wc.cluster_id
 JOIN namespace_usage nu
     ON nu.usage_start = wc.usage_start AND nu.cluster_id = wc.cluster_id
+LEFT JOIN worker_infra wi
+    ON wi.usage_start = wc.usage_start AND wi.cluster_id = wc.cluster_id
+LEFT JOIN worker_total_rate wt
+    ON wt.usage_start = wc.usage_start AND wt.cluster_id = wc.cluster_id
 WHERE CASE WHEN {{distribution}} = 'cpu' THEN
           CASE WHEN d.usage_cpu_sum <= 0 THEN 0
                ELSE (nu.ns_cpu / d.usage_cpu_sum) * wc.rate_cost
+                    * CASE WHEN wt.total_rate_cost > 0
+                           THEN (wt.total_rate_cost + COALESCE(wi.infra_total, 0)) / wt.total_rate_cost
+                           ELSE 1 END
           END
       ELSE
           CASE WHEN d.usage_memory_sum <= 0 THEN 0
                ELSE (nu.ns_memory / d.usage_memory_sum) * wc.rate_cost
+                    * CASE WHEN wt.total_rate_cost > 0
+                           THEN (wt.total_rate_cost + COALESCE(wi.infra_total, 0)) / wt.total_rate_cost
+                           ELSE 1 END
           END
       END != 0;
 
 -- Negate source: derive negation from the distributed output rows just inserted.
 -- Sums distributed_cost of worker_distributed rows and inserts exact negative,
--- guaranteeing algebraic zero-sum.
+-- guaranteeing algebraic zero-sum. Because the distribution above includes
+-- infrastructure costs via scaling, this derived sum automatically covers both
+-- cost-model and infrastructure components.
 INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
     uuid, report_period_id, source_uuid, usage_start, usage_end,
     cluster_id, cluster_alias, namespace,

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_worker_cost_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_worker_cost_per_rate.sql
@@ -84,7 +84,7 @@ SELECT
     nu.cost_category_id,
     wc.custom_name,
     wc.metric_type,
-    wc.cost_model_rate_type,
+    {{cost_model_rate_type}},
     {{cost_model_rate_type}},
     CASE WHEN {{distribution}} = 'cpu' THEN
         CASE WHEN d.usage_cpu_sum <= 0 THEN 0
@@ -109,3 +109,33 @@ WHERE CASE WHEN {{distribution}} = 'cpu' THEN
                ELSE (nu.ns_memory / d.usage_memory_sum) * wc.rate_cost
           END
       END != 0;
+
+-- Negate source: offset Worker unallocated costs so the net distributed total is zero.
+INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
+    uuid, report_period_id, source_uuid, usage_start, usage_end,
+    cluster_id, cluster_alias, namespace,
+    cost_model_rate_type,
+    monthly_cost_type, distributed_cost
+)
+SELECT
+    uuid_generate_v4(),
+    rtu.report_period_id,
+    rtu.source_uuid,
+    rtu.usage_start,
+    rtu.usage_start,
+    rtu.cluster_id,
+    MAX(rtu.cluster_alias),
+    'Worker unallocated',
+    {{cost_model_rate_type}},
+    {{cost_model_rate_type}},
+    -SUM(COALESCE(rtu.calculated_cost, 0))
+FROM {{schema | sqlsafe}}.rates_to_usage rtu
+WHERE rtu.usage_start >= {{start_date}}::date
+    AND rtu.usage_start <= {{end_date}}::date
+    AND rtu.report_period_id = {{report_period_id}}
+    AND rtu.source_uuid = {{source_uuid}}::uuid
+    AND rtu.namespace = 'Worker unallocated'
+    AND rtu.monthly_cost_type IS NULL
+GROUP BY rtu.report_period_id, rtu.source_uuid, rtu.usage_start,
+         rtu.cluster_id
+HAVING SUM(COALESCE(rtu.calculated_cost, 0)) != 0;

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_worker_cost_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_worker_cost_per_rate.sql
@@ -17,7 +17,10 @@ WITH worker_rtu_cost AS (
         AND rtu.report_period_id = {{report_period_id}}
         AND rtu.source_uuid = {{source_uuid}}::uuid
         AND rtu.namespace = 'Worker unallocated'
-        AND rtu.monthly_cost_type IS NULL
+        AND (rtu.monthly_cost_type IS NULL OR rtu.monthly_cost_type NOT IN (
+            'worker_distributed', 'platform_distributed', 'gpu_distributed',
+            'unattributed_storage', 'unattributed_network'
+        ))
     GROUP BY rtu.usage_start, rtu.source_uuid, rtu.cluster_id,
              rtu.custom_name, rtu.metric_type, rtu.cost_model_rate_type
 ),

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_worker_cost_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_worker_cost_per_rate.sql
@@ -1,0 +1,111 @@
+-- Per-rate worker unallocated cost distribution via rates_to_usage.
+-- Reads per-rate costs from RTU (Worker unallocated namespace), distributes
+-- proportionally to non-Worker namespaces by CPU/memory hours (Pod data_source),
+-- writes distributed rows back to RTU with monthly_cost_type = 'worker_distributed'.
+WITH worker_rtu_cost AS (
+    SELECT
+        rtu.usage_start,
+        rtu.source_uuid,
+        rtu.cluster_id,
+        rtu.custom_name,
+        rtu.metric_type,
+        rtu.cost_model_rate_type,
+        SUM(COALESCE(rtu.calculated_cost, 0)) AS rate_cost
+    FROM {{schema | sqlsafe}}.rates_to_usage rtu
+    WHERE rtu.usage_start >= {{start_date}}::date
+        AND rtu.usage_start <= {{end_date}}::date
+        AND rtu.report_period_id = {{report_period_id}}
+        AND rtu.source_uuid = {{source_uuid}}::uuid
+        AND rtu.namespace = 'Worker unallocated'
+        AND rtu.monthly_cost_type IS NULL
+    GROUP BY rtu.usage_start, rtu.source_uuid, rtu.cluster_id,
+             rtu.custom_name, rtu.metric_type, rtu.cost_model_rate_type
+),
+denominator AS (
+    SELECT
+        lids.usage_start,
+        lids.cluster_id,
+        SUM(lids.pod_effective_usage_cpu_core_hours) AS usage_cpu_sum,
+        SUM(lids.pod_effective_usage_memory_gigabyte_hours) AS usage_memory_sum
+    FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
+    LEFT JOIN {{schema | sqlsafe}}.reporting_ocp_cost_category cat
+        ON lids.cost_category_id = cat.id
+    WHERE lids.usage_start >= {{start_date}}::date
+        AND lids.usage_start <= {{end_date}}::date
+        AND lids.report_period_id = {{report_period_id}}
+        AND lids.namespace != 'Worker unallocated'
+        AND lids.namespace != 'Storage unattributed'
+        AND lids.namespace != 'Network unattributed'
+        AND (lids.cost_category_id IS NULL OR cat.name != 'Platform')
+        AND lids.data_source = 'Pod'
+    GROUP BY lids.usage_start, lids.cluster_id
+),
+namespace_usage AS (
+    SELECT
+        lids.usage_start,
+        lids.cluster_id,
+        lids.namespace,
+        lids.node,
+        MAX(lids.report_period_id) AS report_period_id,
+        MAX(lids.cluster_alias) AS cluster_alias,
+        MAX(lids.cost_category_id) AS cost_category_id,
+        SUM(lids.pod_effective_usage_cpu_core_hours) AS ns_cpu,
+        SUM(lids.pod_effective_usage_memory_gigabyte_hours) AS ns_memory
+    FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
+    LEFT JOIN {{schema | sqlsafe}}.reporting_ocp_cost_category cat
+        ON lids.cost_category_id = cat.id
+    WHERE lids.usage_start >= {{start_date}}::date
+        AND lids.usage_start <= {{end_date}}::date
+        AND lids.report_period_id = {{report_period_id}}
+        AND lids.namespace IS NOT NULL
+        AND lids.namespace != 'Worker unallocated'
+        AND lids.namespace != 'Storage unattributed'
+        AND lids.namespace != 'Network unattributed'
+        AND (lids.cost_category_id IS NULL OR cat.name != 'Platform')
+        AND lids.data_source = 'Pod'
+    GROUP BY lids.usage_start, lids.cluster_id, lids.namespace, lids.node
+)
+INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
+    uuid, report_period_id, source_uuid, usage_start, usage_end,
+    cluster_id, cluster_alias, namespace, node,
+    cost_category_id, custom_name, metric_type, cost_model_rate_type,
+    monthly_cost_type, distributed_cost
+)
+SELECT
+    uuid_generate_v4(),
+    nu.report_period_id,
+    wc.source_uuid,
+    nu.usage_start,
+    nu.usage_start,
+    nu.cluster_id,
+    nu.cluster_alias,
+    nu.namespace,
+    nu.node,
+    nu.cost_category_id,
+    wc.custom_name,
+    wc.metric_type,
+    wc.cost_model_rate_type,
+    {{cost_model_rate_type}},
+    CASE WHEN {{distribution}} = 'cpu' THEN
+        CASE WHEN d.usage_cpu_sum <= 0 THEN 0
+             ELSE (nu.ns_cpu / d.usage_cpu_sum) * wc.rate_cost
+        END
+    ELSE
+        CASE WHEN d.usage_memory_sum <= 0 THEN 0
+             ELSE (nu.ns_memory / d.usage_memory_sum) * wc.rate_cost
+        END
+    END
+FROM worker_rtu_cost wc
+JOIN denominator d
+    ON d.usage_start = wc.usage_start AND d.cluster_id = wc.cluster_id
+JOIN namespace_usage nu
+    ON nu.usage_start = wc.usage_start AND nu.cluster_id = wc.cluster_id
+WHERE CASE WHEN {{distribution}} = 'cpu' THEN
+          CASE WHEN d.usage_cpu_sum <= 0 THEN 0
+               ELSE (nu.ns_cpu / d.usage_cpu_sum) * wc.rate_cost
+          END
+      ELSE
+          CASE WHEN d.usage_memory_sum <= 0 THEN 0
+               ELSE (nu.ns_memory / d.usage_memory_sum) * wc.rate_cost
+          END
+      END != 0;

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_worker_cost_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_worker_cost_per_rate.sql
@@ -85,7 +85,7 @@ SELECT
     wc.custom_name,
     wc.metric_type,
     wc.cost_model_rate_type,
-    {{cost_model_rate_type}},
+    {{distribution_tag}},
     CASE WHEN {{distribution}} = 'cpu' THEN
         CASE WHEN d.usage_cpu_sum <= 0 THEN 0
              ELSE (nu.ns_cpu / d.usage_cpu_sum) * wc.rate_cost

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_worker_cost_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_worker_cost_per_rate.sql
@@ -113,9 +113,9 @@ WHERE CASE WHEN {{distribution}} = 'cpu' THEN
           END
       END != 0;
 
--- Negate source: offset Worker unallocated costs so the net distributed total is zero.
--- Must negate cost-model costs (from RTU) AND infrastructure/markup costs (from
--- daily_summary) so the API's cost_total + worker_distributed sums to zero.
+-- Negate source: derive negation from the distributed output rows just inserted.
+-- Sums distributed_cost of worker_distributed rows and inserts exact negative,
+-- guaranteeing algebraic zero-sum.
 INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
     uuid, report_period_id, source_uuid, usage_start, usage_end,
     cluster_id, cluster_alias, namespace,
@@ -124,51 +124,22 @@ INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
 )
 SELECT
     uuid_generate_v4(),
-    rtu_agg.report_period_id,
-    rtu_agg.source_uuid,
-    rtu_agg.usage_start,
-    rtu_agg.usage_start,
-    rtu_agg.cluster_id,
-    rtu_agg.cluster_alias,
+    MAX(rtu.report_period_id),
+    rtu.source_uuid,
+    rtu.usage_start,
+    rtu.usage_start,
+    rtu.cluster_id,
+    MAX(rtu.cluster_alias),
     'Worker unallocated',
     '', '',
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
-    -(rtu_agg.cost_model_total + COALESCE(infra_agg.infra_total, 0))
-FROM (
-    SELECT
-        rtu.report_period_id,
-        rtu.source_uuid,
-        rtu.usage_start,
-        rtu.cluster_id,
-        MAX(rtu.cluster_alias) AS cluster_alias,
-        SUM(COALESCE(rtu.calculated_cost, 0)) AS cost_model_total
-    FROM {{schema | sqlsafe}}.rates_to_usage rtu
-    WHERE rtu.usage_start >= {{start_date}}::date
-        AND rtu.usage_start <= {{end_date}}::date
-        AND rtu.report_period_id = {{report_period_id}}
-        AND rtu.source_uuid = {{source_uuid}}::uuid
-        AND rtu.namespace = 'Worker unallocated'
-        AND rtu.monthly_cost_type IS NULL
-    GROUP BY rtu.report_period_id, rtu.source_uuid, rtu.usage_start,
-             rtu.cluster_id
-    HAVING SUM(COALESCE(rtu.calculated_cost, 0)) != 0
-) rtu_agg
-LEFT JOIN (
-    SELECT
-        lids.usage_start,
-        lids.cluster_id,
-        SUM(
-            COALESCE(lids.infrastructure_raw_cost, 0) +
-            COALESCE(lids.infrastructure_markup_cost, 0)
-        ) AS infra_total
-    FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
-    WHERE lids.usage_start >= {{start_date}}::date
-        AND lids.usage_start <= {{end_date}}::date
-        AND lids.report_period_id = {{report_period_id}}
-        AND lids.namespace = 'Worker unallocated'
-        AND lids.cost_model_rate_type IS NULL
-    GROUP BY lids.usage_start, lids.cluster_id
-) infra_agg
-    ON rtu_agg.usage_start = infra_agg.usage_start
-    AND rtu_agg.cluster_id = infra_agg.cluster_id;
+    -SUM(rtu.distributed_cost)
+FROM {{schema | sqlsafe}}.rates_to_usage rtu
+WHERE rtu.usage_start >= {{start_date}}::date
+    AND rtu.usage_start <= {{end_date}}::date
+    AND rtu.source_uuid = {{source_uuid}}::uuid
+    AND rtu.monthly_cost_type = {{cost_model_rate_type}}
+    AND rtu.namespace != 'Worker unallocated'
+GROUP BY rtu.source_uuid, rtu.usage_start, rtu.cluster_id
+HAVING SUM(rtu.distributed_cost) != 0;

--- a/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_worker_cost_per_rate.sql
+++ b/koku/masu/database/sql/openshift/cost_model/distribute_cost/distribute_worker_cost_per_rate.sql
@@ -157,35 +157,75 @@ WHERE CASE WHEN {{distribution}} = 'cpu' THEN
           END
       END != 0;
 
--- Negate source: derive negation from the distributed output rows just inserted.
--- Sums distributed_cost of worker_distributed rows and inserts exact negative,
--- guaranteeing algebraic zero-sum. Because the distribution above includes
--- infrastructure costs via scaling, this derived sum automatically covers both
--- cost-model and infrastructure components.
+-- Negate source: per-node negation of Worker unallocated costs.
+-- Computes per-node cost-model total from source RTU + per-node infrastructure
+-- from daily_summary, matching legacy per-node granularity to avoid NULL node
+-- ("No-node") entries in the API.
 INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
     uuid, report_period_id, source_uuid, usage_start, usage_end,
-    cluster_id, cluster_alias, namespace,
+    cluster_id, cluster_alias, namespace, node,
     custom_name, metric_type, cost_model_rate_type,
     monthly_cost_type, distributed_cost
 )
 SELECT
     uuid_generate_v4(),
-    MAX(rtu.report_period_id),
-    rtu.source_uuid,
-    rtu.usage_start,
-    rtu.usage_start,
-    rtu.cluster_id,
-    MAX(rtu.cluster_alias),
+    src.report_period_id,
+    src.source_uuid,
+    src.usage_start,
+    src.usage_start,
+    src.cluster_id,
+    src.cluster_alias,
     'Worker unallocated',
+    src.node,
     '', '',
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
-    -SUM(rtu.distributed_cost)
-FROM {{schema | sqlsafe}}.rates_to_usage rtu
-WHERE rtu.usage_start >= {{start_date}}::date
-    AND rtu.usage_start <= {{end_date}}::date
-    AND rtu.source_uuid = {{source_uuid}}::uuid
-    AND rtu.monthly_cost_type = {{cost_model_rate_type}}
-    AND rtu.namespace != 'Worker unallocated'
-GROUP BY rtu.source_uuid, rtu.usage_start, rtu.cluster_id
-HAVING SUM(rtu.distributed_cost) != 0;
+    -(src.cost_model_total + COALESCE(infra.infra_total, 0))
+FROM (
+    SELECT
+        MAX(rtu.report_period_id) AS report_period_id,
+        rtu.source_uuid,
+        rtu.usage_start,
+        rtu.cluster_id,
+        rtu.node,
+        MAX(rtu.cluster_alias) AS cluster_alias,
+        SUM(COALESCE(rtu.calculated_cost, 0)) AS cost_model_total
+    FROM {{schema | sqlsafe}}.rates_to_usage rtu
+    WHERE rtu.usage_start >= {{start_date}}::date
+        AND rtu.usage_start <= {{end_date}}::date
+        AND rtu.source_uuid = {{source_uuid}}::uuid
+        AND rtu.namespace = 'Worker unallocated'
+        AND (rtu.monthly_cost_type IS NULL OR rtu.monthly_cost_type NOT IN (
+            'worker_distributed', 'platform_distributed', 'gpu_distributed',
+            'unattributed_storage', 'unattributed_network'
+        ))
+    GROUP BY rtu.source_uuid, rtu.usage_start, rtu.cluster_id, rtu.node
+) src
+LEFT JOIN (
+    SELECT
+        lids.usage_start,
+        lids.cluster_id,
+        lids.node,
+        SUM(
+            COALESCE(lids.infrastructure_raw_cost, 0) +
+            COALESCE(lids.infrastructure_markup_cost, 0)
+        ) AS infra_total
+    FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
+    WHERE lids.usage_start >= {{start_date}}::date
+        AND lids.usage_start <= {{end_date}}::date
+        AND lids.report_period_id = {{report_period_id}}
+        AND lids.namespace = 'Worker unallocated'
+        AND lids.cost_model_rate_type IS NULL
+    GROUP BY lids.usage_start, lids.cluster_id, lids.node
+) infra
+    ON src.usage_start = infra.usage_start
+    AND src.cluster_id = infra.cluster_id
+    AND src.node IS NOT DISTINCT FROM infra.node
+WHERE EXISTS (
+    SELECT 1 FROM {{schema | sqlsafe}}.rates_to_usage dist
+    WHERE dist.monthly_cost_type = {{cost_model_rate_type}}
+    AND dist.source_uuid = src.source_uuid
+    AND dist.usage_start = src.usage_start
+    AND dist.cluster_id = src.cluster_id
+)
+AND (src.cost_model_total + COALESCE(infra.infra_total, 0)) != 0;

--- a/koku/masu/database/sql/openshift/cost_model/usage_rates/aggregate_rates_to_daily_summary.sql
+++ b/koku/masu/database/sql/openshift/cost_model/usage_rates/aggregate_rates_to_daily_summary.sql
@@ -1,8 +1,8 @@
--- aggregate_rates_to_daily_summary.sql (Phase 3)
+-- aggregate_rates_to_daily_summary.sql (Phase 3/4)
 --
 -- Rolls up per-rate RatesToUsage rows into daily summary cost columns.
--- Runs AFTER all per-rate INSERTs (usage, monthly, tag) and BEFORE
--- cost distribution.
+-- Runs AFTER all per-rate INSERTs (usage, monthly, tag) and AFTER
+-- cost distribution (Phase 4 re-ordered: distribute -> aggregate -> markup).
 --
 -- Block 1: Aggregates usage-cost RTU rows (monthly_cost_type IS NULL)
 --   with a base-row JOIN for capacity columns not stored in RTU.

--- a/koku/masu/database/sql/openshift/cost_model/usage_rates/aggregate_rates_to_daily_summary.sql
+++ b/koku/masu/database/sql/openshift/cost_model/usage_rates/aggregate_rates_to_daily_summary.sql
@@ -145,6 +145,7 @@ INSERT INTO {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary (
     cost_category_id, cost_model_rate_type,
     cost_model_cpu_cost, cost_model_memory_cost, cost_model_volume_cost,
     cost_model_gpu_cost,
+    distributed_cost,
     monthly_cost_type
 )
 SELECT
@@ -168,6 +169,7 @@ SELECT
     SUM(CASE WHEN rtu.metric_type = 'memory'  THEN rtu.calculated_cost ELSE 0 END),
     SUM(CASE WHEN rtu.metric_type = 'storage' THEN rtu.calculated_cost ELSE 0 END),
     SUM(CASE WHEN rtu.metric_type = 'gpu'     THEN rtu.calculated_cost ELSE 0 END),
+    SUM(COALESCE(rtu.distributed_cost, 0)),
     rtu.monthly_cost_type
 FROM {{schema | sqlsafe}}.rates_to_usage rtu
 WHERE rtu.usage_start >= {{start_date}}

--- a/koku/masu/database/sql/openshift/cost_model/usage_rates/aggregate_rates_to_daily_summary.sql
+++ b/koku/masu/database/sql/openshift/cost_model/usage_rates/aggregate_rates_to_daily_summary.sql
@@ -137,6 +137,34 @@ GROUP BY
 
 -- Step 3: INSERT monthly/tag-cost aggregation (monthly_cost_type IS NOT NULL)
 -- These are synthetic cost rows that don't need base-row capacity columns.
+--
+-- For source-namespace negation rows (namespace = 'Network unattributed' or
+-- 'Storage unattributed'), the distribution SQL puts -(cost_model + infra)
+-- into distributed_cost. But the API multiplies infrastructure_raw_cost by
+-- infra_exchange_rate (currency conversion) while distributed_cost is taken
+-- as-is.  This mismatch leaves a residual of infra * (exchange_rate - 1).
+--
+-- Fix: split the infra portion out of distributed_cost into
+-- infrastructure_raw_cost / infrastructure_markup_cost (with raw_currency)
+-- so the API's exchange-rate annotation cancels the base-row infra correctly.
+WITH source_ns_infra AS (
+    SELECT
+        lids.usage_start,
+        lids.cluster_id,
+        lids.node,
+        lids.namespace,
+        SUM(COALESCE(lids.infrastructure_raw_cost, 0)) AS infra_raw,
+        SUM(COALESCE(lids.infrastructure_markup_cost, 0)) AS infra_markup,
+        MAX(lids.raw_currency) AS raw_currency
+    FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
+    WHERE lids.usage_start >= {{start_date}}
+      AND lids.usage_start <= {{end_date}}
+      AND lids.source_uuid = {{source_uuid}}
+      AND lids.report_period_id = {{report_period_id}}
+      AND lids.namespace IN ('Network unattributed', 'Storage unattributed')
+      AND lids.cost_model_rate_type IS NULL
+    GROUP BY lids.usage_start, lids.cluster_id, lids.node, lids.namespace
+)
 INSERT INTO {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary (
     uuid, report_period_id, cluster_id, cluster_alias, namespace, node,
     usage_start, usage_end, data_source, source_uuid,
@@ -145,8 +173,11 @@ INSERT INTO {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary (
     cost_category_id, cost_model_rate_type,
     cost_model_cpu_cost, cost_model_memory_cost, cost_model_volume_cost,
     cost_model_gpu_cost,
+    infrastructure_raw_cost,
+    infrastructure_markup_cost,
     distributed_cost,
-    monthly_cost_type
+    monthly_cost_type,
+    raw_currency
 )
 SELECT
     uuid_generate_v4(),
@@ -169,9 +200,18 @@ SELECT
     SUM(CASE WHEN rtu.metric_type = 'memory'  THEN rtu.calculated_cost ELSE 0 END),
     SUM(CASE WHEN rtu.metric_type = 'storage' THEN rtu.calculated_cost ELSE 0 END),
     SUM(CASE WHEN rtu.metric_type = 'gpu'     THEN rtu.calculated_cost ELSE 0 END),
-    SUM(COALESCE(rtu.distributed_cost, 0)),
-    rtu.monthly_cost_type
+    CASE WHEN sni.infra_raw IS NOT NULL THEN -sni.infra_raw ELSE 0 END,
+    CASE WHEN sni.infra_markup IS NOT NULL THEN -sni.infra_markup ELSE 0 END,
+    SUM(COALESCE(rtu.distributed_cost, 0))
+        + COALESCE(sni.infra_raw, 0) + COALESCE(sni.infra_markup, 0),
+    rtu.monthly_cost_type,
+    sni.raw_currency
 FROM {{schema | sqlsafe}}.rates_to_usage rtu
+LEFT JOIN source_ns_infra sni
+    ON  rtu.usage_start = sni.usage_start
+    AND rtu.cluster_id  = sni.cluster_id
+    AND rtu.node IS NOT DISTINCT FROM sni.node
+    AND rtu.namespace   = sni.namespace
 WHERE rtu.usage_start >= {{start_date}}
   AND rtu.usage_start <= {{end_date}}
   AND rtu.source_uuid = {{source_uuid}}
@@ -190,4 +230,7 @@ GROUP BY
     rtu.label_hash,
     rtu.cost_category_id,
     rtu.cost_model_rate_type,
-    rtu.monthly_cost_type;
+    rtu.monthly_cost_type,
+    sni.infra_raw,
+    sni.infra_markup,
+    sni.raw_currency;

--- a/koku/masu/database/sql/openshift/cost_model/usage_rates/aggregate_rates_to_daily_summary.sql
+++ b/koku/masu/database/sql/openshift/cost_model/usage_rates/aggregate_rates_to_daily_summary.sql
@@ -138,33 +138,11 @@ GROUP BY
 -- Step 3: INSERT monthly/tag-cost aggregation (monthly_cost_type IS NOT NULL)
 -- These are synthetic cost rows that don't need base-row capacity columns.
 --
--- For source-namespace negation rows (namespace = 'Network unattributed' or
--- 'Storage unattributed'), the distribution SQL puts -(cost_model + infra)
--- into distributed_cost. But the API multiplies infrastructure_raw_cost by
--- infra_exchange_rate (currency conversion) while distributed_cost is taken
--- as-is.  This mismatch leaves a residual of infra * (exchange_rate - 1).
---
--- Fix: split the infra portion out of distributed_cost into
--- infrastructure_raw_cost / infrastructure_markup_cost (with raw_currency)
--- so the API's exchange-rate annotation cancels the base-row infra correctly.
-WITH source_ns_infra AS (
-    SELECT
-        lids.usage_start,
-        lids.cluster_id,
-        lids.node,
-        lids.namespace,
-        SUM(COALESCE(lids.infrastructure_raw_cost, 0)) AS infra_raw,
-        SUM(COALESCE(lids.infrastructure_markup_cost, 0)) AS infra_markup,
-        MAX(lids.raw_currency) AS raw_currency
-    FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
-    WHERE lids.usage_start >= {{start_date}}
-      AND lids.usage_start <= {{end_date}}
-      AND lids.source_uuid = {{source_uuid}}
-      AND lids.report_period_id = {{report_period_id}}
-      AND lids.namespace IN ('Network unattributed', 'Storage unattributed')
-      AND lids.cost_model_rate_type IS NULL
-    GROUP BY lids.usage_start, lids.cluster_id, lids.node, lids.namespace
-)
+-- raw_currency is set to cost_model_currency for distribution rows
+-- (unattributed_network, unattributed_storage) because the distribution SQL
+-- converts infra amounts to the cost model's currency.  The API's
+-- infra_exchange_rate annotation uses raw_currency to convert distributed_cost
+-- from cost_model_currency to the user's requested currency.
 INSERT INTO {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary (
     uuid, report_period_id, cluster_id, cluster_alias, namespace, node,
     usage_start, usage_end, data_source, source_uuid,
@@ -173,8 +151,6 @@ INSERT INTO {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary (
     cost_category_id, cost_model_rate_type,
     cost_model_cpu_cost, cost_model_memory_cost, cost_model_volume_cost,
     cost_model_gpu_cost,
-    infrastructure_raw_cost,
-    infrastructure_markup_cost,
     distributed_cost,
     monthly_cost_type,
     raw_currency
@@ -200,18 +176,13 @@ SELECT
     SUM(CASE WHEN rtu.metric_type = 'memory'  THEN rtu.calculated_cost ELSE 0 END),
     SUM(CASE WHEN rtu.metric_type = 'storage' THEN rtu.calculated_cost ELSE 0 END),
     SUM(CASE WHEN rtu.metric_type = 'gpu'     THEN rtu.calculated_cost ELSE 0 END),
-    CASE WHEN sni.infra_raw IS NOT NULL THEN -sni.infra_raw ELSE 0 END,
-    CASE WHEN sni.infra_markup IS NOT NULL THEN -sni.infra_markup ELSE 0 END,
-    SUM(COALESCE(rtu.distributed_cost, 0))
-        + COALESCE(sni.infra_raw, 0) + COALESCE(sni.infra_markup, 0),
+    SUM(COALESCE(rtu.distributed_cost, 0)),
     rtu.monthly_cost_type,
-    sni.raw_currency
+    CASE WHEN rtu.monthly_cost_type IN ('unattributed_network', 'unattributed_storage')
+         THEN {{cost_model_currency}}
+         ELSE NULL
+    END
 FROM {{schema | sqlsafe}}.rates_to_usage rtu
-LEFT JOIN source_ns_infra sni
-    ON  rtu.usage_start = sni.usage_start
-    AND rtu.cluster_id  = sni.cluster_id
-    AND rtu.node IS NOT DISTINCT FROM sni.node
-    AND rtu.namespace   = sni.namespace
 WHERE rtu.usage_start >= {{start_date}}
   AND rtu.usage_start <= {{end_date}}
   AND rtu.source_uuid = {{source_uuid}}
@@ -230,7 +201,4 @@ GROUP BY
     rtu.label_hash,
     rtu.cost_category_id,
     rtu.cost_model_rate_type,
-    rtu.monthly_cost_type,
-    sni.infra_raw,
-    sni.infra_markup,
-    sni.raw_currency;
+    rtu.monthly_cost_type;

--- a/koku/masu/database/sql/openshift/cost_model/usage_rates/aggregate_rates_to_daily_summary.sql
+++ b/koku/masu/database/sql/openshift/cost_model/usage_rates/aggregate_rates_to_daily_summary.sql
@@ -139,10 +139,10 @@ GROUP BY
 -- These are synthetic cost rows that don't need base-row capacity columns.
 --
 -- raw_currency is set to cost_model_currency for distribution rows
--- (unattributed_network, unattributed_storage) because the distribution SQL
--- converts infra amounts to the cost model's currency.  The API's
--- infra_exchange_rate annotation uses raw_currency to convert distributed_cost
--- from cost_model_currency to the user's requested currency.
+-- (unattributed_network, unattributed_storage) when infra costs were
+-- currency-converted.  When source infra rows have raw_currency IS NULL
+-- (common for OCP-on-cloud), cost_model_currency is passed as NULL so
+-- the API applies the same default exchange rate (1) as the original rows.
 INSERT INTO {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary (
     uuid, report_period_id, cluster_id, cluster_alias, namespace, node,
     usage_start, usage_end, data_source, source_uuid,

--- a/koku/masu/database/trino_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
+++ b/koku/masu/database/trino_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
@@ -74,7 +74,7 @@ SELECT
     nsp.node,
     gc.custom_name,
     gc.metric_type,
-    gc.cost_model_rate_type,
+    {{cost_model_rate_type}},
     {{cost_model_rate_type}},
     MAX(nsp.pod_usage_slice_hours / NULLIF(tu.total_slice_hours, 0) * gc.rate_cost)
 FROM gpu_rtu_cost gc
@@ -91,3 +91,32 @@ JOIN total_usage tu
 GROUP BY nsp.usage_start, nsp.node, nsp.namespace,
          gc.source_uuid, gc.custom_name, gc.metric_type, gc.cost_model_rate_type
 HAVING MAX(nsp.pod_usage_slice_hours / NULLIF(tu.total_slice_hours, 0) * gc.rate_cost) != 0;
+
+-- Negate source: offset GPU unallocated costs so the net distributed total is zero.
+INSERT INTO postgres.{{schema | sqlsafe}}.rates_to_usage (
+    uuid, report_period_id, source_uuid, usage_start, usage_end,
+    cluster_id, cluster_alias, namespace,
+    cost_model_rate_type,
+    monthly_cost_type, distributed_cost
+)
+SELECT
+    uuid(),
+    rtu.report_period_id,
+    rtu.source_uuid,
+    rtu.usage_start,
+    rtu.usage_start,
+    rtu.cluster_id,
+    MAX(rtu.cluster_alias),
+    'GPU unallocated',
+    {{cost_model_rate_type}},
+    {{cost_model_rate_type}},
+    -SUM(COALESCE(rtu.calculated_cost, 0))
+FROM postgres.{{schema | sqlsafe}}.rates_to_usage rtu
+WHERE rtu.usage_start >= DATE({{start_date}})
+    AND rtu.usage_start <= DATE({{end_date}})
+    AND rtu.source_uuid = CAST({{source_uuid}} AS UUID)
+    AND rtu.namespace = 'GPU unallocated'
+    AND rtu.monthly_cost_type IS NULL
+GROUP BY rtu.report_period_id, rtu.source_uuid, rtu.usage_start,
+         rtu.cluster_id
+HAVING SUM(COALESCE(rtu.calculated_cost, 0)) != 0;

--- a/koku/masu/database/trino_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
+++ b/koku/masu/database/trino_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
@@ -38,11 +38,12 @@ gpu_model_map AS (
         node,
         json_extract_scalar(all_labels, '$["gpu-model"]') AS gpu_model,
         usage_start
-    FROM postgres.{{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary
+    FROM postgres.{{schema | sqlsafe}}.rates_to_usage
     WHERE namespace = 'GPU unallocated'
       AND usage_start >= DATE({{start_date}})
       AND usage_start <= DATE({{end_date}})
       AND source_uuid = CAST({{source_uuid}} AS UUID)
+      AND metric_type = 'gpu'
     GROUP BY node, json_extract_scalar(all_labels, '$["gpu-model"]'), usage_start
 ),
 namespace_usage_information AS (

--- a/koku/masu/database/trino_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
+++ b/koku/masu/database/trino_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
@@ -75,7 +75,7 @@ SELECT
     gc.custom_name,
     gc.metric_type,
     gc.cost_model_rate_type,
-    {{cost_model_rate_type}},
+    {{distribution_tag}},
     MAX(nsp.pod_usage_slice_hours / NULLIF(tu.total_slice_hours, 0) * gc.rate_cost)
 FROM gpu_rtu_cost gc
 JOIN gpu_model_map gm

--- a/koku/masu/database/trino_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
+++ b/koku/masu/database/trino_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
@@ -72,7 +72,7 @@ SELECT
     MAX(gc.cluster_alias),
     nsp.namespace,
     nsp.node,
-    gc.custom_name,
+    COALESCE(gc.custom_name, ''),
     gc.metric_type,
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
@@ -96,7 +96,7 @@ HAVING MAX(nsp.pod_usage_slice_hours / NULLIF(tu.total_slice_hours, 0) * gc.rate
 INSERT INTO postgres.{{schema | sqlsafe}}.rates_to_usage (
     uuid, report_period_id, source_uuid, usage_start, usage_end,
     cluster_id, cluster_alias, namespace,
-    cost_model_rate_type,
+    custom_name, cost_model_rate_type,
     monthly_cost_type, distributed_cost
 )
 SELECT
@@ -108,6 +108,7 @@ SELECT
     rtu.cluster_id,
     MAX(rtu.cluster_alias),
     'GPU unallocated',
+    '',
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
     -SUM(COALESCE(rtu.calculated_cost, 0))

--- a/koku/masu/database/trino_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
+++ b/koku/masu/database/trino_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
@@ -95,60 +95,34 @@ GROUP BY nsp.usage_start, nsp.node, nsp.namespace,
          gc.source_uuid, gc.custom_name, gc.metric_type, gc.cost_model_rate_type
 HAVING MAX(nsp.pod_usage_slice_hours / NULLIF(tu.total_slice_hours, 0) * gc.rate_cost) != 0;
 
--- Negate source: offset GPU unallocated costs so the net distributed total is zero.
--- Must negate cost-model costs (from RTU) AND infrastructure/markup costs (from
--- daily_summary) so the API's cost_total + gpu_distributed sums to zero.
+-- Negate source: derive negation from the distributed output rows just inserted.
+-- Sums distributed_cost of gpu_distributed rows and inserts exact negative,
+-- guaranteeing algebraic zero-sum.
 INSERT INTO postgres.{{schema | sqlsafe}}.rates_to_usage (
     uuid, report_period_id, source_uuid, usage_start, usage_end,
-    cluster_id, cluster_alias, namespace,
+    cluster_id, cluster_alias, namespace, node,
     custom_name, metric_type, cost_model_rate_type,
     monthly_cost_type, distributed_cost
 )
 SELECT
     uuid(),
-    rtu_agg.report_period_id,
-    rtu_agg.source_uuid,
-    rtu_agg.usage_start,
-    rtu_agg.usage_start,
-    rtu_agg.cluster_id,
-    rtu_agg.cluster_alias,
+    MAX(rtu.report_period_id),
+    rtu.source_uuid,
+    rtu.usage_start,
+    rtu.usage_start,
+    rtu.cluster_id,
+    MAX(rtu.cluster_alias),
     'GPU unallocated',
+    rtu.node,
     '', '',
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
-    -(rtu_agg.cost_model_total + COALESCE(infra_agg.infra_total, CAST(0 AS DECIMAL)))
-FROM (
-    SELECT
-        rtu.report_period_id,
-        rtu.source_uuid,
-        rtu.usage_start,
-        rtu.cluster_id,
-        MAX(rtu.cluster_alias) AS cluster_alias,
-        SUM(COALESCE(rtu.calculated_cost, CAST(0 AS DECIMAL))) AS cost_model_total
-    FROM postgres.{{schema | sqlsafe}}.rates_to_usage rtu
-    WHERE rtu.usage_start >= DATE({{start_date}})
-        AND rtu.usage_start <= DATE({{end_date}})
-        AND rtu.source_uuid = CAST({{source_uuid}} AS UUID)
-        AND rtu.namespace = 'GPU unallocated'
-        AND rtu.monthly_cost_type IS NULL
-    GROUP BY rtu.report_period_id, rtu.source_uuid, rtu.usage_start,
-             rtu.cluster_id
-    HAVING SUM(COALESCE(rtu.calculated_cost, CAST(0 AS DECIMAL))) != CAST(0 AS DECIMAL)
-) rtu_agg
-LEFT JOIN (
-    SELECT
-        lids.usage_start,
-        lids.cluster_id,
-        SUM(
-            COALESCE(lids.infrastructure_raw_cost, CAST(0 AS DECIMAL)) +
-            COALESCE(lids.infrastructure_markup_cost, CAST(0 AS DECIMAL))
-        ) AS infra_total
-    FROM postgres.{{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
-    WHERE lids.usage_start >= DATE({{start_date}})
-        AND lids.usage_start <= DATE({{end_date}})
-        AND lids.namespace = 'GPU unallocated'
-        AND lids.cost_model_rate_type IS NULL
-    GROUP BY lids.usage_start, lids.cluster_id
-) infra_agg
-    ON rtu_agg.usage_start = infra_agg.usage_start
-    AND rtu_agg.cluster_id = infra_agg.cluster_id;
+    -SUM(rtu.distributed_cost)
+FROM postgres.{{schema | sqlsafe}}.rates_to_usage rtu
+WHERE rtu.usage_start >= DATE({{start_date}})
+    AND rtu.usage_start <= DATE({{end_date}})
+    AND rtu.source_uuid = CAST({{source_uuid}} AS UUID)
+    AND rtu.monthly_cost_type = {{cost_model_rate_type}}
+    AND rtu.namespace != 'GPU unallocated'
+GROUP BY rtu.source_uuid, rtu.usage_start, rtu.cluster_id, rtu.node
+HAVING SUM(rtu.distributed_cost) != CAST(0 AS DECIMAL);

--- a/koku/masu/database/trino_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
+++ b/koku/masu/database/trino_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
@@ -19,13 +19,16 @@ WITH gpu_rtu_cost AS (
         rtu.custom_name,
         rtu.metric_type,
         rtu.cost_model_rate_type,
-        SUM(COALESCE(rtu.calculated_cost, 0)) AS rate_cost
+        SUM(COALESCE(rtu.calculated_cost, CAST(0 AS DECIMAL))) AS rate_cost
     FROM postgres.{{schema | sqlsafe}}.rates_to_usage rtu
     WHERE rtu.usage_start >= DATE({{start_date}})
         AND rtu.usage_start <= DATE({{end_date}})
         AND rtu.source_uuid = CAST({{source_uuid}} AS UUID)
         AND rtu.namespace = 'GPU unallocated'
-        AND rtu.monthly_cost_type IS NULL
+        AND (rtu.monthly_cost_type IS NULL OR rtu.monthly_cost_type NOT IN (
+            'worker_distributed', 'platform_distributed', 'gpu_distributed',
+            'unattributed_storage', 'unattributed_network'
+        ))
     GROUP BY rtu.usage_start, rtu.source_uuid, rtu.cluster_id, rtu.cluster_alias,
              rtu.report_period_id, rtu.node,
              rtu.custom_name, rtu.metric_type, rtu.cost_model_rate_type

--- a/koku/masu/database/trino_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
+++ b/koku/masu/database/trino_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
@@ -96,7 +96,7 @@ HAVING MAX(nsp.pod_usage_slice_hours / NULLIF(tu.total_slice_hours, 0) * gc.rate
 INSERT INTO postgres.{{schema | sqlsafe}}.rates_to_usage (
     uuid, report_period_id, source_uuid, usage_start, usage_end,
     cluster_id, cluster_alias, namespace,
-    custom_name, cost_model_rate_type,
+    custom_name, metric_type, cost_model_rate_type,
     monthly_cost_type, distributed_cost
 )
 SELECT
@@ -108,7 +108,7 @@ SELECT
     rtu.cluster_id,
     MAX(rtu.cluster_alias),
     'GPU unallocated',
-    '',
+    '', '',
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
     -SUM(COALESCE(rtu.calculated_cost, 0))

--- a/koku/masu/database/trino_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
+++ b/koku/masu/database/trino_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
@@ -93,6 +93,8 @@ GROUP BY nsp.usage_start, nsp.node, nsp.namespace,
 HAVING MAX(nsp.pod_usage_slice_hours / NULLIF(tu.total_slice_hours, 0) * gc.rate_cost) != 0;
 
 -- Negate source: offset GPU unallocated costs so the net distributed total is zero.
+-- Must negate cost-model costs (from RTU) AND infrastructure/markup costs (from
+-- daily_summary) so the API's cost_total + gpu_distributed sums to zero.
 INSERT INTO postgres.{{schema | sqlsafe}}.rates_to_usage (
     uuid, report_period_id, source_uuid, usage_start, usage_end,
     cluster_id, cluster_alias, namespace,
@@ -101,23 +103,49 @@ INSERT INTO postgres.{{schema | sqlsafe}}.rates_to_usage (
 )
 SELECT
     uuid(),
-    rtu.report_period_id,
-    rtu.source_uuid,
-    rtu.usage_start,
-    rtu.usage_start,
-    rtu.cluster_id,
-    MAX(rtu.cluster_alias),
+    rtu_agg.report_period_id,
+    rtu_agg.source_uuid,
+    rtu_agg.usage_start,
+    rtu_agg.usage_start,
+    rtu_agg.cluster_id,
+    rtu_agg.cluster_alias,
     'GPU unallocated',
     '', '',
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
-    -SUM(COALESCE(rtu.calculated_cost, 0))
-FROM postgres.{{schema | sqlsafe}}.rates_to_usage rtu
-WHERE rtu.usage_start >= DATE({{start_date}})
-    AND rtu.usage_start <= DATE({{end_date}})
-    AND rtu.source_uuid = CAST({{source_uuid}} AS UUID)
-    AND rtu.namespace = 'GPU unallocated'
-    AND rtu.monthly_cost_type IS NULL
-GROUP BY rtu.report_period_id, rtu.source_uuid, rtu.usage_start,
-         rtu.cluster_id
-HAVING SUM(COALESCE(rtu.calculated_cost, 0)) != 0;
+    -(rtu_agg.cost_model_total + COALESCE(infra_agg.infra_total, CAST(0 AS DECIMAL)))
+FROM (
+    SELECT
+        rtu.report_period_id,
+        rtu.source_uuid,
+        rtu.usage_start,
+        rtu.cluster_id,
+        MAX(rtu.cluster_alias) AS cluster_alias,
+        SUM(COALESCE(rtu.calculated_cost, CAST(0 AS DECIMAL))) AS cost_model_total
+    FROM postgres.{{schema | sqlsafe}}.rates_to_usage rtu
+    WHERE rtu.usage_start >= DATE({{start_date}})
+        AND rtu.usage_start <= DATE({{end_date}})
+        AND rtu.source_uuid = CAST({{source_uuid}} AS UUID)
+        AND rtu.namespace = 'GPU unallocated'
+        AND rtu.monthly_cost_type IS NULL
+    GROUP BY rtu.report_period_id, rtu.source_uuid, rtu.usage_start,
+             rtu.cluster_id
+    HAVING SUM(COALESCE(rtu.calculated_cost, CAST(0 AS DECIMAL))) != CAST(0 AS DECIMAL)
+) rtu_agg
+LEFT JOIN (
+    SELECT
+        lids.usage_start,
+        lids.cluster_id,
+        SUM(
+            COALESCE(lids.infrastructure_raw_cost, CAST(0 AS DECIMAL)) +
+            COALESCE(lids.infrastructure_markup_cost, CAST(0 AS DECIMAL))
+        ) AS infra_total
+    FROM postgres.{{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
+    WHERE lids.usage_start >= DATE({{start_date}})
+        AND lids.usage_start <= DATE({{end_date}})
+        AND lids.namespace = 'GPU unallocated'
+        AND lids.cost_model_rate_type IS NULL
+    GROUP BY lids.usage_start, lids.cluster_id
+) infra_agg
+    ON rtu_agg.usage_start = infra_agg.usage_start
+    AND rtu_agg.cluster_id = infra_agg.cluster_id;

--- a/koku/masu/database/trino_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
+++ b/koku/masu/database/trino_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
@@ -81,7 +81,7 @@ SELECT
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
     MAX(nsp.pod_usage_slice_hours / NULLIF(tu.total_slice_hours, 0) * gc.rate_cost),
-    {{cost_model_id}}
+    CAST({{cost_model_id}} AS UUID)
 FROM gpu_rtu_cost gc
 JOIN gpu_model_map gm
     ON gm.node = gc.node AND gm.usage_start = gc.usage_start
@@ -120,7 +120,7 @@ SELECT
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
     -SUM(rtu.distributed_cost),
-    {{cost_model_id}}
+    CAST({{cost_model_id}} AS UUID)
 FROM postgres.{{schema | sqlsafe}}.rates_to_usage rtu
 WHERE rtu.usage_start >= DATE({{start_date}})
     AND rtu.usage_start <= DATE({{end_date}})

--- a/koku/masu/database/trino_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
+++ b/koku/masu/database/trino_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
@@ -6,7 +6,7 @@ INSERT INTO postgres.{{schema | sqlsafe}}.rates_to_usage (
     uuid, report_period_id, source_uuid, usage_start, usage_end,
     cluster_id, cluster_alias, namespace, node,
     custom_name, metric_type, cost_model_rate_type,
-    monthly_cost_type, distributed_cost
+    monthly_cost_type, distributed_cost, cost_model_id
 )
 WITH gpu_rtu_cost AS (
     SELECT
@@ -80,7 +80,8 @@ SELECT
     gc.metric_type,
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
-    MAX(nsp.pod_usage_slice_hours / NULLIF(tu.total_slice_hours, 0) * gc.rate_cost)
+    MAX(nsp.pod_usage_slice_hours / NULLIF(tu.total_slice_hours, 0) * gc.rate_cost),
+    {{cost_model_id}}
 FROM gpu_rtu_cost gc
 JOIN gpu_model_map gm
     ON gm.node = gc.node AND gm.usage_start = gc.usage_start
@@ -103,7 +104,7 @@ INSERT INTO postgres.{{schema | sqlsafe}}.rates_to_usage (
     uuid, report_period_id, source_uuid, usage_start, usage_end,
     cluster_id, cluster_alias, namespace, node,
     custom_name, metric_type, cost_model_rate_type,
-    monthly_cost_type, distributed_cost
+    monthly_cost_type, distributed_cost, cost_model_id
 )
 SELECT
     uuid(),
@@ -118,7 +119,8 @@ SELECT
     '', '',
     {{cost_model_rate_type}},
     {{cost_model_rate_type}},
-    -SUM(rtu.distributed_cost)
+    -SUM(rtu.distributed_cost),
+    {{cost_model_id}}
 FROM postgres.{{schema | sqlsafe}}.rates_to_usage rtu
 WHERE rtu.usage_start >= DATE({{start_date}})
     AND rtu.usage_start <= DATE({{end_date}})

--- a/koku/masu/database/trino_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
+++ b/koku/masu/database/trino_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
@@ -75,7 +75,7 @@ SELECT
     gc.custom_name,
     gc.metric_type,
     gc.cost_model_rate_type,
-    {{distribution_tag}},
+    {{cost_model_rate_type}},
     MAX(nsp.pod_usage_slice_hours / NULLIF(tu.total_slice_hours, 0) * gc.rate_cost)
 FROM gpu_rtu_cost gc
 JOIN gpu_model_map gm

--- a/koku/masu/database/trino_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
+++ b/koku/masu/database/trino_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql
@@ -1,0 +1,93 @@
+-- Per-rate GPU unallocated cost distribution via rates_to_usage (Trino/SaaS).
+-- Reads per-rate GPU costs from RTU (GPU unallocated namespace), distributes
+-- proportionally by MIG-aware slice-hours, writes distributed rows back to RTU
+-- with monthly_cost_type = 'gpu_distributed'.
+INSERT INTO postgres.{{schema | sqlsafe}}.rates_to_usage (
+    uuid, report_period_id, source_uuid, usage_start, usage_end,
+    cluster_id, cluster_alias, namespace, node,
+    custom_name, metric_type, cost_model_rate_type,
+    monthly_cost_type, distributed_cost
+)
+WITH gpu_rtu_cost AS (
+    SELECT
+        rtu.usage_start,
+        rtu.source_uuid,
+        rtu.cluster_id,
+        rtu.cluster_alias,
+        rtu.report_period_id,
+        rtu.node,
+        rtu.custom_name,
+        rtu.metric_type,
+        rtu.cost_model_rate_type,
+        SUM(COALESCE(rtu.calculated_cost, 0)) AS rate_cost
+    FROM postgres.{{schema | sqlsafe}}.rates_to_usage rtu
+    WHERE rtu.usage_start >= DATE({{start_date}})
+        AND rtu.usage_start <= DATE({{end_date}})
+        AND rtu.source_uuid = CAST({{source_uuid}} AS UUID)
+        AND rtu.namespace = 'GPU unallocated'
+        AND rtu.monthly_cost_type IS NULL
+    GROUP BY rtu.usage_start, rtu.source_uuid, rtu.cluster_id, rtu.cluster_alias,
+             rtu.report_period_id, rtu.node,
+             rtu.custom_name, rtu.metric_type, rtu.cost_model_rate_type
+),
+gpu_model_map AS (
+    SELECT
+        node,
+        json_extract_scalar(all_labels, '$["gpu-model"]') AS gpu_model,
+        usage_start
+    FROM postgres.{{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary
+    WHERE namespace = 'GPU unallocated'
+      AND usage_start >= DATE({{start_date}})
+      AND usage_start <= DATE({{end_date}})
+      AND source_uuid = CAST({{source_uuid}} AS UUID)
+    GROUP BY node, json_extract_scalar(all_labels, '$["gpu-model"]'), usage_start
+),
+namespace_usage_information AS (
+    SELECT gpu_model_name,
+        gpu_usage.namespace,
+        gpu_usage.node,
+        SUM(gpu_pod_uptime * COALESCE(gpu_usage.mig_slice_count, 1)) AS pod_usage_slice_hours,
+        DATE(interval_start) AS usage_start
+    FROM hive.{{schema | sqlsafe}}.openshift_gpu_usage_line_items_daily AS gpu_usage
+    WHERE source = {{source_uuid}}
+      AND year = {{year}}
+      AND month = {{month}}
+      AND DATE(interval_start) >= DATE({{start_date}})
+      AND DATE(interval_start) <= DATE({{end_date}})
+    GROUP BY gpu_model_name, gpu_usage.node, namespace, DATE(interval_start)
+),
+total_usage AS (
+    SELECT node, gpu_model_name, usage_start,
+           SUM(pod_usage_slice_hours) AS total_slice_hours
+    FROM namespace_usage_information
+    GROUP BY node, gpu_model_name, usage_start
+)
+SELECT
+    uuid(),
+    MAX(gc.report_period_id),
+    gc.source_uuid,
+    nsp.usage_start,
+    nsp.usage_start,
+    MAX(gc.cluster_id),
+    MAX(gc.cluster_alias),
+    nsp.namespace,
+    nsp.node,
+    gc.custom_name,
+    gc.metric_type,
+    gc.cost_model_rate_type,
+    {{cost_model_rate_type}},
+    MAX(nsp.pod_usage_slice_hours / NULLIF(tu.total_slice_hours, 0) * gc.rate_cost)
+FROM gpu_rtu_cost gc
+JOIN gpu_model_map gm
+    ON gm.node = gc.node AND gm.usage_start = gc.usage_start
+JOIN namespace_usage_information nsp
+    ON nsp.node = gc.node
+    AND nsp.gpu_model_name = gm.gpu_model
+    AND nsp.usage_start = gc.usage_start
+JOIN total_usage tu
+    ON tu.node = nsp.node
+    AND tu.gpu_model_name = nsp.gpu_model_name
+    AND tu.usage_start = nsp.usage_start
+GROUP BY nsp.usage_start, nsp.node, nsp.namespace,
+         gc.source_uuid, gc.custom_name, gc.metric_type, gc.cost_model_rate_type
+HAVING MAX(nsp.pod_usage_slice_hours / NULLIF(tu.total_slice_hours, 0) * gc.rate_cost) != 0;

--- a/koku/masu/processor/ocp/ocp_cost_model_cost_updater.py
+++ b/koku/masu/processor/ocp/ocp_cost_model_cost_updater.py
@@ -779,6 +779,8 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
         Distribution runs per-month so report_period_id resolves correctly for
         each month in a multi-month range.
         """
+        # Each step auto-commits independently. Recovery relies on the idempotent
+        # DELETE + INSERT pattern — the same approach used by all other masu pipelines.
         self._ensure_rates_to_usage_partitions(summary_range.start_date, summary_range.end_date)
         with OCPReportDBAccessor(self._schema) as accessor:
             for month_range in summary_range.iter_summary_range_by_month():
@@ -787,13 +789,14 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                 )
                 self._aggregate_rates_to_daily_summary(month_range.start_date, month_range.end_date)
                 self._update_markup_cost(month_range.start_date, month_range.end_date)
-                accessor.populate_ui_summary_tables(month_range, self._provider.uuid)
+                accessor.populate_ui_summary_tables(month_range, self._provider_uuid)
 
-                if report_period := accessor.report_periods_for_provider_uuid(
-                    self._provider_uuid, month_range.summary_start
-                ):
-                    report_period.derived_cost_datetime = timezone.now()
-                    report_period.save()
+                with schema_context(self._schema):
+                    if report_period := accessor.report_periods_for_provider_uuid(
+                        self._provider_uuid, month_range.summary_start
+                    ):
+                        report_period.derived_cost_datetime = timezone.now()
+                        report_period.save()
 
     def update_summary_cost_model_costs(self, summary_range: SummaryRangeConfig) -> None:
         """Update the OCP summary table with the charge information.

--- a/koku/masu/processor/ocp/ocp_cost_model_cost_updater.py
+++ b/koku/masu/processor/ocp/ocp_cost_model_cost_updater.py
@@ -887,6 +887,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                     self._distribution_info,
                     infra_to_cm_rate=infra_to_cm_rate,
                     cost_model_currency=cost_model_currency,
+                    cost_model_id=self._cost_model_id,
                 )
             distribution_raw_currency = cost_model_currency if has_infra_currency else None
             self._aggregate_rates_to_daily_summary(

--- a/koku/masu/processor/ocp/ocp_cost_model_cost_updater.py
+++ b/koku/masu/processor/ocp/ocp_cost_model_cost_updater.py
@@ -5,6 +5,7 @@
 """Updates report summary tables in the database with charge information."""
 import logging
 import time
+import uuid
 from decimal import Decimal
 
 from django.db import transaction
@@ -530,7 +531,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
             report_accessor.populate_usage_rates_to_usage(
                 start_date,
                 end_date,
-                self._provider_uuid,
+                uuid.UUID(self._provider_uuid),
                 report_period_id,
                 self._cost_model_id,
             )
@@ -683,7 +684,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                 accessor.populate_markup_rates_to_usage(
                     start_date,
                     end_date,
-                    self._provider_uuid,
+                    uuid.UUID(self._provider_uuid),
                     self._cluster_id,
                     self._cost_model_id,
                 )

--- a/koku/masu/processor/ocp/ocp_cost_model_cost_updater.py
+++ b/koku/masu/processor/ocp/ocp_cost_model_cost_updater.py
@@ -788,22 +788,23 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
         a subsequent month's atomic block fails.
         """
         self._ensure_rates_to_usage_partitions(summary_range.start_date, summary_range.end_date)
-        with OCPReportDBAccessor(self._schema) as accessor:
-            for month_range in summary_range.iter_summary_range_by_month():
-                with transaction.atomic():
+        for month_range in summary_range.iter_summary_range_by_month():
+            with transaction.atomic():
+                with OCPReportDBAccessor(self._schema) as accessor:
                     month_range = accessor.populate_distributed_cost_sql(
                         month_range, self._provider_uuid, self._distribution_info
                     )
-                    self._aggregate_rates_to_daily_summary(month_range.start_date, month_range.end_date)
-                    self._update_markup_cost(month_range.start_date, month_range.end_date)
+                self._aggregate_rates_to_daily_summary(month_range.start_date, month_range.end_date)
+                self._update_markup_cost(month_range.start_date, month_range.end_date)
+                with OCPReportDBAccessor(self._schema) as accessor:
                     accessor.populate_ui_summary_tables(month_range, self._provider_uuid)
 
-                with schema_context(self._schema):
-                    if report_period := accessor.report_periods_for_provider_uuid(
-                        self._provider_uuid, month_range.summary_start
-                    ):
-                        report_period.derived_cost_datetime = timezone.now()
-                        report_period.save()
+            with OCPReportDBAccessor(self._schema) as accessor:
+                if report_period := accessor.report_periods_for_provider_uuid(
+                    self._provider_uuid, month_range.summary_start
+                ):
+                    report_period.derived_cost_datetime = timezone.now()
+                    report_period.save()
 
     def update_summary_cost_model_costs(self, summary_range: SummaryRangeConfig) -> None:
         """Update the OCP summary table with the charge information.

--- a/koku/masu/processor/ocp/ocp_cost_model_cost_updater.py
+++ b/koku/masu/processor/ocp/ocp_cost_model_cost_updater.py
@@ -254,7 +254,11 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
         combined_case_statements = {}
         if openshift_resource_type in ["Node", "Node_Core_Month"]:
             node_core = metric_constants.OCP_NODE_CORE_MONTH if openshift_resource_type == "Node_Core_Month" else ""
-            (cost_case_statements, unallocated_cost_case_statements, labels_case_statement,) = self._node_statements(
+            (
+                cost_case_statements,
+                unallocated_cost_case_statements,
+                labels_case_statement,
+            ) = self._node_statements(
                 rates,
                 start_date,
                 default_rates,
@@ -279,7 +283,11 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
 
     def _get_all_node_hour_tag_based_case_statements(self, rates, default_rates, start_date):
         """Call and organize cost, unallocated, and label case statements."""
-        (cost_case_statements, unallocated_cost_case_statements, labels_case_statement,) = self._node_statements(
+        (
+            cost_case_statements,
+            unallocated_cost_case_statements,
+            labels_case_statement,
+        ) = self._node_statements(
             rates,
             start_date,
             default_rates,

--- a/koku/masu/processor/ocp/ocp_cost_model_cost_updater.py
+++ b/koku/masu/processor/ocp/ocp_cost_model_cost_updater.py
@@ -536,7 +536,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
             )
             RTU_POPULATE_DURATION.labels(provider_type=self._provider.type).observe(time.monotonic() - t0)
 
-    def _aggregate_rates_to_daily_summary(self, start_date, end_date):
+    def _aggregate_rates_to_daily_summary(self, start_date, end_date, cost_model_currency="USD"):
         """Aggregate RatesToUsage rows into daily summary cost columns."""
         if not self._cost_model_id:
             LOG.debug(
@@ -563,7 +563,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                 return
             t0 = time.monotonic()
             report_accessor.aggregate_rates_to_daily_summary(
-                start_date, end_date, self._provider_uuid, report_period.id
+                start_date, end_date, self._provider_uuid, report_period.id, cost_model_currency
             )
             RTU_AGGREGATE_DURATION.labels(provider_type=self._provider.type).observe(time.monotonic() - t0)
 
@@ -773,6 +773,64 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                 },
             )
 
+    def _get_infra_to_cm_rate(self, cost_model_currency, start_date, end_date):
+        """Return the exchange rate from infrastructure raw_currency to cost_model_currency.
+
+        Queries distinct raw_currency from unattributed namespace rows in daily_summary.
+        If infra currency matches cost model currency (or no infra exists), returns 1.
+        """
+        if not cost_model_currency:
+            return Decimal(1)
+
+        with schema_context(self._schema):
+            infra_currencies = (
+                OCPUsageLineItemDailySummary.objects.filter(
+                    source_uuid=self._provider_uuid,
+                    usage_start__gte=start_date,
+                    usage_start__lte=end_date,
+                    namespace__in=["Network unattributed", "Storage unattributed"],
+                    cost_model_rate_type__isnull=True,
+                    raw_currency__isnull=False,
+                )
+                .values_list("raw_currency", flat=True)
+                .distinct()
+            )
+            infra_currencies = list(infra_currencies)
+
+        if not infra_currencies or all(c == cost_model_currency for c in infra_currencies):
+            return Decimal(1)
+
+        infra_currency = infra_currencies[0]
+        if infra_currency == cost_model_currency:
+            return Decimal(1)
+
+        from api.currency.models import ExchangeRateDictionary
+
+        exchange_dict = ExchangeRateDictionary.objects.first()
+        if not exchange_dict or not exchange_dict.currency_exchange_dictionary:
+            LOG.warning(
+                log_json(
+                    msg="no exchange rate dictionary found, defaulting infra_to_cm_rate to 1",
+                    infra_currency=infra_currency,
+                    cost_model_currency=cost_model_currency,
+                )
+            )
+            return Decimal(1)
+
+        rates = exchange_dict.currency_exchange_dictionary
+        rate = rates.get(infra_currency, {}).get(cost_model_currency)
+        if rate is None:
+            LOG.warning(
+                log_json(
+                    msg="exchange rate not found, defaulting to 1",
+                    infra_currency=infra_currency,
+                    cost_model_currency=cost_model_currency,
+                )
+            )
+            return Decimal(1)
+
+        return Decimal(str(rate))
+
     def distribute_costs_and_update_ui_summary(self, summary_range: SummaryRangeConfig):
         """Distribute per-rate costs, aggregate, apply markup, and update UI summaries.
 
@@ -796,6 +854,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
         schema context managers corrupting the PostgreSQL search_path.
         """
         markup_pct = self._get_markup_percentage()
+        cost_model_currency = self._cost_model.currency if self._cost_model else "USD"
         self._ensure_rates_to_usage_partitions(summary_range.start_date, summary_range.end_date)
         for month_range in summary_range.iter_summary_range_by_month():
             if markup_pct:
@@ -803,11 +862,20 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                     accessor.populate_markup_cost(
                         markup_pct, month_range.start_date, month_range.end_date, self._cluster_id
                     )
+            infra_to_cm_rate = self._get_infra_to_cm_rate(
+                cost_model_currency, month_range.start_date, month_range.end_date
+            )
             with OCPReportDBAccessor(self._schema) as accessor:
                 month_range = accessor.populate_distributed_cost_sql(
-                    month_range, self._provider_uuid, self._distribution_info
+                    month_range,
+                    self._provider_uuid,
+                    self._distribution_info,
+                    infra_to_cm_rate=infra_to_cm_rate,
+                    cost_model_currency=cost_model_currency,
                 )
-            self._aggregate_rates_to_daily_summary(month_range.start_date, month_range.end_date)
+            self._aggregate_rates_to_daily_summary(
+                month_range.start_date, month_range.end_date, cost_model_currency
+            )
             self._update_markup_cost(month_range.start_date, month_range.end_date)
             with OCPReportDBAccessor(self._schema) as accessor:
                 accessor.populate_ui_summary_tables(month_range, self._provider_uuid)

--- a/koku/masu/processor/ocp/ocp_cost_model_cost_updater.py
+++ b/koku/masu/processor/ocp/ocp_cost_model_cost_updater.py
@@ -776,15 +776,33 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
     def distribute_costs_and_update_ui_summary(self, summary_range: SummaryRangeConfig):
         """Distribute per-rate costs, aggregate, apply markup, and update UI summaries.
 
-        Phase 4 order per month: distribute -> aggregate -> markup -> UI summary.
+        Phase 4 order per month: markup(daily_summary) -> distribute -> aggregate -> markup(full) -> UI summary.
+
+        Markup must run on daily_summary BEFORE distribution because the
+        distribution SQL reads infrastructure_markup_cost from daily_summary.
+        Without pre-applying markup, infrastructure_markup_cost is 0 and
+        OCP-on-cloud infrastructure costs are under-distributed (only raw cost
+        is distributed, not raw + markup).  The ORM UPDATE is idempotent so
+        running it again after aggregation is safe.
+
+        RTU markup rows (populate_markup_rates_to_usage) are created only in
+        the post-aggregation _update_markup_cost call to avoid double-counting
+        in the distribution source CTEs.
+
         Distribution runs per-month so report_period_id resolves correctly for
         each month in a multi-month range.
 
         Each step uses its own OCPReportDBAccessor context to avoid nested
         schema context managers corrupting the PostgreSQL search_path.
         """
+        markup_pct = self._get_markup_percentage()
         self._ensure_rates_to_usage_partitions(summary_range.start_date, summary_range.end_date)
         for month_range in summary_range.iter_summary_range_by_month():
+            if markup_pct:
+                with OCPReportDBAccessor(self._schema) as accessor:
+                    accessor.populate_markup_cost(
+                        markup_pct, month_range.start_date, month_range.end_date, self._cluster_id
+                    )
             with OCPReportDBAccessor(self._schema) as accessor:
                 month_range = accessor.populate_distributed_cost_sql(
                     month_range, self._provider_uuid, self._distribution_info
@@ -800,6 +818,19 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                 ):
                     report_period.derived_cost_datetime = timezone.now()
                     report_period.save()
+
+    def _get_markup_percentage(self):
+        """Return the markup percentage as a Decimal, or None if no markup configured."""
+        with CostModelDBAccessor(
+            self._schema, self._provider_uuid, price_list_effective_on=None
+        ) as cost_model_accessor:
+            markup = cost_model_accessor.markup
+            if not markup:
+                return None
+            value = Decimal(markup.get("value", 0))
+            if not value:
+                return None
+            return value / 100
 
     def update_summary_cost_model_costs(self, summary_range: SummaryRangeConfig) -> None:
         """Update the OCP summary table with the charge information.

--- a/koku/masu/processor/ocp/ocp_cost_model_cost_updater.py
+++ b/koku/masu/processor/ocp/ocp_cost_model_cost_updater.py
@@ -74,10 +74,14 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
         ) as cost_model_accessor:
             self._infra_rates = cost_model_accessor.infrastructure_rates
             self._tag_infra_rates = cost_model_accessor.tag_infrastructure_rates
-            self._tag_default_infra_rates = cost_model_accessor.tag_default_infrastructure_rates
+            self._tag_default_infra_rates = (
+                cost_model_accessor.tag_default_infrastructure_rates
+            )
             self._supplementary_rates = cost_model_accessor.supplementary_rates
             self._tag_supplementary_rates = cost_model_accessor.tag_supplementary_rates
-            self._tag_default_supplementary_rates = cost_model_accessor.tag_default_supplementary_rates
+            self._tag_default_supplementary_rates = (
+                cost_model_accessor.tag_default_supplementary_rates
+            )
             self.metric_to_tag_params_map = cost_model_accessor.metric_to_tag_params_map
             self._price_list_effective_on = cost_model_accessor.price_list_effective_on
             self._rate_info_map = cost_model_accessor.rate_info_map
@@ -85,7 +89,9 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
     def _ensure_rates_to_usage_partitions(self, start_date, end_date):
         """Create monthly partitions for rates_to_usage on demand."""
         with schema_context(self._schema):
-            self._handle_partitions(self._schema, ["rates_to_usage"], start_date, end_date)
+            self._handle_partitions(
+                self._schema, ["rates_to_usage"], start_date, end_date
+            )
 
     def _build_node_tag_cost_case_statements(  # noqa: C901
         self,
@@ -205,7 +211,9 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
             case_dict[tag_key] = "\n".join(statement_list)
         return case_dict
 
-    def _build_volume_tag_cost_case_statements(self, rate_dict, start_date, default_rate_dict={}):
+    def _build_volume_tag_cost_case_statements(
+        self, rate_dict, start_date, default_rate_dict={}
+    ):
         """Given a tag key, value, and rate return a CASE SQL statement."""
         case_dict = {}
         for tag_key, tag_value_rates in rate_dict.items():
@@ -230,7 +238,9 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
             )
         return case_dict
 
-    def _node_statements(self, rates, start_date, default_rates, *, node_core, amortized):
+    def _node_statements(
+        self, rates, start_date, default_rates, *, node_core, amortized
+    ):
         cost_case_statements = self._build_node_tag_cost_case_statements(
             rates, start_date, default_rates, node_core=node_core, amortized=amortized
         )
@@ -242,20 +252,32 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
             node_core=node_core,
             amortized=amortized,
         )
-        labels_case_statement = self._build_labels_case_statement(rates, "pod_labels", default_rate=default_rates)
+        labels_case_statement = self._build_labels_case_statement(
+            rates, "pod_labels", default_rate=default_rates
+        )
         return (
             cost_case_statements,
             unallocated_cost_case_statements,
             labels_case_statement,
         )
 
-    def _get_all_monthly_tag_based_case_statements(self, openshift_resource_type, rates, default_rates, start_date):
+    def _get_all_monthly_tag_based_case_statements(
+        self, openshift_resource_type, rates, default_rates, start_date
+    ):
         """Call and organize cost, unallocated, and label case statements."""
         cost_case_statements = {}
         combined_case_statements = {}
         if openshift_resource_type in ["Node", "Node_Core_Month"]:
-            node_core = metric_constants.OCP_NODE_CORE_MONTH if openshift_resource_type == "Node_Core_Month" else ""
-            (cost_case_statements, unallocated_cost_case_statements, labels_case_statement,) = self._node_statements(
+            node_core = (
+                metric_constants.OCP_NODE_CORE_MONTH
+                if openshift_resource_type == "Node_Core_Month"
+                else ""
+            )
+            (
+                cost_case_statements,
+                unallocated_cost_case_statements,
+                labels_case_statement,
+            ) = self._node_statements(
                 rates,
                 start_date,
                 default_rates,
@@ -263,7 +285,9 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                 amortized=True,
             )
         elif openshift_resource_type == "PVC":
-            cost_case_statements = self._build_volume_tag_cost_case_statements(rates, start_date, default_rates)
+            cost_case_statements = self._build_volume_tag_cost_case_statements(
+                rates, start_date, default_rates
+            )
             # No unallocated cost for volumes
             unallocated_cost_case_statements = {}
             labels_case_statement = self._build_labels_case_statement(
@@ -278,9 +302,15 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
             }
         return combined_case_statements
 
-    def _get_all_node_hour_tag_based_case_statements(self, rates, default_rates, start_date):
+    def _get_all_node_hour_tag_based_case_statements(
+        self, rates, default_rates, start_date
+    ):
         """Call and organize cost, unallocated, and label case statements."""
-        (cost_case_statements, unallocated_cost_case_statements, labels_case_statement,) = self._node_statements(
+        (
+            cost_case_statements,
+            unallocated_cost_case_statements,
+            labels_case_statement,
+        ) = self._node_statements(
             rates,
             start_date,
             default_rates,
@@ -331,7 +361,11 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                 )
 
                 amortized_rate = get_amortized_monthly_cost_model_rate(rate, start_date)
-                rate_info = self._rate_info_map.get((rate_term, rate_type, ""), {}) if rate_type else {}
+                rate_info = (
+                    self._rate_info_map.get((rate_term, rate_type, ""), {})
+                    if rate_type
+                    else {}
+                )
                 report_accessor.populate_monthly_cost_sql(
                     cost_type,
                     rate_type,
@@ -364,12 +398,23 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                     metric_constants.INFRASTRUCTURE_COST_TYPE,
                     metric_constants.SUPPLEMENTARY_COST_TYPE,
                 ):
-                    if cost_model_cost_type == metric_constants.INFRASTRUCTURE_COST_TYPE:
+                    if (
+                        cost_model_cost_type
+                        == metric_constants.INFRASTRUCTURE_COST_TYPE
+                    ):
                         rates = self._tag_infra_rates.get(monthly_cost_metric, {})
-                        default_rates = self._tag_default_infra_rates.get(monthly_cost_metric, {})
-                    elif cost_model_cost_type == metric_constants.SUPPLEMENTARY_COST_TYPE:
-                        rates = self._tag_supplementary_rates.get(monthly_cost_metric, {})
-                        default_rates = self._tag_default_supplementary_rates.get(monthly_cost_metric, {})
+                        default_rates = self._tag_default_infra_rates.get(
+                            monthly_cost_metric, {}
+                        )
+                    elif (
+                        cost_model_cost_type == metric_constants.SUPPLEMENTARY_COST_TYPE
+                    ):
+                        rates = self._tag_supplementary_rates.get(
+                            monthly_cost_metric, {}
+                        )
+                        default_rates = self._tag_default_supplementary_rates.get(
+                            monthly_cost_metric, {}
+                        )
 
                     if not rates:
                         # The cost model has no rates for this metric
@@ -387,12 +432,16 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                         )
                     )
 
-                    per_tag_key_case_statements = self._get_all_monthly_tag_based_case_statements(
-                        openshift_resource_type, rates, default_rates, start_date
+                    per_tag_key_case_statements = (
+                        self._get_all_monthly_tag_based_case_statements(
+                            openshift_resource_type, rates, default_rates, start_date
+                        )
                     )
 
                     for tag_key, case_statements in per_tag_key_case_statements.items():
-                        rate_info = self._rate_info_map.get((monthly_cost_metric, cost_model_cost_type, tag_key), {})
+                        rate_info = self._rate_info_map.get(
+                            (monthly_cost_metric, cost_model_cost_type, tag_key), {}
+                        )
                         report_accessor.populate_tag_cost_sql(
                             openshift_resource_type,
                             cost_model_cost_type,
@@ -420,7 +469,9 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                     default_rates = self._tag_default_infra_rates.get(cost_metric, {})
                 elif cost_model_cost_type == metric_constants.SUPPLEMENTARY_COST_TYPE:
                     rates = self._tag_supplementary_rates.get(cost_metric, {})
-                    default_rates = self._tag_default_supplementary_rates.get(cost_metric, {})
+                    default_rates = self._tag_default_supplementary_rates.get(
+                        cost_metric, {}
+                    )
                 if not rates:
                     # The cost model has no rates for this metric
                     continue
@@ -435,8 +486,10 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                         end_date=end_date,
                     )
                 )
-                per_tag_key_case_statements = self._get_all_node_hour_tag_based_case_statements(
-                    rates, default_rates, start_date
+                per_tag_key_case_statements = (
+                    self._get_all_node_hour_tag_based_case_statements(
+                        rates, default_rates, start_date
+                    )
                 )
                 for tag_key, case_statements in per_tag_key_case_statements.items():
                     rate_info = self._rate_info_map.get(
@@ -469,7 +522,9 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
             metric_constants.SUPPLEMENTARY_COST_TYPE: self._supplementary_rates,
         }
         with OCPReportDBAccessor(self._schema) as report_accessor:
-            report_period = report_accessor.report_periods_for_provider_uuid(self._provider_uuid, start_date)
+            report_period = report_accessor.report_periods_for_provider_uuid(
+                self._provider_uuid, start_date
+            )
             if not report_period:
                 LOG.info(
                     log_json(
@@ -487,7 +542,9 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
             for report_type, report_type_dict in report_type_map.items():
                 report_accessor.populate_usage_costs(
                     report_type,
-                    filter_dictionary(report_type_dict, metric_constants.COST_MODEL_USAGE_RATES),
+                    filter_dictionary(
+                        report_type_dict, metric_constants.COST_MODEL_USAGE_RATES
+                    ),
                     self._distribution,
                     start_date,
                     end_date,
@@ -508,7 +565,9 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
             return
 
         with OCPReportDBAccessor(self._schema) as report_accessor:
-            report_period = report_accessor.report_periods_for_provider_uuid(self._provider_uuid, start_date)
+            report_period = report_accessor.report_periods_for_provider_uuid(
+                self._provider_uuid, start_date
+            )
             if not report_period:
                 LOG.info(
                     log_json(
@@ -534,9 +593,13 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                 report_period_id,
                 self._cost_model_id,
             )
-            RTU_POPULATE_DURATION.labels(provider_type=self._provider.type).observe(time.monotonic() - t0)
+            RTU_POPULATE_DURATION.labels(provider_type=self._provider.type).observe(
+                time.monotonic() - t0
+            )
 
-    def _aggregate_rates_to_daily_summary(self, start_date, end_date, cost_model_currency="USD"):
+    def _aggregate_rates_to_daily_summary(
+        self, start_date, end_date, cost_model_currency="USD"
+    ):
         """Aggregate RatesToUsage rows into daily summary cost columns."""
         if not self._cost_model_id:
             LOG.debug(
@@ -547,7 +610,9 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
             )
             return
         with OCPReportDBAccessor(self._schema) as report_accessor:
-            report_period = report_accessor.report_periods_for_provider_uuid(self._provider_uuid, start_date)
+            report_period = report_accessor.report_periods_for_provider_uuid(
+                self._provider_uuid, start_date
+            )
             if not report_period:
                 LOG.info(
                     log_json(
@@ -563,9 +628,15 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                 return
             t0 = time.monotonic()
             report_accessor.aggregate_rates_to_daily_summary(
-                start_date, end_date, self._provider_uuid, report_period.id, cost_model_currency
+                start_date,
+                end_date,
+                self._provider_uuid,
+                report_period.id,
+                cost_model_currency,
             )
-            RTU_AGGREGATE_DURATION.labels(provider_type=self._provider.type).observe(time.monotonic() - t0)
+            RTU_AGGREGATE_DURATION.labels(provider_type=self._provider.type).observe(
+                time.monotonic() - t0
+            )
 
     def _cleanup_stale_rtu_costs(self, start_date, end_date):
         """Remove stale cost-model rows when the cost model has been deleted.
@@ -574,7 +645,9 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
         Cleans both rates_to_usage and the daily summary cost-model rows.
         """
         with OCPReportDBAccessor(self._schema) as report_accessor:
-            report_period = report_accessor.report_periods_for_provider_uuid(self._provider_uuid, start_date)
+            report_period = report_accessor.report_periods_for_provider_uuid(
+                self._provider_uuid, start_date
+            )
             if not report_period:
                 return
             report_period_id = report_period.id
@@ -624,14 +697,18 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
             metric_constants.SUPPLEMENTARY_COST_TYPE: self._supplementary_rates,
         }
         with OCPReportDBAccessor(self._schema) as report_accessor:
-            report_period = report_accessor.report_periods_for_provider_uuid(self._provider_uuid, start_date)
+            report_period = report_accessor.report_periods_for_provider_uuid(
+                self._provider_uuid, start_date
+            )
             if not report_period:
                 return
             report_period_id = report_period.id
             for report_type, report_type_dict in report_type_map.items():
                 report_accessor.populate_vm_usage_costs(
                     report_type,
-                    filter_dictionary(report_type_dict, metric_constants.COST_MODEL_VM_USAGE_RATES),
+                    filter_dictionary(
+                        report_type_dict, metric_constants.COST_MODEL_VM_USAGE_RATES
+                    ),
                     start_date,
                     end_date,
                     self._provider_uuid,
@@ -677,7 +754,9 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                     end_date=end_date,
                 )
             )
-            accessor.populate_markup_cost(markup, start_date, end_date, self._cluster_id)
+            accessor.populate_markup_cost(
+                markup, start_date, end_date, self._cluster_id
+            )
             if self._cost_model_id:
                 t0 = time.monotonic()
                 accessor.populate_markup_rates_to_usage(
@@ -687,7 +766,9 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                     self._cluster_id,
                     self._cost_model_id,
                 )
-                RTU_MARKUP_DURATION.labels(provider_type=self._provider.type).observe(time.monotonic() - t0)
+                RTU_MARKUP_DURATION.labels(provider_type=self._provider.type).observe(
+                    time.monotonic() - t0
+                )
         LOG.info(
             log_json(
                 msg="finished updating markup costs",
@@ -703,7 +784,9 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
     def _update_tag_usage_costs(self, start_date, end_date):
         """Update infrastructure and supplementary tag based usage costs."""
         with OCPReportDBAccessor(self._schema) as report_accessor:
-            report_period = report_accessor.report_periods_for_provider_uuid(self._provider_uuid, start_date)
+            report_period = report_accessor.report_periods_for_provider_uuid(
+                self._provider_uuid, start_date
+            )
             report_period_id = report_period.id if report_period else None
             report_accessor.populate_tag_usage_costs(
                 self._tag_infra_rates,
@@ -720,7 +803,9 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
     def _update_tag_usage_default_costs(self, start_date, end_date):
         """Update infrastructure and supplementary tag based usage costs based on default values."""
         with OCPReportDBAccessor(self._schema) as report_accessor:
-            report_period = report_accessor.report_periods_for_provider_uuid(self._provider_uuid, start_date)
+            report_period = report_accessor.report_periods_for_provider_uuid(
+                self._provider_uuid, start_date
+            )
             report_period_id = report_period.id if report_period else None
             report_accessor.populate_tag_usage_default_costs(
                 self._tag_default_infra_rates,
@@ -739,7 +824,9 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
         # Delete existing records
         with OCPReportDBAccessor(self._schema) as report_accessor:
             with schema_context(self._schema):
-                report_period = report_accessor.report_periods_for_provider_uuid(self._provider_uuid, start_date)
+                report_period = report_accessor.report_periods_for_provider_uuid(
+                    self._provider_uuid, start_date
+                )
                 if not report_period:
                     LOG.info(
                         log_json(
@@ -774,13 +861,18 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
             )
 
     def _get_infra_to_cm_rate(self, cost_model_currency, start_date, end_date):
-        """Return the exchange rate from infrastructure raw_currency to cost_model_currency.
+        """Return (exchange_rate, has_infra_currency) for infra → cost_model_currency conversion.
 
         Queries distinct raw_currency from unattributed namespace rows in daily_summary.
-        If infra currency matches cost model currency (or no infra exists), returns 1.
+        If infra currency matches cost model currency (or no infra exists), returns (1, flag).
+
+        The second element indicates whether source rows have a non-NULL raw_currency.
+        The caller uses this to decide the raw_currency on aggregated distribution rows:
+        when False, raw_currency should be NULL so the API applies the same default
+        exchange rate (1) as the original infrastructure rows.
         """
         if not cost_model_currency:
-            return Decimal(1)
+            return Decimal(1), False
 
         with schema_context(self._schema):
             infra_currencies = (
@@ -797,12 +889,15 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
             )
             infra_currencies = list(infra_currencies)
 
-        if not infra_currencies or all(c == cost_model_currency for c in infra_currencies):
-            return Decimal(1)
+        if not infra_currencies:
+            return Decimal(1), False
+
+        if all(c == cost_model_currency for c in infra_currencies):
+            return Decimal(1), True
 
         infra_currency = infra_currencies[0]
         if infra_currency == cost_model_currency:
-            return Decimal(1)
+            return Decimal(1), True
 
         from api.currency.models import ExchangeRateDictionary
 
@@ -815,7 +910,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                     cost_model_currency=cost_model_currency,
                 )
             )
-            return Decimal(1)
+            return Decimal(1), True
 
         rates = exchange_dict.currency_exchange_dictionary
         rate = rates.get(infra_currency, {}).get(cost_model_currency)
@@ -827,9 +922,9 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                     cost_model_currency=cost_model_currency,
                 )
             )
-            return Decimal(1)
+            return Decimal(1), True
 
-        return Decimal(str(rate))
+        return Decimal(str(rate)), True
 
     def distribute_costs_and_update_ui_summary(self, summary_range: SummaryRangeConfig):
         """Distribute per-rate costs, aggregate, apply markup, and update UI summaries.
@@ -855,14 +950,19 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
         """
         markup_pct = self._get_markup_percentage()
         cost_model_currency = self._cost_model.currency if self._cost_model else "USD"
-        self._ensure_rates_to_usage_partitions(summary_range.start_date, summary_range.end_date)
+        self._ensure_rates_to_usage_partitions(
+            summary_range.start_date, summary_range.end_date
+        )
         for month_range in summary_range.iter_summary_range_by_month():
             if markup_pct:
                 with OCPReportDBAccessor(self._schema) as accessor:
                     accessor.populate_markup_cost(
-                        markup_pct, month_range.start_date, month_range.end_date, self._cluster_id
+                        markup_pct,
+                        month_range.start_date,
+                        month_range.end_date,
+                        self._cluster_id,
                     )
-            infra_to_cm_rate = self._get_infra_to_cm_rate(
+            infra_to_cm_rate, has_infra_currency = self._get_infra_to_cm_rate(
                 cost_model_currency, month_range.start_date, month_range.end_date
             )
             with OCPReportDBAccessor(self._schema) as accessor:
@@ -873,8 +973,11 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                     infra_to_cm_rate=infra_to_cm_rate,
                     cost_model_currency=cost_model_currency,
                 )
+            distribution_raw_currency = (
+                cost_model_currency if has_infra_currency else None
+            )
             self._aggregate_rates_to_daily_summary(
-                month_range.start_date, month_range.end_date, cost_model_currency
+                month_range.start_date, month_range.end_date, distribution_raw_currency
             )
             self._update_markup_cost(month_range.start_date, month_range.end_date)
             with OCPReportDBAccessor(self._schema) as accessor:
@@ -900,7 +1003,9 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                 return None
             return value / 100
 
-    def update_summary_cost_model_costs(self, summary_range: SummaryRangeConfig) -> None:
+    def update_summary_cost_model_costs(
+        self, summary_range: SummaryRangeConfig
+    ) -> None:
         """Update the OCP summary table with the charge information.
 
         Phase 3 converted all monthly/tag/VM SQL to INSERT into rates_to_usage,
@@ -957,7 +1062,9 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                 log_json(
                     msg="RTU pipeline path selected",
                     rtu_enabled=rtu_enabled,
-                    cost_model_id=str(self._cost_model_id) if self._cost_model_id else None,
+                    cost_model_id=(
+                        str(self._cost_model_id) if self._cost_model_id else None
+                    ),
                     provider_uuid=self._provider_uuid,
                 )
             )

--- a/koku/masu/processor/ocp/ocp_cost_model_cost_updater.py
+++ b/koku/masu/processor/ocp/ocp_cost_model_cost_updater.py
@@ -781,10 +781,11 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
         Distribution runs per-month so report_period_id resolves correctly for
         each month in a multi-month range.
 
-        The per-month body is wrapped in transaction.atomic() so a mid-pipeline
-        failure rolls back all data changes for that month, preventing partial
-        breakdown state.  The idempotent DELETE+INSERT pattern still ensures
-        safe re-runs on the next processing cycle.
+        The per-month pipeline is wrapped in transaction.atomic() so a
+        mid-pipeline failure rolls back all data changes for that month,
+        preventing partial breakdown state.  derived_cost_datetime is updated
+        outside the atomic block so the completion marker persists even if
+        a subsequent month's atomic block fails.
         """
         self._ensure_rates_to_usage_partitions(summary_range.start_date, summary_range.end_date)
         with OCPReportDBAccessor(self._schema) as accessor:
@@ -797,12 +798,12 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                     self._update_markup_cost(month_range.start_date, month_range.end_date)
                     accessor.populate_ui_summary_tables(month_range, self._provider_uuid)
 
-                    with schema_context(self._schema):
-                        if report_period := accessor.report_periods_for_provider_uuid(
-                            self._provider_uuid, month_range.summary_start
-                        ):
-                            report_period.derived_cost_datetime = timezone.now()
-                            report_period.save()
+                with schema_context(self._schema):
+                    if report_period := accessor.report_periods_for_provider_uuid(
+                        self._provider_uuid, month_range.summary_start
+                    ):
+                        report_period.derived_cost_datetime = timezone.now()
+                        report_period.save()
 
     def update_summary_cost_model_costs(self, summary_range: SummaryRangeConfig) -> None:
         """Update the OCP summary table with the charge information.

--- a/koku/masu/processor/ocp/ocp_cost_model_cost_updater.py
+++ b/koku/masu/processor/ocp/ocp_cost_model_cost_updater.py
@@ -74,14 +74,10 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
         ) as cost_model_accessor:
             self._infra_rates = cost_model_accessor.infrastructure_rates
             self._tag_infra_rates = cost_model_accessor.tag_infrastructure_rates
-            self._tag_default_infra_rates = (
-                cost_model_accessor.tag_default_infrastructure_rates
-            )
+            self._tag_default_infra_rates = cost_model_accessor.tag_default_infrastructure_rates
             self._supplementary_rates = cost_model_accessor.supplementary_rates
             self._tag_supplementary_rates = cost_model_accessor.tag_supplementary_rates
-            self._tag_default_supplementary_rates = (
-                cost_model_accessor.tag_default_supplementary_rates
-            )
+            self._tag_default_supplementary_rates = cost_model_accessor.tag_default_supplementary_rates
             self.metric_to_tag_params_map = cost_model_accessor.metric_to_tag_params_map
             self._price_list_effective_on = cost_model_accessor.price_list_effective_on
             self._rate_info_map = cost_model_accessor.rate_info_map
@@ -89,9 +85,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
     def _ensure_rates_to_usage_partitions(self, start_date, end_date):
         """Create monthly partitions for rates_to_usage on demand."""
         with schema_context(self._schema):
-            self._handle_partitions(
-                self._schema, ["rates_to_usage"], start_date, end_date
-            )
+            self._handle_partitions(self._schema, ["rates_to_usage"], start_date, end_date)
 
     def _build_node_tag_cost_case_statements(  # noqa: C901
         self,
@@ -211,9 +205,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
             case_dict[tag_key] = "\n".join(statement_list)
         return case_dict
 
-    def _build_volume_tag_cost_case_statements(
-        self, rate_dict, start_date, default_rate_dict={}
-    ):
+    def _build_volume_tag_cost_case_statements(self, rate_dict, start_date, default_rate_dict={}):
         """Given a tag key, value, and rate return a CASE SQL statement."""
         case_dict = {}
         for tag_key, tag_value_rates in rate_dict.items():
@@ -238,9 +230,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
             )
         return case_dict
 
-    def _node_statements(
-        self, rates, start_date, default_rates, *, node_core, amortized
-    ):
+    def _node_statements(self, rates, start_date, default_rates, *, node_core, amortized):
         cost_case_statements = self._build_node_tag_cost_case_statements(
             rates, start_date, default_rates, node_core=node_core, amortized=amortized
         )
@@ -252,32 +242,20 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
             node_core=node_core,
             amortized=amortized,
         )
-        labels_case_statement = self._build_labels_case_statement(
-            rates, "pod_labels", default_rate=default_rates
-        )
+        labels_case_statement = self._build_labels_case_statement(rates, "pod_labels", default_rate=default_rates)
         return (
             cost_case_statements,
             unallocated_cost_case_statements,
             labels_case_statement,
         )
 
-    def _get_all_monthly_tag_based_case_statements(
-        self, openshift_resource_type, rates, default_rates, start_date
-    ):
+    def _get_all_monthly_tag_based_case_statements(self, openshift_resource_type, rates, default_rates, start_date):
         """Call and organize cost, unallocated, and label case statements."""
         cost_case_statements = {}
         combined_case_statements = {}
         if openshift_resource_type in ["Node", "Node_Core_Month"]:
-            node_core = (
-                metric_constants.OCP_NODE_CORE_MONTH
-                if openshift_resource_type == "Node_Core_Month"
-                else ""
-            )
-            (
-                cost_case_statements,
-                unallocated_cost_case_statements,
-                labels_case_statement,
-            ) = self._node_statements(
+            node_core = metric_constants.OCP_NODE_CORE_MONTH if openshift_resource_type == "Node_Core_Month" else ""
+            (cost_case_statements, unallocated_cost_case_statements, labels_case_statement,) = self._node_statements(
                 rates,
                 start_date,
                 default_rates,
@@ -285,9 +263,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                 amortized=True,
             )
         elif openshift_resource_type == "PVC":
-            cost_case_statements = self._build_volume_tag_cost_case_statements(
-                rates, start_date, default_rates
-            )
+            cost_case_statements = self._build_volume_tag_cost_case_statements(rates, start_date, default_rates)
             # No unallocated cost for volumes
             unallocated_cost_case_statements = {}
             labels_case_statement = self._build_labels_case_statement(
@@ -302,15 +278,9 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
             }
         return combined_case_statements
 
-    def _get_all_node_hour_tag_based_case_statements(
-        self, rates, default_rates, start_date
-    ):
+    def _get_all_node_hour_tag_based_case_statements(self, rates, default_rates, start_date):
         """Call and organize cost, unallocated, and label case statements."""
-        (
-            cost_case_statements,
-            unallocated_cost_case_statements,
-            labels_case_statement,
-        ) = self._node_statements(
+        (cost_case_statements, unallocated_cost_case_statements, labels_case_statement,) = self._node_statements(
             rates,
             start_date,
             default_rates,
@@ -361,11 +331,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                 )
 
                 amortized_rate = get_amortized_monthly_cost_model_rate(rate, start_date)
-                rate_info = (
-                    self._rate_info_map.get((rate_term, rate_type, ""), {})
-                    if rate_type
-                    else {}
-                )
+                rate_info = self._rate_info_map.get((rate_term, rate_type, ""), {}) if rate_type else {}
                 report_accessor.populate_monthly_cost_sql(
                     cost_type,
                     rate_type,
@@ -398,23 +364,12 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                     metric_constants.INFRASTRUCTURE_COST_TYPE,
                     metric_constants.SUPPLEMENTARY_COST_TYPE,
                 ):
-                    if (
-                        cost_model_cost_type
-                        == metric_constants.INFRASTRUCTURE_COST_TYPE
-                    ):
+                    if cost_model_cost_type == metric_constants.INFRASTRUCTURE_COST_TYPE:
                         rates = self._tag_infra_rates.get(monthly_cost_metric, {})
-                        default_rates = self._tag_default_infra_rates.get(
-                            monthly_cost_metric, {}
-                        )
-                    elif (
-                        cost_model_cost_type == metric_constants.SUPPLEMENTARY_COST_TYPE
-                    ):
-                        rates = self._tag_supplementary_rates.get(
-                            monthly_cost_metric, {}
-                        )
-                        default_rates = self._tag_default_supplementary_rates.get(
-                            monthly_cost_metric, {}
-                        )
+                        default_rates = self._tag_default_infra_rates.get(monthly_cost_metric, {})
+                    elif cost_model_cost_type == metric_constants.SUPPLEMENTARY_COST_TYPE:
+                        rates = self._tag_supplementary_rates.get(monthly_cost_metric, {})
+                        default_rates = self._tag_default_supplementary_rates.get(monthly_cost_metric, {})
 
                     if not rates:
                         # The cost model has no rates for this metric
@@ -432,16 +387,12 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                         )
                     )
 
-                    per_tag_key_case_statements = (
-                        self._get_all_monthly_tag_based_case_statements(
-                            openshift_resource_type, rates, default_rates, start_date
-                        )
+                    per_tag_key_case_statements = self._get_all_monthly_tag_based_case_statements(
+                        openshift_resource_type, rates, default_rates, start_date
                     )
 
                     for tag_key, case_statements in per_tag_key_case_statements.items():
-                        rate_info = self._rate_info_map.get(
-                            (monthly_cost_metric, cost_model_cost_type, tag_key), {}
-                        )
+                        rate_info = self._rate_info_map.get((monthly_cost_metric, cost_model_cost_type, tag_key), {})
                         report_accessor.populate_tag_cost_sql(
                             openshift_resource_type,
                             cost_model_cost_type,
@@ -469,9 +420,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                     default_rates = self._tag_default_infra_rates.get(cost_metric, {})
                 elif cost_model_cost_type == metric_constants.SUPPLEMENTARY_COST_TYPE:
                     rates = self._tag_supplementary_rates.get(cost_metric, {})
-                    default_rates = self._tag_default_supplementary_rates.get(
-                        cost_metric, {}
-                    )
+                    default_rates = self._tag_default_supplementary_rates.get(cost_metric, {})
                 if not rates:
                     # The cost model has no rates for this metric
                     continue
@@ -486,10 +435,8 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                         end_date=end_date,
                     )
                 )
-                per_tag_key_case_statements = (
-                    self._get_all_node_hour_tag_based_case_statements(
-                        rates, default_rates, start_date
-                    )
+                per_tag_key_case_statements = self._get_all_node_hour_tag_based_case_statements(
+                    rates, default_rates, start_date
                 )
                 for tag_key, case_statements in per_tag_key_case_statements.items():
                     rate_info = self._rate_info_map.get(
@@ -522,9 +469,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
             metric_constants.SUPPLEMENTARY_COST_TYPE: self._supplementary_rates,
         }
         with OCPReportDBAccessor(self._schema) as report_accessor:
-            report_period = report_accessor.report_periods_for_provider_uuid(
-                self._provider_uuid, start_date
-            )
+            report_period = report_accessor.report_periods_for_provider_uuid(self._provider_uuid, start_date)
             if not report_period:
                 LOG.info(
                     log_json(
@@ -542,9 +487,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
             for report_type, report_type_dict in report_type_map.items():
                 report_accessor.populate_usage_costs(
                     report_type,
-                    filter_dictionary(
-                        report_type_dict, metric_constants.COST_MODEL_USAGE_RATES
-                    ),
+                    filter_dictionary(report_type_dict, metric_constants.COST_MODEL_USAGE_RATES),
                     self._distribution,
                     start_date,
                     end_date,
@@ -565,9 +508,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
             return
 
         with OCPReportDBAccessor(self._schema) as report_accessor:
-            report_period = report_accessor.report_periods_for_provider_uuid(
-                self._provider_uuid, start_date
-            )
+            report_period = report_accessor.report_periods_for_provider_uuid(self._provider_uuid, start_date)
             if not report_period:
                 LOG.info(
                     log_json(
@@ -593,13 +534,9 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                 report_period_id,
                 self._cost_model_id,
             )
-            RTU_POPULATE_DURATION.labels(provider_type=self._provider.type).observe(
-                time.monotonic() - t0
-            )
+            RTU_POPULATE_DURATION.labels(provider_type=self._provider.type).observe(time.monotonic() - t0)
 
-    def _aggregate_rates_to_daily_summary(
-        self, start_date, end_date, cost_model_currency="USD"
-    ):
+    def _aggregate_rates_to_daily_summary(self, start_date, end_date, cost_model_currency="USD"):
         """Aggregate RatesToUsage rows into daily summary cost columns."""
         if not self._cost_model_id:
             LOG.debug(
@@ -610,9 +547,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
             )
             return
         with OCPReportDBAccessor(self._schema) as report_accessor:
-            report_period = report_accessor.report_periods_for_provider_uuid(
-                self._provider_uuid, start_date
-            )
+            report_period = report_accessor.report_periods_for_provider_uuid(self._provider_uuid, start_date)
             if not report_period:
                 LOG.info(
                     log_json(
@@ -634,9 +569,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                 report_period.id,
                 cost_model_currency,
             )
-            RTU_AGGREGATE_DURATION.labels(provider_type=self._provider.type).observe(
-                time.monotonic() - t0
-            )
+            RTU_AGGREGATE_DURATION.labels(provider_type=self._provider.type).observe(time.monotonic() - t0)
 
     def _cleanup_stale_rtu_costs(self, start_date, end_date):
         """Remove stale cost-model rows when the cost model has been deleted.
@@ -645,9 +578,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
         Cleans both rates_to_usage and the daily summary cost-model rows.
         """
         with OCPReportDBAccessor(self._schema) as report_accessor:
-            report_period = report_accessor.report_periods_for_provider_uuid(
-                self._provider_uuid, start_date
-            )
+            report_period = report_accessor.report_periods_for_provider_uuid(self._provider_uuid, start_date)
             if not report_period:
                 return
             report_period_id = report_period.id
@@ -697,18 +628,14 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
             metric_constants.SUPPLEMENTARY_COST_TYPE: self._supplementary_rates,
         }
         with OCPReportDBAccessor(self._schema) as report_accessor:
-            report_period = report_accessor.report_periods_for_provider_uuid(
-                self._provider_uuid, start_date
-            )
+            report_period = report_accessor.report_periods_for_provider_uuid(self._provider_uuid, start_date)
             if not report_period:
                 return
             report_period_id = report_period.id
             for report_type, report_type_dict in report_type_map.items():
                 report_accessor.populate_vm_usage_costs(
                     report_type,
-                    filter_dictionary(
-                        report_type_dict, metric_constants.COST_MODEL_VM_USAGE_RATES
-                    ),
+                    filter_dictionary(report_type_dict, metric_constants.COST_MODEL_VM_USAGE_RATES),
                     start_date,
                     end_date,
                     self._provider_uuid,
@@ -754,9 +681,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                     end_date=end_date,
                 )
             )
-            accessor.populate_markup_cost(
-                markup, start_date, end_date, self._cluster_id
-            )
+            accessor.populate_markup_cost(markup, start_date, end_date, self._cluster_id)
             if self._cost_model_id:
                 t0 = time.monotonic()
                 accessor.populate_markup_rates_to_usage(
@@ -766,9 +691,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                     self._cluster_id,
                     self._cost_model_id,
                 )
-                RTU_MARKUP_DURATION.labels(provider_type=self._provider.type).observe(
-                    time.monotonic() - t0
-                )
+                RTU_MARKUP_DURATION.labels(provider_type=self._provider.type).observe(time.monotonic() - t0)
         LOG.info(
             log_json(
                 msg="finished updating markup costs",
@@ -784,9 +707,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
     def _update_tag_usage_costs(self, start_date, end_date):
         """Update infrastructure and supplementary tag based usage costs."""
         with OCPReportDBAccessor(self._schema) as report_accessor:
-            report_period = report_accessor.report_periods_for_provider_uuid(
-                self._provider_uuid, start_date
-            )
+            report_period = report_accessor.report_periods_for_provider_uuid(self._provider_uuid, start_date)
             report_period_id = report_period.id if report_period else None
             report_accessor.populate_tag_usage_costs(
                 self._tag_infra_rates,
@@ -803,9 +724,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
     def _update_tag_usage_default_costs(self, start_date, end_date):
         """Update infrastructure and supplementary tag based usage costs based on default values."""
         with OCPReportDBAccessor(self._schema) as report_accessor:
-            report_period = report_accessor.report_periods_for_provider_uuid(
-                self._provider_uuid, start_date
-            )
+            report_period = report_accessor.report_periods_for_provider_uuid(self._provider_uuid, start_date)
             report_period_id = report_period.id if report_period else None
             report_accessor.populate_tag_usage_default_costs(
                 self._tag_default_infra_rates,
@@ -824,9 +743,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
         # Delete existing records
         with OCPReportDBAccessor(self._schema) as report_accessor:
             with schema_context(self._schema):
-                report_period = report_accessor.report_periods_for_provider_uuid(
-                    self._provider_uuid, start_date
-                )
+                report_period = report_accessor.report_periods_for_provider_uuid(self._provider_uuid, start_date)
                 if not report_period:
                     LOG.info(
                         log_json(
@@ -950,9 +867,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
         """
         markup_pct = self._get_markup_percentage()
         cost_model_currency = self._cost_model.currency if self._cost_model else "USD"
-        self._ensure_rates_to_usage_partitions(
-            summary_range.start_date, summary_range.end_date
-        )
+        self._ensure_rates_to_usage_partitions(summary_range.start_date, summary_range.end_date)
         for month_range in summary_range.iter_summary_range_by_month():
             if markup_pct:
                 with OCPReportDBAccessor(self._schema) as accessor:
@@ -973,9 +888,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                     infra_to_cm_rate=infra_to_cm_rate,
                     cost_model_currency=cost_model_currency,
                 )
-            distribution_raw_currency = (
-                cost_model_currency if has_infra_currency else None
-            )
+            distribution_raw_currency = cost_model_currency if has_infra_currency else None
             self._aggregate_rates_to_daily_summary(
                 month_range.start_date, month_range.end_date, distribution_raw_currency
             )
@@ -1003,9 +916,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                 return None
             return value / 100
 
-    def update_summary_cost_model_costs(
-        self, summary_range: SummaryRangeConfig
-    ) -> None:
+    def update_summary_cost_model_costs(self, summary_range: SummaryRangeConfig) -> None:
         """Update the OCP summary table with the charge information.
 
         Phase 3 converted all monthly/tag/VM SQL to INSERT into rates_to_usage,
@@ -1062,9 +973,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                 log_json(
                     msg="RTU pipeline path selected",
                     rtu_enabled=rtu_enabled,
-                    cost_model_id=(
-                        str(self._cost_model_id) if self._cost_model_id else None
-                    ),
+                    cost_model_id=(str(self._cost_model_id) if self._cost_model_id else None),
                     provider_uuid=self._provider_uuid,
                 )
             )

--- a/koku/masu/processor/ocp/ocp_cost_model_cost_updater.py
+++ b/koku/masu/processor/ocp/ocp_cost_model_cost_updater.py
@@ -807,9 +807,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                         accessor.populate_ui_summary_tables(month_range, self._provider_uuid)
                     LOG.info(log_json(msg="phase4: atomic block complete", context=month_ctx))
             except Exception:
-                LOG.exception(
-                    log_json(msg="phase4: distribute_costs_and_update_ui_summary FAILED", context=month_ctx)
-                )
+                LOG.exception(log_json(msg="phase4: distribute_costs_and_update_ui_summary FAILED", context=month_ctx))
                 raise
 
             with OCPReportDBAccessor(self._schema) as accessor:

--- a/koku/masu/processor/ocp/ocp_cost_model_cost_updater.py
+++ b/koku/masu/processor/ocp/ocp_cost_model_cost_updater.py
@@ -254,11 +254,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
         combined_case_statements = {}
         if openshift_resource_type in ["Node", "Node_Core_Month"]:
             node_core = metric_constants.OCP_NODE_CORE_MONTH if openshift_resource_type == "Node_Core_Month" else ""
-            (
-                cost_case_statements,
-                unallocated_cost_case_statements,
-                labels_case_statement,
-            ) = self._node_statements(
+            (cost_case_statements, unallocated_cost_case_statements, labels_case_statement,) = self._node_statements(
                 rates,
                 start_date,
                 default_rates,
@@ -283,11 +279,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
 
     def _get_all_node_hour_tag_based_case_statements(self, rates, default_rates, start_date):
         """Call and organize cost, unallocated, and label case statements."""
-        (
-            cost_case_statements,
-            unallocated_cost_case_statements,
-            labels_case_statement,
-        ) = self._node_statements(
+        (cost_case_statements, unallocated_cost_case_statements, labels_case_statement,) = self._node_statements(
             rates,
             start_date,
             default_rates,

--- a/koku/masu/processor/ocp/ocp_cost_model_cost_updater.py
+++ b/koku/masu/processor/ocp/ocp_cost_model_cost_updater.py
@@ -8,7 +8,6 @@ import time
 import uuid
 from decimal import Decimal
 
-from django.db import transaction
 from django.utils import timezone
 from django_tenants.utils import schema_context
 
@@ -781,34 +780,19 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
         Distribution runs per-month so report_period_id resolves correctly for
         each month in a multi-month range.
 
-        The per-month pipeline is wrapped in transaction.atomic() so a
-        mid-pipeline failure rolls back all data changes for that month,
-        preventing partial breakdown state.  derived_cost_datetime is updated
-        outside the atomic block so the completion marker persists even if
-        a subsequent month's atomic block fails.
+        Each step uses its own OCPReportDBAccessor context to avoid nested
+        schema context managers corrupting the PostgreSQL search_path.
         """
-        log_ctx = {"provider_uuid": self._provider_uuid, "schema": self._schema}
         self._ensure_rates_to_usage_partitions(summary_range.start_date, summary_range.end_date)
         for month_range in summary_range.iter_summary_range_by_month():
-            month_ctx = {**log_ctx, "start_date": str(month_range.start_date), "end_date": str(month_range.end_date)}
-            try:
-                with transaction.atomic():
-                    LOG.info(log_json(msg="phase4: starting distribute", context=month_ctx))
-                    with OCPReportDBAccessor(self._schema) as accessor:
-                        month_range = accessor.populate_distributed_cost_sql(
-                            month_range, self._provider_uuid, self._distribution_info
-                        )
-                    LOG.info(log_json(msg="phase4: starting aggregate", context=month_ctx))
-                    self._aggregate_rates_to_daily_summary(month_range.start_date, month_range.end_date)
-                    LOG.info(log_json(msg="phase4: starting markup", context=month_ctx))
-                    self._update_markup_cost(month_range.start_date, month_range.end_date)
-                    LOG.info(log_json(msg="phase4: starting ui_summary", context=month_ctx))
-                    with OCPReportDBAccessor(self._schema) as accessor:
-                        accessor.populate_ui_summary_tables(month_range, self._provider_uuid)
-                    LOG.info(log_json(msg="phase4: atomic block complete", context=month_ctx))
-            except Exception:
-                LOG.exception(log_json(msg="phase4: distribute_costs_and_update_ui_summary FAILED", context=month_ctx))
-                raise
+            with OCPReportDBAccessor(self._schema) as accessor:
+                month_range = accessor.populate_distributed_cost_sql(
+                    month_range, self._provider_uuid, self._distribution_info
+                )
+            self._aggregate_rates_to_daily_summary(month_range.start_date, month_range.end_date)
+            self._update_markup_cost(month_range.start_date, month_range.end_date)
+            with OCPReportDBAccessor(self._schema) as accessor:
+                accessor.populate_ui_summary_tables(month_range, self._provider_uuid)
 
             with OCPReportDBAccessor(self._schema) as accessor:
                 if report_period := accessor.report_periods_for_provider_uuid(

--- a/koku/masu/processor/ocp/ocp_cost_model_cost_updater.py
+++ b/koku/masu/processor/ocp/ocp_cost_model_cost_updater.py
@@ -787,17 +787,30 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
         outside the atomic block so the completion marker persists even if
         a subsequent month's atomic block fails.
         """
+        log_ctx = {"provider_uuid": self._provider_uuid, "schema": self._schema}
         self._ensure_rates_to_usage_partitions(summary_range.start_date, summary_range.end_date)
         for month_range in summary_range.iter_summary_range_by_month():
-            with transaction.atomic():
-                with OCPReportDBAccessor(self._schema) as accessor:
-                    month_range = accessor.populate_distributed_cost_sql(
-                        month_range, self._provider_uuid, self._distribution_info
-                    )
-                self._aggregate_rates_to_daily_summary(month_range.start_date, month_range.end_date)
-                self._update_markup_cost(month_range.start_date, month_range.end_date)
-                with OCPReportDBAccessor(self._schema) as accessor:
-                    accessor.populate_ui_summary_tables(month_range, self._provider_uuid)
+            month_ctx = {**log_ctx, "start_date": str(month_range.start_date), "end_date": str(month_range.end_date)}
+            try:
+                with transaction.atomic():
+                    LOG.info(log_json(msg="phase4: starting distribute", context=month_ctx))
+                    with OCPReportDBAccessor(self._schema) as accessor:
+                        month_range = accessor.populate_distributed_cost_sql(
+                            month_range, self._provider_uuid, self._distribution_info
+                        )
+                    LOG.info(log_json(msg="phase4: starting aggregate", context=month_ctx))
+                    self._aggregate_rates_to_daily_summary(month_range.start_date, month_range.end_date)
+                    LOG.info(log_json(msg="phase4: starting markup", context=month_ctx))
+                    self._update_markup_cost(month_range.start_date, month_range.end_date)
+                    LOG.info(log_json(msg="phase4: starting ui_summary", context=month_ctx))
+                    with OCPReportDBAccessor(self._schema) as accessor:
+                        accessor.populate_ui_summary_tables(month_range, self._provider_uuid)
+                    LOG.info(log_json(msg="phase4: atomic block complete", context=month_ctx))
+            except Exception:
+                LOG.exception(
+                    log_json(msg="phase4: distribute_costs_and_update_ui_summary FAILED", context=month_ctx)
+                )
+                raise
 
             with OCPReportDBAccessor(self._schema) as accessor:
                 if report_period := accessor.report_periods_for_provider_uuid(

--- a/koku/masu/processor/ocp/ocp_cost_model_cost_updater.py
+++ b/koku/masu/processor/ocp/ocp_cost_model_cost_updater.py
@@ -7,6 +7,7 @@ import logging
 import time
 from decimal import Decimal
 
+from django.db import transaction
 from django.utils import timezone
 from django_tenants.utils import schema_context
 
@@ -468,14 +469,14 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
             metric_constants.SUPPLEMENTARY_COST_TYPE: self._supplementary_rates,
         }
         with OCPReportDBAccessor(self._schema) as report_accessor:
-            report_period = report_accessor.report_periods_for_provider_uuid(self._provider.uuid, start_date)
+            report_period = report_accessor.report_periods_for_provider_uuid(self._provider_uuid, start_date)
             if not report_period:
                 LOG.info(
                     log_json(
                         msg="no report period for OCP provider, skipping populate_usage_costs update",
                         context={
                             "schema": self._schema,
-                            "provider_uuid": self._provider.uuid,
+                            "provider_uuid": self._provider_uuid,
                             "start_date": start_date,
                             "end_date": end_date,
                         },
@@ -490,7 +491,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                     self._distribution,
                     start_date,
                     end_date,
-                    self._provider.uuid,
+                    self._provider_uuid,
                     report_period_id,
                 )
         self._update_vm_usage_costs(start_date, end_date)
@@ -507,14 +508,14 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
             return
 
         with OCPReportDBAccessor(self._schema) as report_accessor:
-            report_period = report_accessor.report_periods_for_provider_uuid(self._provider.uuid, start_date)
+            report_period = report_accessor.report_periods_for_provider_uuid(self._provider_uuid, start_date)
             if not report_period:
                 LOG.info(
                     log_json(
                         msg="no report period for OCP provider, skipping rates_to_usage insert",
                         context={
                             "schema": self._schema,
-                            "provider_uuid": self._provider.uuid,
+                            "provider_uuid": self._provider_uuid,
                             "start_date": start_date,
                             "end_date": end_date,
                         },
@@ -529,7 +530,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
             report_accessor.populate_usage_rates_to_usage(
                 start_date,
                 end_date,
-                self._provider.uuid,
+                self._provider_uuid,
                 report_period_id,
                 self._cost_model_id,
             )
@@ -546,14 +547,14 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
             )
             return
         with OCPReportDBAccessor(self._schema) as report_accessor:
-            report_period = report_accessor.report_periods_for_provider_uuid(self._provider.uuid, start_date)
+            report_period = report_accessor.report_periods_for_provider_uuid(self._provider_uuid, start_date)
             if not report_period:
                 LOG.info(
                     log_json(
                         msg="no report period for OCP provider, skipping rates_to_usage aggregation",
                         context={
                             "schema": self._schema,
-                            "provider_uuid": self._provider.uuid,
+                            "provider_uuid": self._provider_uuid,
                             "start_date": start_date,
                             "end_date": end_date,
                         },
@@ -562,7 +563,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                 return
             t0 = time.monotonic()
             report_accessor.aggregate_rates_to_daily_summary(
-                start_date, end_date, self._provider.uuid, report_period.id
+                start_date, end_date, self._provider_uuid, report_period.id
             )
             RTU_AGGREGATE_DURATION.labels(provider_type=self._provider.type).observe(time.monotonic() - t0)
 
@@ -573,7 +574,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
         Cleans both rates_to_usage and the daily summary cost-model rows.
         """
         with OCPReportDBAccessor(self._schema) as report_accessor:
-            report_period = report_accessor.report_periods_for_provider_uuid(self._provider.uuid, start_date)
+            report_period = report_accessor.report_periods_for_provider_uuid(self._provider_uuid, start_date)
             if not report_period:
                 return
             report_period_id = report_period.id
@@ -591,7 +592,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                 metric_constants.SUPPLEMENTARY_COST_TYPE,
             ):
                 report_accessor.delete_line_item_daily_summary_entries_for_date_range_raw(
-                    self._provider.uuid,
+                    self._provider_uuid,
                     start_date,
                     end_date,
                     table=OCPUsageLineItemDailySummary,
@@ -607,7 +608,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                 RatesToUsage.objects.filter(
                     usage_start__gte=start_date,
                     usage_start__lte=end_date,
-                    source_uuid=self._provider.uuid,
+                    source_uuid=self._provider_uuid,
                     report_period_id=report_period_id,
                 ).delete()
 
@@ -623,7 +624,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
             metric_constants.SUPPLEMENTARY_COST_TYPE: self._supplementary_rates,
         }
         with OCPReportDBAccessor(self._schema) as report_accessor:
-            report_period = report_accessor.report_periods_for_provider_uuid(self._provider.uuid, start_date)
+            report_period = report_accessor.report_periods_for_provider_uuid(self._provider_uuid, start_date)
             if not report_period:
                 return
             report_period_id = report_period.id
@@ -633,7 +634,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                     filter_dictionary(report_type_dict, metric_constants.COST_MODEL_VM_USAGE_RATES),
                     start_date,
                     end_date,
-                    self._provider.uuid,
+                    self._provider_uuid,
                     report_period_id,
                     cost_model_id=self._cost_model_id,
                     rate_info_map=self._rate_info_map,
@@ -702,7 +703,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
     def _update_tag_usage_costs(self, start_date, end_date):
         """Update infrastructure and supplementary tag based usage costs."""
         with OCPReportDBAccessor(self._schema) as report_accessor:
-            report_period = report_accessor.report_periods_for_provider_uuid(self._provider.uuid, start_date)
+            report_period = report_accessor.report_periods_for_provider_uuid(self._provider_uuid, start_date)
             report_period_id = report_period.id if report_period else None
             report_accessor.populate_tag_usage_costs(
                 self._tag_infra_rates,
@@ -712,14 +713,14 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                 self._cluster_id,
                 cost_model_id=self._cost_model_id,
                 rate_info_map=self._rate_info_map,
-                source_uuid=self._provider.uuid,
+                source_uuid=self._provider_uuid,
                 report_period_id=report_period_id,
             )
 
     def _update_tag_usage_default_costs(self, start_date, end_date):
         """Update infrastructure and supplementary tag based usage costs based on default values."""
         with OCPReportDBAccessor(self._schema) as report_accessor:
-            report_period = report_accessor.report_periods_for_provider_uuid(self._provider.uuid, start_date)
+            report_period = report_accessor.report_periods_for_provider_uuid(self._provider_uuid, start_date)
             report_period_id = report_period.id if report_period else None
             report_accessor.populate_tag_usage_default_costs(
                 self._tag_default_infra_rates,
@@ -729,7 +730,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                 self._cluster_id,
                 cost_model_id=self._cost_model_id,
                 rate_info_map=self._rate_info_map,
-                source_uuid=self._provider.uuid,
+                source_uuid=self._provider_uuid,
                 report_period_id=report_period_id,
             )
 
@@ -738,12 +739,12 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
         # Delete existing records
         with OCPReportDBAccessor(self._schema) as report_accessor:
             with schema_context(self._schema):
-                report_period = report_accessor.report_periods_for_provider_uuid(self._provider.uuid, start_date)
+                report_period = report_accessor.report_periods_for_provider_uuid(self._provider_uuid, start_date)
                 if not report_period:
                     LOG.info(
                         log_json(
                             msg="no report period for provider",
-                            provider_uuid=self._provider.uuid,
+                            provider_uuid=self._provider_uuid,
                             start_date=start_date,
                             end_date=end_date,
                             schema=self._schema,
@@ -778,25 +779,29 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
         Phase 4 order per month: distribute -> aggregate -> markup -> UI summary.
         Distribution runs per-month so report_period_id resolves correctly for
         each month in a multi-month range.
+
+        The per-month body is wrapped in transaction.atomic() so a mid-pipeline
+        failure rolls back all data changes for that month, preventing partial
+        breakdown state.  The idempotent DELETE+INSERT pattern still ensures
+        safe re-runs on the next processing cycle.
         """
-        # Each step auto-commits independently. Recovery relies on the idempotent
-        # DELETE + INSERT pattern — the same approach used by all other masu pipelines.
         self._ensure_rates_to_usage_partitions(summary_range.start_date, summary_range.end_date)
         with OCPReportDBAccessor(self._schema) as accessor:
             for month_range in summary_range.iter_summary_range_by_month():
-                month_range = accessor.populate_distributed_cost_sql(
-                    month_range, self._provider_uuid, self._distribution_info
-                )
-                self._aggregate_rates_to_daily_summary(month_range.start_date, month_range.end_date)
-                self._update_markup_cost(month_range.start_date, month_range.end_date)
-                accessor.populate_ui_summary_tables(month_range, self._provider_uuid)
+                with transaction.atomic():
+                    month_range = accessor.populate_distributed_cost_sql(
+                        month_range, self._provider_uuid, self._distribution_info
+                    )
+                    self._aggregate_rates_to_daily_summary(month_range.start_date, month_range.end_date)
+                    self._update_markup_cost(month_range.start_date, month_range.end_date)
+                    accessor.populate_ui_summary_tables(month_range, self._provider_uuid)
 
-                with schema_context(self._schema):
-                    if report_period := accessor.report_periods_for_provider_uuid(
-                        self._provider_uuid, month_range.summary_start
-                    ):
-                        report_period.derived_cost_datetime = timezone.now()
-                        report_period.save()
+                    with schema_context(self._schema):
+                        if report_period := accessor.report_periods_for_provider_uuid(
+                            self._provider_uuid, month_range.summary_start
+                        ):
+                            report_period.derived_cost_datetime = timezone.now()
+                            report_period.save()
 
     def update_summary_cost_model_costs(self, summary_range: SummaryRangeConfig) -> None:
         """Update the OCP summary table with the charge information.
@@ -877,7 +882,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
             self._update_monthly_cost(start_date, end_date)
 
             if self._tag_infra_rates != {} or self._tag_supplementary_rates != {}:
-                self._delete_tag_usage_costs(start_date, end_date, self._provider.uuid)
+                self._delete_tag_usage_costs(start_date, end_date, self._provider_uuid)
                 self._update_tag_usage_costs(start_date, end_date)
                 self._update_tag_usage_default_costs(start_date, end_date)
                 self._update_monthly_tag_based_cost(start_date, end_date)
@@ -890,14 +895,14 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                     report_accessor.populate_tag_based_costs(
                         start_date,
                         end_date,
-                        self._provider.uuid,
+                        self._provider_uuid,
                         self.metric_to_tag_params_map,
                         cluster_params,
                         cost_model_id=self._cost_model_id,
                         rate_info_map=self._rate_info_map,
                     )
             if not (self._tag_infra_rates or self._tag_supplementary_rates):
-                self._delete_tag_usage_costs(start_date, end_date, self._provider.uuid)
+                self._delete_tag_usage_costs(start_date, end_date, self._provider_uuid)
 
             self._update_vm_usage_costs(start_date, end_date)
 

--- a/koku/masu/processor/ocp/ocp_cost_model_cost_updater.py
+++ b/koku/masu/processor/ocp/ocp_cost_model_cost_updater.py
@@ -773,12 +773,20 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
             )
 
     def distribute_costs_and_update_ui_summary(self, summary_range: SummaryRangeConfig):
-        """Distribute cost model costs and update UI summary tables"""
+        """Distribute per-rate costs, aggregate, apply markup, and update UI summaries.
+
+        Phase 4 order per month: distribute -> aggregate -> markup -> UI summary.
+        Distribution runs per-month so report_period_id resolves correctly for
+        each month in a multi-month range.
+        """
+        self._ensure_rates_to_usage_partitions(summary_range.start_date, summary_range.end_date)
         with OCPReportDBAccessor(self._schema) as accessor:
-            summary_range = accessor.populate_distributed_cost_sql(
-                summary_range, self._provider_uuid, self._distribution_info
-            )
             for month_range in summary_range.iter_summary_range_by_month():
+                month_range = accessor.populate_distributed_cost_sql(
+                    month_range, self._provider_uuid, self._distribution_info
+                )
+                self._aggregate_rates_to_daily_summary(month_range.start_date, month_range.end_date)
+                self._update_markup_cost(month_range.start_date, month_range.end_date)
                 accessor.populate_ui_summary_tables(month_range, self._provider.uuid)
 
                 if report_period := accessor.report_periods_for_provider_uuid(
@@ -889,7 +897,5 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                 self._delete_tag_usage_costs(start_date, end_date, self._provider.uuid)
 
             self._update_vm_usage_costs(start_date, end_date)
-            self._aggregate_rates_to_daily_summary(start_date, end_date)
-            self._update_markup_cost(start_date, end_date)
 
         self.distribute_costs_and_update_ui_summary(summary_range)

--- a/koku/masu/processor/ocp/ocp_report_db_cleaner.py
+++ b/koku/masu/processor/ocp/ocp_report_db_cleaner.py
@@ -87,6 +87,12 @@ class OCPReportDBCleaner:
             if not simulate:
                 cascade_delete(usage_period_objs.query.model, usage_period_objs)
 
+                # RatesToUsage.report_period_id is an IntegerField (not a FK),
+                # so cascade_delete above does not touch it.
+                from reporting.provider.ocp.models import RatesToUsage
+
+                RatesToUsage.objects.filter(source_uuid=provider_uuid).delete()
+
                 # For on-prem, also delete from self-hosted tables
                 if settings.ONPREM:
                     accessor.delete_self_hosted_data_by_source(provider_uuid)

--- a/koku/masu/test/database/test_ocp_report_db_accessor.py
+++ b/koku/masu/test/database/test_ocp_report_db_accessor.py
@@ -1095,7 +1095,7 @@ class OCPReportDBAccessorTest(MasuTestCase):
                     # Double check the specific GPU SQL file was never requested
                     gpu_call = call(
                         masu_database,
-                        "trino_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_cost.sql",
+                        "trino_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql",
                     )
                     self.assertNotIn(gpu_call, mock_data_get.call_args_list)
 
@@ -1134,7 +1134,7 @@ class OCPReportDBAccessorTest(MasuTestCase):
             )
             gpu_call = call(
                 masu_database,
-                "trino_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_cost.sql",
+                "trino_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql",
             )
             self.assertIn(gpu_call, mock_data_get.call_args_list)
             mock_trino_execute.assert_called()
@@ -1183,7 +1183,7 @@ class OCPReportDBAccessorTest(MasuTestCase):
             # GPU should NOT run — already finalized
             gpu_call = call(
                 masu_database,
-                "trino_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_cost.sql",
+                "trino_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql",
             )
             self.assertNotIn(gpu_call, mock_data_get.call_args_list)
             mock_trino_execute.assert_not_called()
@@ -1235,7 +1235,7 @@ class OCPReportDBAccessorTest(MasuTestCase):
             # GPU SHOULD run — not yet finalized
             gpu_call = call(
                 masu_database,
-                "trino_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_cost.sql",
+                "trino_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql",
             )
             self.assertIn(gpu_call, mock_data_get.call_args_list)
             mock_trino_execute.assert_called()
@@ -1266,7 +1266,7 @@ class OCPReportDBAccessorTest(MasuTestCase):
             # Natural path (is_current_month=False) should ALWAYS run GPU distribution
             gpu_call = call(
                 masu_database,
-                "trino_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_cost.sql",
+                "trino_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql",
             )
             self.assertIn(gpu_call, mock_data_get.call_args_list)
             mock_trino_execute.assert_called()
@@ -1306,7 +1306,7 @@ class OCPReportDBAccessorTest(MasuTestCase):
             )
             gpu_call = call(
                 masu_database,
-                "trino_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_cost.sql",
+                "trino_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql",
             )
             self.assertNotIn(gpu_call, mock_data_get.call_args_list)
 
@@ -1335,7 +1335,7 @@ class OCPReportDBAccessorTest(MasuTestCase):
             )
             gpu_call = call(
                 masu_database,
-                "trino_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_cost.sql",
+                "trino_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql",
             )
             self.assertIn(gpu_call, mock_data_get.call_args_list)
             mock_trino_execute.assert_called()
@@ -1381,7 +1381,7 @@ class OCPReportDBAccessorTest(MasuTestCase):
             # GPU should NOT be called since no report period exists for previous month
             gpu_call = call(
                 masu_database,
-                "trino_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_cost.sql",
+                "trino_sql/openshift/cost_model/distribute_cost/distribute_unallocated_gpu_per_rate.sql",
             )
             self.assertNotIn(gpu_call, mock_data_get.call_args_list)
             mock_trino_execute.assert_not_called()

--- a/koku/masu/test/database/test_ocp_report_db_accessor.py
+++ b/koku/masu/test/database/test_ocp_report_db_accessor.py
@@ -70,14 +70,20 @@ class OCPReportDBAccessorTest(MasuTestCase):
         """Test that periods are returned filtered by provider id and start date."""
         with self.accessor as acc:
             provider_uuid = self.ocp_provider_uuid
-            reporting_period = OCPUsageReportPeriod.objects.filter(provider=self.ocp_provider_uuid).first()
+            reporting_period = OCPUsageReportPeriod.objects.filter(
+                provider=self.ocp_provider_uuid
+            ).first()
             start_date = str(reporting_period.report_period_start)
             period = acc.report_periods_for_provider_uuid(provider_uuid, start_date)
             self.assertEqual(period.provider_id, provider_uuid)
 
     @patch("masu.database.ocp_report_db_accessor.trino_table_exists")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.delete_ocp_hive_partition_by_day")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.delete_ocp_hive_partition_by_day"
+    )
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query"
+    )
     def test_populate_line_item_daily_summary_table_trino(self, mock_execute, *args):
         """
         Test that OCP trino processing calls executescript
@@ -90,12 +96,19 @@ class OCPReportDBAccessorTest(MasuTestCase):
         source = self.provider_uuid
         with self.accessor as acc:
             acc.populate_line_item_daily_summary_table_trino(
-                start_date, end_date, report_period_id, cluster_id, cluster_alias, source
+                start_date,
+                end_date,
+                report_period_id,
+                cluster_id,
+                cluster_alias,
+                source,
             )
             mock_execute.assert_called()
 
     @patch("masu.database.ocp_report_db_accessor.trino_table_exists", return_value=True)
-    def test_populate_line_item_daily_summary_table_trino_exception_warn(self, mock_table_exists):
+    def test_populate_line_item_daily_summary_table_trino_exception_warn(
+        self, mock_table_exists
+    ):
         """
         Test that a warning is logged when a TrinoStatementExecError is raised because
         a partion already exists.
@@ -110,9 +123,13 @@ class OCPReportDBAccessorTest(MasuTestCase):
         message = "One or more Partitions Already exist"
         with (
             patch.object(self.accessor, "delete_ocp_hive_partition_by_day"),
-            patch.object(self.accessor, "_execute_trino_multipart_sql_query") as mock_sql_query,
+            patch.object(
+                self.accessor, "_execute_trino_multipart_sql_query"
+            ) as mock_sql_query,
             self.accessor as acc,
-            self.assertLogs("masu.database.ocp_report_db_accessor", level="WARN") as logger,
+            self.assertLogs(
+                "masu.database.ocp_report_db_accessor", level="WARN"
+            ) as logger,
         ):
             trino_error = TrinoUserError(
                 {
@@ -121,10 +138,17 @@ class OCPReportDBAccessorTest(MasuTestCase):
                     "message": message,
                 }
             )
-            mock_sql_query.side_effect = TrinoStatementExecError("SELECT * from table", 1, {}, trino_error)
+            mock_sql_query.side_effect = TrinoStatementExecError(
+                "SELECT * from table", 1, {}, trino_error
+            )
 
             acc.populate_line_item_daily_summary_table_trino(
-                start_date, end_date, report_period_id, cluster_id, cluster_alias, source
+                start_date,
+                end_date,
+                report_period_id,
+                cluster_id,
+                cluster_alias,
+                source,
             )
 
         self.assertIn(
@@ -133,7 +157,9 @@ class OCPReportDBAccessorTest(MasuTestCase):
         )
 
     @patch("masu.database.ocp_report_db_accessor.trino_table_exists", return_value=True)
-    def test_populate_line_item_daily_summary_table_trino_exception(self, mock_table_exists):
+    def test_populate_line_item_daily_summary_table_trino_exception(
+        self, mock_table_exists
+    ):
         """
         Test that a TrinoStatementExecError is raised for errors that are not partition related.
         """
@@ -146,7 +172,9 @@ class OCPReportDBAccessorTest(MasuTestCase):
         source = self.provider_uuid
         with (
             patch.object(self.accessor, "delete_ocp_hive_partition_by_day"),
-            patch.object(self.accessor, "_execute_trino_multipart_sql_query") as mock_sql_query,
+            patch.object(
+                self.accessor, "_execute_trino_multipart_sql_query"
+            ) as mock_sql_query,
             self.accessor as acc,
             self.assertRaisesRegex(TrinoStatementExecError, "Something went wrong"),
         ):
@@ -157,10 +185,17 @@ class OCPReportDBAccessorTest(MasuTestCase):
                     "message": "Something went wrong",
                 }
             )
-            mock_sql_query.side_effect = TrinoStatementExecError("SELECT * from table", 1, {}, trino_error)
+            mock_sql_query.side_effect = TrinoStatementExecError(
+                "SELECT * from table", 1, {}, trino_error
+            )
 
             acc.populate_line_item_daily_summary_table_trino(
-                start_date, end_date, report_period_id, cluster_id, cluster_alias, source
+                start_date,
+                end_date,
+                report_period_id,
+                cluster_id,
+                cluster_alias,
+                source,
             )
 
     def test_populate_tag_based_usage_costs(self):  # noqa: C901
@@ -176,9 +211,18 @@ class OCPReportDBAccessorTest(MasuTestCase):
             "cpu_core_usage_per_hour": ["cpu", "pod_usage_cpu_core_hours"],
             "cpu_core_request_per_hour": ["cpu", "pod_request_cpu_core_hours"],
             "memory_gb_usage_per_hour": ["memory", "pod_usage_memory_gigabyte_hours"],
-            "memory_gb_request_per_hour": ["memory", "pod_request_memory_gigabyte_hours"],
-            "storage_gb_usage_per_month": ["storage", "persistentvolumeclaim_usage_gigabyte_months"],
-            "storage_gb_request_per_month": ["storage", "volume_request_storage_gigabyte_months"],
+            "memory_gb_request_per_hour": [
+                "memory",
+                "pod_request_memory_gigabyte_hours",
+            ],
+            "storage_gb_usage_per_month": [
+                "storage",
+                "persistentvolumeclaim_usage_gigabyte_months",
+            ],
+            "storage_gb_request_per_month": [
+                "storage",
+                "volume_request_storage_gigabyte_months",
+            ],
         }
         start_date = self.dh.this_month_start
         end_date = self.dh.this_month_end
@@ -215,7 +259,8 @@ class OCPReportDBAccessorTest(MasuTestCase):
                     # get the three querysets to be evaluated based on the pod_labels
                     banking_qset = (
                         OCPUsageLineItemDailySummary.objects.filter(
-                            cluster_id=self.cluster_id, pod_labels__contains={"app": "banking"}
+                            cluster_id=self.cluster_id,
+                            pod_labels__contains={"app": "banking"},
                         )
                         .values("usage_start")
                         .annotate(
@@ -225,7 +270,8 @@ class OCPReportDBAccessorTest(MasuTestCase):
                     )
                     mobile_qset = (
                         OCPUsageLineItemDailySummary.objects.filter(
-                            cluster_id=self.cluster_id, pod_labels__contains={"app": "mobile"}
+                            cluster_id=self.cluster_id,
+                            pod_labels__contains={"app": "mobile"},
                         )
                         .values("usage_start")
                         .annotate(
@@ -235,7 +281,8 @@ class OCPReportDBAccessorTest(MasuTestCase):
                     )
                     weather_qset = (
                         OCPUsageLineItemDailySummary.objects.filter(
-                            cluster_id=self.cluster_id, pod_labels__contains={"app": "weather"}
+                            cluster_id=self.cluster_id,
+                            pod_labels__contains={"app": "weather"},
                         )
                         .values("usage_start")
                         .annotate(
@@ -263,7 +310,11 @@ class OCPReportDBAccessorTest(MasuTestCase):
                     RatesToUsage.objects.filter(cluster_id=self.cluster_id).delete()
 
                     acc.populate_tag_usage_costs(
-                        infrastructure_rates, supplementary_rates, start_date, end_date, self.cluster_id
+                        infrastructure_rates,
+                        supplementary_rates,
+                        start_date,
+                        end_date,
+                        self.cluster_id,
                     )
 
                     for value, rate in rate_costs.get(cost).get("app").items():
@@ -277,7 +328,10 @@ class OCPReportDBAccessorTest(MasuTestCase):
                             .values("usage_start")
                             .annotate(cost=Sum("calculated_cost"))
                         )
-                        rtu_costs = {entry["usage_start"]: float(entry["cost"]) for entry in rtu_qset}
+                        rtu_costs = {
+                            entry["usage_start"]: float(entry["cost"])
+                            for entry in rtu_qset
+                        }
 
                         for day, vals in initial_results_dict.get(value).items():
                             with self.subTest(
@@ -297,9 +351,18 @@ class OCPReportDBAccessorTest(MasuTestCase):
             "cpu_core_usage_per_hour": ["cpu", "pod_usage_cpu_core_hours"],
             "cpu_core_request_per_hour": ["cpu", "pod_request_cpu_core_hours"],
             "memory_gb_usage_per_hour": ["memory", "pod_usage_memory_gigabyte_hours"],
-            "memory_gb_request_per_hour": ["memory", "pod_request_memory_gigabyte_hours"],
-            "storage_gb_usage_per_month": ["storage", "persistentvolumeclaim_usage_gigabyte_months"],
-            "storage_gb_request_per_month": ["storage", "volume_request_storage_gigabyte_months"],
+            "memory_gb_request_per_hour": [
+                "memory",
+                "pod_request_memory_gigabyte_hours",
+            ],
+            "storage_gb_usage_per_month": [
+                "storage",
+                "persistentvolumeclaim_usage_gigabyte_months",
+            ],
+            "storage_gb_request_per_month": [
+                "storage",
+                "volume_request_storage_gigabyte_months",
+            ],
         }
         start_date = self.dh.this_month_start
         end_date = self.dh.this_month_end
@@ -327,7 +390,10 @@ class OCPReportDBAccessorTest(MasuTestCase):
                     """
 
                     rate_costs[cost] = {
-                        "app": {"default_value": random.randrange(1, 100), "defined_keys": ["mobile", "banking"]}
+                        "app": {
+                            "default_value": random.randrange(1, 100),
+                            "defined_keys": ["mobile", "banking"],
+                        }
                     }
                     # define the arguments for the function based on what usage type needs to be tested
                     if usage_type == "Infrastructure":
@@ -339,7 +405,8 @@ class OCPReportDBAccessorTest(MasuTestCase):
                     # get the three querysets to be evaluated based on the pod_labels
                     banking_qset = (
                         OCPUsageLineItemDailySummary.objects.filter(
-                            cluster_id=self.cluster_id, pod_labels__contains={"app": "banking"}
+                            cluster_id=self.cluster_id,
+                            pod_labels__contains={"app": "banking"},
                         )
                         .values("usage_start")
                         .annotate(
@@ -349,7 +416,8 @@ class OCPReportDBAccessorTest(MasuTestCase):
                     )
                     mobile_qset = (
                         OCPUsageLineItemDailySummary.objects.filter(
-                            cluster_id=self.cluster_id, pod_labels__contains={"app": "mobile"}
+                            cluster_id=self.cluster_id,
+                            pod_labels__contains={"app": "mobile"},
                         )
                         .values("usage_start")
                         .annotate(
@@ -359,7 +427,8 @@ class OCPReportDBAccessorTest(MasuTestCase):
                     )
                     weather_qset = (
                         OCPUsageLineItemDailySummary.objects.filter(
-                            cluster_id=self.cluster_id, pod_labels__contains={"app": "weather"}
+                            cluster_id=self.cluster_id,
+                            pod_labels__contains={"app": "weather"},
                         )
                         .values("usage_start")
                         .annotate(
@@ -370,7 +439,11 @@ class OCPReportDBAccessorTest(MasuTestCase):
 
                     # populate a results dictionary for each item in the querysets using the cost before the update
                     initial_results_dict = defaultdict(dict)
-                    mapper = {"banking": banking_qset, "mobile": mobile_qset, "weather": weather_qset}
+                    mapper = {
+                        "banking": banking_qset,
+                        "mobile": mobile_qset,
+                        "weather": weather_qset,
+                    }
                     for word, qset in mapper.items():
                         for entry in qset:
                             # For each label, by date store the usage, cost
@@ -382,7 +455,11 @@ class OCPReportDBAccessorTest(MasuTestCase):
                     RatesToUsage.objects.filter(cluster_id=self.cluster_id).delete()
 
                     acc.populate_tag_usage_default_costs(
-                        infrastructure_rates, supplementary_rates, start_date, end_date, self.cluster_id
+                        infrastructure_rates,
+                        supplementary_rates,
+                        start_date,
+                        end_date,
+                        self.cluster_id,
                     )
 
                     tag_values = ["banking", "mobile", "weather"]
@@ -397,7 +474,10 @@ class OCPReportDBAccessorTest(MasuTestCase):
                             .values("usage_start")
                             .annotate(cost=Sum("calculated_cost"))
                         )
-                        rtu_costs = {entry["usage_start"]: float(entry["cost"]) for entry in rtu_qset}
+                        rtu_costs = {
+                            entry["usage_start"]: float(entry["cost"])
+                            for entry in rtu_qset
+                        }
 
                         for day, vals in initial_results_dict.get(value).items():
                             with self.subTest(
@@ -407,7 +487,11 @@ class OCPReportDBAccessorTest(MasuTestCase):
                                     expected_cost = 0
                                 else:
                                     if day >= start_date.date():
-                                        rate = rate_costs.get(cost).get("app").get("default_value")
+                                        rate = (
+                                            rate_costs.get(cost)
+                                            .get("app")
+                                            .get("default_value")
+                                        )
                                         expected_cost = float(vals[0] * rate)
                                     else:
                                         expected_cost = 0
@@ -415,16 +499,22 @@ class OCPReportDBAccessorTest(MasuTestCase):
                                 self.assertAlmostEqual(actual_cost, expected_cost)
 
     def test_table_properties(self):
-        self.assertEqual(self.accessor.line_item_daily_summary_table, OCPUsageLineItemDailySummary)
+        self.assertEqual(
+            self.accessor.line_item_daily_summary_table, OCPUsageLineItemDailySummary
+        )
 
     def test_table_map(self):
         self.assertEqual(self.accessor._table_map, OCP_REPORT_TABLE_MAP)
 
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query"
+    )
     def test_get_ocp_infrastructure_map_trino(self, mock_trino):
         """Test that Trino is used to find matched tags."""
         subtests = ["aws", "gcp", "azure"]
-        mock_trino.side_effect = [True, True, [["test", "test", "test"]]] * len(subtests)
+        mock_trino.side_effect = [True, True, [["test", "test", "test"]]] * len(
+            subtests
+        )
         for p_type_var_substring in subtests:
             with self.subTest(p_type_var_substring=p_type_var_substring):
                 kwargs = {
@@ -436,7 +526,9 @@ class OCPReportDBAccessorTest(MasuTestCase):
                 result = accessor.get_ocp_infrastructure_map_trino(**kwargs)
                 self.assertEqual(result, {"test": ("test", "test")})
 
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query"
+    )
     def test_get_ocp_infrastructure_map_trino_table_does_not_exist(self, table_exists):
         """Test trino returns empty dict if table does not exit"""
         subtests = ["aws", "gcp", "azure"]
@@ -453,8 +545,12 @@ class OCPReportDBAccessorTest(MasuTestCase):
                 self.assertEqual(result, {})
 
     @patch("masu.database.ocp_report_db_accessor.trino_table_exists")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.get_projects_trino")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.get_projects_trino"
+    )
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query"
+    )
     @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.get_nodes_trino")
     def test_populate_openshift_cluster_information_tables(
         self, mock_get_nodes, mock_get_pvcs, mock_get_projects, mock_table
@@ -480,15 +576,21 @@ class OCPReportDBAccessorTest(MasuTestCase):
         end_date = self.dh.this_month_end.date()
 
         with self.accessor as acc:
-            cluster = acc.populate_cluster_table(self.aws_provider, cluster_id, cluster_alias)
+            cluster = acc.populate_cluster_table(
+                self.aws_provider, cluster_id, cluster_alias
+            )
             OCPPVC.objects.get_or_create(
-                persistent_volume_claim=pvcs[0], persistent_volume=volumes[0], cluster=cluster
+                persistent_volume_claim=pvcs[0],
+                persistent_volume=volumes[0],
+                cluster=cluster,
             )
             acc.populate_openshift_cluster_information_tables(
                 self.aws_provider, cluster_id, cluster_alias, start_date, end_date
             )
 
-            self.assertIsNotNone(OCPCluster.objects.filter(cluster_id=cluster_id).first())
+            self.assertIsNotNone(
+                OCPCluster.objects.filter(cluster_id=cluster_id).first()
+            )
             for node in nodes:
                 db_node = OCPNode.objects.filter(node=node).first()
                 self.assertIsNotNone(db_node)
@@ -498,7 +600,9 @@ class OCPReportDBAccessorTest(MasuTestCase):
                 self.assertIsNotNone(db_node.cluster_id)
                 self.assertIsNotNone(db_node.node_role)
             for pvc in pvcs:
-                self.assertIsNotNone(OCPPVC.objects.filter(persistent_volume_claim=pvc).first())
+                self.assertIsNotNone(
+                    OCPPVC.objects.filter(persistent_volume_claim=pvc).first()
+                )
             for project in projects:
                 self.assertIsNotNone(OCPProject.objects.filter(project=project).first())
 
@@ -512,7 +616,9 @@ class OCPReportDBAccessorTest(MasuTestCase):
             mock_get_pvcs.assert_not_called()
 
     @patch("masu.database.ocp_report_db_accessor.trino_table_exists")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.get_projects_trino")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.get_projects_trino"
+    )
     @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.get_pvcs_trino")
     @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.get_nodes_trino")
     def test_get_openshift_topology_for_multiple_providers(
@@ -549,7 +655,9 @@ class OCPReportDBAccessorTest(MasuTestCase):
             nodes = OCPNode.objects.filter(cluster=cluster).all()
             pvcs = OCPPVC.objects.filter(cluster=cluster).all()
             projects = OCPProject.objects.filter(cluster=cluster).all()
-            topology = acc.get_openshift_topology_for_multiple_providers([self.aws_provider_uuid])
+            topology = acc.get_openshift_topology_for_multiple_providers(
+                [self.aws_provider_uuid]
+            )
             self.assertEqual(len(topology), 1)
             topo = topology[0]
             self.assertEqual(topo.get("cluster_id"), cluster_id)
@@ -557,7 +665,9 @@ class OCPReportDBAccessorTest(MasuTestCase):
             for node in nodes:
                 self.assertIn(node.node, topo.get("nodes"))
             for pvc in pvcs:
-                self.assertIn(pvc.persistent_volume_claim, topo.get("persistent_volume_claims"))
+                self.assertIn(
+                    pvc.persistent_volume_claim, topo.get("persistent_volume_claims")
+                )
                 self.assertIn(pvc.persistent_volume, topo.get("persistent_volumes"))
                 self.assertIn(pvc.csi_volume_handle, topo.get("csi_volume_handle"))
             for project in projects:
@@ -566,7 +676,9 @@ class OCPReportDBAccessorTest(MasuTestCase):
     @patch("masu.database.ocp_report_db_accessor.trino_table_exists")
     @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.get_pvcs_trino")
     @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.get_nodes_trino")
-    def test_get_filtered_openshift_topology_for_multiple_providers(self, mock_get_nodes, mock_get_pvcs, mock_table):
+    def test_get_filtered_openshift_topology_for_multiple_providers(
+        self, mock_get_nodes, mock_get_pvcs, mock_table
+    ):
         """Test that OpenShift topology is populated."""
         nodes = ["test_node_1", "test_node_2"]
         resource_ids = ["id_1", "id_2"]
@@ -585,7 +697,9 @@ class OCPReportDBAccessorTest(MasuTestCase):
 
         with self.accessor as acc:
             cluster = OCPCluster(
-                cluster_id=cluster_id, cluster_alias=cluster_alias, provider_id=self.gcp_provider_uuid
+                cluster_id=cluster_id,
+                cluster_alias=cluster_alias,
+                provider_id=self.gcp_provider_uuid,
             )
             cluster.save()
             topology = acc.get_filtered_openshift_topology_for_multiple_providers(
@@ -606,14 +720,22 @@ class OCPReportDBAccessorTest(MasuTestCase):
         cluster_id = str(uuid.uuid4())
         cluster_alias = "node_role_test"
         with self.accessor as acc:
-            cluster = acc.populate_cluster_table(self.aws_provider, cluster_id, cluster_alias)
+            cluster = acc.populate_cluster_table(
+                self.aws_provider, cluster_id, cluster_alias
+            )
             node = OCPNode.objects.create(
-                node=node_info[0], resource_id=node_info[1], node_capacity_cpu_cores=node_info[2], cluster=cluster
+                node=node_info[0],
+                resource_id=node_info[1],
+                node_capacity_cpu_cores=node_info[2],
+                cluster=cluster,
             )
             self.assertIsNone(node.node_role)
             acc.populate_node_table(cluster, [node_info])
             node = OCPNode.objects.get(
-                node=node_info[0], resource_id=node_info[1], node_capacity_cpu_cores=node_info[2], cluster=cluster
+                node=node_info[0],
+                resource_id=node_info[1],
+                node_capacity_cpu_cores=node_info[2],
+                cluster=cluster,
             )
             self.assertEqual(node.node_role, node_info[3])
 
@@ -623,7 +745,9 @@ class OCPReportDBAccessorTest(MasuTestCase):
         cluster_id = str(uuid.uuid4())
         cluster_alias = "node_role_test"
         with self.accessor as acc:
-            cluster = acc.populate_cluster_table(self.aws_provider, cluster_id, cluster_alias)
+            cluster = acc.populate_cluster_table(
+                self.aws_provider, cluster_id, cluster_alias
+            )
             node = OCPNode.objects.create(
                 node=node_info[0],
                 resource_id=node_info[1],
@@ -635,7 +759,10 @@ class OCPReportDBAccessorTest(MasuTestCase):
             self.assertIsNone(node.architecture)
             acc.populate_node_table(cluster, [node_info])
             node = OCPNode.objects.get(
-                node=node_info[0], resource_id=node_info[1], node_capacity_cpu_cores=node_info[2], cluster=cluster
+                node=node_info[0],
+                resource_id=node_info[1],
+                node_capacity_cpu_cores=node_info[2],
+                cluster=cluster,
             )
             self.assertEqual(node.architecture, node_info[4])
 
@@ -660,7 +787,9 @@ class OCPReportDBAccessorTest(MasuTestCase):
             acc.populate_cluster_table(self.aws_provider, cluster_id, "cluster_alias")
             # Forcefully create a second entry
             OCPCluster.objects.get_or_create(
-                cluster_id=cluster_id, cluster_alias=self.aws_provider.name, provider_id=self.aws_provider_uuid
+                cluster_id=cluster_id,
+                cluster_alias=self.aws_provider.name,
+                provider_id=self.aws_provider_uuid,
             )
             acc.populate_cluster_table(self.aws_provider, cluster_id, new_cluster_alias)
             clusters = OCPCluster.objects.filter(cluster_id=cluster_id)
@@ -674,19 +803,30 @@ class OCPReportDBAccessorTest(MasuTestCase):
         cluster_id = str(uuid.uuid4())
         cluster_alias = "node_role_test"
         with self.accessor as acc:
-            cluster = acc.populate_cluster_table(self.aws_provider, cluster_id, cluster_alias)
+            cluster = acc.populate_cluster_table(
+                self.aws_provider, cluster_id, cluster_alias
+            )
             acc.populate_node_table(cluster, [node_info])
             node_count = OCPNode.objects.filter(
-                node=node_info[0], resource_id=node_info[1], node_capacity_cpu_cores=node_info[2], cluster=cluster
+                node=node_info[0],
+                resource_id=node_info[1],
+                node_capacity_cpu_cores=node_info[2],
+                cluster=cluster,
             ).count()
             self.assertEqual(node_count, 1)
             acc.populate_node_table(cluster, [node_info])
             node_count = OCPNode.objects.filter(
-                node=node_info[0], resource_id=node_info[1], node_capacity_cpu_cores=node_info[2], cluster=cluster
+                node=node_info[0],
+                resource_id=node_info[1],
+                node_capacity_cpu_cores=node_info[2],
+                cluster=cluster,
             ).count()
             self.assertEqual(node_count, 1)
 
-    @patch("reporting.provider.ocp.models.OCPPVC.objects.create", side_effect=IntegrityError)
+    @patch(
+        "reporting.provider.ocp.models.OCPPVC.objects.create",
+        side_effect=IntegrityError,
+    )
     @patch("masu.database.ocp_report_db_accessor.LOG.warning")
     def test_populate_pvc_table_handles_integrity_error(self, mock_log, mock_create):
         """Test that populating OCPPVC table handles IntegrityError exception."""
@@ -696,12 +836,17 @@ class OCPReportDBAccessorTest(MasuTestCase):
         cluster_alias = "test-cluster-1"
 
         with self.accessor as accessor:
-            cluster = accessor.populate_cluster_table(self.ocp_provider, cluster_id, cluster_alias)
+            cluster = accessor.populate_cluster_table(
+                self.ocp_provider, cluster_id, cluster_alias
+            )
             accessor.populate_pvc_table(cluster, pvcs)
 
             mock_create.assert_called()
             self.assertTrue(
-                any("IntegrityError raised when creating pvc" in str(call) for call in mock_log.call_args_list)
+                any(
+                    "IntegrityError raised when creating pvc" in str(call)
+                    for call in mock_log.call_args_list
+                )
             )
 
     def test_delete_infrastructure_raw_cost_from_daily_summary(self):
@@ -709,75 +854,127 @@ class OCPReportDBAccessorTest(MasuTestCase):
         with self.accessor as acc:
             start_date = self.dh.this_month_start.date()
             end_date = self.dh.this_month_end.date()
-            report_period = acc.report_periods_for_provider_uuid(self.ocpaws_provider_uuid, start_date)
+            report_period = acc.report_periods_for_provider_uuid(
+                self.ocpaws_provider_uuid, start_date
+            )
             report_period_id = report_period.id
             count = OCPUsageLineItemDailySummary.objects.filter(
-                report_period_id=report_period_id, usage_start__gte=start_date, infrastructure_raw_cost__gt=0
+                report_period_id=report_period_id,
+                usage_start__gte=start_date,
+                infrastructure_raw_cost__gt=0,
             ).count()
             self.assertNotEqual(count, 0)
             acc.delete_infrastructure_raw_cost_from_daily_summary(
                 self.ocpaws_provider_uuid, report_period_id, start_date, end_date
             )
             count = OCPUsageLineItemDailySummary.objects.filter(
-                report_period_id=report_period_id, usage_start__gte=start_date, infrastructure_raw_cost__gt=0
+                report_period_id=report_period_id,
+                usage_start__gte=start_date,
+                infrastructure_raw_cost__gt=0,
             ).count()
             self.assertEqual(count, 0)
 
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.schema_exists_trino")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.table_exists_trino")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.schema_exists_trino"
+    )
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.table_exists_trino"
+    )
     @patch("masu.database.report_db_accessor_base.trino_db.connect")
     @patch("time.sleep", return_value=None)
-    def test_delete_ocp_hive_partition_by_day(self, mock_sleep, mock_connect, mock_table_exists, mock_schema_exists):
+    def test_delete_ocp_hive_partition_by_day(
+        self, mock_sleep, mock_connect, mock_table_exists, mock_schema_exists
+    ):
         """Test that deletions work with retries."""
         mock_schema_exists.return_value = False
-        self.accessor.delete_ocp_hive_partition_by_day([1], self.ocp_provider_uuid, self.ocp_provider_uuid, "2022")
+        self.accessor.delete_ocp_hive_partition_by_day(
+            [1], self.ocp_provider_uuid, self.ocp_provider_uuid, "2022"
+        )
         mock_connect.assert_not_called()
 
         mock_connect.reset_mock()
 
         mock_schema_exists.return_value = True
-        attrs = {"cursor.side_effect": TrinoExternalError({"errorName": "HIVE_METASTORE_ERROR"})}
+        attrs = {
+            "cursor.side_effect": TrinoExternalError(
+                {"errorName": "HIVE_METASTORE_ERROR"}
+            )
+        }
         mock_connect.return_value = Mock(**attrs)
 
         with self.assertRaises(TrinoHiveMetastoreError):
-            self.accessor.delete_ocp_hive_partition_by_day([1], self.aws_provider_uuid, self.ocp_provider_uuid, "2022")
+            self.accessor.delete_ocp_hive_partition_by_day(
+                [1], self.aws_provider_uuid, self.ocp_provider_uuid, "2022"
+            )
 
         mock_connect.assert_called()
-        self.assertEqual(mock_connect.call_count, settings.HIVE_PARTITION_DELETE_RETRIES)
+        self.assertEqual(
+            mock_connect.call_count, settings.HIVE_PARTITION_DELETE_RETRIES
+        )
 
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.table_exists_trino")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query")
-    def test_delete_hive_partitions_by_source_success(self, mock_trino, mock_table_exist):
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.table_exists_trino"
+    )
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query"
+    )
+    def test_delete_hive_partitions_by_source_success(
+        self, mock_trino, mock_table_exist
+    ):
         """Test that deletions work with retries."""
-        result = self.accessor.delete_hive_partitions_by_source("table", "partition_column", self.ocp_provider_uuid)
+        result = self.accessor.delete_hive_partitions_by_source(
+            "table", "partition_column", self.ocp_provider_uuid
+        )
         mock_trino.assert_called()
         self.assertTrue(result)
 
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.table_exists_trino")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.table_exists_trino"
+    )
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query"
+    )
     def test_find_expired_trino_partitions_success(self, mock_trino, mock_table_exist):
         """Test that deletions work with retries."""
-        result = self.accessor.find_expired_trino_partitions("table", "source_column", "2024-06-01")
+        result = self.accessor.find_expired_trino_partitions(
+            "table", "source_column", "2024-06-01"
+        )
         mock_trino.assert_called()
         self.assertTrue(result)
 
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.schema_exists_trino")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.schema_exists_trino"
+    )
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query"
+    )
     def test_find_expired_trino_partitions_no_schema(self, mock_trino, mock_schema):
         """Test that deletions work with retries."""
         mock_schema.return_value = False
-        result = self.accessor.find_expired_trino_partitions("table", "source_column", "2024-06-01")
+        result = self.accessor.find_expired_trino_partitions(
+            "table", "source_column", "2024-06-01"
+        )
         mock_trino.assert_not_called()
         self.assertFalse(result)
 
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.schema_exists_trino")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.table_exists_trino")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query")
-    def test_find_expired_trino_partitions_no_table(self, mock_trino, mock_table_exist, mock_schema):
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.schema_exists_trino"
+    )
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.table_exists_trino"
+    )
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query"
+    )
+    def test_find_expired_trino_partitions_no_table(
+        self, mock_trino, mock_table_exist, mock_schema
+    ):
         """Test that deletions work with retries."""
         mock_schema.return_value = True
         mock_table_exist.return_value = False
-        result = self.accessor.find_expired_trino_partitions("table", "source_column", "2024-06-01")
+        result = self.accessor.find_expired_trino_partitions(
+            "table", "source_column", "2024-06-01"
+        )
         mock_trino.assert_not_called()
         self.assertFalse(result)
 
@@ -803,9 +1000,13 @@ class OCPReportDBAccessorTest(MasuTestCase):
                 result = acc.delete_self_hosted_data_by_source(self.ocp_provider_uuid)
 
                 # Verify staging table filtered by source_uuid
-                mock_staging_model.objects.filter.assert_called_with(source_uuid=str(self.ocp_provider_uuid))
+                mock_staging_model.objects.filter.assert_called_with(
+                    source_uuid=str(self.ocp_provider_uuid)
+                )
                 # Verify line item table filtered by source
-                mock_line_item_model.objects.filter.assert_called_with(source=str(self.ocp_provider_uuid))
+                mock_line_item_model.objects.filter.assert_called_with(
+                    source=str(self.ocp_provider_uuid)
+                )
                 self.assertEqual(result, 15)  # 5 + 10
 
     @patch("reporting.provider.ocp.self_hosted_models.get_self_hosted_models")
@@ -821,8 +1022,12 @@ class OCPReportDBAccessorTest(MasuTestCase):
             result = acc.delete_self_hosted_data_by_source(uuid.uuid4())
             self.assertEqual(result, 0)
 
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.schema_exists_trino")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.table_exists_trino")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.schema_exists_trino"
+    )
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.table_exists_trino"
+    )
     @patch("masu.database.report_db_accessor_base.trino_db.connect")
     @patch("time.sleep", return_value=None)
     def test_delete_hive_partitions_by_source_failure(
@@ -830,22 +1035,34 @@ class OCPReportDBAccessorTest(MasuTestCase):
     ):
         """Test that deletions work with retries."""
         mock_schema_exists.return_value = False
-        self.accessor.delete_hive_partitions_by_source("table", "partition_column", self.ocp_provider_uuid)
+        self.accessor.delete_hive_partitions_by_source(
+            "table", "partition_column", self.ocp_provider_uuid
+        )
         mock_connect.assert_not_called()
         mock_connect.reset_mock()
 
         mock_schema_exists.return_value = True
 
-        attrs = {"cursor.side_effect": TrinoExternalError({"errorName": "HIVE_METASTORE_ERROR"})}
+        attrs = {
+            "cursor.side_effect": TrinoExternalError(
+                {"errorName": "HIVE_METASTORE_ERROR"}
+            )
+        }
         mock_connect.return_value = Mock(**attrs)
 
         with self.assertRaises(TrinoHiveMetastoreError):
-            self.accessor.delete_hive_partitions_by_source("table", "partition_column", self.ocp_provider_uuid)
+            self.accessor.delete_hive_partitions_by_source(
+                "table", "partition_column", self.ocp_provider_uuid
+            )
 
         mock_connect.assert_called()
-        self.assertEqual(mock_connect.call_count, settings.HIVE_PARTITION_DELETE_RETRIES)
+        self.assertEqual(
+            mock_connect.call_count, settings.HIVE_PARTITION_DELETE_RETRIES
+        )
 
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query"
+    )
     def test_get_max_min_timestamp_from_parquet(self, mock_query):
         """Get the max and min timestamps for parquet data given a date range"""
         start_date, end_date = datetime(2022, 3, 1), datetime(2022, 3, 30)
@@ -855,19 +1072,31 @@ class OCPReportDBAccessorTest(MasuTestCase):
                 "return": ["2022-04-01", "2022-04-30"],
                 "expected": (datetime(2022, 4, 1), datetime(2022, 4, 30)),
             },
-            {"name": "none-dates", "return": [None, None], "expected": (start_date, end_date)},
+            {
+                "name": "none-dates",
+                "return": [None, None],
+                "expected": (start_date, end_date),
+            },
             {
                 "name": "none-start-date",
                 "return": [None, "2022-04-30"],
                 "expected": (start_date, datetime(2022, 4, 30)),
             },
-            {"name": "none-end-date", "return": ["2022-04-01", None], "expected": (datetime(2022, 4, 1), end_date)},
+            {
+                "name": "none-end-date",
+                "return": ["2022-04-01", None],
+                "expected": (datetime(2022, 4, 1), end_date),
+            },
         ]
 
         for test in table:
             with self.subTest(test=test["name"]):
-                mock_query.return_value = [test["return"]]  # returned value is a list of a list
-                result = self.accessor.get_max_min_timestamp_from_parquet(uuid.uuid4(), start_date, end_date)
+                mock_query.return_value = [
+                    test["return"]
+                ]  # returned value is a list of a list
+                result = self.accessor.get_max_min_timestamp_from_parquet(
+                    uuid.uuid4(), start_date, end_date
+                )
                 self.assertEqual(result, test["expected"])
                 self.assertTrue(hasattr(result[0], "date"))
                 self.assertTrue(hasattr(result[1], "date"))
@@ -880,12 +1109,15 @@ class OCPReportDBAccessorTest(MasuTestCase):
 
             # First test an OCP on Cloud source to make sure we don't delete that data
             provider_uuid = self.ocp_on_aws_ocp_provider.uuid
-            report_period = acc.report_periods_for_provider_uuid(provider_uuid, start_date)
+            report_period = acc.report_periods_for_provider_uuid(
+                provider_uuid, start_date
+            )
 
             report_period_id = report_period.id
             initial_non_raw_count = (
                 OCPUsageLineItemDailySummary.objects.filter(
-                    Q(infrastructure_raw_cost__isnull=True) | Q(infrastructure_raw_cost=0),
+                    Q(infrastructure_raw_cost__isnull=True)
+                    | Q(infrastructure_raw_cost=0),
                     report_period_id=report_period_id,
                 )
                 .exclude(cost_model_rate_type="platform_distributed")
@@ -894,7 +1126,8 @@ class OCPReportDBAccessorTest(MasuTestCase):
             )
             # the distributed cost is being added so the initial count is no longer zero.
             initial_raw_count = OCPUsageLineItemDailySummary.objects.filter(
-                Q(infrastructure_raw_cost__isnull=False) & ~Q(infrastructure_raw_cost=0),
+                Q(infrastructure_raw_cost__isnull=False)
+                & ~Q(infrastructure_raw_cost=0),
                 report_period_id=report_period_id,
             ).count()
 
@@ -904,14 +1137,16 @@ class OCPReportDBAccessorTest(MasuTestCase):
 
             new_non_raw_count = (
                 OCPUsageLineItemDailySummary.objects.filter(
-                    Q(infrastructure_raw_cost__isnull=True) | Q(infrastructure_raw_cost=0),
+                    Q(infrastructure_raw_cost__isnull=True)
+                    | Q(infrastructure_raw_cost=0),
                     report_period_id=report_period_id,
                 )
                 .exclude(data_source="GPU")
                 .count()
             )
             new_raw_count = OCPUsageLineItemDailySummary.objects.filter(
-                Q(infrastructure_raw_cost__isnull=False) & ~Q(infrastructure_raw_cost=0),
+                Q(infrastructure_raw_cost__isnull=False)
+                & ~Q(infrastructure_raw_cost=0),
                 report_period_id=report_period_id,
             ).count()
 
@@ -921,19 +1156,23 @@ class OCPReportDBAccessorTest(MasuTestCase):
 
             # Now test an on prem OCP cluster to make sure we still remove non raw costs
             provider_uuid = self.ocp_provider.uuid
-            report_period = acc.report_periods_for_provider_uuid(provider_uuid, start_date)
+            report_period = acc.report_periods_for_provider_uuid(
+                provider_uuid, start_date
+            )
 
             report_period_id = report_period.id
             initial_non_raw_count = (
                 OCPUsageLineItemDailySummary.objects.filter(
-                    Q(infrastructure_raw_cost__isnull=True) | Q(infrastructure_raw_cost=0),
+                    Q(infrastructure_raw_cost__isnull=True)
+                    | Q(infrastructure_raw_cost=0),
                     report_period_id=report_period_id,
                 )
                 .exclude(data_source="GPU")
                 .count()
             )
             initial_raw_count = OCPUsageLineItemDailySummary.objects.filter(
-                Q(infrastructure_raw_cost__isnull=False) & ~Q(infrastructure_raw_cost=0),
+                Q(infrastructure_raw_cost__isnull=False)
+                & ~Q(infrastructure_raw_cost=0),
                 report_period_id=report_period_id,
             ).count()
 
@@ -943,14 +1182,16 @@ class OCPReportDBAccessorTest(MasuTestCase):
 
             new_non_raw_count = (
                 OCPUsageLineItemDailySummary.objects.filter(
-                    Q(infrastructure_raw_cost__isnull=True) | Q(infrastructure_raw_cost=0),
+                    Q(infrastructure_raw_cost__isnull=True)
+                    | Q(infrastructure_raw_cost=0),
                     report_period_id=report_period_id,
                 )
                 .exclude(data_source="GPU")
                 .count()
             )
             new_raw_count = OCPUsageLineItemDailySummary.objects.filter(
-                Q(infrastructure_raw_cost__isnull=False) & ~Q(infrastructure_raw_cost=0),
+                Q(infrastructure_raw_cost__isnull=False)
+                & ~Q(infrastructure_raw_cost=0),
                 report_period_id=report_period_id,
             ).count()
 
@@ -962,20 +1203,38 @@ class OCPReportDBAccessorTest(MasuTestCase):
         """Test that updating monthly costs without a matching report period no longer throws an error"""
         start_date = "2000-01-01"
         end_date = "2000-02-01"
-        with self.assertLogs("masu.database.ocp_report_db_accessor", level="INFO") as logger:
+        with self.assertLogs(
+            "masu.database.ocp_report_db_accessor", level="INFO"
+        ) as logger:
             with self.accessor as acc:
-                acc.populate_monthly_cost_sql("Cluster", "", "", start_date, end_date, "", self.provider_uuid)
+                acc.populate_monthly_cost_sql(
+                    "Cluster", "", "", start_date, end_date, "", self.provider_uuid
+                )
                 self.assertIn("no report period for OCP provider", logger.output[0])
 
     def test_populate_monthly_cost_sql_invalid_cost_type(self):
         """Test that updating monthly costs without a matching report period no longer throws an error"""
-        with self.assertLogs("masu.database.ocp_report_db_accessor", level="INFO") as logger:
+        with self.assertLogs(
+            "masu.database.ocp_report_db_accessor", level="INFO"
+        ) as logger:
             with self.accessor as acc:
-                acc.populate_monthly_cost_sql("Fake", "", "", self.start_date, self.start_date, "", self.provider_uuid)
-                self.assertIn("Skipping populate_monthly_cost_sql update", logger.output[0])
+                acc.populate_monthly_cost_sql(
+                    "Fake",
+                    "",
+                    "",
+                    self.start_date,
+                    self.start_date,
+                    "",
+                    self.provider_uuid,
+                )
+                self.assertIn(
+                    "Skipping populate_monthly_cost_sql update", logger.output[0]
+                )
 
     @patch("masu.database.ocp_report_db_accessor.trino_table_exists", return_value=True)
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query"
+    )
     def test_populate_usage_costs_vm_rate(self, mock_trino, mock_trino_exists):
         """Test the populate vm hourly usage costs"""
         with self.accessor as acc:
@@ -993,9 +1252,13 @@ class OCPReportDBAccessorTest(MasuTestCase):
         """Test that updating monthly costs without a matching report period no longer throws an error"""
         start_date = "2000-01-01"
         end_date = "2000-02-01"
-        with self.assertLogs("masu.database.ocp_report_db_accessor", level="INFO") as logger:
+        with self.assertLogs(
+            "masu.database.ocp_report_db_accessor", level="INFO"
+        ) as logger:
             with self.accessor as acc:
-                acc.populate_tag_cost_sql("", "", "", "", start_date, end_date, "", self.provider_uuid)
+                acc.populate_tag_cost_sql(
+                    "", "", "", "", start_date, end_date, "", self.provider_uuid
+                )
                 self.assertIn("no report period for OCP provider", logger.output[0])
 
     def test_populate_distributed_cost_sql_no_report_period(self):
@@ -1005,7 +1268,9 @@ class OCPReportDBAccessorTest(MasuTestCase):
         summary_range = SummaryRangeConfig(start_date=start_date, end_date=end_date)
         with self.accessor as acc:
             # Should not raise an exception when no report period exists
-            acc.populate_distributed_cost_sql(summary_range, self.provider_uuid, {"platform_cost": True})
+            acc.populate_distributed_cost_sql(
+                summary_range, self.provider_uuid, {"platform_cost": True}
+            )
 
     def _setup_distributed_cost_sql_mocks(self, start_date, end_date):
         """Helper to set up common mocks for distributed cost SQL tests."""
@@ -1024,7 +1289,10 @@ class OCPReportDBAccessorTest(MasuTestCase):
             "source_uuid": self.ocp_test_provider_uuid,
             "populate": True,
         }
-        delete_monthly = [get_pkgutil_values("delete_monthly_cost_model_rate_type.sql"), default_sql_params]
+        delete_monthly = [
+            get_pkgutil_values("delete_monthly_cost_model_rate_type.sql"),
+            default_sql_params,
+        ]
         delete_rtu = [
             get_pkgutil_values("distribute_cost/delete_distributed_rates_to_usage.sql"),
             default_sql_params,
@@ -1032,16 +1300,36 @@ class OCPReportDBAccessorTest(MasuTestCase):
         side_effect = [
             delete_monthly,
             delete_rtu,
-            [get_pkgutil_values("distribute_cost/distribute_platform_cost_per_rate.sql"), default_sql_params],
+            [
+                get_pkgutil_values(
+                    "distribute_cost/distribute_platform_cost_per_rate.sql"
+                ),
+                default_sql_params,
+            ],
             delete_monthly,
             delete_rtu,
-            [get_pkgutil_values("distribute_cost/distribute_worker_cost_per_rate.sql"), default_sql_params],
+            [
+                get_pkgutil_values(
+                    "distribute_cost/distribute_worker_cost_per_rate.sql"
+                ),
+                default_sql_params,
+            ],
             delete_monthly,
             delete_rtu,
-            [get_pkgutil_values("distribute_cost/distribute_unattributed_storage_per_rate.sql"), default_sql_params],
+            [
+                get_pkgutil_values(
+                    "distribute_cost/distribute_unattributed_storage_per_rate.sql"
+                ),
+                default_sql_params,
+            ],
             delete_monthly,
             delete_rtu,
-            [get_pkgutil_values("distribute_cost/distribute_unattributed_network_per_rate.sql"), default_sql_params],
+            [
+                get_pkgutil_values(
+                    "distribute_cost/distribute_unattributed_network_per_rate.sql"
+                ),
+                default_sql_params,
+            ],
             delete_monthly,
             delete_rtu,
         ]
@@ -1051,8 +1339,12 @@ class OCPReportDBAccessorTest(MasuTestCase):
 
     @patch("masu.util.ocp.common.trino_table_exists", return_value=True)
     @patch("masu.database.ocp_report_db_accessor.pkgutil.get_data")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_raw_sql_query")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_raw_sql_query"
+    )
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query"
+    )
     def test_populate_distributed_cost_sql_called(
         self, mock_trino_execute, mock_sql_execute, mock_data_get, mock_table_exists
     ):
@@ -1064,13 +1356,17 @@ class OCPReportDBAccessorTest(MasuTestCase):
 
         for day in days_to_test:
             with self.subTest(day=day):
-                masu_database, mock_jinja = self._setup_distributed_cost_sql_mocks(start_date, end_date)
+                masu_database, mock_jinja = self._setup_distributed_cost_sql_mocks(
+                    start_date, end_date
+                )
                 mock_data_get.reset_mock()
                 mock_sql_execute.reset_mock()
                 mock_trino_execute.reset_mock()
                 with (
                     self.accessor as acc,
-                    patch("masu.database.ocp_report_db_accessor.DateHelper") as mock_dh_class,
+                    patch(
+                        "masu.database.ocp_report_db_accessor.DateHelper"
+                    ) as mock_dh_class,
                 ):
                     mock_dh = Mock()
                     mock_dh.parse_to_date.return_value = start_date
@@ -1078,12 +1374,18 @@ class OCPReportDBAccessorTest(MasuTestCase):
                     mock_dh_class.return_value = mock_dh
 
                     acc.prepare_query = mock_jinja
-                    summary_range = SummaryRangeConfig(start_date=start_date, end_date=end_date)
+                    summary_range = SummaryRangeConfig(
+                        start_date=start_date, end_date=end_date
+                    )
 
                     acc.populate_distributed_cost_sql(
                         summary_range,
                         self.ocp_test_provider_uuid,
-                        {"worker_cost": True, "platform_cost": True, "gpu_unallocated": True},
+                        {
+                            "worker_cost": True,
+                            "platform_cost": True,
+                            "gpu_unallocated": True,
+                        },
                     )
 
                     # Validate that standard SQL distributions (Platform/Worker) still run
@@ -1100,19 +1402,31 @@ class OCPReportDBAccessorTest(MasuTestCase):
                     self.assertNotIn(gpu_call, mock_data_get.call_args_list)
 
     @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._reporting_period_has_gpu_data", return_value=True
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._reporting_period_has_gpu_data",
+        return_value=True,
     )
     @patch("masu.util.ocp.common.trino_table_exists", return_value=True)
     @patch("masu.database.ocp_report_db_accessor.pkgutil.get_data")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_raw_sql_query")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_raw_sql_query"
+    )
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query"
+    )
     def test_populate_distributed_cost_sql_gpu_runs_prev_month_on_second_of_month(
-        self, mock_trino_execute, mock_sql_execute, mock_data_get, mock_table_exists, mock_has_gpu_data
+        self,
+        mock_trino_execute,
+        mock_sql_execute,
+        mock_data_get,
+        mock_table_exists,
+        mock_has_gpu_data,
     ):
         """Test that GPU distribution runs for previous month only on the second of the month."""
         start_date = self.dh.this_month_start.date()
         end_date = self.dh.this_month_end.date()
-        masu_database, mock_jinja = self._setup_distributed_cost_sql_mocks(start_date, end_date)
+        masu_database, mock_jinja = self._setup_distributed_cost_sql_mocks(
+            start_date, end_date
+        )
 
         with (
             self.accessor as acc,
@@ -1140,12 +1454,17 @@ class OCPReportDBAccessorTest(MasuTestCase):
             mock_trino_execute.assert_called()
 
     @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._reporting_period_has_gpu_data", return_value=True
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._reporting_period_has_gpu_data",
+        return_value=True,
     )
     @patch("masu.util.ocp.common.trino_table_exists", return_value=True)
     @patch("masu.database.ocp_report_db_accessor.pkgutil.get_data")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_raw_sql_query")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_raw_sql_query"
+    )
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query"
+    )
     def test_gpu_distribution_skipped_when_already_finalized(
         self,
         mock_trino_execute,
@@ -1157,12 +1476,16 @@ class OCPReportDBAccessorTest(MasuTestCase):
         """Test that GPU distribution is skipped on day 2 when data already exists."""
         start_date = self.dh.this_month_start.date()
         end_date = self.dh.this_month_end.date()
-        masu_database, mock_jinja = self._setup_distributed_cost_sql_mocks(start_date, end_date)
+        masu_database, mock_jinja = self._setup_distributed_cost_sql_mocks(
+            start_date, end_date
+        )
 
         with (
             self.accessor as acc,
             patch("masu.database.ocp_report_db_accessor.DateHelper") as mock_dh_class,
-            patch("masu.database.ocp_report_db_accessor.OCPUsageLineItemDailySummary.objects") as mock_qs,
+            patch(
+                "masu.database.ocp_report_db_accessor.OCPUsageLineItemDailySummary.objects"
+            ) as mock_qs,
         ):
             mock_qs.filter.return_value.exists.return_value = True
             mock_dh = Mock()
@@ -1192,12 +1515,17 @@ class OCPReportDBAccessorTest(MasuTestCase):
             mock_sql_execute.assert_called()
 
     @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._reporting_period_has_gpu_data", return_value=True
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._reporting_period_has_gpu_data",
+        return_value=True,
     )
     @patch("masu.util.ocp.common.trino_table_exists", return_value=True)
     @patch("masu.database.ocp_report_db_accessor.pkgutil.get_data")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_raw_sql_query")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_raw_sql_query"
+    )
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query"
+    )
     def test_gpu_distribution_runs_when_not_yet_finalized(
         self,
         mock_trino_execute,
@@ -1209,12 +1537,16 @@ class OCPReportDBAccessorTest(MasuTestCase):
         """Test that GPU distribution runs on day 2 when no existing data is found."""
         start_date = self.dh.this_month_start.date()
         end_date = self.dh.this_month_end.date()
-        masu_database, mock_jinja = self._setup_distributed_cost_sql_mocks(start_date, end_date)
+        masu_database, mock_jinja = self._setup_distributed_cost_sql_mocks(
+            start_date, end_date
+        )
 
         with (
             self.accessor as acc,
             patch("masu.database.ocp_report_db_accessor.DateHelper") as mock_dh_class,
-            patch("masu.database.ocp_report_db_accessor.OCPUsageLineItemDailySummary.objects") as mock_qs,
+            patch(
+                "masu.database.ocp_report_db_accessor.OCPUsageLineItemDailySummary.objects"
+            ) as mock_qs,
         ):
             mock_qs.filter.return_value.exists.return_value = False
             mock_dh = Mock()
@@ -1241,19 +1573,31 @@ class OCPReportDBAccessorTest(MasuTestCase):
             mock_trino_execute.assert_called()
 
     @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._reporting_period_has_gpu_data", return_value=True
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._reporting_period_has_gpu_data",
+        return_value=True,
     )
     @patch("masu.util.ocp.common.trino_table_exists", return_value=True)
     @patch("masu.database.ocp_report_db_accessor.pkgutil.get_data")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_raw_sql_query")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_raw_sql_query"
+    )
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query"
+    )
     def test_natural_finalization_not_affected_by_guard(
-        self, mock_trino_execute, mock_sql_execute, mock_data_get, mock_table_exists, mock_has_gpu_data
+        self,
+        mock_trino_execute,
+        mock_sql_execute,
+        mock_data_get,
+        mock_table_exists,
+        mock_has_gpu_data,
     ):
         """Test that natural finalization (previous month data) bypasses the guard entirely."""
         start_date = self.dh.last_month_start.date()
         end_date = self.dh.last_month_end.date()
-        masu_database, mock_jinja = self._setup_distributed_cost_sql_mocks(start_date, end_date)
+        masu_database, mock_jinja = self._setup_distributed_cost_sql_mocks(
+            start_date, end_date
+        )
 
         with self.accessor as acc:
             acc.prepare_query = mock_jinja
@@ -1272,19 +1616,31 @@ class OCPReportDBAccessorTest(MasuTestCase):
             mock_trino_execute.assert_called()
 
     @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._reporting_period_has_gpu_data", return_value=False
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._reporting_period_has_gpu_data",
+        return_value=False,
     )
     @patch("masu.util.ocp.common.trino_table_exists", return_value=True)
     @patch("masu.database.ocp_report_db_accessor.pkgutil.get_data")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_raw_sql_query")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_raw_sql_query"
+    )
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query"
+    )
     def test_populate_distributed_cost_sql_skips_gpu_full_month_when_no_gpu_data(
-        self, mock_trino_execute, mock_sql_execute, mock_data_get, mock_table_exists, mock_has_gpu_data
+        self,
+        mock_trino_execute,
+        mock_sql_execute,
+        mock_data_get,
+        mock_table_exists,
+        mock_has_gpu_data,
     ):
         """Test that GPU distribution is skipped when cluster has no GPU data (day 2)."""
         start_date = self.dh.this_month_start.date()
         end_date = self.dh.this_month_end.date()
-        masu_database, mock_jinja = self._setup_distributed_cost_sql_mocks(start_date, end_date)
+        masu_database, mock_jinja = self._setup_distributed_cost_sql_mocks(
+            start_date, end_date
+        )
 
         with (
             self.accessor as acc,
@@ -1311,19 +1667,31 @@ class OCPReportDBAccessorTest(MasuTestCase):
             self.assertNotIn(gpu_call, mock_data_get.call_args_list)
 
     @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._reporting_period_has_gpu_data", return_value=True
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._reporting_period_has_gpu_data",
+        return_value=True,
     )
     @patch("masu.util.ocp.common.trino_table_exists", return_value=True)
     @patch("masu.database.ocp_report_db_accessor.pkgutil.get_data")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_raw_sql_query")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_raw_sql_query"
+    )
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query"
+    )
     def test_populate_distributed_cost_sql_gpu_runs_for_previous_month(
-        self, mock_trino_execute, mock_sql_execute, mock_data_get, mock_table_exists, mock_has_gpu_data
+        self,
+        mock_trino_execute,
+        mock_sql_execute,
+        mock_data_get,
+        mock_table_exists,
+        mock_has_gpu_data,
     ):
         """Test that GPU distribution runs when directly processing a previous month."""
         start_date = self.dh.last_month_start.date()
         end_date = self.dh.last_month_end.date()
-        masu_database, mock_jinja = self._setup_distributed_cost_sql_mocks(start_date, end_date)
+        masu_database, mock_jinja = self._setup_distributed_cost_sql_mocks(
+            start_date, end_date
+        )
 
         with self.accessor as acc:
             acc.prepare_query = mock_jinja
@@ -1342,16 +1710,29 @@ class OCPReportDBAccessorTest(MasuTestCase):
 
     @patch("masu.util.ocp.common.trino_table_exists", return_value=True)
     @patch("masu.database.ocp_report_db_accessor.pkgutil.get_data")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_raw_sql_query")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.report_periods_for_provider_uuid")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_raw_sql_query"
+    )
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query"
+    )
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.report_periods_for_provider_uuid"
+    )
     def test_populate_distributed_cost_sql_gpu_skipped_no_prev_report_period(
-        self, mock_report_periods, mock_trino_execute, mock_sql_execute, mock_data_get, mock_table_exists
+        self,
+        mock_report_periods,
+        mock_trino_execute,
+        mock_sql_execute,
+        mock_data_get,
+        mock_table_exists,
     ):
         """Test that GPU distribution is skipped when no report period exists for previous month."""
         start_date = self.dh.this_month_start.date()
         end_date = self.dh.this_month_end.date()
-        masu_database, mock_jinja = self._setup_distributed_cost_sql_mocks(start_date, end_date)
+        masu_database, mock_jinja = self._setup_distributed_cost_sql_mocks(
+            start_date, end_date
+        )
 
         # Return current month report period, but None for previous month
         current_report_period = Mock()
@@ -1392,7 +1773,9 @@ class OCPReportDBAccessorTest(MasuTestCase):
         """
         populated_keys = []
         with schema_context(self.schema):
-            enabled_tags = EnabledTagKeys.objects.filter(provider_type=Provider.PROVIDER_OCP, enabled=True)
+            enabled_tags = EnabledTagKeys.objects.filter(
+                provider_type=Provider.PROVIDER_OCP, enabled=True
+            )
             for enabled_tag in enabled_tags:
                 tag_count = OCPUsageLineItemDailySummary.objects.filter(
                     all_labels__has_key=enabled_tag.key,
@@ -1412,8 +1795,12 @@ class OCPReportDBAccessorTest(MasuTestCase):
                 usage_start__lte=self.dh.today,
             ).count()
             TagMapping.objects.create(parent=parent_obj, child=child_obj)
-            self.accessor.update_line_item_daily_summary_with_tag_mapping(self.dh.this_month_start, self.dh.today)
-            expected_parent_count = (parent_count + child_count) - value_precedence_count
+            self.accessor.update_line_item_daily_summary_with_tag_mapping(
+                self.dh.this_month_start, self.dh.today
+            )
+            expected_parent_count = (
+                parent_count + child_count
+            ) - value_precedence_count
             actual_parent_count = OCPUsageLineItemDailySummary.objects.filter(
                 all_labels__has_key=parent_key,
                 usage_start__gte=self.dh.this_month_start,
@@ -1431,7 +1818,8 @@ class OCPReportDBAccessorTest(MasuTestCase):
             tested = False
             distinct_values = (
                 OCPUsageLineItemDailySummary.objects.filter(
-                    usage_start__gte=self.dh.this_month_start, usage_start__lte=self.dh.today
+                    usage_start__gte=self.dh.this_month_start,
+                    usage_start__lte=self.dh.today,
                 )
                 .values_list(f"volume_labels__{parent_key}", flat=True)
                 .distinct()
@@ -1454,16 +1842,26 @@ class OCPReportDBAccessorTest(MasuTestCase):
         Test that if a valid report period is not found.
         """
         with self.accessor as acc:
-            result = acc.populate_tag_based_costs("1970-10-01", "1970-10-31", self.ocp_provider_uuid, {}, {})
+            result = acc.populate_tag_based_costs(
+                "1970-10-01", "1970-10-31", self.ocp_provider_uuid, {}, {}
+            )
             self.assertFalse(result)
 
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
-    @patch("masu.database.ocp_report_db_accessor.trino_table_exists", return_value=False)
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
+    )
+    @patch(
+        "masu.database.ocp_report_db_accessor.trino_table_exists", return_value=False
+    )
     def test_monthly_populate_vm_tag_based_costs(self, mock_trino_exists, mock_psql):
         """Test monthly populated of vm count tag based costs."""
         test_mapping = {
             metric_constants.OCP_VM_MONTH: [
-                {"rate_type": "Supplementary", "tag_key": "group", "value_rates": {"Engineering": 0.05}}
+                {
+                    "rate_type": "Supplementary",
+                    "tag_key": "group",
+                    "value_rates": {"Engineering": 0.05},
+                }
             ]
         }
         with self.accessor as acc:
@@ -1476,23 +1874,37 @@ class OCPReportDBAccessorTest(MasuTestCase):
             )
             mock_psql.assert_called()
 
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query")
-    @patch("masu.database.ocp_report_db_accessor.trino_table_exists", return_value=False)
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query"
+    )
+    @patch(
+        "masu.database.ocp_report_db_accessor.trino_table_exists", return_value=False
+    )
     def test_hourly_populate_vm_tag_based_costs(self, mock_trino_exists, mock_trino):
         """Test hourly populated of vm count tag based costs."""
         cluster_params = {"cluster_id": "test", "cluster_alias": "test"}
         test_mapping = {
             metric_constants.OCP_VM_HOUR: [
-                {"rate_type": "Supplementary", "tag_key": "group", "value_rates": {"Engineering": 0.05}}
+                {
+                    "rate_type": "Supplementary",
+                    "tag_key": "group",
+                    "value_rates": {"Engineering": 0.05},
+                }
             ]
         }
         with self.accessor as acc:
             acc.populate_tag_based_costs(
-                self.start_date, self.dh.this_month_end, self.ocp_provider_uuid, test_mapping, cluster_params
+                self.start_date,
+                self.dh.this_month_end,
+                self.ocp_provider_uuid,
+                test_mapping,
+                cluster_params,
             )
             mock_trino.assert_called()
 
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
+    )
     def test_no_tag_rates(self, mock_psql):
         """Test monthly populated of vm count tag based costs."""
         with self.accessor as acc:
@@ -1505,16 +1917,24 @@ class OCPReportDBAccessorTest(MasuTestCase):
             )
             mock_psql.assert_not_called()
 
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._populate_virtualization_ui_summary_table")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._populate_gpu_ui_summary_table_with_usage_only")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._populate_virtualization_ui_summary_table"
+    )
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._populate_gpu_ui_summary_table_with_usage_only"
+    )
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
+    )
     def test_populate_ui_summary_tables_skips_virtualization_for_previous_month(
         self, mock_psql, mock_gpu_populate, mock_virt_populate
     ):
         """Test that virtualization UI table is not populated when summarizing previous month (not current month)."""
         start_date = self.dh.last_month_start.date()
         end_date = self.dh.last_month_end.date()
-        summary_range = SummaryRangeConfig(start_date=start_date, end_date=end_date, summarize_previous_month=True)
+        summary_range = SummaryRangeConfig(
+            start_date=start_date, end_date=end_date, summarize_previous_month=True
+        )
         source_uuid = self.ocp_provider_uuid
         with self.accessor as acc:
             acc.populate_ui_summary_tables(summary_range, source_uuid, tables=[])
@@ -1522,48 +1942,89 @@ class OCPReportDBAccessorTest(MasuTestCase):
         mock_gpu_populate.assert_called_once()
         mock_virt_populate.assert_not_called()
 
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.schema_exists_trino", return_value=False)
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
-    def test__populate_virtualization_ui_summary_table_no_trino_schema(self, mock_psql, mock_schema_exists):
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.schema_exists_trino",
+        return_value=False,
+    )
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
+    )
+    def test__populate_virtualization_ui_summary_table_no_trino_schema(
+        self, mock_psql, mock_schema_exists
+    ):
         """Test that sql is not run when the trino schema does not exist."""
         with self.accessor as acc:
             acc._populate_virtualization_ui_summary_table({})
             mock_psql.assert_not_called()
 
-    @patch("masu.database.ocp_report_db_accessor.trino_table_exists", return_value=[True, False])
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.schema_exists_trino", return_value=True)
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
-    def test__populate_virtualization_ui_summary_table_no_trino_table(self, mock_psql, *args):
+    @patch(
+        "masu.database.ocp_report_db_accessor.trino_table_exists",
+        return_value=[True, False],
+    )
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.schema_exists_trino",
+        return_value=True,
+    )
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
+    )
+    def test__populate_virtualization_ui_summary_table_no_trino_table(
+        self, mock_psql, *args
+    ):
         """Test that sql is not run when the trino table does not exist."""
         with self.accessor as acc:
             acc._populate_virtualization_ui_summary_table({})
             mock_psql.assert_not_called()
 
-    @patch("masu.database.ocp_report_db_accessor.trino_table_exists", return_value=[True, True])
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.schema_exists_trino", return_value=True)
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
-    def test__populate_virtualization_ui_summary_table_no_sql_param(self, mock_psql, *args):
+    @patch(
+        "masu.database.ocp_report_db_accessor.trino_table_exists",
+        return_value=[True, True],
+    )
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.schema_exists_trino",
+        return_value=True,
+    )
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
+    )
+    def test__populate_virtualization_ui_summary_table_no_sql_param(
+        self, mock_psql, *args
+    ):
         """Test that sql is not run when sql params are not provided."""
         with self.accessor as acc:
             acc._populate_virtualization_ui_summary_table({})
             mock_psql.assert_not_called()
 
-    @patch("masu.database.ocp_report_db_accessor.trino_table_exists", return_value=[True, True])
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.schema_exists_trino", return_value=True)
+    @patch(
+        "masu.database.ocp_report_db_accessor.trino_table_exists",
+        return_value=[True, True],
+    )
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.schema_exists_trino",
+        return_value=True,
+    )
     @patch(
         "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query",
         side_effect=Exception,
     )
-    def test__populate_virtualization_ui_summary_table_all_true_raise_error(self, mock_psql, *args):
+    def test__populate_virtualization_ui_summary_table_all_true_raise_error(
+        self, mock_psql, *args
+    ):
         """Test that sql is run when all requirements are met. Test uses an exception to show that sql would be run."""
         with self.accessor as acc:
             with self.assertRaises(Exception):
-                acc._populate_virtualization_ui_summary_table({"start_date": "1970-01-01"})
+                acc._populate_virtualization_ui_summary_table(
+                    {"start_date": "1970-01-01"}
+                )
             mock_psql.assert_called()
 
     @patch("masu.database.ocp_report_db_accessor.trino_table_exists", return_value=True)
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query")
-    def test_monthly_populate_gpu_tag_based_costs(self, mock_trino_exec, mock_trino_exists):
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query"
+    )
+    def test_monthly_populate_gpu_tag_based_costs(
+        self, mock_trino_exec, mock_trino_exists
+    ):
         """Test monthly population of GPU tag based costs."""
         # Tag key is the GPU vendor, value_rates contains model-specific rates
         test_mapping = {
@@ -1586,10 +2047,17 @@ class OCPReportDBAccessorTest(MasuTestCase):
             )
             mock_trino_exec.assert_called()
 
-    @patch("masu.database.ocp_report_db_accessor.is_feature_flag_enabled_by_schema", return_value=False)
+    @patch(
+        "masu.database.ocp_report_db_accessor.is_feature_flag_enabled_by_schema",
+        return_value=False,
+    )
     @patch("masu.database.ocp_report_db_accessor.trino_table_exists", return_value=True)
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query")
-    def test_gpu_cost_model_disabled_by_unleash(self, mock_trino_exec, mock_trino_exists, mock_feature_flag):
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query"
+    )
+    def test_gpu_cost_model_disabled_by_unleash(
+        self, mock_trino_exec, mock_trino_exists, mock_feature_flag
+    ):
         """Test that GPU cost model is skipped when Unleash flag is disabled."""
         # Tag key is the GPU vendor, value_rates contains model-specific rates
         test_mapping = {
@@ -1614,8 +2082,12 @@ class OCPReportDBAccessorTest(MasuTestCase):
             mock_trino_exec.assert_not_called()
 
     @patch("masu.database.ocp_report_db_accessor.trino_table_exists", return_value=True)
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query")
-    def test_gpu_tag_based_costs_skipped_when_no_cluster_id(self, mock_trino_exec, mock_trino_exists):
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query"
+    )
+    def test_gpu_tag_based_costs_skipped_when_no_cluster_id(
+        self, mock_trino_exec, mock_trino_exists
+    ):
         """Test that GPU tag based costs are skipped when cluster_id is None."""
         test_mapping = {
             metric_constants.OCP_GPU_MONTH: [
@@ -1650,7 +2122,9 @@ class OCPReportDBAccessorTest(MasuTestCase):
         """
         from jinjasql import JinjaSql
 
-        sql_template = pkgutil.get_data("masu.database", "trino_sql/openshift/cost_model/monthly_cost_gpu.sql")
+        sql_template = pkgutil.get_data(
+            "masu.database", "trino_sql/openshift/cost_model/monthly_cost_gpu.sql"
+        )
         sql_template = sql_template.decode("utf-8")
 
         params = {
@@ -1675,7 +2149,9 @@ class OCPReportDBAccessorTest(MasuTestCase):
             # no default_rate — this is the case that previously caused rows to vanish
         }
 
-        rendered_sql, _ = JinjaSql(param_style="named").prepare_query(sql_template, params)
+        rendered_sql, _ = JinjaSql(param_style="named").prepare_query(
+            sql_template, params
+        )
 
         # gpu.gpu_model_name = 'A100' must appear exactly once: in the CASE WHEN expression.
         # Any additional occurrence means the restrictive WHERE filter was not removed.
@@ -1683,11 +2159,15 @@ class OCPReportDBAccessorTest(MasuTestCase):
         # The CASE must fall back to 0 for unmatched models (ELSE 0)
         self.assertIn("ELSE 0", rendered_sql)
 
-    def test_self_hosted_gpu_sql_template_includes_unmatched_models_with_zero_cost(self):
+    def test_self_hosted_gpu_sql_template_includes_unmatched_models_with_zero_cost(
+        self,
+    ):
         """COST-7243: on-prem (self-hosted/PG) GPU template must not filter unmatched models."""
         from jinjasql import JinjaSql
 
-        sql_template = pkgutil.get_data("masu.database", "self_hosted_sql/openshift/cost_model/monthly_cost_gpu.sql")
+        sql_template = pkgutil.get_data(
+            "masu.database", "self_hosted_sql/openshift/cost_model/monthly_cost_gpu.sql"
+        )
         sql_template = sql_template.decode("utf-8")
 
         params = {
@@ -1710,7 +2190,9 @@ class OCPReportDBAccessorTest(MasuTestCase):
             "value_rates": {"A100": 5000},
         }
 
-        rendered_sql, _ = JinjaSql(param_style="named").prepare_query(sql_template, params)
+        rendered_sql, _ = JinjaSql(param_style="named").prepare_query(
+            sql_template, params
+        )
 
         # gpu.gpu_model_name = 'A100' must appear exactly once: in the CASE WHEN expression.
         self.assertEqual(rendered_sql.count("gpu.gpu_model_name = 'A100'"), 1)
@@ -1735,13 +2217,21 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
         }
 
     @patch("masu.database.ocp_report_db_accessor.trino_table_exists")
-    def test_reporting_period_has_gpu_data_returns_false_when_no_table(self, mock_trino_table_exists):
+    def test_reporting_period_has_gpu_data_returns_false_when_no_table(
+        self, mock_trino_table_exists
+    ):
         """Test that _reporting_period_has_gpu_data returns False when GPU table does not exist."""
         mock_trino_table_exists.return_value = False
         with self.accessor as acc:
-            self.assertFalse(acc._reporting_period_has_gpu_data(self.ocp_provider.uuid, self.dh.last_month_start))
+            self.assertFalse(
+                acc._reporting_period_has_gpu_data(
+                    self.ocp_provider.uuid, self.dh.last_month_start
+                )
+            )
 
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query"
+    )
     @patch("masu.database.ocp_report_db_accessor.trino_table_exists")
     def test_reporting_period_has_gpu_data_returns_false_when_source_not_in_partitions(
         self, mock_trino_table_exists, mock_trino_raw_sql
@@ -1750,9 +2240,15 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
         mock_trino_table_exists.return_value = True
         mock_trino_raw_sql.return_value = [[0]]
         with self.accessor as acc:
-            self.assertFalse(acc._reporting_period_has_gpu_data(self.ocp_provider.uuid, self.dh.last_month_start))
+            self.assertFalse(
+                acc._reporting_period_has_gpu_data(
+                    self.ocp_provider.uuid, self.dh.last_month_start
+                )
+            )
 
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query"
+    )
     @patch("masu.database.ocp_report_db_accessor.trino_table_exists")
     def test_reporting_period_has_gpu_data_returns_true_when_source_has_data(
         self, mock_trino_table_exists, mock_trino_raw_sql
@@ -1761,9 +2257,15 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
         mock_trino_table_exists.return_value = True
         mock_trino_raw_sql.return_value = [[3]]
         with self.accessor as acc:
-            self.assertTrue(acc._reporting_period_has_gpu_data(self.ocp_provider.uuid, self.dh.last_month_start))
+            self.assertTrue(
+                acc._reporting_period_has_gpu_data(
+                    self.ocp_provider.uuid, self.dh.last_month_start
+                )
+            )
 
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query"
+    )
     @patch("masu.database.ocp_report_db_accessor.trino_table_exists")
     def test_reporting_period_has_gpu_data_filters_by_year_and_month(
         self, mock_trino_table_exists, mock_trino_raw_sql
@@ -1783,7 +2285,9 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
         )
 
     @override_settings(ONPREM=True)
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_raw_sql_query"
+    )
     @patch("masu.database.ocp_report_db_accessor.trino_table_exists")
     def test_reporting_period_has_gpu_data_onprem_queries_postgres_not_hive(
         self, mock_trino_table_exists, mock_execute_raw_sql
@@ -1792,15 +2296,23 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
         mock_trino_table_exists.return_value = True
         mock_execute_raw_sql.return_value = [(2,)]
         with self.accessor as acc:
-            self.assertTrue(acc._reporting_period_has_gpu_data(self.ocp_provider.uuid, self.dh.last_month_start))
+            self.assertTrue(
+                acc._reporting_period_has_gpu_data(
+                    self.ocp_provider.uuid, self.dh.last_month_start
+                )
+            )
         mock_execute_raw_sql.assert_called_once()
         executed_sql = mock_execute_raw_sql.call_args[0][1]
-        self.assertIn(f'"{self.schema}"."openshift_gpu_usage_line_items_daily"', executed_sql)
+        self.assertIn(
+            f'"{self.schema}"."openshift_gpu_usage_line_items_daily"', executed_sql
+        )
         self.assertNotIn("hive.", executed_sql)
         self.assertNotIn("$partitions", executed_sql)
 
     @override_settings(ONPREM=True)
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_raw_sql_query"
+    )
     @patch("masu.database.ocp_report_db_accessor.trino_table_exists")
     def test_reporting_period_has_gpu_data_onprem_returns_false_when_zero_rows(
         self, mock_trino_table_exists, mock_execute_raw_sql
@@ -1808,12 +2320,18 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
         mock_trino_table_exists.return_value = True
         mock_execute_raw_sql.return_value = [(0,)]
         with self.accessor as acc:
-            self.assertFalse(acc._reporting_period_has_gpu_data(self.ocp_provider.uuid, self.dh.last_month_start))
+            self.assertFalse(
+                acc._reporting_period_has_gpu_data(
+                    self.ocp_provider.uuid, self.dh.last_month_start
+                )
+            )
 
     @patch("masu.database.ocp_report_db_accessor.get_cluster_id_from_provider")
     @patch("masu.database.ocp_report_db_accessor.CostModelDBAccessor")
     @patch("masu.database.ocp_report_db_accessor.trino_table_exists")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query"
+    )
     def test_populate_gpu_ui_summary_table_with_usage_only_no_cluster_id(
         self,
         mock_trino_raw_sql,
@@ -1829,7 +2347,9 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
         mock_cost_model_instance.metric_to_tag_params_map = {}
         mock_cost_model_accessor.return_value = mock_cost_model_instance
         with (
-            patch.object(self.accessor, "_execute_trino_multipart_sql_query") as mock_trino_exec,
+            patch.object(
+                self.accessor, "_execute_trino_multipart_sql_query"
+            ) as mock_trino_exec,
             self.accessor as acc,
         ):
             acc._populate_gpu_ui_summary_table_with_usage_only(self.sql_params)
@@ -1837,7 +2357,9 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
             mock_get_cluster_id.assert_called_once_with(self.ocp_provider.uuid)
 
     @patch("masu.database.ocp_report_db_accessor.trino_table_exists")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query"
+    )
     def test_populate_gpu_ui_summary_table_with_usage_only_no_gpu_data(
         self, mock_trino_raw_sql, mock_trino_table_exists
     ):
@@ -1845,7 +2367,9 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
         mock_trino_table_exists.return_value = True
         mock_trino_raw_sql.return_value = [[0]]  # No GPU data (count is 0)
         with (
-            patch.object(self.accessor, "_execute_trino_multipart_sql_query") as mock_trino_exec,
+            patch.object(
+                self.accessor, "_execute_trino_multipart_sql_query"
+            ) as mock_trino_exec,
             self.accessor as acc,
         ):
             acc._populate_gpu_ui_summary_table_with_usage_only(self.sql_params)
@@ -1853,7 +2377,9 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
 
     @patch("masu.database.ocp_report_db_accessor.CostModelDBAccessor")
     @patch("masu.database.ocp_report_db_accessor.trino_table_exists")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query"
+    )
     def test_populate_gpu_ui_summary_table_with_usage_only_has_cost_model(
         self, mock_trino_raw_sql, mock_trino_table_exists, mock_cost_model_accessor
     ):
@@ -1862,12 +2388,18 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
         mock_trino_raw_sql.return_value = [[5]]  # Source has GPU data (5 partitions)
         mock_cost_model_instance = Mock()
         mock_cost_model_instance.metric_to_tag_params_map = {
-            metric_constants.OCP_GPU_MONTH: [{"rate_type": "Infrastructure", "tag_key": "nvidia"}]
+            metric_constants.OCP_GPU_MONTH: [
+                {"rate_type": "Infrastructure", "tag_key": "nvidia"}
+            ]
         }
-        mock_cost_model_accessor.return_value.__enter__ = Mock(return_value=mock_cost_model_instance)
+        mock_cost_model_accessor.return_value.__enter__ = Mock(
+            return_value=mock_cost_model_instance
+        )
         mock_cost_model_accessor.return_value.__exit__ = Mock(return_value=False)
         with (
-            patch.object(self.accessor, "_execute_trino_multipart_sql_query") as mock_trino_exec,
+            patch.object(
+                self.accessor, "_execute_trino_multipart_sql_query"
+            ) as mock_trino_exec,
             self.accessor as acc,
         ):
             acc._populate_gpu_ui_summary_table_with_usage_only(self.sql_params)
@@ -1877,7 +2409,9 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
     @patch("masu.database.ocp_report_db_accessor.get_cluster_id_from_provider")
     @patch("masu.database.ocp_report_db_accessor.CostModelDBAccessor")
     @patch("masu.database.ocp_report_db_accessor.trino_table_exists")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query"
+    )
     def test_populate_gpu_ui_summary_table_with_usage_only_no_cost_model(
         self,
         mock_trino_raw_sql,
@@ -1895,14 +2429,18 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
         mock_get_cluster_id.return_value = "test-cluster-id"
         mock_get_cluster_alias.return_value = "test-cluster-alias"
         with (
-            patch.object(self.accessor, "_execute_trino_multipart_sql_query") as mock_trino_exec,
+            patch.object(
+                self.accessor, "_execute_trino_multipart_sql_query"
+            ) as mock_trino_exec,
             self.accessor as acc,
         ):
             acc._populate_gpu_ui_summary_table_with_usage_only(self.sql_params)
             mock_trino_exec.assert_called_once()
 
     @patch("masu.database.ocp_report_db_accessor.trino_table_exists")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query"
+    )
     def test_populate_gpu_ui_summary_table_with_usage_only_source_in_trino_returns_zero(
         self, mock_trino_raw_sql, mock_trino_table_exists
     ):
@@ -1910,7 +2448,9 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
         mock_trino_table_exists.return_value = True
         mock_trino_raw_sql.return_value = [[0]]  # Source has no GPU data (count is 0)
         with (
-            patch.object(self.accessor, "_execute_trino_multipart_sql_query") as mock_trino_exec,
+            patch.object(
+                self.accessor, "_execute_trino_multipart_sql_query"
+            ) as mock_trino_exec,
             self.accessor as acc,
         ):
             acc._populate_gpu_ui_summary_table_with_usage_only(self.sql_params)
@@ -1920,7 +2460,9 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
     @patch("masu.database.ocp_report_db_accessor.get_cluster_alias_from_cluster_id")
     @patch("masu.database.ocp_report_db_accessor.get_cluster_id_from_provider")
     @patch("masu.database.ocp_report_db_accessor.CostModelDBAccessor")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.get_sql_folder_name")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.get_sql_folder_name"
+    )
     @patch("reporting.provider.ocp.self_hosted_models.OCPGPUUsageLineItem")
     def test_populate_gpu_ui_summary_table_onprem_no_gpu_data(
         self,
@@ -1934,7 +2476,9 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
         mock_get_sql_folder.return_value = "self_hosted_sql"
         mock_gpu_model.objects.filter.return_value.exists.return_value = False
         with (
-            patch.object(self.accessor, "_prepare_and_execute_raw_sql_query") as mock_psql_exec,
+            patch.object(
+                self.accessor, "_prepare_and_execute_raw_sql_query"
+            ) as mock_psql_exec,
             self.accessor as acc,
         ):
             acc._populate_gpu_ui_summary_table_with_usage_only(self.sql_params)
@@ -1943,7 +2487,9 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
     @patch("masu.database.ocp_report_db_accessor.get_cluster_alias_from_cluster_id")
     @patch("masu.database.ocp_report_db_accessor.get_cluster_id_from_provider")
     @patch("masu.database.ocp_report_db_accessor.CostModelDBAccessor")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.get_sql_folder_name")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.get_sql_folder_name"
+    )
     @patch("reporting.provider.ocp.self_hosted_models.OCPGPUUsageLineItem")
     def test_populate_gpu_ui_summary_table_onprem_with_gpu_data(
         self,
@@ -1962,7 +2508,9 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
         mock_get_cluster_alias.return_value = "test-cluster-alias"
         mock_gpu_model.objects.filter.return_value.exists.return_value = True
         with (
-            patch.object(self.accessor, "_prepare_and_execute_raw_sql_query") as mock_psql_exec,
+            patch.object(
+                self.accessor, "_prepare_and_execute_raw_sql_query"
+            ) as mock_psql_exec,
             self.accessor as acc,
         ):
             acc._populate_gpu_ui_summary_table_with_usage_only(self.sql_params)
@@ -1971,7 +2519,9 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
     @patch("masu.database.ocp_report_db_accessor.get_cluster_alias_from_cluster_id")
     @patch("masu.database.ocp_report_db_accessor.get_cluster_id_from_provider")
     @patch("masu.database.ocp_report_db_accessor.CostModelDBAccessor")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.get_sql_folder_name")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.get_sql_folder_name"
+    )
     @patch("reporting.provider.ocp.self_hosted_models.OCPGPUUsageLineItem")
     def test_populate_gpu_ui_summary_table_onprem_with_cost_model(
         self,
@@ -1985,14 +2535,18 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
         mock_get_sql_folder.return_value = "self_hosted_sql"
         mock_cost_model_instance = Mock()
         mock_cost_model_instance.metric_to_tag_params_map = {
-            metric_constants.OCP_GPU_MONTH: [{"rate_type": "Infrastructure", "tag_key": "nvidia"}]
+            metric_constants.OCP_GPU_MONTH: [
+                {"rate_type": "Infrastructure", "tag_key": "nvidia"}
+            ]
         }
         mock_cost_model_accessor.return_value = mock_cost_model_instance
         mock_get_cluster_id.return_value = "test-cluster-id"
         mock_get_cluster_alias.return_value = "test-cluster-alias"
         mock_gpu_model.objects.filter.return_value.exists.return_value = True
         with (
-            patch.object(self.accessor, "_prepare_and_execute_raw_sql_query") as mock_psql_exec,
+            patch.object(
+                self.accessor, "_prepare_and_execute_raw_sql_query"
+            ) as mock_psql_exec,
             self.accessor as acc,
         ):
             acc._populate_gpu_ui_summary_table_with_usage_only(self.sql_params)
@@ -2001,7 +2555,9 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
 
     @patch("masu.database.ocp_report_db_accessor.get_cluster_id_from_provider")
     @patch("masu.database.ocp_report_db_accessor.CostModelDBAccessor")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.get_sql_folder_name")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.get_sql_folder_name"
+    )
     @patch("reporting.provider.ocp.self_hosted_models.OCPGPUUsageLineItem")
     def test_populate_gpu_ui_summary_table_onprem_no_cluster_id(
         self,
@@ -2018,16 +2574,25 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
         mock_get_cluster_id.return_value = None  # No cluster ID
         mock_gpu_model.objects.filter.return_value.exists.return_value = True
         with (
-            patch.object(self.accessor, "_prepare_and_execute_raw_sql_query") as mock_psql_exec,
+            patch.object(
+                self.accessor, "_prepare_and_execute_raw_sql_query"
+            ) as mock_psql_exec,
             self.accessor as acc,
         ):
             acc._populate_gpu_ui_summary_table_with_usage_only(self.sql_params)
             mock_psql_exec.assert_not_called()
 
     @patch("masu.database.ocp_report_db_accessor.trino_table_exists")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.schema_exists_trino", return_value=True)
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.schema_exists_trino",
+        return_value=True,
+    )
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
+    )
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query"
+    )
     def test_populate_virtualization_ui_summary_table_uses_source_in_trino_table(
         self, mock_trino_sql, mock_psql, mock_schema_exists, mock_trino_table_exists
     ):
@@ -2043,9 +2608,16 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
             mock_trino_sql.assert_called()
 
     @patch("masu.database.ocp_report_db_accessor.trino_table_exists")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.schema_exists_trino", return_value=True)
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.schema_exists_trino",
+        return_value=True,
+    )
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
+    )
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query"
+    )
     def test_populate_virtualization_ui_summary_table_vm_table_not_in_source(
         self, mock_trino_sql, mock_psql, mock_schema_exists, mock_trino_table_exists
     ):
@@ -2054,7 +2626,9 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
         mock_trino_sql.return_value = [[0]]  # Source NOT found in VM table (count is 0)
         with (
             patch.object(self.accessor, "_execute_trino_multipart_sql_query"),
-            patch("masu.database.ocp_report_db_accessor.pkgutil.get_data") as mock_get_data,
+            patch(
+                "masu.database.ocp_report_db_accessor.pkgutil.get_data"
+            ) as mock_get_data,
             self.accessor as acc,
         ):
             mock_get_data.return_value = b"SELECT 1"
@@ -2063,4 +2637,6 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
             calls = mock_get_data.call_args_list
             # Should use populate_vm_tmp_table.sql (fallback) instead of populate_vm_tmp_table_with_vm_report.sql
             sql_files_used = [str(call) for call in calls]
-            self.assertTrue(any("populate_vm_tmp_table.sql" in s for s in sql_files_used))
+            self.assertTrue(
+                any("populate_vm_tmp_table.sql" in s for s in sql_files_used)
+            )

--- a/koku/masu/test/database/test_ocp_report_db_accessor.py
+++ b/koku/masu/test/database/test_ocp_report_db_accessor.py
@@ -70,20 +70,14 @@ class OCPReportDBAccessorTest(MasuTestCase):
         """Test that periods are returned filtered by provider id and start date."""
         with self.accessor as acc:
             provider_uuid = self.ocp_provider_uuid
-            reporting_period = OCPUsageReportPeriod.objects.filter(
-                provider=self.ocp_provider_uuid
-            ).first()
+            reporting_period = OCPUsageReportPeriod.objects.filter(provider=self.ocp_provider_uuid).first()
             start_date = str(reporting_period.report_period_start)
             period = acc.report_periods_for_provider_uuid(provider_uuid, start_date)
             self.assertEqual(period.provider_id, provider_uuid)
 
     @patch("masu.database.ocp_report_db_accessor.trino_table_exists")
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.delete_ocp_hive_partition_by_day"
-    )
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.delete_ocp_hive_partition_by_day")
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query")
     def test_populate_line_item_daily_summary_table_trino(self, mock_execute, *args):
         """
         Test that OCP trino processing calls executescript
@@ -106,9 +100,7 @@ class OCPReportDBAccessorTest(MasuTestCase):
             mock_execute.assert_called()
 
     @patch("masu.database.ocp_report_db_accessor.trino_table_exists", return_value=True)
-    def test_populate_line_item_daily_summary_table_trino_exception_warn(
-        self, mock_table_exists
-    ):
+    def test_populate_line_item_daily_summary_table_trino_exception_warn(self, mock_table_exists):
         """
         Test that a warning is logged when a TrinoStatementExecError is raised because
         a partion already exists.
@@ -123,13 +115,9 @@ class OCPReportDBAccessorTest(MasuTestCase):
         message = "One or more Partitions Already exist"
         with (
             patch.object(self.accessor, "delete_ocp_hive_partition_by_day"),
-            patch.object(
-                self.accessor, "_execute_trino_multipart_sql_query"
-            ) as mock_sql_query,
+            patch.object(self.accessor, "_execute_trino_multipart_sql_query") as mock_sql_query,
             self.accessor as acc,
-            self.assertLogs(
-                "masu.database.ocp_report_db_accessor", level="WARN"
-            ) as logger,
+            self.assertLogs("masu.database.ocp_report_db_accessor", level="WARN") as logger,
         ):
             trino_error = TrinoUserError(
                 {
@@ -138,9 +126,7 @@ class OCPReportDBAccessorTest(MasuTestCase):
                     "message": message,
                 }
             )
-            mock_sql_query.side_effect = TrinoStatementExecError(
-                "SELECT * from table", 1, {}, trino_error
-            )
+            mock_sql_query.side_effect = TrinoStatementExecError("SELECT * from table", 1, {}, trino_error)
 
             acc.populate_line_item_daily_summary_table_trino(
                 start_date,
@@ -157,9 +143,7 @@ class OCPReportDBAccessorTest(MasuTestCase):
         )
 
     @patch("masu.database.ocp_report_db_accessor.trino_table_exists", return_value=True)
-    def test_populate_line_item_daily_summary_table_trino_exception(
-        self, mock_table_exists
-    ):
+    def test_populate_line_item_daily_summary_table_trino_exception(self, mock_table_exists):
         """
         Test that a TrinoStatementExecError is raised for errors that are not partition related.
         """
@@ -172,9 +156,7 @@ class OCPReportDBAccessorTest(MasuTestCase):
         source = self.provider_uuid
         with (
             patch.object(self.accessor, "delete_ocp_hive_partition_by_day"),
-            patch.object(
-                self.accessor, "_execute_trino_multipart_sql_query"
-            ) as mock_sql_query,
+            patch.object(self.accessor, "_execute_trino_multipart_sql_query") as mock_sql_query,
             self.accessor as acc,
             self.assertRaisesRegex(TrinoStatementExecError, "Something went wrong"),
         ):
@@ -185,9 +167,7 @@ class OCPReportDBAccessorTest(MasuTestCase):
                     "message": "Something went wrong",
                 }
             )
-            mock_sql_query.side_effect = TrinoStatementExecError(
-                "SELECT * from table", 1, {}, trino_error
-            )
+            mock_sql_query.side_effect = TrinoStatementExecError("SELECT * from table", 1, {}, trino_error)
 
             acc.populate_line_item_daily_summary_table_trino(
                 start_date,
@@ -328,10 +308,7 @@ class OCPReportDBAccessorTest(MasuTestCase):
                             .values("usage_start")
                             .annotate(cost=Sum("calculated_cost"))
                         )
-                        rtu_costs = {
-                            entry["usage_start"]: float(entry["cost"])
-                            for entry in rtu_qset
-                        }
+                        rtu_costs = {entry["usage_start"]: float(entry["cost"]) for entry in rtu_qset}
 
                         for day, vals in initial_results_dict.get(value).items():
                             with self.subTest(
@@ -474,10 +451,7 @@ class OCPReportDBAccessorTest(MasuTestCase):
                             .values("usage_start")
                             .annotate(cost=Sum("calculated_cost"))
                         )
-                        rtu_costs = {
-                            entry["usage_start"]: float(entry["cost"])
-                            for entry in rtu_qset
-                        }
+                        rtu_costs = {entry["usage_start"]: float(entry["cost"]) for entry in rtu_qset}
 
                         for day, vals in initial_results_dict.get(value).items():
                             with self.subTest(
@@ -487,11 +461,7 @@ class OCPReportDBAccessorTest(MasuTestCase):
                                     expected_cost = 0
                                 else:
                                     if day >= start_date.date():
-                                        rate = (
-                                            rate_costs.get(cost)
-                                            .get("app")
-                                            .get("default_value")
-                                        )
+                                        rate = rate_costs.get(cost).get("app").get("default_value")
                                         expected_cost = float(vals[0] * rate)
                                     else:
                                         expected_cost = 0
@@ -499,22 +469,16 @@ class OCPReportDBAccessorTest(MasuTestCase):
                                 self.assertAlmostEqual(actual_cost, expected_cost)
 
     def test_table_properties(self):
-        self.assertEqual(
-            self.accessor.line_item_daily_summary_table, OCPUsageLineItemDailySummary
-        )
+        self.assertEqual(self.accessor.line_item_daily_summary_table, OCPUsageLineItemDailySummary)
 
     def test_table_map(self):
         self.assertEqual(self.accessor._table_map, OCP_REPORT_TABLE_MAP)
 
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query")
     def test_get_ocp_infrastructure_map_trino(self, mock_trino):
         """Test that Trino is used to find matched tags."""
         subtests = ["aws", "gcp", "azure"]
-        mock_trino.side_effect = [True, True, [["test", "test", "test"]]] * len(
-            subtests
-        )
+        mock_trino.side_effect = [True, True, [["test", "test", "test"]]] * len(subtests)
         for p_type_var_substring in subtests:
             with self.subTest(p_type_var_substring=p_type_var_substring):
                 kwargs = {
@@ -526,9 +490,7 @@ class OCPReportDBAccessorTest(MasuTestCase):
                 result = accessor.get_ocp_infrastructure_map_trino(**kwargs)
                 self.assertEqual(result, {"test": ("test", "test")})
 
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query")
     def test_get_ocp_infrastructure_map_trino_table_does_not_exist(self, table_exists):
         """Test trino returns empty dict if table does not exit"""
         subtests = ["aws", "gcp", "azure"]
@@ -545,12 +507,8 @@ class OCPReportDBAccessorTest(MasuTestCase):
                 self.assertEqual(result, {})
 
     @patch("masu.database.ocp_report_db_accessor.trino_table_exists")
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.get_projects_trino"
-    )
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.get_projects_trino")
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query")
     @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.get_nodes_trino")
     def test_populate_openshift_cluster_information_tables(
         self, mock_get_nodes, mock_get_pvcs, mock_get_projects, mock_table
@@ -576,9 +534,7 @@ class OCPReportDBAccessorTest(MasuTestCase):
         end_date = self.dh.this_month_end.date()
 
         with self.accessor as acc:
-            cluster = acc.populate_cluster_table(
-                self.aws_provider, cluster_id, cluster_alias
-            )
+            cluster = acc.populate_cluster_table(self.aws_provider, cluster_id, cluster_alias)
             OCPPVC.objects.get_or_create(
                 persistent_volume_claim=pvcs[0],
                 persistent_volume=volumes[0],
@@ -588,9 +544,7 @@ class OCPReportDBAccessorTest(MasuTestCase):
                 self.aws_provider, cluster_id, cluster_alias, start_date, end_date
             )
 
-            self.assertIsNotNone(
-                OCPCluster.objects.filter(cluster_id=cluster_id).first()
-            )
+            self.assertIsNotNone(OCPCluster.objects.filter(cluster_id=cluster_id).first())
             for node in nodes:
                 db_node = OCPNode.objects.filter(node=node).first()
                 self.assertIsNotNone(db_node)
@@ -600,9 +554,7 @@ class OCPReportDBAccessorTest(MasuTestCase):
                 self.assertIsNotNone(db_node.cluster_id)
                 self.assertIsNotNone(db_node.node_role)
             for pvc in pvcs:
-                self.assertIsNotNone(
-                    OCPPVC.objects.filter(persistent_volume_claim=pvc).first()
-                )
+                self.assertIsNotNone(OCPPVC.objects.filter(persistent_volume_claim=pvc).first())
             for project in projects:
                 self.assertIsNotNone(OCPProject.objects.filter(project=project).first())
 
@@ -616,9 +568,7 @@ class OCPReportDBAccessorTest(MasuTestCase):
             mock_get_pvcs.assert_not_called()
 
     @patch("masu.database.ocp_report_db_accessor.trino_table_exists")
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.get_projects_trino"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.get_projects_trino")
     @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.get_pvcs_trino")
     @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.get_nodes_trino")
     def test_get_openshift_topology_for_multiple_providers(
@@ -655,9 +605,7 @@ class OCPReportDBAccessorTest(MasuTestCase):
             nodes = OCPNode.objects.filter(cluster=cluster).all()
             pvcs = OCPPVC.objects.filter(cluster=cluster).all()
             projects = OCPProject.objects.filter(cluster=cluster).all()
-            topology = acc.get_openshift_topology_for_multiple_providers(
-                [self.aws_provider_uuid]
-            )
+            topology = acc.get_openshift_topology_for_multiple_providers([self.aws_provider_uuid])
             self.assertEqual(len(topology), 1)
             topo = topology[0]
             self.assertEqual(topo.get("cluster_id"), cluster_id)
@@ -665,9 +613,7 @@ class OCPReportDBAccessorTest(MasuTestCase):
             for node in nodes:
                 self.assertIn(node.node, topo.get("nodes"))
             for pvc in pvcs:
-                self.assertIn(
-                    pvc.persistent_volume_claim, topo.get("persistent_volume_claims")
-                )
+                self.assertIn(pvc.persistent_volume_claim, topo.get("persistent_volume_claims"))
                 self.assertIn(pvc.persistent_volume, topo.get("persistent_volumes"))
                 self.assertIn(pvc.csi_volume_handle, topo.get("csi_volume_handle"))
             for project in projects:
@@ -676,9 +622,7 @@ class OCPReportDBAccessorTest(MasuTestCase):
     @patch("masu.database.ocp_report_db_accessor.trino_table_exists")
     @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.get_pvcs_trino")
     @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.get_nodes_trino")
-    def test_get_filtered_openshift_topology_for_multiple_providers(
-        self, mock_get_nodes, mock_get_pvcs, mock_table
-    ):
+    def test_get_filtered_openshift_topology_for_multiple_providers(self, mock_get_nodes, mock_get_pvcs, mock_table):
         """Test that OpenShift topology is populated."""
         nodes = ["test_node_1", "test_node_2"]
         resource_ids = ["id_1", "id_2"]
@@ -720,9 +664,7 @@ class OCPReportDBAccessorTest(MasuTestCase):
         cluster_id = str(uuid.uuid4())
         cluster_alias = "node_role_test"
         with self.accessor as acc:
-            cluster = acc.populate_cluster_table(
-                self.aws_provider, cluster_id, cluster_alias
-            )
+            cluster = acc.populate_cluster_table(self.aws_provider, cluster_id, cluster_alias)
             node = OCPNode.objects.create(
                 node=node_info[0],
                 resource_id=node_info[1],
@@ -745,9 +687,7 @@ class OCPReportDBAccessorTest(MasuTestCase):
         cluster_id = str(uuid.uuid4())
         cluster_alias = "node_role_test"
         with self.accessor as acc:
-            cluster = acc.populate_cluster_table(
-                self.aws_provider, cluster_id, cluster_alias
-            )
+            cluster = acc.populate_cluster_table(self.aws_provider, cluster_id, cluster_alias)
             node = OCPNode.objects.create(
                 node=node_info[0],
                 resource_id=node_info[1],
@@ -803,9 +743,7 @@ class OCPReportDBAccessorTest(MasuTestCase):
         cluster_id = str(uuid.uuid4())
         cluster_alias = "node_role_test"
         with self.accessor as acc:
-            cluster = acc.populate_cluster_table(
-                self.aws_provider, cluster_id, cluster_alias
-            )
+            cluster = acc.populate_cluster_table(self.aws_provider, cluster_id, cluster_alias)
             acc.populate_node_table(cluster, [node_info])
             node_count = OCPNode.objects.filter(
                 node=node_info[0],
@@ -836,17 +774,12 @@ class OCPReportDBAccessorTest(MasuTestCase):
         cluster_alias = "test-cluster-1"
 
         with self.accessor as accessor:
-            cluster = accessor.populate_cluster_table(
-                self.ocp_provider, cluster_id, cluster_alias
-            )
+            cluster = accessor.populate_cluster_table(self.ocp_provider, cluster_id, cluster_alias)
             accessor.populate_pvc_table(cluster, pvcs)
 
             mock_create.assert_called()
             self.assertTrue(
-                any(
-                    "IntegrityError raised when creating pvc" in str(call)
-                    for call in mock_log.call_args_list
-                )
+                any("IntegrityError raised when creating pvc" in str(call) for call in mock_log.call_args_list)
             )
 
     def test_delete_infrastructure_raw_cost_from_daily_summary(self):
@@ -854,9 +787,7 @@ class OCPReportDBAccessorTest(MasuTestCase):
         with self.accessor as acc:
             start_date = self.dh.this_month_start.date()
             end_date = self.dh.this_month_end.date()
-            report_period = acc.report_periods_for_provider_uuid(
-                self.ocpaws_provider_uuid, start_date
-            )
+            report_period = acc.report_periods_for_provider_uuid(self.ocpaws_provider_uuid, start_date)
             report_period_id = report_period.id
             count = OCPUsageLineItemDailySummary.objects.filter(
                 report_period_id=report_period_id,
@@ -874,107 +805,61 @@ class OCPReportDBAccessorTest(MasuTestCase):
             ).count()
             self.assertEqual(count, 0)
 
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.schema_exists_trino"
-    )
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.table_exists_trino"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.schema_exists_trino")
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.table_exists_trino")
     @patch("masu.database.report_db_accessor_base.trino_db.connect")
     @patch("time.sleep", return_value=None)
-    def test_delete_ocp_hive_partition_by_day(
-        self, mock_sleep, mock_connect, mock_table_exists, mock_schema_exists
-    ):
+    def test_delete_ocp_hive_partition_by_day(self, mock_sleep, mock_connect, mock_table_exists, mock_schema_exists):
         """Test that deletions work with retries."""
         mock_schema_exists.return_value = False
-        self.accessor.delete_ocp_hive_partition_by_day(
-            [1], self.ocp_provider_uuid, self.ocp_provider_uuid, "2022"
-        )
+        self.accessor.delete_ocp_hive_partition_by_day([1], self.ocp_provider_uuid, self.ocp_provider_uuid, "2022")
         mock_connect.assert_not_called()
 
         mock_connect.reset_mock()
 
         mock_schema_exists.return_value = True
-        attrs = {
-            "cursor.side_effect": TrinoExternalError(
-                {"errorName": "HIVE_METASTORE_ERROR"}
-            )
-        }
+        attrs = {"cursor.side_effect": TrinoExternalError({"errorName": "HIVE_METASTORE_ERROR"})}
         mock_connect.return_value = Mock(**attrs)
 
         with self.assertRaises(TrinoHiveMetastoreError):
-            self.accessor.delete_ocp_hive_partition_by_day(
-                [1], self.aws_provider_uuid, self.ocp_provider_uuid, "2022"
-            )
+            self.accessor.delete_ocp_hive_partition_by_day([1], self.aws_provider_uuid, self.ocp_provider_uuid, "2022")
 
         mock_connect.assert_called()
-        self.assertEqual(
-            mock_connect.call_count, settings.HIVE_PARTITION_DELETE_RETRIES
-        )
+        self.assertEqual(mock_connect.call_count, settings.HIVE_PARTITION_DELETE_RETRIES)
 
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.table_exists_trino"
-    )
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query"
-    )
-    def test_delete_hive_partitions_by_source_success(
-        self, mock_trino, mock_table_exist
-    ):
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.table_exists_trino")
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query")
+    def test_delete_hive_partitions_by_source_success(self, mock_trino, mock_table_exist):
         """Test that deletions work with retries."""
-        result = self.accessor.delete_hive_partitions_by_source(
-            "table", "partition_column", self.ocp_provider_uuid
-        )
+        result = self.accessor.delete_hive_partitions_by_source("table", "partition_column", self.ocp_provider_uuid)
         mock_trino.assert_called()
         self.assertTrue(result)
 
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.table_exists_trino"
-    )
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.table_exists_trino")
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query")
     def test_find_expired_trino_partitions_success(self, mock_trino, mock_table_exist):
         """Test that deletions work with retries."""
-        result = self.accessor.find_expired_trino_partitions(
-            "table", "source_column", "2024-06-01"
-        )
+        result = self.accessor.find_expired_trino_partitions("table", "source_column", "2024-06-01")
         mock_trino.assert_called()
         self.assertTrue(result)
 
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.schema_exists_trino"
-    )
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.schema_exists_trino")
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query")
     def test_find_expired_trino_partitions_no_schema(self, mock_trino, mock_schema):
         """Test that deletions work with retries."""
         mock_schema.return_value = False
-        result = self.accessor.find_expired_trino_partitions(
-            "table", "source_column", "2024-06-01"
-        )
+        result = self.accessor.find_expired_trino_partitions("table", "source_column", "2024-06-01")
         mock_trino.assert_not_called()
         self.assertFalse(result)
 
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.schema_exists_trino"
-    )
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.table_exists_trino"
-    )
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query"
-    )
-    def test_find_expired_trino_partitions_no_table(
-        self, mock_trino, mock_table_exist, mock_schema
-    ):
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.schema_exists_trino")
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.table_exists_trino")
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query")
+    def test_find_expired_trino_partitions_no_table(self, mock_trino, mock_table_exist, mock_schema):
         """Test that deletions work with retries."""
         mock_schema.return_value = True
         mock_table_exist.return_value = False
-        result = self.accessor.find_expired_trino_partitions(
-            "table", "source_column", "2024-06-01"
-        )
+        result = self.accessor.find_expired_trino_partitions("table", "source_column", "2024-06-01")
         mock_trino.assert_not_called()
         self.assertFalse(result)
 
@@ -1000,13 +885,9 @@ class OCPReportDBAccessorTest(MasuTestCase):
                 result = acc.delete_self_hosted_data_by_source(self.ocp_provider_uuid)
 
                 # Verify staging table filtered by source_uuid
-                mock_staging_model.objects.filter.assert_called_with(
-                    source_uuid=str(self.ocp_provider_uuid)
-                )
+                mock_staging_model.objects.filter.assert_called_with(source_uuid=str(self.ocp_provider_uuid))
                 # Verify line item table filtered by source
-                mock_line_item_model.objects.filter.assert_called_with(
-                    source=str(self.ocp_provider_uuid)
-                )
+                mock_line_item_model.objects.filter.assert_called_with(source=str(self.ocp_provider_uuid))
                 self.assertEqual(result, 15)  # 5 + 10
 
     @patch("reporting.provider.ocp.self_hosted_models.get_self_hosted_models")
@@ -1022,12 +903,8 @@ class OCPReportDBAccessorTest(MasuTestCase):
             result = acc.delete_self_hosted_data_by_source(uuid.uuid4())
             self.assertEqual(result, 0)
 
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.schema_exists_trino"
-    )
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.table_exists_trino"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.schema_exists_trino")
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.table_exists_trino")
     @patch("masu.database.report_db_accessor_base.trino_db.connect")
     @patch("time.sleep", return_value=None)
     def test_delete_hive_partitions_by_source_failure(
@@ -1035,34 +912,22 @@ class OCPReportDBAccessorTest(MasuTestCase):
     ):
         """Test that deletions work with retries."""
         mock_schema_exists.return_value = False
-        self.accessor.delete_hive_partitions_by_source(
-            "table", "partition_column", self.ocp_provider_uuid
-        )
+        self.accessor.delete_hive_partitions_by_source("table", "partition_column", self.ocp_provider_uuid)
         mock_connect.assert_not_called()
         mock_connect.reset_mock()
 
         mock_schema_exists.return_value = True
 
-        attrs = {
-            "cursor.side_effect": TrinoExternalError(
-                {"errorName": "HIVE_METASTORE_ERROR"}
-            )
-        }
+        attrs = {"cursor.side_effect": TrinoExternalError({"errorName": "HIVE_METASTORE_ERROR"})}
         mock_connect.return_value = Mock(**attrs)
 
         with self.assertRaises(TrinoHiveMetastoreError):
-            self.accessor.delete_hive_partitions_by_source(
-                "table", "partition_column", self.ocp_provider_uuid
-            )
+            self.accessor.delete_hive_partitions_by_source("table", "partition_column", self.ocp_provider_uuid)
 
         mock_connect.assert_called()
-        self.assertEqual(
-            mock_connect.call_count, settings.HIVE_PARTITION_DELETE_RETRIES
-        )
+        self.assertEqual(mock_connect.call_count, settings.HIVE_PARTITION_DELETE_RETRIES)
 
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query")
     def test_get_max_min_timestamp_from_parquet(self, mock_query):
         """Get the max and min timestamps for parquet data given a date range"""
         start_date, end_date = datetime(2022, 3, 1), datetime(2022, 3, 30)
@@ -1091,12 +956,8 @@ class OCPReportDBAccessorTest(MasuTestCase):
 
         for test in table:
             with self.subTest(test=test["name"]):
-                mock_query.return_value = [
-                    test["return"]
-                ]  # returned value is a list of a list
-                result = self.accessor.get_max_min_timestamp_from_parquet(
-                    uuid.uuid4(), start_date, end_date
-                )
+                mock_query.return_value = [test["return"]]  # returned value is a list of a list
+                result = self.accessor.get_max_min_timestamp_from_parquet(uuid.uuid4(), start_date, end_date)
                 self.assertEqual(result, test["expected"])
                 self.assertTrue(hasattr(result[0], "date"))
                 self.assertTrue(hasattr(result[1], "date"))
@@ -1109,15 +970,12 @@ class OCPReportDBAccessorTest(MasuTestCase):
 
             # First test an OCP on Cloud source to make sure we don't delete that data
             provider_uuid = self.ocp_on_aws_ocp_provider.uuid
-            report_period = acc.report_periods_for_provider_uuid(
-                provider_uuid, start_date
-            )
+            report_period = acc.report_periods_for_provider_uuid(provider_uuid, start_date)
 
             report_period_id = report_period.id
             initial_non_raw_count = (
                 OCPUsageLineItemDailySummary.objects.filter(
-                    Q(infrastructure_raw_cost__isnull=True)
-                    | Q(infrastructure_raw_cost=0),
+                    Q(infrastructure_raw_cost__isnull=True) | Q(infrastructure_raw_cost=0),
                     report_period_id=report_period_id,
                 )
                 .exclude(cost_model_rate_type="platform_distributed")
@@ -1126,8 +984,7 @@ class OCPReportDBAccessorTest(MasuTestCase):
             )
             # the distributed cost is being added so the initial count is no longer zero.
             initial_raw_count = OCPUsageLineItemDailySummary.objects.filter(
-                Q(infrastructure_raw_cost__isnull=False)
-                & ~Q(infrastructure_raw_cost=0),
+                Q(infrastructure_raw_cost__isnull=False) & ~Q(infrastructure_raw_cost=0),
                 report_period_id=report_period_id,
             ).count()
 
@@ -1137,16 +994,14 @@ class OCPReportDBAccessorTest(MasuTestCase):
 
             new_non_raw_count = (
                 OCPUsageLineItemDailySummary.objects.filter(
-                    Q(infrastructure_raw_cost__isnull=True)
-                    | Q(infrastructure_raw_cost=0),
+                    Q(infrastructure_raw_cost__isnull=True) | Q(infrastructure_raw_cost=0),
                     report_period_id=report_period_id,
                 )
                 .exclude(data_source="GPU")
                 .count()
             )
             new_raw_count = OCPUsageLineItemDailySummary.objects.filter(
-                Q(infrastructure_raw_cost__isnull=False)
-                & ~Q(infrastructure_raw_cost=0),
+                Q(infrastructure_raw_cost__isnull=False) & ~Q(infrastructure_raw_cost=0),
                 report_period_id=report_period_id,
             ).count()
 
@@ -1156,23 +1011,19 @@ class OCPReportDBAccessorTest(MasuTestCase):
 
             # Now test an on prem OCP cluster to make sure we still remove non raw costs
             provider_uuid = self.ocp_provider.uuid
-            report_period = acc.report_periods_for_provider_uuid(
-                provider_uuid, start_date
-            )
+            report_period = acc.report_periods_for_provider_uuid(provider_uuid, start_date)
 
             report_period_id = report_period.id
             initial_non_raw_count = (
                 OCPUsageLineItemDailySummary.objects.filter(
-                    Q(infrastructure_raw_cost__isnull=True)
-                    | Q(infrastructure_raw_cost=0),
+                    Q(infrastructure_raw_cost__isnull=True) | Q(infrastructure_raw_cost=0),
                     report_period_id=report_period_id,
                 )
                 .exclude(data_source="GPU")
                 .count()
             )
             initial_raw_count = OCPUsageLineItemDailySummary.objects.filter(
-                Q(infrastructure_raw_cost__isnull=False)
-                & ~Q(infrastructure_raw_cost=0),
+                Q(infrastructure_raw_cost__isnull=False) & ~Q(infrastructure_raw_cost=0),
                 report_period_id=report_period_id,
             ).count()
 
@@ -1182,16 +1033,14 @@ class OCPReportDBAccessorTest(MasuTestCase):
 
             new_non_raw_count = (
                 OCPUsageLineItemDailySummary.objects.filter(
-                    Q(infrastructure_raw_cost__isnull=True)
-                    | Q(infrastructure_raw_cost=0),
+                    Q(infrastructure_raw_cost__isnull=True) | Q(infrastructure_raw_cost=0),
                     report_period_id=report_period_id,
                 )
                 .exclude(data_source="GPU")
                 .count()
             )
             new_raw_count = OCPUsageLineItemDailySummary.objects.filter(
-                Q(infrastructure_raw_cost__isnull=False)
-                & ~Q(infrastructure_raw_cost=0),
+                Q(infrastructure_raw_cost__isnull=False) & ~Q(infrastructure_raw_cost=0),
                 report_period_id=report_period_id,
             ).count()
 
@@ -1203,20 +1052,14 @@ class OCPReportDBAccessorTest(MasuTestCase):
         """Test that updating monthly costs without a matching report period no longer throws an error"""
         start_date = "2000-01-01"
         end_date = "2000-02-01"
-        with self.assertLogs(
-            "masu.database.ocp_report_db_accessor", level="INFO"
-        ) as logger:
+        with self.assertLogs("masu.database.ocp_report_db_accessor", level="INFO") as logger:
             with self.accessor as acc:
-                acc.populate_monthly_cost_sql(
-                    "Cluster", "", "", start_date, end_date, "", self.provider_uuid
-                )
+                acc.populate_monthly_cost_sql("Cluster", "", "", start_date, end_date, "", self.provider_uuid)
                 self.assertIn("no report period for OCP provider", logger.output[0])
 
     def test_populate_monthly_cost_sql_invalid_cost_type(self):
         """Test that updating monthly costs without a matching report period no longer throws an error"""
-        with self.assertLogs(
-            "masu.database.ocp_report_db_accessor", level="INFO"
-        ) as logger:
+        with self.assertLogs("masu.database.ocp_report_db_accessor", level="INFO") as logger:
             with self.accessor as acc:
                 acc.populate_monthly_cost_sql(
                     "Fake",
@@ -1227,14 +1070,10 @@ class OCPReportDBAccessorTest(MasuTestCase):
                     "",
                     self.provider_uuid,
                 )
-                self.assertIn(
-                    "Skipping populate_monthly_cost_sql update", logger.output[0]
-                )
+                self.assertIn("Skipping populate_monthly_cost_sql update", logger.output[0])
 
     @patch("masu.database.ocp_report_db_accessor.trino_table_exists", return_value=True)
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query")
     def test_populate_usage_costs_vm_rate(self, mock_trino, mock_trino_exists):
         """Test the populate vm hourly usage costs"""
         with self.accessor as acc:
@@ -1252,13 +1091,9 @@ class OCPReportDBAccessorTest(MasuTestCase):
         """Test that updating monthly costs without a matching report period no longer throws an error"""
         start_date = "2000-01-01"
         end_date = "2000-02-01"
-        with self.assertLogs(
-            "masu.database.ocp_report_db_accessor", level="INFO"
-        ) as logger:
+        with self.assertLogs("masu.database.ocp_report_db_accessor", level="INFO") as logger:
             with self.accessor as acc:
-                acc.populate_tag_cost_sql(
-                    "", "", "", "", start_date, end_date, "", self.provider_uuid
-                )
+                acc.populate_tag_cost_sql("", "", "", "", start_date, end_date, "", self.provider_uuid)
                 self.assertIn("no report period for OCP provider", logger.output[0])
 
     def test_populate_distributed_cost_sql_no_report_period(self):
@@ -1268,9 +1103,7 @@ class OCPReportDBAccessorTest(MasuTestCase):
         summary_range = SummaryRangeConfig(start_date=start_date, end_date=end_date)
         with self.accessor as acc:
             # Should not raise an exception when no report period exists
-            acc.populate_distributed_cost_sql(
-                summary_range, self.provider_uuid, {"platform_cost": True}
-            )
+            acc.populate_distributed_cost_sql(summary_range, self.provider_uuid, {"platform_cost": True})
 
     def _setup_distributed_cost_sql_mocks(self, start_date, end_date):
         """Helper to set up common mocks for distributed cost SQL tests."""
@@ -1301,33 +1134,25 @@ class OCPReportDBAccessorTest(MasuTestCase):
             delete_monthly,
             delete_rtu,
             [
-                get_pkgutil_values(
-                    "distribute_cost/distribute_platform_cost_per_rate.sql"
-                ),
+                get_pkgutil_values("distribute_cost/distribute_platform_cost_per_rate.sql"),
                 default_sql_params,
             ],
             delete_monthly,
             delete_rtu,
             [
-                get_pkgutil_values(
-                    "distribute_cost/distribute_worker_cost_per_rate.sql"
-                ),
+                get_pkgutil_values("distribute_cost/distribute_worker_cost_per_rate.sql"),
                 default_sql_params,
             ],
             delete_monthly,
             delete_rtu,
             [
-                get_pkgutil_values(
-                    "distribute_cost/distribute_unattributed_storage_per_rate.sql"
-                ),
+                get_pkgutil_values("distribute_cost/distribute_unattributed_storage_per_rate.sql"),
                 default_sql_params,
             ],
             delete_monthly,
             delete_rtu,
             [
-                get_pkgutil_values(
-                    "distribute_cost/distribute_unattributed_network_per_rate.sql"
-                ),
+                get_pkgutil_values("distribute_cost/distribute_unattributed_network_per_rate.sql"),
                 default_sql_params,
             ],
             delete_monthly,
@@ -1339,12 +1164,8 @@ class OCPReportDBAccessorTest(MasuTestCase):
 
     @patch("masu.util.ocp.common.trino_table_exists", return_value=True)
     @patch("masu.database.ocp_report_db_accessor.pkgutil.get_data")
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_raw_sql_query"
-    )
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_raw_sql_query")
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query")
     def test_populate_distributed_cost_sql_called(
         self, mock_trino_execute, mock_sql_execute, mock_data_get, mock_table_exists
     ):
@@ -1356,17 +1177,13 @@ class OCPReportDBAccessorTest(MasuTestCase):
 
         for day in days_to_test:
             with self.subTest(day=day):
-                masu_database, mock_jinja = self._setup_distributed_cost_sql_mocks(
-                    start_date, end_date
-                )
+                masu_database, mock_jinja = self._setup_distributed_cost_sql_mocks(start_date, end_date)
                 mock_data_get.reset_mock()
                 mock_sql_execute.reset_mock()
                 mock_trino_execute.reset_mock()
                 with (
                     self.accessor as acc,
-                    patch(
-                        "masu.database.ocp_report_db_accessor.DateHelper"
-                    ) as mock_dh_class,
+                    patch("masu.database.ocp_report_db_accessor.DateHelper") as mock_dh_class,
                 ):
                     mock_dh = Mock()
                     mock_dh.parse_to_date.return_value = start_date
@@ -1374,9 +1191,7 @@ class OCPReportDBAccessorTest(MasuTestCase):
                     mock_dh_class.return_value = mock_dh
 
                     acc.prepare_query = mock_jinja
-                    summary_range = SummaryRangeConfig(
-                        start_date=start_date, end_date=end_date
-                    )
+                    summary_range = SummaryRangeConfig(start_date=start_date, end_date=end_date)
 
                     acc.populate_distributed_cost_sql(
                         summary_range,
@@ -1407,12 +1222,8 @@ class OCPReportDBAccessorTest(MasuTestCase):
     )
     @patch("masu.util.ocp.common.trino_table_exists", return_value=True)
     @patch("masu.database.ocp_report_db_accessor.pkgutil.get_data")
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_raw_sql_query"
-    )
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_raw_sql_query")
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query")
     def test_populate_distributed_cost_sql_gpu_runs_prev_month_on_second_of_month(
         self,
         mock_trino_execute,
@@ -1424,9 +1235,7 @@ class OCPReportDBAccessorTest(MasuTestCase):
         """Test that GPU distribution runs for previous month only on the second of the month."""
         start_date = self.dh.this_month_start.date()
         end_date = self.dh.this_month_end.date()
-        masu_database, mock_jinja = self._setup_distributed_cost_sql_mocks(
-            start_date, end_date
-        )
+        masu_database, mock_jinja = self._setup_distributed_cost_sql_mocks(start_date, end_date)
 
         with (
             self.accessor as acc,
@@ -1459,12 +1268,8 @@ class OCPReportDBAccessorTest(MasuTestCase):
     )
     @patch("masu.util.ocp.common.trino_table_exists", return_value=True)
     @patch("masu.database.ocp_report_db_accessor.pkgutil.get_data")
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_raw_sql_query"
-    )
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_raw_sql_query")
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query")
     def test_gpu_distribution_skipped_when_already_finalized(
         self,
         mock_trino_execute,
@@ -1476,16 +1281,12 @@ class OCPReportDBAccessorTest(MasuTestCase):
         """Test that GPU distribution is skipped on day 2 when data already exists."""
         start_date = self.dh.this_month_start.date()
         end_date = self.dh.this_month_end.date()
-        masu_database, mock_jinja = self._setup_distributed_cost_sql_mocks(
-            start_date, end_date
-        )
+        masu_database, mock_jinja = self._setup_distributed_cost_sql_mocks(start_date, end_date)
 
         with (
             self.accessor as acc,
             patch("masu.database.ocp_report_db_accessor.DateHelper") as mock_dh_class,
-            patch(
-                "masu.database.ocp_report_db_accessor.OCPUsageLineItemDailySummary.objects"
-            ) as mock_qs,
+            patch("masu.database.ocp_report_db_accessor.OCPUsageLineItemDailySummary.objects") as mock_qs,
         ):
             mock_qs.filter.return_value.exists.return_value = True
             mock_dh = Mock()
@@ -1520,12 +1321,8 @@ class OCPReportDBAccessorTest(MasuTestCase):
     )
     @patch("masu.util.ocp.common.trino_table_exists", return_value=True)
     @patch("masu.database.ocp_report_db_accessor.pkgutil.get_data")
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_raw_sql_query"
-    )
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_raw_sql_query")
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query")
     def test_gpu_distribution_runs_when_not_yet_finalized(
         self,
         mock_trino_execute,
@@ -1537,16 +1334,12 @@ class OCPReportDBAccessorTest(MasuTestCase):
         """Test that GPU distribution runs on day 2 when no existing data is found."""
         start_date = self.dh.this_month_start.date()
         end_date = self.dh.this_month_end.date()
-        masu_database, mock_jinja = self._setup_distributed_cost_sql_mocks(
-            start_date, end_date
-        )
+        masu_database, mock_jinja = self._setup_distributed_cost_sql_mocks(start_date, end_date)
 
         with (
             self.accessor as acc,
             patch("masu.database.ocp_report_db_accessor.DateHelper") as mock_dh_class,
-            patch(
-                "masu.database.ocp_report_db_accessor.OCPUsageLineItemDailySummary.objects"
-            ) as mock_qs,
+            patch("masu.database.ocp_report_db_accessor.OCPUsageLineItemDailySummary.objects") as mock_qs,
         ):
             mock_qs.filter.return_value.exists.return_value = False
             mock_dh = Mock()
@@ -1578,12 +1371,8 @@ class OCPReportDBAccessorTest(MasuTestCase):
     )
     @patch("masu.util.ocp.common.trino_table_exists", return_value=True)
     @patch("masu.database.ocp_report_db_accessor.pkgutil.get_data")
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_raw_sql_query"
-    )
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_raw_sql_query")
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query")
     def test_natural_finalization_not_affected_by_guard(
         self,
         mock_trino_execute,
@@ -1595,9 +1384,7 @@ class OCPReportDBAccessorTest(MasuTestCase):
         """Test that natural finalization (previous month data) bypasses the guard entirely."""
         start_date = self.dh.last_month_start.date()
         end_date = self.dh.last_month_end.date()
-        masu_database, mock_jinja = self._setup_distributed_cost_sql_mocks(
-            start_date, end_date
-        )
+        masu_database, mock_jinja = self._setup_distributed_cost_sql_mocks(start_date, end_date)
 
         with self.accessor as acc:
             acc.prepare_query = mock_jinja
@@ -1621,12 +1408,8 @@ class OCPReportDBAccessorTest(MasuTestCase):
     )
     @patch("masu.util.ocp.common.trino_table_exists", return_value=True)
     @patch("masu.database.ocp_report_db_accessor.pkgutil.get_data")
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_raw_sql_query"
-    )
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_raw_sql_query")
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query")
     def test_populate_distributed_cost_sql_skips_gpu_full_month_when_no_gpu_data(
         self,
         mock_trino_execute,
@@ -1638,9 +1421,7 @@ class OCPReportDBAccessorTest(MasuTestCase):
         """Test that GPU distribution is skipped when cluster has no GPU data (day 2)."""
         start_date = self.dh.this_month_start.date()
         end_date = self.dh.this_month_end.date()
-        masu_database, mock_jinja = self._setup_distributed_cost_sql_mocks(
-            start_date, end_date
-        )
+        masu_database, mock_jinja = self._setup_distributed_cost_sql_mocks(start_date, end_date)
 
         with (
             self.accessor as acc,
@@ -1672,12 +1453,8 @@ class OCPReportDBAccessorTest(MasuTestCase):
     )
     @patch("masu.util.ocp.common.trino_table_exists", return_value=True)
     @patch("masu.database.ocp_report_db_accessor.pkgutil.get_data")
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_raw_sql_query"
-    )
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_raw_sql_query")
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query")
     def test_populate_distributed_cost_sql_gpu_runs_for_previous_month(
         self,
         mock_trino_execute,
@@ -1689,9 +1466,7 @@ class OCPReportDBAccessorTest(MasuTestCase):
         """Test that GPU distribution runs when directly processing a previous month."""
         start_date = self.dh.last_month_start.date()
         end_date = self.dh.last_month_end.date()
-        masu_database, mock_jinja = self._setup_distributed_cost_sql_mocks(
-            start_date, end_date
-        )
+        masu_database, mock_jinja = self._setup_distributed_cost_sql_mocks(start_date, end_date)
 
         with self.accessor as acc:
             acc.prepare_query = mock_jinja
@@ -1710,15 +1485,9 @@ class OCPReportDBAccessorTest(MasuTestCase):
 
     @patch("masu.util.ocp.common.trino_table_exists", return_value=True)
     @patch("masu.database.ocp_report_db_accessor.pkgutil.get_data")
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_raw_sql_query"
-    )
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query"
-    )
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.report_periods_for_provider_uuid"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_raw_sql_query")
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query")
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.report_periods_for_provider_uuid")
     def test_populate_distributed_cost_sql_gpu_skipped_no_prev_report_period(
         self,
         mock_report_periods,
@@ -1730,9 +1499,7 @@ class OCPReportDBAccessorTest(MasuTestCase):
         """Test that GPU distribution is skipped when no report period exists for previous month."""
         start_date = self.dh.this_month_start.date()
         end_date = self.dh.this_month_end.date()
-        masu_database, mock_jinja = self._setup_distributed_cost_sql_mocks(
-            start_date, end_date
-        )
+        masu_database, mock_jinja = self._setup_distributed_cost_sql_mocks(start_date, end_date)
 
         # Return current month report period, but None for previous month
         current_report_period = Mock()
@@ -1773,9 +1540,7 @@ class OCPReportDBAccessorTest(MasuTestCase):
         """
         populated_keys = []
         with schema_context(self.schema):
-            enabled_tags = EnabledTagKeys.objects.filter(
-                provider_type=Provider.PROVIDER_OCP, enabled=True
-            )
+            enabled_tags = EnabledTagKeys.objects.filter(provider_type=Provider.PROVIDER_OCP, enabled=True)
             for enabled_tag in enabled_tags:
                 tag_count = OCPUsageLineItemDailySummary.objects.filter(
                     all_labels__has_key=enabled_tag.key,
@@ -1795,12 +1560,8 @@ class OCPReportDBAccessorTest(MasuTestCase):
                 usage_start__lte=self.dh.today,
             ).count()
             TagMapping.objects.create(parent=parent_obj, child=child_obj)
-            self.accessor.update_line_item_daily_summary_with_tag_mapping(
-                self.dh.this_month_start, self.dh.today
-            )
-            expected_parent_count = (
-                parent_count + child_count
-            ) - value_precedence_count
+            self.accessor.update_line_item_daily_summary_with_tag_mapping(self.dh.this_month_start, self.dh.today)
+            expected_parent_count = (parent_count + child_count) - value_precedence_count
             actual_parent_count = OCPUsageLineItemDailySummary.objects.filter(
                 all_labels__has_key=parent_key,
                 usage_start__gte=self.dh.this_month_start,
@@ -1842,17 +1603,11 @@ class OCPReportDBAccessorTest(MasuTestCase):
         Test that if a valid report period is not found.
         """
         with self.accessor as acc:
-            result = acc.populate_tag_based_costs(
-                "1970-10-01", "1970-10-31", self.ocp_provider_uuid, {}, {}
-            )
+            result = acc.populate_tag_based_costs("1970-10-01", "1970-10-31", self.ocp_provider_uuid, {}, {})
             self.assertFalse(result)
 
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
-    )
-    @patch(
-        "masu.database.ocp_report_db_accessor.trino_table_exists", return_value=False
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
+    @patch("masu.database.ocp_report_db_accessor.trino_table_exists", return_value=False)
     def test_monthly_populate_vm_tag_based_costs(self, mock_trino_exists, mock_psql):
         """Test monthly populated of vm count tag based costs."""
         test_mapping = {
@@ -1874,12 +1629,8 @@ class OCPReportDBAccessorTest(MasuTestCase):
             )
             mock_psql.assert_called()
 
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query"
-    )
-    @patch(
-        "masu.database.ocp_report_db_accessor.trino_table_exists", return_value=False
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query")
+    @patch("masu.database.ocp_report_db_accessor.trino_table_exists", return_value=False)
     def test_hourly_populate_vm_tag_based_costs(self, mock_trino_exists, mock_trino):
         """Test hourly populated of vm count tag based costs."""
         cluster_params = {"cluster_id": "test", "cluster_alias": "test"}
@@ -1902,9 +1653,7 @@ class OCPReportDBAccessorTest(MasuTestCase):
             )
             mock_trino.assert_called()
 
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
     def test_no_tag_rates(self, mock_psql):
         """Test monthly populated of vm count tag based costs."""
         with self.accessor as acc:
@@ -1917,24 +1666,16 @@ class OCPReportDBAccessorTest(MasuTestCase):
             )
             mock_psql.assert_not_called()
 
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._populate_virtualization_ui_summary_table"
-    )
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._populate_gpu_ui_summary_table_with_usage_only"
-    )
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._populate_virtualization_ui_summary_table")
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._populate_gpu_ui_summary_table_with_usage_only")
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
     def test_populate_ui_summary_tables_skips_virtualization_for_previous_month(
         self, mock_psql, mock_gpu_populate, mock_virt_populate
     ):
         """Test that virtualization UI table is not populated when summarizing previous month (not current month)."""
         start_date = self.dh.last_month_start.date()
         end_date = self.dh.last_month_end.date()
-        summary_range = SummaryRangeConfig(
-            start_date=start_date, end_date=end_date, summarize_previous_month=True
-        )
+        summary_range = SummaryRangeConfig(start_date=start_date, end_date=end_date, summarize_previous_month=True)
         source_uuid = self.ocp_provider_uuid
         with self.accessor as acc:
             acc.populate_ui_summary_tables(summary_range, source_uuid, tables=[])
@@ -1946,12 +1687,8 @@ class OCPReportDBAccessorTest(MasuTestCase):
         "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.schema_exists_trino",
         return_value=False,
     )
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
-    )
-    def test__populate_virtualization_ui_summary_table_no_trino_schema(
-        self, mock_psql, mock_schema_exists
-    ):
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
+    def test__populate_virtualization_ui_summary_table_no_trino_schema(self, mock_psql, mock_schema_exists):
         """Test that sql is not run when the trino schema does not exist."""
         with self.accessor as acc:
             acc._populate_virtualization_ui_summary_table({})
@@ -1965,12 +1702,8 @@ class OCPReportDBAccessorTest(MasuTestCase):
         "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.schema_exists_trino",
         return_value=True,
     )
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
-    )
-    def test__populate_virtualization_ui_summary_table_no_trino_table(
-        self, mock_psql, *args
-    ):
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
+    def test__populate_virtualization_ui_summary_table_no_trino_table(self, mock_psql, *args):
         """Test that sql is not run when the trino table does not exist."""
         with self.accessor as acc:
             acc._populate_virtualization_ui_summary_table({})
@@ -1984,12 +1717,8 @@ class OCPReportDBAccessorTest(MasuTestCase):
         "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.schema_exists_trino",
         return_value=True,
     )
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
-    )
-    def test__populate_virtualization_ui_summary_table_no_sql_param(
-        self, mock_psql, *args
-    ):
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
+    def test__populate_virtualization_ui_summary_table_no_sql_param(self, mock_psql, *args):
         """Test that sql is not run when sql params are not provided."""
         with self.accessor as acc:
             acc._populate_virtualization_ui_summary_table({})
@@ -2007,24 +1736,16 @@ class OCPReportDBAccessorTest(MasuTestCase):
         "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query",
         side_effect=Exception,
     )
-    def test__populate_virtualization_ui_summary_table_all_true_raise_error(
-        self, mock_psql, *args
-    ):
+    def test__populate_virtualization_ui_summary_table_all_true_raise_error(self, mock_psql, *args):
         """Test that sql is run when all requirements are met. Test uses an exception to show that sql would be run."""
         with self.accessor as acc:
             with self.assertRaises(Exception):
-                acc._populate_virtualization_ui_summary_table(
-                    {"start_date": "1970-01-01"}
-                )
+                acc._populate_virtualization_ui_summary_table({"start_date": "1970-01-01"})
             mock_psql.assert_called()
 
     @patch("masu.database.ocp_report_db_accessor.trino_table_exists", return_value=True)
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query"
-    )
-    def test_monthly_populate_gpu_tag_based_costs(
-        self, mock_trino_exec, mock_trino_exists
-    ):
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query")
+    def test_monthly_populate_gpu_tag_based_costs(self, mock_trino_exec, mock_trino_exists):
         """Test monthly population of GPU tag based costs."""
         # Tag key is the GPU vendor, value_rates contains model-specific rates
         test_mapping = {
@@ -2052,12 +1773,8 @@ class OCPReportDBAccessorTest(MasuTestCase):
         return_value=False,
     )
     @patch("masu.database.ocp_report_db_accessor.trino_table_exists", return_value=True)
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query"
-    )
-    def test_gpu_cost_model_disabled_by_unleash(
-        self, mock_trino_exec, mock_trino_exists, mock_feature_flag
-    ):
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query")
+    def test_gpu_cost_model_disabled_by_unleash(self, mock_trino_exec, mock_trino_exists, mock_feature_flag):
         """Test that GPU cost model is skipped when Unleash flag is disabled."""
         # Tag key is the GPU vendor, value_rates contains model-specific rates
         test_mapping = {
@@ -2082,12 +1799,8 @@ class OCPReportDBAccessorTest(MasuTestCase):
             mock_trino_exec.assert_not_called()
 
     @patch("masu.database.ocp_report_db_accessor.trino_table_exists", return_value=True)
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query"
-    )
-    def test_gpu_tag_based_costs_skipped_when_no_cluster_id(
-        self, mock_trino_exec, mock_trino_exists
-    ):
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query")
+    def test_gpu_tag_based_costs_skipped_when_no_cluster_id(self, mock_trino_exec, mock_trino_exists):
         """Test that GPU tag based costs are skipped when cluster_id is None."""
         test_mapping = {
             metric_constants.OCP_GPU_MONTH: [
@@ -2122,9 +1835,7 @@ class OCPReportDBAccessorTest(MasuTestCase):
         """
         from jinjasql import JinjaSql
 
-        sql_template = pkgutil.get_data(
-            "masu.database", "trino_sql/openshift/cost_model/monthly_cost_gpu.sql"
-        )
+        sql_template = pkgutil.get_data("masu.database", "trino_sql/openshift/cost_model/monthly_cost_gpu.sql")
         sql_template = sql_template.decode("utf-8")
 
         params = {
@@ -2149,9 +1860,7 @@ class OCPReportDBAccessorTest(MasuTestCase):
             # no default_rate — this is the case that previously caused rows to vanish
         }
 
-        rendered_sql, _ = JinjaSql(param_style="named").prepare_query(
-            sql_template, params
-        )
+        rendered_sql, _ = JinjaSql(param_style="named").prepare_query(sql_template, params)
 
         # gpu.gpu_model_name = 'A100' must appear exactly once: in the CASE WHEN expression.
         # Any additional occurrence means the restrictive WHERE filter was not removed.
@@ -2165,9 +1874,7 @@ class OCPReportDBAccessorTest(MasuTestCase):
         """COST-7243: on-prem (self-hosted/PG) GPU template must not filter unmatched models."""
         from jinjasql import JinjaSql
 
-        sql_template = pkgutil.get_data(
-            "masu.database", "self_hosted_sql/openshift/cost_model/monthly_cost_gpu.sql"
-        )
+        sql_template = pkgutil.get_data("masu.database", "self_hosted_sql/openshift/cost_model/monthly_cost_gpu.sql")
         sql_template = sql_template.decode("utf-8")
 
         params = {
@@ -2190,9 +1897,7 @@ class OCPReportDBAccessorTest(MasuTestCase):
             "value_rates": {"A100": 5000},
         }
 
-        rendered_sql, _ = JinjaSql(param_style="named").prepare_query(
-            sql_template, params
-        )
+        rendered_sql, _ = JinjaSql(param_style="named").prepare_query(sql_template, params)
 
         # gpu.gpu_model_name = 'A100' must appear exactly once: in the CASE WHEN expression.
         self.assertEqual(rendered_sql.count("gpu.gpu_model_name = 'A100'"), 1)
@@ -2217,21 +1922,13 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
         }
 
     @patch("masu.database.ocp_report_db_accessor.trino_table_exists")
-    def test_reporting_period_has_gpu_data_returns_false_when_no_table(
-        self, mock_trino_table_exists
-    ):
+    def test_reporting_period_has_gpu_data_returns_false_when_no_table(self, mock_trino_table_exists):
         """Test that _reporting_period_has_gpu_data returns False when GPU table does not exist."""
         mock_trino_table_exists.return_value = False
         with self.accessor as acc:
-            self.assertFalse(
-                acc._reporting_period_has_gpu_data(
-                    self.ocp_provider.uuid, self.dh.last_month_start
-                )
-            )
+            self.assertFalse(acc._reporting_period_has_gpu_data(self.ocp_provider.uuid, self.dh.last_month_start))
 
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query")
     @patch("masu.database.ocp_report_db_accessor.trino_table_exists")
     def test_reporting_period_has_gpu_data_returns_false_when_source_not_in_partitions(
         self, mock_trino_table_exists, mock_trino_raw_sql
@@ -2240,15 +1937,9 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
         mock_trino_table_exists.return_value = True
         mock_trino_raw_sql.return_value = [[0]]
         with self.accessor as acc:
-            self.assertFalse(
-                acc._reporting_period_has_gpu_data(
-                    self.ocp_provider.uuid, self.dh.last_month_start
-                )
-            )
+            self.assertFalse(acc._reporting_period_has_gpu_data(self.ocp_provider.uuid, self.dh.last_month_start))
 
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query")
     @patch("masu.database.ocp_report_db_accessor.trino_table_exists")
     def test_reporting_period_has_gpu_data_returns_true_when_source_has_data(
         self, mock_trino_table_exists, mock_trino_raw_sql
@@ -2257,15 +1948,9 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
         mock_trino_table_exists.return_value = True
         mock_trino_raw_sql.return_value = [[3]]
         with self.accessor as acc:
-            self.assertTrue(
-                acc._reporting_period_has_gpu_data(
-                    self.ocp_provider.uuid, self.dh.last_month_start
-                )
-            )
+            self.assertTrue(acc._reporting_period_has_gpu_data(self.ocp_provider.uuid, self.dh.last_month_start))
 
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query")
     @patch("masu.database.ocp_report_db_accessor.trino_table_exists")
     def test_reporting_period_has_gpu_data_filters_by_year_and_month(
         self, mock_trino_table_exists, mock_trino_raw_sql
@@ -2285,9 +1970,7 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
         )
 
     @override_settings(ONPREM=True)
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_raw_sql_query")
     @patch("masu.database.ocp_report_db_accessor.trino_table_exists")
     def test_reporting_period_has_gpu_data_onprem_queries_postgres_not_hive(
         self, mock_trino_table_exists, mock_execute_raw_sql
@@ -2296,23 +1979,15 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
         mock_trino_table_exists.return_value = True
         mock_execute_raw_sql.return_value = [(2,)]
         with self.accessor as acc:
-            self.assertTrue(
-                acc._reporting_period_has_gpu_data(
-                    self.ocp_provider.uuid, self.dh.last_month_start
-                )
-            )
+            self.assertTrue(acc._reporting_period_has_gpu_data(self.ocp_provider.uuid, self.dh.last_month_start))
         mock_execute_raw_sql.assert_called_once()
         executed_sql = mock_execute_raw_sql.call_args[0][1]
-        self.assertIn(
-            f'"{self.schema}"."openshift_gpu_usage_line_items_daily"', executed_sql
-        )
+        self.assertIn(f'"{self.schema}"."openshift_gpu_usage_line_items_daily"', executed_sql)
         self.assertNotIn("hive.", executed_sql)
         self.assertNotIn("$partitions", executed_sql)
 
     @override_settings(ONPREM=True)
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_raw_sql_query")
     @patch("masu.database.ocp_report_db_accessor.trino_table_exists")
     def test_reporting_period_has_gpu_data_onprem_returns_false_when_zero_rows(
         self, mock_trino_table_exists, mock_execute_raw_sql
@@ -2320,18 +1995,12 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
         mock_trino_table_exists.return_value = True
         mock_execute_raw_sql.return_value = [(0,)]
         with self.accessor as acc:
-            self.assertFalse(
-                acc._reporting_period_has_gpu_data(
-                    self.ocp_provider.uuid, self.dh.last_month_start
-                )
-            )
+            self.assertFalse(acc._reporting_period_has_gpu_data(self.ocp_provider.uuid, self.dh.last_month_start))
 
     @patch("masu.database.ocp_report_db_accessor.get_cluster_id_from_provider")
     @patch("masu.database.ocp_report_db_accessor.CostModelDBAccessor")
     @patch("masu.database.ocp_report_db_accessor.trino_table_exists")
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query")
     def test_populate_gpu_ui_summary_table_with_usage_only_no_cluster_id(
         self,
         mock_trino_raw_sql,
@@ -2347,9 +2016,7 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
         mock_cost_model_instance.metric_to_tag_params_map = {}
         mock_cost_model_accessor.return_value = mock_cost_model_instance
         with (
-            patch.object(
-                self.accessor, "_execute_trino_multipart_sql_query"
-            ) as mock_trino_exec,
+            patch.object(self.accessor, "_execute_trino_multipart_sql_query") as mock_trino_exec,
             self.accessor as acc,
         ):
             acc._populate_gpu_ui_summary_table_with_usage_only(self.sql_params)
@@ -2357,9 +2024,7 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
             mock_get_cluster_id.assert_called_once_with(self.ocp_provider.uuid)
 
     @patch("masu.database.ocp_report_db_accessor.trino_table_exists")
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query")
     def test_populate_gpu_ui_summary_table_with_usage_only_no_gpu_data(
         self, mock_trino_raw_sql, mock_trino_table_exists
     ):
@@ -2367,9 +2032,7 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
         mock_trino_table_exists.return_value = True
         mock_trino_raw_sql.return_value = [[0]]  # No GPU data (count is 0)
         with (
-            patch.object(
-                self.accessor, "_execute_trino_multipart_sql_query"
-            ) as mock_trino_exec,
+            patch.object(self.accessor, "_execute_trino_multipart_sql_query") as mock_trino_exec,
             self.accessor as acc,
         ):
             acc._populate_gpu_ui_summary_table_with_usage_only(self.sql_params)
@@ -2377,9 +2040,7 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
 
     @patch("masu.database.ocp_report_db_accessor.CostModelDBAccessor")
     @patch("masu.database.ocp_report_db_accessor.trino_table_exists")
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query")
     def test_populate_gpu_ui_summary_table_with_usage_only_has_cost_model(
         self, mock_trino_raw_sql, mock_trino_table_exists, mock_cost_model_accessor
     ):
@@ -2388,18 +2049,12 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
         mock_trino_raw_sql.return_value = [[5]]  # Source has GPU data (5 partitions)
         mock_cost_model_instance = Mock()
         mock_cost_model_instance.metric_to_tag_params_map = {
-            metric_constants.OCP_GPU_MONTH: [
-                {"rate_type": "Infrastructure", "tag_key": "nvidia"}
-            ]
+            metric_constants.OCP_GPU_MONTH: [{"rate_type": "Infrastructure", "tag_key": "nvidia"}]
         }
-        mock_cost_model_accessor.return_value.__enter__ = Mock(
-            return_value=mock_cost_model_instance
-        )
+        mock_cost_model_accessor.return_value.__enter__ = Mock(return_value=mock_cost_model_instance)
         mock_cost_model_accessor.return_value.__exit__ = Mock(return_value=False)
         with (
-            patch.object(
-                self.accessor, "_execute_trino_multipart_sql_query"
-            ) as mock_trino_exec,
+            patch.object(self.accessor, "_execute_trino_multipart_sql_query") as mock_trino_exec,
             self.accessor as acc,
         ):
             acc._populate_gpu_ui_summary_table_with_usage_only(self.sql_params)
@@ -2409,9 +2064,7 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
     @patch("masu.database.ocp_report_db_accessor.get_cluster_id_from_provider")
     @patch("masu.database.ocp_report_db_accessor.CostModelDBAccessor")
     @patch("masu.database.ocp_report_db_accessor.trino_table_exists")
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query")
     def test_populate_gpu_ui_summary_table_with_usage_only_no_cost_model(
         self,
         mock_trino_raw_sql,
@@ -2429,18 +2082,14 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
         mock_get_cluster_id.return_value = "test-cluster-id"
         mock_get_cluster_alias.return_value = "test-cluster-alias"
         with (
-            patch.object(
-                self.accessor, "_execute_trino_multipart_sql_query"
-            ) as mock_trino_exec,
+            patch.object(self.accessor, "_execute_trino_multipart_sql_query") as mock_trino_exec,
             self.accessor as acc,
         ):
             acc._populate_gpu_ui_summary_table_with_usage_only(self.sql_params)
             mock_trino_exec.assert_called_once()
 
     @patch("masu.database.ocp_report_db_accessor.trino_table_exists")
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query")
     def test_populate_gpu_ui_summary_table_with_usage_only_source_in_trino_returns_zero(
         self, mock_trino_raw_sql, mock_trino_table_exists
     ):
@@ -2448,9 +2097,7 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
         mock_trino_table_exists.return_value = True
         mock_trino_raw_sql.return_value = [[0]]  # Source has no GPU data (count is 0)
         with (
-            patch.object(
-                self.accessor, "_execute_trino_multipart_sql_query"
-            ) as mock_trino_exec,
+            patch.object(self.accessor, "_execute_trino_multipart_sql_query") as mock_trino_exec,
             self.accessor as acc,
         ):
             acc._populate_gpu_ui_summary_table_with_usage_only(self.sql_params)
@@ -2460,9 +2107,7 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
     @patch("masu.database.ocp_report_db_accessor.get_cluster_alias_from_cluster_id")
     @patch("masu.database.ocp_report_db_accessor.get_cluster_id_from_provider")
     @patch("masu.database.ocp_report_db_accessor.CostModelDBAccessor")
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.get_sql_folder_name"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.get_sql_folder_name")
     @patch("reporting.provider.ocp.self_hosted_models.OCPGPUUsageLineItem")
     def test_populate_gpu_ui_summary_table_onprem_no_gpu_data(
         self,
@@ -2476,9 +2121,7 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
         mock_get_sql_folder.return_value = "self_hosted_sql"
         mock_gpu_model.objects.filter.return_value.exists.return_value = False
         with (
-            patch.object(
-                self.accessor, "_prepare_and_execute_raw_sql_query"
-            ) as mock_psql_exec,
+            patch.object(self.accessor, "_prepare_and_execute_raw_sql_query") as mock_psql_exec,
             self.accessor as acc,
         ):
             acc._populate_gpu_ui_summary_table_with_usage_only(self.sql_params)
@@ -2487,9 +2130,7 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
     @patch("masu.database.ocp_report_db_accessor.get_cluster_alias_from_cluster_id")
     @patch("masu.database.ocp_report_db_accessor.get_cluster_id_from_provider")
     @patch("masu.database.ocp_report_db_accessor.CostModelDBAccessor")
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.get_sql_folder_name"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.get_sql_folder_name")
     @patch("reporting.provider.ocp.self_hosted_models.OCPGPUUsageLineItem")
     def test_populate_gpu_ui_summary_table_onprem_with_gpu_data(
         self,
@@ -2508,9 +2149,7 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
         mock_get_cluster_alias.return_value = "test-cluster-alias"
         mock_gpu_model.objects.filter.return_value.exists.return_value = True
         with (
-            patch.object(
-                self.accessor, "_prepare_and_execute_raw_sql_query"
-            ) as mock_psql_exec,
+            patch.object(self.accessor, "_prepare_and_execute_raw_sql_query") as mock_psql_exec,
             self.accessor as acc,
         ):
             acc._populate_gpu_ui_summary_table_with_usage_only(self.sql_params)
@@ -2519,9 +2158,7 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
     @patch("masu.database.ocp_report_db_accessor.get_cluster_alias_from_cluster_id")
     @patch("masu.database.ocp_report_db_accessor.get_cluster_id_from_provider")
     @patch("masu.database.ocp_report_db_accessor.CostModelDBAccessor")
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.get_sql_folder_name"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.get_sql_folder_name")
     @patch("reporting.provider.ocp.self_hosted_models.OCPGPUUsageLineItem")
     def test_populate_gpu_ui_summary_table_onprem_with_cost_model(
         self,
@@ -2535,18 +2172,14 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
         mock_get_sql_folder.return_value = "self_hosted_sql"
         mock_cost_model_instance = Mock()
         mock_cost_model_instance.metric_to_tag_params_map = {
-            metric_constants.OCP_GPU_MONTH: [
-                {"rate_type": "Infrastructure", "tag_key": "nvidia"}
-            ]
+            metric_constants.OCP_GPU_MONTH: [{"rate_type": "Infrastructure", "tag_key": "nvidia"}]
         }
         mock_cost_model_accessor.return_value = mock_cost_model_instance
         mock_get_cluster_id.return_value = "test-cluster-id"
         mock_get_cluster_alias.return_value = "test-cluster-alias"
         mock_gpu_model.objects.filter.return_value.exists.return_value = True
         with (
-            patch.object(
-                self.accessor, "_prepare_and_execute_raw_sql_query"
-            ) as mock_psql_exec,
+            patch.object(self.accessor, "_prepare_and_execute_raw_sql_query") as mock_psql_exec,
             self.accessor as acc,
         ):
             acc._populate_gpu_ui_summary_table_with_usage_only(self.sql_params)
@@ -2555,9 +2188,7 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
 
     @patch("masu.database.ocp_report_db_accessor.get_cluster_id_from_provider")
     @patch("masu.database.ocp_report_db_accessor.CostModelDBAccessor")
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.get_sql_folder_name"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.get_sql_folder_name")
     @patch("reporting.provider.ocp.self_hosted_models.OCPGPUUsageLineItem")
     def test_populate_gpu_ui_summary_table_onprem_no_cluster_id(
         self,
@@ -2574,9 +2205,7 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
         mock_get_cluster_id.return_value = None  # No cluster ID
         mock_gpu_model.objects.filter.return_value.exists.return_value = True
         with (
-            patch.object(
-                self.accessor, "_prepare_and_execute_raw_sql_query"
-            ) as mock_psql_exec,
+            patch.object(self.accessor, "_prepare_and_execute_raw_sql_query") as mock_psql_exec,
             self.accessor as acc,
         ):
             acc._populate_gpu_ui_summary_table_with_usage_only(self.sql_params)
@@ -2587,12 +2216,8 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
         "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.schema_exists_trino",
         return_value=True,
     )
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
-    )
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query")
     def test_populate_virtualization_ui_summary_table_uses_source_in_trino_table(
         self, mock_trino_sql, mock_psql, mock_schema_exists, mock_trino_table_exists
     ):
@@ -2612,12 +2237,8 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
         "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.schema_exists_trino",
         return_value=True,
     )
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
-    )
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_raw_sql_query")
     def test_populate_virtualization_ui_summary_table_vm_table_not_in_source(
         self, mock_trino_sql, mock_psql, mock_schema_exists, mock_trino_table_exists
     ):
@@ -2626,9 +2247,7 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
         mock_trino_sql.return_value = [[0]]  # Source NOT found in VM table (count is 0)
         with (
             patch.object(self.accessor, "_execute_trino_multipart_sql_query"),
-            patch(
-                "masu.database.ocp_report_db_accessor.pkgutil.get_data"
-            ) as mock_get_data,
+            patch("masu.database.ocp_report_db_accessor.pkgutil.get_data") as mock_get_data,
             self.accessor as acc,
         ):
             mock_get_data.return_value = b"SELECT 1"
@@ -2637,6 +2256,4 @@ class OCPReportDBAccessorGPUUITest(MasuTestCase):
             calls = mock_get_data.call_args_list
             # Should use populate_vm_tmp_table.sql (fallback) instead of populate_vm_tmp_table_with_vm_report.sql
             sql_files_used = [str(call) for call in calls]
-            self.assertTrue(
-                any("populate_vm_tmp_table.sql" in s for s in sql_files_used)
-            )
+            self.assertTrue(any("populate_vm_tmp_table.sql" in s for s in sql_files_used))

--- a/koku/masu/test/database/test_ocp_report_db_accessor.py
+++ b/koku/masu/test/database/test_ocp_report_db_accessor.py
@@ -1024,16 +1024,26 @@ class OCPReportDBAccessorTest(MasuTestCase):
             "source_uuid": self.ocp_test_provider_uuid,
             "populate": True,
         }
+        delete_monthly = [get_pkgutil_values("delete_monthly_cost_model_rate_type.sql"), default_sql_params]
+        delete_rtu = [
+            get_pkgutil_values("distribute_cost/delete_distributed_rates_to_usage.sql"),
+            default_sql_params,
+        ]
         side_effect = [
-            [get_pkgutil_values("delete_monthly_cost_model_rate_type.sql"), default_sql_params],
-            [get_pkgutil_values("distribute_platform_cost.sql"), default_sql_params],
-            [get_pkgutil_values("delete_monthly_cost_model_rate_type.sql"), default_sql_params],
-            [get_pkgutil_values("distribute_worker_cost.sql"), default_sql_params],
-            [get_pkgutil_values("delete_monthly_cost_model_rate_type.sql"), default_sql_params],
-            [get_pkgutil_values("distribute_unattributed_storage_cost.sql"), default_sql_params],
-            [get_pkgutil_values("delete_monthly_cost_model_rate_type.sql"), default_sql_params],
-            [get_pkgutil_values("distribute_unattributed_network_cost.sql"), default_sql_params],
-            [get_pkgutil_values("delete_monthly_cost_model_rate_type.sql"), default_sql_params],
+            delete_monthly,
+            delete_rtu,
+            [get_pkgutil_values("distribute_cost/distribute_platform_cost_per_rate.sql"), default_sql_params],
+            delete_monthly,
+            delete_rtu,
+            [get_pkgutil_values("distribute_cost/distribute_worker_cost_per_rate.sql"), default_sql_params],
+            delete_monthly,
+            delete_rtu,
+            [get_pkgutil_values("distribute_cost/distribute_unattributed_storage_per_rate.sql"), default_sql_params],
+            delete_monthly,
+            delete_rtu,
+            [get_pkgutil_values("distribute_cost/distribute_unattributed_network_per_rate.sql"), default_sql_params],
+            delete_monthly,
+            delete_rtu,
         ]
         mock_jinja = Mock()
         mock_jinja.side_effect = side_effect

--- a/koku/masu/test/processor/ocp/test_ocp_report_db_cleaner.py
+++ b/koku/masu/test/processor/ocp/test_ocp_report_db_cleaner.py
@@ -151,6 +151,37 @@ class OCPReportDBCleanerTest(MasuTestCase):
         self.assertIn(first_period.id, [item.get("usage_period_id") for item in removed_data])
         self.assertIn(str(first_period.report_period_start), [item.get("interval_start") for item in removed_data])
 
+    def test_purge_expired_report_data_for_provider_deletes_rtu(self):
+        """Test that purging by provider_uuid also removes rates_to_usage rows."""
+        from reporting.provider.ocp.models import RatesToUsage
+
+        with schema_context(self.schema):
+            rp = (
+                OCPUsageReportPeriod.objects.filter(provider_id=self.ocp_provider_uuid)
+                .order_by("-report_period_start")
+                .first()
+            )
+            if not rp:
+                self.skipTest("No report period for OCP provider")
+            RatesToUsage.objects.filter(source_uuid=self.ocp_provider_uuid).delete()
+            RatesToUsage.objects.create(
+                source_uuid=self.ocp_provider_uuid,
+                usage_start=rp.report_period_start.date(),
+                usage_end=rp.report_period_start.date(),
+                cluster_id="test-cluster",
+                custom_name="test-rate",
+                metric_type="cpu_usage",
+                report_period_id=rp.id,
+            )
+            self.assertEqual(RatesToUsage.objects.filter(source_uuid=self.ocp_provider_uuid).count(), 1)
+
+        cleaner = OCPReportDBCleaner(self.schema)
+        cleaner.purge_expired_report_data(provider_uuid=self.ocp_provider_uuid)
+
+        with schema_context(self.schema):
+            remaining = RatesToUsage.objects.filter(source_uuid=self.ocp_provider_uuid).count()
+            self.assertEqual(remaining, 0, "RTU rows must be deleted when purging provider data")
+
     def test_purge_expired_report_data_no_args(self):
         """Test that the provider_uuid deletes all data for the provider."""
         cleaner = OCPReportDBCleaner(self.schema)

--- a/koku/masu/test/processor/ocp/test_phase2_rates_to_usage.py
+++ b/koku/masu/test/processor/ocp/test_phase2_rates_to_usage.py
@@ -715,9 +715,9 @@ class TestUpdaterOrchestration(_ReportPeriodMixin, MasuTestCase):
         self.assertLess(call_order.index("rtu"), call_order.index("agg"))
         self.assertNotIn("usage", call_order)
 
-    # TC-44: aggregate before distribute
+    # TC-44: Phase 4 inversion -- distribute before aggregate
     @_make_orchestration_patches()
-    def test_orchestration_order_aggregate_before_distribute(
+    def test_orchestration_order_distribute_before_aggregate(
         self,
         mock_ff,
         mock_load,
@@ -742,7 +742,7 @@ class TestUpdaterOrchestration(_ReportPeriodMixin, MasuTestCase):
 
         self.assertIn("agg", call_order)
         self.assertIn("dist", call_order)
-        self.assertLess(call_order.index("agg"), call_order.index("dist"))
+        self.assertLess(call_order.index("dist"), call_order.index("agg"))
 
     # TC-53: single-pass INSERT (no rate_type loop)
     @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
@@ -1283,7 +1283,7 @@ class TestOrchestrationOrder(_ReportPeriodMixin, MasuTestCase):
             cost_model_update=True,
         )
 
-    # TC-R20-01: full ordering: rtu -> monthly -> vm -> agg -> markup -> dist
+    # TC-R20-01: Phase 4 ordering: rtu -> monthly -> vm -> dist -> agg -> markup
     @_make_orchestration_patches(rtu_enabled=True)
     def test_rtu_enabled_full_ordering(
         self,
@@ -1298,7 +1298,7 @@ class TestOrchestrationOrder(_ReportPeriodMixin, MasuTestCase):
         mock_monthly,
         mock_dist,
     ):
-        """R20: Orchestration order is rtu -> monthly -> vm -> agg -> markup -> dist."""
+        """R20: Phase 4 order is rtu -> monthly -> vm -> dist -> agg -> markup."""
         call_order = []
         mock_rtu.side_effect = lambda *a: call_order.append("rtu")
         mock_monthly.side_effect = lambda *a: call_order.append("monthly")
@@ -1311,7 +1311,7 @@ class TestOrchestrationOrder(_ReportPeriodMixin, MasuTestCase):
         sr = self._make_summary_range()
         updater.update_summary_cost_model_costs(sr)
 
-        expected = ["rtu", "monthly", "vm", "agg", "markup", "dist"]
+        expected = ["rtu", "monthly", "vm", "dist", "agg", "markup"]
         self.assertEqual(call_order, expected, f"R20: expected {expected}, got {call_order}")
         mock_usage.assert_not_called()
         mock_cleanup.assert_not_called()

--- a/koku/masu/test/processor/ocp/test_phase2_rates_to_usage.py
+++ b/koku/masu/test/processor/ocp/test_phase2_rates_to_usage.py
@@ -96,7 +96,9 @@ class TestPriceListSwitch(MasuTestCase):
         with self._get_accessor() as accessor:
             infra = accessor.infrastructure_rates
             self.assertIsInstance(infra, dict)
-            self.assertGreater(len(infra), 0, "Expected at least one infrastructure rate")
+            self.assertGreater(
+                len(infra), 0, "Expected at least one infrastructure rate"
+            )
 
     # TC-05: supplementary_rates populated (BAC-2)
     def test_supplementary_rates_populated(self):
@@ -110,7 +112,9 @@ class TestPriceListSwitch(MasuTestCase):
         from cost_models.models import Rate
         from masu.database.cost_model_db_accessor import CostModelDBAccessor
 
-        with CostModelDBAccessor(self.schema, self.ocp_provider_uuid, price_list_effective_on=None) as accessor:
+        with CostModelDBAccessor(
+            self.schema, self.ocp_provider_uuid, price_list_effective_on=None
+        ) as accessor:
             if not accessor.cost_model:
                 self.skipTest("No cost model for OCP provider")
 
@@ -128,7 +132,9 @@ class TestPriceListSwitch(MasuTestCase):
             for (metric, cost_type), expected_sum in expected.items():
                 self.assertIn(metric, pl, f"Missing metric {metric}")
                 tiered = pl[metric]["tiered_rates"]
-                self.assertIn(cost_type, tiered, f"Missing cost_type {cost_type} for {metric}")
+                self.assertIn(
+                    cost_type, tiered, f"Missing cost_type {cost_type} for {metric}"
+                )
                 actual_sum = tiered[cost_type][0]["value"]
                 self.assertAlmostEqual(actual_sum, expected_sum, places=10)
 
@@ -137,7 +143,9 @@ class TestPriceListSwitch(MasuTestCase):
         from cost_models.models import Rate
         from masu.database.cost_model_db_accessor import CostModelDBAccessor
 
-        with CostModelDBAccessor(self.schema, self.ocp_provider_uuid, price_list_effective_on=None) as accessor:
+        with CostModelDBAccessor(
+            self.schema, self.ocp_provider_uuid, price_list_effective_on=None
+        ) as accessor:
             if not accessor.cost_model:
                 self.skipTest("No cost model for OCP provider")
 
@@ -158,7 +166,9 @@ class TestPriceListSwitch(MasuTestCase):
 
             pl = accessor.price_list
             for metric in tag_only_metrics:
-                self.assertNotIn(metric, pl, f"Tag-only metric {metric} should not be in price_list")
+                self.assertNotIn(
+                    metric, pl, f"Tag-only metric {metric} should not be in price_list"
+                )
 
     # TC-08: unknown provider returns {}
     def test_price_list_empty_for_unknown_provider(self):
@@ -180,14 +190,18 @@ class TestCostModelIdExtraction(MasuTestCase):
 
     # TC-10: cost_model_id populated when cost model exists
     def test_cost_model_id_populated(self):
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
         self.assertIsNotNone(updater._cost_model_id)
 
     # TC-11: cost_model_id None when no cost model
     @patch("masu.processor.ocp.ocp_cost_model_cost_updater.CostModelDBAccessor")
     def test_cost_model_id_none_when_no_cost_model(self, mock_accessor):
         _setup_no_cost_model_mock(mock_accessor)
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
         self.assertIsNone(updater._cost_model_id)
 
 
@@ -200,11 +214,15 @@ class TestSyncTestRateRows(MasuTestCase):
         from cost_models.models import PriceList
 
         with schema_context(self.schema):
-            cm = CostModel.objects.filter(costmodelmap__provider_uuid=self.ocp_provider_uuid).first()
+            cm = CostModel.objects.filter(
+                costmodelmap__provider_uuid=self.ocp_provider_uuid
+            ).first()
             if not cm:
                 self.skipTest("No cost model for OCP provider")
             pl_count = PriceList.objects.filter(cost_model_maps__cost_model=cm).count()
-            self.assertGreater(pl_count, 0, "sync_test_rate_rows should create at least one PriceList")
+            self.assertGreater(
+                pl_count, 0, "sync_test_rate_rows should create at least one PriceList"
+            )
 
     # TC-13: creates Rate rows matching JSON entries
     def test_sync_creates_rate_rows(self):
@@ -212,10 +230,14 @@ class TestSyncTestRateRows(MasuTestCase):
         from cost_models.models import Rate
 
         with schema_context(self.schema):
-            cm = CostModel.objects.filter(costmodelmap__provider_uuid=self.ocp_provider_uuid).first()
+            cm = CostModel.objects.filter(
+                costmodelmap__provider_uuid=self.ocp_provider_uuid
+            ).first()
             if not cm:
                 self.skipTest("No cost model for OCP provider")
-            rate_count = Rate.objects.filter(price_list__cost_model_maps__cost_model=cm).count()
+            rate_count = Rate.objects.filter(
+                price_list__cost_model_maps__cost_model=cm
+            ).count()
             json_rate_count = len(cm.rates) if isinstance(cm.rates, list) else 0
             self.assertEqual(
                 rate_count,
@@ -232,17 +254,23 @@ class TestSyncTestRateRows(MasuTestCase):
         from masu.database.cost_model_db_accessor import CostModelDBAccessor
 
         with schema_context(self.schema):
-            cm = CostModel.objects.filter(costmodelmap__provider_uuid=self.ocp_provider_uuid).first()
+            cm = CostModel.objects.filter(
+                costmodelmap__provider_uuid=self.ocp_provider_uuid
+            ).first()
             if not cm:
                 self.skipTest("No cost model for OCP provider")
 
-        with CostModelDBAccessor(self.schema, self.ocp_provider_uuid, price_list_effective_on=None) as accessor:
+        with CostModelDBAccessor(
+            self.schema, self.ocp_provider_uuid, price_list_effective_on=None
+        ) as accessor:
             pl_before = accessor.price_list
 
         with schema_context(self.schema):
             sync_test_rate_rows(cm)
 
-        with CostModelDBAccessor(self.schema, self.ocp_provider_uuid, price_list_effective_on=None) as accessor:
+        with CostModelDBAccessor(
+            self.schema, self.ocp_provider_uuid, price_list_effective_on=None
+        ) as accessor:
             pl_after = accessor.price_list
 
         self.assertEqual(
@@ -258,7 +286,9 @@ class TestSyncTestRateRows(MasuTestCase):
         from cost_models.models import Rate
 
         with schema_context(self.schema):
-            cm = CostModel.objects.filter(costmodelmap__provider_uuid=self.ocp_provider_uuid).first()
+            cm = CostModel.objects.filter(
+                costmodelmap__provider_uuid=self.ocp_provider_uuid
+            ).first()
             if not cm:
                 self.skipTest("No cost model for OCP provider")
             rate = Rate.objects.filter(
@@ -424,7 +454,9 @@ class TestPopulateUsageRatesToUsage(_ReportPeriodMixin, MasuTestCase):
         )
 
     # TC-22: executes INSERT SQL
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
+    )
     def test_populate_rtu_executes_insert_sql(self, mock_execute):
         with OCPReportDBAccessor(self.schema) as accessor:
             rp = self._get_report_period(accessor)
@@ -435,7 +467,9 @@ class TestPopulateUsageRatesToUsage(_ReportPeriodMixin, MasuTestCase):
         self.assertEqual(kwargs.get("operation"), "INSERT")
 
     # TC-23: cost_model_id included as string
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
+    )
     def test_populate_rtu_includes_cost_model_id(self, mock_execute):
         cost_model_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
         with OCPReportDBAccessor(self.schema) as accessor:
@@ -446,7 +480,9 @@ class TestPopulateUsageRatesToUsage(_ReportPeriodMixin, MasuTestCase):
         self.assertEqual(sql_params["cost_model_id"], cost_model_id)
 
     # TC-25: distribution is now read from cost_model table in SQL, not passed as param
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
+    )
     def test_populate_rtu_no_distribution_param(self, mock_execute):
         with OCPReportDBAccessor(self.schema) as accessor:
             rp = self._get_report_period(accessor)
@@ -456,7 +492,9 @@ class TestPopulateUsageRatesToUsage(_ReportPeriodMixin, MasuTestCase):
         self.assertNotIn("distribution", sql_params)
 
     # TC-25b: cluster_cost_per_hour NOT in sql_params (resolved via SQL JOIN)
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
+    )
     def test_populate_rtu_no_cluster_cost_per_hour_param(self, mock_execute):
         with OCPReportDBAccessor(self.schema) as accessor:
             rp = self._get_report_period(accessor)
@@ -466,7 +504,9 @@ class TestPopulateUsageRatesToUsage(_ReportPeriodMixin, MasuTestCase):
         self.assertNotIn("cluster_cost_per_hour", sql_params)
 
     # TC-25c: rate_type and per-metric params NOT in sql_params (single-pass reads from DB)
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
+    )
     def test_populate_rtu_no_rate_type_or_metric_params(self, mock_execute):
         with OCPReportDBAccessor(self.schema) as accessor:
             rp = self._get_report_period(accessor)
@@ -486,7 +526,9 @@ class TestAggregateRatesToDailySummary(_ReportPeriodMixin, MasuTestCase):
     """Test aggregate_rates_to_daily_summary accessor method (BAC-6)."""
 
     # TC-29: executes INSERT SQL
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
+    )
     def test_aggregate_rtu_executes_insert_sql(self, mock_execute):
         dh = DateHelper()
         with OCPReportDBAccessor(self.schema) as accessor:
@@ -502,7 +544,9 @@ class TestAggregateRatesToDailySummary(_ReportPeriodMixin, MasuTestCase):
         self.assertEqual(kwargs.get("operation"), "INSERT")
 
     # TC-30: params match window
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
+    )
     def test_aggregate_rtu_params_match_window(self, mock_execute):
         dh = DateHelper()
         with OCPReportDBAccessor(self.schema) as accessor:
@@ -525,7 +569,9 @@ class TestValidateRatesToUsage(_ReportPeriodMixin, MasuTestCase):
     """Test validate_rates_against_daily_summary accessor method (BAC-7)."""
 
     # TC-31: executes SELECT SQL
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
+    )
     def test_validate_rtu_executes_select_sql(self, mock_execute):
         dh = DateHelper()
         with OCPReportDBAccessor(self.schema) as accessor:
@@ -541,7 +587,9 @@ class TestValidateRatesToUsage(_ReportPeriodMixin, MasuTestCase):
         self.assertEqual(kwargs.get("operation"), "VALIDATION_QUERY")
 
     # TC-32: params include report_period_id
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
+    )
     def test_validate_rtu_params_include_report_period(self, mock_execute):
         dh = DateHelper()
         with OCPReportDBAccessor(self.schema) as accessor:
@@ -659,7 +707,9 @@ class TestUpdaterOrchestration(_ReportPeriodMixin, MasuTestCase):
         mock_monthly,
         mock_dist,
     ):
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
         sr = self._make_summary_range()
         updater.update_summary_cost_model_costs(sr)
         mock_rtu.assert_called_once_with(sr.start_date, sr.end_date)
@@ -680,7 +730,9 @@ class TestUpdaterOrchestration(_ReportPeriodMixin, MasuTestCase):
         mock_monthly,
         mock_dist,
     ):
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
         sr = self._make_summary_range()
         updater.update_summary_cost_model_costs(sr)
         mock_dist.assert_called_once_with(sr)
@@ -705,7 +757,9 @@ class TestUpdaterOrchestration(_ReportPeriodMixin, MasuTestCase):
         mock_rtu.side_effect = lambda *a: call_order.append("rtu")
         mock_dist.side_effect = lambda *a: call_order.append("dist")
 
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
         sr = self._make_summary_range()
         updater.update_summary_cost_model_costs(sr)
 
@@ -734,7 +788,9 @@ class TestUpdaterOrchestration(_ReportPeriodMixin, MasuTestCase):
         mock_monthly.side_effect = lambda *a: call_order.append("monthly")
         mock_dist.side_effect = lambda *a: call_order.append("dist")
 
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
         sr = self._make_summary_range()
         updater.update_summary_cost_model_costs(sr)
 
@@ -744,10 +800,14 @@ class TestUpdaterOrchestration(_ReportPeriodMixin, MasuTestCase):
         self.assertLess(call_order.index("monthly"), call_order.index("dist"))
 
     # TC-53: single-pass INSERT (no rate_type loop)
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
+    )
     @patch.object(OCPCostModelCostUpdater, "_ensure_rates_to_usage_partitions")
     def test_rtu_insert_single_pass(self, mock_partitions, mock_execute):
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
         if not updater._cost_model_id:
             self.skipTest("No cost model for OCP provider")
         rp = self._get_report_period()
@@ -760,8 +820,12 @@ class TestUpdaterOrchestration(_ReportPeriodMixin, MasuTestCase):
 
         updater._update_usage_rates_to_usage(start_date, end_date)
 
-        insert_calls = [c for c in mock_execute.call_args_list if c[1].get("operation") == "INSERT"]
-        self.assertEqual(len(insert_calls), 1, "Single-pass: exactly one INSERT call expected")
+        insert_calls = [
+            c for c in mock_execute.call_args_list if c[1].get("operation") == "INSERT"
+        ]
+        self.assertEqual(
+            len(insert_calls), 1, "Single-pass: exactly one INSERT call expected"
+        )
         sql_params = insert_calls[0][0][2]
         self.assertIn("cost_model_id", sql_params)
         self.assertNotIn("cluster_cost_per_hour", sql_params)
@@ -783,7 +847,9 @@ class TestUpdaterOrchestration(_ReportPeriodMixin, MasuTestCase):
         mock_dist,
     ):
         """Phase 3 SQL writes to rates_to_usage, so flag OFF still uses RTU pipeline."""
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
         sr = self._make_summary_range()
         updater.update_summary_cost_model_costs(sr)
         mock_rtu.assert_called_once()
@@ -797,17 +863,25 @@ class TestPartitionWiring(MasuTestCase):
     # TC-45: calls _handle_partitions
     @patch.object(OCPCostModelCostUpdater, "_handle_partitions")
     def test_partition_wiring_calls_handle_partitions(self, mock_handle):
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
         dh = DateHelper()
-        updater._ensure_rates_to_usage_partitions(dh.this_month_start, dh.this_month_end)
+        updater._ensure_rates_to_usage_partitions(
+            dh.this_month_start, dh.this_month_end
+        )
         mock_handle.assert_called_once()
 
     # TC-46: correct table name
     @patch.object(OCPCostModelCostUpdater, "_handle_partitions")
     def test_partition_wiring_correct_table_name(self, mock_handle):
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
         dh = DateHelper()
-        updater._ensure_rates_to_usage_partitions(dh.this_month_start, dh.this_month_end)
+        updater._ensure_rates_to_usage_partitions(
+            dh.this_month_start, dh.this_month_end
+        )
         args, kwargs = mock_handle.call_args
         self.assertEqual(args[1], ["rates_to_usage"])
 
@@ -816,36 +890,58 @@ class TestSkipPaths(MasuTestCase):
     """Test skip paths when report period or cost_model_id is missing (BAC-10, BAC-12)."""
 
     # TC-47: RTU insert skips with log when no report period
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.report_periods_for_provider_uuid")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.report_periods_for_provider_uuid"
+    )
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
+    )
     @patch.object(OCPCostModelCostUpdater, "_ensure_rates_to_usage_partitions")
-    def test_rtu_insert_skips_no_report_period(self, mock_partitions, mock_execute, mock_rp):
+    def test_rtu_insert_skips_no_report_period(
+        self, mock_partitions, mock_execute, mock_rp
+    ):
         mock_rp.return_value = None
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
         dh = DateHelper()
         with self.assertLogs("masu.processor.ocp", level="INFO") as cm:
             updater._update_usage_rates_to_usage(dh.this_month_start, dh.this_month_end)
         mock_execute.assert_not_called()
-        self.assertTrue(any("skipping rates_to_usage insert" in msg for msg in cm.output))
+        self.assertTrue(
+            any("skipping rates_to_usage insert" in msg for msg in cm.output)
+        )
 
     # TC-48: RTU aggregate skips with log when no report period
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.report_periods_for_provider_uuid")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.report_periods_for_provider_uuid"
+    )
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
+    )
     def test_rtu_aggregate_skips_no_report_period(self, mock_execute, mock_rp):
         mock_rp.return_value = None
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
         dh = DateHelper()
         with self.assertLogs("masu.processor.ocp", level="INFO") as cm:
-            updater._aggregate_rates_to_daily_summary(dh.this_month_start, dh.this_month_end)
+            updater._aggregate_rates_to_daily_summary(
+                dh.this_month_start, dh.this_month_end
+            )
         mock_execute.assert_not_called()
-        self.assertTrue(any("skipping rates_to_usage aggregation" in msg for msg in cm.output))
+        self.assertTrue(
+            any("skipping rates_to_usage aggregation" in msg for msg in cm.output)
+        )
 
     # TC-49: RTU insert skips when no cost_model_id
     @patch.object(OCPCostModelCostUpdater, "_ensure_rates_to_usage_partitions")
     @patch("masu.processor.ocp.ocp_cost_model_cost_updater.CostModelDBAccessor")
     def test_rtu_insert_skips_no_cost_model_id(self, mock_accessor, mock_part):
         _setup_no_cost_model_mock(mock_accessor)
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
         self.assertIsNone(updater._cost_model_id)
 
         dh = DateHelper()
@@ -856,14 +952,18 @@ class TestSkipPaths(MasuTestCase):
     @patch("masu.processor.ocp.ocp_cost_model_cost_updater.CostModelDBAccessor")
     def test_rtu_aggregate_skips_no_cost_model_id(self, mock_accessor):
         _setup_no_cost_model_mock(mock_accessor)
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
         self.assertIsNone(updater._cost_model_id)
 
         dh = DateHelper()
         with patch(
             "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
         ) as mock_exec:
-            updater._aggregate_rates_to_daily_summary(dh.this_month_start, dh.this_month_end)
+            updater._aggregate_rates_to_daily_summary(
+                dh.this_month_start, dh.this_month_end
+            )
             mock_exec.assert_not_called()
 
 
@@ -875,7 +975,9 @@ class TestPurgeWiring(MasuTestCase):
     @patch("masu.processor.ocp.ocp_report_db_cleaner.cascade_delete")
     @patch("masu.processor.ocp.ocp_report_db_cleaner.PartitionedTable")
     @patch("masu.processor.ocp.ocp_report_db_cleaner.OCPReportDBAccessor")
-    def test_rates_to_usage_in_cleaner_base_list(self, mock_accessor_cls, mock_pt, mock_cascade, mock_delete):
+    def test_rates_to_usage_in_cleaner_base_list(
+        self, mock_accessor_cls, mock_pt, mock_cascade, mock_delete
+    ):
         """Verify partition cleanup includes rates_to_usage table."""
         from datetime import date as date_cls
         from unittest.mock import MagicMock
@@ -887,7 +989,9 @@ class TestPurgeWiring(MasuTestCase):
         mock_qs.__iter__ = MagicMock(return_value=iter([]))
         mock_qs.query = MagicMock()
         mock_accessor.get_report_periods_before_date.return_value = mock_qs
-        mock_accessor._table_map = {"line_item_daily_summary": "reporting_ocpusagelineitem_daily_summary"}
+        mock_accessor._table_map = {
+            "line_item_daily_summary": "reporting_ocpusagelineitem_daily_summary"
+        }
 
         cleaner = OCPReportDBCleaner(self.schema)
         cleaner.purge_expired_report_data_by_date(date_cls(2020, 1, 1))
@@ -931,7 +1035,9 @@ class TestRTUCostBreakdownAPI(_ReportPeriodMixin, MasuTestCase):
         from api.models import Provider
         from api.report.ocp.provider_map import OCPProviderMap
 
-        cls.provider_map = OCPProviderMap(Provider.PROVIDER_OCP, "costs", cls.schema_name)
+        cls.provider_map = OCPProviderMap(
+            Provider.PROVIDER_OCP, "costs", cls.schema_name
+        )
         cls.cost_term = (
             cls.provider_map.cloud_infrastructure_cost
             + cls.provider_map.markup_cost
@@ -946,7 +1052,9 @@ class TestRTUCostBreakdownAPI(_ReportPeriodMixin, MasuTestCase):
         return {
             "source_uuid": self.ocp_provider.uuid,
             "usage_start__gte": (
-                rp.report_period_start.date() if hasattr(rp.report_period_start, "date") else rp.report_period_start
+                rp.report_period_start.date()
+                if hasattr(rp.report_period_start, "date")
+                else rp.report_period_start
             ),
         }
 
@@ -967,7 +1075,9 @@ class TestRTUCostBreakdownAPI(_ReportPeriodMixin, MasuTestCase):
             dh = DateHelper()
             start_date = rp.report_period_start
             end_date = dh.month_end(start_date)
-            updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+            updater = OCPCostModelCostUpdater(
+                schema=self.schema, provider=self.ocp_provider
+            )
             if not updater._cost_model_id:
                 self.skipTest("No cost model for OCP provider")
             updater._load_rates(start_date)
@@ -981,7 +1091,9 @@ class TestRTUCostBreakdownAPI(_ReportPeriodMixin, MasuTestCase):
                     usage_start__gte=rp_filter["usage_start__gte"],
                 ).count()
 
-        self.assertGreater(count, 0, "RTU table should have rows for OCP-on-Prem provider")
+        self.assertGreater(
+            count, 0, "RTU table should have rows for OCP-on-Prem provider"
+        )
 
     # TC-E2E-02: RTU aggregated costs reconcile with daily summary
     def test_rtu_sums_match_daily_summary_cost_model_columns(self):
@@ -1006,7 +1118,9 @@ class TestRTUCostBreakdownAPI(_ReportPeriodMixin, MasuTestCase):
                 .values("metric_type")
                 .annotate(total=Sum("calculated_cost"))
             )
-            rtu_by_metric = {row["metric_type"]: row["total"] or Decimal(0) for row in rtu_agg}
+            rtu_by_metric = {
+                row["metric_type"]: row["total"] or Decimal(0) for row in rtu_agg
+            }
 
             ds_agg = OCPUsageLineItemDailySummary.objects.filter(
                 source_uuid=rp_filter["source_uuid"],
@@ -1070,7 +1184,9 @@ class TestRTUCostBreakdownAPI(_ReportPeriodMixin, MasuTestCase):
 
         with tenant_context(self.tenant):
             cost = (
-                OCPUsageLineItemDailySummary.objects.filter(usage_start__gte=self.dh.this_month_start.date())
+                OCPUsageLineItemDailySummary.objects.filter(
+                    usage_start__gte=self.dh.this_month_start.date()
+                )
                 .annotate(
                     infra_exchange_rate=Value(Decimal(1)),
                     exchange_rate=Value(Decimal(1)),
@@ -1080,7 +1196,13 @@ class TestRTUCostBreakdownAPI(_ReportPeriodMixin, MasuTestCase):
             )
             expected_total = cost if cost is not None else 0
 
-        total = data.get("meta", {}).get("total", {}).get("cost", {}).get("total", {}).get("value", 0)
+        total = (
+            data.get("meta", {})
+            .get("total", {})
+            .get("cost", {})
+            .get("total", {})
+            .get("value", 0)
+        )
         self.assertNotEqual(total, Decimal(0), "API should return non-zero cost total")
         self.assertAlmostEqual(total, expected_total, 6)
 
@@ -1120,14 +1242,18 @@ class TestRTUCostBreakdownAPI(_ReportPeriodMixin, MasuTestCase):
             if found_nonzero:
                 break
 
-        self.assertTrue(found_nonzero, "At least one project should have non-zero cost-model costs")
+        self.assertTrue(
+            found_nonzero, "At least one project should have non-zero cost-model costs"
+        )
 
 
 class TestRTURateResolution(_ReportPeriodMixin, MasuTestCase):
     """drift5-sql: Verify RTU rows resolve rate_id and custom_name from Rate table."""
 
     # TC-D5-01: SQL params include cost_model_id (regression guard)
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
+    )
     def test_populate_rtu_params_include_cost_model_id(self, mock_execute):
         """populate_usage_rates_to_usage passes cost_model_id in SQL params."""
         dh = DateHelper()
@@ -1223,7 +1349,9 @@ class TestRTURateResolution(_ReportPeriodMixin, MasuTestCase):
             ).count()
         if total == 0:
             self.skipTest("No RTU rows to check")
-        self.assertGreaterEqual(total, with_rate, "Total RTU rows should be >= rows with rate FK")
+        self.assertGreaterEqual(
+            total, with_rate, "Total RTU rows should be >= rows with rate FK"
+        )
 
     # TC-D5-05: RTU custom_name falls back to metric name when no Rate exists
     def test_rtu_custom_name_fallback(self):
@@ -1242,7 +1370,9 @@ class TestRTURateResolution(_ReportPeriodMixin, MasuTestCase):
                 rate__isnull=True,
             ).first()
         if not rtu_row:
-            self.skipTest("No RTU rows with NULL rate FK (all rows may have matching Rate)")
+            self.skipTest(
+                "No RTU rows with NULL rate FK (all rows may have matching Rate)"
+            )
         known_identifiers = (
             set(metric_constants.COST_MODEL_USAGE_RATES)
             | set(metric_constants.COST_MODEL_MONTHLY_RATES)
@@ -1257,7 +1387,9 @@ class TestRTURateResolution(_ReportPeriodMixin, MasuTestCase):
                 "Node_Core_Hour",
             }
         )
-        name_recognised = any(ident in rtu_row.custom_name for ident in known_identifiers)
+        name_recognised = any(
+            ident in rtu_row.custom_name for ident in known_identifiers
+        )
         self.assertTrue(
             name_recognised,
             f"RTU custom_name '{rtu_row.custom_name}' should contain a known metric or cost type as fallback",
@@ -1306,12 +1438,16 @@ class TestOrchestrationOrder(_ReportPeriodMixin, MasuTestCase):
         mock_vm.side_effect = lambda *a: call_order.append("vm")
         mock_dist.side_effect = lambda *a: call_order.append("dist")
 
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
         sr = self._make_summary_range()
         updater.update_summary_cost_model_costs(sr)
 
         expected = ["rtu", "monthly", "vm", "dist"]
-        self.assertEqual(call_order, expected, f"R20: expected {expected}, got {call_order}")
+        self.assertEqual(
+            call_order, expected, f"R20: expected {expected}, got {call_order}"
+        )
         mock_usage.assert_not_called()
         mock_cleanup.assert_not_called()
 
@@ -1331,7 +1467,9 @@ class TestOrchestrationOrder(_ReportPeriodMixin, MasuTestCase):
         mock_dist,
     ):
         """R20: distribute_costs_and_update_ui_summary is invoked."""
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
         sr = self._make_summary_range()
         updater.update_summary_cost_model_costs(sr)
 
@@ -1354,7 +1492,9 @@ class TestOrchestrationOrder(_ReportPeriodMixin, MasuTestCase):
     ):
         """R20: When cost_model_id is None, cleanup runs instead of RTU insert.
         Monthly/vm/dist still run (agg+markup are inside dist)."""
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
         updater._cost_model_id = None
         sr = self._make_summary_range()
         updater.update_summary_cost_model_costs(sr)
@@ -1403,7 +1543,9 @@ class TestPriceListValidityGuard(_ReportPeriodMixin, MasuTestCase):
         """When _load_rates finds no effective PL, RTU is skipped and stale rows cleaned."""
         from datetime import date
 
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
 
         def fake_load(start_date):
             updater._infra_rates = {}
@@ -1443,7 +1585,9 @@ class TestPriceListValidityGuard(_ReportPeriodMixin, MasuTestCase):
         mock_dist,
     ):
         """When _price_list_effective_on is None (feature flag disabled), RTU proceeds normally."""
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
 
         def fake_load(start_date):
             updater._infra_rates = {}
@@ -1481,7 +1625,9 @@ class TestPriceListValidityGuard(_ReportPeriodMixin, MasuTestCase):
         """When _load_rates finds an effective PL with rates, RTU proceeds."""
         from datetime import date
 
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
 
         def fake_load(start_date):
             updater._infra_rates = {"cpu_core_usage_per_hour": 0.2}
@@ -1506,7 +1652,9 @@ class TestPriceListValidityGuard(_ReportPeriodMixin, MasuTestCase):
         """_load_rates must propagate price_list_effective_on from the accessor."""
         from datetime import date
 
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
         self.assertIsNone(updater._price_list_effective_on)
 
         test_date = date(2026, 4, 1)
@@ -1523,7 +1671,9 @@ class TestPriceListValidityGuard(_ReportPeriodMixin, MasuTestCase):
         """When DISABLE_PRICE_LIST flag is on, _price_list_effective_on should be None."""
         from datetime import date
 
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
         updater._load_rates(date(2026, 4, 1))
 
         self.assertIsNone(updater._price_list_effective_on)
@@ -1546,7 +1696,9 @@ class TestPriceListValidityGuard(_ReportPeriodMixin, MasuTestCase):
         """Tag-based cost paths must be skipped when no PL covers the month."""
         from datetime import date
 
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
 
         def fake_load(start_date):
             updater._infra_rates = {}
@@ -1577,7 +1729,9 @@ class TestTwoMonthOrchestration(_ReportPeriodMixin, MasuTestCase):
         from datetime import datetime
         from datetime import timezone
 
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
         if not updater._cost_model_id:
             self.skipTest("No cost model for OCP provider")
 
@@ -1611,7 +1765,9 @@ class TestTwoMonthOrchestration(_ReportPeriodMixin, MasuTestCase):
 
         with patch.object(updater, "_load_rates", side_effect=fake_load), patch.object(
             updater, "_update_usage_rates_to_usage"
-        ) as mock_rtu, patch.object(updater, "_aggregate_rates_to_daily_summary"), patch.object(
+        ) as mock_rtu, patch.object(
+            updater, "_aggregate_rates_to_daily_summary"
+        ), patch.object(
             updater, "_update_vm_usage_costs"
         ), patch.object(
             updater, "_cleanup_stale_rtu_costs"
@@ -1652,31 +1808,45 @@ class TestRoutingMetricType(MasuTestCase):
         self.assertEqual(result, "storage")
 
     def test_node_cpu_distribution(self):
-        result = OCPReportDBAccessor._get_routing_metric_type(cost_type="Node", distribution="cpu")
+        result = OCPReportDBAccessor._get_routing_metric_type(
+            cost_type="Node", distribution="cpu"
+        )
         self.assertEqual(result, "cpu")
 
     def test_node_memory_distribution(self):
-        result = OCPReportDBAccessor._get_routing_metric_type(cost_type="Node", distribution="memory")
+        result = OCPReportDBAccessor._get_routing_metric_type(
+            cost_type="Node", distribution="memory"
+        )
         self.assertEqual(result, "memory")
 
     def test_cluster_cpu_distribution(self):
-        result = OCPReportDBAccessor._get_routing_metric_type(cost_type="Cluster", distribution="cpu")
+        result = OCPReportDBAccessor._get_routing_metric_type(
+            cost_type="Cluster", distribution="cpu"
+        )
         self.assertEqual(result, "cpu")
 
     def test_node_core_month_memory(self):
-        result = OCPReportDBAccessor._get_routing_metric_type(cost_type="Node_Core_Month", distribution="memory")
+        result = OCPReportDBAccessor._get_routing_metric_type(
+            cost_type="Node_Core_Month", distribution="memory"
+        )
         self.assertEqual(result, "memory")
 
     def test_gpu_metric_name(self):
-        result = OCPReportDBAccessor._get_routing_metric_type(metric_name="gpu_cost_per_month")
+        result = OCPReportDBAccessor._get_routing_metric_type(
+            metric_name="gpu_cost_per_month"
+        )
         self.assertEqual(result, "gpu")
 
     def test_vm_metric_returns_cpu(self):
-        result = OCPReportDBAccessor._get_routing_metric_type(metric_name="vm_cost_per_hour")
+        result = OCPReportDBAccessor._get_routing_metric_type(
+            metric_name="vm_cost_per_hour"
+        )
         self.assertEqual(result, "cpu")
 
     def test_ocp_vm_cost_type(self):
-        result = OCPReportDBAccessor._get_routing_metric_type(cost_type="OCP_VM", distribution="cpu")
+        result = OCPReportDBAccessor._get_routing_metric_type(
+            cost_type="OCP_VM", distribution="cpu"
+        )
         self.assertEqual(result, "cpu")
 
     def test_usage_type_passthrough(self):
@@ -1694,7 +1864,9 @@ class TestRoutingMetricType(MasuTestCase):
         self.assertEqual(result, "cpu")
 
     def test_node_core_hour(self):
-        result = OCPReportDBAccessor._get_routing_metric_type(cost_type="Node_Core_Hour", distribution="cpu")
+        result = OCPReportDBAccessor._get_routing_metric_type(
+            cost_type="Node_Core_Hour", distribution="cpu"
+        )
         self.assertEqual(result, "cpu")
 
 
@@ -1712,7 +1884,9 @@ class TestPopulateMarkupRatesToUsage(_ReportPeriodMixin, MasuTestCase):
     """
 
     # TC-60: SQL params correct
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
+    )
     def test_markup_rtu_sql_params_correct(self, mock_execute):
         """BAC-16: populate_markup_rates_to_usage passes all required SQL params."""
         dh = DateHelper()
@@ -1737,14 +1911,22 @@ class TestPopulateMarkupRatesToUsage(_ReportPeriodMixin, MasuTestCase):
         )
         for key in required_keys:
             self.assertIn(key, sql_params, f"Missing SQL param: {key}")
-        self.assertNotIn("report_period_id", sql_params, "report_period_id is read from source table, not passed")
+        self.assertNotIn(
+            "report_period_id",
+            sql_params,
+            "report_period_id is read from source table, not passed",
+        )
         self.assertEqual(sql_params["source_uuid"], self.ocp_provider_uuid)
         self.assertEqual(sql_params["start_date"], dh.this_month_start.date())
         self.assertEqual(sql_params["end_date"], dh.this_month_end.date())
-        self.assertEqual(sql_params["cost_model_id"], "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+        self.assertEqual(
+            sql_params["cost_model_id"], "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        )
 
     # TC-61: operation is INSERT
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
+    )
     def test_markup_rtu_operation_is_insert(self, mock_execute):
         """BAC-16: SQL execution uses operation='INSERT'."""
         dh = DateHelper()
@@ -1761,7 +1943,9 @@ class TestPopulateMarkupRatesToUsage(_ReportPeriodMixin, MasuTestCase):
         self.assertEqual(kwargs.get("operation"), "INSERT")
 
     # TC-66: SQL file loaded from correct path
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
+    )
     @patch("masu.database.ocp_report_db_accessor.pkgutil.get_data")
     def test_markup_rtu_sql_file_loaded(self, mock_pkgutil, mock_execute):
         """BAC-16: SQL loaded from insert_markup_rates_to_usage.sql."""
@@ -1794,9 +1978,13 @@ class TestPopulateMarkupRatesToUsage(_ReportPeriodMixin, MasuTestCase):
         insert_start = sql_text.index("INSERT INTO")
         delete_block = sql_text[delete_start:insert_start]
         self.assertIn("metric_type", delete_block, "DELETE must filter by metric_type")
-        self.assertIn("'markup'", delete_block, "DELETE must scope to metric_type = 'markup'")
+        self.assertIn(
+            "'markup'", delete_block, "DELETE must scope to metric_type = 'markup'"
+        )
         self.assertNotIn(
-            "report_period_id", delete_block, "DELETE must NOT filter by report_period_id (avoid global wipe)"
+            "report_period_id",
+            delete_block,
+            "DELETE must NOT filter by report_period_id (avoid global wipe)",
         )
 
 
@@ -1813,7 +2001,9 @@ class TestMarkupRTUIntegration(_ReportPeriodMixin, MasuTestCase):
         rp = self._get_report_period()
         start_date = rp.report_period_start.date()
         end_date = DateHelper().month_end(rp.report_period_start).date()
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
         if not updater._cost_model_id:
             self.skipTest("No cost model for OCP provider")
         with schema_context(self.schema):
@@ -1856,8 +2046,15 @@ class TestMarkupRTUIntegration(_ReportPeriodMixin, MasuTestCase):
                 usage_start__lte=end_date,
                 label_hash__isnull=False,
             ).first()
-        self.assertIsNotNone(row, "Seed succeeded but no markup RTU rows with label_hash — pipeline regression")
-        self.assertEqual(len(row.label_hash), 64, f"Expected 64-char SHA-256 hash, got {len(row.label_hash)} chars")
+        self.assertIsNotNone(
+            row,
+            "Seed succeeded but no markup RTU rows with label_hash — pipeline regression",
+        )
+        self.assertEqual(
+            len(row.label_hash),
+            64,
+            f"Expected 64-char SHA-256 hash, got {len(row.label_hash)} chars",
+        )
 
     # TC-72: markup RTU rows do NOT affect daily summary cost_model_* columns
     def test_markup_rtu_no_aggregation_impact(self):
@@ -1865,7 +2062,9 @@ class TestMarkupRTUIntegration(_ReportPeriodMixin, MasuTestCase):
         rp = self._get_report_period()
         start_date = rp.report_period_start.date()
         end_date = DateHelper().month_end(rp.report_period_start).date()
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
         if not updater._cost_model_id:
             self.skipTest("No cost model for OCP provider")
         updater._load_rates(start_date)
@@ -1920,9 +2119,15 @@ class TestMarkupRTUIntegration(_ReportPeriodMixin, MasuTestCase):
                 usage_start__lte=end_date,
                 metric_type__in=["cpu", "memory", "storage"],
             ).count()
-        self.assertGreater(usage_count_before, 0, "Seed succeeded but no usage RTU rows — pipeline regression")
+        self.assertGreater(
+            usage_count_before,
+            0,
+            "Seed succeeded but no usage RTU rows — pipeline regression",
+        )
 
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
         updater._update_markup_cost(start_date, end_date)
 
         with schema_context(self.schema):
@@ -1949,7 +2154,9 @@ class TestMarkupRTUIntegration(_ReportPeriodMixin, MasuTestCase):
                 usage_start__gte=start_date,
                 usage_start__lte=end_date,
             ).first()
-        self.assertIsNotNone(row, "Seed succeeded but no markup RTU rows — pipeline regression")
+        self.assertIsNotNone(
+            row, "Seed succeeded but no markup RTU rows — pipeline regression"
+        )
         self.assertIsNone(row.rate_id, "Markup rows should have rate_id=None")
         self.assertEqual(row.custom_name, "Markup")
         self.assertEqual(row.cost_model_rate_type, "Infrastructure")
@@ -1966,7 +2173,9 @@ class TestValidateRatesToUsageFix(_ReportPeriodMixin, MasuTestCase):
     """Test validate_rates_against_daily_summary returns results (BAC-24, BAC-25)."""
 
     # TC-65: validate_rates_against_daily_summary uses VALIDATION_QUERY operation
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
+    )
     def test_validation_uses_validation_query_operation(self, mock_execute):
         """BAC-24: operation='VALIDATION_QUERY' is passed so cursor.fetchall() returns results."""
         dh = DateHelper()
@@ -1998,7 +2207,10 @@ class TestValidateRatesToUsageFix(_ReportPeriodMixin, MasuTestCase):
                 self.ocp_provider_uuid,
                 rp.id,
             )
-        self.assertIsNotNone(result, "validate_rates_against_daily_summary should return a list, not None")
+        self.assertIsNotNone(
+            result,
+            "validate_rates_against_daily_summary should return a list, not None",
+        )
         self.assertIsInstance(result, list, "Result should be a list of diff rows")
 
 
@@ -2030,7 +2242,11 @@ class TestPrometheusMetricRegistration(MasuTestCase):
         """BAC-22: RTU metrics use only ['provider_type'] label to avoid cardinality explosion."""
         from masu import prometheus_stats
 
-        for metric_name in ("RTU_POPULATE_DURATION", "RTU_AGGREGATE_DURATION", "RTU_MARKUP_DURATION"):
+        for metric_name in (
+            "RTU_POPULATE_DURATION",
+            "RTU_AGGREGATE_DURATION",
+            "RTU_MARKUP_DURATION",
+        ):
             metric = getattr(prometheus_stats, metric_name)
             self.assertEqual(
                 metric._labelnames,
@@ -2044,34 +2260,53 @@ class TestPrometheusTimingWrappers(_ReportPeriodMixin, MasuTestCase):
 
     # TC-82: _update_usage_rates_to_usage observes RTU_POPULATE_DURATION
     @patch("masu.processor.ocp.ocp_cost_model_cost_updater.RTU_POPULATE_DURATION")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_usage_rates_to_usage")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_usage_rates_to_usage"
+    )
     def test_rtu_populate_observes_histogram(self, mock_populate, mock_histogram):
         """BAC-23: _update_usage_rates_to_usage records duration in RTU_POPULATE_DURATION."""
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
         if not updater._cost_model_id:
             self.skipTest("No cost model for OCP provider")
         dh = DateHelper()
         updater._load_rates(dh.this_month_start.date())
-        updater._update_usage_rates_to_usage(dh.this_month_start.date(), dh.this_month_end.date())
+        updater._update_usage_rates_to_usage(
+            dh.this_month_start.date(), dh.this_month_end.date()
+        )
         mock_histogram.labels.assert_called_with(provider_type=self.ocp_provider.type)
         observe_args = mock_histogram.labels.return_value.observe.call_args
-        self.assertIsNotNone(observe_args, "observe() was never called on RTU_POPULATE_DURATION")
+        self.assertIsNotNone(
+            observe_args, "observe() was never called on RTU_POPULATE_DURATION"
+        )
         observed_duration = observe_args[0][0]
         self.assertGreaterEqual(observed_duration, 0, "Duration must be non-negative")
 
     # TC-83: _update_markup_cost observes RTU_MARKUP_DURATION
     @patch("masu.processor.ocp.ocp_cost_model_cost_updater.RTU_MARKUP_DURATION")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_markup_rates_to_usage")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_markup_rates_to_usage"
+    )
     @patch("masu.processor.ocp.ocp_cost_model_cost_updater.CostModelDBAccessor")
-    def test_markup_rtu_observes_histogram(self, mock_cost_accessor, _mock_rtu, mock_histogram):
+    def test_markup_rtu_observes_histogram(
+        self, mock_cost_accessor, _mock_rtu, mock_histogram
+    ):
         """BAC-23: _update_markup_cost records duration in RTU_MARKUP_DURATION."""
-        mock_cost_accessor.return_value.__enter__.return_value.markup = {"value": 10, "unit": "percent"}
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        mock_cost_accessor.return_value.__enter__.return_value.markup = {
+            "value": 10,
+            "unit": "percent",
+        }
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
         dh = DateHelper()
         updater._update_markup_cost(dh.this_month_start, dh.this_month_end)
         mock_histogram.labels.assert_called_with(provider_type=self.ocp_provider.type)
         observe_args = mock_histogram.labels.return_value.observe.call_args
-        self.assertIsNotNone(observe_args, "observe() was never called on RTU_MARKUP_DURATION")
+        self.assertIsNotNone(
+            observe_args, "observe() was never called on RTU_MARKUP_DURATION"
+        )
         observed_duration = observe_args[0][0]
         self.assertGreaterEqual(observed_duration, 0, "Duration must be non-negative")
 
@@ -2097,19 +2332,30 @@ class TestPhase4Orchestration(_ReportPeriodMixin, MasuTestCase):
         )
 
     @patch.object(OCPCostModelCostUpdater, "_ensure_rates_to_usage_partitions")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_ui_summary_tables")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_distributed_cost_sql")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_ui_summary_tables"
+    )
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_distributed_cost_sql"
+    )
     @patch.object(OCPCostModelCostUpdater, "_update_markup_cost")
     @patch.object(OCPCostModelCostUpdater, "_aggregate_rates_to_daily_summary")
-    def test_phase4_per_month_order(self, mock_agg, mock_markup, mock_dist_sql, mock_ui, mock_partitions):
+    def test_phase4_per_month_order(
+        self, mock_agg, mock_markup, mock_dist_sql, mock_ui, mock_partitions
+    ):
         """Per-month order must be: distribute -> aggregate -> markup -> ui."""
         call_order = []
-        mock_dist_sql.side_effect = lambda sr, *a, **kw: (call_order.append("dist"), sr)[1]
+        mock_dist_sql.side_effect = lambda sr, *a, **kw: (
+            call_order.append("dist"),
+            sr,
+        )[1]
         mock_agg.side_effect = lambda *a: call_order.append("agg")
         mock_markup.side_effect = lambda *a: call_order.append("markup")
         mock_ui.side_effect = lambda *a, **kw: call_order.append("ui")
 
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
         sr = self._make_summary_range()
         updater.distribute_costs_and_update_ui_summary(sr)
 
@@ -2120,23 +2366,35 @@ class TestPhase4Orchestration(_ReportPeriodMixin, MasuTestCase):
         )
 
     @patch.object(OCPCostModelCostUpdater, "_ensure_rates_to_usage_partitions")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_ui_summary_tables")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_distributed_cost_sql")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_ui_summary_tables"
+    )
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_distributed_cost_sql"
+    )
     @patch.object(OCPCostModelCostUpdater, "_update_markup_cost")
     @patch.object(OCPCostModelCostUpdater, "_aggregate_rates_to_daily_summary")
-    def test_distribute_calls_dist_entry_point(self, mock_agg, mock_markup, mock_dist_sql, mock_ui, mock_partitions):
+    def test_distribute_calls_dist_entry_point(
+        self, mock_agg, mock_markup, mock_dist_sql, mock_ui, mock_partitions
+    ):
         """distribute_costs_and_update_ui_summary invokes accessor.populate_distributed_cost_sql."""
         mock_dist_sql.side_effect = lambda sr, *a, **kw: sr
 
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
         sr = self._make_summary_range()
         updater.distribute_costs_and_update_ui_summary(sr)
 
         mock_dist_sql.assert_called_once()
 
     @patch.object(OCPCostModelCostUpdater, "_ensure_rates_to_usage_partitions")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_ui_summary_tables")
-    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_distributed_cost_sql")
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_ui_summary_tables"
+    )
+    @patch(
+        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_distributed_cost_sql"
+    )
     @patch.object(OCPCostModelCostUpdater, "_update_markup_cost")
     @patch.object(OCPCostModelCostUpdater, "_aggregate_rates_to_daily_summary")
     def test_derived_cost_datetime_updated_after_pipeline(
@@ -2145,7 +2403,9 @@ class TestPhase4Orchestration(_ReportPeriodMixin, MasuTestCase):
         """D1: derived_cost_datetime is updated even after nested accessors reset schema."""
         mock_dist_sql.side_effect = lambda sr, *a, **kw: sr
 
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
         sr = self._make_summary_range()
 
         rp = self._get_report_period()

--- a/koku/masu/test/processor/ocp/test_phase2_rates_to_usage.py
+++ b/koku/masu/test/processor/ocp/test_phase2_rates_to_usage.py
@@ -1282,7 +1282,9 @@ class TestOrchestrationOrder(_ReportPeriodMixin, MasuTestCase):
             cost_model_update=True,
         )
 
-    # TC-R20-01: Phase 4 ordering: rtu -> monthly -> vm -> dist -> agg -> markup
+    # TC-R20-01: Phase 4 ordering at outer level: rtu -> monthly -> vm -> dist
+    # (agg and markup now run inside distribute_costs_and_update_ui_summary,
+    #  tested separately in TestPhase4Orchestration)
     @_make_orchestration_patches(rtu_enabled=True)
     def test_rtu_enabled_full_ordering(
         self,
@@ -1297,27 +1299,25 @@ class TestOrchestrationOrder(_ReportPeriodMixin, MasuTestCase):
         mock_monthly,
         mock_dist,
     ):
-        """R20: Phase 4 order is rtu -> monthly -> vm -> dist -> agg -> markup."""
+        """R20: Phase 4 outer order is rtu -> monthly -> vm -> dist."""
         call_order = []
         mock_rtu.side_effect = lambda *a: call_order.append("rtu")
         mock_monthly.side_effect = lambda *a: call_order.append("monthly")
         mock_vm.side_effect = lambda *a: call_order.append("vm")
-        mock_agg.side_effect = lambda *a: call_order.append("agg")
-        mock_markup.side_effect = lambda *a: call_order.append("markup")
         mock_dist.side_effect = lambda *a: call_order.append("dist")
 
         updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         sr = self._make_summary_range()
         updater.update_summary_cost_model_costs(sr)
 
-        expected = ["rtu", "monthly", "vm", "dist", "agg", "markup"]
+        expected = ["rtu", "monthly", "vm", "dist"]
         self.assertEqual(call_order, expected, f"R20: expected {expected}, got {call_order}")
         mock_usage.assert_not_called()
         mock_cleanup.assert_not_called()
 
-    # TC-R20-02: aggregation before markup (proxy for agg-before-tags)
+    # TC-R20-02: distribute is called (agg+markup ordering tested in TestPhase4Orchestration)
     @_make_orchestration_patches(rtu_enabled=True)
-    def test_aggregation_before_markup(
+    def test_distribute_called(
         self,
         mock_ff,
         mock_load,
@@ -1330,24 +1330,14 @@ class TestOrchestrationOrder(_ReportPeriodMixin, MasuTestCase):
         mock_monthly,
         mock_dist,
     ):
-        """R20: _aggregate must run before _update_markup_cost (proxy for agg-before-tags)."""
-        call_order = []
-        mock_agg.side_effect = lambda *a: call_order.append("agg")
-        mock_markup.side_effect = lambda *a: call_order.append("markup")
-
+        """R20: distribute_costs_and_update_ui_summary is invoked."""
         updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         sr = self._make_summary_range()
         updater.update_summary_cost_model_costs(sr)
 
-        self.assertIn("agg", call_order)
-        self.assertIn("markup", call_order)
-        self.assertLess(
-            call_order.index("agg"),
-            call_order.index("markup"),
-            "R20: aggregation must run before markup (and therefore before tags)",
-        )
+        mock_dist.assert_called_once_with(sr)
 
-    # TC-R20-03: cleanup called when cost_model_id is None; monthly/vm/agg/markup still run
+    # TC-R20-03: cleanup called when cost_model_id is None; monthly/vm/dist still run
     @_make_orchestration_patches(rtu_enabled=True)
     def test_cleanup_called_when_no_cost_model(
         self,
@@ -1363,7 +1353,7 @@ class TestOrchestrationOrder(_ReportPeriodMixin, MasuTestCase):
         mock_dist,
     ):
         """R20: When cost_model_id is None, cleanup runs instead of RTU insert.
-        Monthly/vm/agg/markup still run (monthly cleanup, agg guards on cost_model_id)."""
+        Monthly/vm/dist still run (agg+markup are inside dist)."""
         updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         updater._cost_model_id = None
         sr = self._make_summary_range()
@@ -1374,8 +1364,7 @@ class TestOrchestrationOrder(_ReportPeriodMixin, MasuTestCase):
         mock_usage.assert_not_called()
         mock_monthly.assert_called()
         mock_vm.assert_called()
-        mock_agg.assert_called()
-        mock_markup.assert_called()
+        mock_dist.assert_called()
 
 
 # ---------------------------------------------------------------------------
@@ -1433,7 +1422,7 @@ class TestPriceListValidityGuard(_ReportPeriodMixin, MasuTestCase):
 
         mock_cleanup.assert_called()
         mock_rtu.assert_not_called()
-        mock_agg.assert_called()
+        mock_dist.assert_called()
         mock_vm.assert_called()
         mock_monthly.assert_called()
         mock_markup.assert_called()

--- a/koku/masu/test/processor/ocp/test_phase2_rates_to_usage.py
+++ b/koku/masu/test/processor/ocp/test_phase2_rates_to_usage.py
@@ -840,6 +840,24 @@ class TestSkipPaths(MasuTestCase):
         mock_execute.assert_not_called()
         self.assertTrue(any("skipping rates_to_usage aggregation" in msg for msg in cm.output))
 
+    # TC-48b: RTU aggregate forwards cost_model_currency to accessor
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.aggregate_rates_to_daily_summary")
+    def test_rtu_aggregate_forwards_cost_model_currency(self, mock_agg):
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        dh = DateHelper()
+        updater._aggregate_rates_to_daily_summary(dh.this_month_start, dh.this_month_end, "NOK")
+        mock_agg.assert_called_once()
+        self.assertEqual(mock_agg.call_args[0][4], "NOK")
+
+    # TC-48c: RTU aggregate passes None as cost_model_currency when no infra currency
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.aggregate_rates_to_daily_summary")
+    def test_rtu_aggregate_passes_none_currency(self, mock_agg):
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        dh = DateHelper()
+        updater._aggregate_rates_to_daily_summary(dh.this_month_start, dh.this_month_end, None)
+        mock_agg.assert_called_once()
+        self.assertIsNone(mock_agg.call_args[0][4])
+
     # TC-49: RTU insert skips when no cost_model_id
     @patch.object(OCPCostModelCostUpdater, "_ensure_rates_to_usage_partitions")
     @patch("masu.processor.ocp.ocp_cost_model_cost_updater.CostModelDBAccessor")
@@ -2103,6 +2121,216 @@ class TestPrometheusTimingWrappers(_ReportPeriodMixin, MasuTestCase):
         self.assertGreaterEqual(observed_duration, 0, "Duration must be non-negative")
 
 
+class TestGetInfraToCmRate(_ReportPeriodMixin, MasuTestCase):
+    """Test _get_infra_to_cm_rate return values and has_infra_currency flag."""
+
+    def _make_updater(self):
+        return OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+
+    def test_no_cost_model_currency(self):
+        """Returns (1, False) when cost_model_currency is empty/None."""
+        updater = self._make_updater()
+        dh = DateHelper()
+        rate, has_infra = updater._get_infra_to_cm_rate(None, dh.this_month_start, dh.this_month_end)
+        self.assertEqual(rate, Decimal(1))
+        self.assertFalse(has_infra)
+
+        rate, has_infra = updater._get_infra_to_cm_rate("", dh.this_month_start, dh.this_month_end)
+        self.assertEqual(rate, Decimal(1))
+        self.assertFalse(has_infra)
+
+    def test_no_infra_currencies_returns_false(self):
+        """When no unattributed rows have raw_currency, returns (1, False)."""
+        updater = self._make_updater()
+        dh = DateHelper()
+        rate, has_infra = updater._get_infra_to_cm_rate("USD", dh.this_month_start, dh.this_month_end)
+        self.assertEqual(rate, Decimal(1))
+        self.assertFalse(has_infra)
+
+    def test_infra_currency_matches_cost_model(self):
+        """When infra raw_currency matches cost_model_currency, returns (1, True)."""
+        updater = self._make_updater()
+        dh = DateHelper()
+        with schema_context(self.schema):
+            OCPUsageLineItemDailySummary.objects.filter(
+                source_uuid=self.ocp_provider_uuid,
+                usage_start__gte=dh.this_month_start,
+            ).exclude(namespace__in=["Network unattributed", "Storage unattributed"]).update(
+                namespace="Network unattributed",
+                cost_model_rate_type=None,
+                raw_currency="USD",
+            )
+        rate, has_infra = updater._get_infra_to_cm_rate("USD", dh.this_month_start, dh.this_month_end)
+        self.assertEqual(rate, Decimal(1))
+        self.assertTrue(has_infra)
+
+    def test_infra_currency_differs_no_exchange_dict(self):
+        """When currencies differ but no ExchangeRateDictionary exists, returns (1, True)."""
+        updater = self._make_updater()
+        dh = DateHelper()
+        with schema_context(self.schema):
+            OCPUsageLineItemDailySummary.objects.filter(
+                source_uuid=self.ocp_provider_uuid,
+                usage_start__gte=dh.this_month_start,
+            ).exclude(namespace__in=["Network unattributed", "Storage unattributed"]).update(
+                namespace="Network unattributed",
+                cost_model_rate_type=None,
+                raw_currency="EUR",
+            )
+        with patch("api.currency.models.ExchangeRateDictionary") as mock_erd:
+            mock_erd.objects.first.return_value = None
+            rate, has_infra = updater._get_infra_to_cm_rate("USD", dh.this_month_start, dh.this_month_end)
+        self.assertEqual(rate, Decimal(1))
+        self.assertTrue(has_infra)
+
+    def test_infra_currency_differs_with_exchange_rate(self):
+        """When currencies differ and exchange rate exists, returns (rate, True)."""
+        updater = self._make_updater()
+        dh = DateHelper()
+        with schema_context(self.schema):
+            OCPUsageLineItemDailySummary.objects.filter(
+                source_uuid=self.ocp_provider_uuid,
+                usage_start__gte=dh.this_month_start,
+            ).exclude(namespace__in=["Network unattributed", "Storage unattributed"]).update(
+                namespace="Network unattributed",
+                cost_model_rate_type=None,
+                raw_currency="EUR",
+            )
+        mock_dict = type(
+            "MockDict",
+            (),
+            {
+                "currency_exchange_dictionary": {"EUR": {"USD": 1.08}},
+            },
+        )()
+        with patch("api.currency.models.ExchangeRateDictionary") as mock_erd:
+            mock_erd.objects.first.return_value = mock_dict
+            rate, has_infra = updater._get_infra_to_cm_rate("USD", dh.this_month_start, dh.this_month_end)
+        self.assertEqual(rate, Decimal("1.08"))
+        self.assertTrue(has_infra)
+
+    def test_exchange_rate_not_found_for_pair(self):
+        """When exchange dict exists but rate for currency pair is missing, returns (1, True)."""
+        updater = self._make_updater()
+        dh = DateHelper()
+        with schema_context(self.schema):
+            OCPUsageLineItemDailySummary.objects.filter(
+                source_uuid=self.ocp_provider_uuid,
+                usage_start__gte=dh.this_month_start,
+            ).exclude(namespace__in=["Network unattributed", "Storage unattributed"]).update(
+                namespace="Network unattributed",
+                cost_model_rate_type=None,
+                raw_currency="JPY",
+            )
+        mock_dict = type(
+            "MockDict",
+            (),
+            {
+                "currency_exchange_dictionary": {"EUR": {"USD": 1.08}},
+            },
+        )()
+        with patch("api.currency.models.ExchangeRateDictionary") as mock_erd:
+            mock_erd.objects.first.return_value = mock_dict
+            rate, has_infra = updater._get_infra_to_cm_rate("USD", dh.this_month_start, dh.this_month_end)
+        self.assertEqual(rate, Decimal(1))
+        self.assertTrue(has_infra)
+
+
+class TestGetMarkupPercentage(_ReportPeriodMixin, MasuTestCase):
+    """Test _get_markup_percentage extracts markup from cost model correctly."""
+
+    def test_returns_decimal_percentage(self):
+        """Markup value 10 -> 0.1 (divided by 100)."""
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        result = updater._get_markup_percentage()
+        if updater._cost_model:
+            from masu.database.cost_model_db_accessor import CostModelDBAccessor
+
+            with CostModelDBAccessor(self.schema, self.ocp_provider_uuid, price_list_effective_on=None) as acc:
+                markup = acc.markup
+            if markup and markup.get("value"):
+                self.assertEqual(result, Decimal(str(markup["value"])) / 100)
+            else:
+                self.assertIsNone(result)
+        else:
+            self.assertIsNone(result)
+
+    @patch("masu.processor.ocp.ocp_cost_model_cost_updater.CostModelDBAccessor")
+    def test_returns_none_when_no_markup(self, mock_accessor_cls):
+        """Returns None when cost model has no markup configured."""
+        mock_acc = mock_accessor_cls.return_value.__enter__.return_value
+        mock_acc.markup = None
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        result = updater._get_markup_percentage()
+        self.assertIsNone(result)
+
+    @patch("masu.processor.ocp.ocp_cost_model_cost_updater.CostModelDBAccessor")
+    def test_returns_none_when_markup_value_zero(self, mock_accessor_cls):
+        """Returns None when markup value is 0."""
+        mock_acc = mock_accessor_cls.return_value.__enter__.return_value
+        mock_acc.markup = {"value": 0, "unit": "percent"}
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        result = updater._get_markup_percentage()
+        self.assertIsNone(result)
+
+
+class TestDistributionRawCurrency(_ReportPeriodMixin, MasuTestCase):
+    """Test that distribute_costs_and_update_ui_summary passes correct raw_currency to aggregation."""
+
+    def _make_summary_range(self):
+        dh = DateHelper()
+        return SummaryRangeConfig(
+            schema=self.schema,
+            provider_uuid=self.ocp_provider_uuid,
+            start_date=dh.this_month_start,
+            end_date=dh.this_month_end,
+            cost_model_update=True,
+        )
+
+    @patch.object(OCPCostModelCostUpdater, "_ensure_rates_to_usage_partitions")
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_ui_summary_tables")
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_distributed_cost_sql")
+    @patch.object(OCPCostModelCostUpdater, "_update_markup_cost")
+    @patch.object(OCPCostModelCostUpdater, "_aggregate_rates_to_daily_summary")
+    @patch.object(OCPCostModelCostUpdater, "_get_infra_to_cm_rate")
+    def test_has_infra_currency_passes_cost_model_currency(
+        self, mock_rate, mock_agg, mock_markup, mock_dist_sql, mock_ui, mock_partitions
+    ):
+        """When has_infra_currency=True, aggregation receives cost_model_currency."""
+        mock_rate.return_value = (Decimal("0.103"), True)
+        mock_dist_sql.side_effect = lambda sr, *a, **kw: sr
+
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        sr = self._make_summary_range()
+        updater.distribute_costs_and_update_ui_summary(sr)
+
+        agg_call = mock_agg.call_args
+        self.assertIsNotNone(agg_call)
+        cost_model_currency = updater._cost_model.currency if updater._cost_model else "USD"
+        self.assertEqual(agg_call[0][2], cost_model_currency)
+
+    @patch.object(OCPCostModelCostUpdater, "_ensure_rates_to_usage_partitions")
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_ui_summary_tables")
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_distributed_cost_sql")
+    @patch.object(OCPCostModelCostUpdater, "_update_markup_cost")
+    @patch.object(OCPCostModelCostUpdater, "_aggregate_rates_to_daily_summary")
+    @patch.object(OCPCostModelCostUpdater, "_get_infra_to_cm_rate")
+    def test_no_infra_currency_passes_none(
+        self, mock_rate, mock_agg, mock_markup, mock_dist_sql, mock_ui, mock_partitions
+    ):
+        """When has_infra_currency=False, aggregation receives None (raw_currency stays NULL)."""
+        mock_rate.return_value = (Decimal(1), False)
+        mock_dist_sql.side_effect = lambda sr, *a, **kw: sr
+
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        sr = self._make_summary_range()
+        updater.distribute_costs_and_update_ui_summary(sr)
+
+        agg_call = mock_agg.call_args
+        self.assertIsNotNone(agg_call)
+        self.assertIsNone(agg_call[0][2])
+
+
 class TestPhase4Orchestration(_ReportPeriodMixin, MasuTestCase):
     """Test distribute_costs_and_update_ui_summary internal ordering (D1/D2).
 
@@ -2163,6 +2391,25 @@ class TestPhase4Orchestration(_ReportPeriodMixin, MasuTestCase):
         updater.distribute_costs_and_update_ui_summary(sr)
 
         mock_dist_sql.assert_called_once()
+
+    @patch.object(OCPCostModelCostUpdater, "_ensure_rates_to_usage_partitions")
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_ui_summary_tables")
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_distributed_cost_sql")
+    @patch.object(OCPCostModelCostUpdater, "_update_markup_cost")
+    @patch.object(OCPCostModelCostUpdater, "_aggregate_rates_to_daily_summary")
+    def test_distribute_forwards_infra_rate_and_currency(
+        self, mock_agg, mock_markup, mock_dist_sql, mock_ui, mock_partitions
+    ):
+        """populate_distributed_cost_sql receives infra_to_cm_rate and cost_model_currency kwargs."""
+        mock_dist_sql.side_effect = lambda sr, *a, **kw: sr
+
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        sr = self._make_summary_range()
+        updater.distribute_costs_and_update_ui_summary(sr)
+
+        _, kwargs = mock_dist_sql.call_args
+        self.assertIn("infra_to_cm_rate", kwargs)
+        self.assertIn("cost_model_currency", kwargs)
 
     @patch.object(OCPCostModelCostUpdater, "_ensure_rates_to_usage_partitions")
     @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_ui_summary_tables")

--- a/koku/masu/test/processor/ocp/test_phase2_rates_to_usage.py
+++ b/koku/masu/test/processor/ocp/test_phase2_rates_to_usage.py
@@ -665,9 +665,9 @@ class TestUpdaterOrchestration(_ReportPeriodMixin, MasuTestCase):
         mock_rtu.assert_called_once_with(sr.start_date, sr.end_date)
         mock_usage.assert_not_called()
 
-    # TC-41: RTU aggregate called, legacy usage costs NOT called
+    # TC-41: Phase 4 entry point called, legacy usage costs NOT called
     @_make_orchestration_patches()
-    def test_orchestration_calls_rtu_aggregate(
+    def test_orchestration_calls_distribute(
         self,
         mock_ff,
         mock_load,
@@ -683,12 +683,12 @@ class TestUpdaterOrchestration(_ReportPeriodMixin, MasuTestCase):
         updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         sr = self._make_summary_range()
         updater.update_summary_cost_model_costs(sr)
-        mock_agg.assert_called_once_with(sr.start_date, sr.end_date)
+        mock_dist.assert_called_once_with(sr)
         mock_usage.assert_not_called()
 
-    # TC-42: RTU insert before aggregate (both in RTU-enabled path)
+    # TC-42: RTU insert before distribute (both in RTU-enabled path)
     @_make_orchestration_patches()
-    def test_orchestration_order_rtu_before_aggregate(
+    def test_orchestration_order_rtu_before_distribute(
         self,
         mock_ff,
         mock_load,
@@ -703,7 +703,6 @@ class TestUpdaterOrchestration(_ReportPeriodMixin, MasuTestCase):
     ):
         call_order = []
         mock_rtu.side_effect = lambda *a: call_order.append("rtu")
-        mock_agg.side_effect = lambda *a: call_order.append("agg")
         mock_dist.side_effect = lambda *a: call_order.append("dist")
 
         updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
@@ -711,13 +710,13 @@ class TestUpdaterOrchestration(_ReportPeriodMixin, MasuTestCase):
         updater.update_summary_cost_model_costs(sr)
 
         self.assertIn("rtu", call_order)
-        self.assertIn("agg", call_order)
-        self.assertLess(call_order.index("rtu"), call_order.index("agg"))
+        self.assertIn("dist", call_order)
+        self.assertLess(call_order.index("rtu"), call_order.index("dist"))
         self.assertNotIn("usage", call_order)
 
-    # TC-44: Phase 4 inversion -- distribute before aggregate
+    # TC-44: Phase 4 — RTU + monthly before distribute
     @_make_orchestration_patches()
-    def test_orchestration_order_distribute_before_aggregate(
+    def test_orchestration_order_monthly_before_distribute(
         self,
         mock_ff,
         mock_load,
@@ -732,17 +731,17 @@ class TestUpdaterOrchestration(_ReportPeriodMixin, MasuTestCase):
     ):
         call_order = []
         mock_rtu.side_effect = lambda *a: call_order.append("rtu")
-        mock_usage.side_effect = lambda *a: call_order.append("usage")
-        mock_agg.side_effect = lambda *a: call_order.append("agg")
+        mock_monthly.side_effect = lambda *a: call_order.append("monthly")
         mock_dist.side_effect = lambda *a: call_order.append("dist")
 
         updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         sr = self._make_summary_range()
         updater.update_summary_cost_model_costs(sr)
 
-        self.assertIn("agg", call_order)
+        self.assertIn("rtu", call_order)
+        self.assertIn("monthly", call_order)
         self.assertIn("dist", call_order)
-        self.assertLess(call_order.index("dist"), call_order.index("agg"))
+        self.assertLess(call_order.index("monthly"), call_order.index("dist"))
 
     # TC-53: single-pass INSERT (no rate_type loop)
     @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
@@ -788,7 +787,7 @@ class TestUpdaterOrchestration(_ReportPeriodMixin, MasuTestCase):
         sr = self._make_summary_range()
         updater.update_summary_cost_model_costs(sr)
         mock_rtu.assert_called_once()
-        mock_agg.assert_called_once()
+        mock_dist.assert_called_once_with(sr)
         mock_usage.assert_not_called()
 
 
@@ -2086,3 +2085,94 @@ class TestPrometheusTimingWrappers(_ReportPeriodMixin, MasuTestCase):
         self.assertIsNotNone(observe_args, "observe() was never called on RTU_MARKUP_DURATION")
         observed_duration = observe_args[0][0]
         self.assertGreaterEqual(observed_duration, 0, "Duration must be non-negative")
+
+
+class TestPhase4Orchestration(_ReportPeriodMixin, MasuTestCase):
+    """Test distribute_costs_and_update_ui_summary internal ordering (D1/D2).
+
+    Patches at the accessor boundary rather than mocking the whole method,
+    verifying per-month order: distribute -> aggregate -> markup -> ui.
+    """
+
+    def _make_summary_range(self):
+        dh = DateHelper()
+        return SummaryRangeConfig(
+            schema=self.schema,
+            provider_uuid=self.ocp_provider_uuid,
+            start_date=dh.this_month_start,
+            end_date=dh.this_month_end,
+            cost_model_update=True,
+        )
+
+    @patch.object(OCPCostModelCostUpdater, "_ensure_rates_to_usage_partitions")
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_ui_summary_tables")
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_distributed_cost_sql")
+    @patch.object(OCPCostModelCostUpdater, "_update_markup_cost")
+    @patch.object(OCPCostModelCostUpdater, "_aggregate_rates_to_daily_summary")
+    def test_phase4_per_month_order(
+        self, mock_agg, mock_markup, mock_dist_sql, mock_ui, mock_partitions
+    ):
+        """Per-month order must be: distribute -> aggregate -> markup -> ui."""
+        call_order = []
+        mock_dist_sql.side_effect = lambda sr, *a, **kw: (call_order.append("dist"), sr)[1]
+        mock_agg.side_effect = lambda *a: call_order.append("agg")
+        mock_markup.side_effect = lambda *a: call_order.append("markup")
+        mock_ui.side_effect = lambda *a, **kw: call_order.append("ui")
+
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        sr = self._make_summary_range()
+        updater.distribute_costs_and_update_ui_summary(sr)
+
+        self.assertEqual(
+            call_order, ["dist", "agg", "markup", "ui"],
+            f"Expected [dist, agg, markup, ui] but got {call_order}",
+        )
+
+    @patch.object(OCPCostModelCostUpdater, "_ensure_rates_to_usage_partitions")
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_ui_summary_tables")
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_distributed_cost_sql")
+    @patch.object(OCPCostModelCostUpdater, "_update_markup_cost")
+    @patch.object(OCPCostModelCostUpdater, "_aggregate_rates_to_daily_summary")
+    def test_distribute_calls_dist_entry_point(
+        self, mock_agg, mock_markup, mock_dist_sql, mock_ui, mock_partitions
+    ):
+        """distribute_costs_and_update_ui_summary invokes accessor.populate_distributed_cost_sql."""
+        mock_dist_sql.side_effect = lambda sr, *a, **kw: sr
+
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        sr = self._make_summary_range()
+        updater.distribute_costs_and_update_ui_summary(sr)
+
+        mock_dist_sql.assert_called_once()
+
+    @patch.object(OCPCostModelCostUpdater, "_ensure_rates_to_usage_partitions")
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_ui_summary_tables")
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_distributed_cost_sql")
+    @patch.object(OCPCostModelCostUpdater, "_update_markup_cost")
+    @patch.object(OCPCostModelCostUpdater, "_aggregate_rates_to_daily_summary")
+    def test_derived_cost_datetime_updated_after_pipeline(
+        self, mock_agg, mock_markup, mock_dist_sql, mock_ui, mock_partitions
+    ):
+        """D1: derived_cost_datetime is updated even after nested accessors reset schema."""
+        mock_dist_sql.side_effect = lambda sr, *a, **kw: sr
+
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        sr = self._make_summary_range()
+
+        rp = self._get_report_period()
+        old_datetime = rp.derived_cost_datetime
+
+        updater.distribute_costs_and_update_ui_summary(sr)
+
+        with schema_context(self.schema):
+            rp.refresh_from_db()
+        if old_datetime is not None:
+            self.assertGreater(
+                rp.derived_cost_datetime, old_datetime,
+                "derived_cost_datetime should be updated after pipeline run",
+            )
+        else:
+            self.assertIsNotNone(
+                rp.derived_cost_datetime,
+                "derived_cost_datetime should be set after pipeline run",
+            )

--- a/koku/masu/test/processor/ocp/test_phase2_rates_to_usage.py
+++ b/koku/masu/test/processor/ocp/test_phase2_rates_to_usage.py
@@ -96,9 +96,7 @@ class TestPriceListSwitch(MasuTestCase):
         with self._get_accessor() as accessor:
             infra = accessor.infrastructure_rates
             self.assertIsInstance(infra, dict)
-            self.assertGreater(
-                len(infra), 0, "Expected at least one infrastructure rate"
-            )
+            self.assertGreater(len(infra), 0, "Expected at least one infrastructure rate")
 
     # TC-05: supplementary_rates populated (BAC-2)
     def test_supplementary_rates_populated(self):
@@ -112,9 +110,7 @@ class TestPriceListSwitch(MasuTestCase):
         from cost_models.models import Rate
         from masu.database.cost_model_db_accessor import CostModelDBAccessor
 
-        with CostModelDBAccessor(
-            self.schema, self.ocp_provider_uuid, price_list_effective_on=None
-        ) as accessor:
+        with CostModelDBAccessor(self.schema, self.ocp_provider_uuid, price_list_effective_on=None) as accessor:
             if not accessor.cost_model:
                 self.skipTest("No cost model for OCP provider")
 
@@ -132,9 +128,7 @@ class TestPriceListSwitch(MasuTestCase):
             for (metric, cost_type), expected_sum in expected.items():
                 self.assertIn(metric, pl, f"Missing metric {metric}")
                 tiered = pl[metric]["tiered_rates"]
-                self.assertIn(
-                    cost_type, tiered, f"Missing cost_type {cost_type} for {metric}"
-                )
+                self.assertIn(cost_type, tiered, f"Missing cost_type {cost_type} for {metric}")
                 actual_sum = tiered[cost_type][0]["value"]
                 self.assertAlmostEqual(actual_sum, expected_sum, places=10)
 
@@ -143,9 +137,7 @@ class TestPriceListSwitch(MasuTestCase):
         from cost_models.models import Rate
         from masu.database.cost_model_db_accessor import CostModelDBAccessor
 
-        with CostModelDBAccessor(
-            self.schema, self.ocp_provider_uuid, price_list_effective_on=None
-        ) as accessor:
+        with CostModelDBAccessor(self.schema, self.ocp_provider_uuid, price_list_effective_on=None) as accessor:
             if not accessor.cost_model:
                 self.skipTest("No cost model for OCP provider")
 
@@ -166,9 +158,7 @@ class TestPriceListSwitch(MasuTestCase):
 
             pl = accessor.price_list
             for metric in tag_only_metrics:
-                self.assertNotIn(
-                    metric, pl, f"Tag-only metric {metric} should not be in price_list"
-                )
+                self.assertNotIn(metric, pl, f"Tag-only metric {metric} should not be in price_list")
 
     # TC-08: unknown provider returns {}
     def test_price_list_empty_for_unknown_provider(self):
@@ -190,18 +180,14 @@ class TestCostModelIdExtraction(MasuTestCase):
 
     # TC-10: cost_model_id populated when cost model exists
     def test_cost_model_id_populated(self):
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         self.assertIsNotNone(updater._cost_model_id)
 
     # TC-11: cost_model_id None when no cost model
     @patch("masu.processor.ocp.ocp_cost_model_cost_updater.CostModelDBAccessor")
     def test_cost_model_id_none_when_no_cost_model(self, mock_accessor):
         _setup_no_cost_model_mock(mock_accessor)
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         self.assertIsNone(updater._cost_model_id)
 
 
@@ -214,15 +200,11 @@ class TestSyncTestRateRows(MasuTestCase):
         from cost_models.models import PriceList
 
         with schema_context(self.schema):
-            cm = CostModel.objects.filter(
-                costmodelmap__provider_uuid=self.ocp_provider_uuid
-            ).first()
+            cm = CostModel.objects.filter(costmodelmap__provider_uuid=self.ocp_provider_uuid).first()
             if not cm:
                 self.skipTest("No cost model for OCP provider")
             pl_count = PriceList.objects.filter(cost_model_maps__cost_model=cm).count()
-            self.assertGreater(
-                pl_count, 0, "sync_test_rate_rows should create at least one PriceList"
-            )
+            self.assertGreater(pl_count, 0, "sync_test_rate_rows should create at least one PriceList")
 
     # TC-13: creates Rate rows matching JSON entries
     def test_sync_creates_rate_rows(self):
@@ -230,14 +212,10 @@ class TestSyncTestRateRows(MasuTestCase):
         from cost_models.models import Rate
 
         with schema_context(self.schema):
-            cm = CostModel.objects.filter(
-                costmodelmap__provider_uuid=self.ocp_provider_uuid
-            ).first()
+            cm = CostModel.objects.filter(costmodelmap__provider_uuid=self.ocp_provider_uuid).first()
             if not cm:
                 self.skipTest("No cost model for OCP provider")
-            rate_count = Rate.objects.filter(
-                price_list__cost_model_maps__cost_model=cm
-            ).count()
+            rate_count = Rate.objects.filter(price_list__cost_model_maps__cost_model=cm).count()
             json_rate_count = len(cm.rates) if isinstance(cm.rates, list) else 0
             self.assertEqual(
                 rate_count,
@@ -254,23 +232,17 @@ class TestSyncTestRateRows(MasuTestCase):
         from masu.database.cost_model_db_accessor import CostModelDBAccessor
 
         with schema_context(self.schema):
-            cm = CostModel.objects.filter(
-                costmodelmap__provider_uuid=self.ocp_provider_uuid
-            ).first()
+            cm = CostModel.objects.filter(costmodelmap__provider_uuid=self.ocp_provider_uuid).first()
             if not cm:
                 self.skipTest("No cost model for OCP provider")
 
-        with CostModelDBAccessor(
-            self.schema, self.ocp_provider_uuid, price_list_effective_on=None
-        ) as accessor:
+        with CostModelDBAccessor(self.schema, self.ocp_provider_uuid, price_list_effective_on=None) as accessor:
             pl_before = accessor.price_list
 
         with schema_context(self.schema):
             sync_test_rate_rows(cm)
 
-        with CostModelDBAccessor(
-            self.schema, self.ocp_provider_uuid, price_list_effective_on=None
-        ) as accessor:
+        with CostModelDBAccessor(self.schema, self.ocp_provider_uuid, price_list_effective_on=None) as accessor:
             pl_after = accessor.price_list
 
         self.assertEqual(
@@ -286,9 +258,7 @@ class TestSyncTestRateRows(MasuTestCase):
         from cost_models.models import Rate
 
         with schema_context(self.schema):
-            cm = CostModel.objects.filter(
-                costmodelmap__provider_uuid=self.ocp_provider_uuid
-            ).first()
+            cm = CostModel.objects.filter(costmodelmap__provider_uuid=self.ocp_provider_uuid).first()
             if not cm:
                 self.skipTest("No cost model for OCP provider")
             rate = Rate.objects.filter(
@@ -454,9 +424,7 @@ class TestPopulateUsageRatesToUsage(_ReportPeriodMixin, MasuTestCase):
         )
 
     # TC-22: executes INSERT SQL
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
     def test_populate_rtu_executes_insert_sql(self, mock_execute):
         with OCPReportDBAccessor(self.schema) as accessor:
             rp = self._get_report_period(accessor)
@@ -467,9 +435,7 @@ class TestPopulateUsageRatesToUsage(_ReportPeriodMixin, MasuTestCase):
         self.assertEqual(kwargs.get("operation"), "INSERT")
 
     # TC-23: cost_model_id included as string
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
     def test_populate_rtu_includes_cost_model_id(self, mock_execute):
         cost_model_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
         with OCPReportDBAccessor(self.schema) as accessor:
@@ -480,9 +446,7 @@ class TestPopulateUsageRatesToUsage(_ReportPeriodMixin, MasuTestCase):
         self.assertEqual(sql_params["cost_model_id"], cost_model_id)
 
     # TC-25: distribution is now read from cost_model table in SQL, not passed as param
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
     def test_populate_rtu_no_distribution_param(self, mock_execute):
         with OCPReportDBAccessor(self.schema) as accessor:
             rp = self._get_report_period(accessor)
@@ -492,9 +456,7 @@ class TestPopulateUsageRatesToUsage(_ReportPeriodMixin, MasuTestCase):
         self.assertNotIn("distribution", sql_params)
 
     # TC-25b: cluster_cost_per_hour NOT in sql_params (resolved via SQL JOIN)
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
     def test_populate_rtu_no_cluster_cost_per_hour_param(self, mock_execute):
         with OCPReportDBAccessor(self.schema) as accessor:
             rp = self._get_report_period(accessor)
@@ -504,9 +466,7 @@ class TestPopulateUsageRatesToUsage(_ReportPeriodMixin, MasuTestCase):
         self.assertNotIn("cluster_cost_per_hour", sql_params)
 
     # TC-25c: rate_type and per-metric params NOT in sql_params (single-pass reads from DB)
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
     def test_populate_rtu_no_rate_type_or_metric_params(self, mock_execute):
         with OCPReportDBAccessor(self.schema) as accessor:
             rp = self._get_report_period(accessor)
@@ -526,9 +486,7 @@ class TestAggregateRatesToDailySummary(_ReportPeriodMixin, MasuTestCase):
     """Test aggregate_rates_to_daily_summary accessor method (BAC-6)."""
 
     # TC-29: executes INSERT SQL
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
     def test_aggregate_rtu_executes_insert_sql(self, mock_execute):
         dh = DateHelper()
         with OCPReportDBAccessor(self.schema) as accessor:
@@ -544,9 +502,7 @@ class TestAggregateRatesToDailySummary(_ReportPeriodMixin, MasuTestCase):
         self.assertEqual(kwargs.get("operation"), "INSERT")
 
     # TC-30: params match window
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
     def test_aggregate_rtu_params_match_window(self, mock_execute):
         dh = DateHelper()
         with OCPReportDBAccessor(self.schema) as accessor:
@@ -569,9 +525,7 @@ class TestValidateRatesToUsage(_ReportPeriodMixin, MasuTestCase):
     """Test validate_rates_against_daily_summary accessor method (BAC-7)."""
 
     # TC-31: executes SELECT SQL
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
     def test_validate_rtu_executes_select_sql(self, mock_execute):
         dh = DateHelper()
         with OCPReportDBAccessor(self.schema) as accessor:
@@ -587,9 +541,7 @@ class TestValidateRatesToUsage(_ReportPeriodMixin, MasuTestCase):
         self.assertEqual(kwargs.get("operation"), "VALIDATION_QUERY")
 
     # TC-32: params include report_period_id
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
     def test_validate_rtu_params_include_report_period(self, mock_execute):
         dh = DateHelper()
         with OCPReportDBAccessor(self.schema) as accessor:
@@ -707,9 +659,7 @@ class TestUpdaterOrchestration(_ReportPeriodMixin, MasuTestCase):
         mock_monthly,
         mock_dist,
     ):
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         sr = self._make_summary_range()
         updater.update_summary_cost_model_costs(sr)
         mock_rtu.assert_called_once_with(sr.start_date, sr.end_date)
@@ -730,9 +680,7 @@ class TestUpdaterOrchestration(_ReportPeriodMixin, MasuTestCase):
         mock_monthly,
         mock_dist,
     ):
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         sr = self._make_summary_range()
         updater.update_summary_cost_model_costs(sr)
         mock_dist.assert_called_once_with(sr)
@@ -757,9 +705,7 @@ class TestUpdaterOrchestration(_ReportPeriodMixin, MasuTestCase):
         mock_rtu.side_effect = lambda *a: call_order.append("rtu")
         mock_dist.side_effect = lambda *a: call_order.append("dist")
 
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         sr = self._make_summary_range()
         updater.update_summary_cost_model_costs(sr)
 
@@ -788,9 +734,7 @@ class TestUpdaterOrchestration(_ReportPeriodMixin, MasuTestCase):
         mock_monthly.side_effect = lambda *a: call_order.append("monthly")
         mock_dist.side_effect = lambda *a: call_order.append("dist")
 
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         sr = self._make_summary_range()
         updater.update_summary_cost_model_costs(sr)
 
@@ -800,14 +744,10 @@ class TestUpdaterOrchestration(_ReportPeriodMixin, MasuTestCase):
         self.assertLess(call_order.index("monthly"), call_order.index("dist"))
 
     # TC-53: single-pass INSERT (no rate_type loop)
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
     @patch.object(OCPCostModelCostUpdater, "_ensure_rates_to_usage_partitions")
     def test_rtu_insert_single_pass(self, mock_partitions, mock_execute):
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         if not updater._cost_model_id:
             self.skipTest("No cost model for OCP provider")
         rp = self._get_report_period()
@@ -820,12 +760,8 @@ class TestUpdaterOrchestration(_ReportPeriodMixin, MasuTestCase):
 
         updater._update_usage_rates_to_usage(start_date, end_date)
 
-        insert_calls = [
-            c for c in mock_execute.call_args_list if c[1].get("operation") == "INSERT"
-        ]
-        self.assertEqual(
-            len(insert_calls), 1, "Single-pass: exactly one INSERT call expected"
-        )
+        insert_calls = [c for c in mock_execute.call_args_list if c[1].get("operation") == "INSERT"]
+        self.assertEqual(len(insert_calls), 1, "Single-pass: exactly one INSERT call expected")
         sql_params = insert_calls[0][0][2]
         self.assertIn("cost_model_id", sql_params)
         self.assertNotIn("cluster_cost_per_hour", sql_params)
@@ -847,9 +783,7 @@ class TestUpdaterOrchestration(_ReportPeriodMixin, MasuTestCase):
         mock_dist,
     ):
         """Phase 3 SQL writes to rates_to_usage, so flag OFF still uses RTU pipeline."""
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         sr = self._make_summary_range()
         updater.update_summary_cost_model_costs(sr)
         mock_rtu.assert_called_once()
@@ -863,25 +797,17 @@ class TestPartitionWiring(MasuTestCase):
     # TC-45: calls _handle_partitions
     @patch.object(OCPCostModelCostUpdater, "_handle_partitions")
     def test_partition_wiring_calls_handle_partitions(self, mock_handle):
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         dh = DateHelper()
-        updater._ensure_rates_to_usage_partitions(
-            dh.this_month_start, dh.this_month_end
-        )
+        updater._ensure_rates_to_usage_partitions(dh.this_month_start, dh.this_month_end)
         mock_handle.assert_called_once()
 
     # TC-46: correct table name
     @patch.object(OCPCostModelCostUpdater, "_handle_partitions")
     def test_partition_wiring_correct_table_name(self, mock_handle):
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         dh = DateHelper()
-        updater._ensure_rates_to_usage_partitions(
-            dh.this_month_start, dh.this_month_end
-        )
+        updater._ensure_rates_to_usage_partitions(dh.this_month_start, dh.this_month_end)
         args, kwargs = mock_handle.call_args
         self.assertEqual(args[1], ["rates_to_usage"])
 
@@ -890,58 +816,36 @@ class TestSkipPaths(MasuTestCase):
     """Test skip paths when report period or cost_model_id is missing (BAC-10, BAC-12)."""
 
     # TC-47: RTU insert skips with log when no report period
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.report_periods_for_provider_uuid"
-    )
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.report_periods_for_provider_uuid")
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
     @patch.object(OCPCostModelCostUpdater, "_ensure_rates_to_usage_partitions")
-    def test_rtu_insert_skips_no_report_period(
-        self, mock_partitions, mock_execute, mock_rp
-    ):
+    def test_rtu_insert_skips_no_report_period(self, mock_partitions, mock_execute, mock_rp):
         mock_rp.return_value = None
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         dh = DateHelper()
         with self.assertLogs("masu.processor.ocp", level="INFO") as cm:
             updater._update_usage_rates_to_usage(dh.this_month_start, dh.this_month_end)
         mock_execute.assert_not_called()
-        self.assertTrue(
-            any("skipping rates_to_usage insert" in msg for msg in cm.output)
-        )
+        self.assertTrue(any("skipping rates_to_usage insert" in msg for msg in cm.output))
 
     # TC-48: RTU aggregate skips with log when no report period
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.report_periods_for_provider_uuid"
-    )
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.report_periods_for_provider_uuid")
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
     def test_rtu_aggregate_skips_no_report_period(self, mock_execute, mock_rp):
         mock_rp.return_value = None
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         dh = DateHelper()
         with self.assertLogs("masu.processor.ocp", level="INFO") as cm:
-            updater._aggregate_rates_to_daily_summary(
-                dh.this_month_start, dh.this_month_end
-            )
+            updater._aggregate_rates_to_daily_summary(dh.this_month_start, dh.this_month_end)
         mock_execute.assert_not_called()
-        self.assertTrue(
-            any("skipping rates_to_usage aggregation" in msg for msg in cm.output)
-        )
+        self.assertTrue(any("skipping rates_to_usage aggregation" in msg for msg in cm.output))
 
     # TC-49: RTU insert skips when no cost_model_id
     @patch.object(OCPCostModelCostUpdater, "_ensure_rates_to_usage_partitions")
     @patch("masu.processor.ocp.ocp_cost_model_cost_updater.CostModelDBAccessor")
     def test_rtu_insert_skips_no_cost_model_id(self, mock_accessor, mock_part):
         _setup_no_cost_model_mock(mock_accessor)
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         self.assertIsNone(updater._cost_model_id)
 
         dh = DateHelper()
@@ -952,18 +856,14 @@ class TestSkipPaths(MasuTestCase):
     @patch("masu.processor.ocp.ocp_cost_model_cost_updater.CostModelDBAccessor")
     def test_rtu_aggregate_skips_no_cost_model_id(self, mock_accessor):
         _setup_no_cost_model_mock(mock_accessor)
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         self.assertIsNone(updater._cost_model_id)
 
         dh = DateHelper()
         with patch(
             "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
         ) as mock_exec:
-            updater._aggregate_rates_to_daily_summary(
-                dh.this_month_start, dh.this_month_end
-            )
+            updater._aggregate_rates_to_daily_summary(dh.this_month_start, dh.this_month_end)
             mock_exec.assert_not_called()
 
 
@@ -975,9 +875,7 @@ class TestPurgeWiring(MasuTestCase):
     @patch("masu.processor.ocp.ocp_report_db_cleaner.cascade_delete")
     @patch("masu.processor.ocp.ocp_report_db_cleaner.PartitionedTable")
     @patch("masu.processor.ocp.ocp_report_db_cleaner.OCPReportDBAccessor")
-    def test_rates_to_usage_in_cleaner_base_list(
-        self, mock_accessor_cls, mock_pt, mock_cascade, mock_delete
-    ):
+    def test_rates_to_usage_in_cleaner_base_list(self, mock_accessor_cls, mock_pt, mock_cascade, mock_delete):
         """Verify partition cleanup includes rates_to_usage table."""
         from datetime import date as date_cls
         from unittest.mock import MagicMock
@@ -989,9 +887,7 @@ class TestPurgeWiring(MasuTestCase):
         mock_qs.__iter__ = MagicMock(return_value=iter([]))
         mock_qs.query = MagicMock()
         mock_accessor.get_report_periods_before_date.return_value = mock_qs
-        mock_accessor._table_map = {
-            "line_item_daily_summary": "reporting_ocpusagelineitem_daily_summary"
-        }
+        mock_accessor._table_map = {"line_item_daily_summary": "reporting_ocpusagelineitem_daily_summary"}
 
         cleaner = OCPReportDBCleaner(self.schema)
         cleaner.purge_expired_report_data_by_date(date_cls(2020, 1, 1))
@@ -1035,9 +931,7 @@ class TestRTUCostBreakdownAPI(_ReportPeriodMixin, MasuTestCase):
         from api.models import Provider
         from api.report.ocp.provider_map import OCPProviderMap
 
-        cls.provider_map = OCPProviderMap(
-            Provider.PROVIDER_OCP, "costs", cls.schema_name
-        )
+        cls.provider_map = OCPProviderMap(Provider.PROVIDER_OCP, "costs", cls.schema_name)
         cls.cost_term = (
             cls.provider_map.cloud_infrastructure_cost
             + cls.provider_map.markup_cost
@@ -1052,9 +946,7 @@ class TestRTUCostBreakdownAPI(_ReportPeriodMixin, MasuTestCase):
         return {
             "source_uuid": self.ocp_provider.uuid,
             "usage_start__gte": (
-                rp.report_period_start.date()
-                if hasattr(rp.report_period_start, "date")
-                else rp.report_period_start
+                rp.report_period_start.date() if hasattr(rp.report_period_start, "date") else rp.report_period_start
             ),
         }
 
@@ -1075,9 +967,7 @@ class TestRTUCostBreakdownAPI(_ReportPeriodMixin, MasuTestCase):
             dh = DateHelper()
             start_date = rp.report_period_start
             end_date = dh.month_end(start_date)
-            updater = OCPCostModelCostUpdater(
-                schema=self.schema, provider=self.ocp_provider
-            )
+            updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
             if not updater._cost_model_id:
                 self.skipTest("No cost model for OCP provider")
             updater._load_rates(start_date)
@@ -1091,9 +981,7 @@ class TestRTUCostBreakdownAPI(_ReportPeriodMixin, MasuTestCase):
                     usage_start__gte=rp_filter["usage_start__gte"],
                 ).count()
 
-        self.assertGreater(
-            count, 0, "RTU table should have rows for OCP-on-Prem provider"
-        )
+        self.assertGreater(count, 0, "RTU table should have rows for OCP-on-Prem provider")
 
     # TC-E2E-02: RTU aggregated costs reconcile with daily summary
     def test_rtu_sums_match_daily_summary_cost_model_columns(self):
@@ -1118,9 +1006,7 @@ class TestRTUCostBreakdownAPI(_ReportPeriodMixin, MasuTestCase):
                 .values("metric_type")
                 .annotate(total=Sum("calculated_cost"))
             )
-            rtu_by_metric = {
-                row["metric_type"]: row["total"] or Decimal(0) for row in rtu_agg
-            }
+            rtu_by_metric = {row["metric_type"]: row["total"] or Decimal(0) for row in rtu_agg}
 
             ds_agg = OCPUsageLineItemDailySummary.objects.filter(
                 source_uuid=rp_filter["source_uuid"],
@@ -1184,9 +1070,7 @@ class TestRTUCostBreakdownAPI(_ReportPeriodMixin, MasuTestCase):
 
         with tenant_context(self.tenant):
             cost = (
-                OCPUsageLineItemDailySummary.objects.filter(
-                    usage_start__gte=self.dh.this_month_start.date()
-                )
+                OCPUsageLineItemDailySummary.objects.filter(usage_start__gte=self.dh.this_month_start.date())
                 .annotate(
                     infra_exchange_rate=Value(Decimal(1)),
                     exchange_rate=Value(Decimal(1)),
@@ -1196,13 +1080,7 @@ class TestRTUCostBreakdownAPI(_ReportPeriodMixin, MasuTestCase):
             )
             expected_total = cost if cost is not None else 0
 
-        total = (
-            data.get("meta", {})
-            .get("total", {})
-            .get("cost", {})
-            .get("total", {})
-            .get("value", 0)
-        )
+        total = data.get("meta", {}).get("total", {}).get("cost", {}).get("total", {}).get("value", 0)
         self.assertNotEqual(total, Decimal(0), "API should return non-zero cost total")
         self.assertAlmostEqual(total, expected_total, 6)
 
@@ -1242,18 +1120,14 @@ class TestRTUCostBreakdownAPI(_ReportPeriodMixin, MasuTestCase):
             if found_nonzero:
                 break
 
-        self.assertTrue(
-            found_nonzero, "At least one project should have non-zero cost-model costs"
-        )
+        self.assertTrue(found_nonzero, "At least one project should have non-zero cost-model costs")
 
 
 class TestRTURateResolution(_ReportPeriodMixin, MasuTestCase):
     """drift5-sql: Verify RTU rows resolve rate_id and custom_name from Rate table."""
 
     # TC-D5-01: SQL params include cost_model_id (regression guard)
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
     def test_populate_rtu_params_include_cost_model_id(self, mock_execute):
         """populate_usage_rates_to_usage passes cost_model_id in SQL params."""
         dh = DateHelper()
@@ -1349,9 +1223,7 @@ class TestRTURateResolution(_ReportPeriodMixin, MasuTestCase):
             ).count()
         if total == 0:
             self.skipTest("No RTU rows to check")
-        self.assertGreaterEqual(
-            total, with_rate, "Total RTU rows should be >= rows with rate FK"
-        )
+        self.assertGreaterEqual(total, with_rate, "Total RTU rows should be >= rows with rate FK")
 
     # TC-D5-05: RTU custom_name falls back to metric name when no Rate exists
     def test_rtu_custom_name_fallback(self):
@@ -1370,9 +1242,7 @@ class TestRTURateResolution(_ReportPeriodMixin, MasuTestCase):
                 rate__isnull=True,
             ).first()
         if not rtu_row:
-            self.skipTest(
-                "No RTU rows with NULL rate FK (all rows may have matching Rate)"
-            )
+            self.skipTest("No RTU rows with NULL rate FK (all rows may have matching Rate)")
         known_identifiers = (
             set(metric_constants.COST_MODEL_USAGE_RATES)
             | set(metric_constants.COST_MODEL_MONTHLY_RATES)
@@ -1387,9 +1257,7 @@ class TestRTURateResolution(_ReportPeriodMixin, MasuTestCase):
                 "Node_Core_Hour",
             }
         )
-        name_recognised = any(
-            ident in rtu_row.custom_name for ident in known_identifiers
-        )
+        name_recognised = any(ident in rtu_row.custom_name for ident in known_identifiers)
         self.assertTrue(
             name_recognised,
             f"RTU custom_name '{rtu_row.custom_name}' should contain a known metric or cost type as fallback",
@@ -1438,16 +1306,12 @@ class TestOrchestrationOrder(_ReportPeriodMixin, MasuTestCase):
         mock_vm.side_effect = lambda *a: call_order.append("vm")
         mock_dist.side_effect = lambda *a: call_order.append("dist")
 
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         sr = self._make_summary_range()
         updater.update_summary_cost_model_costs(sr)
 
         expected = ["rtu", "monthly", "vm", "dist"]
-        self.assertEqual(
-            call_order, expected, f"R20: expected {expected}, got {call_order}"
-        )
+        self.assertEqual(call_order, expected, f"R20: expected {expected}, got {call_order}")
         mock_usage.assert_not_called()
         mock_cleanup.assert_not_called()
 
@@ -1467,9 +1331,7 @@ class TestOrchestrationOrder(_ReportPeriodMixin, MasuTestCase):
         mock_dist,
     ):
         """R20: distribute_costs_and_update_ui_summary is invoked."""
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         sr = self._make_summary_range()
         updater.update_summary_cost_model_costs(sr)
 
@@ -1492,9 +1354,7 @@ class TestOrchestrationOrder(_ReportPeriodMixin, MasuTestCase):
     ):
         """R20: When cost_model_id is None, cleanup runs instead of RTU insert.
         Monthly/vm/dist still run (agg+markup are inside dist)."""
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         updater._cost_model_id = None
         sr = self._make_summary_range()
         updater.update_summary_cost_model_costs(sr)
@@ -1543,9 +1403,7 @@ class TestPriceListValidityGuard(_ReportPeriodMixin, MasuTestCase):
         """When _load_rates finds no effective PL, RTU is skipped and stale rows cleaned."""
         from datetime import date
 
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
 
         def fake_load(start_date):
             updater._infra_rates = {}
@@ -1585,9 +1443,7 @@ class TestPriceListValidityGuard(_ReportPeriodMixin, MasuTestCase):
         mock_dist,
     ):
         """When _price_list_effective_on is None (feature flag disabled), RTU proceeds normally."""
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
 
         def fake_load(start_date):
             updater._infra_rates = {}
@@ -1625,9 +1481,7 @@ class TestPriceListValidityGuard(_ReportPeriodMixin, MasuTestCase):
         """When _load_rates finds an effective PL with rates, RTU proceeds."""
         from datetime import date
 
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
 
         def fake_load(start_date):
             updater._infra_rates = {"cpu_core_usage_per_hour": 0.2}
@@ -1652,9 +1506,7 @@ class TestPriceListValidityGuard(_ReportPeriodMixin, MasuTestCase):
         """_load_rates must propagate price_list_effective_on from the accessor."""
         from datetime import date
 
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         self.assertIsNone(updater._price_list_effective_on)
 
         test_date = date(2026, 4, 1)
@@ -1671,9 +1523,7 @@ class TestPriceListValidityGuard(_ReportPeriodMixin, MasuTestCase):
         """When DISABLE_PRICE_LIST flag is on, _price_list_effective_on should be None."""
         from datetime import date
 
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         updater._load_rates(date(2026, 4, 1))
 
         self.assertIsNone(updater._price_list_effective_on)
@@ -1696,9 +1546,7 @@ class TestPriceListValidityGuard(_ReportPeriodMixin, MasuTestCase):
         """Tag-based cost paths must be skipped when no PL covers the month."""
         from datetime import date
 
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
 
         def fake_load(start_date):
             updater._infra_rates = {}
@@ -1729,9 +1577,7 @@ class TestTwoMonthOrchestration(_ReportPeriodMixin, MasuTestCase):
         from datetime import datetime
         from datetime import timezone
 
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         if not updater._cost_model_id:
             self.skipTest("No cost model for OCP provider")
 
@@ -1765,9 +1611,7 @@ class TestTwoMonthOrchestration(_ReportPeriodMixin, MasuTestCase):
 
         with patch.object(updater, "_load_rates", side_effect=fake_load), patch.object(
             updater, "_update_usage_rates_to_usage"
-        ) as mock_rtu, patch.object(
-            updater, "_aggregate_rates_to_daily_summary"
-        ), patch.object(
+        ) as mock_rtu, patch.object(updater, "_aggregate_rates_to_daily_summary"), patch.object(
             updater, "_update_vm_usage_costs"
         ), patch.object(
             updater, "_cleanup_stale_rtu_costs"
@@ -1808,45 +1652,31 @@ class TestRoutingMetricType(MasuTestCase):
         self.assertEqual(result, "storage")
 
     def test_node_cpu_distribution(self):
-        result = OCPReportDBAccessor._get_routing_metric_type(
-            cost_type="Node", distribution="cpu"
-        )
+        result = OCPReportDBAccessor._get_routing_metric_type(cost_type="Node", distribution="cpu")
         self.assertEqual(result, "cpu")
 
     def test_node_memory_distribution(self):
-        result = OCPReportDBAccessor._get_routing_metric_type(
-            cost_type="Node", distribution="memory"
-        )
+        result = OCPReportDBAccessor._get_routing_metric_type(cost_type="Node", distribution="memory")
         self.assertEqual(result, "memory")
 
     def test_cluster_cpu_distribution(self):
-        result = OCPReportDBAccessor._get_routing_metric_type(
-            cost_type="Cluster", distribution="cpu"
-        )
+        result = OCPReportDBAccessor._get_routing_metric_type(cost_type="Cluster", distribution="cpu")
         self.assertEqual(result, "cpu")
 
     def test_node_core_month_memory(self):
-        result = OCPReportDBAccessor._get_routing_metric_type(
-            cost_type="Node_Core_Month", distribution="memory"
-        )
+        result = OCPReportDBAccessor._get_routing_metric_type(cost_type="Node_Core_Month", distribution="memory")
         self.assertEqual(result, "memory")
 
     def test_gpu_metric_name(self):
-        result = OCPReportDBAccessor._get_routing_metric_type(
-            metric_name="gpu_cost_per_month"
-        )
+        result = OCPReportDBAccessor._get_routing_metric_type(metric_name="gpu_cost_per_month")
         self.assertEqual(result, "gpu")
 
     def test_vm_metric_returns_cpu(self):
-        result = OCPReportDBAccessor._get_routing_metric_type(
-            metric_name="vm_cost_per_hour"
-        )
+        result = OCPReportDBAccessor._get_routing_metric_type(metric_name="vm_cost_per_hour")
         self.assertEqual(result, "cpu")
 
     def test_ocp_vm_cost_type(self):
-        result = OCPReportDBAccessor._get_routing_metric_type(
-            cost_type="OCP_VM", distribution="cpu"
-        )
+        result = OCPReportDBAccessor._get_routing_metric_type(cost_type="OCP_VM", distribution="cpu")
         self.assertEqual(result, "cpu")
 
     def test_usage_type_passthrough(self):
@@ -1864,9 +1694,7 @@ class TestRoutingMetricType(MasuTestCase):
         self.assertEqual(result, "cpu")
 
     def test_node_core_hour(self):
-        result = OCPReportDBAccessor._get_routing_metric_type(
-            cost_type="Node_Core_Hour", distribution="cpu"
-        )
+        result = OCPReportDBAccessor._get_routing_metric_type(cost_type="Node_Core_Hour", distribution="cpu")
         self.assertEqual(result, "cpu")
 
 
@@ -1884,9 +1712,7 @@ class TestPopulateMarkupRatesToUsage(_ReportPeriodMixin, MasuTestCase):
     """
 
     # TC-60: SQL params correct
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
     def test_markup_rtu_sql_params_correct(self, mock_execute):
         """BAC-16: populate_markup_rates_to_usage passes all required SQL params."""
         dh = DateHelper()
@@ -1919,14 +1745,10 @@ class TestPopulateMarkupRatesToUsage(_ReportPeriodMixin, MasuTestCase):
         self.assertEqual(sql_params["source_uuid"], self.ocp_provider_uuid)
         self.assertEqual(sql_params["start_date"], dh.this_month_start.date())
         self.assertEqual(sql_params["end_date"], dh.this_month_end.date())
-        self.assertEqual(
-            sql_params["cost_model_id"], "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
-        )
+        self.assertEqual(sql_params["cost_model_id"], "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
 
     # TC-61: operation is INSERT
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
     def test_markup_rtu_operation_is_insert(self, mock_execute):
         """BAC-16: SQL execution uses operation='INSERT'."""
         dh = DateHelper()
@@ -1943,9 +1765,7 @@ class TestPopulateMarkupRatesToUsage(_ReportPeriodMixin, MasuTestCase):
         self.assertEqual(kwargs.get("operation"), "INSERT")
 
     # TC-66: SQL file loaded from correct path
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
     @patch("masu.database.ocp_report_db_accessor.pkgutil.get_data")
     def test_markup_rtu_sql_file_loaded(self, mock_pkgutil, mock_execute):
         """BAC-16: SQL loaded from insert_markup_rates_to_usage.sql."""
@@ -1978,9 +1798,7 @@ class TestPopulateMarkupRatesToUsage(_ReportPeriodMixin, MasuTestCase):
         insert_start = sql_text.index("INSERT INTO")
         delete_block = sql_text[delete_start:insert_start]
         self.assertIn("metric_type", delete_block, "DELETE must filter by metric_type")
-        self.assertIn(
-            "'markup'", delete_block, "DELETE must scope to metric_type = 'markup'"
-        )
+        self.assertIn("'markup'", delete_block, "DELETE must scope to metric_type = 'markup'")
         self.assertNotIn(
             "report_period_id",
             delete_block,
@@ -2001,9 +1819,7 @@ class TestMarkupRTUIntegration(_ReportPeriodMixin, MasuTestCase):
         rp = self._get_report_period()
         start_date = rp.report_period_start.date()
         end_date = DateHelper().month_end(rp.report_period_start).date()
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         if not updater._cost_model_id:
             self.skipTest("No cost model for OCP provider")
         with schema_context(self.schema):
@@ -2062,9 +1878,7 @@ class TestMarkupRTUIntegration(_ReportPeriodMixin, MasuTestCase):
         rp = self._get_report_period()
         start_date = rp.report_period_start.date()
         end_date = DateHelper().month_end(rp.report_period_start).date()
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         if not updater._cost_model_id:
             self.skipTest("No cost model for OCP provider")
         updater._load_rates(start_date)
@@ -2125,9 +1939,7 @@ class TestMarkupRTUIntegration(_ReportPeriodMixin, MasuTestCase):
             "Seed succeeded but no usage RTU rows — pipeline regression",
         )
 
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         updater._update_markup_cost(start_date, end_date)
 
         with schema_context(self.schema):
@@ -2154,9 +1966,7 @@ class TestMarkupRTUIntegration(_ReportPeriodMixin, MasuTestCase):
                 usage_start__gte=start_date,
                 usage_start__lte=end_date,
             ).first()
-        self.assertIsNotNone(
-            row, "Seed succeeded but no markup RTU rows — pipeline regression"
-        )
+        self.assertIsNotNone(row, "Seed succeeded but no markup RTU rows — pipeline regression")
         self.assertIsNone(row.rate_id, "Markup rows should have rate_id=None")
         self.assertEqual(row.custom_name, "Markup")
         self.assertEqual(row.cost_model_rate_type, "Infrastructure")
@@ -2173,9 +1983,7 @@ class TestValidateRatesToUsageFix(_ReportPeriodMixin, MasuTestCase):
     """Test validate_rates_against_daily_summary returns results (BAC-24, BAC-25)."""
 
     # TC-65: validate_rates_against_daily_summary uses VALIDATION_QUERY operation
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
     def test_validation_uses_validation_query_operation(self, mock_execute):
         """BAC-24: operation='VALIDATION_QUERY' is passed so cursor.fetchall() returns results."""
         dh = DateHelper()
@@ -2260,53 +2068,37 @@ class TestPrometheusTimingWrappers(_ReportPeriodMixin, MasuTestCase):
 
     # TC-82: _update_usage_rates_to_usage observes RTU_POPULATE_DURATION
     @patch("masu.processor.ocp.ocp_cost_model_cost_updater.RTU_POPULATE_DURATION")
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_usage_rates_to_usage"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_usage_rates_to_usage")
     def test_rtu_populate_observes_histogram(self, mock_populate, mock_histogram):
         """BAC-23: _update_usage_rates_to_usage records duration in RTU_POPULATE_DURATION."""
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         if not updater._cost_model_id:
             self.skipTest("No cost model for OCP provider")
         dh = DateHelper()
         updater._load_rates(dh.this_month_start.date())
-        updater._update_usage_rates_to_usage(
-            dh.this_month_start.date(), dh.this_month_end.date()
-        )
+        updater._update_usage_rates_to_usage(dh.this_month_start.date(), dh.this_month_end.date())
         mock_histogram.labels.assert_called_with(provider_type=self.ocp_provider.type)
         observe_args = mock_histogram.labels.return_value.observe.call_args
-        self.assertIsNotNone(
-            observe_args, "observe() was never called on RTU_POPULATE_DURATION"
-        )
+        self.assertIsNotNone(observe_args, "observe() was never called on RTU_POPULATE_DURATION")
         observed_duration = observe_args[0][0]
         self.assertGreaterEqual(observed_duration, 0, "Duration must be non-negative")
 
     # TC-83: _update_markup_cost observes RTU_MARKUP_DURATION
     @patch("masu.processor.ocp.ocp_cost_model_cost_updater.RTU_MARKUP_DURATION")
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_markup_rates_to_usage"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_markup_rates_to_usage")
     @patch("masu.processor.ocp.ocp_cost_model_cost_updater.CostModelDBAccessor")
-    def test_markup_rtu_observes_histogram(
-        self, mock_cost_accessor, _mock_rtu, mock_histogram
-    ):
+    def test_markup_rtu_observes_histogram(self, mock_cost_accessor, _mock_rtu, mock_histogram):
         """BAC-23: _update_markup_cost records duration in RTU_MARKUP_DURATION."""
         mock_cost_accessor.return_value.__enter__.return_value.markup = {
             "value": 10,
             "unit": "percent",
         }
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         dh = DateHelper()
         updater._update_markup_cost(dh.this_month_start, dh.this_month_end)
         mock_histogram.labels.assert_called_with(provider_type=self.ocp_provider.type)
         observe_args = mock_histogram.labels.return_value.observe.call_args
-        self.assertIsNotNone(
-            observe_args, "observe() was never called on RTU_MARKUP_DURATION"
-        )
+        self.assertIsNotNone(observe_args, "observe() was never called on RTU_MARKUP_DURATION")
         observed_duration = observe_args[0][0]
         self.assertGreaterEqual(observed_duration, 0, "Duration must be non-negative")
 
@@ -2332,17 +2124,11 @@ class TestPhase4Orchestration(_ReportPeriodMixin, MasuTestCase):
         )
 
     @patch.object(OCPCostModelCostUpdater, "_ensure_rates_to_usage_partitions")
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_ui_summary_tables"
-    )
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_distributed_cost_sql"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_ui_summary_tables")
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_distributed_cost_sql")
     @patch.object(OCPCostModelCostUpdater, "_update_markup_cost")
     @patch.object(OCPCostModelCostUpdater, "_aggregate_rates_to_daily_summary")
-    def test_phase4_per_month_order(
-        self, mock_agg, mock_markup, mock_dist_sql, mock_ui, mock_partitions
-    ):
+    def test_phase4_per_month_order(self, mock_agg, mock_markup, mock_dist_sql, mock_ui, mock_partitions):
         """Per-month order must be: distribute -> aggregate -> markup -> ui."""
         call_order = []
         mock_dist_sql.side_effect = lambda sr, *a, **kw: (
@@ -2353,9 +2139,7 @@ class TestPhase4Orchestration(_ReportPeriodMixin, MasuTestCase):
         mock_markup.side_effect = lambda *a: call_order.append("markup")
         mock_ui.side_effect = lambda *a, **kw: call_order.append("ui")
 
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         sr = self._make_summary_range()
         updater.distribute_costs_and_update_ui_summary(sr)
 
@@ -2366,35 +2150,23 @@ class TestPhase4Orchestration(_ReportPeriodMixin, MasuTestCase):
         )
 
     @patch.object(OCPCostModelCostUpdater, "_ensure_rates_to_usage_partitions")
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_ui_summary_tables"
-    )
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_distributed_cost_sql"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_ui_summary_tables")
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_distributed_cost_sql")
     @patch.object(OCPCostModelCostUpdater, "_update_markup_cost")
     @patch.object(OCPCostModelCostUpdater, "_aggregate_rates_to_daily_summary")
-    def test_distribute_calls_dist_entry_point(
-        self, mock_agg, mock_markup, mock_dist_sql, mock_ui, mock_partitions
-    ):
+    def test_distribute_calls_dist_entry_point(self, mock_agg, mock_markup, mock_dist_sql, mock_ui, mock_partitions):
         """distribute_costs_and_update_ui_summary invokes accessor.populate_distributed_cost_sql."""
         mock_dist_sql.side_effect = lambda sr, *a, **kw: sr
 
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         sr = self._make_summary_range()
         updater.distribute_costs_and_update_ui_summary(sr)
 
         mock_dist_sql.assert_called_once()
 
     @patch.object(OCPCostModelCostUpdater, "_ensure_rates_to_usage_partitions")
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_ui_summary_tables"
-    )
-    @patch(
-        "masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_distributed_cost_sql"
-    )
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_ui_summary_tables")
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_distributed_cost_sql")
     @patch.object(OCPCostModelCostUpdater, "_update_markup_cost")
     @patch.object(OCPCostModelCostUpdater, "_aggregate_rates_to_daily_summary")
     def test_derived_cost_datetime_updated_after_pipeline(
@@ -2403,9 +2175,7 @@ class TestPhase4Orchestration(_ReportPeriodMixin, MasuTestCase):
         """D1: derived_cost_datetime is updated even after nested accessors reset schema."""
         mock_dist_sql.side_effect = lambda sr, *a, **kw: sr
 
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         sr = self._make_summary_range()
 
         rp = self._get_report_period()

--- a/koku/masu/test/processor/ocp/test_phase2_rates_to_usage.py
+++ b/koku/masu/test/processor/ocp/test_phase2_rates_to_usage.py
@@ -2080,7 +2080,10 @@ class TestPhase4Orchestration(_ReportPeriodMixin, MasuTestCase):
     """Test distribute_costs_and_update_ui_summary internal ordering (D1/D2).
 
     Patches at the accessor boundary rather than mocking the whole method,
-    verifying per-month order: distribute -> aggregate -> markup -> ui.
+    verifying per-month order: markup(daily_summary) -> distribute -> aggregate -> markup(full) -> ui.
+
+    The pre-distribution populate_markup_cost call is tested separately;
+    these tests verify the tracked major-step sequence.
     """
 
     def _make_summary_range(self):

--- a/koku/masu/test/processor/ocp/test_phase2_rates_to_usage.py
+++ b/koku/masu/test/processor/ocp/test_phase2_rates_to_usage.py
@@ -2109,9 +2109,7 @@ class TestPhase4Orchestration(_ReportPeriodMixin, MasuTestCase):
     @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_distributed_cost_sql")
     @patch.object(OCPCostModelCostUpdater, "_update_markup_cost")
     @patch.object(OCPCostModelCostUpdater, "_aggregate_rates_to_daily_summary")
-    def test_phase4_per_month_order(
-        self, mock_agg, mock_markup, mock_dist_sql, mock_ui, mock_partitions
-    ):
+    def test_phase4_per_month_order(self, mock_agg, mock_markup, mock_dist_sql, mock_ui, mock_partitions):
         """Per-month order must be: distribute -> aggregate -> markup -> ui."""
         call_order = []
         mock_dist_sql.side_effect = lambda sr, *a, **kw: (call_order.append("dist"), sr)[1]
@@ -2124,7 +2122,8 @@ class TestPhase4Orchestration(_ReportPeriodMixin, MasuTestCase):
         updater.distribute_costs_and_update_ui_summary(sr)
 
         self.assertEqual(
-            call_order, ["dist", "agg", "markup", "ui"],
+            call_order,
+            ["dist", "agg", "markup", "ui"],
             f"Expected [dist, agg, markup, ui] but got {call_order}",
         )
 
@@ -2133,9 +2132,7 @@ class TestPhase4Orchestration(_ReportPeriodMixin, MasuTestCase):
     @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_distributed_cost_sql")
     @patch.object(OCPCostModelCostUpdater, "_update_markup_cost")
     @patch.object(OCPCostModelCostUpdater, "_aggregate_rates_to_daily_summary")
-    def test_distribute_calls_dist_entry_point(
-        self, mock_agg, mock_markup, mock_dist_sql, mock_ui, mock_partitions
-    ):
+    def test_distribute_calls_dist_entry_point(self, mock_agg, mock_markup, mock_dist_sql, mock_ui, mock_partitions):
         """distribute_costs_and_update_ui_summary invokes accessor.populate_distributed_cost_sql."""
         mock_dist_sql.side_effect = lambda sr, *a, **kw: sr
 
@@ -2168,7 +2165,8 @@ class TestPhase4Orchestration(_ReportPeriodMixin, MasuTestCase):
             rp.refresh_from_db()
         if old_datetime is not None:
             self.assertGreater(
-                rp.derived_cost_datetime, old_datetime,
+                rp.derived_cost_datetime,
+                old_datetime,
                 "derived_cost_datetime should be updated after pipeline run",
             )
         else:

--- a/koku/masu/test/processor/ocp/test_phase2_rates_to_usage.py
+++ b/koku/masu/test/processor/ocp/test_phase2_rates_to_usage.py
@@ -1425,7 +1425,7 @@ class TestPriceListValidityGuard(_ReportPeriodMixin, MasuTestCase):
         mock_dist.assert_called()
         mock_vm.assert_called()
         mock_monthly.assert_called()
-        mock_markup.assert_called()
+        mock_markup.assert_not_called()
 
     # TC-7492-02: RTU still called when price_list_effective_on is None (feature flag disabled)
     @_make_orchestration_patches(rtu_enabled=True)

--- a/koku/masu/test/processor/ocp/test_phase4_distribution.py
+++ b/koku/masu/test/processor/ocp/test_phase4_distribution.py
@@ -70,14 +70,14 @@ class TestDistributionIntegration(_ReportPeriodMixin, MasuTestCase):
 
     def _seed_and_distribute(self):
         """Ensure RTU usage rows exist and run per-rate distribution."""
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
-        if not updater._cost_model_id:
+        self._updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        if not self._updater._cost_model_id:
             self.skipTest("No cost model for OCP provider")
-        updater._load_rates(self.start_date)
-        if not (updater._infra_rates or updater._supplementary_rates):
+        self._updater._load_rates(self.start_date)
+        if not (self._updater._infra_rates or self._updater._supplementary_rates):
             self.skipTest("No rates loaded for OCP provider")
 
-        updater._update_usage_rates_to_usage(self.start_date, self.end_date)
+        self._updater._update_usage_rates_to_usage(self.start_date, self.end_date)
 
         with schema_context(self.schema):
             usage_count = RatesToUsage.objects.filter(
@@ -96,7 +96,12 @@ class TestDistributionIntegration(_ReportPeriodMixin, MasuTestCase):
         }
         summary_range = SummaryRangeConfig(start_date=self.start_date, end_date=self.end_date)
         with OCPReportDBAccessor(self.schema) as accessor:
-            accessor.populate_distributed_cost_sql(summary_range, self.provider_uuid, distribution_info)
+            accessor.populate_distributed_cost_sql(
+                summary_range,
+                self.provider_uuid,
+                distribution_info,
+                cost_model_id=self._updater._cost_model_id,
+            )
 
     def _distributed_qs(self, distribution_type=None):
         """QuerySet for distributed RTU rows in the test window."""
@@ -337,7 +342,12 @@ class TestDistributionIntegration(_ReportPeriodMixin, MasuTestCase):
         }
         summary_range = SummaryRangeConfig(start_date=self.start_date, end_date=self.end_date)
         with OCPReportDBAccessor(self.schema) as accessor:
-            accessor.populate_distributed_cost_sql(summary_range, self.provider_uuid, distribution_info)
+            accessor.populate_distributed_cost_sql(
+                summary_range,
+                self.provider_uuid,
+                distribution_info,
+                cost_model_id=self._updater._cost_model_id,
+            )
 
         with schema_context(self.schema):
             post_count = self._distributed_qs(dist_type).count()
@@ -430,7 +440,12 @@ class TestDistributionIntegration(_ReportPeriodMixin, MasuTestCase):
         }
         summary_range = SummaryRangeConfig(start_date=self.start_date, end_date=self.end_date)
         with OCPReportDBAccessor(self.schema) as accessor:
-            accessor.populate_distributed_cost_sql(summary_range, self.provider_uuid, distribution_info)
+            accessor.populate_distributed_cost_sql(
+                summary_range,
+                self.provider_uuid,
+                distribution_info,
+                cost_model_id=self._updater._cost_model_id,
+            )
 
         with schema_context(self.schema):
             new_sum = self._distributed_qs(dist_type).aggregate(t=Sum("distributed_cost"))["t"] or Decimal(0)
@@ -443,3 +458,20 @@ class TestDistributionIntegration(_ReportPeriodMixin, MasuTestCase):
             places=10,
             msg="Re-run should produce same total distributed cost",
         )
+
+    # ------------------------------------------------------------------
+    # Assertion 11: Distribution rows carry cost_model_id
+    # ------------------------------------------------------------------
+    def test_distribution_rows_have_cost_model_id(self):
+        """Distribution RTU rows must have cost_model_id set (not NULL)."""
+        with schema_context(self.schema):
+            dist_rows = self._distributed_qs()
+            if not dist_rows.exists():
+                self.skipTest("No distributed rows in test data")
+            null_cm_rows = dist_rows.filter(cost_model__isnull=True)
+            null_types = list(null_cm_rows.values_list("monthly_cost_type", flat=True).distinct())
+            self.assertEqual(
+                null_cm_rows.count(),
+                0,
+                f"Distribution rows with NULL cost_model_id found for types: {null_types}",
+            )

--- a/koku/masu/test/processor/ocp/test_phase4_distribution.py
+++ b/koku/masu/test/processor/ocp/test_phase4_distribution.py
@@ -24,7 +24,6 @@ from masu.database.ocp_report_db_accessor import OCPReportDBAccessor
 from masu.processor.ocp.ocp_cost_model_cost_updater import OCPCostModelCostUpdater
 from masu.test import MasuTestCase
 from masu.util.common import SummaryRangeConfig
-from reporting.provider.ocp.models import OCPUsageLineItemDailySummary
 from reporting.provider.ocp.models import OCPUsageReportPeriod
 from reporting.provider.ocp.models import RatesToUsage
 
@@ -143,11 +142,7 @@ class TestDistributionIntegration(_ReportPeriodMixin, MasuTestCase):
         self._skip_if_no_distributed(dist_type)
 
         with schema_context(self.schema):
-            days = (
-                self._distributed_qs(dist_type)
-                .values_list("usage_start", flat=True)
-                .distinct()[:3]
-            )
+            days = self._distributed_qs(dist_type).values_list("usage_start", flat=True).distinct()[:3]
             for day in days:
                 day_rows = self._distributed_qs(dist_type).filter(usage_start=day)
                 rates = day_rows.values_list("custom_name", flat=True).distinct()
@@ -201,9 +196,7 @@ class TestDistributionIntegration(_ReportPeriodMixin, MasuTestCase):
 
         with schema_context(self.schema):
             source_rates = set(
-                self._source_qs(dist_type)
-                .values_list("custom_name", "metric_type", "cost_model_rate_type")
-                .distinct()
+                self._source_qs(dist_type).values_list("custom_name", "metric_type", "cost_model_rate_type").distinct()
             )
             if not source_rates:
                 self.skipTest("No source rows for platform distribution")
@@ -244,11 +237,7 @@ class TestDistributionIntegration(_ReportPeriodMixin, MasuTestCase):
         self._skip_if_no_distributed(dist_type)
 
         with schema_context(self.schema):
-            day = (
-                self._distributed_qs(dist_type)
-                .values_list("usage_start", flat=True)
-                .first()
-            )
+            day = self._distributed_qs(dist_type).values_list("usage_start", flat=True).first()
             if not day:
                 self.skipTest("No distributed rows")
 
@@ -298,12 +287,8 @@ class TestDistributionIntegration(_ReportPeriodMixin, MasuTestCase):
         self._skip_if_no_distributed(dist_type)
 
         with schema_context(self.schema):
-            total_distributed = (
-                self._distributed_qs(dist_type).aggregate(t=Sum("distributed_cost"))["t"] or Decimal(0)
-            )
-            total_source = (
-                self._source_qs(dist_type).aggregate(t=Sum("calculated_cost"))["t"] or Decimal(0)
-            )
+            total_distributed = self._distributed_qs(dist_type).aggregate(t=Sum("distributed_cost"))["t"] or Decimal(0)
+            total_source = self._source_qs(dist_type).aggregate(t=Sum("calculated_cost"))["t"] or Decimal(0)
             if total_source == 0:
                 self.skipTest("No source cost to distribute")
 
@@ -320,15 +305,13 @@ class TestDistributionIntegration(_ReportPeriodMixin, MasuTestCase):
     def test_07_sign_invariant(self):
         """All distributed_cost values for recipient rows are positive."""
         with schema_context(self.schema):
-            negative_count = (
-                RatesToUsage.objects.filter(
-                    source_uuid=self.provider_uuid,
-                    usage_start__gte=self.start_date,
-                    usage_start__lte=self.end_date,
-                    monthly_cost_type__isnull=False,
-                    distributed_cost__lt=0,
-                ).count()
-            )
+            negative_count = RatesToUsage.objects.filter(
+                source_uuid=self.provider_uuid,
+                usage_start__gte=self.start_date,
+                usage_start__lte=self.end_date,
+                monthly_cost_type__isnull=False,
+                distributed_cost__lt=0,
+            ).count()
             self.assertEqual(
                 negative_count,
                 0,
@@ -425,9 +408,7 @@ class TestDistributionIntegration(_ReportPeriodMixin, MasuTestCase):
         self._skip_if_no_distributed(dist_type)
 
         with schema_context(self.schema):
-            original_sum = (
-                self._distributed_qs(dist_type).aggregate(t=Sum("distributed_cost"))["t"] or Decimal(0)
-            )
+            original_sum = self._distributed_qs(dist_type).aggregate(t=Sum("distributed_cost"))["t"] or Decimal(0)
             original_count = self._distributed_qs(dist_type).count()
 
             RatesToUsage.objects.filter(

--- a/koku/masu/test/processor/ocp/test_phase4_distribution.py
+++ b/koku/masu/test/processor/ocp/test_phase4_distribution.py
@@ -70,7 +70,9 @@ class TestDistributionIntegration(_ReportPeriodMixin, MasuTestCase):
 
     def _seed_and_distribute(self):
         """Ensure RTU usage rows exist and run per-rate distribution."""
-        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater = OCPCostModelCostUpdater(
+            schema=self.schema, provider=self.ocp_provider
+        )
         if not updater._cost_model_id:
             self.skipTest("No cost model for OCP provider")
         updater._load_rates(self.start_date)
@@ -94,9 +96,13 @@ class TestDistributionIntegration(_ReportPeriodMixin, MasuTestCase):
             "platform_cost": True,
             "worker_cost": True,
         }
-        summary_range = SummaryRangeConfig(start_date=self.start_date, end_date=self.end_date)
+        summary_range = SummaryRangeConfig(
+            start_date=self.start_date, end_date=self.end_date
+        )
         with OCPReportDBAccessor(self.schema) as accessor:
-            accessor.populate_distributed_cost_sql(summary_range, self.provider_uuid, distribution_info)
+            accessor.populate_distributed_cost_sql(
+                summary_range, self.provider_uuid, distribution_info
+            )
 
     def _distributed_qs(self, distribution_type=None):
         """QuerySet for distributed RTU rows in the test window."""
@@ -142,16 +148,24 @@ class TestDistributionIntegration(_ReportPeriodMixin, MasuTestCase):
         self._skip_if_no_distributed(dist_type)
 
         with schema_context(self.schema):
-            days = self._distributed_qs(dist_type).values_list("usage_start", flat=True).distinct()[:3]
+            days = (
+                self._distributed_qs(dist_type)
+                .values_list("usage_start", flat=True)
+                .distinct()[:3]
+            )
             for day in days:
                 day_rows = self._distributed_qs(dist_type).filter(usage_start=day)
                 rates = day_rows.values_list("custom_name", flat=True).distinct()
                 for rate_name in rates:
                     rate_rows = day_rows.filter(custom_name=rate_name)
-                    total = rate_rows.aggregate(t=Sum("distributed_cost"))["t"] or Decimal(0)
+                    total = rate_rows.aggregate(t=Sum("distributed_cost"))[
+                        "t"
+                    ] or Decimal(0)
                     if total == 0:
                         continue
-                    ns_totals = rate_rows.values("namespace").annotate(ns_total=Sum("distributed_cost"))
+                    ns_totals = rate_rows.values("namespace").annotate(
+                        ns_total=Sum("distributed_cost")
+                    )
                     for entry in ns_totals:
                         proportion = entry["ns_total"] / total
                         self.assertGreaterEqual(proportion, Decimal(0))
@@ -176,7 +190,9 @@ class TestDistributionIntegration(_ReportPeriodMixin, MasuTestCase):
                 .values("usage_start", "namespace")
                 .annotate(ns_dist=Sum("distributed_cost"))
             )
-            ns_lookup = {(r["usage_start"], r["namespace"]): r["ns_dist"] for r in totals_by_ns}
+            ns_lookup = {
+                (r["usage_start"], r["namespace"]): r["ns_dist"] for r in totals_by_ns
+            }
             for entry in totals_by_rate:
                 key = (entry["usage_start"], entry["namespace"])
                 ns_total = ns_lookup.get(key, Decimal(0))
@@ -196,7 +212,9 @@ class TestDistributionIntegration(_ReportPeriodMixin, MasuTestCase):
 
         with schema_context(self.schema):
             source_rates = set(
-                self._source_qs(dist_type).values_list("custom_name", "metric_type", "cost_model_rate_type").distinct()
+                self._source_qs(dist_type)
+                .values_list("custom_name", "metric_type", "cost_model_rate_type")
+                .distinct()
             )
             if not source_rates:
                 self.skipTest("No source rows for platform distribution")
@@ -226,7 +244,9 @@ class TestDistributionIntegration(_ReportPeriodMixin, MasuTestCase):
                 monthly_cost_type__isnull=False,
                 distributed_cost=0,
             ).count()
-            self.assertEqual(zero_rows, 0, "Distribution should not produce zero-cost rows")
+            self.assertEqual(
+                zero_rows, 0, "Distribution should not produce zero-cost rows"
+            )
 
     # ------------------------------------------------------------------
     # Assertion 5: Independent cross-check (Option 2 formula)
@@ -237,7 +257,11 @@ class TestDistributionIntegration(_ReportPeriodMixin, MasuTestCase):
         self._skip_if_no_distributed(dist_type)
 
         with schema_context(self.schema):
-            day = self._distributed_qs(dist_type).values_list("usage_start", flat=True).first()
+            day = (
+                self._distributed_qs(dist_type)
+                .values_list("usage_start", flat=True)
+                .first()
+            )
             if not day:
                 self.skipTest("No distributed rows")
 
@@ -287,8 +311,12 @@ class TestDistributionIntegration(_ReportPeriodMixin, MasuTestCase):
         self._skip_if_no_distributed(dist_type)
 
         with schema_context(self.schema):
-            total_distributed = self._distributed_qs(dist_type).aggregate(t=Sum("distributed_cost"))["t"] or Decimal(0)
-            total_source = self._source_qs(dist_type).aggregate(t=Sum("calculated_cost"))["t"] or Decimal(0)
+            total_distributed = self._distributed_qs(dist_type).aggregate(
+                t=Sum("distributed_cost")
+            )["t"] or Decimal(0)
+            total_source = self._source_qs(dist_type).aggregate(
+                t=Sum("calculated_cost")
+            )["t"] or Decimal(0)
             if total_source == 0:
                 self.skipTest("No source cost to distribute")
 
@@ -328,22 +356,32 @@ class TestDistributionIntegration(_ReportPeriodMixin, MasuTestCase):
 
         with schema_context(self.schema):
             pre_count = self._distributed_qs(dist_type).count()
-            pre_sum = self._distributed_qs(dist_type).aggregate(t=Sum("distributed_cost"))["t"]
+            pre_sum = self._distributed_qs(dist_type).aggregate(
+                t=Sum("distributed_cost")
+            )["t"]
 
         distribution_info = {
             "distribution_type": "cpu",
             "platform_cost": True,
             "worker_cost": True,
         }
-        summary_range = SummaryRangeConfig(start_date=self.start_date, end_date=self.end_date)
+        summary_range = SummaryRangeConfig(
+            start_date=self.start_date, end_date=self.end_date
+        )
         with OCPReportDBAccessor(self.schema) as accessor:
-            accessor.populate_distributed_cost_sql(summary_range, self.provider_uuid, distribution_info)
+            accessor.populate_distributed_cost_sql(
+                summary_range, self.provider_uuid, distribution_info
+            )
 
         with schema_context(self.schema):
             post_count = self._distributed_qs(dist_type).count()
-            post_sum = self._distributed_qs(dist_type).aggregate(t=Sum("distributed_cost"))["t"]
+            post_sum = self._distributed_qs(dist_type).aggregate(
+                t=Sum("distributed_cost")
+            )["t"]
 
-        self.assertEqual(pre_count, post_count, "Idempotency: row count changed after re-run")
+        self.assertEqual(
+            pre_count, post_count, "Idempotency: row count changed after re-run"
+        )
         self.assertAlmostEqual(
             float(pre_sum or 0),
             float(post_sum or 0),
@@ -360,7 +398,11 @@ class TestDistributionIntegration(_ReportPeriodMixin, MasuTestCase):
         self._skip_if_no_distributed(dist_type)
 
         with schema_context(self.schema):
-            day = self._distributed_qs(dist_type).values_list("usage_start", flat=True).first()
+            day = (
+                self._distributed_qs(dist_type)
+                .values_list("usage_start", flat=True)
+                .first()
+            )
             if not day:
                 self.skipTest("No distributed rows")
 
@@ -408,7 +450,9 @@ class TestDistributionIntegration(_ReportPeriodMixin, MasuTestCase):
         self._skip_if_no_distributed(dist_type)
 
         with schema_context(self.schema):
-            original_sum = self._distributed_qs(dist_type).aggregate(t=Sum("distributed_cost"))["t"] or Decimal(0)
+            original_sum = self._distributed_qs(dist_type).aggregate(
+                t=Sum("distributed_cost")
+            )["t"] or Decimal(0)
             original_count = self._distributed_qs(dist_type).count()
 
             RatesToUsage.objects.filter(
@@ -417,22 +461,34 @@ class TestDistributionIntegration(_ReportPeriodMixin, MasuTestCase):
                 usage_start__lte=self.end_date,
                 monthly_cost_type=dist_type,
             ).delete()
-            self.assertEqual(self._distributed_qs(dist_type).count(), 0, "DELETE should clear all rows")
+            self.assertEqual(
+                self._distributed_qs(dist_type).count(),
+                0,
+                "DELETE should clear all rows",
+            )
 
         distribution_info = {
             "distribution_type": "cpu",
             "platform_cost": True,
             "worker_cost": True,
         }
-        summary_range = SummaryRangeConfig(start_date=self.start_date, end_date=self.end_date)
+        summary_range = SummaryRangeConfig(
+            start_date=self.start_date, end_date=self.end_date
+        )
         with OCPReportDBAccessor(self.schema) as accessor:
-            accessor.populate_distributed_cost_sql(summary_range, self.provider_uuid, distribution_info)
+            accessor.populate_distributed_cost_sql(
+                summary_range, self.provider_uuid, distribution_info
+            )
 
         with schema_context(self.schema):
-            new_sum = self._distributed_qs(dist_type).aggregate(t=Sum("distributed_cost"))["t"] or Decimal(0)
+            new_sum = self._distributed_qs(dist_type).aggregate(
+                t=Sum("distributed_cost")
+            )["t"] or Decimal(0)
             new_count = self._distributed_qs(dist_type).count()
 
-        self.assertEqual(original_count, new_count, "Re-run should produce same row count")
+        self.assertEqual(
+            original_count, new_count, "Re-run should produce same row count"
+        )
         self.assertAlmostEqual(
             float(original_sum),
             float(new_sum),

--- a/koku/masu/test/processor/ocp/test_phase4_distribution.py
+++ b/koku/masu/test/processor/ocp/test_phase4_distribution.py
@@ -1,0 +1,460 @@
+#
+# Copyright 2026 Red Hat Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Phase 4 distribution integration tests — R18 safety net.
+
+These 10 assertions execute actual per-rate distribution SQL against the
+test database (no mocked SQL layer) and verify mathematical correctness.
+They are the sole verification mechanism for per-rate distribution
+correctness, replacing IQ-9 Option 2 (back-allocation) as the runtime
+fallback.
+
+See docs/architecture/cost-breakdown/phased-delivery.md § Concern 1 Resolution.
+See docs/architecture/cost-breakdown/risk-register.md § R18.
+"""
+from decimal import Decimal
+
+from django.db.models import Q
+from django.db.models import Sum
+from django_tenants.utils import schema_context
+
+from api.utils import DateHelper
+from masu.database.ocp_report_db_accessor import OCPReportDBAccessor
+from masu.processor.ocp.ocp_cost_model_cost_updater import OCPCostModelCostUpdater
+from masu.test import MasuTestCase
+from masu.util.common import SummaryRangeConfig
+from reporting.provider.ocp.models import OCPUsageLineItemDailySummary
+from reporting.provider.ocp.models import OCPUsageReportPeriod
+from reporting.provider.ocp.models import RatesToUsage
+
+TOLERANCE = Decimal("0.01")
+
+
+class _ReportPeriodMixin:
+    """Mixin providing report period lookup for distribution tests."""
+
+    def _get_report_period(self):
+        with schema_context(self.schema):
+            rp = (
+                OCPUsageReportPeriod.objects.filter(provider_id=self.ocp_provider_uuid)
+                .order_by("-report_period_start")
+                .first()
+            )
+        if not rp:
+            self.skipTest("No report period for OCP provider")
+        return rp
+
+
+class TestDistributionIntegration(_ReportPeriodMixin, MasuTestCase):
+    """R18 safety net: 10 non-mocked distribution integration assertions.
+
+    Executes actual distribution SQL against the test database and asserts
+    per-rate proportional correctness. Mirrors phased-delivery.md assertions 1-10.
+    """
+
+    _distribution_seeded = False
+
+    def setUp(self):
+        super().setUp()
+        self.dh = DateHelper()
+        self.rp = self._get_report_period()
+        start = self.rp.report_period_start
+        end = self.dh.month_end(start)
+        self.start_date = start.date() if hasattr(start, "date") else start
+        self.end_date = end.date() if hasattr(end, "date") else end
+        self.provider_uuid = self.ocp_provider.uuid
+
+        if not TestDistributionIntegration._distribution_seeded:
+            self._seed_and_distribute()
+            TestDistributionIntegration._distribution_seeded = True
+
+    def _seed_and_distribute(self):
+        """Ensure RTU usage rows exist and run per-rate distribution."""
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        if not updater._cost_model_id:
+            self.skipTest("No cost model for OCP provider")
+        updater._load_rates(self.start_date)
+        if not (updater._infra_rates or updater._supplementary_rates):
+            self.skipTest("No rates loaded for OCP provider")
+
+        updater._update_usage_rates_to_usage(self.start_date, self.end_date)
+
+        with schema_context(self.schema):
+            usage_count = RatesToUsage.objects.filter(
+                source_uuid=self.provider_uuid,
+                usage_start__gte=self.start_date,
+                usage_start__lte=self.end_date,
+                monthly_cost_type__isnull=True,
+            ).count()
+        if usage_count == 0:
+            self.skipTest("No RTU usage rows after seeding")
+
+        distribution_info = {
+            "distribution_type": "cpu",
+            "platform_cost": True,
+            "worker_cost": True,
+        }
+        summary_range = SummaryRangeConfig(start_date=self.start_date, end_date=self.end_date)
+        with OCPReportDBAccessor(self.schema) as accessor:
+            accessor.populate_distributed_cost_sql(summary_range, self.provider_uuid, distribution_info)
+
+    def _distributed_qs(self, distribution_type=None):
+        """QuerySet for distributed RTU rows in the test window."""
+        qs = RatesToUsage.objects.filter(
+            source_uuid=self.provider_uuid,
+            usage_start__gte=self.start_date,
+            usage_start__lte=self.end_date,
+            monthly_cost_type__isnull=False,
+            distributed_cost__isnull=False,
+        ).exclude(distributed_cost=0)
+        if distribution_type:
+            qs = qs.filter(monthly_cost_type=distribution_type)
+        return qs
+
+    def _source_qs(self, distribution_type):
+        """QuerySet for source RTU rows that were distributed."""
+        source_filters = {
+            "platform_distributed": Q(cost_category__name="Platform"),
+            "worker_distributed": Q(namespace="Worker unallocated"),
+        }
+        filt = source_filters.get(distribution_type)
+        if not filt:
+            return RatesToUsage.objects.none()
+        return RatesToUsage.objects.filter(
+            filt,
+            source_uuid=self.provider_uuid,
+            usage_start__gte=self.start_date,
+            usage_start__lte=self.end_date,
+            monthly_cost_type__isnull=True,
+        )
+
+    def _skip_if_no_distributed(self, dist_type):
+        with schema_context(self.schema):
+            if not self._distributed_qs(dist_type).exists():
+                self.skipTest(f"No {dist_type} distributed rows in test data")
+
+    # ------------------------------------------------------------------
+    # Assertion 1: Per-rate proportional correctness
+    # ------------------------------------------------------------------
+    def test_01_per_rate_proportional_correctness(self):
+        """distributed_cost is proportional to namespace CPU usage share."""
+        dist_type = "platform_distributed"
+        self._skip_if_no_distributed(dist_type)
+
+        with schema_context(self.schema):
+            days = (
+                self._distributed_qs(dist_type)
+                .values_list("usage_start", flat=True)
+                .distinct()[:3]
+            )
+            for day in days:
+                day_rows = self._distributed_qs(dist_type).filter(usage_start=day)
+                rates = day_rows.values_list("custom_name", flat=True).distinct()
+                for rate_name in rates:
+                    rate_rows = day_rows.filter(custom_name=rate_name)
+                    total = rate_rows.aggregate(t=Sum("distributed_cost"))["t"] or Decimal(0)
+                    if total == 0:
+                        continue
+                    ns_totals = rate_rows.values("namespace").annotate(ns_total=Sum("distributed_cost"))
+                    for entry in ns_totals:
+                        proportion = entry["ns_total"] / total
+                        self.assertGreaterEqual(proportion, Decimal(0))
+                        self.assertLessEqual(proportion, Decimal(1) + TOLERANCE)
+
+    # ------------------------------------------------------------------
+    # Assertion 2: SUM(per-rate) consistency
+    # ------------------------------------------------------------------
+    def test_02_per_rate_sum_consistency(self):
+        """SUM of per-rate distributed rows is consistent per (namespace, day, dist_type)."""
+        dist_type = "platform_distributed"
+        self._skip_if_no_distributed(dist_type)
+
+        with schema_context(self.schema):
+            totals_by_rate = (
+                self._distributed_qs(dist_type)
+                .values("usage_start", "namespace", "custom_name")
+                .annotate(rate_dist=Sum("distributed_cost"))
+            )
+            totals_by_ns = (
+                self._distributed_qs(dist_type)
+                .values("usage_start", "namespace")
+                .annotate(ns_dist=Sum("distributed_cost"))
+            )
+            ns_lookup = {(r["usage_start"], r["namespace"]): r["ns_dist"] for r in totals_by_ns}
+            for entry in totals_by_rate:
+                key = (entry["usage_start"], entry["namespace"])
+                ns_total = ns_lookup.get(key, Decimal(0))
+                self.assertLessEqual(
+                    abs(entry["rate_dist"]),
+                    abs(ns_total) + TOLERANCE,
+                    f"Per-rate distributed_cost exceeds namespace total for {key}",
+                )
+
+    # ------------------------------------------------------------------
+    # Assertion 3: No orphaned distributed rows
+    # ------------------------------------------------------------------
+    def test_03_no_orphaned_distributed_rows(self):
+        """Every distributed RTU row traces to a valid source rate identity."""
+        dist_type = "platform_distributed"
+        self._skip_if_no_distributed(dist_type)
+
+        with schema_context(self.schema):
+            source_rates = set(
+                self._source_qs(dist_type)
+                .values_list("custom_name", "metric_type", "cost_model_rate_type")
+                .distinct()
+            )
+            if not source_rates:
+                self.skipTest("No source rows for platform distribution")
+
+            dist_rates = set(
+                self._distributed_qs(dist_type)
+                .values_list("custom_name", "metric_type", "cost_model_rate_type")
+                .distinct()
+            )
+            orphans = dist_rates - source_rates
+            self.assertEqual(
+                len(orphans),
+                0,
+                f"Orphaned distributed rows with rate identities not in source: {orphans}",
+            )
+
+    # ------------------------------------------------------------------
+    # Assertion 4: Edge case — zero-cost namespaces excluded
+    # ------------------------------------------------------------------
+    def test_04_zero_cost_rows_excluded(self):
+        """No distributed RTU rows exist with distributed_cost = 0."""
+        with schema_context(self.schema):
+            zero_rows = RatesToUsage.objects.filter(
+                source_uuid=self.provider_uuid,
+                usage_start__gte=self.start_date,
+                usage_start__lte=self.end_date,
+                monthly_cost_type__isnull=False,
+                distributed_cost=0,
+            ).count()
+            self.assertEqual(zero_rows, 0, "Distribution should not produce zero-cost rows")
+
+    # ------------------------------------------------------------------
+    # Assertion 5: Independent cross-check (Option 2 formula)
+    # ------------------------------------------------------------------
+    def test_05_cross_check_option2_formula(self):
+        """Per-rate distributed cost equals (rate_cost / total_source_cost) * namespace_total."""
+        dist_type = "platform_distributed"
+        self._skip_if_no_distributed(dist_type)
+
+        with schema_context(self.schema):
+            day = (
+                self._distributed_qs(dist_type)
+                .values_list("usage_start", flat=True)
+                .first()
+            )
+            if not day:
+                self.skipTest("No distributed rows")
+
+            source_by_rate = dict(
+                self._source_qs(dist_type)
+                .filter(usage_start=day)
+                .values("custom_name")
+                .annotate(cost=Sum("calculated_cost"))
+                .values_list("custom_name", "cost")
+            )
+            total_source = sum(source_by_rate.values())
+            if total_source == 0:
+                self.skipTest("Total source cost is zero")
+
+            ns_totals = dict(
+                self._distributed_qs(dist_type)
+                .filter(usage_start=day)
+                .values("namespace")
+                .annotate(ns_total=Sum("distributed_cost"))
+                .values_list("namespace", "ns_total")
+            )
+
+            for rate_name, rate_cost in source_by_rate.items():
+                rate_rows = (
+                    self._distributed_qs(dist_type)
+                    .filter(usage_start=day, custom_name=rate_name)
+                    .values("namespace")
+                    .annotate(actual=Sum("distributed_cost"))
+                )
+                rate_share = rate_cost / total_source
+                for entry in rate_rows:
+                    ns_total = ns_totals.get(entry["namespace"], Decimal(0))
+                    expected = rate_share * ns_total
+                    self.assertAlmostEqual(
+                        float(entry["actual"]),
+                        float(expected),
+                        places=6,
+                        msg=f"Option 2 cross-check failed for rate={rate_name}, ns={entry['namespace']}",
+                    )
+
+    # ------------------------------------------------------------------
+    # Assertion 6: Cost conservation
+    # ------------------------------------------------------------------
+    def test_06_cost_conservation(self):
+        """Total distributed cost equals total source calculated_cost."""
+        dist_type = "platform_distributed"
+        self._skip_if_no_distributed(dist_type)
+
+        with schema_context(self.schema):
+            total_distributed = (
+                self._distributed_qs(dist_type).aggregate(t=Sum("distributed_cost"))["t"] or Decimal(0)
+            )
+            total_source = (
+                self._source_qs(dist_type).aggregate(t=Sum("calculated_cost"))["t"] or Decimal(0)
+            )
+            if total_source == 0:
+                self.skipTest("No source cost to distribute")
+
+            self.assertAlmostEqual(
+                float(total_distributed),
+                float(total_source),
+                places=2,
+                msg="Cost conservation: total distributed != total source cost",
+            )
+
+    # ------------------------------------------------------------------
+    # Assertion 7: Sign invariant
+    # ------------------------------------------------------------------
+    def test_07_sign_invariant(self):
+        """All distributed_cost values for recipient rows are positive."""
+        with schema_context(self.schema):
+            negative_count = (
+                RatesToUsage.objects.filter(
+                    source_uuid=self.provider_uuid,
+                    usage_start__gte=self.start_date,
+                    usage_start__lte=self.end_date,
+                    monthly_cost_type__isnull=False,
+                    distributed_cost__lt=0,
+                ).count()
+            )
+            self.assertEqual(
+                negative_count,
+                0,
+                "Recipient distributed_cost should never be negative",
+            )
+
+    # ------------------------------------------------------------------
+    # Assertion 8: Idempotency
+    # ------------------------------------------------------------------
+    def test_08_idempotency(self):
+        """Running distribution twice produces identical RTU state."""
+        dist_type = "platform_distributed"
+        self._skip_if_no_distributed(dist_type)
+
+        with schema_context(self.schema):
+            pre_count = self._distributed_qs(dist_type).count()
+            pre_sum = self._distributed_qs(dist_type).aggregate(t=Sum("distributed_cost"))["t"]
+
+        distribution_info = {
+            "distribution_type": "cpu",
+            "platform_cost": True,
+            "worker_cost": True,
+        }
+        summary_range = SummaryRangeConfig(start_date=self.start_date, end_date=self.end_date)
+        with OCPReportDBAccessor(self.schema) as accessor:
+            accessor.populate_distributed_cost_sql(summary_range, self.provider_uuid, distribution_info)
+
+        with schema_context(self.schema):
+            post_count = self._distributed_qs(dist_type).count()
+            post_sum = self._distributed_qs(dist_type).aggregate(t=Sum("distributed_cost"))["t"]
+
+        self.assertEqual(pre_count, post_count, "Idempotency: row count changed after re-run")
+        self.assertAlmostEqual(
+            float(pre_sum or 0),
+            float(post_sum or 0),
+            places=10,
+            msg="Idempotency: total distributed_cost changed after re-run",
+        )
+
+    # ------------------------------------------------------------------
+    # Assertion 9: Multi-rate proportionality
+    # ------------------------------------------------------------------
+    def test_09_multi_rate_proportionality(self):
+        """Rates with higher source cost produce proportionally higher distributed cost."""
+        dist_type = "platform_distributed"
+        self._skip_if_no_distributed(dist_type)
+
+        with schema_context(self.schema):
+            day = self._distributed_qs(dist_type).values_list("usage_start", flat=True).first()
+            if not day:
+                self.skipTest("No distributed rows")
+
+            source_by_rate = dict(
+                self._source_qs(dist_type)
+                .filter(usage_start=day)
+                .values("custom_name")
+                .annotate(cost=Sum("calculated_cost"))
+                .values_list("custom_name", "cost")
+            )
+            dist_by_rate = dict(
+                self._distributed_qs(dist_type)
+                .filter(usage_start=day)
+                .values("custom_name")
+                .annotate(cost=Sum("distributed_cost"))
+                .values_list("custom_name", "cost")
+            )
+            rates = sorted(source_by_rate.keys())
+            if len(rates) < 2:
+                self.skipTest("Need at least 2 rates for proportionality check")
+
+            for i in range(len(rates) - 1):
+                r_a, r_b = rates[i], rates[i + 1]
+                src_a = float(source_by_rate.get(r_a, 0))
+                src_b = float(source_by_rate.get(r_b, 0))
+                dst_a = float(dist_by_rate.get(r_a, 0))
+                dst_b = float(dist_by_rate.get(r_b, 0))
+                if src_b == 0 or dst_b == 0:
+                    continue
+                src_ratio = src_a / src_b
+                dst_ratio = dst_a / dst_b
+                self.assertAlmostEqual(
+                    src_ratio,
+                    dst_ratio,
+                    places=6,
+                    msg=f"Rates {r_a}/{r_b}: source ratio {src_ratio} != distributed ratio {dst_ratio}",
+                )
+
+    # ------------------------------------------------------------------
+    # Assertion 10: Distribution re-run after DELETE (mutation regression)
+    # ------------------------------------------------------------------
+    def test_10_rerun_after_clear(self):
+        """After clearing distributed rows and re-running, results match original."""
+        dist_type = "platform_distributed"
+        self._skip_if_no_distributed(dist_type)
+
+        with schema_context(self.schema):
+            original_sum = (
+                self._distributed_qs(dist_type).aggregate(t=Sum("distributed_cost"))["t"] or Decimal(0)
+            )
+            original_count = self._distributed_qs(dist_type).count()
+
+            RatesToUsage.objects.filter(
+                source_uuid=self.provider_uuid,
+                usage_start__gte=self.start_date,
+                usage_start__lte=self.end_date,
+                monthly_cost_type=dist_type,
+            ).delete()
+            self.assertEqual(self._distributed_qs(dist_type).count(), 0, "DELETE should clear all rows")
+
+        distribution_info = {
+            "distribution_type": "cpu",
+            "platform_cost": True,
+            "worker_cost": True,
+        }
+        summary_range = SummaryRangeConfig(start_date=self.start_date, end_date=self.end_date)
+        with OCPReportDBAccessor(self.schema) as accessor:
+            accessor.populate_distributed_cost_sql(summary_range, self.provider_uuid, distribution_info)
+
+        with schema_context(self.schema):
+            new_sum = self._distributed_qs(dist_type).aggregate(t=Sum("distributed_cost"))["t"] or Decimal(0)
+            new_count = self._distributed_qs(dist_type).count()
+
+        self.assertEqual(original_count, new_count, "Re-run should produce same row count")
+        self.assertAlmostEqual(
+            float(original_sum),
+            float(new_sum),
+            places=10,
+            msg="Re-run should produce same total distributed cost",
+        )

--- a/koku/masu/test/processor/ocp/test_phase4_distribution.py
+++ b/koku/masu/test/processor/ocp/test_phase4_distribution.py
@@ -70,9 +70,7 @@ class TestDistributionIntegration(_ReportPeriodMixin, MasuTestCase):
 
     def _seed_and_distribute(self):
         """Ensure RTU usage rows exist and run per-rate distribution."""
-        updater = OCPCostModelCostUpdater(
-            schema=self.schema, provider=self.ocp_provider
-        )
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
         if not updater._cost_model_id:
             self.skipTest("No cost model for OCP provider")
         updater._load_rates(self.start_date)
@@ -96,13 +94,9 @@ class TestDistributionIntegration(_ReportPeriodMixin, MasuTestCase):
             "platform_cost": True,
             "worker_cost": True,
         }
-        summary_range = SummaryRangeConfig(
-            start_date=self.start_date, end_date=self.end_date
-        )
+        summary_range = SummaryRangeConfig(start_date=self.start_date, end_date=self.end_date)
         with OCPReportDBAccessor(self.schema) as accessor:
-            accessor.populate_distributed_cost_sql(
-                summary_range, self.provider_uuid, distribution_info
-            )
+            accessor.populate_distributed_cost_sql(summary_range, self.provider_uuid, distribution_info)
 
     def _distributed_qs(self, distribution_type=None):
         """QuerySet for distributed RTU rows in the test window."""
@@ -148,24 +142,16 @@ class TestDistributionIntegration(_ReportPeriodMixin, MasuTestCase):
         self._skip_if_no_distributed(dist_type)
 
         with schema_context(self.schema):
-            days = (
-                self._distributed_qs(dist_type)
-                .values_list("usage_start", flat=True)
-                .distinct()[:3]
-            )
+            days = self._distributed_qs(dist_type).values_list("usage_start", flat=True).distinct()[:3]
             for day in days:
                 day_rows = self._distributed_qs(dist_type).filter(usage_start=day)
                 rates = day_rows.values_list("custom_name", flat=True).distinct()
                 for rate_name in rates:
                     rate_rows = day_rows.filter(custom_name=rate_name)
-                    total = rate_rows.aggregate(t=Sum("distributed_cost"))[
-                        "t"
-                    ] or Decimal(0)
+                    total = rate_rows.aggregate(t=Sum("distributed_cost"))["t"] or Decimal(0)
                     if total == 0:
                         continue
-                    ns_totals = rate_rows.values("namespace").annotate(
-                        ns_total=Sum("distributed_cost")
-                    )
+                    ns_totals = rate_rows.values("namespace").annotate(ns_total=Sum("distributed_cost"))
                     for entry in ns_totals:
                         proportion = entry["ns_total"] / total
                         self.assertGreaterEqual(proportion, Decimal(0))
@@ -190,9 +176,7 @@ class TestDistributionIntegration(_ReportPeriodMixin, MasuTestCase):
                 .values("usage_start", "namespace")
                 .annotate(ns_dist=Sum("distributed_cost"))
             )
-            ns_lookup = {
-                (r["usage_start"], r["namespace"]): r["ns_dist"] for r in totals_by_ns
-            }
+            ns_lookup = {(r["usage_start"], r["namespace"]): r["ns_dist"] for r in totals_by_ns}
             for entry in totals_by_rate:
                 key = (entry["usage_start"], entry["namespace"])
                 ns_total = ns_lookup.get(key, Decimal(0))
@@ -212,9 +196,7 @@ class TestDistributionIntegration(_ReportPeriodMixin, MasuTestCase):
 
         with schema_context(self.schema):
             source_rates = set(
-                self._source_qs(dist_type)
-                .values_list("custom_name", "metric_type", "cost_model_rate_type")
-                .distinct()
+                self._source_qs(dist_type).values_list("custom_name", "metric_type", "cost_model_rate_type").distinct()
             )
             if not source_rates:
                 self.skipTest("No source rows for platform distribution")
@@ -244,9 +226,7 @@ class TestDistributionIntegration(_ReportPeriodMixin, MasuTestCase):
                 monthly_cost_type__isnull=False,
                 distributed_cost=0,
             ).count()
-            self.assertEqual(
-                zero_rows, 0, "Distribution should not produce zero-cost rows"
-            )
+            self.assertEqual(zero_rows, 0, "Distribution should not produce zero-cost rows")
 
     # ------------------------------------------------------------------
     # Assertion 5: Independent cross-check (Option 2 formula)
@@ -257,11 +237,7 @@ class TestDistributionIntegration(_ReportPeriodMixin, MasuTestCase):
         self._skip_if_no_distributed(dist_type)
 
         with schema_context(self.schema):
-            day = (
-                self._distributed_qs(dist_type)
-                .values_list("usage_start", flat=True)
-                .first()
-            )
+            day = self._distributed_qs(dist_type).values_list("usage_start", flat=True).first()
             if not day:
                 self.skipTest("No distributed rows")
 
@@ -311,12 +287,8 @@ class TestDistributionIntegration(_ReportPeriodMixin, MasuTestCase):
         self._skip_if_no_distributed(dist_type)
 
         with schema_context(self.schema):
-            total_distributed = self._distributed_qs(dist_type).aggregate(
-                t=Sum("distributed_cost")
-            )["t"] or Decimal(0)
-            total_source = self._source_qs(dist_type).aggregate(
-                t=Sum("calculated_cost")
-            )["t"] or Decimal(0)
+            total_distributed = self._distributed_qs(dist_type).aggregate(t=Sum("distributed_cost"))["t"] or Decimal(0)
+            total_source = self._source_qs(dist_type).aggregate(t=Sum("calculated_cost"))["t"] or Decimal(0)
             if total_source == 0:
                 self.skipTest("No source cost to distribute")
 
@@ -356,32 +328,22 @@ class TestDistributionIntegration(_ReportPeriodMixin, MasuTestCase):
 
         with schema_context(self.schema):
             pre_count = self._distributed_qs(dist_type).count()
-            pre_sum = self._distributed_qs(dist_type).aggregate(
-                t=Sum("distributed_cost")
-            )["t"]
+            pre_sum = self._distributed_qs(dist_type).aggregate(t=Sum("distributed_cost"))["t"]
 
         distribution_info = {
             "distribution_type": "cpu",
             "platform_cost": True,
             "worker_cost": True,
         }
-        summary_range = SummaryRangeConfig(
-            start_date=self.start_date, end_date=self.end_date
-        )
+        summary_range = SummaryRangeConfig(start_date=self.start_date, end_date=self.end_date)
         with OCPReportDBAccessor(self.schema) as accessor:
-            accessor.populate_distributed_cost_sql(
-                summary_range, self.provider_uuid, distribution_info
-            )
+            accessor.populate_distributed_cost_sql(summary_range, self.provider_uuid, distribution_info)
 
         with schema_context(self.schema):
             post_count = self._distributed_qs(dist_type).count()
-            post_sum = self._distributed_qs(dist_type).aggregate(
-                t=Sum("distributed_cost")
-            )["t"]
+            post_sum = self._distributed_qs(dist_type).aggregate(t=Sum("distributed_cost"))["t"]
 
-        self.assertEqual(
-            pre_count, post_count, "Idempotency: row count changed after re-run"
-        )
+        self.assertEqual(pre_count, post_count, "Idempotency: row count changed after re-run")
         self.assertAlmostEqual(
             float(pre_sum or 0),
             float(post_sum or 0),
@@ -398,11 +360,7 @@ class TestDistributionIntegration(_ReportPeriodMixin, MasuTestCase):
         self._skip_if_no_distributed(dist_type)
 
         with schema_context(self.schema):
-            day = (
-                self._distributed_qs(dist_type)
-                .values_list("usage_start", flat=True)
-                .first()
-            )
+            day = self._distributed_qs(dist_type).values_list("usage_start", flat=True).first()
             if not day:
                 self.skipTest("No distributed rows")
 
@@ -450,9 +408,7 @@ class TestDistributionIntegration(_ReportPeriodMixin, MasuTestCase):
         self._skip_if_no_distributed(dist_type)
 
         with schema_context(self.schema):
-            original_sum = self._distributed_qs(dist_type).aggregate(
-                t=Sum("distributed_cost")
-            )["t"] or Decimal(0)
+            original_sum = self._distributed_qs(dist_type).aggregate(t=Sum("distributed_cost"))["t"] or Decimal(0)
             original_count = self._distributed_qs(dist_type).count()
 
             RatesToUsage.objects.filter(
@@ -472,23 +428,15 @@ class TestDistributionIntegration(_ReportPeriodMixin, MasuTestCase):
             "platform_cost": True,
             "worker_cost": True,
         }
-        summary_range = SummaryRangeConfig(
-            start_date=self.start_date, end_date=self.end_date
-        )
+        summary_range = SummaryRangeConfig(start_date=self.start_date, end_date=self.end_date)
         with OCPReportDBAccessor(self.schema) as accessor:
-            accessor.populate_distributed_cost_sql(
-                summary_range, self.provider_uuid, distribution_info
-            )
+            accessor.populate_distributed_cost_sql(summary_range, self.provider_uuid, distribution_info)
 
         with schema_context(self.schema):
-            new_sum = self._distributed_qs(dist_type).aggregate(
-                t=Sum("distributed_cost")
-            )["t"] or Decimal(0)
+            new_sum = self._distributed_qs(dist_type).aggregate(t=Sum("distributed_cost"))["t"] or Decimal(0)
             new_count = self._distributed_qs(dist_type).count()
 
-        self.assertEqual(
-            original_count, new_count, "Re-run should produce same row count"
-        )
+        self.assertEqual(original_count, new_count, "Re-run should produce same row count")
         self.assertAlmostEqual(
             float(original_sum),
             float(new_sum),


### PR DESCRIPTION
## Summary

This PR combines the work from **PR 2** ([#6099](https://github.com/project-koku/koku/pull/6099), closed) and **PR 3** into a single PR:

**From PR 2 — Per-rate distribution SQL files:**
- Add 5 per-rate distribution SQL files (`distribute_platform_cost_per_rate.sql`, `distribute_worker_cost_per_rate.sql`, `distribute_unattributed_storage_per_rate.sql`, `distribute_unattributed_network_per_rate.sql`, `distribute_unallocated_gpu_per_rate.sql`) for PostgreSQL, self-hosted, and Trino
- Add `delete_distributed_rates_to_usage.sql` for idempotent RTU cleanup
- Update `aggregate_rates_to_daily_summary.sql` to carry `distributed_cost` through monthly/tag-cost aggregation
- Rename `{{cost_model_rate_type}}` Jinja parameter to `{{distribution_tag}}` in per-rate SQL to avoid confusion with the `cost_model_rate_type` column

**From PR 3 — Orchestration rewire:**
- Swap `DistributionConfig` entries from legacy SQL files to per-rate SQL files
- Add `_delete_distributed_rtu_rows()` method for RTU idempotency alongside existing daily summary DELETE
- Restructure orchestration: move `_aggregate_rates_to_daily_summary` and `_update_markup_cost` from per-month loop into `distribute_costs_and_update_ui_summary`
- Run distribution per-month to correctly resolve `report_period_id` for multi-month ranges
- Wire `_ensure_rates_to_usage_partitions` at top of distribution method

## Context

This is **PR 3 of 5** for COST-7249 Phase 4 (now incorporating PR 2). This is the **highest-risk** PR as it changes the critical path for all OCP cost processing.

**PR sequence:**
1. PR 1 -- DDL migration ([#6098](https://github.com/project-koku/koku/pull/6098)) ✅ merged
2. ~~PR 2 -- Per-rate distribution SQL ([#6099](https://github.com/project-koku/koku/pull/6099))~~ — folded into this PR
3. **This PR** -- Per-rate distribution SQL + Orchestration rewire + tests
4. PR 4 -- Breakdown population SQL + `UI_SUMMARY_TABLES` registration
5. PR 5 -- API surface (serializers, view, URL)

## Orchestration change

**Before (Phase 3):**
```
for month:
    RTU inserts -> monthly -> tags -> VM -> aggregate -> markup
distribute_costs_and_update_ui_summary(full_range)
```

**After (Phase 4):**
```
for month:
    RTU inserts -> monthly -> tags -> VM
distribute_costs_and_update_ui_summary:
    for month:
        distribute -> aggregate -> markup -> UI summary
```

## Rollback

Legacy distribution SQL files are preserved on disk. Reverting this PR restores Phase 3 orchestration with legacy SQL file references.

## TL Awareness

This PR changes the orchestration order from `agg -> markup -> distribute` to `distribute -> agg -> markup`. The inversion is required because per-rate distribution writes `distributed_cost` to `rates_to_usage`, which aggregation then rolls into daily summary.

## Test plan

- [ ] TC-44: `test_orchestration_order_distribute_before_aggregate` -- verifies distribute runs before aggregate
- [ ] TC-R20-01: `test_rtu_enabled_full_ordering` -- verifies full order: `rtu -> monthly -> vm -> dist -> agg -> markup`
- [ ] TC-R20-02: `test_aggregation_before_markup` -- verifies agg still runs before markup (unchanged invariant)
- [ ] Integration tests for per-rate distribution correctness (to be added in follow-up)