### PR TITLE
[COST-7502] Add event-driven CI Triager workflow

### DIFF
--- a/.github/workflows/ci-triager.yml
+++ b/.github/workflows/ci-triager.yml
@@ -1,0 +1,82 @@
+name: CI Triager
+
+on:
+  check_run:
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to triage"
+        required: true
+      check_name:
+        description: "Failing check name (for context)"
+        required: false
+        default: "manual trigger"
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ci-triager-pr-${{ github.event.check_run.pull_requests[0].number || github.event.inputs.pr_number }}
+  cancel-in-progress: true
+
+jobs:
+  triage:
+    name: CI Triager
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.check_run.conclusion == 'failure' &&
+       toJSON(github.event.check_run.pull_requests) != '[]')
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Resolve event context
+        id: ctx
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            PR_NUMBER="${{ github.event.inputs.pr_number }}"
+            CHECK_NAME="${{ github.event.inputs.check_name }}"
+            HEAD_BRANCH=$(gh pr view "$PR_NUMBER" --repo project-koku/koku --json headRefName --jq '.headRefName')
+          else
+            PR_NUMBER="${{ github.event.check_run.pull_requests[0].number }}"
+            CHECK_NAME="${{ github.event.check_run.name }}"
+            HEAD_BRANCH="${{ github.event.check_run.pull_requests[0].head.ref }}"
+          fi
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "check_name=$CHECK_NAME" >> "$GITHUB_OUTPUT"
+          echo "head_branch=$HEAD_BRANCH" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Debounce — absorb rapid simultaneous failures
+        if: github.event_name == 'check_run'
+        run: sleep 300
+
+      - name: Trigger CI Triager session
+        uses: ambient-code/ambient-action@v0.0.5
+        with:
+          api-url: ${{ secrets.AMBIENT_API_URL }}
+          api-token: ${{ secrets.AMBIENT_API_TOKEN }}
+          project: koku-ci
+          display-name: "CI Triager — PR #${{ steps.ctx.outputs.pr_number }} / ${{ steps.ctx.outputs.check_name }}"
+          repos: '[{"url": "https://github.com/project-koku/koku", "branch": "${{ steps.ctx.outputs.head_branch }}", "autoPush": false}]'
+          stop-on-run-finished: "true"
+          prompt: |
+            You are being triggered for a specific failing CI check.
+            Skip Step 1 (scanning all open PRs) — investigate only:
+
+            - PR: #${{ steps.ctx.outputs.pr_number }}
+            - Failing check: ${{ steps.ctx.outputs.check_name }}
+            - Head branch: ${{ steps.ctx.outputs.head_branch }}
+
+            The full triager instructions are in
+            `docs/team_workflows/ci-triager/prompt.md` in the cloned
+            repository. Read that file first, then start from Step 1b
+            (Bootstrap Konflux access) and proceed directly to Step 2
+            for the PR and check listed above.


### PR DESCRIPTION
## Jira Ticket
[COST-7502](https://redhat.atlassian.net/browse/COST-7502)

## Description

This change replaces the Ambient Code cron-based CI Triager (which ran every 2 hours regardless of activity) with an event-driven GitHub Actions workflow.

The new workflow triggers an Ambient Code session **immediately** when any `check_run` fails on a PR — including GitHub Actions checks (`Sanity`, `Units - 3.11`, `codecov/*`) and Konflux checks (`koku-ci`, `koku-pr`).

**Key design decisions:**

- **`check_run` trigger** (not `workflow_run`): captures failures from both GitHub Actions and Konflux, which is an external check system invisible to `workflow_run`
- **300s debounce**: a `sleep 300` before calling the AC API collapses rapid simultaneous failures (e.g. `sanity` + `units` failing in the same CI run) into a single AC session
- **Concurrency with `cancel-in-progress`**: ensures only one triager session runs per PR at a time; a new failure cancels the previous pending run
- **`workflow_dispatch`**: manual trigger for testing without requiring a real CI failure
- **Prompt as source of truth**: the AC session reads `docs/team_workflows/ci-triager/prompt.md` from the cloned repo — no prompt duplication in the workflow YAML

**Secrets required in this repo (Settings → Secrets → Actions):**
- `AMBIENT_API_URL`: Ambient Code Platform API URL
- `AMBIENT_API_TOKEN`: Access Key from the AC UI (Access Keys → Create Key)

## Testing

1. Checkout branch and merge to `main` (workflow must be on default branch for `check_run` triggers to work)
2. Add `AMBIENT_API_URL` and `AMBIENT_API_TOKEN` to repo secrets
3. **Option A (manual):** Go to Actions → CI Triager → Run workflow, enter a PR number and check name
4. **Option B (real failure):** Open a PR with a deliberate `Sanity` failure (e.g. bad formatting); when `check_run` fires with `conclusion=failure`, the triager should start ~5 minutes later (after debounce)
5. Verify an AC session appears in the `koku-ci` project for that PR
6. Verify the bot comments on the PR as expected

## Release Notes
- [ ] proposed release note

```markdown
* [COST-7502](https://redhat.atlassian.net/browse/COST-7502) Replace CI Triager cron schedule with event-driven GitHub Actions workflow
```

Made with [Cursor](https://cursor.com)