### PR TITLE
[COST-7727] add operator 4.4.2 build commits to operator_versions

### DIFF
--- a/koku/masu/util/ocp/operator_versions.py
+++ b/koku/masu/util/ocp/operator_versions.py
@@ -15,6 +15,7 @@ from packaging.version import Version
 
 OPERATOR_RELEASES = [
     # (version, downstream_commit, upstream_commit)
+    ("4.4.2", "cdd836a19466190844727ff8f71730cd39dc28b7", None),
     ("4.4.1", "53d63c3aa6dc255ec8bc0cecf5d62c3a30066df3", "78eabeb962648926f98b4cc239a6f59541f001cd"),
     ("4.4.0", "74ab8043a31a07d831035d5233cce0e44f3fb082", "765fc5be236ca2ca2494b2e5ca57fbb93a94e943"),
     ("4.3.1", "ec11d7bddaa8ea3a980236b364780fed0cd2cb0f", "ec6bc48a434b78e21681233585fcb0f3b2dba223"),


### PR DESCRIPTION
## Jira Ticket

[COST-7727](https://redhat.atlassian.net/browse/COST-7727)

## Description

This change adds the downstream commit SHA for operator version 4.4.2 to the `operator_versions` mapping.

The operator sends its git commit SHA as the `version` field in manifest payloads. This mapping allows koku to resolve those SHAs to human-readable version strings (e.g. `costmanagement-metrics-operator:4.4.2`).

| Field | SHA | Source |
|---|---|---|
| `downstream_commit` | `cdd836a19466190844727ff8f71730cd39dc28b7` | [`downstream bundle for v4.4.2 (#1017)`](https://github.com/project-koku/koku-metrics-operator/commit/cdd836a19466190844727ff8f71730cd39dc28b7) |
| `upstream_commit` | `None` | No upstream release for 4.4.2 (downstream-only security release) |

## Testing

1. Checkout branch
2. Run `python -c "from masu.util.ocp.operator_versions import OPERATOR_VERSIONS, LATEST_OPERATOR_VERSION; print(LATEST_OPERATOR_VERSION)"`
3. Should print `4.4.2`

Made with [Cursor](https://cursor.com)