### PR TITLE
Update codecov-action from v6.0.1 to v7.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,7 +235,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: needs.changed-files.outputs.run_tests == 'true'
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:


### PR DESCRIPTION
## Summary

- Updates `codecov/codecov-action` from v6.0.1 to v7.0.0 to fix GPG signature verification failure

Codecov lost access to their `keybase.io/codecovsecurity` GPG key account and migrated to `keybase.io/codecovsecops` ([codecov/codecov-action#1956](https://github.com/codecov/codecov-action/issues/1956)). This broke GPG signature verification for the CLI binary download, causing all coverage uploads to fail with:

```
gpg: no valid OpenPGP data found.
gpg: Can't check signature: No public key
==> Could not verify signature. Please contact Codecov if problem continues
```

v7.0.0 includes the updated GPG key.

## Test plan

- [ ] CI Coverage job passes with the updated action

Made with [Cursor](https://cursor.com)