### PR TITLE
Run lockfile maintenance weekly

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,10 @@
     ],
     "updateNotScheduled": false,
     "lockFileMaintenance": {
-        "enabled": true
+        "enabled": true,
+        "schedule": [
+            "on Tuesday after 3am and before 10am"
+        ]
     },
     "packageRules": [
         {


### PR DESCRIPTION
## Jira Ticket

None

## Description

This change updates Renovate lock file maintenance to run only once per week by setting a `lockFileMaintenance.schedule` override, aligned to the existing Tuesday maintenance window. It is intended to reduce lockfile PR churn from daily updates.


## Release Notes
- [ ] proposed release note

```markdown
* None (internal Renovate scheduling noise reduction)
```