### PR TITLE
fix(ci-triager): add workflow_run trigger for GitHub Actions CI failures

### DIFF
--- a/.github/workflows/ci-triager.yml
+++ b/.github/workflows/ci-triager.yml
@@ -1,8 +1,18 @@
 name: CI Triager
 
 on:
+  # Catches GitHub Actions CI failures (Sanity, Units, Coverage).
+  # workflow_run fires once when the entire CI workflow completes — no debounce needed.
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+  # Catches external check failures (Konflux koku-ci, koku-pr, Codecov, Snyk...).
+  # GitHub Actions check runs do NOT trigger this event (GitHub limitation),
+  # so there is no overlap with workflow_run above.
   check_run:
     types: [completed]
+
   workflow_dispatch:
     inputs:
       pr_number:
@@ -18,7 +28,7 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: ci-triager-pr-${{ github.event.check_run.pull_requests[0].number || github.event.inputs.pr_number }}
+  group: ci-triager-pr-${{ github.event.check_run.pull_requests[0].number || github.event.workflow_run.pull_requests[0].number || github.event.inputs.pr_number }}
   cancel-in-progress: true
 
 jobs:
@@ -27,7 +37,11 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       github.event_name == 'workflow_dispatch' ||
-      (github.event.check_run.conclusion == 'failure' &&
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.conclusion == 'failure' &&
+       github.event.workflow_run.event == 'pull_request') ||
+      (github.event_name == 'check_run' &&
+       github.event.check_run.conclusion == 'failure' &&
        toJSON(github.event.check_run.pull_requests) != '[]')
 
     steps:
@@ -43,17 +57,26 @@ jobs:
             PR_NUMBER="${{ github.event.inputs.pr_number }}"
             CHECK_NAME="${{ github.event.inputs.check_name }}"
             HEAD_BRANCH=$(gh pr view "$PR_NUMBER" --repo project-koku/koku --json headRefName --jq '.headRefName')
+
+          elif [ "${{ github.event_name }}" = "workflow_run" ]; then
+            PR_NUMBER="${{ github.event.workflow_run.pull_requests[0].number }}"
+            CHECK_NAME="CI (GitHub Actions)"
+            HEAD_BRANCH="${{ github.event.workflow_run.head_branch }}"
+
           else
             PR_NUMBER="${{ github.event.check_run.pull_requests[0].number }}"
             CHECK_NAME="${{ github.event.check_run.name }}"
             HEAD_BRANCH="${{ github.event.check_run.pull_requests[0].head.ref }}"
           fi
+
           echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
           echo "check_name=$CHECK_NAME" >> "$GITHUB_OUTPUT"
           echo "head_branch=$HEAD_BRANCH" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ github.token }}
 
+      # Debounce only for check_run: Konflux koku-ci and koku-pr can fail
+      # within seconds of each other. workflow_run already fires once per CI run.
       - name: Debounce — absorb rapid simultaneous failures
         if: github.event_name == 'check_run'
         run: sleep 300


### PR DESCRIPTION
## Jira Ticket
[COST-7502](https://redhat.atlassian.net/browse/COST-7502)

## Description

Follow-up fix for #6105. During validation with the test PR #6112, we discovered that GitHub Actions check runs (Sanity, Units, Coverage) do **not** fire `check_run` webhook events in other workflows — this is a GitHub platform limitation:

> Events triggered by `GITHUB_TOKEN` will not create a new workflow run.

As a result, the `check_run` trigger alone only captures **external checks** (Konflux, Codecov, Snyk). It never fires for `Sanity`, `Units - 3.11`, or `Coverage`.

**Fix:** add a `workflow_run` trigger on the `CI` workflow to catch GitHub Actions failures, keeping `check_run` for Konflux and other external checks.

| Trigger | Captures | Debounce |
|---|---|---|
| `workflow_run` on "CI" | Sanity, Units, Coverage | None (fires once per CI run) |
| `check_run` | Konflux koku-ci/koku-pr, Codecov, Snyk | 300s (collapses rapid simultaneous failures) |
| `workflow_dispatch` | Manual testing | None |

No overlap between the two triggers — GitHub Actions check runs don't fire `check_run` events.

## Testing

1. Merge this PR (must be on `main` for triggers to work)
2. Validate with test PR #6112 — push a new commit to re-trigger CI
3. Verify the CI Triager workflow fires from `workflow_run` when Sanity fails

## Release Notes
N/A — internal tooling fix

Made with [Cursor](https://cursor.com)