### PR TITLE
[COST-7930] Block disabling currencies used by cloud provider sources

### DIFF
--- a/koku/api/settings/currency_views.py
+++ b/koku/api/settings/currency_views.py
@@ -6,6 +6,7 @@
 import logging
 from collections import defaultdict
 
+from django.db.models import Q
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import never_cache
 from rest_framework import status
@@ -41,17 +42,13 @@ LOG = logging.getLogger(__name__)
 
 def _get_cloud_providers_using_currency(code, customer):
     """Return cloud providers whose billing data uses ``code`` as a base currency."""
-    source_uuids_qs = (
-        AWSCostSummaryP.objects.filter(currency_code=code)
-        .values_list("source_uuid", flat=True)
-        .union(
-            AzureCostSummaryP.objects.filter(currency=code).values_list("source_uuid", flat=True),
-            GCPCostSummaryP.objects.filter(currency=code).values_list("source_uuid", flat=True),
-        )
-    )
+    aws_uuids = AWSCostSummaryP.objects.filter(currency_code=code).values_list("source_uuid", flat=True)
+    azure_uuids = AzureCostSummaryP.objects.filter(currency=code).values_list("source_uuid", flat=True)
+    gcp_uuids = GCPCostSummaryP.objects.filter(currency=code).values_list("source_uuid", flat=True)
+
     return list(
         Provider.objects.filter(
-            uuid__in=source_uuids_qs,
+            Q(uuid__in=aws_uuids) | Q(uuid__in=azure_uuids) | Q(uuid__in=gcp_uuids),
             type__in=Provider.CLOUD_PROVIDER_LIST,
             customer=customer,
         ).values("uuid", "name", "type")

--- a/koku/api/settings/currency_views.py
+++ b/koku/api/settings/currency_views.py
@@ -42,9 +42,9 @@ LOG = logging.getLogger(__name__)
 
 def _get_cloud_providers_using_currency(code, customer):
     """Return cloud providers whose billing data uses ``code`` as a base currency."""
-    aws_uuids = AWSCostSummaryP.objects.filter(currency_code=code).values_list("source_uuid", flat=True)
-    azure_uuids = AzureCostSummaryP.objects.filter(currency=code).values_list("source_uuid", flat=True)
-    gcp_uuids = GCPCostSummaryP.objects.filter(currency=code).values_list("source_uuid", flat=True)
+    aws_uuids = AWSCostSummaryP.objects.filter(currency_code=code).values_list("source_uuid", flat=True).distinct()
+    azure_uuids = AzureCostSummaryP.objects.filter(currency=code).values_list("source_uuid", flat=True).distinct()
+    gcp_uuids = GCPCostSummaryP.objects.filter(currency=code).values_list("source_uuid", flat=True).distinct()
 
     return list(
         Provider.objects.filter(

--- a/koku/api/settings/currency_views.py
+++ b/koku/api/settings/currency_views.py
@@ -21,6 +21,7 @@ from api.currency.currencies import get_currency_info
 from api.currency.currencies import get_dynamic_rate_currencies
 from api.currency.currencies import get_enabled_currency_codes
 from api.currency.currencies import is_valid_iso_currency
+from api.provider.models import Provider
 from cost_models.models import CostModel
 from cost_models.models import EnabledCurrency
 from cost_models.models import PriceList
@@ -30,9 +31,31 @@ from cost_models.monthly_exchange_rate_utils import remove_monthly_rates
 from cost_models.static_exchange_rate_serializer import StaticExchangeRateSerializer
 from koku.cache import invalidate_view_cache_for_tenant_and_all_source_types
 from koku.settings import KOKU_DEFAULT_CURRENCY
+from reporting.provider.aws.models import AWSCostSummaryP
+from reporting.provider.azure.models import AzureCostSummaryP
+from reporting.provider.gcp.models import GCPCostSummaryP
 from reporting.user_settings.models import UserSettings
 
 LOG = logging.getLogger(__name__)
+
+
+def _get_cloud_providers_using_currency(code, customer):
+    """Return cloud providers whose billing data uses ``code`` as a base currency."""
+    source_uuids_qs = (
+        AWSCostSummaryP.objects.filter(currency_code=code)
+        .values_list("source_uuid", flat=True)
+        .union(
+            AzureCostSummaryP.objects.filter(currency=code).values_list("source_uuid", flat=True),
+            GCPCostSummaryP.objects.filter(currency=code).values_list("source_uuid", flat=True),
+        )
+    )
+    return list(
+        Provider.objects.filter(
+            uuid__in=source_uuids_qs,
+            type__in=Provider.CLOUD_PROVIDER_LIST,
+            customer=customer,
+        ).values("uuid", "name", "type")
+    )
 
 
 class CurrencySettingsView(APIView):
@@ -124,6 +147,10 @@ class EnabledCurrencyView(APIView):
         if account_settings and account_settings.settings.get("currency") == code:
             reasons.append("it is the account default currency")
 
+        affected_cloud_providers = _get_cloud_providers_using_currency(code, request.user.customer)
+        if affected_cloud_providers:
+            reasons.append(f"it is currently used by {len(affected_cloud_providers)} cloud provider source(s)")
+
         affected_cost_models = list(CostModel.objects.filter(currency=code).values("uuid", "name"))
         if affected_cost_models:
             reasons.append(f"it is used by {len(affected_cost_models)} cost model(s)")
@@ -139,6 +166,7 @@ class EnabledCurrencyView(APIView):
                     msg="Currency disable blocked",
                     currency=code,
                     reasons=reasons,
+                    affected_cloud_providers=affected_cloud_providers,
                     affected_cost_models=affected_cost_models,
                     affected_price_lists=affected_price_lists,
                 )
@@ -152,6 +180,7 @@ class EnabledCurrencyView(APIView):
                             "status": status.HTTP_400_BAD_REQUEST,
                         }
                     ],
+                    "affected_cloud_providers": affected_cloud_providers,
                     "affected_cost_models": affected_cost_models,
                     "affected_price_lists": affected_price_lists,
                 },

--- a/koku/api/settings/currency_views.py
+++ b/koku/api/settings/currency_views.py
@@ -49,7 +49,6 @@ def _get_cloud_providers_using_currency(code, customer):
     return list(
         Provider.objects.filter(
             Q(uuid__in=aws_uuids) | Q(uuid__in=azure_uuids) | Q(uuid__in=gcp_uuids),
-            type__in=Provider.CLOUD_PROVIDER_LIST,
             customer=customer,
         ).values("uuid", "name", "type")
     )

--- a/koku/api/settings/test/test_currency_views.py
+++ b/koku/api/settings/test/test_currency_views.py
@@ -3,15 +3,22 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 """Tests for currency settings views."""
+from uuid import uuid4
+
 from django.urls import reverse
 from django_tenants.utils import tenant_context
 from rest_framework import status
 from rest_framework.test import APIClient
 
 from api.iam.test.iam_test_case import IamTestCase
+from api.provider.models import Provider
 from cost_models.models import CostModel
 from cost_models.models import EnabledCurrency
 from cost_models.models import PriceList
+from reporting.provider.aws.models import AWSCostSummaryP
+from reporting.provider.azure.models import AzureCostSummaryP
+from reporting.provider.gcp.models import GCPCostSummaryP
+from reporting.provider.models import TenantAPIProvider
 
 
 class CurrencySettingsViewTest(IamTestCase):
@@ -155,6 +162,43 @@ class EnabledCurrencyViewTest(IamTestCase):
             response = self.client.delete(self._url("EUR"), **self.headers)
             self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
             self.assertTrue(EnabledCurrency.objects.filter(currency_code="EUR").exists())
+
+    def test_disable_currency_in_use_by_cloud_provider_blocked(self):
+        """Disabling a currency used by AWS, Azure, or GCP providers must return 400."""
+        cloud_providers = [
+            (Provider.PROVIDER_AWS, AWSCostSummaryP, "currency_code", "AUD"),
+            (Provider.PROVIDER_AZURE, AzureCostSummaryP, "currency", "CAD"),
+            (Provider.PROVIDER_GCP, GCPCostSummaryP, "currency", "EUR"),
+        ]
+        with tenant_context(self.tenant):
+            for provider_type, summary_model, currency_field, code in cloud_providers:
+                provider = Provider.objects.create(
+                    name=f"{provider_type} {code} Source",
+                    type=provider_type,
+                    customer=self.customer,
+                )
+                tenant_provider = TenantAPIProvider.objects.create(
+                    uuid=provider.uuid, name=provider.name, type=provider.type, provider=provider
+                )
+                summary_model.objects.create(
+                    id=uuid4(),
+                    usage_start="2026-01-01",
+                    usage_end="2026-01-01",
+                    source_uuid=tenant_provider,
+                    **{currency_field: code},
+                )
+
+            EnabledCurrency.objects.all().delete()
+            EnabledCurrency.objects.create(currency_code="USD")
+            EnabledCurrency.objects.create(currency_code="AUD")
+            EnabledCurrency.objects.create(currency_code="CAD")
+            EnabledCurrency.objects.create(currency_code="EUR")
+
+            for _, _, _, code in cloud_providers:
+                with self.subTest(code=code):
+                    response = self.client.delete(self._url(code), **self.headers)
+                    self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+                    self.assertTrue(EnabledCurrency.objects.filter(currency_code=code).exists())
 
     def test_disable_default_currency_blocked(self):
         """Disabling the system default currency (USD) must return 400."""


### PR DESCRIPTION
## Summary

- Prevents disabling a currency that is actively used as the billing currency by AWS, Azure, or GCP provider sources
- Queries `AWSCostSummaryP`, `AzureCostSummaryP`, and `GCPCostSummaryP` to find providers billing in the target currency, and blocks the disable with a 400 response listing the affected providers
- Adds the `affected_cloud_providers` list to the error response alongside the existing `affected_cost_models` and `affected_price_lists`

## Test plan

- [x] Unit test: `test_disable_currency_in_use_by_cloud_provider_blocked` — verifies all three cloud provider types (AWS/Azure/GCP) block currency disable
- [x] Verify existing currency disable tests still pass
- [x] Manual validation against a dev environment with cloud provider data


Made with [Cursor](https://cursor.com)