### PR TITLE
[COST-7701] fix expired trino partition for month-partitioned managed tables

### DIFF
--- a/koku/koku/reportdb_accessor_trino.py
+++ b/koku/koku/reportdb_accessor_trino.py
@@ -13,6 +13,13 @@ from koku.reportdb_accessor import ReportDBAccessor
 
 LOG = logging.getLogger(__name__)
 
+MONTH_PARTITIONED_MANAGED_TABLES = {
+    "managed_aws_openshift_disk_capacities_temp",
+    "managed_azure_openshift_disk_capacities_temp",
+    "managed_gcp_openshift_disk_capacities_temp",
+    "managed_reporting_ocpgcpcostlineitem_project_daily_summary_temp",
+}
+
 
 class TrinoReportDBAccessor(ReportDBAccessor):
     """Trino implementation of report database accessor."""
@@ -145,19 +152,26 @@ WHERE {partition_column} = '{provider_uuid}'"""
 
     def get_expired_data_ocp_sql(self, schema_name: str, table_name: str, source_column: str, expired_date: str):
         """Generate Trino SQL to find expired partitions."""
+        if table_name in MONTH_PARTITIONED_MANAGED_TABLES:
+            day_select_sql = ""
+            partition_date_sql = "cast(date_parse(concat(year, '-', month, '-01'), '%Y-%m-%d') as date)"
+        else:
+            day_select_sql = "day as day,"
+            partition_date_sql = "cast(date_parse(concat(year, '-', month, '-', day), '%Y-%m-%d') as date)"
+
         return f"""
-SELECT partitions.year, partitions.month, partitions.source
-FROM (
-    SELECT year as year,
-        month as month,
-        day as day,
-        cast(date_parse(concat(year, '-', month, '-', day), '%Y-%m-%d') as date) as partition_date,
-        {source_column} as source
-    FROM  "{table_name}$partitions"
-) as partitions
-WHERE partitions.partition_date < DATE '{expired_date}'
-GROUP BY partitions.year, partitions.month, partitions.source
-"""
+            SELECT partitions.year, partitions.month, partitions.source
+            FROM (
+                SELECT year as year,
+                    month as month,
+                    {day_select_sql}
+                    {partition_date_sql} as partition_date,
+                    {source_column} as source
+                FROM  "{table_name}$partitions"
+            ) as partitions
+            WHERE partitions.partition_date < DATE '{expired_date}'
+            GROUP BY partitions.year, partitions.month, partitions.source
+        """
 
     def get_check_source_in_partitions_sql(self, schema_name: str, table_name: str, source_uuid: str):
         """Generate Trino SQL to check if source exists in table partitions."""

--- a/koku/koku/reportdb_accessor_trino.py
+++ b/koku/koku/reportdb_accessor_trino.py
@@ -13,13 +13,6 @@ from koku.reportdb_accessor import ReportDBAccessor
 
 LOG = logging.getLogger(__name__)
 
-MONTH_PARTITIONED_MANAGED_TABLES = {
-    "managed_aws_openshift_disk_capacities_temp",
-    "managed_azure_openshift_disk_capacities_temp",
-    "managed_gcp_openshift_disk_capacities_temp",
-    "managed_reporting_ocpgcpcostlineitem_project_daily_summary_temp",
-}
-
 
 class TrinoReportDBAccessor(ReportDBAccessor):
     """Trino implementation of report database accessor."""
@@ -151,21 +144,16 @@ AND day = '{day}'"""
 WHERE {partition_column} = '{provider_uuid}'"""
 
     def get_expired_data_ocp_sql(self, schema_name: str, table_name: str, source_column: str, expired_date: str):
-        """Generate Trino SQL to find expired partitions."""
-        if table_name in MONTH_PARTITIONED_MANAGED_TABLES:
-            day_select_sql = ""
-            partition_date_sql = "cast(date_parse(concat(year, '-', month, '-01'), '%Y-%m-%d') as date)"
-        else:
-            day_select_sql = "day as day,"
-            partition_date_sql = "cast(date_parse(concat(year, '-', month, '-', day), '%Y-%m-%d') as date)"
+        """Generate Trino SQL to find expired partitions at month granularity.
 
+        We anchor to day `01` so this query does not rely on a day partition column.
+        """
         return f"""
 SELECT partitions.year, partitions.month, partitions.source
 FROM (
     SELECT year as year,
         month as month,
-        {day_select_sql}
-        {partition_date_sql} as partition_date,
+        cast(date_parse(concat(year, '-', month, '-01'), '%Y-%m-%d') as date) as partition_date,
         {source_column} as source
     FROM  "{table_name}$partitions"
 ) as partitions

--- a/koku/koku/reportdb_accessor_trino.py
+++ b/koku/koku/reportdb_accessor_trino.py
@@ -160,18 +160,18 @@ WHERE {partition_column} = '{provider_uuid}'"""
             partition_date_sql = "cast(date_parse(concat(year, '-', month, '-', day), '%Y-%m-%d') as date)"
 
         return f"""
-            SELECT partitions.year, partitions.month, partitions.source
-            FROM (
-                SELECT year as year,
-                    month as month,
-                    {day_select_sql}
-                    {partition_date_sql} as partition_date,
-                    {source_column} as source
-                FROM  "{table_name}$partitions"
-            ) as partitions
-            WHERE partitions.partition_date < DATE '{expired_date}'
-            GROUP BY partitions.year, partitions.month, partitions.source
-        """
+SELECT partitions.year, partitions.month, partitions.source
+FROM (
+    SELECT year as year,
+        month as month,
+        {day_select_sql}
+        {partition_date_sql} as partition_date,
+        {source_column} as source
+    FROM  "{table_name}$partitions"
+) as partitions
+WHERE partitions.partition_date < DATE '{expired_date}'
+GROUP BY partitions.year, partitions.month, partitions.source
+"""
 
     def get_check_source_in_partitions_sql(self, schema_name: str, table_name: str, source_uuid: str):
         """Generate Trino SQL to check if source exists in table partitions."""

--- a/koku/koku/test/test_reportdb_accessor.py
+++ b/koku/koku/test/test_reportdb_accessor.py
@@ -8,6 +8,7 @@ from django.test.utils import override_settings
 
 from koku.reportdb_accessor import get_report_db_accessor
 from koku.reportdb_accessor_postgres import PostgresReportDBAccessor
+from koku.reportdb_accessor_trino import TrinoReportDBAccessor
 
 
 class TestGetReportDBAccessor(TestCase):
@@ -191,3 +192,34 @@ class TestPostgresReportDBAccessor(TestCase):
         )
         self.assertIn("DELETE FROM", sql)
         self.assertIn("ocp_source", sql)
+
+
+class TestTrinoReportDBAccessor(TestCase):
+    """Test TrinoReportDBAccessor methods."""
+
+    def setUp(self):
+        self.accessor = TrinoReportDBAccessor()
+        self.schema_name = "test_schema"
+        self.source_uuid = "12345678-1234-1234-1234-123456789012"
+
+    def test_get_expired_data_ocp_sql_for_day_partitioned_table(self):
+        """Test expired data SQL generation for day-partitioned tables."""
+        sql = self.accessor.get_expired_data_ocp_sql(
+            self.schema_name,
+            "managed_reporting_ocpawscostlineitem_project_daily_summary",
+            "ocp_source",
+            "2024-01-01",
+        )
+        self.assertIn("day as day", sql)
+        self.assertIn("concat(year, '-', month, '-', day)", sql)
+
+    def test_get_expired_data_ocp_sql_for_month_partitioned_table(self):
+        """Test expired data SQL generation for month-partitioned tables."""
+        sql = self.accessor.get_expired_data_ocp_sql(
+            self.schema_name,
+            "managed_gcp_openshift_disk_capacities_temp",
+            "ocp_source",
+            "2024-01-01",
+        )
+        self.assertNotIn("day as day", sql)
+        self.assertIn("concat(year, '-', month, '-01')", sql)

--- a/koku/koku/test/test_reportdb_accessor.py
+++ b/koku/koku/test/test_reportdb_accessor.py
@@ -210,8 +210,8 @@ class TestTrinoReportDBAccessor(TestCase):
             "ocp_source",
             "2024-01-01",
         )
-        self.assertIn("day as day", sql)
-        self.assertIn("concat(year, '-', month, '-', day)", sql)
+        self.assertNotIn("day as day", sql)
+        self.assertIn("concat(year, '-', month, '-01')", sql)
 
     def test_get_expired_data_ocp_sql_for_month_partitioned_table(self):
         """Test expired data SQL generation for month-partitioned tables."""

--- a/koku/reporting/models.py
+++ b/koku/reporting/models.py
@@ -157,7 +157,6 @@ OCP_ON_AZURE_PERSPECTIVES = (
 # Empty dict for on-prem to allow safe imports without errors
 if getattr(settings, "ONPREM", False):
     TRINO_MANAGED_TABLES = {}
-    EXPIRE_MANAGED_TABLES = {}
 else:
     TRINO_MANAGED_TABLES = {
         "reporting_ocpusagelineitem_daily_summary": "source",
@@ -173,9 +172,4 @@ else:
         "managed_azure_openshift_disk_capacities_temp": "ocp_source",
         "managed_reporting_ocpazurecostlineitem_project_daily_summary_temp": "ocp_source",
         "managed_reporting_ocpazurecostlineitem_project_daily_summary": "ocp_source",
-    }
-
-    # These are cleaned during expired_data flow
-    EXPIRE_MANAGED_TABLES = {
-        "reporting_ocpusagelineitem_daily_summary": "source",
     }


### PR DESCRIPTION
## Jira Ticket

[COST-7701](https://issues.redhat.com/browse/COST-7701)

## Description

This change updates expired Trino partition discovery SQL to support both day-partitioned and month-partitioned managed OCP tables, preventing `TrinoUserError: Column 'day' cannot be resolved` during cleanup.

## Testing

1. Checkout branch.

2. Start shell in tenant schema and run runtime validation against affected tables.
   ```bash
   TRINO_HOST=localhost TRINO_PORT=8080 make shell-schema schema=org1234567
   ```
   ```python
   from masu.database.ocp_report_db_accessor import OCPReportDBAccessor

   schema = "org1234567"
   tables = [
       ("managed_gcp_openshift_disk_capacities_temp", "ocp_source"),
       ("managed_aws_openshift_disk_capacities_temp", "ocp_source"),
       ("managed_azure_openshift_disk_capacities_temp", "ocp_source"),
       ("managed_reporting_ocpgcpcostlineitem_project_daily_summary_temp", "ocp_source"),
       ("reporting_ocpusagelineitem_daily_summary", "source"),
   ]

   with OCPReportDBAccessor(schema) as accessor:
       for table, source_col in tables:
           result = accessor.find_expired_trino_partitions(table, source_col, "2026-07-01")
           print(table, "OK", type(result).__name__, result[:2] if isinstance(result, list) else result)
   ```
   - You should see `OK` for all tables.
   - You should **not** see `Column 'day' cannot be resolved`.


## Release Notes
- [ ] proposed release note

```markdown
* Fix expired Trino partition cleanup for month-partitioned managed OCP tables.
```