### PR TITLE
Fix OcpTagQueryThrottle to enforce rate limit on inverted date ranges

### DIFF
--- a/koku/api/common/test_throttling.py
+++ b/koku/api/common/test_throttling.py
@@ -78,6 +78,21 @@ class OcpTagQueryThrottleGetCacheKeyTest(TestCase):
         self.assertIsNone(throttle.get_cache_key(request, None))
 
     @patch("api.common.throttling.is_feature_flag_enabled_by_schema", return_value=True)
+    def test_get_cache_key_inverted_dates_returns_key(self, mock_flag):
+        """Inverted dates (end_date < start_date) are treated as heavy; throttle must apply."""
+        throttle = OcpTagQueryThrottle()
+        request = Mock()
+        request.user.customer.schema_name = "org11748336"
+        request.query_params = {
+            "group_by[tag:bhf_pod_name]": "*",
+            "start_date": "2026-06-16",
+            "end_date": "2026-06-15",
+        }
+        key = throttle.get_cache_key(request, None)
+        self.assertIsNotNone(key, "Inverted date range must be treated as heavy and trigger throttle")
+        self.assertEqual(key, "tag_query_throttle:org11748336")
+
+    @patch("api.common.throttling.is_feature_flag_enabled_by_schema", return_value=True)
     def test_get_cache_key_success_returns_key(self, mock_flag):
         """When all conditions pass, return cache key."""
         throttle = OcpTagQueryThrottle()
@@ -111,6 +126,11 @@ class OcpTagQueryThrottleGetDateRangeDaysTest(TestCase):
         """Invalid date strings raise ValueError/TypeError; return 0."""
         params = {"start_date": "not-a-date", "end_date": "2024-12-31"}
         self.assertEqual(OcpTagQueryThrottle._get_date_range_days(params), 0)
+
+    def test_inverted_dates_returns_negative(self):
+        """When end_date is before start_date, return a negative number of days."""
+        params = {"start_date": "2026-06-16", "end_date": "2026-06-15"}
+        self.assertLess(OcpTagQueryThrottle._get_date_range_days(params), 0)
 
 
 class AwsTagQueryThrottleGetCacheKeyTest(TestCase):

--- a/koku/api/common/throttling.py
+++ b/koku/api/common/throttling.py
@@ -122,8 +122,10 @@ class OcpTagQueryThrottle(BaseTagQueryThrottle):
         return bool(keys)
 
     def _is_heavy_query(self, query_params):
-        """OCP: heavy when start_date/end_date range >= DAYS_RANGE_LIMIT."""
-        return self._get_date_range_days(query_params) >= self.DAYS_RANGE_LIMIT
+        """OCP: heavy when start_date/end_date range >= DAYS_RANGE_LIMIT or dates are inverted."""
+        days = self._get_date_range_days(query_params)
+        # Inverted dates (end_date < start_date) are malformed requests; treat as heavy.
+        return days < 0 or days >= self.DAYS_RANGE_LIMIT
 
     @staticmethod
     def _get_date_range_days(query_params):


### PR DESCRIPTION
## Description

This change fixes an edge case in `OcpTagQueryThrottle` where requests with inverted date ranges (`end_date < start_date`) bypassed the tag-query rate limit.

`_get_date_range_days()` returns a negative value when `end_date < start_date`. The previous check (`days >= DAYS_RANGE_LIMIT`) silently treated negative values as "light" queries, skipping the throttle entirely — even for schemas with the `cost-management.backend.rate-limit-tag-queries` Unleash flag enabled.

This was observed when BrightHouseFinancial sent a request to `/reports/openshift/volumes/` with `start_date=2026-06-16&end_date=2026-06-15`, `group_by[tag:bhf_pod_name]=*`, and `limit=0`, causing a gunicorn WORKER TIMEOUT (SIGKILL after ~78s).

The fix treats inverted dates (`days < 0`) as heavy queries, activating the throttle for flagged schemas.

## Testing

1. Checkout branch
2. Enable `cost-management.backend.rate-limit-tag-queries` Unleash flag for a test schema
3. Hit the endpoint with inverted dates:
    ```
    GET /api/cost-management/v1/reports/openshift/volumes/?start_date=2026-06-16&end_date=2026-06-15&group_by[tag:env]=*
    ```
    1. First request should return `200`
    2. Second request within 12h should return `429 Too Many Requests`

## Release Notes
- [ ] proposed release note

```markdown
* Fix OcpTagQueryThrottle to enforce rate limit on requests with inverted date ranges
```