### PR TITLE
[COST-7907] Reject disabled currencies on price list create

### DIFF
--- a/koku/cost_models/price_list_serializer.py
+++ b/koku/cost_models/price_list_serializer.py
@@ -9,6 +9,7 @@ from datetime import timedelta
 from rest_framework import serializers
 
 from api.common import error_obj
+from api.currency.currencies import CurrencyField
 from api.metrics import constants as metric_constants
 from api.metrics.views import CostModelMetricMapJSONException
 from api.provider.models import Provider
@@ -33,7 +34,7 @@ class PriceListSerializer(BaseSerializer):
     uuid = serializers.UUIDField(read_only=True)
     name = serializers.CharField(max_length=255, required=False)
     description = serializers.CharField(allow_blank=True, required=False)
-    currency = serializers.CharField(required=False)
+    currency = CurrencyField(required=False, enabled_only=True)
     effective_start_date = serializers.DateField(required=False)
     effective_end_date = serializers.DateField(required=False)
     enabled = serializers.BooleanField(required=False)

--- a/koku/cost_models/test/test_price_list_view.py
+++ b/koku/cost_models/test/test_price_list_view.py
@@ -123,6 +123,14 @@ class PriceListViewTests(IamTestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("Duplicate custom_name", str(response.data))
 
+    def test_create_price_list_disabled_currency(self):
+        """Test that creating a price list with a disabled currency fails."""
+        url = reverse("price-lists-list")
+        data = self.price_list_data.copy()
+        data["currency"] = "PLN"
+        response = self.client.post(url, data=data, format="json", **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
     def test_create_price_list_without_name(self):
         """Test that creating a price list without a name fails."""
         url = reverse("price-lists-list")


### PR DESCRIPTION
## Summary
- Validate price list currency with `CurrencyField(enabled_only=True)`, matching cost model behavior
- Reject create requests that use a disabled currency with HTTP 400
- Add unit coverage for disabled-currency price list creation

## Test plan
- [x] Unit: `cost_models.test.test_price_list_view.PriceListViewTests.test_create_price_list_disabled_currency`
- [x] Manual: `POST /price-lists/` with disabled `AUD` returns 400 (`"AUD" is not an enabled currency.`)
- [x] Manual: `POST /price-lists/` with enabled `USD` still returns 201
- [ ] CI unit tests pass