### PR TITLE
[COST-7932] Prevent base_currency modification on static exchange rate update

### DIFF
--- a/koku/cost_models/static_exchange_rate_serializer.py
+++ b/koku/cost_models/static_exchange_rate_serializer.py
@@ -71,25 +71,29 @@ class StaticExchangeRateSerializer(serializers.ModelSerializer):
 
     def _validate_update(self, base, target, start, end, current_month_start, has_finalized_months):
         """Validate constraints specific to updating an existing rate."""
+        if base != self.instance.base_currency:
+            raise serializers.ValidationError(
+                "Base currency cannot be modified. Delete and recreate the exchange rate instead."
+            )
         if self.instance.end_date < current_month_start:
             raise serializers.ValidationError(
                 f"This rate ended on {self.instance.end_date} and all its months have been finalized. "
                 "To set a new rate, create a new record starting from the current month."
             )
         if has_finalized_months:
-            if base != self.instance.base_currency or target != self.instance.target_currency:
+            if target != self.instance.target_currency:
                 raise serializers.ValidationError(
-                    "Currencies cannot be changed because this rate has finalized months."
+                    "Target currency cannot be changed because this rate has finalized months."
                 )
             if start != self.instance.start_date:
                 raise serializers.ValidationError(
-                    "start_date cannot be changed because this rate has finalized months. "
+                    "Start date cannot be changed because this rate has finalized months. "
                     "Shrink the end_date instead, then create a new rate for the remaining period."
                 )
             min_end_date = current_month_start - timedelta(days=1)
             if end < min_end_date:
                 raise serializers.ValidationError(
-                    "end_date cannot be earlier than the previous month when shrinking a finalized rate."
+                    "End date cannot be earlier than the previous month when shrinking a finalized rate."
                 )
 
     def validate(self, attrs):
@@ -99,10 +103,10 @@ class StaticExchangeRateSerializer(serializers.ModelSerializer):
         end = attrs.get("end_date")
 
         if base == target:
-            raise serializers.ValidationError("base_currency and target_currency must be different.")
+            raise serializers.ValidationError("Base currency and target currency must be different.")
 
         if end < start:
-            raise serializers.ValidationError("end_date must be on or after start_date.")
+            raise serializers.ValidationError("End date must be on or after start date.")
 
         today = timezone.now().date()
         current_month_start = today.replace(day=1)
@@ -111,7 +115,7 @@ class StaticExchangeRateSerializer(serializers.ModelSerializer):
             self._validate_update(base, target, start, end, current_month_start, has_finalized_months)
 
         if not has_finalized_months and start < current_month_start:
-            raise serializers.ValidationError("start_date cannot be in a past month.")
+            raise serializers.ValidationError("Start date cannot be in a past month.")
 
         overlapping = StaticExchangeRate.objects.filter(
             base_currency=base,

--- a/koku/cost_models/test/test_static_exchange_rate_view.py
+++ b/koku/cost_models/test/test_static_exchange_rate_view.py
@@ -374,6 +374,94 @@ class StaticExchangeRateDetailViewTest(IamTestCase):
         response = self.client.delete(self._url(uuid.uuid4()), **self.headers)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
+    def test_update_base_currency_rejected(self):
+        """base_currency is immutable and can never be changed on update."""
+        today = timezone.now().date()
+        month_start = today.replace(day=1)
+        month_end = _month_end(today)
+        next_month_start = month_end + timedelta(days=1)
+        next_month_end = _month_end(next_month_start)
+        with tenant_context(self.tenant):
+            current_rate = StaticExchangeRate.objects.create(
+                base_currency="USD",
+                target_currency="EUR",
+                exchange_rate="0.920000000000000",
+                start_date=month_start,
+                end_date=month_end,
+            )
+            future_rate = StaticExchangeRate.objects.create(
+                base_currency="CNY",
+                target_currency="EUR",
+                exchange_rate="0.130000000000000",
+                start_date=next_month_start,
+                end_date=next_month_end,
+            )
+
+        payload = {
+            "base_currency": "GBP",
+            "target_currency": "EUR",
+            "exchange_rate": 0.85,
+            "start_date": month_start.isoformat(),
+            "end_date": month_end.isoformat(),
+        }
+        response = self.client.put(self._url(current_rate.uuid), payload, format="json", **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        payload["start_date"] = next_month_start.isoformat()
+        payload["end_date"] = next_month_end.isoformat()
+        response = self.client.put(self._url(future_rate.uuid), payload, format="json", **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_update_target_currency_allowed(self):
+        """target_currency can be changed on a rate with no finalized months."""
+        today = timezone.now().date()
+        month_start = today.replace(day=1)
+        month_end = _month_end(today)
+        with tenant_context(self.tenant):
+            rate = StaticExchangeRate.objects.create(
+                base_currency="USD",
+                target_currency="EUR",
+                exchange_rate="0.920000000000000",
+                start_date=month_start,
+                end_date=month_end,
+            )
+
+        payload = {
+            "base_currency": "USD",
+            "target_currency": "GBP",
+            "exchange_rate": 0.79,
+            "start_date": month_start.isoformat(),
+            "end_date": month_end.isoformat(),
+        }
+        response = self.client.put(self._url(rate.uuid), payload, format="json", **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["target_currency"], "GBP")
+        self.assertEqual(response.data["name"], "USD-GBP")
+
+    def test_update_target_currency_with_finalized_months_rejected(self):
+        """target_currency cannot be changed when the rate has finalized months."""
+        today = timezone.now().date()
+        past_start = date(2020, 1, 1)
+        future_end = _month_end(today)
+        with tenant_context(self.tenant):
+            rate = StaticExchangeRate.objects.create(
+                base_currency="USD",
+                target_currency="EUR",
+                exchange_rate="0.920000000000000",
+                start_date=past_start,
+                end_date=future_end,
+            )
+
+        payload = {
+            "base_currency": "USD",
+            "target_currency": "GBP",
+            "exchange_rate": 0.79,
+            "start_date": past_start.isoformat(),
+            "end_date": future_end.isoformat(),
+        }
+        response = self.client.put(self._url(rate.uuid), payload, format="json", **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
     def test_update_nonexistent_returns_404(self):
         today = timezone.now().date()
         payload = {


### PR DESCRIPTION
## Summary
- `base_currency` is now unconditionally immutable on PUT requests to `/settings/currency/static-rates/{uuid}/`, preventing data integrity issues where a rate's identity silently changes while keeping the same UUID.
- `target_currency` remains updatable on rates without finalized months, but is protected on rates that have finalized months.
- Error messages updated to use user-friendly capitalized phrasing.

## Test plan
- [x] New test: `test_update_base_currency_rejected` — verifies base_currency change is rejected on both current and future rates
- [x] New test: `test_update_target_currency_allowed` — verifies target_currency can be changed on non-finalized rates
- [x] New test: `test_update_target_currency_with_finalized_months_rejected` — verifies target_currency is protected when finalized months exist
- [x] All existing tests pass (`pipenv run tox -e py311 -- cost_models.test.test_static_exchange_rate_view`)


Made with [Cursor](https://cursor.com)