### PR TITLE
[COST-7252] Add StaticExchangeRate model and migration

### DIFF
--- a/koku/cost_models/migrations/0015_static_exchange_rate.py
+++ b/koku/cost_models/migrations/0015_static_exchange_rate.py
@@ -1,0 +1,54 @@
+#
+# Copyright 2026 Red Hat Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Add StaticExchangeRate model for admin-defined currency rates with monthly validity."""
+import uuid
+
+from django.db import migrations
+from django.db import models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("cost_models", "0014_enabled_currency"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="StaticExchangeRate",
+            fields=[
+                (
+                    "uuid",
+                    models.UUIDField(default=uuid.uuid4, primary_key=True, serialize=False),
+                ),
+                ("base_currency", models.CharField(max_length=5)),
+                ("target_currency", models.CharField(max_length=5)),
+                ("exchange_rate", models.DecimalField(decimal_places=15, max_digits=33)),
+                ("start_date", models.DateField()),
+                ("end_date", models.DateField()),
+                ("created_timestamp", models.DateTimeField(auto_now_add=True)),
+                ("updated_timestamp", models.DateTimeField(auto_now=True)),
+            ],
+            options={
+                "db_table": "static_exchange_rate",
+                "ordering": ["-start_date"],
+                "unique_together": {("base_currency", "target_currency", "start_date", "end_date")},
+            },
+        ),
+        migrations.AddConstraint(
+            model_name="staticexchangerate",
+            constraint=models.CheckConstraint(
+                check=models.Q(end_date__gte=models.F("start_date")),
+                name="static_rate_end_gte_start",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="staticexchangerate",
+            index=models.Index(
+                fields=["base_currency", "target_currency"],
+                name="static_rate_pair_idx",
+            ),
+        ),
+    ]

--- a/koku/cost_models/models.py
+++ b/koku/cost_models/models.py
@@ -208,3 +208,37 @@ class EnabledCurrency(models.Model):
 
     currency_code = models.CharField(max_length=5, unique=True)
     created_timestamp = models.DateTimeField(auto_now_add=True)
+
+
+class StaticExchangeRate(models.Model):
+    """User-defined exchange rates with validity periods."""
+
+    class Meta:
+        db_table = "static_exchange_rate"
+        ordering = ["-start_date"]
+        unique_together = [("base_currency", "target_currency", "start_date", "end_date")]
+        constraints = [
+            models.CheckConstraint(
+                check=models.Q(end_date__gte=models.F("start_date")),
+                name="static_rate_end_gte_start",
+            ),
+        ]
+        indexes = [
+            models.Index(
+                fields=["base_currency", "target_currency"],
+                name="static_rate_pair_idx",
+            ),
+        ]
+
+    uuid = models.UUIDField(primary_key=True, default=uuid4)
+    base_currency = models.CharField(max_length=5)
+    target_currency = models.CharField(max_length=5)
+    exchange_rate = models.DecimalField(max_digits=33, decimal_places=15)
+    start_date = models.DateField()
+    end_date = models.DateField()
+    created_timestamp = models.DateTimeField(auto_now_add=True)
+    updated_timestamp = models.DateTimeField(auto_now=True)
+
+    @property
+    def name(self):
+        return f"{self.base_currency}-{self.target_currency}"


### PR DESCRIPTION
## Summary

**PR 2** of the currency refactor series, split from #6005.

- Add `StaticExchangeRate` model to `cost_models` app (tenant-scoped) for admin-defined exchange rates with monthly validity periods
- Add migration `0015_static_exchange_rate`
- Model fields: `uuid`, `base_currency`, `target_currency`, `exchange_rate`, `start_date`, `end_date`, timestamps
- Computed `name` property returns `"{base}-{target}"` (e.g. `"USD-EUR"`)
- DB constraints: `unique_together` on `(base_currency, target_currency, start_date, end_date)`, check constraint ensuring `end_date >= start_date`
- Index on `(base_currency, target_currency)` for pair lookups
- No impact on rate calculations — dynamic rates are still used everywhere

## Test plan

- [ ] Migration applies cleanly on fresh DB
- [ ] Migration applies on top of 0014 (EnabledCurrency)
- [ ] Model can create/query/delete StaticExchangeRate rows in tenant schema
- [ ] `unique_together` constraint prevents duplicate (base, target, start, end) tuples
- [ ] Check constraint rejects `end_date < start_date`
- [ ] `name` property returns correct `"{base}-{target}"` format


Made with [Cursor](https://cursor.com)