### PR TITLE
Fix source_uuids return on cost model api

### DIFF
--- a/koku/cost_models/serializers.py
+++ b/koku/cost_models/serializers.py
@@ -707,12 +707,12 @@ class CostModelSerializer(BaseSerializer):
             source_type = SOURCE_TYPE_MAP[source_type]
         rep["source_type"] = source_type
 
-        rep["source_uuids"] = rep.get("provider_uuids", [])
         if rep.get("provider_uuids"):
             del rep["provider_uuids"]
         cm_uuid = cost_model_obj.uuid
-        source_uuids = CostModelManager(cm_uuid).get_provider_names_uuids()
-        rep.update({"sources": source_uuids})
+        sources = CostModelManager(cm_uuid).get_provider_names_uuids()
+        rep["source_uuids"] = [source["uuid"] for source in sources]
+        rep["sources"] = sources
 
         price_list_maps = cost_model_obj.price_list_maps.all()
         rep["price_lists"] = [

--- a/koku/cost_models/serializers.py
+++ b/koku/cost_models/serializers.py
@@ -707,10 +707,9 @@ class CostModelSerializer(BaseSerializer):
             source_type = SOURCE_TYPE_MAP[source_type]
         rep["source_type"] = source_type
 
-        if rep.get("provider_uuids"):
-            del rep["provider_uuids"]
-        cm_uuid = cost_model_obj.uuid
-        sources = CostModelManager(cm_uuid).get_provider_names_uuids()
+        manager = CostModelManager()
+        manager._model = cost_model_obj
+        sources = manager.get_provider_names_uuids()
         rep["source_uuids"] = [source["uuid"] for source in sources]
         rep["sources"] = sources
 


### PR DESCRIPTION
## Jira Ticket

[COST-####](https://issues.redhat.com/browse/COST-####)

## Description

`rep.get("provider_uuids", [])` is always `[]` because provider_uuids is not a model field — it only exists on the internal write-path representation. The real data is fetched via `get_provider_names_uuids()` but only placed into `sources`, never back into `source_uuids`.

The fix is to extract the UUIDs from the already-fetched list and assign them to rep["source_uuids"].



## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Release Notes
- [ ] proposed release note

```markdown
* [COST-####](https://issues.redhat.com/browse/COST-####) Fix some things
```
