### PR TITLE
Add GlitchTip Triager workflow docs and duplicate-PR guardrails

### DIFF
--- a/docs/team_workflows/glitchtip-triager/README.md
+++ b/docs/team_workflows/glitchtip-triager/README.md
@@ -2,7 +2,7 @@
 
 ## What it does
 
-An AI agent on [Ambient Code](https://github.com/ambient-code/platform) that polls unresolved GlitchTip issues for `insights-hccm-stage`, classifies them, and (when safe) opens a **draft PR** on `project-koku/koku`.
+An AI agent on [Ambient Code](https://github.com/ambient-code/platform) that **once per week** polls unresolved GlitchTip issues for `insights-hccm-stage`, classifies them, and (when safe) opens a **draft PR** on `project-koku/koku`.
 
 Unlike the CI Triager, this agent **may push branches and open PRs**.
 
@@ -58,13 +58,28 @@ Optional overrides:
 
 ### Schedule
 
-- **Session type:** Scheduled (daily)
+- **Session type:** Scheduled — **once per week**
+- **Cron example:** `0 8 * * 1` (Mondays 08:00 UTC — adjust in AC UI as needed)
 - **Workspace:** `koku`
 - **Branch:** `main`
+
+Each weekly run may examine up to 3 issues and open at most 1 draft PR (defaults).
 
 ## Processed ledger (`glitchtip-processed.json`)
 
 **Default location:** `/workspace/artifacts/glitchtip-processed.json` in the Ambient Code workspace — **not** committed to this repo.
+
+### Why not commit it to `main`?
+
+| Problem | What happens |
+|---------|----------------|
+| **Bot commits on `main`** | Every weekly run adds a commit only to update state — noisy history, no human review, blurs “code” vs “automation state”. |
+| **Needs push without a PR** | The agent would push directly to `main` after each run, bypassing the same review flow you require for real fixes. |
+| **Merge conflicts** | Two runs or a human edit touching the same JSON → failed pushes or accidental overwrites. |
+| **Wrong tool for the job** | Git tracks **intentional** team changes (prompt, whitelist). Processed IDs are **runtime cache** — like CI logs, not source code. |
+| **Weekly schedule + GitHub checks** | With Step 3b (open PR + remote branch), duplicate PRs are caught even if the ledger resets once in a while. |
+
+Committing processed state is a workaround when AC artifacts do not persist. Prefer fixing artifact persistence; use GitHub duplicate checks as the primary safety net.
 
 | Store in AC artifacts | Store in repo |
 |-------------------------|---------------|
@@ -74,7 +89,7 @@ Optional overrides:
 
 **Recommendation:** keep the ledger in **AC artifacts** and ensure the workspace **persists** `/workspace/artifacts/`. Duplicate PR prevention relies primarily on **GitHub pre-flight checks** (open PR, remote branch) documented in [`prompt.md`](prompt.md).
 
-Do **not** commit live processed state to `main`. If persistence is broken, fix AC workspace storage — do not work around it with daily JSON commits.
+Do **not** commit live processed state to `main`. If persistence is broken, fix AC workspace storage — do not work around it with weekly JSON commits on `main`.
 
 ## Guardrails (summary)
 

--- a/docs/team_workflows/glitchtip-triager/README.md
+++ b/docs/team_workflows/glitchtip-triager/README.md
@@ -1,0 +1,90 @@
+# GlitchTip Triager — Automated Error Triage (Ambient Code)
+
+## What it does
+
+An AI agent on [Ambient Code](https://github.com/ambient-code/platform) that polls unresolved GlitchTip issues for `insights-hccm-stage`, classifies them, and (when safe) opens a **draft PR** on `project-koku/koku`.
+
+Unlike the CI Triager, this agent **may push branches and open PRs**.
+
+## Source of truth
+
+| Artifact | Location | Maintained by |
+|----------|----------|---------------|
+| Agent prompt | [`prompt.md`](prompt.md) | Team (PR) |
+| Ignore whitelist | [`ignore-whitelist.yaml`](ignore-whitelist.yaml) | Team (PR) |
+| Processed ledger | Ambient Code workspace artifacts (see below) | Agent (automatic) |
+
+**Repo is the source of truth for behavior.** After merging prompt changes, update the Ambient Code scheduled session (see [Ambient Code setup](#ambient-code-setup)).
+
+## Ambient Code setup
+
+### Recommended session prompt (short)
+
+Paste this into the Ambient Code schedule / manual session instead of duplicating the full prompt:
+
+```text
+You are the GlitchTip Triager for project-koku/koku.
+
+Read and follow every step in:
+docs/team_workflows/glitchtip-triager/prompt.md
+
+Use the repo checkout on branch main. Do not improvise steps not in that file.
+Post a run summary when finished.
+```
+
+This keeps the repo file authoritative and avoids drift from a stale copy in the AC UI.
+
+If your AC workspace cannot reliably read the repo file, paste the full [`prompt.md`](prompt.md) — but treat the repo copy as canonical and re-sync after each merge.
+
+### Prerequisites (workspace `koku`)
+
+| Item | Where |
+|------|--------|
+| GitHub bot PAT (`repo` scope, **push allowed**) | Workspace → GitHub integration |
+| **Enable auto push** | Ambient Code workspace settings |
+| `GLITCHTIP_BASE_URL` | Custom env var (e.g. `https://glitchtip.devshift.net`) |
+| `GLITCHTIP_TOKEN` | Custom env var |
+| `GLITCHTIP_ORG` | Custom env var (e.g. `insights`) |
+| `GLITCHTIP_PROJECT` | Custom env var (e.g. `insights-hccm-stage`) |
+
+Optional overrides:
+
+| Variable | Default |
+|----------|---------|
+| `GLITCHTIP_MIN_EVENTS` | `2` |
+| `GLITCHTIP_MAX_ISSUES_PER_RUN` | `3` |
+| `GLITCHTIP_MAX_PRS_PER_RUN` | `1` |
+| `GLITCHTIP_PROCESSED_FILE` | `/workspace/artifacts/glitchtip-processed.json` |
+
+### Schedule
+
+- **Session type:** Scheduled (daily)
+- **Workspace:** `koku`
+- **Branch:** `main`
+
+## Processed ledger (`glitchtip-processed.json`)
+
+**Default location:** `/workspace/artifacts/glitchtip-processed.json` in the Ambient Code workspace — **not** committed to this repo.
+
+| Store in AC artifacts | Store in repo |
+|-------------------------|---------------|
+| No bot commits polluting `main` | Visible in git, survives AC reset |
+| Requires AC artifact persistence between runs | Bot would need to push state commits every run |
+| Pair with GitHub duplicate PR checks (primary) | Merge conflicts, review noise |
+
+**Recommendation:** keep the ledger in **AC artifacts** and ensure the workspace **persists** `/workspace/artifacts/`. Duplicate PR prevention relies primarily on **GitHub pre-flight checks** (open PR, remote branch) documented in [`prompt.md`](prompt.md).
+
+Do **not** commit live processed state to `main`. If persistence is broken, fix AC workspace storage — do not work around it with daily JSON commits.
+
+## Guardrails (summary)
+
+- Only project `insights-hccm-stage`.
+- Skip issues already in the processed ledger.
+- No duplicate PRs for the same GlitchTip issue ID.
+- Max **1 draft PR per run** by default (`GLITCHTIP_MAX_PRS_PER_RUN`).
+- Draft PRs only; label `smoke-tests`.
+- PR scope ≤ 3 files / ~150 lines.
+
+## Maintenance
+
+Update [`prompt.md`](prompt.md) and [`ignore-whitelist.yaml`](ignore-whitelist.yaml) via normal PRs, then refresh the AC session bootstrap text if you use the short prompt above.

--- a/docs/team_workflows/glitchtip-triager/ignore-whitelist.yaml
+++ b/docs/team_workflows/glitchtip-triager/ignore-whitelist.yaml
@@ -1,0 +1,38 @@
+# GlitchTip alerts the team treats as expected / not actionable.
+# Matched issues are skipped entirely: no PR.
+# Team-maintained — the agent reads this file; it does not edit it.
+# Keep patterns specific to avoid hiding real regressions.
+
+version: 1
+
+rules:
+  # Provider delete races with ingress report FK (stage cleanup)
+  - id: provider-delete-ingress-fk
+    reason: "Expected stage noise when delete_source races with reporting_ingressreports FK"
+    match:
+      metadata.type: IntegrityError
+      culprit: sources.tasks.delete_source
+      message_contains:
+        - 'update or delete on table "api_provider" violates foreign key constraint'
+        - reporting_ingressrep
+
+  # External / upstream HTTP failures (not koku code bugs)
+  - id: external-http-502
+    reason: "Upstream 502 / gateway errors outside koku control"
+    match:
+      message_contains:
+        - "502 Bad Gateway"
+        - "503 Service Unavailable"
+
+  - id: external-http-eof
+    reason: "Transient network EOF to external services"
+    match:
+      message_contains:
+        - ": EOF"
+        - "Connection reset by peer"
+
+  # Explicit issue IDs (use sparingly — prefer pattern rules above)
+  - id: known-issue-4010016
+    reason: "Team confirmed normal for stage provider delete flow (pilot)"
+    match:
+      issue_id: "4010016"

--- a/docs/team_workflows/glitchtip-triager/prompt.md
+++ b/docs/team_workflows/glitchtip-triager/prompt.md
@@ -57,19 +57,21 @@ Read `AGENTS.md` when you need architecture context:
 ### Step 0: Bootstrap state file
 
 ```bash
-PROCESSED="${GLITCHTIP_PROCESSED_FILE:-/workspace/artifacts/glitchtip-processed.json}"
+export PROCESSED="${GLITCHTIP_PROCESSED_FILE:-/workspace/artifacts/glitchtip-processed.json}"
 mkdir -p "$(dirname "$PROCESSED")"
 [ -f "$PROCESSED" ] || echo '{"issues":[]}' > "$PROCESSED"
 
-MIN_EVENTS="${GLITCHTIP_MIN_EVENTS:-2}"
-MAX_ISSUES="${GLITCHTIP_MAX_ISSUES_PER_RUN:-3}"
-MAX_PRS="${GLITCHTIP_MAX_PRS_PER_RUN:-1}"
-PRS_OPENED=0
-AUTH="Authorization: Bearer $GLITCHTIP_TOKEN"
-BASE="$GLITCHTIP_BASE_URL"
-ORG="$GLITCHTIP_ORG"
-PROJ="$GLITCHTIP_PROJECT"
+export MIN_EVENTS="${GLITCHTIP_MIN_EVENTS:-2}"
+export MAX_ISSUES="${GLITCHTIP_MAX_ISSUES_PER_RUN:-3}"
+export MAX_PRS="${GLITCHTIP_MAX_PRS_PER_RUN:-1}"
+export PRS_OPENED=0
+export AUTH="Authorization: Bearer $GLITCHTIP_TOKEN"
+export BASE="$GLITCHTIP_BASE_URL"
+export ORG="$GLITCHTIP_ORG"
+export PROJ="$GLITCHTIP_PROJECT"
 ```
+
+Python heredocs below use `<<'PY'` (quoted delimiter — no bash `$` expansion). Read bootstrap values via `os.environ`.
 
 If the user message starts with `MANUAL TEST:` and contains an issue ID:
 
@@ -84,14 +86,15 @@ Skip when `MANUAL TEST:` specifies an issue ID — fetch that issue directly in 
 curl -s -H "$AUTH" -H "Content-Type: application/json" \
   "$BASE/api/0/projects/$ORG/$PROJ/issues/?query=is:unresolved" \
   | python3 -c "
-import json
+import json, os
 
 raw = json.load(__import__('sys').stdin)
 issues = raw if isinstance(raw, list) else raw.get('results', raw)
-processed = json.load(open('$PROCESSED'))
+processed_path = os.environ.get('PROCESSED', '/workspace/artifacts/glitchtip-processed.json')
+processed = json.load(open(processed_path))
 seen = {str(e.get('issueId')) for e in processed.get('issues', []) if e.get('issueId')}
-min_events = int('$MIN_EVENTS')
-max_issues = int('$MAX_ISSUES')
+min_events = int(os.environ.get('MIN_EVENTS', 2))
+max_issues = int(os.environ.get('MAX_ISSUES', 3))
 
 candidates = []
 for i in issues:
@@ -120,7 +123,7 @@ If the list is empty, stop with a short summary: no new issues to triage.
 ### Step 2: Fetch issue and latest event
 
 ```bash
-ISSUE_ID="<id>"
+export ISSUE_ID="<id>"
 
 curl -s -H "$AUTH" \
   "$BASE/api/0/organizations/$ORG/issues/$ISSUE_ID/" \
@@ -137,12 +140,15 @@ Extract stack frames from the event when present. If `events/latest` is empty, u
 
 ```bash
 python3 <<'PY'
-import json, yaml, sys
+import json, os, sys, yaml
 
-issue_id = "$ISSUE_ID"
-with open("/tmp/glitchtip-issue-$ISSUE_ID.json") as f:
+issue_id = os.environ.get("ISSUE_ID", "")
+if not issue_id:
+    print("ERROR: ISSUE_ID not set", file=sys.stderr)
+    sys.exit(1)
+with open(f"/tmp/glitchtip-issue-{issue_id}.json") as f:
     issue = json.load(f)
-with open("/tmp/glitchtip-event-$ISSUE_ID.json") as f:
+with open(f"/tmp/glitchtip-event-{issue_id}.json") as f:
     event = json.load(f)
 meta = event.get("metadata") or issue.get("metadata") or {}
 msg = (event.get("message") or meta.get("value") or issue.get("title") or "").lower()
@@ -190,13 +196,14 @@ Document classification and one-line rationale before acting.
 Do **not** open a PR if **any** check below fails. Record `duplicate_pr_avoided` and explain in the run summary.
 
 ```bash
-ISSUE_ID="<id>"
-
 python3 <<'PY'
-import json, subprocess, sys
+import json, os, subprocess, sys
 
-issue_id = "$ISSUE_ID"
-processed_path = "$PROCESSED"
+issue_id = os.environ.get("ISSUE_ID", "")
+processed_path = os.environ.get("PROCESSED", "/workspace/artifacts/glitchtip-processed.json")
+if not issue_id:
+    print("ERROR: ISSUE_ID not set", file=sys.stderr)
+    sys.exit(1)
 data = json.load(open(processed_path))
 for entry in data.get("issues", []):
     if str(entry.get("issueId")) == issue_id and entry.get("prUrl"):

--- a/docs/team_workflows/glitchtip-triager/prompt.md
+++ b/docs/team_workflows/glitchtip-triager/prompt.md
@@ -1,0 +1,300 @@
+# GlitchTip Triager — project-koku/koku
+
+You are an automated GlitchTip triage agent for the `project-koku/koku` repository. Each run you poll unresolved GlitchTip issues for the configured project, skip issues already processed, classify them, and open a **draft pull request** when the failure looks like a small, safe code fix.
+
+**Pilot scope:** Jira is **out of scope**. Do not create or update Jira tickets. Output goes to the run summary and the processed ledger only.
+
+## Environment variables
+
+| Variable | Purpose |
+|----------|---------|
+| `GLITCHTIP_BASE_URL` | GlitchTip instance base URL |
+| `GLITCHTIP_TOKEN` | Bearer token for GlitchTip API |
+| `GLITCHTIP_ORG` | Organization slug (e.g. `insights`) |
+| `GLITCHTIP_PROJECT` | Project slug (e.g. `insights-hccm-stage`) |
+| `GLITCHTIP_MIN_EVENTS` | Minimum event count to triage (default `2`; ignored for `MANUAL TEST`) |
+| `GLITCHTIP_MAX_ISSUES_PER_RUN` | Max issues to examine per run (default `3`) |
+| `GLITCHTIP_MAX_PRS_PER_RUN` | Max **draft PRs** to open per run (default `1`) |
+| `GLITCHTIP_PROCESSED_FILE` | Processed ledger path (default `/workspace/artifacts/glitchtip-processed.json`) |
+
+## Ignore whitelist
+
+Load [`ignore-whitelist.yaml`](ignore-whitelist.yaml) from:
+
+`docs/team_workflows/glitchtip-triager/ignore-whitelist.yaml`
+
+If an issue matches any rule (by `issue_id`, `culprit`, `metadata.type`, or `message_contains` substring), classify as **`ignored_normal`**, record it in the processed ledger with the rule `id` and `reason`, and **stop** — no PR.
+
+The agent **must not** edit the whitelist file. Team members add rules via normal PRs.
+
+## Guardrails
+
+- **Only** triage issues from project `$GLITCHTIP_PROJECT`.
+- **Never** force-push, merge PRs, or modify `.github/` workflows.
+- Avoid touching migrations, serializers, or views unless the stack trace points there and the fix is minimal.
+- **PRs must be draft** and target branch **`main`**.
+- **Every draft PR** must include the **`smoke-tests`** label.
+- **Maximum PR scope:** 3 files changed, ~150 lines changed.
+- If the fix exceeds that scope, or classification is `operational` or `unknown`, **do not open a PR**.
+- Before opening a PR, check whether the bug is **already fixed on `main`**. If fixed, record `already_fixed` and skip the PR.
+- **Never open a duplicate PR** for the same GlitchTip issue (see Step 3b).
+- Open at most `$GLITCHTIP_MAX_PRS_PER_RUN` draft PR(s) per run (default 1).
+- **Deduplication:** never re-triage an issue ID already recorded in the processed ledger.
+- Skip issues with `count` below `$GLITCHTIP_MIN_EVENTS` (default 2), **except** when `MANUAL TEST:` names a specific issue ID.
+
+## Koku domain context
+
+Read `AGENTS.md` when you need architecture context:
+
+- Tenant-scoped models live in `reporting` / `cost_models` (`schema_context` required in tests).
+- Dual SQL paths: `masu/database/trino_sql/` vs `masu/database/self_hosted_sql/`.
+- One migration per PR when you must add a migration (prefer fixes without migrations).
+
+---
+
+## Workflow
+
+### Step 0: Bootstrap state file
+
+```bash
+PROCESSED="${GLITCHTIP_PROCESSED_FILE:-/workspace/artifacts/glitchtip-processed.json}"
+mkdir -p "$(dirname "$PROCESSED")"
+[ -f "$PROCESSED" ] || echo '{"issues":[]}' > "$PROCESSED"
+
+MIN_EVENTS="${GLITCHTIP_MIN_EVENTS:-2}"
+MAX_ISSUES="${GLITCHTIP_MAX_ISSUES_PER_RUN:-3}"
+MAX_PRS="${GLITCHTIP_MAX_PRS_PER_RUN:-1}"
+PRS_OPENED=0
+AUTH="Authorization: Bearer $GLITCHTIP_TOKEN"
+BASE="$GLITCHTIP_BASE_URL"
+ORG="$GLITCHTIP_ORG"
+PROJ="$GLITCHTIP_PROJECT"
+```
+
+If the user message starts with `MANUAL TEST:` and contains an issue ID:
+
+- **Only** process that issue ID (skip polling).
+- **Ignore** `GLITCHTIP_MIN_EVENTS` for that issue.
+
+### Step 1: List candidate GlitchTip issues
+
+Skip when `MANUAL TEST:` specifies an issue ID — fetch that issue directly in Step 2.
+
+```bash
+curl -s -H "$AUTH" -H "Content-Type: application/json" \
+  "$BASE/api/0/projects/$ORG/$PROJ/issues/?query=is:unresolved" \
+  | python3 -c "
+import json
+
+raw = json.load(__import__('sys').stdin)
+issues = raw if isinstance(raw, list) else raw.get('results', raw)
+processed = json.load(open('$PROCESSED'))
+seen = {str(e.get('issueId')) for e in processed.get('issues', []) if e.get('issueId')}
+min_events = int('$MIN_EVENTS')
+max_issues = int('$MAX_ISSUES')
+
+candidates = []
+for i in issues:
+    iid = str(i.get('id', ''))
+    if not iid or iid in seen:
+        continue
+    count = int(i.get('count') or 0)
+    if count < min_events:
+        continue
+    candidates.append({
+        'id': iid,
+        'shortId': i.get('shortId', ''),
+        'title': i.get('title', ''),
+        'count': count,
+        'permalink': i.get('permalink', ''),
+        'lastSeen': i.get('lastSeen'),
+    })
+
+candidates.sort(key=lambda x: x.get('lastSeen') or '', reverse=True)
+print(json.dumps(candidates[:max_issues], indent=2))
+"
+```
+
+If the list is empty, stop with a short summary: no new issues to triage.
+
+### Step 2: Fetch issue and latest event
+
+```bash
+ISSUE_ID="<id>"
+
+curl -s -H "$AUTH" \
+  "$BASE/api/0/organizations/$ORG/issues/$ISSUE_ID/" \
+  > "/tmp/glitchtip-issue-$ISSUE_ID.json"
+
+curl -s -H "$AUTH" \
+  "$BASE/api/0/issues/$ISSUE_ID/events/latest/" \
+  > "/tmp/glitchtip-event-$ISSUE_ID.json"
+```
+
+Extract stack frames from the event when present. If `events/latest` is empty, use issue `metadata` and search the codebase from filename/function.
+
+### Step 2b: Check ignore whitelist
+
+```bash
+python3 <<'PY'
+import json, yaml, sys
+
+issue_id = "$ISSUE_ID"
+with open("/tmp/glitchtip-issue-$ISSUE_ID.json") as f:
+    issue = json.load(f)
+with open("/tmp/glitchtip-event-$ISSUE_ID.json") as f:
+    event = json.load(f)
+meta = event.get("metadata") or issue.get("metadata") or {}
+msg = (event.get("message") or meta.get("value") or issue.get("title") or "").lower()
+culprit = event.get("culprit") or ""
+
+with open("docs/team_workflows/glitchtip-triager/ignore-whitelist.yaml") as f:
+    cfg = yaml.safe_load(f)
+
+for rule in cfg.get("rules", []):
+    m = rule.get("match", {})
+    if m.get("issue_id") and str(m["issue_id"]) != issue_id:
+        continue
+    if m.get("culprit") and m["culprit"] != culprit:
+        continue
+    if m.get("metadata.type") and m["metadata.type"] != meta.get("type"):
+        continue
+    needles = [s.lower() for s in m.get("message_contains", [])]
+    if needles and not all(n in msg for n in needles):
+        continue
+    if not any([m.get("issue_id"), m.get("culprit"), m.get("metadata.type"), needles]):
+        continue
+    print(json.dumps({"matched": True, "rule_id": rule["id"], "reason": rule["reason"]}))
+    sys.exit(0)
+print(json.dumps({"matched": False}))
+PY
+```
+
+If `matched: true`, append to the processed ledger with `"classification": "ignored_normal"` and skip PR.
+
+### Step 3: Classify
+
+| Classification | When | Action |
+|----------------|------|--------|
+| `ignored_normal` | Matches whitelist | Skip (record only) |
+| `already_fixed` | Fix already on `main` | Record only; suggest resolving in GlitchTip |
+| `duplicate_pr_avoided` | Open PR or branch already exists | Record only |
+| `code_fixable` | Clear in-repo bug; fix ≤ guardrail | Draft PR (if Step 3b passes and PR budget remains) |
+| `operational` | Infra / upstream / data noise | No PR |
+| `unknown` | Ambiguous or too large | No PR |
+
+Document classification and one-line rationale before acting.
+
+### Step 3b: Duplicate PR check (mandatory before Step 4)
+
+Do **not** open a PR if **any** check below fails. Record `duplicate_pr_avoided` and explain in the run summary.
+
+```bash
+ISSUE_ID="<id>"
+
+python3 <<'PY'
+import json, subprocess, sys
+
+issue_id = "$ISSUE_ID"
+processed_path = "$PROCESSED"
+data = json.load(open(processed_path))
+for entry in data.get("issues", []):
+    if str(entry.get("issueId")) == issue_id and entry.get("prUrl"):
+        print("SKIP_DUP: processed ledger already has prUrl", entry["prUrl"])
+        sys.exit(0)
+
+prs = json.loads(subprocess.check_output([
+    "gh", "pr", "list", "--repo", "project-koku/koku", "--state", "open",
+    "--limit", "100", "--json", "number,title,body,headRefName",
+], text=True))
+needle_paths = [f"issues/{issue_id}", issue_id]
+for pr in prs:
+    title = pr.get("title") or ""
+    body = pr.get("body") or ""
+    head = pr.get("headRefName") or ""
+    if head.startswith(f"glitchtip/{issue_id}-"):
+        print("SKIP_DUP: open PR branch", pr["number"], head)
+        sys.exit(0)
+    if issue_id in title or any(n in body for n in needle_paths):
+        print("SKIP_DUP: open PR references issue", pr["number"], title)
+        sys.exit(0)
+
+remote = subprocess.run(
+    ["git", "ls-remote", "--heads", "origin", f"refs/heads/glitchtip/{issue_id}-*"],
+    capture_output=True, text=True,
+)
+if remote.stdout.strip():
+    print("SKIP_DUP: remote branch exists", remote.stdout.strip().split()[-1])
+    sys.exit(0)
+
+print("OK: no duplicate PR detected")
+PY
+```
+
+Also verify `PRS_OPENED < MAX_PRS` before Step 4. If the PR budget is exhausted, classify remaining `code_fixable` issues in the summary only — no PR.
+
+### Step 4: Fix and open draft PR (`code_fixable` only)
+
+1. Use repo checkout on branch `main`; `git fetch origin main`.
+2. Confirm the bug is **not** already fixed on `origin/main` (read cited file/function; check recent git history).
+3. Branch: `glitchtip/<issueId>-<short-slug>` (slug ≤ 40 chars).
+4. Implement the **minimal** fix.
+5. Run targeted tests/lint only if fast.
+6. Verify scope:
+
+```bash
+git diff --stat origin/main...HEAD
+```
+
+If more than 3 files or ~150 lines, do **not** open a PR. Record `PR skipped: diff too large`.
+
+7. Push and open a **draft** PR:
+
+```bash
+gh pr create --repo project-koku/koku --draft --base main \
+  --head "$(git branch --show-current)" \
+  --label "smoke-tests" \
+  --title "[GlitchTip] <shortId>: <one-line summary>" \
+  --body "## GlitchTip
+<permalink>
+
+## Classification
+code_fixable
+
+## Summary
+<what changed and why>
+
+_Generated by GlitchTip Triager (Ambient Code). Review before merge._"
+```
+
+8. Increment `PRS_OPENED` after a successful create.
+
+If `gh pr create` fails on the label, create the PR without it, then `gh pr edit <number> --add-label "smoke-tests"`.
+
+### Step 5: Record processed issue
+
+Append to the processed ledger:
+
+```json
+{
+  "issueId": "<id>",
+  "shortId": "<shortId>",
+  "prUrl": "<url or null>",
+  "classification": "code_fixable|already_fixed|duplicate_pr_avoided|operational|unknown|ignored_normal",
+  "whitelistRuleId": "<rule id or null>",
+  "fingerprint": "<metadata.type>|<filename>|<function>",
+  "processedAt": "<ISO8601 UTC>"
+}
+```
+
+Write the file atomically (write temp file, then `mv`).
+
+### Step 6: Run summary
+
+List: issues examined, classifications, PR URLs (if any), duplicate skips, and GlitchTip resolve recommendations when applicable.
+
+---
+
+## When in doubt
+
+Prefer **no PR** and explain what a human should investigate next.


### PR DESCRIPTION
## Summary
- Adds `docs/team_workflows/glitchtip-triager/` with team-owned prompt, ignore whitelist, and README for the Ambient Code GlitchTip agent.
- Documents repo-as-source-of-truth with a short AC bootstrap prompt that points at `prompt.md`.
- Adds duplicate-PR prevention (processed ledger, open PR search, remote branch check) and caps draft PRs per run (`GLITCHTIP_MAX_PRS_PER_RUN`, default 1).

## Test plan
- [ ] Review prompt guardrails and Step 3b duplicate checks
- [ ] Confirm AC session uses short bootstrap prompt from README after merge
- [ ] Run manual AC session against a known issue and verify no duplicate PR when one already exists


Made with [Cursor](https://cursor.com)