### PR TITLE
[COST-7252] Add MonthlyExchangeRate model + migration

### DIFF
--- a/koku/cost_models/migrations/0016_monthly_exchange_rate.py
+++ b/koku/cost_models/migrations/0016_monthly_exchange_rate.py
@@ -31,7 +31,7 @@ class Migration(migrations.Migration):
             ],
             options={
                 "db_table": "monthly_exchange_rate",
-                "unique_together": {("effective_date", "base_currency", "target_currency")},
+                "unique_together": {("base_currency", "target_currency", "effective_date")},
             },
         ),
     ]

--- a/koku/cost_models/migrations/0016_monthly_exchange_rate.py
+++ b/koku/cost_models/migrations/0016_monthly_exchange_rate.py
@@ -1,0 +1,37 @@
+#
+# Copyright 2026 Red Hat Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Add MonthlyExchangeRate model — single source of truth for per-month exchange rates."""
+from django.db import migrations
+from django.db import models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("cost_models", "0015_static_exchange_rate"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="MonthlyExchangeRate",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID"),
+                ),
+                ("effective_date", models.DateField()),
+                ("base_currency", models.CharField(max_length=5)),
+                ("target_currency", models.CharField(max_length=5)),
+                ("exchange_rate", models.DecimalField(decimal_places=15, max_digits=33)),
+                ("rate_type", models.CharField(choices=[("static", "Static"), ("dynamic", "Dynamic")], max_length=10)),
+                ("created_timestamp", models.DateTimeField(auto_now_add=True)),
+                ("updated_timestamp", models.DateTimeField(auto_now=True)),
+            ],
+            options={
+                "db_table": "monthly_exchange_rate",
+                "unique_together": {("effective_date", "base_currency", "target_currency")},
+            },
+        ),
+    ]

--- a/koku/cost_models/models.py
+++ b/koku/cost_models/models.py
@@ -210,6 +210,11 @@ class EnabledCurrency(models.Model):
     created_timestamp = models.DateTimeField(auto_now_add=True)
 
 
+class RateType(models.TextChoices):
+    STATIC = "static", "Static"
+    DYNAMIC = "dynamic", "Dynamic"
+
+
 class StaticExchangeRate(models.Model):
     """User-defined exchange rates with validity periods."""
 
@@ -242,3 +247,23 @@ class StaticExchangeRate(models.Model):
     @property
     def name(self):
         return f"{self.base_currency}-{self.target_currency}"
+
+
+class MonthlyExchangeRate(models.Model):
+    """Single source of truth for exchange rates used in reports.
+
+    Stores both static and dynamic rates as per-pair rows, one row per month.
+    The query handler reads from this table for all months.
+    """
+
+    class Meta:
+        db_table = "monthly_exchange_rate"
+        unique_together = ("effective_date", "base_currency", "target_currency")
+
+    effective_date = models.DateField()
+    base_currency = models.CharField(max_length=5)
+    target_currency = models.CharField(max_length=5)
+    exchange_rate = models.DecimalField(max_digits=33, decimal_places=15)
+    rate_type = models.CharField(max_length=10, choices=RateType.choices)
+    created_timestamp = models.DateTimeField(auto_now_add=True)
+    updated_timestamp = models.DateTimeField(auto_now=True)

--- a/koku/cost_models/models.py
+++ b/koku/cost_models/models.py
@@ -258,7 +258,7 @@ class MonthlyExchangeRate(models.Model):
 
     class Meta:
         db_table = "monthly_exchange_rate"
-        unique_together = ("effective_date", "base_currency", "target_currency")
+        unique_together = ("base_currency", "target_currency", "effective_date")
 
     effective_date = models.DateField()
     base_currency = models.CharField(max_length=5)


### PR DESCRIPTION
## Summary

- Adds the `MonthlyExchangeRate` tenant-scoped model as the single source of truth for per-month exchange rates used in report queries
- Adds the `RateType` TextChoices enum (`static` / `dynamic`) shared by exchange rate models
- Migration `cost_models/0016_monthly_exchange_rate` creates the `monthly_exchange_rate` table with a unique constraint on `(effective_date, base_currency, target_currency)`

This is PR 3 in the constant-currency series. The model is consumed by the Celery population task and query handler wiring in subsequent PRs. Reports still consume rates the old way.

## Test plan

- [ ] Migration applies cleanly via `migrate_schemas`
- [ ] `MonthlyExchangeRate` rows can be created with `update_or_create` keyed on `(effective_date, base_currency, target_currency)`
- [ ] Unique constraint prevents duplicate month+pair rows
- [ ] `RateType.choices` resolves correctly in `rate_type` field validation


Made with [Cursor](https://cursor.com)