### PR TITLE
[COST-7252] Block disabling currencies that are in use

### DIFF
--- a/koku/api/currency/exceptions.py
+++ b/koku/api/currency/exceptions.py
@@ -13,7 +13,7 @@ class ExchangeRateNotFound(ValidationError):
     def __init__(self, base_currencies, target_currency, start_date, end_date, missing_months=None):
         missing_pairs = ", ".join(f"{base} -> {target_currency}" for base in base_currencies)
         if missing_months:
-            months_str = ", ".join(str(m) for m in sorted(missing_months))
+            months_str = ", ".join(m.strftime("%Y-%m") for m in sorted(missing_months))
             detail = f"Exchange rate missing for {missing_pairs} for months: {months_str}."
         else:
             detail = f"No exchange rate available for {missing_pairs} for {start_date} to {end_date}."

--- a/koku/api/currency/exceptions.py
+++ b/koku/api/currency/exceptions.py
@@ -1,0 +1,25 @@
+#
+# Copyright 2026 Red Hat Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Currency-related exceptions."""
+from django.conf import settings
+from rest_framework.exceptions import ValidationError
+
+
+class ExchangeRateNotFound(ValidationError):
+    """Raised when no exchange rate exists for a required currency pair."""
+
+    def __init__(self, base_currencies, target_currency, start_date, end_date, missing_months=None):
+        missing_pairs = ", ".join(f"{base} -> {target_currency}" for base in base_currencies)
+        if missing_months:
+            months_str = ", ".join(str(m) for m in sorted(missing_months))
+            detail = f"Exchange rate missing for {missing_pairs} for months: {months_str}."
+        else:
+            detail = f"No exchange rate available for {missing_pairs} for {start_date} to {end_date}."
+
+        if settings.CURRENCY_URL:
+            detail += " Ask your administrator to configure static exchange rates."
+        else:
+            detail += " Ask your administrator to configure static exchange rates or enable dynamic exchange rates."
+        super().__init__({"currency": detail})

--- a/koku/api/currency/utils.py
+++ b/koku/api/currency/utils.py
@@ -2,9 +2,20 @@
 # Copyright 2021 Red Hat Inc.
 # SPDX-License-Identifier: Apache-2.0
 #
+import logging
 from decimal import Decimal
 
+from dateutil.relativedelta import relativedelta
+from django.db.models import OuterRef
+from django.db.models import Subquery
+from django.db.models.functions import ExtractMonth
+from django.db.models.functions import ExtractYear
+
+from api.currency.exceptions import ExchangeRateNotFound
 from api.currency.models import ExchangeRateDictionary
+from cost_models.models import MonthlyExchangeRate
+
+LOG = logging.getLogger(__name__)
 
 
 def build_exchange_dictionary(rates):
@@ -25,3 +36,66 @@ def exchange_dictionary(rates):
     else:
         current_data.currency_exchange_dictionary = exchange_data
         current_data.save()
+
+
+def build_monthly_rate_annotation(base_currency, target_currency):
+    """Build a Subquery annotation that resolves the exchange rate for the row's month.
+
+    Matches the row's usage_start year/month against MonthlyExchangeRate.effective_date.
+    Returns NULL for months with no MER row.
+
+    Args:
+        base_currency: the base currency to convert from (e.g. "USD")
+        target_currency: the target currency to convert to (e.g. "EUR")
+    """
+    return Subquery(
+        MonthlyExchangeRate.objects.filter(
+            effective_date__year=ExtractYear(OuterRef("usage_start")),
+            effective_date__month=ExtractMonth(OuterRef("usage_start")),
+            base_currency=base_currency,
+            target_currency=target_currency,
+        ).values("exchange_rate")[:1]
+    )
+
+
+def validate_exchange_rate_coverage(base_currencies, target_currency, start_date, end_date):
+    """Check that MonthlyExchangeRate rows exist for every base currency and every month in the range.
+
+    Raises ExchangeRateNotFound if:
+    - A base currency is completely missing from MER
+    - A base currency has rates for some months but not all months in the range
+    """
+    bases_needing_conversion = base_currencies - {target_currency}
+    if not bases_needing_conversion:
+        return
+
+    start_month = start_date.replace(day=1) if hasattr(start_date, "replace") else start_date
+    end_month = end_date.replace(day=1) if hasattr(end_date, "replace") else end_date
+
+    rates = MonthlyExchangeRate.objects.filter(
+        effective_date__gte=start_month,
+        effective_date__lte=end_month,
+        base_currency__in=bases_needing_conversion,
+        target_currency=target_currency,
+    ).values_list("base_currency", "effective_date")
+
+    covered_by_currency = {}
+    for base, effective_date in rates:
+        covered_by_currency.setdefault(base, set()).add(effective_date)
+
+    missing = bases_needing_conversion - set(covered_by_currency.keys())
+    if missing:
+        LOG.warning(f"No exchange rates found for {missing} -> {target_currency}")
+        raise ExchangeRateNotFound(list(missing), target_currency, start_month, end_month)
+
+    expected_months = set()
+    current = start_month
+    while current <= end_month:
+        expected_months.add(current)
+        current += relativedelta(months=1)
+
+    for base, covered_months in covered_by_currency.items():
+        gaps = expected_months - covered_months
+        if gaps:
+            LOG.warning(f"Exchange rate gap for {base} -> {target_currency}: missing months {sorted(gaps)}")
+            raise ExchangeRateNotFound([base], target_currency, start_month, end_month, missing_months=gaps)

--- a/koku/api/query_handler.py
+++ b/koku/api/query_handler.py
@@ -13,18 +13,22 @@ from django.conf import settings
 from django.core.exceptions import FieldDoesNotExist
 from django.db.models import Case
 from django.db.models import DecimalField
+from django.db.models import OuterRef
 from django.db.models import Value
 from django.db.models import When
 from django.db.models.functions import TruncDay
 from django.db.models.functions import TruncMonth
 
 from api.currency.models import ExchangeRateDictionary
+from api.currency.utils import build_monthly_rate_annotation
 from api.query_filter import QueryFilter
 from api.query_filter import QueryFilterCollection
 from api.report.constants import RESOLUTION_DAILY
 from api.report.constants import TIME_SCOPE_UNITS_DAILY
 from api.report.constants import TIME_SCOPE_VALUES_DAILY
 from api.utils import DateHelper
+from masu.processor import CONSTANT_CURRENCY_FLAG
+from masu.processor import is_feature_flag_enabled_by_schema
 
 LOG = logging.getLogger(__name__)
 WILDCARD = "*"
@@ -130,12 +134,23 @@ class QueryHandler:
 
     @cached_property
     def exchange_rate_annotation_dict(self):
-        """Get the exchange rate annotation based on the exchange_rates property."""
-        whens = [
-            When(**{self._mapper.cost_units_key: k, "then": Value(v.get(self.currency))})
-            for k, v in self.exchange_rates.items()
-        ]
-        return {"exchange_rate": Case(*whens, default=1, output_field=DecimalField())}
+        """Get the exchange rate annotation.
+
+        When constant currency is enabled, uses per-month Subquery from
+        MonthlyExchangeRate. Otherwise uses ExchangeRateDictionary.
+        """
+        if is_feature_flag_enabled_by_schema(self.tenant.schema_name, CONSTANT_CURRENCY_FLAG):
+            exchange_rate_annotation = build_monthly_rate_annotation(
+                OuterRef(self._mapper.cost_units_key), self.currency
+            )
+        else:
+            whens = [
+                When(**{self._mapper.cost_units_key: k, "then": Value(v.get(self.currency))})
+                for k, v in self.exchange_rates.items()
+            ]
+            exchange_rate_annotation = Case(*whens, default=1, output_field=DecimalField())
+
+        return {"exchange_rate": exchange_rate_annotation}
 
     @property
     def order(self):

--- a/koku/api/report/aws/openshift/query_handler.py
+++ b/koku/api/report/aws/openshift/query_handler.py
@@ -59,7 +59,7 @@ class OCPInfrastructureReportQueryHandlerBase(AWSReportQueryHandler):
             query_group_by = ["date"] + group_by_value
             query_order_by = ["-date", self.order]
 
-            annotations = self._mapper.report_type_map.get("annotations")
+            annotations = self.report_annotations
             query_data = query.values(*query_group_by).annotate(**annotations)
             if is_grouped_by_project(self.parameters):
                 query_data = self._project_classification_annotation(query_data)

--- a/koku/api/report/aws/query_handler.py
+++ b/koku/api/report/aws/query_handler.py
@@ -434,7 +434,7 @@ class AWSReportQueryHandler(ReportQueryHandler):
             query_group_by = ["date"] + self._get_group_by()
             query_order_by = ["-date", self.order]
 
-            annotations = self._mapper.report_type_map.get("annotations", {})
+            annotations = self.report_annotations
             query_data = query.values(*query_group_by).annotate(**annotations)
 
             if "account" in query_group_by:

--- a/koku/api/report/azure/openshift/query_handler.py
+++ b/koku/api/report/azure/openshift/query_handler.py
@@ -89,7 +89,7 @@ class OCPAzureReportQueryHandler(AzureReportQueryHandler):
             query_group_by = ["date"] + group_by_value
             query_order_by = ["-date", self.order]
 
-            annotations = self._mapper.report_type_map.get("annotations")
+            annotations = self.report_annotations
             query_data = query.values(*query_group_by).annotate(**annotations)
 
             if "subscription_guid" in query_group_by:

--- a/koku/api/report/azure/query_handler.py
+++ b/koku/api/report/azure/query_handler.py
@@ -154,7 +154,7 @@ class AzureReportQueryHandler(ReportQueryHandler):
             query_group_by = ["date"] + self._get_group_by()
             query_order_by = ["-date", self.order]
 
-            annotations = self._mapper.report_type_map.get("annotations")
+            annotations = self.report_annotations
             query_data = query.values(*query_group_by).annotate(**annotations)
             query_sum = self._build_sum(query)
 

--- a/koku/api/report/gcp/openshift/query_handler.py
+++ b/koku/api/report/gcp/openshift/query_handler.py
@@ -95,7 +95,7 @@ class OCPGCPReportQueryHandler(GCPReportQueryHandler):
             query_group_by = ["date"] + group_by_value
             query_order_by = ["-date", self.order]
 
-            annotations = self._mapper.report_type_map.get("annotations")
+            annotations = self.report_annotations
             query_data = query.values(*query_group_by).annotate(**annotations)
             if is_grouped_by_project(self.parameters):
                 query_data = self._project_classification_annotation(query_data)

--- a/koku/api/report/gcp/query_handler.py
+++ b/koku/api/report/gcp/query_handler.py
@@ -182,7 +182,7 @@ class GCPReportQueryHandler(ReportQueryHandler):
             query_group_by = ["date"] + self._get_group_by()
             query_order_by = ["-date", self.order]
 
-            annotations = self._mapper.report_type_map.get("annotations")
+            annotations = copy.copy(self.report_annotations)
             for alias_key, alias_value in self.group_by_alias.items():
                 if alias_key in query_group_by:
                     annotations[f"{alias_key}_alias"] = F(alias_value)

--- a/koku/api/report/ocp/query_handler.py
+++ b/koku/api/report/ocp/query_handler.py
@@ -15,12 +15,15 @@ from django.db.models import Case
 from django.db.models import CharField
 from django.db.models import DecimalField
 from django.db.models import F
+from django.db.models import OuterRef
+from django.db.models import Subquery
 from django.db.models import Value
 from django.db.models import When
 from django.db.models.fields.json import KT
 from django.db.models.functions import Coalesce
 from django_tenants.utils import tenant_context
 
+from api.currency.utils import build_monthly_rate_annotation
 from api.models import Provider
 from api.report.ocp.capacity.cluster_capacity import calculate_unused
 from api.report.ocp.capacity.cluster_capacity import ClusterCapacity
@@ -31,6 +34,8 @@ from api.report.queries import is_grouped_by_project
 from api.report.queries import ReportQueryHandler
 from cost_models.models import CostModel
 from cost_models.models import CostModelMap
+from masu.processor import CONSTANT_CURRENCY_FLAG
+from masu.processor import is_feature_flag_enabled_by_schema
 
 LOG = logging.getLogger(__name__)
 
@@ -178,19 +183,53 @@ class OCPReportQueryHandler(ReportQueryHandler):
 
     @cached_property
     def exchange_rate_annotation_dict(self):
-        """Get the exchange rate annotation based on the exchange_rates property."""
-        exchange_rate_whens = [
-            When(**{"source_uuid": uuid, "then": Value(self.exchange_rates.get(cur, {}).get(self.currency, 1))})
-            for uuid, cur in self.source_to_currency_map.items()
-        ]
-        infra_exchange_rate_whens = [
-            When(**{self._mapper.cost_units_key: k, "then": Value(v.get(self.currency))})
-            for k, v in self.exchange_rates.items()
-        ]
+        """Get per-month exchange rate annotations from MonthlyExchangeRate via Subquery.
+
+        When constant currency is enabled, OCP needs two annotations:
+        - exchange_rate: cost model currency (resolved via source_uuid -> CostModel.currency)
+        - infra_exchange_rate: cloud bill currency (raw_currency column)
+
+        Falls back to the Case/When approach when the flag is off.
+        """
+        if is_feature_flag_enabled_by_schema(self.tenant.schema_name, CONSTANT_CURRENCY_FLAG):
+            cost_model_currency = Subquery(
+                CostModel.objects.filter(costmodelmap__provider_uuid=OuterRef(OuterRef("source_uuid")),).values(
+                    "currency"
+                )[:1],
+            )
+            exchange_rate_annotation = build_monthly_rate_annotation(cost_model_currency, self.currency)
+            infra_exchange_rate_annotation = build_monthly_rate_annotation(
+                OuterRef(self._mapper.cost_units_key), self.currency
+            )
+        else:
+            exchange_rate_whens = [
+                When(**{"source_uuid": uuid, "then": Value(self.exchange_rates.get(cur, {}).get(self.currency, 1))})
+                for uuid, cur in self.source_to_currency_map.items()
+            ]
+            infra_exchange_rate_whens = [
+                When(**{self._mapper.cost_units_key: k, "then": Value(v.get(self.currency))})
+                for k, v in self.exchange_rates.items()
+            ]
+            exchange_rate_annotation = Case(*exchange_rate_whens, default=1, output_field=DecimalField())
+            infra_exchange_rate_annotation = Case(*infra_exchange_rate_whens, default=1, output_field=DecimalField())
+
         return {
-            "exchange_rate": Case(*exchange_rate_whens, default=1, output_field=DecimalField()),
-            "infra_exchange_rate": Case(*infra_exchange_rate_whens, default=1, output_field=DecimalField()),
+            "exchange_rate": exchange_rate_annotation,
+            "infra_exchange_rate": infra_exchange_rate_annotation,
         }
+
+    def _get_base_currencies_for_conversion(self):
+        """Return base currencies from both raw_currency and cost model currencies."""
+        base_currencies = super()._get_base_currencies_for_conversion()
+        cm_currencies = set(
+            CostModel.objects.filter(
+                costmodelmap__provider_uuid__in=self._mapper.query_table.objects.filter(
+                    usage_start__gte=self.start_datetime.date(),
+                    usage_start__lte=self.end_datetime.date(),
+                ).values("source_uuid"),
+            ).values_list("currency", flat=True)
+        )
+        return (base_currencies | cm_currencies) - {None}
 
     def format_tags(self, tags_iterable):
         """

--- a/koku/api/report/ocp/query_handler.py
+++ b/koku/api/report/ocp/query_handler.py
@@ -15,6 +15,7 @@ from django.db.models import Case
 from django.db.models import CharField
 from django.db.models import DecimalField
 from django.db.models import F
+from django.db.models import Max
 from django.db.models import OuterRef
 from django.db.models import Subquery
 from django.db.models import Value
@@ -230,6 +231,18 @@ class OCPReportQueryHandler(ReportQueryHandler):
             ).values_list("currency", flat=True)
         )
         return (base_currencies | cm_currencies) - {None}
+
+    @property
+    def report_annotations(self):
+        """Return annotations with OCP-specific infra_exchange_rate for CSV output."""
+        annotations = self._mapper.report_type_map.get("annotations", {})
+        if self.is_csv_output:
+            annotations = {
+                **annotations,
+                "base_currency": Max(self._mapper.cost_units_key),
+                "exchange_rate": Max("infra_exchange_rate"),
+            }
+        return annotations
 
     def format_tags(self, tags_iterable):
         """

--- a/koku/api/report/ocp/query_handler.py
+++ b/koku/api/report/ocp/query_handler.py
@@ -224,7 +224,7 @@ class OCPReportQueryHandler(ReportQueryHandler):
         base_currencies = super()._get_base_currencies_for_conversion()
         cm_currencies = set(
             CostModel.objects.filter(
-                costmodelmap__provider_uuid__in=self._mapper.query_table.objects.filter(
+                costmodelmap__provider_uuid__in=self.query_table.objects.filter(
                     usage_start__gte=self.start_datetime.date(),
                     usage_start__lte=self.end_datetime.date(),
                 ).values("source_uuid"),

--- a/koku/api/report/ocp/query_handler.py
+++ b/koku/api/report/ocp/query_handler.py
@@ -15,7 +15,6 @@ from django.db.models import Case
 from django.db.models import CharField
 from django.db.models import DecimalField
 from django.db.models import F
-from django.db.models import Max
 from django.db.models import OuterRef
 from django.db.models import Subquery
 from django.db.models import Value
@@ -164,18 +163,6 @@ class OCPReportQueryHandler(ReportQueryHandler):
         if special_annotations := self._mapper.report_type_map.get("report_type_annotations"):
             annotations.update(special_annotations)
 
-        return annotations
-
-    @property
-    def report_annotations(self):
-        """Return annotations with CSV-specific exchange rate columns for OCP."""
-        annotations = self._mapper.report_type_map.get("annotations", {})
-        if self.is_csv_output:
-            annotations = {
-                **annotations,
-                "base_currency": Max(self._mapper.cost_units_key),
-                "exchange_rate": Max("exchange_rate"),
-            }
         return annotations
 
     @cached_property

--- a/koku/api/report/ocp/query_handler.py
+++ b/koku/api/report/ocp/query_handler.py
@@ -240,7 +240,7 @@ class OCPReportQueryHandler(ReportQueryHandler):
             annotations = {
                 **annotations,
                 "base_currency": Max(self._mapper.cost_units_key),
-                "exchange_rate": Max("infra_exchange_rate"),
+                "exchange_rate": Coalesce(Max("infra_exchange_rate"), Value(1), output_field=DecimalField()),
             }
         return annotations
 

--- a/koku/api/report/ocp/query_handler.py
+++ b/koku/api/report/ocp/query_handler.py
@@ -15,6 +15,7 @@ from django.db.models import Case
 from django.db.models import CharField
 from django.db.models import DecimalField
 from django.db.models import F
+from django.db.models import Max
 from django.db.models import OuterRef
 from django.db.models import Subquery
 from django.db.models import Value
@@ -163,6 +164,18 @@ class OCPReportQueryHandler(ReportQueryHandler):
         if special_annotations := self._mapper.report_type_map.get("report_type_annotations"):
             annotations.update(special_annotations)
 
+        return annotations
+
+    @property
+    def report_annotations(self):
+        """Return annotations with CSV-specific exchange rate columns for OCP."""
+        annotations = self._mapper.report_type_map.get("annotations", {})
+        if self.is_csv_output:
+            annotations = {
+                **annotations,
+                "base_currency": Max(self._mapper.cost_units_key),
+                "exchange_rate": Max("exchange_rate"),
+            }
         return annotations
 
     @cached_property

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -24,6 +24,7 @@ import pandas as pd
 from django.contrib.postgres.aggregates import ArrayAgg
 from django.db.models import Case
 from django.db.models import CharField
+from django.db.models import DecimalField
 from django.db.models import F
 from django.db.models import Max
 from django.db.models import Q
@@ -187,7 +188,7 @@ class ReportQueryHandler(QueryHandler):
             annotations = {
                 **annotations,
                 "base_currency": Max(self._mapper.cost_units_key),
-                "exchange_rate": Max("exchange_rate"),
+                "exchange_rate": Coalesce(Max("exchange_rate"), Value(1), output_field=DecimalField()),
             }
         return annotations
 

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -24,8 +24,8 @@ import pandas as pd
 from django.contrib.postgres.aggregates import ArrayAgg
 from django.db.models import Case
 from django.db.models import CharField
-from django.db.models import DecimalField
 from django.db.models import F
+from django.db.models import Max
 from django.db.models import Q
 from django.db.models import Value
 from django.db.models import When
@@ -35,9 +35,10 @@ from django.db.models.expressions import RawSQL
 from django.db.models.functions import Coalesce
 from django.db.models.functions import Concat
 from django.db.models.functions import RowNumber
+from django_tenants.utils import tenant_context
 from pandas.api.types import CategoricalDtype
 
-from api.currency.models import ExchangeRateDictionary
+from api.currency.utils import validate_exchange_rate_coverage
 from api.models import Provider
 from api.query_filter import QueryFilter
 from api.query_filter import QueryFilterCollection
@@ -45,6 +46,8 @@ from api.query_handler import QueryHandler
 from api.report.constants import AWS_CATEGORY_PREFIX
 from api.report.constants import TAG_PREFIX
 from api.report.constants import URL_ENCODED_SAFE
+from masu.processor import CONSTANT_CURRENCY_FLAG
+from masu.processor import is_feature_flag_enabled_by_schema
 
 LOG = logging.getLogger(__name__)
 
@@ -179,7 +182,14 @@ class ReportQueryHandler(QueryHandler):
     @property
     def report_annotations(self):
         """Return annotations with the correct capacity field."""
-        return self._mapper.report_type_map.get("annotations", {})
+        annotations = self._mapper.report_type_map.get("annotations", {})
+        if self.is_csv_output:
+            annotations = {
+                **annotations,
+                "base_currency": Max(self._mapper.cost_units_key),
+                "exchange_rate": Max("exchange_rate"),
+            }
+        return annotations
 
     @cached_property
     def query_table(self):
@@ -880,23 +890,6 @@ class ReportQueryHandler(QueryHandler):
                 group_by.append((db_name, group_pos, original_aws_category))
         return group_by
 
-    @cached_property
-    def exchange_rates(self):
-        try:
-            return ExchangeRateDictionary.objects.first().currency_exchange_dictionary
-        except AttributeError as err:
-            LOG.warning(f"Exchange rates dictionary is not populated resulting in {err}.")
-            return {}
-
-    @cached_property
-    def exchange_rate_annotation_dict(self):
-        """Get the exchange rate annotation based on the exchange_rates property."""
-        whens = [
-            When(**{self._mapper.cost_units_key: k, "then": Value(v.get(self.currency))})
-            for k, v in self.exchange_rates.items()
-        ]
-        return {"exchange_rate": Case(*whens, default=1, output_field=DecimalField())}
-
     def _project_classification_annotation(self, query_data):
         """Get the correct annotation for a project or category"""
         whens = [
@@ -1070,7 +1063,32 @@ class ReportQueryHandler(QueryHandler):
         # remove access from the output
         output.pop("access")
 
+        if self.currency:
+            output["currency"] = self.currency
+            if is_feature_flag_enabled_by_schema(self.tenant.schema_name, CONSTANT_CURRENCY_FLAG):
+                with tenant_context(self.tenant):
+                    validate_exchange_rate_coverage(
+                        self._get_base_currencies_for_conversion(),
+                        self.currency,
+                        self.start_datetime.date(),
+                        self.end_datetime.date(),
+                    )
+
         return output
+
+    def _get_base_currencies_for_conversion(self):
+        """Return the set of base currencies present in the query range.
+
+        Subclasses (e.g. OCP) can override to include additional currency sources.
+        """
+        return set(
+            self._mapper.query_table.objects.filter(
+                usage_start__gte=self.start_datetime.date(),
+                usage_start__lte=self.end_datetime.date(),
+            )
+            .values_list(self._mapper.cost_units_key, flat=True)
+            .distinct()
+        ) - {None}
 
     def _pack_data_object(self, data, **kwargs):  # noqa: C901
         """Pack data into object format."""

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -25,6 +25,7 @@ from django.contrib.postgres.aggregates import ArrayAgg
 from django.db.models import Case
 from django.db.models import CharField
 from django.db.models import F
+from django.db.models import Max
 from django.db.models import Q
 from django.db.models import Value
 from django.db.models import When
@@ -181,7 +182,14 @@ class ReportQueryHandler(QueryHandler):
     @property
     def report_annotations(self):
         """Return annotations with the correct capacity field."""
-        return self._mapper.report_type_map.get("annotations", {})
+        annotations = self._mapper.report_type_map.get("annotations", {})
+        if self.is_csv_output:
+            annotations = {
+                **annotations,
+                "base_currency": Max(self._mapper.cost_units_key),
+                "exchange_rate": Max("exchange_rate"),
+            }
+        return annotations
 
     @cached_property
     def query_table(self):

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -1082,7 +1082,7 @@ class ReportQueryHandler(QueryHandler):
         Subclasses (e.g. OCP) can override to include additional currency sources.
         """
         return set(
-            self._mapper.query_table.objects.filter(
+            self.query_table.objects.filter(
                 usage_start__gte=self.start_datetime.date(),
                 usage_start__lte=self.end_datetime.date(),
             )

--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -25,7 +25,6 @@ from django.contrib.postgres.aggregates import ArrayAgg
 from django.db.models import Case
 from django.db.models import CharField
 from django.db.models import F
-from django.db.models import Max
 from django.db.models import Q
 from django.db.models import Value
 from django.db.models import When
@@ -182,14 +181,7 @@ class ReportQueryHandler(QueryHandler):
     @property
     def report_annotations(self):
         """Return annotations with the correct capacity field."""
-        annotations = self._mapper.report_type_map.get("annotations", {})
-        if self.is_csv_output:
-            annotations = {
-                **annotations,
-                "base_currency": Max(self._mapper.cost_units_key),
-                "exchange_rate": Max("exchange_rate"),
-            }
-        return annotations
+        return self._mapper.report_type_map.get("annotations", {})
 
     @cached_property
     def query_table(self):

--- a/koku/api/settings/currency_views.py
+++ b/koku/api/settings/currency_views.py
@@ -112,24 +112,31 @@ class EnabledCurrencyView(APIView):
         if EnabledCurrency.objects.count() == 1:
             raise ValidationError({"error": "At least one currency must be enabled."})
 
+        reasons = []
+
+        if code == KOKU_DEFAULT_CURRENCY:
+            reasons.append("it is the system default currency")
+
+        if UserSettings.objects.filter(settings__currency=code).exists():
+            reasons.append("it is set as a user's default display currency")
+
         affected_cost_models = list(CostModel.objects.filter(currency=code).values("uuid", "name"))
+        if affected_cost_models:
+            reasons.append(f"it is used by {len(affected_cost_models)} cost model(s)")
+
         affected_price_lists = list(PriceList.objects.filter(currency=code).values("uuid", "name"))
-        has_conflict = affected_cost_models or affected_price_lists
+        if affected_price_lists:
+            reasons.append(f"it is used by {len(affected_price_lists)} price list(s)")
 
-        if has_conflict:
-            LOG.warning(
-                log_json(
-                    msg="Disabling currency that is in use by cost models or price lists",
-                    currency=code,
-                    affected_cost_models=len(affected_cost_models),
-                    affected_price_lists=len(affected_price_lists),
-                )
+        if reasons:
+            detail = f"Cannot disable {code} because {'; '.join(reasons)}."
+            raise ValidationError(
+                {
+                    "error": detail,
+                    "affected_cost_models": affected_cost_models,
+                    "affected_price_lists": affected_price_lists,
+                }
             )
-
-        for user_setting in UserSettings.objects.filter(settings__currency=code):
-            user_setting.settings["currency"] = KOKU_DEFAULT_CURRENCY
-            user_setting.save(update_fields=["settings"])
-            LOG.info(log_json(msg="Account currency reset to default", previous=code, new=KOKU_DEFAULT_CURRENCY))
 
         EnabledCurrency.objects.filter(currency_code=code).delete()
         remove_monthly_rates(code=code)
@@ -137,16 +144,4 @@ class EnabledCurrencyView(APIView):
         invalidate_view_cache_for_tenant_and_all_source_types(schema_name)
         LOG.info(log_json(msg="Currency disabled", currency=code))
 
-        if has_conflict:
-            total = len(affected_cost_models) + len(affected_price_lists)
-            return Response(
-                {
-                    "warning": f"Currency {code} was disabled but is still referenced by "
-                    f"{total} cost model(s) or price list(s). "
-                    "Those items may become uneditable until the currency is re-enabled.",
-                    "affected_cost_models": affected_cost_models,
-                    "affected_price_lists": affected_price_lists,
-                },
-                status=status.HTTP_200_OK,
-            )
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/koku/api/settings/test/test_currency_views.py
+++ b/koku/api/settings/test/test_currency_views.py
@@ -120,8 +120,8 @@ class EnabledCurrencyViewTest(IamTestCase):
             self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
             self.assertTrue(EnabledCurrency.objects.filter(currency_code="USD").exists())
 
-    def test_disable_currency_in_use_by_cost_model_warns(self):
-        """Disabling a currency referenced by a CostModel should succeed with a warning."""
+    def test_disable_currency_in_use_by_cost_model_blocked(self):
+        """Disabling a currency referenced by a CostModel must return 400."""
         with tenant_context(self.tenant):
             EnabledCurrency.objects.create(currency_code="USD")
             EnabledCurrency.objects.create(currency_code="GBP")
@@ -135,14 +135,11 @@ class EnabledCurrencyViewTest(IamTestCase):
             )
 
             response = self.client.delete(self._url("GBP"), **self.headers)
-            self.assertEqual(response.status_code, status.HTTP_200_OK)
-            self.assertIn("warning", response.data)
-            self.assertEqual(len(response.data["affected_cost_models"]), 1)
-            self.assertEqual(response.data["affected_price_lists"], [])
-            self.assertFalse(EnabledCurrency.objects.filter(currency_code="GBP").exists())
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+            self.assertTrue(EnabledCurrency.objects.filter(currency_code="GBP").exists())
 
-    def test_disable_currency_in_use_by_price_list_warns(self):
-        """Disabling a currency referenced by a PriceList should succeed with a warning."""
+    def test_disable_currency_in_use_by_price_list_blocked(self):
+        """Disabling a currency referenced by a PriceList must return 400."""
         with tenant_context(self.tenant):
             EnabledCurrency.objects.create(currency_code="USD")
             EnabledCurrency.objects.create(currency_code="EUR")
@@ -156,8 +153,15 @@ class EnabledCurrencyViewTest(IamTestCase):
             )
 
             response = self.client.delete(self._url("EUR"), **self.headers)
-            self.assertEqual(response.status_code, status.HTTP_200_OK)
-            self.assertIn("warning", response.data)
-            self.assertEqual(response.data["affected_cost_models"], [])
-            self.assertEqual(len(response.data["affected_price_lists"]), 1)
-            self.assertFalse(EnabledCurrency.objects.filter(currency_code="EUR").exists())
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+            self.assertTrue(EnabledCurrency.objects.filter(currency_code="EUR").exists())
+
+    def test_disable_default_currency_blocked(self):
+        """Disabling the system default currency (USD) must return 400."""
+        with tenant_context(self.tenant):
+            EnabledCurrency.objects.create(currency_code="USD")
+            EnabledCurrency.objects.create(currency_code="GBP")
+
+            response = self.client.delete(self._url("USD"), **self.headers)
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+            self.assertTrue(EnabledCurrency.objects.filter(currency_code="USD").exists())

--- a/koku/cost_models/test/test_exchange_rate_annotations.py
+++ b/koku/cost_models/test/test_exchange_rate_annotations.py
@@ -3,35 +3,20 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 """Tests for exchange rate annotation builders and feature-flag gating."""
+from datetime import date
+from decimal import Decimal
 from unittest.mock import patch
 
 from django.test import TestCase
 from django_tenants.utils import schema_context
+from django_tenants.utils import tenant_context
 
 from api.currency.exceptions import ExchangeRateNotFound
 from api.currency.utils import build_monthly_rate_annotation
+from api.currency.utils import validate_exchange_rate_coverage
 from api.report.ocp.view import OCPCostView
+from cost_models.models import MonthlyExchangeRate
 from masu.test import MasuTestCase
-
-
-class ExchangeRateNotFoundTest(TestCase):
-    """Test error message formatting for ExchangeRateNotFound."""
-
-    @patch("api.currency.exceptions.settings")
-    def test_message_with_currency_url(self, mock_settings):
-        mock_settings.CURRENCY_URL = "https://example.com"
-        exc = ExchangeRateNotFound(["USD", "GBP"], "EUR", "2026-01-01", "2026-03-01")
-        msg = exc.detail["currency"]
-        self.assertIn("USD -> EUR", msg)
-        self.assertIn("GBP -> EUR", msg)
-        self.assertNotIn("dynamic exchange rates", msg)
-
-    @patch("api.currency.exceptions.settings")
-    def test_message_without_currency_url(self, mock_settings):
-        mock_settings.CURRENCY_URL = ""
-        exc = ExchangeRateNotFound(["USD"], "EUR", "2026-01-01", "2026-03-01")
-        msg = exc.detail["currency"]
-        self.assertIn("dynamic exchange rates", msg)
 
 
 class AnnotationBuilderTest(TestCase):
@@ -43,6 +28,44 @@ class AnnotationBuilderTest(TestCase):
 
         result = build_monthly_rate_annotation(OuterRef("raw_currency"), "EUR")
         self.assertIsInstance(result, Subquery)
+
+
+class ValidateExchangeRateCoverageTest(MasuTestCase):
+    """Tests for validate_exchange_rate_coverage()."""
+
+    def test_raises_when_currency_completely_missing(self):
+        """Raises ExchangeRateNotFound when no MER rows exist for a base currency."""
+        with (
+            schema_context(self.schema),
+            self.assertRaises(ExchangeRateNotFound),
+        ):
+            validate_exchange_rate_coverage({"GBP"}, "EUR", date(2026, 1, 1), date(2026, 1, 31))
+
+    def test_raises_when_monthly_gap_exists(self):
+        """Raises ExchangeRateNotFound when a month has no rate for a covered currency."""
+        with schema_context(self.schema):
+            MonthlyExchangeRate.objects.create(
+                effective_date=date(2026, 1, 1),
+                base_currency="GBP",
+                target_currency="EUR",
+                exchange_rate=Decimal("1.17"),
+                rate_type="static",
+            )
+            with self.assertRaises(ExchangeRateNotFound):
+                validate_exchange_rate_coverage({"GBP"}, "EUR", date(2026, 1, 1), date(2026, 2, 1))
+
+    def test_passes_when_all_months_covered(self):
+        """No exception when every month in the range has an MER row."""
+        with schema_context(self.schema):
+            for month in [date(2026, 1, 1), date(2026, 2, 1)]:
+                MonthlyExchangeRate.objects.create(
+                    effective_date=month,
+                    base_currency="GBP",
+                    target_currency="EUR",
+                    exchange_rate=Decimal("1.17"),
+                    rate_type="static",
+                )
+            validate_exchange_rate_coverage({"GBP"}, "EUR", date(2026, 1, 1), date(2026, 2, 1))
 
 
 class QueryHandlerFeatureFlagTest(MasuTestCase):
@@ -68,8 +91,19 @@ class QueryHandlerFeatureFlagTest(MasuTestCase):
             ann = self._make_handler().exchange_rate_annotation_dict
         self.assertEqual(set(ann.keys()), {"exchange_rate", "infra_exchange_rate"})
 
-    def test_response_output_includes_currency(self):
-        """_initialize_response_output always includes currency."""
+    @patch("api.report.queries.validate_exchange_rate_coverage")
+    def test_initialize_response_output(self, mock_validate):
+        """_initialize_response_output includes currency and calls validation (flag ON by default)."""
         handler = self._make_handler()
         output = handler._initialize_response_output(handler.parameters)
         self.assertIn("currency", output)
+        mock_validate.assert_called_once()
+
+    @patch("api.report.ocp.query_handler.is_feature_flag_enabled_by_schema", return_value=False)
+    def test_get_base_currencies_returns_set(self, _):
+        """_get_base_currencies_for_conversion returns a set excluding None."""
+        handler = self._make_handler()
+        with tenant_context(handler.tenant):
+            currencies = handler._get_base_currencies_for_conversion()
+        self.assertIsInstance(currencies, set)
+        self.assertNotIn(None, currencies)

--- a/koku/cost_models/test/test_exchange_rate_annotations.py
+++ b/koku/cost_models/test/test_exchange_rate_annotations.py
@@ -91,9 +91,10 @@ class QueryHandlerFeatureFlagTest(MasuTestCase):
             ann = self._make_handler().exchange_rate_annotation_dict
         self.assertEqual(set(ann.keys()), {"exchange_rate", "infra_exchange_rate"})
 
+    @patch("api.report.queries.is_feature_flag_enabled_by_schema", return_value=True)
     @patch("api.report.queries.validate_exchange_rate_coverage")
-    def test_initialize_response_output(self, mock_validate):
-        """_initialize_response_output includes currency and calls validation (flag ON by default)."""
+    def test_initialize_response_output(self, mock_validate, _):
+        """_initialize_response_output includes currency and calls validation (flag ON)."""
         handler = self._make_handler()
         output = handler._initialize_response_output(handler.parameters)
         self.assertIn("currency", output)

--- a/koku/cost_models/test/test_exchange_rate_annotations.py
+++ b/koku/cost_models/test/test_exchange_rate_annotations.py
@@ -1,0 +1,75 @@
+#
+# Copyright 2026 Red Hat Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Tests for exchange rate annotation builders and feature-flag gating."""
+from unittest.mock import patch
+
+from django.test import TestCase
+from django_tenants.utils import schema_context
+
+from api.currency.exceptions import ExchangeRateNotFound
+from api.currency.utils import build_monthly_rate_annotation
+from api.report.ocp.view import OCPCostView
+from masu.test import MasuTestCase
+
+
+class ExchangeRateNotFoundTest(TestCase):
+    """Test error message formatting for ExchangeRateNotFound."""
+
+    @patch("api.currency.exceptions.settings")
+    def test_message_with_currency_url(self, mock_settings):
+        mock_settings.CURRENCY_URL = "https://example.com"
+        exc = ExchangeRateNotFound(["USD", "GBP"], "EUR", "2026-01-01", "2026-03-01")
+        msg = exc.detail["currency"]
+        self.assertIn("USD -> EUR", msg)
+        self.assertIn("GBP -> EUR", msg)
+        self.assertNotIn("dynamic exchange rates", msg)
+
+    @patch("api.currency.exceptions.settings")
+    def test_message_without_currency_url(self, mock_settings):
+        mock_settings.CURRENCY_URL = ""
+        exc = ExchangeRateNotFound(["USD"], "EUR", "2026-01-01", "2026-03-01")
+        msg = exc.detail["currency"]
+        self.assertIn("dynamic exchange rates", msg)
+
+
+class AnnotationBuilderTest(TestCase):
+    """Test that build_monthly_rate_annotation returns a Subquery expression."""
+
+    def test_returns_subquery(self):
+        from django.db.models import OuterRef
+        from django.db.models import Subquery
+
+        result = build_monthly_rate_annotation(OuterRef("raw_currency"), "EUR")
+        self.assertIsInstance(result, Subquery)
+
+
+class QueryHandlerFeatureFlagTest(MasuTestCase):
+    """Test that the feature flag gates exchange-rate behaviour in query handlers."""
+
+    OCP_PATH = "/api/cost-management/v1/reports/openshift/costs/"
+
+    def _make_handler(self):
+        from api.report.ocp.query_handler import OCPReportQueryHandler
+
+        return OCPReportQueryHandler(self.mocked_query_params("?", OCPCostView, path=self.OCP_PATH))
+
+    @patch("api.report.ocp.query_handler.is_feature_flag_enabled_by_schema", return_value=True)
+    def test_flag_on_uses_subquery_annotations(self, _):
+        """Flag ON → OCP handler returns Subquery-based annotations (both keys present)."""
+        ann = self._make_handler().exchange_rate_annotation_dict
+        self.assertEqual(set(ann.keys()), {"exchange_rate", "infra_exchange_rate"})
+
+    @patch("api.report.ocp.query_handler.is_feature_flag_enabled_by_schema", return_value=False)
+    def test_flag_off_uses_dict_annotations(self, _):
+        """Flag OFF → OCP handler returns Case/When annotations (both keys present)."""
+        with schema_context(self.schema):
+            ann = self._make_handler().exchange_rate_annotation_dict
+        self.assertEqual(set(ann.keys()), {"exchange_rate", "infra_exchange_rate"})
+
+    def test_response_output_includes_currency(self):
+        """_initialize_response_output always includes currency."""
+        handler = self._make_handler()
+        output = handler._initialize_response_output(handler.parameters)
+        self.assertIn("currency", output)

--- a/koku/forecast/forecast.py
+++ b/koku/forecast/forecast.py
@@ -21,7 +21,9 @@ from django.db.models import CharField
 from django.db.models import DecimalField
 from django.db.models import ExpressionWrapper
 from django.db.models import F
+from django.db.models import OuterRef
 from django.db.models import Q
+from django.db.models import Subquery
 from django.db.models import Value
 from django.db.models import When
 from django.db.models.functions import Coalesce
@@ -30,6 +32,8 @@ from statsmodels.sandbox.regression.predstd import wls_prediction_std
 from statsmodels.tools.sm_exceptions import ValueWarning
 
 from api.currency.models import ExchangeRateDictionary
+from api.currency.utils import build_monthly_rate_annotation
+from api.currency.utils import validate_exchange_rate_coverage
 from api.models import Provider
 from api.query_filter import QueryFilter
 from api.query_filter import QueryFilterCollection
@@ -45,6 +49,8 @@ from api.utils import DateHelper
 from api.utils import get_cost_type
 from cost_models.models import CostModel
 from cost_models.models import CostModelMap
+from masu.processor import CONSTANT_CURRENCY_FLAG
+from masu.processor import is_feature_flag_enabled_by_schema
 from reporting.provider.aws.models import AWSOrganizationalUnit
 
 LOG = logging.getLogger(__name__)
@@ -159,12 +165,23 @@ class Forecast:
 
     @cached_property
     def exchange_rate_annotation_dict(self):
-        """Get the exchange rate annotation based on the exchange_rates property."""
-        whens = [
-            When(**{self.provider_map.cost_units_key: k, "then": Value(v.get(self.currency))})
-            for k, v in self.exchange_rates.items()
-        ]
-        return {"exchange_rate": Case(*whens, default=1, output_field=DecimalField())}
+        """Get exchange rate annotation.
+
+        When constant currency is enabled, uses per-month Subquery from
+        MonthlyExchangeRate. Otherwise uses ExchangeRateDictionary via Case/When.
+        """
+        if is_feature_flag_enabled_by_schema(self.params.tenant.schema_name, CONSTANT_CURRENCY_FLAG):
+            exchange_rate_annotation = build_monthly_rate_annotation(
+                OuterRef(self.provider_map.cost_units_key), self.currency
+            )
+        else:
+            whens = [
+                When(**{self.provider_map.cost_units_key: k, "then": Value(v.get(self.currency))})
+                for k, v in self.exchange_rates.items()
+            ]
+            exchange_rate_annotation = Case(*whens, default=1, output_field=DecimalField())
+
+        return {"exchange_rate": exchange_rate_annotation}
 
     def get_data(self):
         """Query the database."""
@@ -184,6 +201,24 @@ class Forecast:
         """Define ORM query to run forecast and return prediction."""
         cost_predictions = {}
         with tenant_context(self.params.tenant):
+            if (
+                is_feature_flag_enabled_by_schema(self.params.tenant.schema_name, CONSTANT_CURRENCY_FLAG)
+                and self.currency
+            ):
+                base_currencies = set(
+                    self.provider_map.query_table.objects.filter(
+                        usage_start__gte=self.query_range[0],
+                        usage_start__lte=self.query_range[1],
+                    )
+                    .values_list(self.provider_map.cost_units_key, flat=True)
+                    .distinct()
+                ) - {None}
+                validate_exchange_rate_coverage(
+                    base_currencies,
+                    self.currency,
+                    self.query_range[0].date(),
+                    self.query_range[1].date(),
+                )
             data = self.get_data()
 
             for fieldname in COST_FIELD_NAMES:
@@ -614,18 +649,36 @@ class OCPForecast(Forecast):
 
     @cached_property
     def exchange_rate_annotation_dict(self):
-        """Get the exchange rate annotation based on the exchange_rates property."""
-        exchange_rate_whens = [
-            When(**{"source_uuid": uuid, "then": Value(self.exchange_rates.get(cur, {}).get(self.currency, 1))})
-            for uuid, cur in self.source_to_currency_map.items()
-        ]
-        infra_exchange_rate_whens = [
-            When(**{self.provider_map.cost_units_key: k, "then": Value(v.get(self.currency))})
-            for k, v in self.exchange_rates.items()
-        ]
+        """Get per-month exchange rate annotations from MonthlyExchangeRate via Subquery.
+
+        When constant currency is enabled, uses OCP-specific dual annotations.
+        Falls back to ExchangeRateDictionary via Case/When when the flag is off.
+        """
+        if is_feature_flag_enabled_by_schema(self.params.tenant.schema_name, CONSTANT_CURRENCY_FLAG):
+            cost_model_currency = Subquery(
+                CostModel.objects.filter(costmodelmap__provider_uuid=OuterRef(OuterRef("source_uuid")),).values(
+                    "currency"
+                )[:1],
+            )
+            exchange_rate_annotation = build_monthly_rate_annotation(cost_model_currency, self.currency)
+            infra_exchange_rate_annotation = build_monthly_rate_annotation(
+                OuterRef(self.provider_map.cost_units_key), self.currency
+            )
+        else:
+            exchange_rate_whens = [
+                When(**{"source_uuid": uuid, "then": Value(self.exchange_rates.get(cur, {}).get(self.currency, 1))})
+                for uuid, cur in self.source_to_currency_map.items()
+            ]
+            infra_exchange_rate_whens = [
+                When(**{self.provider_map.cost_units_key: k, "then": Value(v.get(self.currency))})
+                for k, v in self.exchange_rates.items()
+            ]
+            exchange_rate_annotation = Case(*exchange_rate_whens, default=1, output_field=DecimalField())
+            infra_exchange_rate_annotation = Case(*infra_exchange_rate_whens, default=1, output_field=DecimalField())
+
         return {
-            "exchange_rate": Case(*exchange_rate_whens, default=1, output_field=DecimalField()),
-            "infra_exchange_rate": Case(*infra_exchange_rate_whens, default=1, output_field=DecimalField()),
+            "exchange_rate": exchange_rate_annotation,
+            "infra_exchange_rate": infra_exchange_rate_annotation,
         }
 
 

--- a/koku/forecast/forecast.py
+++ b/koku/forecast/forecast.py
@@ -206,7 +206,7 @@ class Forecast:
                 and self.currency
             ):
                 base_currencies = set(
-                    self.provider_map.query_table.objects.filter(
+                    self.cost_summary_table.objects.filter(
                         usage_start__gte=self.query_range[0],
                         usage_start__lte=self.query_range[1],
                     )

--- a/koku/forecast/test/test_forecast.py
+++ b/koku/forecast/test/test_forecast.py
@@ -923,8 +923,9 @@ class LinearForecastResultTest(IamTestCase):
 class ForecastExchangeRateTest(IamTestCase):
     """Tests for exchange rate annotation and validation in forecast classes."""
 
-    def test_base_forecast_flag_on_uses_subquery(self):
-        """Flag ON (default) → Forecast.exchange_rate_annotation_dict returns a Subquery annotation."""
+    @patch("forecast.forecast.is_feature_flag_enabled_by_schema", return_value=True)
+    def test_base_forecast_flag_on_uses_subquery(self, _):
+        """Flag ON → Forecast.exchange_rate_annotation_dict returns a Subquery annotation."""
         params = self.mocked_query_params("?", AWSCostForecastView)
         instance = AWSForecast(params)
         ann = instance.exchange_rate_annotation_dict
@@ -940,11 +941,13 @@ class ForecastExchangeRateTest(IamTestCase):
         self.assertIn("exchange_rate", ann)
         self.assertIsInstance(ann["exchange_rate"], Case)
 
-    def test_ocp_forecast_flag_on_returns_dual_annotations(self):
-        """Flag ON (default) → OCPForecast returns both exchange_rate and infra_exchange_rate."""
+    @patch("forecast.forecast.is_feature_flag_enabled_by_schema", return_value=True)
+    def test_ocp_forecast_flag_on_returns_dual_annotations(self, _):
+        """Flag ON → OCPForecast returns both exchange_rate and infra_exchange_rate."""
         params = self.mocked_query_params("?", OCPCostForecastView)
         instance = OCPForecast(params)
-        ann = instance.exchange_rate_annotation_dict
+        with schema_context(self.schema_name):
+            ann = instance.exchange_rate_annotation_dict
         self.assertEqual(set(ann.keys()), {"exchange_rate", "infra_exchange_rate"})
 
     @patch("forecast.forecast.is_feature_flag_enabled_by_schema", return_value=False)

--- a/koku/forecast/test/test_forecast.py
+++ b/koku/forecast/test/test_forecast.py
@@ -13,6 +13,9 @@ from unittest.mock import Mock
 from unittest.mock import patch
 from uuid import uuid4
 
+from django.db.models import Case
+from django.db.models import Subquery
+from django_tenants.utils import schema_context
 from statsmodels.tools.sm_exceptions import ValueWarning
 
 from api.forecast.views import AWSCostForecastView
@@ -915,3 +918,64 @@ class LinearForecastResultTest(IamTestCase):
         self.assertEqual(lfr.pvalues, ["99999.00000000", "88888.00000000"])
         self.assertEqual(lfr.slope, 77777)
         self.assertEqual(lfr.intercept, 66666)
+
+
+class ForecastExchangeRateTest(IamTestCase):
+    """Tests for exchange rate annotation and validation in forecast classes."""
+
+    def test_base_forecast_flag_on_uses_subquery(self):
+        """Flag ON (default) → Forecast.exchange_rate_annotation_dict returns a Subquery annotation."""
+        params = self.mocked_query_params("?", AWSCostForecastView)
+        instance = AWSForecast(params)
+        ann = instance.exchange_rate_annotation_dict
+        self.assertIn("exchange_rate", ann)
+        self.assertIsInstance(ann["exchange_rate"], Subquery)
+
+    @patch("forecast.forecast.is_feature_flag_enabled_by_schema", return_value=False)
+    def test_base_forecast_flag_off_uses_case(self, _):
+        """Flag OFF → Forecast.exchange_rate_annotation_dict returns a Case annotation."""
+        params = self.mocked_query_params("?", AWSCostForecastView)
+        instance = AWSForecast(params)
+        ann = instance.exchange_rate_annotation_dict
+        self.assertIn("exchange_rate", ann)
+        self.assertIsInstance(ann["exchange_rate"], Case)
+
+    def test_ocp_forecast_flag_on_returns_dual_annotations(self):
+        """Flag ON (default) → OCPForecast returns both exchange_rate and infra_exchange_rate."""
+        params = self.mocked_query_params("?", OCPCostForecastView)
+        instance = OCPForecast(params)
+        ann = instance.exchange_rate_annotation_dict
+        self.assertEqual(set(ann.keys()), {"exchange_rate", "infra_exchange_rate"})
+
+    @patch("forecast.forecast.is_feature_flag_enabled_by_schema", return_value=False)
+    def test_ocp_forecast_flag_off_returns_dual_case_annotations(self, _):
+        """Flag OFF → OCPForecast returns both keys via Case/When."""
+        params = self.mocked_query_params("?", OCPCostForecastView)
+        instance = OCPForecast(params)
+        with schema_context(self.schema_name):
+            ann = instance.exchange_rate_annotation_dict
+        self.assertEqual(set(ann.keys()), {"exchange_rate", "infra_exchange_rate"})
+        self.assertIsInstance(ann["exchange_rate"], Case)
+
+    @patch("forecast.forecast.validate_exchange_rate_coverage")
+    @patch("forecast.forecast.is_feature_flag_enabled_by_schema", return_value=False)
+    def test_predict_skips_validation_when_flag_off(self, _, mock_validate):
+        """predict() does not call validate_exchange_rate_coverage when flag is disabled."""
+        dh = DateHelper()
+        expected = [
+            {
+                "usage_start": dh.n_days_ago(dh.today, 10 - n).date(),
+                "total_cost": 5 + (0.01 * n),
+                "infrastructure_cost": 3 + (0.01 * n),
+                "supplementary_cost": 2 + (0.01 * n),
+            }
+            for n in range(10)
+        ]
+        mock_qset = MockQuerySet(expected)
+        params = self.mocked_query_params("?", AWSCostForecastView)
+        instance = AWSForecast(params)
+
+        with patch("forecast.forecast.AWSForecast.get_data", return_value=mock_qset):
+            instance.predict()
+
+        mock_validate.assert_not_called()

--- a/koku/koku/feature_flags.py
+++ b/koku/koku/feature_flags.py
@@ -33,6 +33,7 @@ class MockUnleashClient:
         "cost-management.backend.ocp_gpu_cost_model": True,
         "cost-management.backend.disable-ingress-rate-limit": True,
         "cost-management.backend.override_customer_group_by_limit": False,
+        "cost-management.backend.constant-currency": True,
     }
 
     def __init__(self, app_name, environment, instance_id, **kwargs):

--- a/koku/koku/test_feature_flags.py
+++ b/koku/koku/test_feature_flags.py
@@ -29,6 +29,11 @@ class MockUnleashClientTest(TestCase):
         result = self.client.is_enabled("cost-management.backend.disable-ingress-rate-limit")
         self.assertTrue(result)
 
+    def test_onprem_constant_currency_flag_returns_true(self):
+        """Override map returns True for constant-currency."""
+        result = self.client.is_enabled("cost-management.backend.constant-currency")
+        self.assertTrue(result)
+
     def test_override_takes_precedence_over_fallback(self):
         """Override map is checked before the fallback function."""
 

--- a/koku/masu/api/monthly_exchange_rates.py
+++ b/koku/masu/api/monthly_exchange_rates.py
@@ -6,6 +6,7 @@
 import datetime
 
 from django.views.decorators.cache import never_cache
+from django_tenants.utils import schema_context
 from rest_framework.decorators import api_view
 from rest_framework.decorators import permission_classes
 from rest_framework.decorators import renderer_classes
@@ -25,11 +26,16 @@ def monthly_exchange_rates(request):
     """Return stored MonthlyExchangeRate rows, optionally filtered by date range and currency pair.
 
     Query parameters:
-        start_date  - filter effective_date >= (YYYY-MM-DD, default: no lower bound)
-        end_date    - filter effective_date <= (YYYY-MM-DD, default: no upper bound)
+        schema          - tenant schema name (required)
+        start_date      - filter effective_date >= (YYYY-MM-DD, default: no lower bound)
+        end_date        - filter effective_date <= (YYYY-MM-DD, default: no upper bound)
         base_currency   - filter by base currency code
         target_currency - filter by target currency code
     """
+    schema = request.query_params.get("schema")
+    if not schema:
+        raise ValidationError({"schema": "This parameter is required."})
+
     filters = {}
     if start := request.query_params.get("start_date"):
         try:
@@ -48,10 +54,11 @@ def monthly_exchange_rates(request):
     if target := request.query_params.get("target_currency"):
         filters["target_currency"] = target.upper()
 
-    rates = list(
-        MonthlyExchangeRate.objects.filter(**filters)
-        .order_by("base_currency", "target_currency", "effective_date")
-        .values("effective_date", "base_currency", "target_currency", "exchange_rate", "rate_type")
-    )
+    with schema_context(schema):
+        rates = list(
+            MonthlyExchangeRate.objects.filter(**filters)
+            .order_by("base_currency", "target_currency", "effective_date")
+            .values("effective_date", "base_currency", "target_currency", "exchange_rate", "rate_type")
+        )
 
     return Response({"count": len(rates), "rates": rates})

--- a/koku/masu/api/monthly_exchange_rates.py
+++ b/koku/masu/api/monthly_exchange_rates.py
@@ -3,10 +3,13 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 """Admin endpoint to inspect MonthlyExchangeRate rows."""
+import datetime
+
 from django.views.decorators.cache import never_cache
 from rest_framework.decorators import api_view
 from rest_framework.decorators import permission_classes
 from rest_framework.decorators import renderer_classes
+from rest_framework.exceptions import ValidationError
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.settings import api_settings
@@ -29,8 +32,16 @@ def monthly_exchange_rates(request):
     """
     filters = {}
     if start := request.query_params.get("start_date"):
+        try:
+            datetime.date.fromisoformat(start)
+        except ValueError:
+            raise ValidationError({"start_date": "Invalid date format. Use YYYY-MM-DD."})
         filters["effective_date__gte"] = start
     if end := request.query_params.get("end_date"):
+        try:
+            datetime.date.fromisoformat(end)
+        except ValueError:
+            raise ValidationError({"end_date": "Invalid date format. Use YYYY-MM-DD."})
         filters["effective_date__lte"] = end
     if base := request.query_params.get("base_currency"):
         filters["base_currency"] = base.upper()

--- a/koku/masu/api/monthly_exchange_rates.py
+++ b/koku/masu/api/monthly_exchange_rates.py
@@ -1,0 +1,46 @@
+#
+# Copyright 2026 Red Hat Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Admin endpoint to inspect MonthlyExchangeRate rows."""
+from django.views.decorators.cache import never_cache
+from rest_framework.decorators import api_view
+from rest_framework.decorators import permission_classes
+from rest_framework.decorators import renderer_classes
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from rest_framework.settings import api_settings
+
+from cost_models.models import MonthlyExchangeRate
+
+
+@never_cache
+@api_view(http_method_names=["GET"])
+@permission_classes((AllowAny,))
+@renderer_classes(tuple(api_settings.DEFAULT_RENDERER_CLASSES))
+def monthly_exchange_rates(request):
+    """Return stored MonthlyExchangeRate rows, optionally filtered by date range and currency pair.
+
+    Query parameters:
+        start_date  - filter effective_date >= (YYYY-MM-DD, default: no lower bound)
+        end_date    - filter effective_date <= (YYYY-MM-DD, default: no upper bound)
+        base_currency   - filter by base currency code
+        target_currency - filter by target currency code
+    """
+    filters = {}
+    if start := request.query_params.get("start_date"):
+        filters["effective_date__gte"] = start
+    if end := request.query_params.get("end_date"):
+        filters["effective_date__lte"] = end
+    if base := request.query_params.get("base_currency"):
+        filters["base_currency"] = base.upper()
+    if target := request.query_params.get("target_currency"):
+        filters["target_currency"] = target.upper()
+
+    rates = list(
+        MonthlyExchangeRate.objects.filter(**filters)
+        .order_by("base_currency", "target_currency", "effective_date")
+        .values("effective_date", "base_currency", "target_currency", "exchange_rate", "rate_type")
+    )
+
+    return Response({"count": len(rates), "rates": rates})

--- a/koku/masu/api/monthly_exchange_rates.py
+++ b/koku/masu/api/monthly_exchange_rates.py
@@ -15,7 +15,16 @@ from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.settings import api_settings
 
+from api.iam.models import Tenant
 from cost_models.models import MonthlyExchangeRate
+
+
+def _validate_date_param(value, param_name):
+    """Validate an ISO-format date string, raising ValidationError on failure."""
+    try:
+        datetime.date.fromisoformat(value)
+    except ValueError:
+        raise ValidationError({param_name: "Invalid date format. Use YYYY-MM-DD."})
 
 
 @never_cache
@@ -35,19 +44,15 @@ def monthly_exchange_rates(request):
     schema = request.query_params.get("schema")
     if not schema:
         raise ValidationError({"schema": "This parameter is required."})
+    if not Tenant.objects.filter(schema_name=schema).exists():
+        raise ValidationError({"schema": f"Schema '{schema}' does not exist."})
 
     filters = {}
     if start := request.query_params.get("start_date"):
-        try:
-            datetime.date.fromisoformat(start)
-        except ValueError:
-            raise ValidationError({"start_date": "Invalid date format. Use YYYY-MM-DD."})
+        _validate_date_param(start, "start_date")
         filters["effective_date__gte"] = start
     if end := request.query_params.get("end_date"):
-        try:
-            datetime.date.fromisoformat(end)
-        except ValueError:
-            raise ValidationError({"end_date": "Invalid date format. Use YYYY-MM-DD."})
+        _validate_date_param(end, "end_date")
         filters["effective_date__lte"] = end
     if base := request.query_params.get("base_currency"):
         filters["base_currency"] = base.upper()

--- a/koku/masu/api/urls.py
+++ b/koku/masu/api/urls.py
@@ -31,6 +31,7 @@ from masu.api.views import ingress_reports
 from masu.api.views import invalidate_cache
 from masu.api.views import lockinfo
 from masu.api.views import ManifestStatusViewSet
+from masu.api.views import monthly_exchange_rates
 from masu.api.views import notification
 from masu.api.views import pg_engine_version
 from masu.api.views import purge_trino_files
@@ -85,6 +86,7 @@ urlpatterns = [
     path("db-performance/db-version/", pg_engine_version, name="db_version"),
     path("db-performance/schema-sizes/", schema_sizes, name="schema_sizes"),
     path("invalidate_cache/", invalidate_cache, name="invalidate_cache"),
+    path("monthly_exchange_rates/", monthly_exchange_rates, name="monthly_exchange_rates"),
 ]
 
 if settings.DEBUG:

--- a/koku/masu/api/views.py
+++ b/koku/masu/api/views.py
@@ -24,6 +24,7 @@ from masu.api.ingest_ocp_payload import ingest_ocp_payload
 from masu.api.ingress_reports import ingress_reports
 from masu.api.invalidate_cache import invalidate_cache
 from masu.api.manifest.views import ManifestStatusViewSet
+from masu.api.monthly_exchange_rates import monthly_exchange_rates
 from masu.api.notifications import notification
 from masu.api.purge_trino_files import purge_trino_files
 from masu.api.recheck_infra_map import recheck_infra_map

--- a/koku/masu/processor/__init__.py
+++ b/koku/masu/processor/__init__.py
@@ -27,6 +27,7 @@ COST_MODEL_WRITE_FREEZE_FLAG = "cost-management.backend.disable-cost-model-write
 COST_BREAKDOWN_RTU_UNLEASH_FLAG = "cost-management.backend.cost_breakdown_rates_to_usage"
 CROSS_ORG_CLUSTER_LOOKUP_FLAG = "cost-management.backend.is_cross_org_cluster_lookup_enabled"
 OCP_POST_WRITE_PARQUET_DEDUP_FLAG = "cost-management.backend.ocp_post_write_parquet_dedup"
+CONSTANT_CURRENCY_FLAG = "cost-management.backend.constant-currency"
 
 
 def is_feature_flag_enabled_by_schema(schema, feature_flag, dev_fallback=False):  # pragma: no cover

--- a/koku/masu/test/api/test_monthly_exchange_rates.py
+++ b/koku/masu/test/api/test_monthly_exchange_rates.py
@@ -54,3 +54,10 @@ class MonthlyExchangeRatesTest(MasuTestCase):
             reverse("monthly_exchange_rates"), {"schema": self.schema, "end_date": "not-a-date"}
         )
         self.assertEqual(response.status_code, 400)
+
+    @patch("koku.middleware.MASU", return_value=True)
+    def test_nonexistent_schema_returns_400(self, _):
+        """Test that a non-existent schema returns 400 instead of 500."""
+        response = self.client.get(reverse("monthly_exchange_rates"), {"schema": "nonexistent"})
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("does not exist", response.json()["errors"][0]["detail"])

--- a/koku/masu/test/api/test_monthly_exchange_rates.py
+++ b/koku/masu/test/api/test_monthly_exchange_rates.py
@@ -1,0 +1,31 @@
+#
+# Copyright 2026 Red Hat Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Test the monthly_exchange_rates endpoint view."""
+from unittest.mock import patch
+
+from django.test.utils import override_settings
+from django.urls import reverse
+
+from masu.test import MasuTestCase
+
+
+@override_settings(ROOT_URLCONF="masu.urls")
+class MonthlyExchangeRatesTest(MasuTestCase):
+    """Test Cases for the monthly_exchange_rates endpoint."""
+
+    @patch("koku.middleware.MASU", return_value=True)
+    def test_missing_schema_returns_400(self, _):
+        """Test that omitting the schema parameter returns 400."""
+        response = self.client.get(reverse("monthly_exchange_rates"))
+        self.assertEqual(response.status_code, 400)
+
+    @patch("koku.middleware.MASU", return_value=True)
+    def test_get_rates(self, _):
+        """Test the endpoint returns 200 with valid schema."""
+        response = self.client.get(reverse("monthly_exchange_rates"), {"schema": self.schema})
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertIn("count", body)
+        self.assertIn("rates", body)

--- a/koku/masu/test/api/test_monthly_exchange_rates.py
+++ b/koku/masu/test/api/test_monthly_exchange_rates.py
@@ -23,9 +23,34 @@ class MonthlyExchangeRatesTest(MasuTestCase):
 
     @patch("koku.middleware.MASU", return_value=True)
     def test_get_rates(self, _):
-        """Test the endpoint returns 200 with valid schema."""
-        response = self.client.get(reverse("monthly_exchange_rates"), {"schema": self.schema})
+        """Test the endpoint returns 200 with all optional filters."""
+        response = self.client.get(
+            reverse("monthly_exchange_rates"),
+            {
+                "schema": self.schema,
+                "start_date": "2026-01-01",
+                "end_date": "2026-06-01",
+                "base_currency": "usd",
+                "target_currency": "eur",
+            },
+        )
         self.assertEqual(response.status_code, 200)
         body = response.json()
         self.assertIn("count", body)
         self.assertIn("rates", body)
+
+    @patch("koku.middleware.MASU", return_value=True)
+    def test_invalid_start_date_returns_400(self, _):
+        """Test that an invalid start_date format returns 400."""
+        response = self.client.get(
+            reverse("monthly_exchange_rates"), {"schema": self.schema, "start_date": "not-a-date"}
+        )
+        self.assertEqual(response.status_code, 400)
+
+    @patch("koku.middleware.MASU", return_value=True)
+    def test_invalid_end_date_returns_400(self, _):
+        """Test that an invalid end_date format returns 400."""
+        response = self.client.get(
+            reverse("monthly_exchange_rates"), {"schema": self.schema, "end_date": "not-a-date"}
+        )
+        self.assertEqual(response.status_code, 400)


### PR DESCRIPTION
## Summary
- Return **400** instead of allowing a disable with a warning when the currency is referenced by cost models, price lists, or is the system/user default currency.
- Per PRD requirement: *"Customers are prevented from disabling base currencies currently in use (Cloud providers, cost models, or defined as the default currency). The system MUST block the user from disabling these."*
- Adds a new test for blocking the system default currency (USD).

## Test plan
- [x] `test_disable_currency_in_use_by_cost_model_blocked` — returns 400, currency remains enabled
- [x] `test_disable_currency_in_use_by_price_list_blocked` — returns 400, currency remains enabled
- [x] `test_disable_default_currency_blocked` — returns 400, USD remains enabled
- [x] `test_disable_currency` — currencies not in use can still be disabled (204)
- [x] All existing currency view tests pass


Made with [Cursor](https://cursor.com)