### PR TITLE
Fix host-side S3 endpoint in load-test-customer-data

### DIFF
--- a/dev/scripts/common/utils.sh
+++ b/dev/scripts/common/utils.sh
@@ -1,5 +1,19 @@
 #!/usr/bin/env bash
 
+# Map Docker Compose S3 hostnames to a host-reachable endpoint (s4-path-proxy on :9000).
+normalize_host_s3_endpoint() {
+    local endpoint="${1:-http://localhost:9000}"
+    endpoint="${endpoint/koku-s4-proxy/localhost}"
+    endpoint="${endpoint/koku-s4/localhost}"
+    endpoint="${endpoint/koku-minio/localhost}"
+    endpoint="${endpoint/http:\/\/s4/http:\/\/localhost}"
+    # S4 RGW listens on 7480 in-container; compose publishes host 9000 -> 7480.
+    if [[ "${endpoint}" == *localhost* && "${endpoint}" == *:7480* ]]; then
+        endpoint="${endpoint/:7480/:9000}"
+    fi
+    echo "${endpoint}"
+}
+
 check_vars() {
     # Variable validation.
     #

--- a/dev/scripts/load_test_customer_data.sh
+++ b/dev/scripts/load_test_customer_data.sh
@@ -77,8 +77,9 @@ export S3_ACCESS_KEY="${S3_ACCESS_KEY:-s4admin}"
 export S3_SECRET_KEY="${S3_SECRET:-s4secret}"
 export S3_BUCKET_NAME="${S3_BUCKET_NAME_OCP_INGRESS-ocp-ingress}"
 
-# nise runs on the host; S3_ENDPOINT is host-only (default: localhost:9000 via s4-path-proxy).
-export MINIO_UPLOAD="${S3_ENDPOINT-http://localhost:9000}"
+# nise runs on the host; normalize Docker-internal S3_ENDPOINT values from .env.
+export MINIO_UPLOAD="$(normalize_host_s3_endpoint "${S3_ENDPOINT:-http://localhost:9000}")"
+log-info "OCP ingress upload endpoint (host): ${MINIO_UPLOAD}"
 log-debug "MINIO_UPLOAD=${MINIO_UPLOAD}"
 
 
@@ -201,6 +202,29 @@ trigger_download() {
   done
 }
 
+verify_ocp_payload_in_s3() {
+  #
+  # Args:
+  #   1 - S3 object key (payload name)
+  #
+  local payload_key=$1
+  if ! command -v docker &>/dev/null; then
+    log-warn "docker not available; skipping S3 payload verification for ${payload_key}"
+    return 0
+  fi
+  if ! docker run --rm --network host \
+    -e AWS_ACCESS_KEY_ID="${S3_ACCESS_KEY}" \
+    -e AWS_SECRET_ACCESS_KEY="${S3_SECRET_KEY}" \
+    amazon/aws-cli:latest \
+    --endpoint-url "${MINIO_UPLOAD}" \
+    s3api head-object --bucket "${S3_BUCKET_NAME}" --key "${payload_key}" &>/dev/null; then
+    log-err "OCP payload not found in s3://${S3_BUCKET_NAME}/${payload_key}"
+    log-err "nise upload likely failed. Confirm s4-path-proxy is running and MINIO_UPLOAD=${MINIO_UPLOAD} is reachable."
+    exit 1
+  fi
+  log-info "Verified OCP payload exists in S3: ${payload_key}"
+}
+
 trigger_ocp_ingest() {
   #
   # Args:
@@ -224,6 +248,7 @@ trigger_ocp_ingest() {
     fi
     while [ ! "$formatted_start_date" \> "$formatted_end_date" ]; do
       local payload_name="$2.$formatted_start_date.tar.gz"
+      verify_ocp_payload_in_s3 "${payload_name}"
       log-info "Triggering ingest for, source_name: $1, uuid: $UUID, org_id: $ORG_ID, payload_name: $payload_name"
       local url="$MASU_URL_PREFIX/v1/ingest_ocp_payload/?org_id=$ORG_ID&payload_name=$payload_name"
       log-info "url: $url"

--- a/dev/scripts/load_test_customer_data.sh
+++ b/dev/scripts/load_test_customer_data.sh
@@ -208,16 +208,26 @@ verify_ocp_payload_in_s3() {
   #   1 - S3 object key (payload name)
   #
   local payload_key=$1
-  if ! command -v docker &>/dev/null; then
-    log-warn "docker not available; skipping S3 payload verification for ${payload_key}"
+  local exit_code=0
+
+  if command -v aws &>/dev/null; then
+    AWS_ACCESS_KEY_ID="${S3_ACCESS_KEY}" AWS_SECRET_ACCESS_KEY="${S3_SECRET_KEY}" \
+      aws --endpoint-url "${MINIO_UPLOAD}" s3api head-object \
+      --bucket "${S3_BUCKET_NAME}" --key "${payload_key}" &>/dev/null || exit_code=$?
+  elif command -v docker &>/dev/null; then
+    log-warn "aws CLI not found; falling back to docker for S3 payload verification"
+    docker run --rm --network host \
+      -e AWS_ACCESS_KEY_ID="${S3_ACCESS_KEY}" \
+      -e AWS_SECRET_ACCESS_KEY="${S3_SECRET_KEY}" \
+      amazon/aws-cli:latest \
+      --endpoint-url "${MINIO_UPLOAD}" \
+      s3api head-object --bucket "${S3_BUCKET_NAME}" --key "${payload_key}" &>/dev/null || exit_code=$?
+  else
+    log-warn "Neither aws CLI nor docker is available; skipping S3 payload verification for ${payload_key}"
     return 0
   fi
-  if ! docker run --rm --network host \
-    -e AWS_ACCESS_KEY_ID="${S3_ACCESS_KEY}" \
-    -e AWS_SECRET_ACCESS_KEY="${S3_SECRET_KEY}" \
-    amazon/aws-cli:latest \
-    --endpoint-url "${MINIO_UPLOAD}" \
-    s3api head-object --bucket "${S3_BUCKET_NAME}" --key "${payload_key}" &>/dev/null; then
+
+  if [[ ${exit_code} -ne 0 ]]; then
     log-err "OCP payload not found in s3://${S3_BUCKET_NAME}/${payload_key}"
     log-err "nise upload likely failed. Confirm s4-path-proxy is running and MINIO_UPLOAD=${MINIO_UPLOAD} is reachable."
     exit 1

--- a/dev/scripts/s3_smoke_test.sh
+++ b/dev/scripts/s3_smoke_test.sh
@@ -24,6 +24,7 @@ DEV_SCRIPTS_PATH=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 KOKU_ROOT=$(cd -- "${DEV_SCRIPTS_PATH}/../.." &>/dev/null && pwd)
 
 source "${DEV_SCRIPTS_PATH}/common/logging.sh"
+source "${DEV_SCRIPTS_PATH}/common/utils.sh"
 
 # Defaults match S4 local dev (see docker-compose.yml).
 S3_ENDPOINT="${S3_ENDPOINT:-http://localhost:9000}"
@@ -34,20 +35,7 @@ KOKU_BUCKET="${S3_BUCKET_NAME:-koku-bucket}"
 OCP_BUCKET="${S3_BUCKET_NAME_OCP_INGRESS:-ocp-ingress}"
 METASTORE_BUCKET="${S3_METASTORE_BUCKET:-metastore}"
 
-# When running from the host, Docker-internal hostnames are not resolvable.
-# Map common compose service names to localhost (port must match compose publish).
-normalize_host_endpoint() {
-    local endpoint=$1
-    endpoint="${endpoint/koku-s4-proxy/localhost}"
-    endpoint="${endpoint/koku-s4/localhost}"
-    endpoint="${endpoint/koku-minio/localhost}"
-    endpoint="${endpoint/http:\/\/s4/http:\/\/localhost}"
-    # S4 RGW listens on 7480 in-container; compose publishes host 9000 -> 7480.
-    if [[ "${endpoint}" == *localhost* && "${endpoint}" == *:7480* ]]; then
-        endpoint="${endpoint/:7480/:9000}"
-    fi
-    echo "${endpoint}"
-}
+S3_HOST_ENDPOINT="$(normalize_host_s3_endpoint "${S3_ENDPOINT}")"
 
 endpoint_port() {
     local endpoint=$1
@@ -60,7 +48,6 @@ endpoint_port() {
     fi
 }
 
-S3_HOST_ENDPOINT="$(normalize_host_endpoint "${S3_ENDPOINT}")"
 S3_ENDPOINT_PORT="$(endpoint_port "${S3_HOST_ENDPOINT}")"
 
 export AWS_ACCESS_KEY_ID="${S3_ACCESS_KEY}"


### PR DESCRIPTION
## Summary
- Add shared `normalize_host_s3_endpoint()` so host scripts map Docker-internal S3 URLs (e.g. `koku-s4-proxy:7480`) to `localhost:9000`
- Use the normalized endpoint in `load_test_customer_data.sh` when nise uploads OCP payloads via `--minio-upload`
- Verify the payload exists in `ocp-ingress` before triggering ingest, avoiding opaque masu 404 errors
- Reuse the shared helper in `s3_smoke_test.sh` instead of duplicating the logic

## Problem
`make load-test-customer-data` runs nise on the host but `.env` sets `S3_ENDPOINT` to a Docker-internal hostname. Uploads fail silently and ingest later returns 404 because the object was never stored in S4.

## Test plan
- [ ] `make trino-stack-up` (ensure `s4-path-proxy` is on port 9000)
- [ ] `make create-test-customer` (if needed)
- [ ] `make load-test-customer-data test_source=ONPREM` with `S3_ENDPOINT=http://koku-s4-proxy:7480` in `.env`
- [ ] Confirm log shows `OCP ingress upload endpoint (host): http://localhost:9000`
- [ ] Confirm payloads appear in `s3://ocp-ingress/` and ingest completes without 404


Made with [Cursor](https://cursor.com)