### PR TITLE
[FLPATH-4307] Add on-prem build support with configurable image name label

### DIFF
--- a/.tekton/koku-onprem-push.yaml
+++ b/.tekton/koku-onprem-push.yaml
@@ -1,0 +1,51 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/project-koku/koku?rev={{ revision }}
+    build.appstudio.redhat.com/commit_sha: '{{ revision }}'
+    build.appstudio.redhat.com/target_branch: '{{ target_branch }}'
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
+    pipelinesascode.tekton.dev/pipeline: "https://raw.githubusercontent.com/project-koku/koku-ci/main/pipelines/pipeline-build.yaml"
+  creationTimestamp: null
+
+  labels:
+    appstudio.openshift.io/application: koku
+    appstudio.openshift.io/component: koku-onprem
+    pipelines.appstudio.openshift.io/type: build
+
+  namespace: cost-mgmt-dev-tenant
+  name: koku-onprem-on-push
+
+spec:
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-koku
+
+  params:
+    - name: git-url
+      value: '{{ source_url }}'
+
+    - name: revision
+      value: '{{ revision }}'
+
+    - name: output-image
+      value: quay.io/redhat-user-workloads/cost-mgmt-dev-tenant/koku-onprem:{{ revision }}
+
+    - name: dockerfile
+      value: Dockerfile
+
+    - name: path-context
+      value: .
+
+    - name: build-args
+      value:
+        - IMAGE_NAME=costmanagement/costmanagement-server-rhel9
+
+  pipelineRef:
+    name: pipeline-build
+
+  workspaces:
+    - name: git-auth
+      secret:
+        secretName: '{{ git_auth_secret }}'

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,17 +17,6 @@ ENV PYTHON_VERSION=3.11 \
 ENV SUMMARY="Koku is the Cost Management application" \
     DESCRIPTION="Koku is the Cost Management application"
 
-LABEL summary="$SUMMARY" \
-    description="$DESCRIPTION" \
-    io.k8s.description="$DESCRIPTION" \
-    io.k8s.display-name="Koku" \
-    io.openshift.expose-services="8000:http" \
-    io.openshift.tags="builder,python,python3.11,rh-python3.11" \
-    com.redhat.component="python3.11-docker" \
-    name="Koku" \
-    version="1" \
-    maintainer="Red Hat Cost Management Services <cost-mgmt@redhat.com>"
-
 # Very minimal set of packages
 # glibc-langpack-en is needed to set locale to en_US and disable warning about it
 # gcc to compile some python packages (e.g. ciso8601)
@@ -95,6 +84,18 @@ EXPOSE 8000
 # Set this at the end to leverage build caching
 ARG GIT_COMMIT=undefined
 ENV GIT_COMMIT=${GIT_COMMIT}
+
+ARG IMAGE_NAME=Koku
+LABEL summary="$SUMMARY" \
+    description="$DESCRIPTION" \
+    io.k8s.description="$DESCRIPTION" \
+    io.k8s.display-name="Koku" \
+    io.openshift.expose-services="8000:http" \
+    io.openshift.tags="builder,python,python3.11,rh-python3.11" \
+    com.redhat.component="python3.11-docker" \
+    name="$IMAGE_NAME" \
+    version="1" \
+    maintainer="Red Hat Cost Management Services <cost-mgmt@redhat.com>"
 
 # Set the default CMD.
 CMD ["./scripts/entrypoint.sh"]


### PR DESCRIPTION
## Summary
- Add `IMAGE_NAME` build arg to Dockerfile (defaults to `Koku` for SaaS backward compat)
- Add on-prem tekton pipelines (`koku-onprem-push.yaml`, `koku-onprem-pull_request.yaml`) that override `IMAGE_NAME` to `costmanagement/costmanagement-server-rhel9` for registry.redhat.io
- Existing SaaS builds are unaffected (no `BUILD_ARGS` passed, default applies)

## Context
The on-prem product release pipeline (`enforceContainerFirstSecurityLabels: true`) requires the container `name` label to match the registry destination path. This change makes the label configurable per build without affecting existing SaaS builds.

## Test plan
- [ ] Verify existing SaaS build still produces image with `name=Koku`
- [ ] Verify on-prem build produces image with `name=costmanagement/costmanagement-server-rhel9`