### PR TITLE
Add CLAUDE.md development guidelines and .claude/ rules infrastructure

### DIFF
--- a/.claude/commands/koku-database.md
+++ b/.claude/commands/koku-database.md
@@ -1,0 +1,100 @@
+---
+description: "Run read-only SQL queries against prod/stage koku databases via gabi-cli"
+---
+
+Investigate the koku database. The argument is: $ARGUMENTS
+
+The input can be:
+- A SQL query to run
+- A table or schema to explore
+- A provider UUID, org_id, or customer to look up
+- A question like "how many rows in rates_to_usage for org X?"
+
+## Tool: gabi-cli
+
+Use [gabi-cli](https://github.com/vkrizan/gabi-cli) for all database queries.
+Install: `go install github.com/vkrizan/gabi-cli@latest`
+
+`oc` must be logged in to the target cluster. Verify:
+
+```bash
+oc whoami 2>&1 && oc project 2>&1
+```
+
+If not logged in, tell the user to run `! oc login` with a token from the
+OpenShift console (username → **Copy login command**).
+
+| Env | Namespace | Console |
+|-----|-----------|---------|
+| **Prod** | `hccm-prod` | `https://console-openshift-console.apps.crcp01ue1.o9m8.p1.openshiftapps.com` |
+| **Stage** | `hccm-stage` | `https://console-openshift-console.apps.crcs02ue1.urby.p1.openshiftapps.com` |
+
+## Running queries
+
+```bash
+gabi-cli -n hccm-prod "SELECT current_timestamp;"   # one-shot
+gabi-cli -n hccm-stage                               # interactive
+```
+
+Flags: `-q` (quiet), `-display table|expanded|auto`, `-fancy`.
+**Queries must end with `;`** or they will not execute.
+
+For multi-line queries:
+
+```bash
+QUERY=$(cat <<'EOF'
+SELECT p.uuid, p.name, p.type, c.org_id
+FROM public.api_provider p
+JOIN public.api_customer c ON p.customer_id = c.id
+WHERE p.uuid = 'YOUR-UUID';
+EOF
+)
+gabi-cli -n hccm-prod -q "$QUERY"
+```
+
+## Schema structure
+
+Koku uses django-tenants with PostgreSQL schemas:
+
+- **`public`** — shared: `api_customer`, `api_provider`, `api_sources`
+- **`orgNNNNNNN`** — per-tenant: `reporting_*`, `rates_to_usage`, `cost_model`, `cost_model_rate`
+
+To query a tenant table: `SELECT * FROM orgNNNNNNN.rates_to_usage;`
+
+### Finding the schema for a customer
+
+```sql
+SELECT schema_name FROM public.api_customer WHERE org_id = 'YOUR_ORG_ID';
+
+SELECT c.schema_name, c.org_id FROM public.api_provider p
+JOIN public.api_customer c ON p.customer_id = c.id
+WHERE p.uuid = 'YOUR-UUID';
+```
+
+## Common queries
+
+```sql
+-- Providers for an org
+SELECT p.uuid, p.name, p.type, p.setup_complete, p.active
+FROM public.api_provider p
+JOIN public.api_customer c ON p.customer_id = c.id
+WHERE c.org_id = 'YOUR_ORG_ID';
+
+-- Cost models for a tenant
+SELECT uuid, name, source_type, updated_timestamp
+FROM orgNNNNNNN.cost_model;
+
+-- rates_to_usage row count
+SELECT count(*) FROM orgNNNNNNN.rates_to_usage;
+
+-- Recent manifests for a provider
+SELECT id, billing_period_start_datetime, completed_datetime, num_total_files
+FROM public.reporting_common_costusagereportmanifest
+WHERE provider_id = 'YOUR-UUID'
+ORDER BY id DESC LIMIT 10;
+```
+
+## Safety
+
+- Queries run through GABI, which is deployed with a **read-only** PostgreSQL role — cannot modify data
+- Queries timeout after ~60s

--- a/.claude/commands/koku-sql-check.md
+++ b/.claude/commands/koku-sql-check.md
@@ -1,0 +1,51 @@
+---
+description: "Check if trino_sql and self_hosted_sql templates are in sync"
+---
+
+# Koku SQL Check — Template Sync Verification
+
+Find all SQL templates that exist in both `trino_sql/` and `self_hosted_sql/`
+and check whether they've diverged. The dialects differ (Trino vs PostgreSQL),
+so compare intent, not literal content.
+
+## Steps
+
+### 1. Discover shared templates
+
+```bash
+# Find files that exist in both directories
+comm -12 \
+  <(cd koku/masu/database/trino_sql && find . -name '*.sql' | sort) \
+  <(cd koku/masu/database/self_hosted_sql && find . -name '*.sql' | sort)
+```
+
+### 2. Check for recent drift
+
+For each shared template, compare when it was last modified in each directory:
+
+```bash
+for f in $(comm -12 \
+  <(cd koku/masu/database/trino_sql && find . -name '*.sql' | sort) \
+  <(cd koku/masu/database/self_hosted_sql && find . -name '*.sql' | sort)); do
+  trino_date=$(git log -1 --format='%ai' -- "koku/masu/database/trino_sql/$f" 2>/dev/null)
+  onprem_date=$(git log -1 --format='%ai' -- "koku/masu/database/self_hosted_sql/$f" 2>/dev/null)
+  if [ "$trino_date" != "$onprem_date" ]; then
+    echo "DIVERGED: $f"
+    echo "  trino_sql:        $trino_date"
+    echo "  self_hosted_sql:   $onprem_date"
+  fi
+done
+```
+
+### 3. Present results
+
+Output a table:
+
+```
+| Template | trino_sql | self_hosted_sql | Status |
+|----------|-----------|-----------------|--------|
+```
+
+Status: `in sync` / `diverged (N days)` / `missing`
+
+For any diverged templates, read both versions and summarize what differs.

--- a/.claude/rules/cost-pipeline.md
+++ b/.claude/rules/cost-pipeline.md
@@ -1,0 +1,94 @@
+---
+globs:
+  - koku/masu/processor/**
+  - koku/cost_models/**
+  - koku/masu/database/sql/openshift/cost_model/**
+  - koku/masu/database/trino_sql/openshift/cost_model/**
+  - koku/masu/database/self_hosted_sql/openshift/cost_model/**
+---
+
+# Cost model pipeline — critical path reference
+
+This is the most dangerous code path in koku. Changes here affect cost
+calculations for all tenants. Always gate behind an Unleash flag.
+
+## Full call chain
+
+```
+HTTP POST/PUT /api/cost-management/v1/cost-models/
+  → CostModelViewSet (cost_models/view.py)
+    → CostModelSerializer (cost_models/serializers.py)
+      → CostModelManager (cost_models/cost_model_manager.py)
+        → CostModel.objects.create() / save()
+        → update_provider_uuids()
+          → update_cost_model_costs.apply_async()  ← Celery task per provider
+        → sync_rate_table() (cost_models/rate_sync.py)
+
+# Async path (Celery worker, triggered by apply_async above):
+update_cost_model_costs task
+  → CostModelCostUpdater (masu/processor/cost_model_cost_updater.py)
+    → routes to provider-specific updater
+```
+
+### OCP path (full rate + markup + distribution)
+
+```
+OCPCostModelCostUpdater.update_summary_cost_model_costs()
+  for each month:
+    → _load_rates()
+    → if RTU enabled:
+        if cost_model + effective price list:
+          → _update_usage_rates_to_usage()       sql/openshift/cost_model/usage_rates/
+        else:
+          → _cleanup_stale_rtu_costs()
+      else (legacy):
+        → _update_usage_costs()
+    → _update_monthly_cost()                     sql/openshift/cost_model/monthly_cost_*
+    → if tag rates exist:
+        → _delete_tag_usage_costs()
+        → _update_tag_usage_costs()              sql/openshift/cost_model/*_tag_rates.sql
+        → _update_tag_usage_default_costs()
+        → _update_monthly_tag_based_cost()
+        → _update_node_hour_tag_based_cost()
+        → populate_tag_based_costs()             (via OCPReportDBAccessor)
+      else:
+        → _delete_tag_usage_costs()              (cleanup only)
+    → _update_vm_usage_costs()                   trino_sql|self_hosted_sql/openshift/cost_model/hourly_*
+    → if RTU enabled:
+        → _aggregate_rates_to_daily_summary()    sql/openshift/cost_model/usage_rates/aggregate_*
+    → _update_markup_cost()
+  → distribute_costs_and_update_ui_summary()
+    → populate_distributed_cost_sql()            sql/openshift/cost_model/distribute_cost/
+    → populate_ui_summary_tables()
+```
+
+### AWS/Azure/GCP path (markup only)
+
+```
+{Provider}CostModelCostUpdater._update_markup_cost()
+  → {Provider}ReportDBAccessor.populate_markup_cost()
+  → populate_ui_summary_tables()
+```
+
+## Key files (modify any → test the whole chain)
+
+| Step | File(s) |
+|------|---------|
+| API/Serializer | `cost_models/view.py`, `cost_models/serializers.py` |
+| Manager | `cost_models/cost_model_manager.py` |
+| Rate sync | `cost_models/rate_sync.py` |
+| Models | `cost_models/models.py`, `reporting/provider/ocp/models.py` |
+| Celery task | `masu/processor/tasks.py` |
+| Router | `masu/processor/cost_model_cost_updater.py` |
+| OCP updater | `masu/processor/ocp/ocp_cost_model_cost_updater.py` |
+| DB accessors | `masu/database/ocp_report_db_accessor.py` |
+| SQL (PG) | `masu/database/sql/openshift/cost_model/` (20+ templates) |
+| SQL (Trino) | `masu/database/trino_sql/openshift/cost_model/` |
+| SQL (on-prem) | `masu/database/self_hosted_sql/openshift/cost_model/` |
+
+## Summary tables affected
+
+- `reporting_ocpusagelineitem_daily_summary` (main line item table)
+- `rates_to_usage` (per-rate cost rows, partitioned)
+- 12+ OCP UI summary tables (`reporting_ocp_cost_summary_p`, `_by_node_p`, etc.)
+- AWS/Azure/GCP: markup columns on their respective daily summary tables

--- a/.claude/rules/migrations.md
+++ b/.claude/rules/migrations.md
@@ -1,0 +1,39 @@
+---
+globs:
+  - koku/reporting/migrations/**
+  - koku/cost_models/migrations/**
+---
+
+# Migrations — detailed rules
+
+## Multi-release strategy (required for zero-downtime deploys)
+
+All migrations must be additive — running them must not break the
+currently-deployed code.
+
+| Operation | Release N | Release N+1 | Release N+2 |
+|-----------|-----------|-------------|-------------|
+| **Add column** | Migration: add column (**MUST be nullable**) | Code uses the column; migration to backfill if needed | — |
+| **Drop column** | Code stops using column (incl. model changes) | Migration to drop column | — |
+| **Change type** | Migration: add new column with temp name | Code uses new column; migration to swap/backfill | Migration: drop old column |
+| **Add table** | Migration: create table | Code uses table | — |
+| **Drop table** | Code stops using table | Migration: drop table | — |
+
+## Key rules
+
+- New columns **MUST** be nullable or have a constant default
+  (e.g., `BooleanField(default=True)` — PG 11+ stores it in metadata,
+  no table rewrite).  Volatile defaults (`uuid_generate_v4()`) still
+  require nullable.
+- If a new column needs a default from code, the code change must deploy
+  **before** the migration runs.
+- Django `makemigrations` output almost always needs manual editing —
+  it won't generate safe multi-release migrations on its own.
+- Migrations should detect if changes have already been applied and
+  handle that case gracefully.
+- Prefer **one migration per PR** for easier rollback.
+- Migrations adding indexes to large or partitioned tables should use
+  `CREATE INDEX CONCURRENTLY` via `RunSQL` with `atomic = False`.
+- New `reporting` migrations continue from the current highest number.
+  Declare `cost_models` migration dependencies if touching cost_models FKs.
+- Keep migration PRs separate from feature code PRs when possible.

--- a/.claude/rules/partitioned-tables.md
+++ b/.claude/rules/partitioned-tables.md
@@ -1,0 +1,60 @@
+---
+globs:
+  - koku/reporting/provider/*/models.py
+  - koku/koku/database.py
+  - koku/reporting/migrations/**
+---
+
+# Partitioned tables — detailed reference
+
+There are 95 partitioned models in `koku/reporting/provider/`, all using
+`PartitionInfo` with RANGE partitioning on `usage_start`. Every FK from
+these tables points at a non-partitioned model — which is the dangerous
+pattern for Django's Collector.
+
+## SET_NULL FKs (highest risk — COST-7736 pattern)
+
+| Model | FK Field | Target |
+|-------|----------|--------|
+| RatesToUsage | `rate` | cost_models.Rate |
+| RatesToUsage | `cost_model` | cost_models.CostModel |
+| AWSCostEntryLineItemDailySummary | `organizational_unit` | AWSOrganizationalUnit |
+| 7 AWS UI summary models | `account_alias` | AWSAccountAlias |
+| 7 AWS UI summary models | `organizational_unit` | AWSOrganizationalUnit |
+| OCPAWSCostLineItemDailySummaryP | `account_alias` | AWSAccountAlias |
+| OCPAWSCostLineItemProjectDailySummaryP | `account_alias` | AWSAccountAlias |
+| OCPAllCostLineItemDailySummaryP | `account_alias` | AWSAccountAlias |
+| OCPAllCostLineItemProjectDailySummaryP | `account_alias` | AWSAccountAlias |
+
+## Why Django's on_delete doesn't work reliably here
+
+Django creates FK constraints as `NO ACTION DEFERRABLE INITIALLY DEFERRED`.
+Django handles SET_NULL/CASCADE in Python via the Collector — issuing
+UPDATE/DELETE SQL before the main DELETE. But:
+
+1. The DB has no `ON DELETE SET NULL` — just `NO ACTION`
+2. The deferred check fires at COMMIT, not per-statement
+3. PostgreSQL has documented bugs with FK triggers on partitioned tables
+   (BUG #16908 — ATTACH/DETACH catalog corruption, fixed PG 16.5)
+4. The custom partition manager (`trfn_partition_manager`) can leave FK
+   triggers in a corrupted state after partition creation
+
+## cascade_delete() — the safe alternative
+
+`koku/koku/database.py` provides `cascade_delete()` which:
+1. Walks Django model relations manually
+2. Calls `SET CONSTRAINTS ALL IMMEDIATE` before each operation
+3. Issues SET_NULL UPDATEs via raw SQL
+4. Deletes in the correct order
+
+Use this instead of `Model.objects.filter(...).delete()` when the model
+has FK references from partitioned tables.
+
+## Performance characteristics (rates_to_usage)
+
+The table is heavily skewed — most tenants have zero rows, but a small
+number of large tenants have millions.  An unindexed UPDATE/DELETE on
+`rate_id` sequential-scans all partitions.  For large tenants this can
+take tens of seconds, blocking the API request under `@transaction.atomic`.
+
+Always add an index on FK columns in partitioned tables.

--- a/.claude/rules/sql-templates.md
+++ b/.claude/rules/sql-templates.md
@@ -1,0 +1,28 @@
+---
+globs:
+  - koku/masu/database/trino_sql/**
+  - koku/masu/database/self_hosted_sql/**
+---
+
+# SQL template sync — trino_sql ↔ self_hosted_sql
+
+Any template that exists in BOTH `trino_sql/` and `self_hosted_sql/` must
+stay in sync. The SQL dialects differ (Trino vs PostgreSQL) — port changes,
+don't copy.
+
+To find the shared templates:
+
+```bash
+comm -12 \
+  <(cd koku/masu/database/trino_sql && find . -name '*.sql' | sort) \
+  <(cd koku/masu/database/self_hosted_sql && find . -name '*.sql' | sort)
+```
+
+Files only in `trino_sql/` are cloud-provider-specific (aws/, azure/, gcp/)
+and OCP-cloud matched-tags. On-prem does not process cloud billing data.
+
+## Third directory: masu/database/sql/
+
+PostgreSQL templates used by DB accessors on both SaaS and on-prem.
+NOT a mirror of trino_sql — but when changing cost model behavior, check
+all three directories for related templates.

--- a/.claude/rules/trino-migrations.md
+++ b/.claude/rules/trino-migrations.md
@@ -1,0 +1,27 @@
+---
+globs:
+  - koku/masu/management/commands/migrate_trino_tables.py
+  - deploy/clowdapp.yaml
+---
+
+# Trino migrations
+
+Trino tables come in two types — handle them differently:
+
+| Type | Data location | Safe to drop? | Identified by |
+|------|--------------|---------------|---------------|
+| **External** | S3/Minio (`external_location` in DDL) | Yes — only metadata lost, data stays in S3 | `SHOW CREATE TABLE` shows `external_location` |
+| **Managed** | Owned by AWS Glue | **NO — dropping = data loss** | No `external_location` in DDL |
+
+## Rules
+
+- Managed table changes must be column add/drop only.  Never drop a
+  managed table.
+- Use the `migrate_trino_tables` management command for all Trino schema
+  changes.  It has built-in safeguards.
+- New tables must be registered in `EXTERNAL_TABLES` or `MANAGED_TABLES`
+  in `koku/masu/management/commands/migrate_trino_tables.py`.
+- Test locally with: `DJANGO_READ_DOT_ENV_FILE=True TRINO_HOST=localhost koku/manage.py migrate_trino_tables --help`
+- In prod/stage, Trino migrations run via a ClowdJobInvocation
+  (`MGMT_IMAGE_TAG`, `MGMT_INVOCATION`, `MGMT_COMMAND` in
+  app-interface deploy-clowder.yml).

--- a/.gitignore
+++ b/.gitignore
@@ -156,4 +156,7 @@ dev/containers/unleash/cache/
 .cursor/*
 !.cursor/rules/
 !.cursor/commands/
-.claude/
+# Claude Code — share commands/rules, keep everything else local
+.claude/*
+!.claude/commands/
+!.claude/rules/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,117 @@
 # Koku development notes
 
-## SQL templates — always update both SaaS and on-prem
+## Quick reference
 
-Cost model SQL templates exist in two parallel locations:
+**Key commands:**
+```
+make docker-up-min          # start dev stack (PG, Redis, Minio, Trino, workers)
+make serve                  # Django dev server (:8000)
+make run-migrations         # apply pending migrations
+make lint                   # pre-commit checks
+pipenv run tox              # run test suite
+make docker-reinitdb        # nuke + rebuild DB from scratch
+```
 
-- `koku/masu/database/trino_sql/` — SaaS path, runs on Trino against Hive/S3 Parquet data
-- `koku/masu/database/self_hosted_sql/` — on-prem path, runs directly on PostgreSQL
+**Project structure:**
+```
+koku/api/                   # REST API views, serializers, URL routing
+koku/cost_models/           # cost model CRUD, rate sync, price lists
+koku/koku/                  # Django project config (settings, database, feature flags)
+koku/masu/                  # data pipeline: processors, Celery tasks, SQL templates
+koku/masu/database/sql/     # PostgreSQL SQL templates (SaaS + on-prem)
+koku/masu/database/trino_sql/       # SaaS-only Trino SQL templates
+koku/masu/database/self_hosted_sql/ # on-prem-only PostgreSQL SQL templates
+koku/reporting/             # Django models, migrations (reporting app)
+deploy/                     # ClowdApp, kustomize, deployment configs
+docs/specs/openapi.json     # OpenAPI spec (main API)
+```
 
-Any bug fix or behaviour change to a SQL template under one path must be mirrored in the equivalent template under the other path. The two directories have the same subdirectory structure, so the counterpart file is always at the same relative path.
+**Dev stack:** PostgreSQL :15432, Valkey :6379, S4 (S3-compat) :7480, Trino :8080
+
+## PR workflow and releases
+
+1. Open PRs as **DRAFT**.  Mark **Ready for Review** when done.
+2. Add the `smoke-test` label to kick off IQE smoke tests.
+3. Smoke tests **must pass** before merging (unless the PR only touches
+   non-build files like docs).
+4. Merges to `main` **auto-deploy to stage**.
+5. Production releases are manual — Mon/Thu cadence via app-interface MRs.
+   Use `make get-release-commit` to get the right commit hash (the commit
+   before midnight UTC, so IQE has tested it).
+6. Run `pre-commit run --all-files` before pushing.  Also run gitleaks
+   with Red Hat patterns: `pre-commit run --config ~/.config/pre-commit/config.yaml`.
+
+## Feature flags (Unleash) — gate risky changes
+
+New features, SQL pipeline changes, and any code path change that could
+negatively affect production **must** be gated behind an Unleash feature flag
+with a default of **OFF** (`dev_fallback=True` for dev/test).
+
+**What must be flagged:**
+- New or changed SQL INSERT/UPDATE/DELETE templates in the pipeline
+- New pipeline steps or changes to the cost model update flow
+- New tables, FK relationships, or changes to FK on_delete behavior
+- Changes to data written to reporting/summary tables
+
+API-only additions that are purely additive (new endpoints, new optional
+fields) may skip flagging if they don't affect data processing.
+
+**Pattern:**
+
+```python
+# 1. Define in koku/masu/processor/__init__.py
+MY_FEATURE_UNLEASH_FLAG = "cost-management.backend.my_feature_name"
+
+# 2. Gate the code path
+from masu.processor import is_feature_flag_enabled_by_schema, MY_FEATURE_UNLEASH_FLAG
+
+if is_feature_flag_enabled_by_schema(schema, MY_FEATURE_UNLEASH_FLAG, dev_fallback=True):
+    # new path
+else:
+    # legacy path — must remain functional
+```
+
+The legacy path must remain functional and tested.  Do not delete legacy SQL
+files or code until the flag has been enabled in production for at least one
+full billing cycle and validated.
+
+See existing flags in `koku/masu/processor/__init__.py` for naming convention
+(`cost-management.backend.<feature_name>`).  For flags checked from multiple
+call sites, define a wrapper function in `__init__.py` (e.g.,
+`is_customer_large()`) instead of inlining `is_feature_flag_enabled_by_schema()`
+everywhere.
+
+## Key rules (detail in `.claude/rules/`)
+
+- **SQL templates** — three directories (`sql/`, `trino_sql/`, `self_hosted_sql/`).
+  Shared openshift templates must stay in sync across `trino_sql/` and `self_hosted_sql/`.
+  Port changes, don't copy — the SQL dialects differ.
+- **API changes** — any PR adding/modifying endpoints **must** update
+  `docs/specs/openapi.json`.  Check `koku/sources/openapi.json` and
+  `koku/masu/openapi.json` too.
+- **Migrations** — one per PR.  New columns **MUST** be nullable.
+  Use multi-release strategy for zero-downtime deploys (add in release N,
+  use in N+1, drop old in N+2).  Keep migration PRs separate from feature PRs.
+- **Trino migrations** — external tables (S3-backed) safe to drop; managed
+  tables (Glue-owned) **never drop**.  Use `migrate_trino_tables` command.
+- **Partitioned tables** — Django's `on_delete` unreliable on partitioned tables.
+  Use `cascade_delete()` from `koku/koku/database.py`.  Index FK columns.
+- **On-prem parity** — test with both `ONPREM=True` and `ONPREM=False`
+  when touching `get_sql_folder_name()`.
+
+## When modifying...
+
+| When you modify... | Also update... |
+|--------------------|----------------|
+| SQL templates in `trino_sql/openshift/` | Check `self_hosted_sql/openshift/` for counterpart |
+| OCP updater (`ocp_cost_model_cost_updater.py`) | Check all 3 SQL template directories |
+| `cost_models/models.py` or `rate_sync.py` | Test cost model create/update/delete end-to-end |
+| API views or serializers | `docs/specs/openapi.json` |
+| Environment variables | `deploy/clowdapp.yaml`, `koku/koku/settings.py`, `.env.example` |
+| Celery tasks | Ensure `@celery_app.task(name=...)` matches function name (exception: legacy names for backwards compat) |
+| New Unleash flag | `koku/masu/processor/__init__.py` (constant); `koku/koku/feature_flags.py` only if on-prem default needed |
+| Provider-specific code (aws/azure/gcp/ocp) | Check other providers for parity |
+| Django models (field changes) | Include migration in same or paired PR |
+| New periodic Celery task | Add beat_schedule entry in `koku/koku/celery.py` |
+| New Celery queue | `koku/common/queues.py` + `deploy/clowdapp.yaml` |
+| New Kafka topic | `koku/kafka_utils/utils.py` constants + `deploy/clowdapp.yaml` kafkaTopics |


### PR DESCRIPTION
## Summary

Add CLAUDE.md development guidelines and `.claude/` infrastructure
(slash commands, path-scoped rules) for the koku project.

Based on: PR #6166 adversarial review, commit history analysis,
service-docs architecture/operations docs, and insights-host-inventory patterns.

## What's included

### CLAUDE.md (117 lines — terse cheat sheet)

- **Quick reference** — key commands, project structure, dev stack ports
- **PR workflow and releases** — DRAFT PRs, smoke-test label, auto-deploy to stage, Mon/Thu prod cadence
- **Feature flags (Unleash)** — gate risky changes behind Unleash (default OFF), with code pattern + wrapper function guidance
- **Key rules** — one-liner summaries for SQL templates, API changes, migrations, Trino migrations, partitioned tables, on-prem parity (detail in `.claude/rules/`)
- **When modifying...** — cross-file sync table (12 rules)

### .claude/rules/ (glob-gated, loaded only when touching relevant files)

| File | Globs | Content |
|------|-------|---------|
| `cost-pipeline.md` | `koku/masu/processor/**`, `koku/cost_models/**` | Full OCP cost pipeline call chain with branching logic |
| `migrations.md` | `koku/reporting/migrations/**`, `koku/cost_models/migrations/**` | Multi-release strategy, nullable/default columns |
| `trino-migrations.md` | `koku/masu/management/commands/migrate_trino_tables.py` | External vs managed tables |
| `sql-templates.md` | `koku/masu/database/trino_sql/**`, `self_hosted_sql/**` | Dynamic shared template discovery |
| `partitioned-tables.md` | `koku/reporting/provider/*/models.py`, `koku/koku/database.py` | FK constraint reference, `cascade_delete()` |

### .claude/commands/ (slash commands)

| Command | Purpose |
|---------|---------|
| `/koku-sql-check` | Verify trino_sql ↔ self_hosted_sql template sync (dynamic discovery) |
| `/koku-database` | Run read-only SQL queries against prod/stage via gabi-cli |

### .gitignore change

Previously `.claude/` was fully gitignored. Now uses allowlist pattern —
tracks `commands/` and `rules/`, ignores everything else.

## Design principles

- **Progressive disclosure** — CLAUDE.md is a ~120-line cheat sheet always loaded into context. Detailed reference lives in `.claude/rules/` files with `globs:` frontmatter, loaded only when touching matching files.
- **Actionable, not informational** — CLAUDE.md tells Claude what to do, not how the system works.
- **No duplication** — each topic has one authoritative location.
- **No hardcoded lists** — shared templates and counts are discovered dynamically so docs don't rot.

## Test plan

- [ ] Start a new Claude session in koku — verify CLAUDE.md loads correctly
- [ ] Run `/koku-sql-check` — verify sync status table discovers shared templates dynamically
- [ ] Run `/koku-database` — verify gabi-cli queries work against stage
- [ ] Touch a file under `koku/masu/processor/` — verify `cost-pipeline.md` rule loads
- [ ] Touch a file under `koku/masu/database/trino_sql/` — verify `sql-templates.md` rule loads
- [ ] Verify `.claude/settings.json` and `.claude/worktrees/` are gitignored