### PR TITLE
[COST-7511] add operator 4.4.1 build commits to operator_versions

### DIFF
--- a/koku/masu/util/ocp/operator_versions.py
+++ b/koku/masu/util/ocp/operator_versions.py
@@ -15,7 +15,7 @@ from packaging.version import Version
 
 OPERATOR_RELEASES = [
     # (version, downstream_commit, upstream_commit)
-    ("4.4.1", "215b322c744166119f94f2529a2e77582220ddae", "78eabeb962648926f98b4cc239a6f59541f001cd"),
+    ("4.4.1", "53d63c3aa6dc255ec8bc0cecf5d62c3a30066df3", "78eabeb962648926f98b4cc239a6f59541f001cd"),
     ("4.4.0", "74ab8043a31a07d831035d5233cce0e44f3fb082", "765fc5be236ca2ca2494b2e5ca57fbb93a94e943"),
     ("4.3.1", "ec11d7bddaa8ea3a980236b364780fed0cd2cb0f", "ec6bc48a434b78e21681233585fcb0f3b2dba223"),
     ("4.3.0", "078c8d706ff3bc4198d2364c6fad1e3f7074cbe8", "c78ce96835e6dd4430e9f75cc23e914af2b3706b"),

--- a/koku/masu/util/ocp/operator_versions.py
+++ b/koku/masu/util/ocp/operator_versions.py
@@ -15,6 +15,7 @@ from packaging.version import Version
 
 OPERATOR_RELEASES = [
     # (version, downstream_commit, upstream_commit)
+    ("4.4.1", "215b322c744166119f94f2529a2e77582220ddae", "78eabeb962648926f98b4cc239a6f59541f001cd"),
     ("4.4.0", "74ab8043a31a07d831035d5233cce0e44f3fb082", "765fc5be236ca2ca2494b2e5ca57fbb93a94e943"),
     ("4.3.1", "ec11d7bddaa8ea3a980236b364780fed0cd2cb0f", "ec6bc48a434b78e21681233585fcb0f3b2dba223"),
     ("4.3.0", "078c8d706ff3bc4198d2364c6fad1e3f7074cbe8", "c78ce96835e6dd4430e9f75cc23e914af2b3706b"),


### PR DESCRIPTION
## Jira Ticket

[COST-7511](https://redhat.atlassian.net/browse/COST-7511)

## Description

This change adds the downstream and upstream commit SHAs for operator version 4.4.1 to the \`operator_versions\` mapping.

The operator sends its git commit SHA as the \`version\` field in manifest payloads. This mapping allows koku to resolve those SHAs to human-readable version strings (e.g. \`costmanagement-metrics-operator:4.4.1\`).

| Field | SHA | Source |
|---|---|---|
| \`downstream_commit\` | \`215b322c744166119f94f2529a2e77582220ddae\` | [\`[COST-7376] downstream updates for v4.4.1\`](https://github.com/project-koku/koku-metrics-operator/commit/215b322c744166119f94f2529a2e77582220ddae) |
| \`upstream_commit\` | \`78eabeb962648926f98b4cc239a6f59541f001cd\` | [\`[COST-7376] add whats new in v4.4.1 to CSV description\`](https://github.com/project-koku/koku-metrics-operator/commit/78eabeb962648926f98b4cc239a6f59541f001cd) (tag \`v4.4.1\`) |

## Testing

1. Checkout branch
2. Run `python -c "from masu.util.ocp.operator_versions import OPERATOR_VERSIONS, LATEST_OPERATOR_VERSION; print(LATEST_OPERATOR_VERSION)"`
3. Should print \`4.4.1\`

## Release Notes
- [ ] No release note needed (data mapping update only)