### PR TITLE
Disable constant-currency flag for on-prem until MER backfill is implemented

### DIFF
--- a/koku/koku/feature_flags.py
+++ b/koku/koku/feature_flags.py
@@ -33,7 +33,7 @@ class MockUnleashClient:
         "cost-management.backend.ocp_gpu_cost_model": True,
         "cost-management.backend.disable-ingress-rate-limit": True,
         "cost-management.backend.override_customer_group_by_limit": False,
-        "cost-management.backend.constant-currency": True,
+        "cost-management.backend.constant-currency": False,
     }
 
     def __init__(self, app_name, environment, instance_id, **kwargs):

--- a/koku/koku/test_feature_flags.py
+++ b/koku/koku/test_feature_flags.py
@@ -29,10 +29,10 @@ class MockUnleashClientTest(TestCase):
         result = self.client.is_enabled("cost-management.backend.disable-ingress-rate-limit")
         self.assertTrue(result)
 
-    def test_onprem_constant_currency_flag_returns_true(self):
-        """Override map returns True for constant-currency."""
+    def test_onprem_constant_currency_flag_returns_false(self):
+        """Override map returns False for constant-currency (disabled until MER backfill is implemented)."""
         result = self.client.is_enabled("cost-management.backend.constant-currency")
-        self.assertTrue(result)
+        self.assertFalse(result)
 
     def test_override_takes_precedence_over_fallback(self):
         """Override map is checked before the fallback function."""

--- a/koku/koku/test_feature_flags.py
+++ b/koku/koku/test_feature_flags.py
@@ -29,11 +29,6 @@ class MockUnleashClientTest(TestCase):
         result = self.client.is_enabled("cost-management.backend.disable-ingress-rate-limit")
         self.assertTrue(result)
 
-    def test_onprem_constant_currency_flag_returns_false(self):
-        """Override map returns False for constant-currency (disabled until MER backfill is implemented)."""
-        result = self.client.is_enabled("cost-management.backend.constant-currency")
-        self.assertFalse(result)
-
     def test_override_takes_precedence_over_fallback(self):
         """Override map is checked before the fallback function."""
 


### PR DESCRIPTION
## Summary

After [#6175](https://github.com/project-koku/koku/pull/6175) was merged, on-prem tests in ephemeral environments started failing with:

```
400 Bad Request: No exchange rate available for CAD -> USD, NOK -> USD... for 2026-06-01 to 2026-06-01.
Ask your administrator to configure static exchange rates.
```

**Root cause:** `constant-currency` was set to `True` in `ONPREM_FLAG_DEFAULTS`, which activates `validate_exchange_rate_coverage` on every report request. In ephemeral environments, `MonthlyExchangeRate` (MER) starts empty — the Celery task only populates the current month — so requests covering historical months return 400 with no fallback.

This is a rollout gap: the feature was enabled before the MER population strategy for ephemeral/historical months was in place.

## Fix

Set `constant-currency` to `False` in `ONPREM_FLAG_DEFAULTS` to restore previous behavior and unblock on-prem testing pipelines.

Note: `CURRENCY_URL` is not the issue — it already has a default value (`open.er-api.com`) in `settings.py`.

## Follow-up

A separate PR will implement the on-demand MER backfill described in the PRD (section 9): when a required rate is missing for a historical month, trigger an on-demand fetch from `CURRENCY_URL` and apply it retrospectively. Once that is in place, this flag can be re-enabled.

## Testing

- On-prem ephemeral tests should pass again after this change
- No impact on SaaS — SaaS uses the real `UnleashClient` which has the flag disabled by default

Made with [Cursor](https://cursor.com)