### PR TITLE
s4 image override for arm64 developers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,6 +86,8 @@ DEVELOPMENT_IDENTITY='{"identity": {"account_number": "10001", "org_id": "123456
 CACHED_VIEWS_DISABLED=False
 ENHANCED_ORG_ADMIN=True
 
+# S4 image override for Apple Silicon (arm64) developers:
+# S4_IMAGE=quay.io/dnakabaa/s4:0.3.2-arm64
 DOCKER_BUILDKIT=1
 QE_SCHEMA=""
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -657,7 +657,7 @@ services:
 
   s4:
     container_name: koku-s4
-    image: quay.io/rh-aiservices-bu/s4:0.3.2-2
+    image: ${S4_IMAGE:-quay.io/rh-aiservices-bu/s4:0.3.2-2}
     # S3 API: use koku-s4-proxy on host port 9000, or direct backend on 9001.
     ports:
       - "9001:7480"


### PR DESCRIPTION
## Description

This change makes the S4 container image configurable via the `S4_IMAGE` environment variable, defaulting to the existing amd64 image. This allows developers on arm arch to use a native arm64 build (`quay.io/dnakabaa/s4:0.3.2-arm64`) without manually editing `docker-compose.yml` or risking accidental commits that break other developers.

The official `quay.io/rh-aiservices-bu/s4:0.3.2-2` image is amd64-only, which fails on ARM Macs.

## Testing

1. Checkout branch.
2. Verify the default (no `S4_IMAGE` set) still uses the original image:

    ```bash
    unset S4_IMAGE
    docker compose config | grep "image:" | grep s4
    ```

    You should see:

    ```
    image: quay.io/rh-aiservices-bu/s4:0.3.2-2
    ```

3. Set the override and verify it takes effect:

    ```bash
    export S4_IMAGE=quay.io/dnakabaa/s4:0.3.2-arm64
    docker compose config | grep "image:" | grep s4
    ```

    You should see:

    ```
    image: quay.io/dnakabaa/s4:0.3.2-arm64
    ```

4. (ARM developers) Add `S4_IMAGE=quay.io/dnakabaa/s4:0.3.2-arm64` to your `.env`, then start the Trino stack:

    ```bash
    make trino-stack-up
    ```

    S4 should start without the platform mismatch warning and pass its healthcheck.

## Release Notes
- [ ] proposed release note

```markdown
* Allow S4 image override via `S4_IMAGE` env var for developers on arm arch.