### PR TITLE
drop get_report_db_accessor, wrong for dual-target validation

### DIFF
--- a/koku/masu/processor/_tasks/data_validation.py
+++ b/koku/masu/processor/_tasks/data_validation.py
@@ -11,7 +11,8 @@ from trino.exceptions import TrinoExternalError
 from api.common import log_json
 from api.provider.models import Provider
 from api.utils import DateHelper
-from koku.reportdb_accessor import get_report_db_accessor
+from koku.reportdb_accessor_postgres import PostgresReportDBAccessor
+from koku.reportdb_accessor_trino import TrinoReportDBAccessor
 from masu.database import AWS_CUR_TABLE_MAP
 from masu.database import AZURE_REPORT_TABLE_MAP
 from masu.database import GCP_REPORT_TABLE_MAP
@@ -150,16 +151,17 @@ class DataValidator:
         report_db_accessor = ReportDBAccessorBase(self.schema)
         # Set provider filter, when running ocp{aws/gcp/azure} checks we need to rely on the cluster id
         provider_filter = self.provider_uuid if not self.ocp_on_cloud_type else cluster_id
-        # query trino/postgres
+        # Dialect follows query target (trino flag), not ONPREM deployment mode.
         table, query_filters = self.get_table_filters_for_provider(provider_type, trino)
-        for start, end in date_range_pair(self.start_date, self.end_date, step=self.date_step):
-            # Determine source column name based on database type and whether it's OCP-on-cloud
-            if trino:
-                source = "source" if not self.ocp_on_cloud_type else "cluster_id"
-            else:
-                source = "source_uuid" if not self.ocp_on_cloud_type else "cluster_id"
+        if trino:
+            source = "source" if not self.ocp_on_cloud_type else "cluster_id"
+            sql_accessor = TrinoReportDBAccessor()
+        else:
+            source = "source_uuid" if not self.ocp_on_cloud_type else "cluster_id"
+            sql_accessor = PostgresReportDBAccessor()
 
-            sql = get_report_db_accessor().get_data_validation_sql(
+        for start, end in date_range_pair(self.start_date, self.end_date, step=self.date_step):
+            sql = sql_accessor.get_data_validation_sql(
                 schema_name=self.schema,
                 table_name=table,
                 source_column=source,

--- a/koku/masu/processor/tasks.py
+++ b/koku/masu/processor/tasks.py
@@ -1156,7 +1156,7 @@ def remove_stale_tenants():
 @celery_app.task(name="masu.processor.tasks.validate_daily_data", queue=PriorityQueue.DEFAULT)
 def validate_daily_data(schema, start_date, end_date, provider_uuid, ocp_on_cloud_type=None, context=None):
     # collect and validate cost metrics between postgres and trino tables.
-    if is_validation_enabled(schema):
+    if is_validation_enabled(schema) and not settings.ONPREM:
         data_validator = DataValidator(schema, start_date, end_date, provider_uuid, ocp_on_cloud_type, context)
         data_validator.check_data_integrity()
     else:

--- a/koku/masu/test/processor/test_data_validation.py
+++ b/koku/masu/test/processor/test_data_validation.py
@@ -5,6 +5,7 @@
 """Test cases for VataValidator"""
 from unittest.mock import patch
 
+from django.test import override_settings
 from trino.exceptions import TrinoExternalError
 
 from api.provider.models import Provider
@@ -116,6 +117,35 @@ class TestDataValidator(MasuTestCase):
         validator.execute_relevant_query("AWS")
         mock_pg_query.assert_called()
 
+    @override_settings(ONPREM=False)
+    @patch("masu.database.report_db_accessor_base.ReportDBAccessorBase._prepare_and_execute_raw_sql_query")
+    def test_query_postgres_sql_is_postgres_dialect_on_saas(self, mock_pg_query):
+        """SaaS postgres validation must use PG SQL, not hive-qualified Trino SQL."""
+        mock_pg_query.return_value = []
+        validator = DataValidator(
+            self.schema, self.start_date, self.end_date, self.provider_uuid, None, context="test"
+        )
+        validator.execute_relevant_query("AWS")
+        mock_pg_query.assert_called()
+        sql = mock_pg_query.call_args.args[1]
+        self.assertNotIn("hive.", sql)
+        self.assertIn(f"{self.schema}.", sql)
+        self.assertIn("source_uuid", sql)
+
+    @override_settings(ONPREM=False)
+    @patch("masu.database.report_db_accessor_base.ReportDBAccessorBase._execute_trino_raw_sql_query")
+    def test_query_trino_sql_is_trino_dialect_on_saas(self, mock_trino_query):
+        """SaaS trino validation must use hive-qualified Trino SQL."""
+        mock_trino_query.return_value = []
+        validator = DataValidator(
+            self.schema, self.start_date, self.end_date, self.provider_uuid, None, context="test"
+        )
+        validator.execute_relevant_query("AWS", trino=True)
+        mock_trino_query.assert_called()
+        sql = mock_trino_query.call_args.args[0]
+        self.assertIn(f"hive.{self.schema}.", sql)
+        self.assertIn("source", sql)
+
     @patch("masu.database.report_db_accessor_base.ReportDBAccessorBase._execute_trino_raw_sql_query")
     def test_query_trino(self, mock_trino_query):
         """Test making trino queries."""
@@ -165,6 +195,7 @@ class TestDataValidator(MasuTestCase):
             found = any(expected in log for log in logger.output)
             self.assertTrue(found)
 
+    @override_settings(ONPREM=False)
     @patch("masu.database.report_db_accessor_base.ReportDBAccessorBase._prepare_and_execute_raw_sql_query")
     @patch("masu.database.report_db_accessor_base.ReportDBAccessorBase._execute_trino_raw_sql_query")
     def test_check_data_integrity_trino_error(self, mock_trino_query, mock_pg_query):
@@ -179,6 +210,7 @@ class TestDataValidator(MasuTestCase):
             found = any(expected in log for log in logger.output)
             self.assertTrue(found)
 
+    @override_settings(ONPREM=False)
     @patch("masu.database.report_db_accessor_base.ReportDBAccessorBase._prepare_and_execute_raw_sql_query")
     @patch("masu.database.report_db_accessor_base.ReportDBAccessorBase._execute_trino_raw_sql_query")
     def test_partition_dropped_during_verification(self, mock_trino_query, mock_pg_query):
@@ -192,6 +224,7 @@ class TestDataValidator(MasuTestCase):
             validator.check_data_integrity()
             self.assertTrue(any("Partition dropped during verification" in log for log in logger.output))
 
+    @override_settings(ONPREM=False)
     @patch("masu.database.report_db_accessor_base.ReportDBAccessorBase._prepare_and_execute_raw_sql_query")
     @patch("masu.database.report_db_accessor_base.ReportDBAccessorBase._execute_trino_raw_sql_query")
     def test_partition_dropped_during_verification_unknown_error(self, mock_trino_query, mock_pg_query):

--- a/koku/masu/test/processor/test_tasks.py
+++ b/koku/masu/test/processor/test_tasks.py
@@ -552,6 +552,7 @@ class TestProcessorTasks(MasuTestCase):
         get_report_files(**self.get_report_args)
         mock_cache_remove.assert_called()
 
+    @override_settings(ONPREM=False)
     @patch("masu.processor.tasks.DataValidator")
     @patch(
         "masu.processor.tasks.is_validation_enabled",
@@ -563,9 +564,26 @@ class TestProcessorTasks(MasuTestCase):
         validate_daily_data(self.schema, self.start_date, self.start_date, self.aws_provider_uuid, context=context)
         mock_validate_daily_data.assert_called()
 
+    @override_settings(ONPREM=False)
     @patch("masu.processor.tasks.DataValidator")
     def test_validate_data_task_skip(self, mock_validate_daily_data):
         """Test skipping validate data task."""
+        context = {"unit": "test"}
+        with self.assertLogs("masu.processor.tasks", level="INFO") as logger:
+            validate_daily_data(self.schema, self.start_date, self.start_date, self.aws_provider_uuid, context=context)
+            mock_validate_daily_data.assert_not_called()
+            expected = "skipping validation, disabled for schema"
+            found = any(expected in log for log in logger.output)
+            self.assertTrue(found)
+
+    @override_settings(ONPREM=True)
+    @patch("masu.processor.tasks.DataValidator")
+    @patch(
+        "masu.processor.tasks.is_validation_enabled",
+        return_value=True,
+    )
+    def test_validate_data_task_skip_onprem(self, mock_unleash, mock_validate_daily_data):
+        """Data validation is skipped on-prem for now."""
         context = {"unit": "test"}
         with self.assertLogs("masu.processor.tasks", level="INFO") as logger:
             validate_daily_data(self.schema, self.start_date, self.start_date, self.aws_provider_uuid, context=context)


### PR DESCRIPTION
## Jira Ticket

None

## Description

This change fixes SaaS data validation incorrectly generating Trino/Hive SQL for the Postgres comparison query (`cross-database references are not implemented: "hive.<schema>..."`). SQL dialect is now selected by query target (`trino` flag): Postgres path uses `PostgresReportDBAccessor`, Trino path uses `TrinoReportDBAccessor`. Data validation is also skipped when `ONPREM=True` for now.

## Testing

1. Checkout branch `fix-data-validation`.
2. Ensure test DB is available (`localhost:15432`).
3. Run and confirm unit tests are passing:

```bash
KEEPDB=True pipenv run python koku/manage.py test \
  masu.test.processor.test_data_validation \
  masu.test.processor.test_tasks.TestProcessorTasks.test_validate_data_task \
  masu.test.processor.test_tasks.TestProcessorTasks.test_validate_data_task_skip \
  masu.test.processor.test_tasks.TestProcessorTasks.test_validate_data_task_skip_onprem \
  --no-input -v 2
```


## Release Notes
- [x] proposed release note

```markdown
* Fix SaaS data validation using Hive SQL against Postgres, and skip validation on-prem for now
```