### PR TITLE
[COST-7909] Strip trailing zeros from exchange rate API responses

### DIFF
--- a/koku/cost_models/static_exchange_rate_serializer.py
+++ b/koku/cost_models/static_exchange_rate_serializer.py
@@ -32,8 +32,14 @@ class TrailingZeroStrippingDecimalField(serializers.DecimalField):
         if value is None:
             return None
         if not isinstance(value, Decimal):
-            value = Decimal(value)
-        return format(value.normalize(), "f")
+            value = Decimal(str(value).strip())
+        # Format then strip trailing zeros — avoid Decimal.normalize(), which
+        # rounds under the thread decimal context (default prec=28) and can
+        # truncate values within this field's max_digits=33.
+        val_str = format(value, "f")
+        if "." in val_str:
+            val_str = val_str.rstrip("0").rstrip(".")
+        return val_str
 
 
 class StaticExchangeRateSerializer(serializers.ModelSerializer):

--- a/koku/cost_models/static_exchange_rate_serializer.py
+++ b/koku/cost_models/static_exchange_rate_serializer.py
@@ -30,10 +30,12 @@ class TrailingZeroStrippingDecimalField(serializers.DecimalField):
     def to_representation(self, value):
         if value is None:
             return None
-        # DecimalField already coerces/quantizes to a fixed-point string;
-        # strip trailing zeros (and a leftover decimal point) for a compact API value.
+        # DecimalField already coerces/quantizes; normalize to str then strip
+        # trailing zeros (and a leftover decimal point) for a compact API value.
         val_str = super().to_representation(value)
-        if isinstance(val_str, str) and "." in val_str:
+        if not isinstance(val_str, str):
+            val_str = format(val_str, "f")
+        if "." in val_str:
             return val_str.rstrip("0").rstrip(".")
         return val_str
 

--- a/koku/cost_models/static_exchange_rate_serializer.py
+++ b/koku/cost_models/static_exchange_rate_serializer.py
@@ -6,7 +6,6 @@
 import calendar
 import logging
 from datetime import timedelta
-from decimal import Decimal
 
 from django.db import transaction
 from django.utils import timezone
@@ -31,14 +30,11 @@ class TrailingZeroStrippingDecimalField(serializers.DecimalField):
     def to_representation(self, value):
         if value is None:
             return None
-        if not isinstance(value, Decimal):
-            value = Decimal(str(value).strip())
-        # Format then strip trailing zeros — avoid Decimal.normalize(), which
-        # rounds under the thread decimal context (default prec=28) and can
-        # truncate values within this field's max_digits=33.
-        val_str = format(value, "f")
-        if "." in val_str:
-            val_str = val_str.rstrip("0").rstrip(".")
+        # DecimalField already coerces/quantizes to a fixed-point string;
+        # strip trailing zeros (and a leftover decimal point) for a compact API value.
+        val_str = super().to_representation(value)
+        if isinstance(val_str, str) and "." in val_str:
+            return val_str.rstrip("0").rstrip(".")
         return val_str
 
 

--- a/koku/cost_models/static_exchange_rate_serializer.py
+++ b/koku/cost_models/static_exchange_rate_serializer.py
@@ -6,6 +6,7 @@
 import calendar
 import logging
 from datetime import timedelta
+from decimal import Decimal
 
 from django.db import transaction
 from django.utils import timezone
@@ -21,10 +22,25 @@ from koku.cache import invalidate_view_cache_for_tenant_and_all_source_types
 LOG = logging.getLogger(__name__)
 
 
+class TrailingZeroStrippingDecimalField(serializers.DecimalField):
+    """Serialize Decimals as strings without unnecessary trailing zeros.
+
+    Storage keeps full DecimalField precision; only the API representation is trimmed.
+    """
+
+    def to_representation(self, value):
+        if value is None:
+            return None
+        if not isinstance(value, Decimal):
+            value = Decimal(value)
+        return format(value.normalize(), "f")
+
+
 class StaticExchangeRateSerializer(serializers.ModelSerializer):
     """Serializer for creating and updating static exchange rates."""
 
     name = serializers.CharField(read_only=True)
+    exchange_rate = TrailingZeroStrippingDecimalField(max_digits=33, decimal_places=15)
 
     class Meta:
         model = StaticExchangeRate

--- a/koku/cost_models/test/test_static_exchange_rate_view.py
+++ b/koku/cost_models/test/test_static_exchange_rate_view.py
@@ -7,7 +7,9 @@ import calendar
 import uuid
 from datetime import date
 from datetime import timedelta
+from decimal import Decimal
 
+from django.test import SimpleTestCase
 from django.urls import reverse
 from django.utils import timezone
 from django_tenants.utils import tenant_context
@@ -16,10 +18,28 @@ from rest_framework.test import APIClient
 
 from api.iam.test.iam_test_case import IamTestCase
 from cost_models.models import StaticExchangeRate
+from cost_models.static_exchange_rate_serializer import TrailingZeroStrippingDecimalField
 
 
 def _month_end(d):
     return d.replace(day=calendar.monthrange(d.year, d.month)[1])
+
+
+class TrailingZeroStrippingDecimalFieldTest(SimpleTestCase):
+    """Unit tests for API decimal representation of exchange rates."""
+
+    def test_strips_trailing_zeros_preserves_precision(self):
+        field = TrailingZeroStrippingDecimalField(max_digits=33, decimal_places=15)
+        cases = (
+            (Decimal("1.500000000000000"), "1.5"),
+            (Decimal("0.920000000000000"), "0.92"),
+            (Decimal("1.234567890123456"), "1.234567890123456"),
+            (Decimal("100.000000000000000"), "100"),
+            (Decimal("0.000000000000001"), "0.000000000000001"),
+        )
+        for value, expected in cases:
+            with self.subTest(value=value):
+                self.assertEqual(field.to_representation(value), expected)
 
 
 class StaticExchangeRateListViewTest(IamTestCase):
@@ -50,7 +70,7 @@ class StaticExchangeRateListViewTest(IamTestCase):
         self.assertEqual(data["name"], "USD-EUR")
         self.assertEqual(data["base_currency"], "USD")
         self.assertEqual(data["target_currency"], "EUR")
-        self.assertEqual(data["exchange_rate"], "0.920000000000000")
+        self.assertEqual(data["exchange_rate"], "0.92")
         self.assertEqual(data["start_date"], month_start.isoformat())
         self.assertEqual(data["end_date"], month_end.isoformat())
         self.assertIn("created_timestamp", data)
@@ -187,7 +207,7 @@ class StaticExchangeRateDetailViewTest(IamTestCase):
         }
         response = self.client.put(self._url(rate.uuid), payload, format="json", **self.headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["exchange_rate"], "0.950000000000000")
+        self.assertEqual(response.data["exchange_rate"], "0.95")
 
     def test_update_fully_finalized_rejected(self):
         """A rate whose end_date is entirely in the past cannot be edited."""
@@ -233,7 +253,7 @@ class StaticExchangeRateDetailViewTest(IamTestCase):
         }
         response = self.client.put(self._url(rate.uuid), payload, format="json", **self.headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["exchange_rate"], "0.950000000000000")
+        self.assertEqual(response.data["exchange_rate"], "0.95")
 
     def test_update_shrink_end_date_to_past(self):
         """User can shrink end_date to close out a rate"""

--- a/koku/cost_models/test/test_static_exchange_rate_view.py
+++ b/koku/cost_models/test/test_static_exchange_rate_view.py
@@ -30,12 +30,17 @@ class TrailingZeroStrippingDecimalFieldTest(SimpleTestCase):
 
     def test_strips_trailing_zeros_preserves_precision(self):
         field = TrailingZeroStrippingDecimalField(max_digits=33, decimal_places=15)
+        # 33 significant digits — must survive without Decimal.normalize() context rounding
+        high_precision = "1." + ("2" * 31)
         cases = (
+            (None, None),
+            ("1.500000000000000", "1.5"),
             (Decimal("1.500000000000000"), "1.5"),
             (Decimal("0.920000000000000"), "0.92"),
             (Decimal("1.234567890123456"), "1.234567890123456"),
             (Decimal("100.000000000000000"), "100"),
             (Decimal("0.000000000000001"), "0.000000000000001"),
+            (Decimal(high_precision), high_precision),
         )
         for value, expected in cases:
             with self.subTest(value=value):

--- a/koku/cost_models/test/test_static_exchange_rate_view.py
+++ b/koku/cost_models/test/test_static_exchange_rate_view.py
@@ -8,6 +8,7 @@ import uuid
 from datetime import date
 from datetime import timedelta
 from decimal import Decimal
+from unittest.mock import patch
 
 from django.test import SimpleTestCase
 from django.urls import reverse
@@ -44,6 +45,20 @@ class TrailingZeroStrippingDecimalFieldTest(SimpleTestCase):
         for value, expected in cases:
             with self.subTest(value=value):
                 self.assertEqual(field.to_representation(value), expected)
+
+    def test_coerce_to_string_false_still_strips_zeros(self):
+        """Cover non-string parent output (coerce_to_string=False returns Decimal)."""
+        field = TrailingZeroStrippingDecimalField(max_digits=33, decimal_places=15, coerce_to_string=False)
+        self.assertEqual(field.to_representation(Decimal("1.500000000000000")), "1.5")
+
+    def test_integer_string_without_decimal_point(self):
+        """Cover the no-dot fallback when parent returns an integer-like string."""
+        field = TrailingZeroStrippingDecimalField(max_digits=33, decimal_places=15)
+        with patch(
+            "rest_framework.serializers.DecimalField.to_representation",
+            return_value="100",
+        ):
+            self.assertEqual(field.to_representation(Decimal("100")), "100")
 
 
 class StaticExchangeRateListViewTest(IamTestCase):

--- a/koku/cost_models/test/test_static_exchange_rate_view.py
+++ b/koku/cost_models/test/test_static_exchange_rate_view.py
@@ -30,8 +30,6 @@ class TrailingZeroStrippingDecimalFieldTest(SimpleTestCase):
 
     def test_strips_trailing_zeros_preserves_precision(self):
         field = TrailingZeroStrippingDecimalField(max_digits=33, decimal_places=15)
-        # 33 significant digits — must survive without Decimal.normalize() context rounding
-        high_precision = "1." + ("2" * 31)
         cases = (
             (None, None),
             ("1.500000000000000", "1.5"),
@@ -40,7 +38,8 @@ class TrailingZeroStrippingDecimalFieldTest(SimpleTestCase):
             (Decimal("1.234567890123456"), "1.234567890123456"),
             (Decimal("100.000000000000000"), "100"),
             (Decimal("0.000000000000001"), "0.000000000000001"),
-            (Decimal(high_precision), high_precision),
+            # Parent DecimalField quantizes to decimal_places=15 before we strip zeros
+            (Decimal("1." + ("2" * 31)), "1.222222222222222"),
         )
         for value, expected in cases:
             with self.subTest(value=value):


### PR DESCRIPTION
## Jira Ticket
[COST-7909](https://issues.redhat.com/browse/COST-7909)

## Description

Static exchange rates were serialized with all 15 DecimalField decimal places (e.g. `"1.500000000000000"`). This change trims unnecessary trailing zeros in the API representation via a custom DecimalField on `StaticExchangeRateSerializer`, without changing stored precision.

## Testing

1. Checkout this branch and restart `koku-server`
2. Create or use an existing static rate, then call:
   - `GET /api/cost-management/v1/settings/currency/`
   - `GET|POST /api/cost-management/v1/settings/currency/static-rates/`
3. Confirm `exchange_rate` values omit trailing zeros (e.g. `"1.5"`, `"0.92"`) while high-precision rates keep significant digits
4. Unit tests: `pipenv run tox -- cost_models.test.test_static_exchange_rate_view`

## Release Notes
- [x] proposed release note

```markdown
* [COST-7909](https://issues.redhat.com/browse/COST-7909) Strip unnecessary trailing zeros from static exchange rate API responses
```

Made with [Cursor](https://cursor.com)