### PR TITLE
[COST-7785] Fix Django cache CONNECTION_POOL_KWARGS key name

### DIFF
--- a/koku/koku/settings.py
+++ b/koku/koku/settings.py
@@ -296,7 +296,7 @@ else:
                 "CLIENT_CLASS": "django_redis.client.DefaultClient",
                 "IGNORE_EXCEPTIONS": True,
                 "MAX_ENTRIES": 1_000,
-                "CONNECTION_POOL_CLASS_KWARGS": REDIS_CONNECTION_POOL_KWARGS,
+                "CONNECTION_POOL_KWARGS": REDIS_CONNECTION_POOL_KWARGS,
             },
         },
         CacheEnum.api: {
@@ -310,7 +310,7 @@ else:
                 "CLIENT_CLASS": "django_redis.client.DefaultClient",
                 "IGNORE_EXCEPTIONS": True,
                 "MAX_ENTRIES": 1_000,
-                "CONNECTION_POOL_CLASS_KWARGS": REDIS_CONNECTION_POOL_KWARGS,
+                "CONNECTION_POOL_KWARGS": REDIS_CONNECTION_POOL_KWARGS,
             },
         },
         CacheEnum.rbac: {
@@ -322,7 +322,7 @@ else:
                 "CLIENT_CLASS": "django_redis.client.DefaultClient",
                 "IGNORE_EXCEPTIONS": True,
                 "MAX_ENTRIES": 1_000,
-                "CONNECTION_POOL_CLASS_KWARGS": REDIS_CONNECTION_POOL_KWARGS,
+                "CONNECTION_POOL_KWARGS": REDIS_CONNECTION_POOL_KWARGS,
             },
         },
         CacheEnum.worker: {


### PR DESCRIPTION
## Summary

- Renames `CONNECTION_POOL_CLASS_KWARGS` → `CONNECTION_POOL_KWARGS` in all three Redis-backed Django cache backends (default, api, rbac)
- `django-redis` reads `CONNECTION_POOL_KWARGS` — the extra `CLASS_` prefix caused SSL params (`ssl_cert_reqs`, `ssl_ca_certs`) to be silently ignored, breaking Django cache over TLS
- `IGNORE_EXCEPTIONS: True` swallowed the TLS handshake errors, so cache silently stopped working (all gets return `None`, all sets are no-ops)

Found during QE verification of COST-7745 on cost-verify.qe.lab.redhat.com (OCP 4.21 compact, external Redis + TLS + self-signed CA cert + password auth).

## Test plan

- [x] Verified on cluster: patched running pod with the rename — all three cache backends work correctly over TLS
- [x] Complex object round-trips (`cache.set` / `cache.get`) and deletes verified
- [x] Pre-commit hooks pass

Made with [Cursor](https://cursor.com)