### PR TITLE
RTU: unleash control for populate_tag_based_costs

### DIFF
--- a/koku/masu/database/ocp_report_db_accessor.py
+++ b/koku/masu/database/ocp_report_db_accessor.py
@@ -1807,11 +1807,12 @@ AND (month = {{month_no_zero}} OR month = {{month}})
         cluster_params,
         cost_model_id=None,
         rate_info_map=None,
+        use_rtu: bool = False,
     ):
         """Populate the tag based costs.
 
-        This method populates the daily summary table with tag-based costs for
-        the metrics highlighted in the metadata section.
+        Inserts per-tag usage costs into rates_to_usage (use_rtu=True) or
+        directly into the daily summary table (legacy, use_rtu=False).
         """
         report_period = self.report_periods_for_provider_uuid(provider_uuid, start_date)
         if not report_period or not metric_to_tag_params_map:
@@ -1829,34 +1830,35 @@ AND (month = {{month_no_zero}} OR month = {{month}})
         ]
         requires_gpu_table = [metric_constants.OCP_GPU_MONTH]
 
+        _rtu = "_rtu" if use_rtu else ""
         metric_metadata = {
             metric_constants.OCP_VM_HOUR: {
                 "log_msg": "populating hourly VM tag based costs",
-                "file_path": f"{self.get_sql_folder_name()}/openshift/cost_model/hourly_cost_vm_tag_based.sql",
+                "file_path": f"{self.get_sql_folder_name()}/openshift/cost_model/hourly_cost_vm_tag_based{_rtu}.sql",
                 "metric_params": {"use_fractional_hours": vm_table_exists},
             },
             metric_constants.OCP_VM_MONTH: {
                 "log_msg": "populating monthly VM tag based costs",
-                "file_path": "sql/openshift/cost_model/monthly_cost_virtual_machine.sql",
+                "file_path": f"sql/openshift/cost_model/monthly_cost_virtual_machine{_rtu}.sql",
                 "metric_params": monthly_params,
             },
             metric_constants.OCP_VM_CORE_MONTH: {
                 "log_msg": "populating monthly VM Core based costs",
-                "file_path": f"{self.get_sql_folder_name()}/openshift/cost_model/monthly_vm_core_tag_based.sql",
+                "file_path": f"{self.get_sql_folder_name()}/openshift/cost_model/monthly_vm_core_tag_based{_rtu}.sql",
                 "metric_params": monthly_params,
             },
             metric_constants.OCP_VM_CORE_HOUR: {
                 "log_msg": "populating hourly VM Core based costs",
-                "file_path": f"{self.get_sql_folder_name()}/openshift/cost_model/hourly_vm_core_tag_based.sql",
+                "file_path": f"{self.get_sql_folder_name()}/openshift/cost_model/hourly_vm_core_tag_based{_rtu}.sql",
             },
             metric_constants.OCP_GPU_MONTH: {
                 "log_msg": "populating monthly GPU tag based costs",
-                "file_path": f"{self.get_sql_folder_name()}/openshift/cost_model/monthly_cost_gpu.sql",
+                "file_path": f"{self.get_sql_folder_name()}/openshift/cost_model/monthly_cost_gpu{_rtu}.sql",
                 "metric_params": {**monthly_params, **cluster_params},
             },
             metric_constants.OCP_PROJECT_MONTH: {
                 "log_msg": "populating monthly project tag costs",
-                "file_path": f"{self.get_sql_folder_name()}/openshift/cost_model/monthly_project_tag_based.sql",
+                "file_path": f"{self.get_sql_folder_name()}/openshift/cost_model/monthly_project_tag_based{_rtu}.sql",
                 "metric_params": {**monthly_params, **cluster_params},
             },
         }

--- a/koku/masu/processor/ocp/ocp_cost_model_cost_updater.py
+++ b/koku/masu/processor/ocp/ocp_cost_model_cost_updater.py
@@ -790,11 +790,12 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
     def update_summary_cost_model_costs(self, summary_range: SummaryRangeConfig) -> None:
         """Update the OCP summary table with the charge information.
 
-        Phase 3 converted all monthly/tag/VM SQL to INSERT into rates_to_usage,
-        so all cost types now require the RTU pipeline.  The feature flag is
-        checked and a warning is emitted when it is OFF, but the RTU path runs
-        unconditionally because aggregation (which rebuilds daily-summary from
-        RTU) would otherwise discard any legacy direct-written rows.
+        Phase 3 converted all monthly/tag/VM SQL to INSERT into rates_to_usage.
+        When COST_BREAKDOWN_RTU_UNLEASH_FLAG is enabled, usage costs are written
+        to rates_to_usage and then aggregated back into the daily summary via
+        aggregate_rates_to_daily_summary. When it is disabled, usage costs and
+        the monthly/tag/VM costs below write directly to the daily summary and
+        no aggregation step is needed.
 
         Args:
             start_date (str, Optional) - Start date of range to update derived cost.
@@ -831,17 +832,15 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                 self._schema, COST_BREAKDOWN_RTU_UNLEASH_FLAG, dev_fallback=False
             )
 
-            LOG.info(
-                log_json(
-                    msg="cost pipeline path selected",
-                    rtu_enabled=rtu_enabled,
-                    cost_model_id=str(self._cost_model_id) if self._cost_model_id else None,
-                    provider_uuid=self._provider_uuid,
-                )
-            )
-
             if rtu_enabled:
-                # RTU path (Phase 3): all cost types write through rates_to_usage,
+                LOG.info(
+                    log_json(
+                        msg="RTU pipeline path selected",
+                        cost_model_id=str(self._cost_model_id) if self._cost_model_id else None,
+                        provider_uuid=self._provider_uuid,
+                    )
+                )
+                # RTU path (Phase 3): usage costs write through rates_to_usage,
                 # then aggregate_rates_to_daily_summary rebuilds daily summary from RTU.
                 if self._cost_model_id and not no_effective_pl:
                     self._update_usage_rates_to_usage(start_date, end_date)
@@ -856,65 +855,49 @@ class OCPCostModelCostUpdater(OCPCloudUpdaterBase, PartitionHandlerMixin):
                     self._cleanup_stale_rtu_costs(start_date, end_date)
                 else:
                     self._cleanup_stale_rtu_costs(start_date, end_date)
-
-                self._update_monthly_cost(start_date, end_date, use_rtu=True)
-
-                if self._tag_infra_rates != {} or self._tag_supplementary_rates != {}:
-                    self._delete_tag_usage_costs(start_date, end_date, self._provider.uuid)
-                    self._update_tag_usage_costs(start_date, end_date, use_rtu=True)
-                    self._update_tag_usage_default_costs(start_date, end_date, use_rtu=True)
-                    self._update_monthly_tag_based_cost(start_date, end_date, use_rtu=True)
-                    self._update_node_hour_tag_based_cost(start_date, end_date, use_rtu=True)
-                    with OCPReportDBAccessor(self._schema) as report_accessor:
-                        cluster_params = {
-                            "cluster_id": self._cluster_id,
-                            "cluster_alias": self._cluster_alias,
-                        }
-                        report_accessor.populate_tag_based_costs(
-                            start_date,
-                            end_date,
-                            self._provider.uuid,
-                            self.metric_to_tag_params_map,
-                            cluster_params,
-                            cost_model_id=self._cost_model_id,
-                            rate_info_map=self._rate_info_map,
-                        )
-                if not (self._tag_infra_rates or self._tag_supplementary_rates):
-                    self._delete_tag_usage_costs(start_date, end_date, self._provider.uuid)
-
-                self._update_vm_usage_costs(start_date, end_date, use_rtu=True)
-                self._aggregate_rates_to_daily_summary(start_date, end_date)
             else:
-                # Legacy path (pre-Phase 3): all cost types write directly to daily summary.
+                LOG.info(
+                    log_json(
+                        msg="Legacy pipeline path selected",
+                        cost_model_id=str(self._cost_model_id) if self._cost_model_id else None,
+                        provider_uuid=self._provider_uuid,
+                    )
+                )
+                # Legacy path (pre-Phase 3): usage costs write directly to daily summary.
                 self._update_usage_costs(start_date, end_date)
 
-                self._update_monthly_cost(start_date, end_date, use_rtu=False)
+            self._update_monthly_cost(start_date, end_date, use_rtu=rtu_enabled)
 
-                if self._tag_infra_rates != {} or self._tag_supplementary_rates != {}:
-                    self._delete_tag_usage_costs(start_date, end_date, self._provider.uuid)
-                    self._update_tag_usage_costs(start_date, end_date, use_rtu=False)
-                    self._update_tag_usage_default_costs(start_date, end_date, use_rtu=False)
-                    self._update_monthly_tag_based_cost(start_date, end_date, use_rtu=False)
-                    self._update_node_hour_tag_based_cost(start_date, end_date, use_rtu=False)
-                    with OCPReportDBAccessor(self._schema) as report_accessor:
-                        cluster_params = {
-                            "cluster_id": self._cluster_id,
-                            "cluster_alias": self._cluster_alias,
-                        }
-                        report_accessor.populate_tag_based_costs(
-                            start_date,
-                            end_date,
-                            self._provider.uuid,
-                            self.metric_to_tag_params_map,
-                            cluster_params,
-                            cost_model_id=self._cost_model_id,
-                            rate_info_map=self._rate_info_map,
-                        )
-                if not (self._tag_infra_rates or self._tag_supplementary_rates):
-                    self._delete_tag_usage_costs(start_date, end_date, self._provider.uuid)
+            if self._tag_infra_rates != {} or self._tag_supplementary_rates != {}:
+                self._delete_tag_usage_costs(start_date, end_date, self._provider.uuid)
+                self._update_tag_usage_costs(start_date, end_date, use_rtu=rtu_enabled)
+                self._update_tag_usage_default_costs(start_date, end_date, use_rtu=rtu_enabled)
+                self._update_monthly_tag_based_cost(start_date, end_date, use_rtu=rtu_enabled)
+                self._update_node_hour_tag_based_cost(start_date, end_date, use_rtu=rtu_enabled)
+                with OCPReportDBAccessor(self._schema) as report_accessor:
+                    cluster_params = {
+                        "cluster_id": self._cluster_id,
+                        "cluster_alias": self._cluster_alias,
+                    }
+                    report_accessor.populate_tag_based_costs(
+                        start_date,
+                        end_date,
+                        self._provider.uuid,
+                        self.metric_to_tag_params_map,
+                        cluster_params,
+                        cost_model_id=self._cost_model_id,
+                        rate_info_map=self._rate_info_map,
+                        use_rtu=rtu_enabled,
+                    )
+            if not (self._tag_infra_rates or self._tag_supplementary_rates):
+                self._delete_tag_usage_costs(start_date, end_date, self._provider.uuid)
 
-                self._update_vm_usage_costs(start_date, end_date, use_rtu=False)
-                # No aggregate step — monthly/tag/VM wrote directly to daily summary.
+            self._update_vm_usage_costs(start_date, end_date, use_rtu=rtu_enabled)
+
+            if rtu_enabled:
+                # Monthly/tag/VM costs above wrote to rates_to_usage; rebuild the
+                # daily summary cost-model rows from those RTU rows.
+                self._aggregate_rates_to_daily_summary(start_date, end_date)
 
             self._update_markup_cost(start_date, end_date)
 

--- a/koku/masu/test/database/test_ocp_report_db_accessor.py
+++ b/koku/masu/test/database/test_ocp_report_db_accessor.py
@@ -1583,6 +1583,35 @@ class OCPReportDBAccessorTest(MasuTestCase):
             )
             mock_trino_exec.assert_called()
 
+    @patch("masu.database.ocp_report_db_accessor.trino_table_exists", return_value=True)
+    @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query")
+    @patch("masu.database.ocp_report_db_accessor.pkgutil.get_data", wraps=pkgutil.get_data)
+    def test_populate_tag_based_costs_use_rtu(self, mock_get_data, mock_trino_exec, mock_trino_exists):
+        """Test that use_rtu=True selects the rates_to_usage SQL template variants."""
+        test_mapping = {
+            metric_constants.OCP_GPU_MONTH: [
+                {
+                    "rate_type": "Infrastructure",
+                    "tag_key": "nvidia",
+                    "value_rates": {"Tesla T4": 1000},
+                    "default_rate": 1000,
+                },
+            ]
+        }
+        with self.accessor as acc:
+            acc.populate_tag_based_costs(
+                self.start_date,
+                self.dh.this_month_end,
+                self.ocp_provider_uuid,
+                test_mapping,
+                {"cluster_id": "test", "cluster_alias": "test"},
+                use_rtu=True,
+            )
+        used_paths = [call_args.args[1] for call_args in mock_get_data.call_args_list]
+        self.assertTrue(used_paths)
+        for path in used_paths:
+            self.assertTrue(path.endswith("_rtu.sql"), f"expected rtu SQL file, got {path}")
+
     @patch("masu.database.ocp_report_db_accessor.is_feature_flag_enabled_by_schema", return_value=False)
     @patch("masu.database.ocp_report_db_accessor.trino_table_exists", return_value=True)
     @patch("masu.database.ocp_report_db_accessor.OCPReportDBAccessor._execute_trino_multipart_sql_query")


### PR DESCRIPTION
## Jira Ticket

[COST-####](https://issues.redhat.com/browse/COST-####)

## Description

_rtu-suffixed SQL templates (writing to rates_to_usage) already existed in trino_sql/, self_hosted_sql/, and sql/ for all six tag-based cost templates (hourly_cost_vm_tag_based, monthly_cost_virtual_machine, monthly_vm_core_tag_based, hourly_vm_core_tag_based, monthly_cost_gpu, monthly_project_tag_based), but populate_tag_based_costs() never selected them — it always loaded the legacy file variant.

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Release Notes
- [ ] proposed release note

```markdown
* [COST-####](https://issues.redhat.com/browse/COST-####) Fix some things
```
