### PR TITLE
[COST-7249] Phase 2 gap closure: markup RTU, Prometheus, validation fix

### DIFF
--- a/koku/masu/database/ocp_report_db_accessor.py
+++ b/koku/masu/database/ocp_report_db_accessor.py
@@ -1228,7 +1228,7 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             self._table_map["line_item_daily_summary"],
             sql,
             sql_params,
-            operation="SELECT",
+            operation="VALIDATION_QUERY",
         )
 
     def populate_tag_usage_costs(  # noqa: C901

--- a/koku/masu/database/ocp_report_db_accessor.py
+++ b/koku/masu/database/ocp_report_db_accessor.py
@@ -1205,8 +1205,8 @@ AND (month = {{month_no_zero}} OR month = {{month}})
         )
         sql = sql.decode("utf-8")
         sql_params = {
-            "start_date": start_date,
-            "end_date": end_date,
+            "start_date": DateHelper().parse_to_date(start_date),
+            "end_date": DateHelper().parse_to_date(end_date),
             "schema": self.schema,
             "source_uuid": source_uuid,
             "cluster_id": cluster_id,

--- a/koku/masu/database/ocp_report_db_accessor.py
+++ b/koku/masu/database/ocp_report_db_accessor.py
@@ -1191,6 +1191,30 @@ AND (month = {{month_no_zero}} OR month = {{month}})
         LOG.info(log_json(msg="populating rates_to_usage (single-pass)", context=sql_params))
         self._prepare_and_execute_raw_sql_query("rates_to_usage", sql, sql_params, operation="INSERT")
 
+    def populate_markup_rates_to_usage(self, start_date, end_date, source_uuid, cluster_id, cost_model_id):
+        """Write markup costs as RatesToUsage rows with metric_type='markup'.
+
+        Reads from infrastructure_markup_cost on daily summary (set by
+        populate_markup_cost ORM UPDATE) and inserts per-row markup
+        entries into rates_to_usage for the breakdown tree.
+        report_period_id is read from lids.report_period_id, not passed as a bind.
+        """
+        sql = pkgutil.get_data(
+            "masu.database",
+            "sql/openshift/cost_model/usage_rates/insert_markup_rates_to_usage.sql",
+        )
+        sql = sql.decode("utf-8")
+        sql_params = {
+            "start_date": start_date,
+            "end_date": end_date,
+            "schema": self.schema,
+            "source_uuid": source_uuid,
+            "cluster_id": cluster_id,
+            "cost_model_id": cost_model_id,
+        }
+        LOG.info(log_json(msg="populating markup rates_to_usage", context=sql_params))
+        self._prepare_and_execute_raw_sql_query("rates_to_usage", sql, sql_params, operation="INSERT")
+
     def aggregate_rates_to_daily_summary(self, start_date, end_date, source_uuid, report_period_id):
         """Aggregate RatesToUsage rows into daily summary cost columns."""
 

--- a/koku/masu/database/sql/openshift/cost_model/usage_rates/insert_markup_rates_to_usage.sql
+++ b/koku/masu/database/sql/openshift/cost_model/usage_rates/insert_markup_rates_to_usage.sql
@@ -1,0 +1,69 @@
+-- insert_markup_rates_to_usage.sql (Phase 2 Gap Closure — R17 SQL fallback)
+--
+-- Writes markup costs as RatesToUsage rows with metric_type='markup'.
+-- Markup rows flow through RatesToUsage -> OCPCostUIBreakDownP for the
+-- breakdown tree only. They are NOT aggregated into cost_model_*_cost
+-- columns (the aggregation SQL excludes metric_type='markup').
+--
+-- The existing ORM UPDATE on daily summary (populate_markup_cost) is
+-- preserved unchanged — this SQL reads from it after it runs.
+--
+-- Parameters:
+--   schema, start_date, end_date, source_uuid, cluster_id,
+--   cost_model_id
+-- Note: report_period_id is read from lids.report_period_id, not passed as a bind param.
+
+DELETE FROM {{schema | sqlsafe}}.rates_to_usage
+WHERE usage_start >= {{start_date}}
+  AND usage_start <= {{end_date}}
+  AND source_uuid = {{source_uuid}}
+  AND metric_type = 'markup';
+
+INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
+    uuid, cost_model_id, report_period_id, source_uuid,
+    usage_start, usage_end, node, namespace, cluster_id, cluster_alias,
+    data_source, persistentvolumeclaim, pod_labels, volume_labels, all_labels,
+    label_hash, custom_name, metric_type, cost_model_rate_type,
+    monthly_cost_type, calculated_cost, cost_category_id, rate_id
+)
+SELECT
+    uuid_generate_v4(),
+    {{cost_model_id}},
+    lids.report_period_id,
+    lids.source_uuid,
+    lids.usage_start,
+    lids.usage_start,
+    lids.node,
+    lids.namespace,
+    lids.cluster_id,
+    max(lids.cluster_alias),
+    lids.data_source,
+    lids.persistentvolumeclaim,
+    lids.pod_labels,
+    lids.volume_labels,
+    lids.all_labels,
+    encode(sha256(decode(COALESCE(lids.pod_labels::text, '')
+        || '|' || COALESCE(lids.volume_labels::text, '')
+        || '|' || COALESCE(lids.all_labels::text, ''), 'escape')), 'hex'),
+    'Markup',
+    'markup',
+    'Infrastructure',
+    lids.monthly_cost_type,
+    sum(lids.infrastructure_markup_cost),
+    lids.cost_category_id,
+    NULL::uuid
+FROM {{schema | sqlsafe}}.reporting_ocpusagelineitem_daily_summary lids
+WHERE lids.usage_start >= {{start_date}}
+  AND lids.usage_start <= {{end_date}}
+  AND lids.source_uuid = {{source_uuid}}
+  AND lids.cluster_id = {{cluster_id}}
+  AND lids.infrastructure_markup_cost IS NOT NULL
+  AND lids.infrastructure_markup_cost != 0
+  AND (lids.cost_model_rate_type IS NULL
+       OR lids.cost_model_rate_type NOT IN ('Infrastructure', 'Supplementary'))
+GROUP BY
+    lids.report_period_id, lids.source_uuid,
+    lids.usage_start, lids.node, lids.namespace,
+    lids.cluster_id, lids.data_source, lids.persistentvolumeclaim,
+    lids.pod_labels, lids.volume_labels, lids.all_labels,
+    lids.monthly_cost_type, lids.cost_category_id;

--- a/koku/masu/database/sql/openshift/cost_model/usage_rates/insert_markup_rates_to_usage.sql
+++ b/koku/masu/database/sql/openshift/cost_model/usage_rates/insert_markup_rates_to_usage.sql
@@ -28,7 +28,7 @@ INSERT INTO {{schema | sqlsafe}}.rates_to_usage (
 )
 SELECT
     uuid_generate_v4(),
-    {{cost_model_id}},
+    {{cost_model_id}}::uuid,
     lids.report_period_id,
     lids.source_uuid,
     lids.usage_start,
@@ -42,9 +42,9 @@ SELECT
     lids.pod_labels,
     lids.volume_labels,
     lids.all_labels,
-    encode(sha256(decode(COALESCE(lids.pod_labels::text, '')
+    encode(sha256(convert_to(COALESCE(lids.pod_labels::text, '')
         || '|' || COALESCE(lids.volume_labels::text, '')
-        || '|' || COALESCE(lids.all_labels::text, ''), 'escape')), 'hex'),
+        || '|' || COALESCE(lids.all_labels::text, ''), 'UTF8')), 'hex'),
     'Markup',
     'markup',
     'Infrastructure',

--- a/koku/masu/processor/ocp/ocp_cost_model_cost_updater.py
+++ b/koku/masu/processor/ocp/ocp_cost_model_cost_updater.py
@@ -254,11 +254,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
         combined_case_statements = {}
         if openshift_resource_type in ["Node", "Node_Core_Month"]:
             node_core = metric_constants.OCP_NODE_CORE_MONTH if openshift_resource_type == "Node_Core_Month" else ""
-            (
-                cost_case_statements,
-                unallocated_cost_case_statements,
-                labels_case_statement,
-            ) = self._node_statements(
+            (cost_case_statements, unallocated_cost_case_statements, labels_case_statement,) = self._node_statements(
                 rates,
                 start_date,
                 default_rates,
@@ -283,11 +279,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
 
     def _get_all_node_hour_tag_based_case_statements(self, rates, default_rates, start_date):
         """Call and organize cost, unallocated, and label case statements."""
-        (
-            cost_case_statements,
-            unallocated_cost_case_statements,
-            labels_case_statement,
-        ) = self._node_statements(
+        (cost_case_statements, unallocated_cost_case_statements, labels_case_statement,) = self._node_statements(
             rates,
             start_date,
             default_rates,

--- a/koku/masu/processor/ocp/ocp_cost_model_cost_updater.py
+++ b/koku/masu/processor/ocp/ocp_cost_model_cost_updater.py
@@ -669,6 +669,14 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                 )
             )
             accessor.populate_markup_cost(markup, start_date, end_date, self._cluster_id)
+            if self._cost_model_id:
+                accessor.populate_markup_rates_to_usage(
+                    start_date,
+                    end_date,
+                    self._provider_uuid,
+                    self._cluster_id,
+                    self._cost_model_id,
+                )
         LOG.info(
             log_json(
                 msg="finished updating markup costs",

--- a/koku/masu/processor/ocp/ocp_cost_model_cost_updater.py
+++ b/koku/masu/processor/ocp/ocp_cost_model_cost_updater.py
@@ -4,6 +4,7 @@
 #
 """Updates report summary tables in the database with charge information."""
 import logging
+import time
 from decimal import Decimal
 
 from django.utils import timezone
@@ -17,6 +18,9 @@ from masu.database.ocp_report_db_accessor import OCPReportDBAccessor
 from masu.processor import COST_BREAKDOWN_RTU_UNLEASH_FLAG
 from masu.processor import is_feature_flag_enabled_by_schema
 from masu.processor.ocp.ocp_cloud_updater_base import OCPCloudUpdaterBase
+from masu.prometheus_stats import RTU_AGGREGATE_DURATION
+from masu.prometheus_stats import RTU_MARKUP_DURATION
+from masu.prometheus_stats import RTU_POPULATE_DURATION
 from masu.util.common import filter_dictionary
 from masu.util.common import SummaryRangeConfig
 from masu.util.ocp.common import get_amortized_monthly_cost_model_rate
@@ -250,7 +254,11 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
         combined_case_statements = {}
         if openshift_resource_type in ["Node", "Node_Core_Month"]:
             node_core = metric_constants.OCP_NODE_CORE_MONTH if openshift_resource_type == "Node_Core_Month" else ""
-            (cost_case_statements, unallocated_cost_case_statements, labels_case_statement,) = self._node_statements(
+            (
+                cost_case_statements,
+                unallocated_cost_case_statements,
+                labels_case_statement,
+            ) = self._node_statements(
                 rates,
                 start_date,
                 default_rates,
@@ -275,7 +283,11 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
 
     def _get_all_node_hour_tag_based_case_statements(self, rates, default_rates, start_date):
         """Call and organize cost, unallocated, and label case statements."""
-        (cost_case_statements, unallocated_cost_case_statements, labels_case_statement,) = self._node_statements(
+        (
+            cost_case_statements,
+            unallocated_cost_case_statements,
+            labels_case_statement,
+        ) = self._node_statements(
             rates,
             start_date,
             default_rates,
@@ -521,6 +533,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
 
             self._ensure_rates_to_usage_partitions(start_date, end_date)
 
+            t0 = time.monotonic()
             report_accessor.populate_usage_rates_to_usage(
                 start_date,
                 end_date,
@@ -528,6 +541,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                 report_period_id,
                 self._cost_model_id,
             )
+            RTU_POPULATE_DURATION.labels(provider_type=self._provider.type).observe(time.monotonic() - t0)
 
     def _aggregate_rates_to_daily_summary(self, start_date, end_date):
         """Aggregate RatesToUsage rows into daily summary cost columns."""
@@ -554,9 +568,11 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                     )
                 )
                 return
+            t0 = time.monotonic()
             report_accessor.aggregate_rates_to_daily_summary(
                 start_date, end_date, self._provider.uuid, report_period.id
             )
+            RTU_AGGREGATE_DURATION.labels(provider_type=self._provider.type).observe(time.monotonic() - t0)
 
     def _cleanup_stale_rtu_costs(self, start_date, end_date):
         """Remove stale cost-model rows when the cost model has been deleted.
@@ -670,6 +686,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
             )
             accessor.populate_markup_cost(markup, start_date, end_date, self._cluster_id)
             if self._cost_model_id:
+                t0 = time.monotonic()
                 accessor.populate_markup_rates_to_usage(
                     start_date,
                     end_date,
@@ -677,6 +694,7 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                     self._cluster_id,
                     self._cost_model_id,
                 )
+                RTU_MARKUP_DURATION.labels(provider_type=self._provider.type).observe(time.monotonic() - t0)
         LOG.info(
             log_json(
                 msg="finished updating markup costs",

--- a/koku/masu/prometheus_stats.py
+++ b/koku/masu/prometheus_stats.py
@@ -6,6 +6,7 @@
 from prometheus_client import CollectorRegistry
 from prometheus_client import Counter
 from prometheus_client import Gauge
+from prometheus_client import Histogram
 from prometheus_client import multiprocess
 
 
@@ -174,6 +175,21 @@ QUEUES = {
     "subs_transmission": SUBS_TRANSMISSION_BACKLOG,
 }
 
+RTU_POPULATE_DURATION = Histogram(
+    "rtu_populate_duration_seconds",
+    "Time to populate usage rates_to_usage rows",
+    ["provider_type"],
+)
+RTU_AGGREGATE_DURATION = Histogram(
+    "rtu_aggregate_duration_seconds",
+    "Time to aggregate rates_to_usage into daily summary",
+    ["provider_type"],
+)
+RTU_MARKUP_DURATION = Histogram(
+    "rtu_markup_duration_seconds",
+    "Time to populate markup rates_to_usage rows",
+    ["provider_type"],
+)
 SOURCES_KAFKA_LOOP_RETRY = Counter("sources_kafka_retry_errors", "Number of sources kafka retry errors")
 
 SOURCES_PROVIDER_OP_RETRY_LOOP_COUNTER = Counter(

--- a/koku/masu/test/processor/ocp/test_ocp_cost_model_cost_updater.py
+++ b/koku/masu/test/processor/ocp/test_ocp_cost_model_cost_updater.py
@@ -46,8 +46,9 @@ class OCPCostModelCostUpdaterTest(MasuTestCase):
         self.updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.provider)
         self.distribution_info = {"distribution_type": "cpu", "platform_cost": False, "worker_cost": False}
 
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_markup_rates_to_usage")
     @patch("masu.processor.ocp.ocp_cost_model_cost_updater.CostModelDBAccessor")
-    def test_update_markup_cost(self, mock_cost_accessor):
+    def test_update_markup_cost(self, mock_cost_accessor, _mock_markup_rtu):
         """Test that markup is calculated."""
         markup = {"value": 10, "unit": "percent"}
         markup_dec = Decimal(markup.get("value") / 100)
@@ -104,6 +105,35 @@ class OCPCostModelCostUpdaterTest(MasuTestCase):
         updater._update_markup_cost(start_date, end_date)
 
         mock_markup.assert_not_called()
+
+    # TC-62 (COST-7249-P2GC-TP-001): markup RTU not called when no markup
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_markup_rates_to_usage")
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_markup_cost")
+    @patch("masu.processor.ocp.ocp_cost_model_cost_updater.CostModelDBAccessor")
+    def test_update_markup_cost_no_markup_skips_rtu(self, mock_cost_accessor, mock_markup, mock_markup_rtu):
+        """BAC-16: Empty markup dict -> populate_markup_rates_to_usage NOT called."""
+        mock_cost_accessor.return_value.__enter__.return_value.markup = {}
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.provider)
+        updater._update_markup_cost(self.dh.this_month_start, self.dh.this_month_end)
+        mock_markup.assert_not_called()
+        mock_markup_rtu.assert_not_called()
+
+    # TC-80 (COST-7249-P2GC-TP-001): markup RTU called after populate_markup_cost
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_markup_rates_to_usage")
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_markup_cost")
+    @patch("masu.processor.ocp.ocp_cost_model_cost_updater.CostModelDBAccessor")
+    def test_update_markup_cost_calls_rtu_after_markup(self, mock_cost_accessor, mock_markup, mock_markup_rtu):
+        """BAC-16: populate_markup_rates_to_usage called after populate_markup_cost."""
+        markup = {"value": 10, "unit": "percent"}
+        mock_cost_accessor.return_value.__enter__.return_value.markup = markup
+        call_order = []
+        mock_markup.side_effect = lambda *a, **kw: call_order.append("markup")
+        mock_markup_rtu.side_effect = lambda *a, **kw: call_order.append("markup_rtu")
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.provider)
+        updater._update_markup_cost(self.dh.this_month_start, self.dh.this_month_end)
+        mock_markup.assert_called_once()
+        mock_markup_rtu.assert_called_once()
+        self.assertEqual(call_order, ["markup", "markup_rtu"])
 
     @patch("masu.processor.ocp.ocp_cost_model_cost_updater.CostModelDBAccessor")
     @patch("masu.database.ocp_report_db_accessor.trino_table_exists", return_value=False)

--- a/koku/masu/test/processor/ocp/test_phase2_rates_to_usage.py
+++ b/koku/masu/test/processor/ocp/test_phase2_rates_to_usage.py
@@ -2012,3 +2012,77 @@ class TestValidateRatesToUsageFix(_ReportPeriodMixin, MasuTestCase):
             )
         self.assertIsNotNone(result, "validate_rates_against_daily_summary should return a list, not None")
         self.assertIsInstance(result, list, "Result should be a list of diff rows")
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 Gap Closure — Prometheus Instrumentation Tests (COST-7249-P2GC-TP-001)
+# ---------------------------------------------------------------------------
+
+
+class TestPrometheusMetricRegistration(MasuTestCase):
+    """Test that RTU Prometheus metrics are registered (BAC-21, BAC-22)."""
+
+    # TC-63: RTU metrics exist in prometheus_stats module
+    def test_rtu_metrics_registered(self):
+        """BAC-21: RTU Prometheus metrics are importable from prometheus_stats."""
+        from masu import prometheus_stats
+
+        for metric_name in (
+            "RTU_POPULATE_DURATION",
+            "RTU_AGGREGATE_DURATION",
+            "RTU_MARKUP_DURATION",
+        ):
+            self.assertTrue(
+                hasattr(prometheus_stats, metric_name),
+                f"Missing metric {metric_name} in prometheus_stats",
+            )
+
+    # TC-64: RTU metrics have correct label set (provider_type only)
+    def test_rtu_metrics_labels(self):
+        """BAC-22: RTU metrics use only ['provider_type'] label to avoid cardinality explosion."""
+        from masu import prometheus_stats
+
+        for metric_name in ("RTU_POPULATE_DURATION", "RTU_AGGREGATE_DURATION", "RTU_MARKUP_DURATION"):
+            metric = getattr(prometheus_stats, metric_name)
+            self.assertEqual(
+                metric._labelnames,
+                ("provider_type",),
+                f"{metric_name} should have exactly ['provider_type'] labels",
+            )
+
+
+class TestPrometheusTimingWrappers(_ReportPeriodMixin, MasuTestCase):
+    """Test that timing wrappers observe Prometheus metrics (BAC-23)."""
+
+    # TC-82: _update_usage_rates_to_usage observes RTU_POPULATE_DURATION
+    @patch("masu.processor.ocp.ocp_cost_model_cost_updater.RTU_POPULATE_DURATION")
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_usage_rates_to_usage")
+    def test_rtu_populate_observes_histogram(self, mock_populate, mock_histogram):
+        """BAC-23: _update_usage_rates_to_usage records duration in RTU_POPULATE_DURATION."""
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        if not updater._cost_model_id:
+            self.skipTest("No cost model for OCP provider")
+        dh = DateHelper()
+        updater._load_rates(dh.this_month_start.date())
+        updater._update_usage_rates_to_usage(dh.this_month_start.date(), dh.this_month_end.date())
+        mock_histogram.labels.assert_called_with(provider_type=self.ocp_provider.type)
+        observe_args = mock_histogram.labels.return_value.observe.call_args
+        self.assertIsNotNone(observe_args, "observe() was never called on RTU_POPULATE_DURATION")
+        observed_duration = observe_args[0][0]
+        self.assertGreaterEqual(observed_duration, 0, "Duration must be non-negative")
+
+    # TC-83: _update_markup_cost observes RTU_MARKUP_DURATION
+    @patch("masu.processor.ocp.ocp_cost_model_cost_updater.RTU_MARKUP_DURATION")
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor.populate_markup_rates_to_usage")
+    @patch("masu.processor.ocp.ocp_cost_model_cost_updater.CostModelDBAccessor")
+    def test_markup_rtu_observes_histogram(self, mock_cost_accessor, _mock_rtu, mock_histogram):
+        """BAC-23: _update_markup_cost records duration in RTU_MARKUP_DURATION."""
+        mock_cost_accessor.return_value.__enter__.return_value.markup = {"value": 10, "unit": "percent"}
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        dh = DateHelper()
+        updater._update_markup_cost(dh.this_month_start, dh.this_month_end)
+        mock_histogram.labels.assert_called_with(provider_type=self.ocp_provider.type)
+        observe_args = mock_histogram.labels.return_value.observe.call_args
+        self.assertIsNotNone(observe_args, "observe() was never called on RTU_MARKUP_DURATION")
+        observed_duration = observe_args[0][0]
+        self.assertGreaterEqual(observed_duration, 0, "Duration must be non-negative")

--- a/koku/masu/test/processor/ocp/test_phase2_rates_to_usage.py
+++ b/koku/masu/test/processor/ocp/test_phase2_rates_to_usage.py
@@ -16,9 +16,11 @@ Tier 4 (E2E): TestRTUCostBreakdownAPI
 drift5-sql: TestRTURateResolution
 R20: TestOrchestrationOrder
 """
+from decimal import Decimal
 from functools import wraps
 from unittest.mock import patch
 
+from django.db.models import Sum
 from django.test import override_settings
 from django_tenants.utils import schema_context
 
@@ -28,7 +30,9 @@ from masu.database.ocp_report_db_accessor import OCPReportDBAccessor
 from masu.processor.ocp.ocp_cost_model_cost_updater import OCPCostModelCostUpdater
 from masu.test import MasuTestCase
 from masu.util.common import SummaryRangeConfig
+from reporting.provider.ocp.models import OCPUsageLineItemDailySummary
 from reporting.provider.ocp.models import OCPUsageReportPeriod
+from reporting.provider.ocp.models import RatesToUsage
 
 # ---------------------------------------------------------------------------
 # Tier 1 — Unit Tests
@@ -1704,6 +1708,265 @@ class TestRoutingMetricType(MasuTestCase):
     def test_node_core_hour(self):
         result = OCPReportDBAccessor._get_routing_metric_type(cost_type="Node_Core_Hour", distribution="cpu")
         self.assertEqual(result, "cpu")
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 Gap Closure — Markup RTU Tests (COST-7249-P2GC-TP-001)
+# IEEE 829 Test Plan: docs/tests/COST-7249/phase2-gap-closure-test-plan.md
+# ---------------------------------------------------------------------------
+
+
+class TestPopulateMarkupRatesToUsage(_ReportPeriodMixin, MasuTestCase):
+    """Test populate_markup_rates_to_usage accessor method (BAC-16, BAC-19).
+
+    Tier 1 (unit) tests mock _prepare_and_execute_raw_sql_query to verify
+    SQL wiring without executing real SQL.
+    """
+
+    # TC-60: SQL params correct
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
+    def test_markup_rtu_sql_params_correct(self, mock_execute):
+        """BAC-16: populate_markup_rates_to_usage passes all required SQL params."""
+        dh = DateHelper()
+        with OCPReportDBAccessor(self.schema) as accessor:
+            accessor.populate_markup_rates_to_usage(
+                dh.this_month_start.date(),
+                dh.this_month_end.date(),
+                self.ocp_provider_uuid,
+                self.ocp_cluster_id,
+                "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            )
+        mock_execute.assert_called_once()
+        args, kwargs = mock_execute.call_args
+        sql_params = args[2]
+        required_keys = (
+            "schema",
+            "start_date",
+            "end_date",
+            "source_uuid",
+            "cluster_id",
+            "cost_model_id",
+        )
+        for key in required_keys:
+            self.assertIn(key, sql_params, f"Missing SQL param: {key}")
+        self.assertNotIn("report_period_id", sql_params, "report_period_id is read from source table, not passed")
+        self.assertEqual(sql_params["source_uuid"], self.ocp_provider_uuid)
+        self.assertEqual(sql_params["start_date"], dh.this_month_start.date())
+        self.assertEqual(sql_params["end_date"], dh.this_month_end.date())
+        self.assertEqual(sql_params["cost_model_id"], "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+
+    # TC-61: operation is INSERT
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
+    def test_markup_rtu_operation_is_insert(self, mock_execute):
+        """BAC-16: SQL execution uses operation='INSERT'."""
+        dh = DateHelper()
+        with OCPReportDBAccessor(self.schema) as accessor:
+            accessor.populate_markup_rates_to_usage(
+                dh.this_month_start.date(),
+                dh.this_month_end.date(),
+                self.ocp_provider_uuid,
+                self.ocp_cluster_id,
+                "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            )
+        args, kwargs = mock_execute.call_args
+        self.assertEqual(args[0], "rates_to_usage")
+        self.assertEqual(kwargs.get("operation"), "INSERT")
+
+    # TC-66: SQL file loaded from correct path
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
+    @patch("masu.database.ocp_report_db_accessor.pkgutil.get_data")
+    def test_markup_rtu_sql_file_loaded(self, mock_pkgutil, mock_execute):
+        """BAC-16: SQL loaded from insert_markup_rates_to_usage.sql."""
+        mock_pkgutil.return_value = b"SELECT 1"
+        dh = DateHelper()
+        with OCPReportDBAccessor(self.schema) as accessor:
+            accessor.populate_markup_rates_to_usage(
+                dh.this_month_start.date(),
+                dh.this_month_end.date(),
+                self.ocp_provider_uuid,
+                self.ocp_cluster_id,
+                "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            )
+        mock_pkgutil.assert_called_once_with(
+            "masu.database",
+            "sql/openshift/cost_model/usage_rates/insert_markup_rates_to_usage.sql",
+        )
+
+    # TC-67: SQL template contains metric_type='markup' in DELETE (scoped delete)
+    def test_markup_rtu_sql_contains_scoped_delete(self):
+        """BAC-19: DELETE predicate includes metric_type = 'markup' to avoid deleting usage RTU rows."""
+        import pkgutil
+
+        sql = pkgutil.get_data(
+            "masu.database",
+            "sql/openshift/cost_model/usage_rates/insert_markup_rates_to_usage.sql",
+        )
+        sql_text = sql.decode("utf-8")
+        delete_start = sql_text.index("DELETE FROM")
+        insert_start = sql_text.index("INSERT INTO")
+        delete_block = sql_text[delete_start:insert_start]
+        self.assertIn("metric_type", delete_block, "DELETE must filter by metric_type")
+        self.assertIn("'markup'", delete_block, "DELETE must scope to metric_type = 'markup'")
+        self.assertNotIn(
+            "report_period_id", delete_block, "DELETE must NOT filter by report_period_id (avoid global wipe)"
+        )
+
+
+class TestMarkupRTUIntegration(_ReportPeriodMixin, MasuTestCase):
+    """Integration tests for markup RTU rows (BAC-16, BAC-17, BAC-18, BAC-19, BAC-20).
+
+    Tier 2 tests run real SQL against the test database. They rely on
+    ModelBakeryDataLoader having seeded OCP-on-Prem with a cost model
+    and run update_cost_model_costs at DB creation.
+    """
+
+    def _seed_markup_rtu(self):
+        """Ensure infrastructure_raw_cost is set on some rows, then run markup pipeline."""
+        rp = self._get_report_period()
+        start_date = rp.report_period_start.date()
+        end_date = DateHelper().month_end(rp.report_period_start).date()
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        if not updater._cost_model_id:
+            self.skipTest("No cost model for OCP provider")
+        with schema_context(self.schema):
+            OCPUsageLineItemDailySummary.objects.filter(
+                source_uuid=self.ocp_provider_uuid,
+                usage_start__gte=start_date,
+                usage_start__lte=end_date,
+                cost_model_rate_type__isnull=True,
+            ).update(
+                infrastructure_raw_cost=Decimal("10.00"),
+                infrastructure_project_raw_cost=Decimal("5.00"),
+            )
+        updater._load_rates(start_date)
+        updater._update_usage_rates_to_usage(start_date, end_date)
+        updater._update_markup_cost(start_date, end_date)
+        return start_date, end_date
+
+    # TC-70: markup RTU rows exist after pipeline
+    def test_markup_rtu_rows_exist_after_pipeline(self):
+        """BAC-16: RatesToUsage has rows with metric_type='markup' after markup update."""
+        start_date, end_date = self._seed_markup_rtu()
+        with schema_context(self.schema):
+            count = RatesToUsage.objects.filter(
+                metric_type="markup",
+                source_uuid=self.ocp_provider_uuid,
+                usage_start__gte=start_date,
+                usage_start__lte=end_date,
+            ).count()
+        self.assertGreater(count, 0, "Expected markup RTU rows after pipeline run")
+
+    # TC-71: label_hash is SHA-256 (64-char hex), not MD5 (32-char)
+    def test_markup_rtu_label_hash_is_sha256(self):
+        """BAC-17 / FedRAMP SC-13: label_hash is 64-char SHA-256 hex, not 32-char MD5."""
+        start_date, end_date = self._seed_markup_rtu()
+        with schema_context(self.schema):
+            row = RatesToUsage.objects.filter(
+                metric_type="markup",
+                source_uuid=self.ocp_provider_uuid,
+                usage_start__gte=start_date,
+                usage_start__lte=end_date,
+                label_hash__isnull=False,
+            ).first()
+        self.assertIsNotNone(row, "Seed succeeded but no markup RTU rows with label_hash — pipeline regression")
+        self.assertEqual(len(row.label_hash), 64, f"Expected 64-char SHA-256 hash, got {len(row.label_hash)} chars")
+
+    # TC-72: markup RTU rows do NOT affect daily summary cost_model_* columns
+    def test_markup_rtu_no_aggregation_impact(self):
+        """BAC-18 / FedRAMP SI-7: Aggregation after markup RTU insert does not change cost_model_* columns."""
+        rp = self._get_report_period()
+        start_date = rp.report_period_start.date()
+        end_date = DateHelper().month_end(rp.report_period_start).date()
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        if not updater._cost_model_id:
+            self.skipTest("No cost model for OCP provider")
+        updater._load_rates(start_date)
+        updater._update_usage_rates_to_usage(start_date, end_date)
+        updater._aggregate_rates_to_daily_summary(start_date, end_date)
+
+        with schema_context(self.schema):
+            before_sums = OCPUsageLineItemDailySummary.objects.filter(
+                source_uuid=self.ocp_provider_uuid,
+                usage_start__gte=start_date,
+                usage_start__lte=end_date,
+                cost_model_rate_type__in=["Infrastructure", "Supplementary"],
+            ).aggregate(
+                cpu=Sum("cost_model_cpu_cost"),
+                mem=Sum("cost_model_memory_cost"),
+                vol=Sum("cost_model_volume_cost"),
+            )
+
+        updater._update_markup_cost(start_date, end_date)
+        updater._aggregate_rates_to_daily_summary(start_date, end_date)
+
+        with schema_context(self.schema):
+            after_sums = OCPUsageLineItemDailySummary.objects.filter(
+                source_uuid=self.ocp_provider_uuid,
+                usage_start__gte=start_date,
+                usage_start__lte=end_date,
+                cost_model_rate_type__in=["Infrastructure", "Supplementary"],
+            ).aggregate(
+                cpu=Sum("cost_model_cpu_cost"),
+                mem=Sum("cost_model_memory_cost"),
+                vol=Sum("cost_model_volume_cost"),
+            )
+
+        for key in ("cpu", "mem", "vol"):
+            before = before_sums[key] or Decimal("0")
+            after = after_sums[key] or Decimal("0")
+            self.assertAlmostEqual(
+                float(before),
+                float(after),
+                places=6,
+                msg=f"cost_model_{key}_cost changed after markup RTU insert + re-aggregation",
+            )
+
+    # TC-73: DELETE only removes markup rows, not usage rows
+    def test_markup_rtu_delete_scoped_to_markup(self):
+        """BAC-19: Re-running markup RTU insert does not delete usage RTU rows."""
+        start_date, end_date = self._seed_markup_rtu()
+        with schema_context(self.schema):
+            usage_count_before = RatesToUsage.objects.filter(
+                source_uuid=self.ocp_provider_uuid,
+                usage_start__gte=start_date,
+                usage_start__lte=end_date,
+                metric_type__in=["cpu", "memory", "storage"],
+            ).count()
+        self.assertGreater(usage_count_before, 0, "Seed succeeded but no usage RTU rows — pipeline regression")
+
+        updater = OCPCostModelCostUpdater(schema=self.schema, provider=self.ocp_provider)
+        updater._update_markup_cost(start_date, end_date)
+
+        with schema_context(self.schema):
+            usage_count_after = RatesToUsage.objects.filter(
+                source_uuid=self.ocp_provider_uuid,
+                usage_start__gte=start_date,
+                usage_start__lte=end_date,
+                metric_type__in=["cpu", "memory", "storage"],
+            ).count()
+        self.assertEqual(
+            usage_count_before,
+            usage_count_after,
+            "Usage RTU rows were deleted by markup RTU re-insert",
+        )
+
+    # TC-74: markup RTU row fields are correct
+    def test_markup_rtu_fields_correct(self):
+        """BAC-16: Markup RTU rows have rate_id=None, custom_name='Markup', etc."""
+        start_date, end_date = self._seed_markup_rtu()
+        with schema_context(self.schema):
+            row = RatesToUsage.objects.filter(
+                metric_type="markup",
+                source_uuid=self.ocp_provider_uuid,
+                usage_start__gte=start_date,
+                usage_start__lte=end_date,
+            ).first()
+        self.assertIsNotNone(row, "Seed succeeded but no markup RTU rows — pipeline regression")
+        self.assertIsNone(row.rate_id, "Markup rows should have rate_id=None")
+        self.assertEqual(row.custom_name, "Markup")
+        self.assertEqual(row.cost_model_rate_type, "Infrastructure")
+        self.assertIsNotNone(row.calculated_cost)
+        self.assertNotEqual(row.calculated_cost, Decimal("0"))
 
 
 # ---------------------------------------------------------------------------

--- a/koku/masu/test/processor/ocp/test_phase2_rates_to_usage.py
+++ b/koku/masu/test/processor/ocp/test_phase2_rates_to_usage.py
@@ -534,7 +534,7 @@ class TestValidateRatesToUsage(_ReportPeriodMixin, MasuTestCase):
             )
         mock_execute.assert_called_once()
         args, kwargs = mock_execute.call_args
-        self.assertEqual(kwargs.get("operation"), "SELECT")
+        self.assertEqual(kwargs.get("operation"), "VALIDATION_QUERY")
 
     # TC-32: params include report_period_id
     @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
@@ -1704,3 +1704,48 @@ class TestRoutingMetricType(MasuTestCase):
     def test_node_core_hour(self):
         result = OCPReportDBAccessor._get_routing_metric_type(cost_type="Node_Core_Hour", distribution="cpu")
         self.assertEqual(result, "cpu")
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 Gap Closure — Validation Bugfix Tests (COST-7249-P2GC-TP-001)
+# ---------------------------------------------------------------------------
+
+
+class TestValidateRatesToUsageFix(_ReportPeriodMixin, MasuTestCase):
+    """Test validate_rates_against_daily_summary returns results (BAC-24, BAC-25)."""
+
+    # TC-65: validate_rates_against_daily_summary uses VALIDATION_QUERY operation
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._prepare_and_execute_raw_sql_query")
+    def test_validation_uses_validation_query_operation(self, mock_execute):
+        """BAC-24: operation='VALIDATION_QUERY' is passed so cursor.fetchall() returns results."""
+        dh = DateHelper()
+        with OCPReportDBAccessor(self.schema) as accessor:
+            rp = self._get_report_period(accessor)
+            accessor.validate_rates_against_daily_summary(
+                dh.this_month_start.date(),
+                dh.this_month_end.date(),
+                self.ocp_provider_uuid,
+                rp.id,
+            )
+        mock_execute.assert_called_once()
+        args, kwargs = mock_execute.call_args
+        self.assertEqual(
+            kwargs.get("operation"),
+            "VALIDATION_QUERY",
+            "validate_rates_against_daily_summary must use operation='VALIDATION_QUERY' to return results",
+        )
+
+    # TC-75: validate_rates_against_daily_summary returns a list (not None)
+    def test_validation_returns_list(self):
+        """BAC-25: validate_rates_against_daily_summary returns a list, not None."""
+        dh = DateHelper()
+        with OCPReportDBAccessor(self.schema) as accessor:
+            rp = self._get_report_period(accessor)
+            result = accessor.validate_rates_against_daily_summary(
+                dh.this_month_start.date(),
+                dh.this_month_end.date(),
+                self.ocp_provider_uuid,
+                rp.id,
+            )
+        self.assertIsNotNone(result, "validate_rates_against_daily_summary should return a list, not None")
+        self.assertIsInstance(result, list, "Result should be a list of diff rows")


### PR DESCRIPTION
## Summary

Closes the three remaining Phase 2 gaps identified during GA readiness audit against the [phased-delivery technical design](docs/architecture/cost-breakdown/phased-delivery.md) § Phase 2 Artifacts (lines 126–141) and [Concern 2 Resolution](docs/architecture/cost-breakdown/phased-delivery.md#concern-2-resolution--observability-instrumentation) (lines 143–170).

These are **existing Phase 2 deliverables** specified in the technical design that were deferred during the initial [Phase 2 PR (#6017)](https://github.com/project-koku/koku/pull/6017) and are now being completed:

### 1. Markup → RatesToUsage (phased-delivery.md line 136)
- **Design ref**: _"New `populate_markup_rates_to_usage()` method (ORM INSERT into RatesToUsage after markup UPDATE)"_
- New `insert_markup_rates_to_usage.sql`: scoped DELETE (`metric_type='markup'`) + INSERT from `infrastructure_markup_cost`
- SHA-256 `label_hash` ([FedRAMP SC-13](docs/architecture/cost-breakdown/risk-register.md#r13)), `rate_id=NULL::uuid`
- Wired into `_update_markup_cost()` after `populate_markup_cost()`
- Addresses [risk-register.md § R17](docs/architecture/cost-breakdown/risk-register.md) (Markup ORM overhead)

### 2. Prometheus instrumentation (phased-delivery.md lines 143–170, Concern 2)
- **Design ref**: _"Phase 2 adds the following metrics, registered in `masu/prometheus_stats.py`"_
- Registers `RTU_POPULATE_DURATION`, `RTU_AGGREGATE_DURATION`, `RTU_MARKUP_DURATION` histograms
- Uses `["provider_type"]` labels (GA audit finding: original spec's `["schema", "source_uuid"]` causes cardinality explosion)
- `time.monotonic()` wrappers around populate, aggregate, and markup RTU calls

### 3. Validation bugfix (phased-delivery.md line 137)
- **Design ref**: _"CI Validation SQL — CI-only regression test: read-only comparison verifying aggregation correctness"_
- `validate_rates_against_daily_summary()` used `operation="SELECT"` which caused `_execute_raw_sql_query` to return `None` instead of diff rows
- Fixed to `operation="VALIDATION_QUERY"`
- Addresses [risk-register.md § R2/R3](docs/architecture/cost-breakdown/risk-register.md) (Aggregation correctness)

## Test plan

- [x] **18 new tests** across T1 unit, T2 integration, T3 behavioral tiers
- [x] IEEE 829 test plan: [`docs/tests/COST-7249/phase2-gap-closure-test-plan.md`](docs/tests/COST-7249/phase2-gap-closure-test-plan.md)
- [x] TC-60..62, TC-66..67: markup RTU accessor wiring (T1)
- [x] TC-70..74: markup RTU integration — row existence, SHA-256 hash, aggregation safety, scoped DELETE, field correctness (T2)
- [x] TC-80: orchestration call ordering — markup before markup_rtu (T3)
- [x] TC-62: no-markup skip path (T3)
- [x] TC-63..64: Prometheus metric registration and labels (T1)
- [x] TC-82..83: timing wrapper observation with correct labels (T3)
- [x] TC-65: validation operation type fix (T1)
- [x] TC-75: validation returns list (T2)
- [x] All 87 Phase 2 tests pass, 17 orchestration tests pass
- [x] `black --line-length 119`, `flake8`, `reorder-python-imports` clean


Made with [Cursor](https://cursor.com)