### PR TITLE
[COST-7345] Add MonthlyExchangeRate retention cleanup

### DIFF
--- a/koku/cost_models/monthly_exchange_rate_utils.py
+++ b/koku/cost_models/monthly_exchange_rate_utils.py
@@ -182,13 +182,14 @@ def remove_monthly_rates(code):
     return deleted
 
 
-def _get_existing_rates_by_pair(start, end, enabled_codes, code=None):
+def _get_existing_rates_by_pair(start, end, code=None):
     """Return existing MER rates grouped by pair, ordered newest-first.
 
     {("USD", "EUR"): {date(2026, 6, 1): Decimal("0.45"), date(2026, 4, 1): Decimal("0.40")}}
 
     Dict insertion order is newest-first, so next(iter(d.items())) gives the latest rate.
     """
+    enabled_codes = set(EnabledCurrency.objects.values_list("currency_code", flat=True))
     qs = MonthlyExchangeRate.objects.filter(
         base_currency__in=enabled_codes,
         target_currency__in=enabled_codes,
@@ -225,8 +226,7 @@ def _backfill_missing_past_months(current_month, code=None):
         )
         return
 
-    enabled_codes = set(EnabledCurrency.objects.values_list("currency_code", flat=True))
-    rates_by_pair = _get_existing_rates_by_pair(retention_start, current_month, enabled_codes, code=code)
+    rates_by_pair = _get_existing_rates_by_pair(retention_start, current_month, code=code)
 
     if not rates_by_pair:
         return

--- a/koku/cost_models/monthly_exchange_rate_utils.py
+++ b/koku/cost_models/monthly_exchange_rate_utils.py
@@ -9,9 +9,11 @@ from decimal import Decimal
 from dateutil.relativedelta import relativedelta
 from django.db import connection
 from django.db.models import Q
+from django_tenants.utils import schema_context
 
 from api.common import log_json
 from api.currency.models import ExchangeRateDictionary
+from api.iam.models import Tenant
 from api.utils import DateHelper
 from api.utils import materialized_view_month_start
 from api.utils import to_date
@@ -185,6 +187,41 @@ def remove_monthly_rates(code):
     )
     LOG.info(log_json(msg="Removed MonthlyExchangeRate rows", code=code, deleted=deleted))
     return deleted
+
+
+def _purge_expired_monthly_rates():
+    """Delete MonthlyExchangeRate rows older than the retention window.
+
+    Uses the same retention boundary as backfill (materialized_view_month_start).
+    Must be called within a schema_context.
+    """
+    expired_date = to_date(materialized_view_month_start(schema_name=connection.schema_name))
+    deleted, _ = MonthlyExchangeRate.objects.filter(effective_date__lt=expired_date).delete()
+    if deleted:
+        LOG.info(
+            log_json(
+                msg="Purged expired MonthlyExchangeRate rows",
+                deleted=deleted,
+                expired_date=str(expired_date),
+            )
+        )
+    return deleted
+
+
+def purge_expired_exchange_rates_for_all_tenants():
+    """Purge expired MonthlyExchangeRate rows for all tenants."""
+    for tenant in Tenant.objects.exclude(schema_name="public"):
+        try:
+            with schema_context(tenant.schema_name):
+                _purge_expired_monthly_rates()
+        except Exception as e:
+            LOG.error(
+                log_json(
+                    msg="Failed to purge expired monthly exchange rates",
+                    schema=tenant.schema_name,
+                    error=str(e),
+                )
+            )
 
 
 def _get_existing_rates_by_pair(start, end, enabled_codes, code=None):

--- a/koku/cost_models/monthly_exchange_rate_utils.py
+++ b/koku/cost_models/monthly_exchange_rate_utils.py
@@ -210,12 +210,16 @@ def _backfill_missing_past_months(current_month, code=None):
     if code:
         rates_qs = rates_qs.filter(Q(base_currency=code) | Q(target_currency=code))
 
-    # {("USD", "EUR"): {date(2026, 4, 1): Decimal("0.40"), date(2026, 6, 1): Decimal("0.45")}}
+    # Newest effective_date first so the first row per pair is the latest MER.
+    # {("USD", "EUR"): {date(2026, 6, 1): Decimal("0.45"), date(2026, 4, 1): Decimal("0.40")}}
     rates_by_pair = {}
-    for base, target, effective, rate in rates_qs.values_list(
-        "base_currency", "target_currency", "effective_date", "exchange_rate"
-    ):
-        rates_by_pair.setdefault((base, target), {})[effective] = rate
+    latest_by_pair = {}
+    for base, target, effective, rate in rates_qs.order_by(
+        "base_currency", "target_currency", "-effective_date"
+    ).values_list("base_currency", "target_currency", "effective_date", "exchange_rate"):
+        pair = (base, target)
+        rates_by_pair.setdefault(pair, {})[effective] = rate
+        latest_by_pair.setdefault(pair, (effective, rate))
 
     if not rates_by_pair:
         return
@@ -223,8 +227,7 @@ def _backfill_missing_past_months(current_month, code=None):
     to_create = []
     for (base, target), existing in rates_by_pair.items():
         # Walk down from the month before the latest available MER row.
-        latest_month = max(existing)
-        latest_rate = existing[latest_month]
+        latest_month, latest_rate = latest_by_pair[(base, target)]
         month = latest_month - relativedelta(months=1)
         while month >= start:
             if month in existing:

--- a/koku/cost_models/monthly_exchange_rate_utils.py
+++ b/koku/cost_models/monthly_exchange_rate_utils.py
@@ -101,73 +101,68 @@ def populate_dynamic_monthly_rates(code=None, backfill_past_months=False):  # no
 
     Reads the latest rates from ExchangeRateDictionary and writes dynamic
     MonthlyExchangeRate rows for each enabled currency pair. Static overrides are preserved.
+    If ERD is missing/empty and backfill_past_months is True, still backfill from existing MER.
 
     When code is provided, only pairs involving that currency are processed.
     When None, all enabled currency pairs are processed.
     """
     enabled_codes = set(EnabledCurrency.objects.values_list("currency_code", flat=True))
     if not enabled_codes:
-        return 0
+        return
 
-    erd = ExchangeRateDictionary.objects.first()
-    if not erd or not erd.currency_exchange_dictionary:
-        return 0
-
-    exchange_dict = erd.currency_exchange_dictionary
     current_month = DateHelper().this_month_start.date()
+    erd = ExchangeRateDictionary.objects.first()
+    if erd and erd.currency_exchange_dictionary:
+        exchange_dict = erd.currency_exchange_dictionary
 
-    static_pairs = set(
-        MonthlyExchangeRate.objects.filter(
-            effective_date=current_month,
-            rate_type=RateType.STATIC,
-        ).values_list("base_currency", "target_currency")
-    )
-
-    # Collect rates and synthesize inverses when not already in the dictionary
-    dynamic_rates = {}
-    for base_cur, rates_by_target in exchange_dict.items():
-        for target_cur, rate in rates_by_target.items():
-            if base_cur == target_cur:
-                continue
-            if base_cur not in enabled_codes or target_cur not in enabled_codes:
-                continue
-            if code and code != base_cur and code != target_cur:
-                continue
-
-            forward_pair = (base_cur, target_cur)
-            inverse_pair = (target_cur, base_cur)
-
-            rate_dec = Decimal(str(rate))
-            if rate_dec <= 0:
-                LOG.warning(
-                    log_json(
-                        msg="Skipping non-positive rate from ExchangeRateDictionary",
-                        base_currency=base_cur,
-                        target_currency=target_cur,
-                        rate=str(rate),
-                    )
-                )
-                continue
-            dynamic_rates[forward_pair] = rate_dec
-            dynamic_rates.setdefault(inverse_pair, Decimal(1) / rate_dec)
-
-    # Exclude pairs that already have a static override for this month
-    pairs_to_upsert = {pair: rate for pair, rate in dynamic_rates.items() if pair not in static_pairs}
-
-    count = 0
-    for (base_cur, target_cur), rate in pairs_to_upsert.items():
-        MonthlyExchangeRate.objects.update_or_create(
-            effective_date=current_month,
-            base_currency=base_cur,
-            target_currency=target_cur,
-            defaults={"exchange_rate": rate, "rate_type": RateType.DYNAMIC},
+        static_pairs = set(
+            MonthlyExchangeRate.objects.filter(
+                effective_date=current_month,
+                rate_type=RateType.STATIC,
+            ).values_list("base_currency", "target_currency")
         )
-        count += 1
+
+        # Collect rates and synthesize inverses when not already in the dictionary
+        dynamic_rates = {}
+        for base_cur, rates_by_target in exchange_dict.items():
+            for target_cur, rate in rates_by_target.items():
+                if base_cur == target_cur:
+                    continue
+                if base_cur not in enabled_codes or target_cur not in enabled_codes:
+                    continue
+                if code and code != base_cur and code != target_cur:
+                    continue
+
+                forward_pair = (base_cur, target_cur)
+                inverse_pair = (target_cur, base_cur)
+
+                rate_dec = Decimal(str(rate))
+                if rate_dec <= 0:
+                    LOG.warning(
+                        log_json(
+                            msg="Skipping non-positive rate from ExchangeRateDictionary",
+                            base_currency=base_cur,
+                            target_currency=target_cur,
+                            rate=str(rate),
+                        )
+                    )
+                    continue
+                dynamic_rates[forward_pair] = rate_dec
+                dynamic_rates.setdefault(inverse_pair, Decimal(1) / rate_dec)
+
+        # Exclude pairs that already have a static override for this month
+        pairs_to_upsert = {pair: rate for pair, rate in dynamic_rates.items() if pair not in static_pairs}
+
+        for (base_cur, target_cur), rate in pairs_to_upsert.items():
+            MonthlyExchangeRate.objects.update_or_create(
+                effective_date=current_month,
+                base_currency=base_cur,
+                target_currency=target_cur,
+                defaults={"exchange_rate": rate, "rate_type": RateType.DYNAMIC},
+            )
 
     if backfill_past_months:
-        _backfill_missing_past_months(dynamic_rates.keys(), current_month)
-
-    return count
+        _backfill_missing_past_months(current_month, code=code)
 
 
 def remove_monthly_rates(code):
@@ -203,14 +198,33 @@ def _mer_rates_by_pair(currency_pairs):
     return rates_by_pair
 
 
-def _backfill_missing_past_months(currency_pairs, current_month):
+def _backfill_missing_past_months(current_month, code=None, currency_pairs=None):
     """Fill gaps walking downward; each missing month inherits the next later rate.
 
     Example (Jan–Jun, rows at Apr/Jun): May<-Jun, Mar<-Apr, Feb<-Apr, Jan<-Apr.
+
+    When currency_pairs is omitted, discover pairs from existing MER rows in the retention window.
     """
-    pairs = set(currency_pairs)
     start = to_date(materialized_view_month_start(schema_name=getattr(connection, "schema_name", None)))
-    if not pairs or start >= current_month:
+    if start >= current_month:
+        return
+
+    if currency_pairs is None:
+        enabled_codes = set(EnabledCurrency.objects.values_list("currency_code", flat=True))
+        pairs = set(
+            MonthlyExchangeRate.objects.filter(
+                base_currency__in=enabled_codes,
+                target_currency__in=enabled_codes,
+                effective_date__gte=start,
+                effective_date__lte=current_month,
+            ).values_list("base_currency", "target_currency")
+        )
+        if code:
+            pairs = {(base, target) for base, target in pairs if code in (base, target)}
+    else:
+        pairs = set(currency_pairs)
+
+    if not pairs:
         return
 
     to_create = []

--- a/koku/cost_models/monthly_exchange_rate_utils.py
+++ b/koku/cost_models/monthly_exchange_rate_utils.py
@@ -186,24 +186,21 @@ def remove_monthly_rates(code):
 
 
 def _mer_rates_by_pair(currency_pairs):
-    """Return {pair: [(effective_date, rate), ...]} ordered by effective_date.
+    """Return {pair: {effective_date: rate}} for the given currency pairs.
 
-    Example: {("USD", "EUR"): [(Apr 1, 0.40), (Jun 1, 0.45)]}.
+    Example: {("USD", "EUR"): {date(2026, 4, 1): Decimal("0.40"), date(2026, 6, 1): Decimal("0.45")}}.
     """
-    base_currencies = {base for base, _ in currency_pairs}
-    target_currencies = {target for _, target in currency_pairs}
-    rates = {}
-    for base, target, effective, rate in (
-        MonthlyExchangeRate.objects.filter(
-            base_currency__in=base_currencies,
-            target_currency__in=target_currencies,
-        )
-        .order_by("effective_date")
-        .values_list("base_currency", "target_currency", "effective_date", "exchange_rate")
-    ):
-        if (base, target) in currency_pairs:
-            rates.setdefault((base, target), []).append((effective, rate))
-    return rates
+    pairs = set(currency_pairs)
+    base_currencies = {base for base, _ in pairs}
+    target_currencies = {target for _, target in pairs}
+    rates_by_pair = {}
+    for base, target, effective, rate in MonthlyExchangeRate.objects.filter(
+        base_currency__in=base_currencies,
+        target_currency__in=target_currencies,
+    ).values_list("base_currency", "target_currency", "effective_date", "exchange_rate"):
+        if (base, target) in pairs:
+            rates_by_pair.setdefault((base, target), {})[effective] = rate
+    return rates_by_pair
 
 
 def _backfill_missing_past_months(currency_pairs, current_month):
@@ -217,12 +214,12 @@ def _backfill_missing_past_months(currency_pairs, current_month):
         return
 
     to_create = []
-    for (base, target), dated_rates in _mer_rates_by_pair(pairs).items():
-        if not dated_rates:
+    for (base, target), existing in _mer_rates_by_pair(pairs).items():
+        if not existing:
             continue
-        existing = dict(dated_rates)
         # Walk down from the month before the latest available MER row.
-        latest_month, latest_rate = dated_rates[-1]
+        latest_month = max(existing)
+        latest_rate = existing[latest_month]
         month = latest_month - relativedelta(months=1)
         while month >= start:
             if month in existing:

--- a/koku/cost_models/monthly_exchange_rate_utils.py
+++ b/koku/cost_models/monthly_exchange_rate_utils.py
@@ -231,26 +231,26 @@ def _backfill_missing_past_months(current_month, code=None):
     if not rates_by_pair:
         return
 
-    to_create = []
-    for (base, target), existing in rates_by_pair.items():
+    rows_to_create = []
+    for (base, target), existing_rates in rates_by_pair.items():
         # First entry is the latest because the query is ordered newest-first.
-        latest_month, latest_rate = next(iter(existing.items()))
-        month = latest_month - relativedelta(months=1)
-        while month >= retention_start:
-            if month in existing:
-                latest_rate = existing[month]
+        most_recent_month, fill_rate = next(iter(existing_rates.items()))
+        current_fill_month = most_recent_month - relativedelta(months=1)
+        while current_fill_month >= retention_start:
+            if current_fill_month in existing_rates:
+                fill_rate = existing_rates[current_fill_month]
             else:
-                to_create.append(
+                rows_to_create.append(
                     MonthlyExchangeRate(
-                        effective_date=month,
+                        effective_date=current_fill_month,
                         base_currency=base,
                         target_currency=target,
-                        exchange_rate=latest_rate,
+                        exchange_rate=fill_rate,
                         rate_type=RateType.DYNAMIC,
                     )
                 )
-            month -= relativedelta(months=1)
+            current_fill_month -= relativedelta(months=1)
 
-    if to_create:
-        MonthlyExchangeRate.objects.bulk_create(to_create, ignore_conflicts=True)
-        LOG.info(log_json(msg="Backfilled missing monthly exchange rates", created=len(to_create)))
+    if rows_to_create:
+        MonthlyExchangeRate.objects.bulk_create(rows_to_create, ignore_conflicts=True)
+        LOG.info(log_json(msg="Backfilled missing monthly exchange rates", created=len(rows_to_create)))

--- a/koku/cost_models/monthly_exchange_rate_utils.py
+++ b/koku/cost_models/monthly_exchange_rate_utils.py
@@ -182,24 +182,6 @@ def remove_monthly_rates(code):
     return deleted
 
 
-def _mer_rates_by_pair(currency_pairs):
-    """Return {pair: {effective_date: rate}} for the given currency pairs.
-
-    Example: {("USD", "EUR"): {date(2026, 4, 1): Decimal("0.40"), date(2026, 6, 1): Decimal("0.45")}}.
-    """
-    pairs = set(currency_pairs)
-    base_currencies = {base for base, _ in pairs}
-    target_currencies = {target for _, target in pairs}
-    rates_by_pair = {}
-    for base, target, effective, rate in MonthlyExchangeRate.objects.filter(
-        base_currency__in=base_currencies,
-        target_currency__in=target_currencies,
-    ).values_list("base_currency", "target_currency", "effective_date", "exchange_rate"):
-        if (base, target) in pairs:
-            rates_by_pair.setdefault((base, target), {})[effective] = rate
-    return rates_by_pair
-
-
 def _backfill_missing_past_months(current_month, code=None):
     """Fill gaps walking downward; each missing month inherits the next later rate.
 
@@ -219,23 +201,27 @@ def _backfill_missing_past_months(current_month, code=None):
         return
 
     enabled_codes = set(EnabledCurrency.objects.values_list("currency_code", flat=True))
-    pairs_qs = MonthlyExchangeRate.objects.filter(
+    rates_qs = MonthlyExchangeRate.objects.filter(
         base_currency__in=enabled_codes,
         target_currency__in=enabled_codes,
         effective_date__gte=start,
         effective_date__lte=current_month,
     )
     if code:
-        pairs_qs = pairs_qs.filter(Q(base_currency=code) | Q(target_currency=code))
-    pairs = set(pairs_qs.values_list("base_currency", "target_currency"))
+        rates_qs = rates_qs.filter(Q(base_currency=code) | Q(target_currency=code))
 
-    if not pairs:
+    # {("USD", "EUR"): {date(2026, 4, 1): Decimal("0.40"), date(2026, 6, 1): Decimal("0.45")}}
+    rates_by_pair = {}
+    for base, target, effective, rate in rates_qs.values_list(
+        "base_currency", "target_currency", "effective_date", "exchange_rate"
+    ):
+        rates_by_pair.setdefault((base, target), {})[effective] = rate
+
+    if not rates_by_pair:
         return
 
     to_create = []
-    for (base, target), existing in _mer_rates_by_pair(pairs).items():
-        if not existing:
-            continue
+    for (base, target), existing in rates_by_pair.items():
         # Walk down from the month before the latest available MER row.
         latest_month = max(existing)
         latest_rate = existing[latest_month]

--- a/koku/cost_models/monthly_exchange_rate_utils.py
+++ b/koku/cost_models/monthly_exchange_rate_utils.py
@@ -182,6 +182,31 @@ def remove_monthly_rates(code):
     return deleted
 
 
+def _get_existing_rates_by_pair(start, end, enabled_codes, code=None):
+    """Return existing MER rates grouped by pair, ordered newest-first.
+
+    {("USD", "EUR"): {date(2026, 6, 1): Decimal("0.45"), date(2026, 4, 1): Decimal("0.40")}}
+
+    Dict insertion order is newest-first, so next(iter(d.items())) gives the latest rate.
+    """
+    qs = MonthlyExchangeRate.objects.filter(
+        base_currency__in=enabled_codes,
+        target_currency__in=enabled_codes,
+        effective_date__gte=start,
+        effective_date__lte=end,
+    )
+    if code:
+        qs = qs.filter(Q(base_currency=code) | Q(target_currency=code))
+
+    rates_by_pair = {}
+    for base, target, effective, rate in qs.order_by(
+        "base_currency", "target_currency", "-effective_date"
+    ).values_list("base_currency", "target_currency", "effective_date", "exchange_rate"):
+        rates_by_pair.setdefault((base, target), {})[effective] = rate
+
+    return rates_by_pair
+
+
 def _backfill_missing_past_months(current_month, code=None):
     """Fill gaps walking downward; each missing month inherits the next later rate.
 
@@ -201,33 +226,15 @@ def _backfill_missing_past_months(current_month, code=None):
         return
 
     enabled_codes = set(EnabledCurrency.objects.values_list("currency_code", flat=True))
-    rates_qs = MonthlyExchangeRate.objects.filter(
-        base_currency__in=enabled_codes,
-        target_currency__in=enabled_codes,
-        effective_date__gte=start,
-        effective_date__lte=current_month,
-    )
-    if code:
-        rates_qs = rates_qs.filter(Q(base_currency=code) | Q(target_currency=code))
-
-    # Newest effective_date first so the first row per pair is the latest MER.
-    # {("USD", "EUR"): {date(2026, 6, 1): Decimal("0.45"), date(2026, 4, 1): Decimal("0.40")}}
-    rates_by_pair = {}
-    latest_by_pair = {}
-    for base, target, effective, rate in rates_qs.order_by(
-        "base_currency", "target_currency", "-effective_date"
-    ).values_list("base_currency", "target_currency", "effective_date", "exchange_rate"):
-        pair = (base, target)
-        rates_by_pair.setdefault(pair, {})[effective] = rate
-        latest_by_pair.setdefault(pair, (effective, rate))
+    rates_by_pair = _get_existing_rates_by_pair(start, current_month, enabled_codes, code=code)
 
     if not rates_by_pair:
         return
 
     to_create = []
     for (base, target), existing in rates_by_pair.items():
-        # Walk down from the month before the latest available MER row.
-        latest_month, latest_rate = latest_by_pair[(base, target)]
+        # First entry is the latest because the query is ordered newest-first.
+        latest_month, latest_rate = next(iter(existing.items()))
         month = latest_month - relativedelta(months=1)
         while month >= start:
             if month in existing:

--- a/koku/cost_models/monthly_exchange_rate_utils.py
+++ b/koku/cost_models/monthly_exchange_rate_utils.py
@@ -4,7 +4,6 @@
 #
 """Utilities for managing MonthlyExchangeRate side effects."""
 import logging
-from bisect import bisect_right
 from decimal import Decimal
 
 from dateutil.relativedelta import relativedelta
@@ -186,22 +185,9 @@ def remove_monthly_rates(code):
     return deleted
 
 
-def _backfill_missing_past_months(currency_pairs, current_month):
-    """Fill each missing month with the next later existing MER rate for that pair.
-
-    Example (retention months 1-6, current=6, existing rows at 2 and 4):
-    month 1 <- rate from 2, month 3 <- rate from 4, month 5 <- rate from 6.
-    """
-    currency_pairs = set(currency_pairs)
-    month = to_date(materialized_view_month_start(schema_name=getattr(connection, "schema_name", None)))
-    past_months = []
-    while month < current_month:
-        past_months.append(month)
-        month += relativedelta(months=1)
-    if not currency_pairs or not past_months:
-        return
-
-    rates_by_pair = {}
+def _mer_rates_by_pair(currency_pairs):
+    """Return {pair: [(effective_date, rate), ...]} ordered by effective_date."""
+    rates = {}
     for base, target, effective, rate in (
         MonthlyExchangeRate.objects.filter(
             base_currency__in={b for b, _ in currency_pairs},
@@ -211,34 +197,37 @@ def _backfill_missing_past_months(currency_pairs, current_month):
         .values_list("base_currency", "target_currency", "effective_date", "exchange_rate")
     ):
         if (base, target) in currency_pairs:
-            rates_by_pair.setdefault((base, target), []).append((effective, rate))
+            rates.setdefault((base, target), []).append((effective, rate))
+    return rates
+
+
+def _backfill_missing_past_months(currency_pairs, current_month):
+    """Fill gaps with the next later MER rate (e.g. 1<-2, 3<-4, 5<-6)."""
+    pairs = set(currency_pairs)
+    cursor_start = to_date(materialized_view_month_start(schema_name=getattr(connection, "schema_name", None)))
+    if not pairs or cursor_start >= current_month:
+        return
 
     to_create = []
-    for (base, target), dated_rates in rates_by_pair.items():
-        dates = [effective for effective, _ in dated_rates]
-        covered = set(dates)
-        for missing in past_months:
-            if missing in covered:
-                continue
-            idx = bisect_right(dates, missing)
-            if idx >= len(dates):
-                continue
-            to_create.append(
-                MonthlyExchangeRate(
-                    effective_date=missing,
-                    base_currency=base,
-                    target_currency=target,
-                    exchange_rate=dated_rates[idx][1],
-                    rate_type=RateType.DYNAMIC,
+    for (base, target), dated_rates in _mer_rates_by_pair(pairs).items():
+        cursor = cursor_start
+        for effective, rate in dated_rates:
+            # Months before this existing row inherit its rate.
+            while cursor < effective and cursor < current_month:
+                to_create.append(
+                    MonthlyExchangeRate(
+                        effective_date=cursor,
+                        base_currency=base,
+                        target_currency=target,
+                        exchange_rate=rate,
+                        rate_type=RateType.DYNAMIC,
+                    )
                 )
-            )
+                cursor += relativedelta(months=1)
+            # Skip the existing month itself.
+            if cursor == effective:
+                cursor += relativedelta(months=1)
 
     if to_create:
         MonthlyExchangeRate.objects.bulk_create(to_create, ignore_conflicts=True)
-        LOG.info(
-            log_json(
-                msg="Backfilled missing monthly exchange rates for retention window",
-                created=len(to_create),
-                months=len(past_months),
-            )
-        )
+        LOG.info(log_json(msg="Backfilled missing monthly exchange rates", created=len(to_create)))

--- a/koku/cost_models/monthly_exchange_rate_utils.py
+++ b/koku/cost_models/monthly_exchange_rate_utils.py
@@ -200,12 +200,12 @@ def _mer_rates_by_pair(currency_pairs):
     return rates_by_pair
 
 
-def _backfill_missing_past_months(current_month, code=None, currency_pairs=None):
+def _backfill_missing_past_months(current_month, code=None):
     """Fill gaps walking downward; each missing month inherits the next later rate.
 
     Example (Jan–Jun, rows at Apr/Jun): May<-Jun, Mar<-Apr, Feb<-Apr, Jan<-Apr.
 
-    When currency_pairs is omitted, discover pairs from existing MER rows in the retention window.
+    Discovers pairs from existing MER rows in the retention window.
     """
     start = to_date(materialized_view_month_start(schema_name=getattr(connection, "schema_name", None)))
     if start >= current_month:
@@ -218,20 +218,16 @@ def _backfill_missing_past_months(current_month, code=None, currency_pairs=None)
         )
         return
 
-    if currency_pairs is None:
-        enabled_codes = set(EnabledCurrency.objects.values_list("currency_code", flat=True))
-        pairs = set(
-            MonthlyExchangeRate.objects.filter(
-                base_currency__in=enabled_codes,
-                target_currency__in=enabled_codes,
-                effective_date__gte=start,
-                effective_date__lte=current_month,
-            ).values_list("base_currency", "target_currency")
-        )
-        if code:
-            pairs = {(base, target) for base, target in pairs if code in (base, target)}
-    else:
-        pairs = set(currency_pairs)
+    enabled_codes = set(EnabledCurrency.objects.values_list("currency_code", flat=True))
+    pairs_qs = MonthlyExchangeRate.objects.filter(
+        base_currency__in=enabled_codes,
+        target_currency__in=enabled_codes,
+        effective_date__gte=start,
+        effective_date__lte=current_month,
+    )
+    if code:
+        pairs_qs = pairs_qs.filter(Q(base_currency=code) | Q(target_currency=code))
+    pairs = set(pairs_qs.values_list("base_currency", "target_currency"))
 
     if not pairs:
         return

--- a/koku/cost_models/monthly_exchange_rate_utils.py
+++ b/koku/cost_models/monthly_exchange_rate_utils.py
@@ -148,8 +148,9 @@ def populate_dynamic_monthly_rates(code=None, backfill_past_months=False):  # no
                         )
                     )
                     continue
+                inverse_rate = Decimal(1) / rate_dec
                 dynamic_rates[forward_pair] = rate_dec
-                dynamic_rates.setdefault(inverse_pair, Decimal(1) / rate_dec)
+                dynamic_rates.setdefault(inverse_pair, inverse_rate)
 
         # Exclude pairs that already have a static override for this month
         pairs_to_upsert = {pair: rate for pair, rate in dynamic_rates.items() if pair not in static_pairs}

--- a/koku/cost_models/monthly_exchange_rate_utils.py
+++ b/koku/cost_models/monthly_exchange_rate_utils.py
@@ -186,12 +186,17 @@ def remove_monthly_rates(code):
 
 
 def _mer_rates_by_pair(currency_pairs):
-    """Return {pair: [(effective_date, rate), ...]} ordered by effective_date."""
+    """Return {pair: [(effective_date, rate), ...]} ordered by effective_date.
+
+    Example: {("USD", "EUR"): [(Apr 1, 0.40), (Jun 1, 0.45)]}.
+    """
+    base_currencies = {base for base, _ in currency_pairs}
+    target_currencies = {target for _, target in currency_pairs}
     rates = {}
     for base, target, effective, rate in (
         MonthlyExchangeRate.objects.filter(
-            base_currency__in={b for b, _ in currency_pairs},
-            target_currency__in={t for _, t in currency_pairs},
+            base_currency__in=base_currencies,
+            target_currency__in=target_currencies,
         )
         .order_by("effective_date")
         .values_list("base_currency", "target_currency", "effective_date", "exchange_rate")
@@ -202,31 +207,37 @@ def _mer_rates_by_pair(currency_pairs):
 
 
 def _backfill_missing_past_months(currency_pairs, current_month):
-    """Fill gaps with the next later MER rate (e.g. 1<-2, 3<-4, 5<-6)."""
+    """Fill gaps walking downward; each missing month inherits the next later rate.
+
+    Example (Jan–Jun, rows at Apr/Jun): May<-Jun, Mar<-Apr, Feb<-Apr, Jan<-Apr.
+    """
     pairs = set(currency_pairs)
-    cursor_start = to_date(materialized_view_month_start(schema_name=getattr(connection, "schema_name", None)))
-    if not pairs or cursor_start >= current_month:
+    start = to_date(materialized_view_month_start(schema_name=getattr(connection, "schema_name", None)))
+    if not pairs or start >= current_month:
         return
 
     to_create = []
     for (base, target), dated_rates in _mer_rates_by_pair(pairs).items():
-        cursor = cursor_start
-        for effective, rate in dated_rates:
-            # Months before this existing row inherit its rate.
-            while cursor < effective and cursor < current_month:
+        if not dated_rates:
+            continue
+        existing = dict(dated_rates)
+        # Walk down from the month before the latest available MER row.
+        latest_month, latest_rate = dated_rates[-1]
+        month = latest_month - relativedelta(months=1)
+        while month >= start:
+            if month in existing:
+                latest_rate = existing[month]
+            else:
                 to_create.append(
                     MonthlyExchangeRate(
-                        effective_date=cursor,
+                        effective_date=month,
                         base_currency=base,
                         target_currency=target,
-                        exchange_rate=rate,
+                        exchange_rate=latest_rate,
                         rate_type=RateType.DYNAMIC,
                     )
                 )
-                cursor += relativedelta(months=1)
-            # Skip the existing month itself.
-            if cursor == effective:
-                cursor += relativedelta(months=1)
+            month -= relativedelta(months=1)
 
     if to_create:
         MonthlyExchangeRate.objects.bulk_create(to_create, ignore_conflicts=True)

--- a/koku/cost_models/monthly_exchange_rate_utils.py
+++ b/koku/cost_models/monthly_exchange_rate_utils.py
@@ -91,12 +91,12 @@ def replace_static_to_dynamic_monthly_rates(base_currency, target_currency, star
     populate_dynamic_monthly_rates(code=base_currency)
 
 
-def _backfill_missing_past_months(dynamic_rates, current_month, enabled=False):
+def _backfill_missing_past_months(dynamic_rates, current_month):
     """Insert today's rate for missing MonthlyExchangeRate rows in the retention window.
 
     Existing rows (static or dynamic) are never overwritten.
     """
-    if not enabled or not dynamic_rates:
+    if not dynamic_rates:
         return
 
     schema_name = getattr(connection, "schema_name", None)
@@ -142,7 +142,7 @@ def _backfill_missing_past_months(dynamic_rates, current_month, enabled=False):
     )
 
 
-def populate_dynamic_monthly_rates(code=None, backfill_past_months=False):
+def populate_dynamic_monthly_rates(code=None, backfill_past_months=False):  # noqa: C901
     """Populate dynamic MonthlyExchangeRate rows for the current month only.
 
     Past months are finalized and read-only — only the current month is written,
@@ -215,7 +215,8 @@ def populate_dynamic_monthly_rates(code=None, backfill_past_months=False):
         )
         count += 1
 
-    _backfill_missing_past_months(dynamic_rates, current_month, enabled=backfill_past_months)
+    if backfill_past_months:
+        _backfill_missing_past_months(dynamic_rates, current_month)
 
     return count
 

--- a/koku/cost_models/monthly_exchange_rate_utils.py
+++ b/koku/cost_models/monthly_exchange_rate_utils.py
@@ -14,6 +14,7 @@ from api.common import log_json
 from api.currency.models import ExchangeRateDictionary
 from api.utils import DateHelper
 from api.utils import materialized_view_month_start
+from api.utils import to_date
 from cost_models.models import EnabledCurrency
 from cost_models.models import MonthlyExchangeRate
 from cost_models.models import RateType
@@ -90,67 +91,32 @@ def replace_static_to_dynamic_monthly_rates(base_currency, target_currency, star
     populate_dynamic_monthly_rates(code=base_currency)
 
 
-def _retention_months_before_current(current_month):
-    """Return month-start dates in the tenant retention window before the current month.
-
-    Uses the same retention window as data purge (per-tenant when available).
-    """
-    schema_name = getattr(connection, "schema_name", None)
-    earliest = materialized_view_month_start(schema_name=schema_name)
-    if hasattr(earliest, "date"):
-        earliest = earliest.date()
-
-    months = []
-    month = earliest
-    while month < current_month:
-        months.append(month)
-        month += relativedelta(months=1)
-    return months
-
-
-def _collect_dynamic_rates(exchange_dict, enabled_codes, code=None):
-    """Build enabled currency-pair rates from ExchangeRateDictionary, with inverses."""
-    dynamic_rates = {}
-    for base_cur, rates_by_target in exchange_dict.items():
-        for target_cur, rate in rates_by_target.items():
-            if base_cur == target_cur:
-                continue
-            if base_cur not in enabled_codes or target_cur not in enabled_codes:
-                continue
-            if code and code != base_cur and code != target_cur:
-                continue
-
-            rate_dec = Decimal(str(rate))
-            if rate_dec <= 0:
-                LOG.warning(
-                    log_json(
-                        msg="Skipping non-positive rate from ExchangeRateDictionary",
-                        base_currency=base_cur,
-                        target_currency=target_cur,
-                        rate=str(rate),
-                    )
-                )
-                continue
-            dynamic_rates[(base_cur, target_cur)] = rate_dec
-            dynamic_rates.setdefault((target_cur, base_cur), Decimal(1) / rate_dec)
-    return dynamic_rates
-
-
-def _backfill_missing_past_months(dynamic_rates, past_months):
-    """Insert today's rate for any missing MonthlyExchangeRate rows in past months.
+def _backfill_missing_past_months(dynamic_rates, current_month, enabled=False):
+    """Insert today's rate for missing MonthlyExchangeRate rows in the retention window.
 
     Existing rows (static or dynamic) are never overwritten.
     """
-    if not dynamic_rates or not past_months:
+    if not enabled or not dynamic_rates:
+        return
+
+    schema_name = getattr(connection, "schema_name", None)
+    earliest = to_date(materialized_view_month_start(schema_name=schema_name))
+    past_months = []
+    month = earliest
+    while month < current_month:
+        past_months.append(month)
+        month += relativedelta(months=1)
+    if not past_months:
         return
 
     existing = set(
         MonthlyExchangeRate.objects.filter(
             effective_date__gte=past_months[0],
             effective_date__lte=past_months[-1],
+            base_currency__in={pair[0] for pair in dynamic_rates},
+            target_currency__in={pair[1] for pair in dynamic_rates},
         ).values_list("base_currency", "target_currency", "effective_date")
     )
-
     to_create = [
         MonthlyExchangeRate(
             effective_date=month,
@@ -177,29 +143,29 @@ def _backfill_missing_past_months(dynamic_rates, past_months):
 
 
 def populate_dynamic_monthly_rates(code=None, backfill_past_months=False):
-    """Populate dynamic MonthlyExchangeRate rows for the current month.
+    """Populate dynamic MonthlyExchangeRate rows for the current month only.
 
-    Current month: upserted from ExchangeRateDictionary (daily refresh). Static
-    overrides for the current month are preserved.
+    Past months are finalized and read-only — only the current month is written,
+    unless backfill_past_months is True (daily Celery crawl), in which case missing
+    MonthlyExchangeRate rows in the tenant retention window are filled with today's rate.
+    Existing past-month rows (static or dynamic) are never overwritten.
 
-    When backfill_past_months is True, also insert
-    today's rate for any missing MonthlyExchangeRate rows in past months within
-    the tenant retention window. Existing rows (static or dynamic) are never
-    overwritten.
+    Reads the latest rates from ExchangeRateDictionary and writes dynamic
+    MonthlyExchangeRate rows for each enabled currency pair. Static overrides are preserved.
 
     When code is provided, only pairs involving that currency are processed.
     When None, all enabled currency pairs are processed.
     """
     enabled_codes = set(EnabledCurrency.objects.values_list("currency_code", flat=True))
     if not enabled_codes:
-        return
+        return 0
 
     erd = ExchangeRateDictionary.objects.first()
     if not erd or not erd.currency_exchange_dictionary:
-        return
+        return 0
 
+    exchange_dict = erd.currency_exchange_dictionary
     current_month = DateHelper().this_month_start.date()
-    dynamic_rates = _collect_dynamic_rates(erd.currency_exchange_dictionary, enabled_codes, code)
 
     static_pairs = set(
         MonthlyExchangeRate.objects.filter(
@@ -208,18 +174,50 @@ def populate_dynamic_monthly_rates(code=None, backfill_past_months=False):
         ).values_list("base_currency", "target_currency")
     )
 
-    for (base_cur, target_cur), rate in dynamic_rates.items():
-        if (base_cur, target_cur) in static_pairs:
-            continue
+    # Collect rates and synthesize inverses when not already in the dictionary
+    dynamic_rates = {}
+    for base_cur, rates_by_target in exchange_dict.items():
+        for target_cur, rate in rates_by_target.items():
+            if base_cur == target_cur:
+                continue
+            if base_cur not in enabled_codes or target_cur not in enabled_codes:
+                continue
+            if code and code != base_cur and code != target_cur:
+                continue
+
+            forward_pair = (base_cur, target_cur)
+            inverse_pair = (target_cur, base_cur)
+
+            rate_dec = Decimal(str(rate))
+            if rate_dec <= 0:
+                LOG.warning(
+                    log_json(
+                        msg="Skipping non-positive rate from ExchangeRateDictionary",
+                        base_currency=base_cur,
+                        target_currency=target_cur,
+                        rate=str(rate),
+                    )
+                )
+                continue
+            dynamic_rates[forward_pair] = rate_dec
+            dynamic_rates.setdefault(inverse_pair, Decimal(1) / rate_dec)
+
+    # Exclude pairs that already have a static override for this month
+    pairs_to_upsert = {pair: rate for pair, rate in dynamic_rates.items() if pair not in static_pairs}
+
+    count = 0
+    for (base_cur, target_cur), rate in pairs_to_upsert.items():
         MonthlyExchangeRate.objects.update_or_create(
             effective_date=current_month,
             base_currency=base_cur,
             target_currency=target_cur,
             defaults={"exchange_rate": rate, "rate_type": RateType.DYNAMIC},
         )
+        count += 1
 
-    if backfill_past_months:
-        _backfill_missing_past_months(dynamic_rates, _retention_months_before_current(current_month))
+    _backfill_missing_past_months(dynamic_rates, current_month, enabled=backfill_past_months)
+
+    return count
 
 
 def remove_monthly_rates(code):

--- a/koku/cost_models/monthly_exchange_rate_utils.py
+++ b/koku/cost_models/monthly_exchange_rate_utils.py
@@ -91,6 +91,45 @@ def replace_static_to_dynamic_monthly_rates(base_currency, target_currency, star
     populate_dynamic_monthly_rates(code=base_currency)
 
 
+def _build_enabled_pair_rates(exchange_dict, enabled_codes, code=None):
+    """Build (base, target) -> rate for enabled pairs, synthesizing missing inverses.
+
+    Example:
+        exchange_dict = {"USD": {"EUR": "0.87", "USD": "1.0"}, "EUR": {"EUR": "1.0"}}
+        enabled_codes = {"USD", "EUR"}
+
+        # Returns both the forward rate and a synthesized inverse:
+        # {("USD", "EUR"): Decimal("0.87"), ("EUR", "USD"): Decimal("1") / Decimal("0.87")}
+    """
+    dynamic_rates = {}
+    for base_cur, rates_by_target in exchange_dict.items():
+        for target_cur, rate in rates_by_target.items():
+            if base_cur == target_cur:
+                continue
+            if base_cur not in enabled_codes or target_cur not in enabled_codes:
+                continue
+            if code and code != base_cur and code != target_cur:
+                continue
+
+            forward_pair = (base_cur, target_cur)
+            inverse_pair = (target_cur, base_cur)
+
+            rate_dec = Decimal(str(rate))
+            if rate_dec <= 0:
+                LOG.warning(
+                    log_json(
+                        msg="Skipping non-positive rate from ExchangeRateDictionary",
+                        base_currency=base_cur,
+                        target_currency=target_cur,
+                        rate=str(rate),
+                    )
+                )
+                continue
+            dynamic_rates[forward_pair] = rate_dec
+            dynamic_rates.setdefault(inverse_pair, Decimal(1) / rate_dec)
+    return dynamic_rates
+
+
 def _backfill_missing_past_months(dynamic_rates, current_month):
     """Insert today's rate for missing MonthlyExchangeRate rows in the retention window.
 
@@ -142,7 +181,7 @@ def _backfill_missing_past_months(dynamic_rates, current_month):
     )
 
 
-def populate_dynamic_monthly_rates(code=None, backfill_past_months=False):  # noqa: C901
+def populate_dynamic_monthly_rates(code=None, backfill_past_months=False):
     """Populate dynamic MonthlyExchangeRate rows for the current month only.
 
     Past months are finalized and read-only — only the current month is written,
@@ -164,8 +203,8 @@ def populate_dynamic_monthly_rates(code=None, backfill_past_months=False):  # no
     if not erd or not erd.currency_exchange_dictionary:
         return 0
 
-    exchange_dict = erd.currency_exchange_dictionary
     current_month = DateHelper().this_month_start.date()
+    dynamic_rates = _build_enabled_pair_rates(erd.currency_exchange_dictionary, enabled_codes, code)
 
     static_pairs = set(
         MonthlyExchangeRate.objects.filter(
@@ -173,34 +212,6 @@ def populate_dynamic_monthly_rates(code=None, backfill_past_months=False):  # no
             rate_type=RateType.STATIC,
         ).values_list("base_currency", "target_currency")
     )
-
-    # Collect rates and synthesize inverses when not already in the dictionary
-    dynamic_rates = {}
-    for base_cur, rates_by_target in exchange_dict.items():
-        for target_cur, rate in rates_by_target.items():
-            if base_cur == target_cur:
-                continue
-            if base_cur not in enabled_codes or target_cur not in enabled_codes:
-                continue
-            if code and code != base_cur and code != target_cur:
-                continue
-
-            forward_pair = (base_cur, target_cur)
-            inverse_pair = (target_cur, base_cur)
-
-            rate_dec = Decimal(str(rate))
-            if rate_dec <= 0:
-                LOG.warning(
-                    log_json(
-                        msg="Skipping non-positive rate from ExchangeRateDictionary",
-                        base_currency=base_cur,
-                        target_currency=target_cur,
-                        rate=str(rate),
-                    )
-                )
-                continue
-            dynamic_rates[forward_pair] = rate_dec
-            dynamic_rates.setdefault(inverse_pair, Decimal(1) / rate_dec)
 
     # Exclude pairs that already have a static override for this month
     pairs_to_upsert = {pair: rate for pair, rate in dynamic_rates.items() if pair not in static_pairs}

--- a/koku/cost_models/monthly_exchange_rate_utils.py
+++ b/koku/cost_models/monthly_exchange_rate_utils.py
@@ -214,19 +214,19 @@ def _backfill_missing_past_months(current_month, code=None):
 
     Discovers pairs from existing MER rows in the retention window.
     """
-    start = to_date(materialized_view_month_start(schema_name=getattr(connection, "schema_name", None)))
-    if start >= current_month:
+    retention_start = to_date(materialized_view_month_start(schema_name=getattr(connection, "schema_name", None)))
+    if retention_start >= current_month:
         LOG.warning(
             log_json(
                 msg="Skipping MER backfill; retention start is at or after current month",
-                retention_start=str(start),
+                retention_start=str(retention_start),
                 current_month=str(current_month),
             )
         )
         return
 
     enabled_codes = set(EnabledCurrency.objects.values_list("currency_code", flat=True))
-    rates_by_pair = _get_existing_rates_by_pair(start, current_month, enabled_codes, code=code)
+    rates_by_pair = _get_existing_rates_by_pair(retention_start, current_month, enabled_codes, code=code)
 
     if not rates_by_pair:
         return
@@ -236,7 +236,7 @@ def _backfill_missing_past_months(current_month, code=None):
         # First entry is the latest because the query is ordered newest-first.
         latest_month, latest_rate = next(iter(existing.items()))
         month = latest_month - relativedelta(months=1)
-        while month >= start:
+        while month >= retention_start:
             if month in existing:
                 latest_rate = existing[month]
             else:

--- a/koku/cost_models/monthly_exchange_rate_utils.py
+++ b/koku/cost_models/monthly_exchange_rate_utils.py
@@ -186,77 +186,49 @@ def remove_monthly_rates(code):
     return deleted
 
 
-def _retention_months_before_current(current_month):
-    """Return month-start dates in the tenant retention window before the current month."""
-    schema_name = getattr(connection, "schema_name", None)
-    earliest = to_date(materialized_view_month_start(schema_name=schema_name))
-    months = []
-    month = earliest
+def _backfill_missing_past_months(currency_pairs, current_month):
+    """Fill missing past months from each pair's oldest MonthlyExchangeRate rate."""
+    currency_pairs = set(currency_pairs)
+    month = to_date(materialized_view_month_start(schema_name=getattr(connection, "schema_name", None)))
+    past_months = []
     while month < current_month:
-        months.append(month)
+        past_months.append(month)
         month += relativedelta(months=1)
-    return months
+    if not currency_pairs or not past_months:
+        return
 
-
-def _oldest_rates_and_coverage(currency_pairs):
-    """Return oldest exchange_rate per pair and the set of existing (pair, month) keys."""
-    existing_rows = (
+    oldest, covered = {}, set()
+    for base, target, effective, rate in (
         MonthlyExchangeRate.objects.filter(
-            base_currency__in={pair[0] for pair in currency_pairs},
-            target_currency__in={pair[1] for pair in currency_pairs},
+            base_currency__in={b for b, _ in currency_pairs},
+            target_currency__in={t for _, t in currency_pairs},
         )
         .order_by("effective_date")
         .values_list("base_currency", "target_currency", "effective_date", "exchange_rate")
-    )
-
-    oldest_rate_by_pair = {}
-    existing = set()
-    for base_cur, target_cur, effective_date, exchange_rate in existing_rows:
-        pair = (base_cur, target_cur)
-        if pair not in currency_pairs:
+    ):
+        if (base, target) not in currency_pairs:
             continue
-        existing.add((base_cur, target_cur, effective_date))
-        if pair not in oldest_rate_by_pair:
-            oldest_rate_by_pair[pair] = exchange_rate
-    return oldest_rate_by_pair, existing
+        covered.add((base, target, effective))
+        oldest.setdefault((base, target), rate)
 
-
-def _backfill_missing_past_months(currency_pairs, current_month):
-    """Fill missing past months using each pair's oldest MonthlyExchangeRate.
-
-    Copies the exchange_rate from the earliest existing MER row for that pair
-    (not today's ExchangeRateDictionary value). Existing rows are never overwritten.
-    Pairs with no existing MER rows are skipped.
-    """
-    currency_pairs = set(currency_pairs)
-    if not currency_pairs:
-        return
-
-    past_months = _retention_months_before_current(current_month)
-    if not past_months:
-        return
-
-    oldest_rate_by_pair, existing = _oldest_rates_and_coverage(currency_pairs)
     to_create = [
         MonthlyExchangeRate(
-            effective_date=month,
-            base_currency=base_cur,
-            target_currency=target_cur,
-            exchange_rate=exchange_rate,
+            effective_date=m,
+            base_currency=base,
+            target_currency=target,
+            exchange_rate=rate,
             rate_type=RateType.DYNAMIC,
         )
-        for (base_cur, target_cur), exchange_rate in oldest_rate_by_pair.items()
-        for month in past_months
-        if (base_cur, target_cur, month) not in existing
+        for (base, target), rate in oldest.items()
+        for m in past_months
+        if (base, target, m) not in covered
     ]
-    if not to_create:
-        return
-
-    MonthlyExchangeRate.objects.bulk_create(to_create, ignore_conflicts=True)
-    LOG.info(
-        log_json(
-            msg="Backfilled missing monthly exchange rates for retention window",
-            created=len(to_create),
-            months=len(past_months),
+    if to_create:
+        MonthlyExchangeRate.objects.bulk_create(to_create, ignore_conflicts=True)
+        LOG.info(
+            log_json(
+                msg="Backfilled missing monthly exchange rates for retention window",
+                created=len(to_create),
+                months=len(past_months),
+            )
         )
-    )

--- a/koku/cost_models/monthly_exchange_rate_utils.py
+++ b/koku/cost_models/monthly_exchange_rate_utils.py
@@ -109,9 +109,10 @@ def populate_dynamic_monthly_rates(code=None, backfill_past_months=False):  # no
     enabled_codes = set(EnabledCurrency.objects.values_list("currency_code", flat=True))
     if not enabled_codes:
         LOG.warning(log_json(msg="No enabled currencies; skipping monthly exchange rate populate"))
-        return
+        return 0
 
     current_month = DateHelper().this_month_start.date()
+    updated_count = 0
     erd = ExchangeRateDictionary.objects.first()
     if erd and erd.currency_exchange_dictionary:
         exchange_dict = erd.currency_exchange_dictionary
@@ -162,9 +163,13 @@ def populate_dynamic_monthly_rates(code=None, backfill_past_months=False):  # no
                 target_currency=target_cur,
                 defaults={"exchange_rate": rate, "rate_type": RateType.DYNAMIC},
             )
+            updated_count += 1
 
+    backfilled_count = 0
     if backfill_past_months:
-        _backfill_missing_past_months(current_month, code=code)
+        backfilled_count = _backfill_missing_past_months(current_month, enabled_codes=enabled_codes, code=code)
+
+    return updated_count + backfilled_count
 
 
 def remove_monthly_rates(code):
@@ -182,14 +187,13 @@ def remove_monthly_rates(code):
     return deleted
 
 
-def _get_existing_rates_by_pair(start, end, code=None):
+def _get_existing_rates_by_pair(start, end, enabled_codes, code=None):
     """Return existing MER rates grouped by pair, ordered newest-first.
 
     {("USD", "EUR"): {date(2026, 6, 1): Decimal("0.45"), date(2026, 4, 1): Decimal("0.40")}}
 
     Dict insertion order is newest-first, so next(iter(d.items())) gives the latest rate.
     """
-    enabled_codes = set(EnabledCurrency.objects.values_list("currency_code", flat=True))
     qs = MonthlyExchangeRate.objects.filter(
         base_currency__in=enabled_codes,
         target_currency__in=enabled_codes,
@@ -208,12 +212,13 @@ def _get_existing_rates_by_pair(start, end, code=None):
     return rates_by_pair
 
 
-def _backfill_missing_past_months(current_month, code=None):
+def _backfill_missing_past_months(current_month, enabled_codes, code=None):
     """Fill gaps walking downward; each missing month inherits the next later rate.
 
     Example (Jan–Jun, rows at Apr/Jun): May<-Jun, Mar<-Apr, Feb<-Apr, Jan<-Apr.
 
     Discovers pairs from existing MER rows in the retention window.
+    Returns the number of rows created.
     """
     retention_start = to_date(materialized_view_month_start(schema_name=getattr(connection, "schema_name", None)))
     if retention_start >= current_month:
@@ -224,12 +229,12 @@ def _backfill_missing_past_months(current_month, code=None):
                 current_month=str(current_month),
             )
         )
-        return
+        return 0
 
-    rates_by_pair = _get_existing_rates_by_pair(retention_start, current_month, code=code)
+    rates_by_pair = _get_existing_rates_by_pair(retention_start, current_month, enabled_codes=enabled_codes, code=code)
 
     if not rates_by_pair:
-        return
+        return 0
 
     rows_to_create = []
     for (base, target), existing_rates in rates_by_pair.items():
@@ -254,3 +259,5 @@ def _backfill_missing_past_months(current_month, code=None):
     if rows_to_create:
         MonthlyExchangeRate.objects.bulk_create(rows_to_create, ignore_conflicts=True)
         LOG.info(log_json(msg="Backfilled missing monthly exchange rates", created=len(rows_to_create)))
+
+    return len(rows_to_create)

--- a/koku/cost_models/monthly_exchange_rate_utils.py
+++ b/koku/cost_models/monthly_exchange_rate_utils.py
@@ -91,16 +91,39 @@ def replace_static_to_dynamic_monthly_rates(base_currency, target_currency, star
     populate_dynamic_monthly_rates(code=base_currency)
 
 
-def _build_enabled_pair_rates(exchange_dict, enabled_codes, code=None):
-    """Build (base, target) -> rate for enabled pairs, synthesizing missing inverses.
+def populate_dynamic_monthly_rates(code=None, backfill_past_months=False):  # noqa: C901
+    """Populate dynamic MonthlyExchangeRate rows for the current month only.
 
-    Example:
-        exchange_dict = {"USD": {"EUR": "0.87", "USD": "1.0"}, "EUR": {"EUR": "1.0"}}
-        enabled_codes = {"USD", "EUR"}
+    Past months are finalized and read-only — only the current month is written,
+    unless backfill_past_months is True (daily Celery crawl), in which case missing
+    MonthlyExchangeRate rows in the tenant retention window are filled with today's rate.
+    Existing past-month rows (static or dynamic) are never overwritten.
 
-        # Returns both the forward rate and a synthesized inverse:
-        # {("USD", "EUR"): Decimal("0.87"), ("EUR", "USD"): Decimal("1") / Decimal("0.87")}
+    Reads the latest rates from ExchangeRateDictionary and writes dynamic
+    MonthlyExchangeRate rows for each enabled currency pair. Static overrides are preserved.
+
+    When code is provided, only pairs involving that currency are processed.
+    When None, all enabled currency pairs are processed.
     """
+    enabled_codes = set(EnabledCurrency.objects.values_list("currency_code", flat=True))
+    if not enabled_codes:
+        return 0
+
+    erd = ExchangeRateDictionary.objects.first()
+    if not erd or not erd.currency_exchange_dictionary:
+        return 0
+
+    exchange_dict = erd.currency_exchange_dictionary
+    current_month = DateHelper().this_month_start.date()
+
+    static_pairs = set(
+        MonthlyExchangeRate.objects.filter(
+            effective_date=current_month,
+            rate_type=RateType.STATIC,
+        ).values_list("base_currency", "target_currency")
+    )
+
+    # Collect rates and synthesize inverses when not already in the dictionary
     dynamic_rates = {}
     for base_cur, rates_by_target in exchange_dict.items():
         for target_cur, rate in rates_by_target.items():
@@ -127,7 +150,39 @@ def _build_enabled_pair_rates(exchange_dict, enabled_codes, code=None):
                 continue
             dynamic_rates[forward_pair] = rate_dec
             dynamic_rates.setdefault(inverse_pair, Decimal(1) / rate_dec)
-    return dynamic_rates
+
+    # Exclude pairs that already have a static override for this month
+    pairs_to_upsert = {pair: rate for pair, rate in dynamic_rates.items() if pair not in static_pairs}
+
+    count = 0
+    for (base_cur, target_cur), rate in pairs_to_upsert.items():
+        MonthlyExchangeRate.objects.update_or_create(
+            effective_date=current_month,
+            base_currency=base_cur,
+            target_currency=target_cur,
+            defaults={"exchange_rate": rate, "rate_type": RateType.DYNAMIC},
+        )
+        count += 1
+
+    if backfill_past_months:
+        _backfill_missing_past_months(dynamic_rates, current_month)
+
+    return count
+
+
+def remove_monthly_rates(code):
+    """Remove all MonthlyExchangeRate rows (dynamic and static) involving the given currency for the current month.
+
+    Past months are finalized and read-only — only the current month is touched.
+    """
+    current_month = DateHelper().this_month_start.date()
+    deleted, _ = (
+        MonthlyExchangeRate.objects.filter(effective_date=current_month)
+        .filter(Q(base_currency=code) | Q(target_currency=code))
+        .delete()
+    )
+    LOG.info(log_json(msg="Removed MonthlyExchangeRate rows", code=code, deleted=deleted))
+    return deleted
 
 
 def _backfill_missing_past_months(dynamic_rates, current_month):
@@ -179,69 +234,3 @@ def _backfill_missing_past_months(dynamic_rates, current_month):
             months=len(past_months),
         )
     )
-
-
-def populate_dynamic_monthly_rates(code=None, backfill_past_months=False):
-    """Populate dynamic MonthlyExchangeRate rows for the current month only.
-
-    Past months are finalized and read-only — only the current month is written,
-    unless backfill_past_months is True (daily Celery crawl), in which case missing
-    MonthlyExchangeRate rows in the tenant retention window are filled with today's rate.
-    Existing past-month rows (static or dynamic) are never overwritten.
-
-    Reads the latest rates from ExchangeRateDictionary and writes dynamic
-    MonthlyExchangeRate rows for each enabled currency pair. Static overrides are preserved.
-
-    When code is provided, only pairs involving that currency are processed.
-    When None, all enabled currency pairs are processed.
-    """
-    enabled_codes = set(EnabledCurrency.objects.values_list("currency_code", flat=True))
-    if not enabled_codes:
-        return 0
-
-    erd = ExchangeRateDictionary.objects.first()
-    if not erd or not erd.currency_exchange_dictionary:
-        return 0
-
-    current_month = DateHelper().this_month_start.date()
-    dynamic_rates = _build_enabled_pair_rates(erd.currency_exchange_dictionary, enabled_codes, code)
-
-    static_pairs = set(
-        MonthlyExchangeRate.objects.filter(
-            effective_date=current_month,
-            rate_type=RateType.STATIC,
-        ).values_list("base_currency", "target_currency")
-    )
-
-    # Exclude pairs that already have a static override for this month
-    pairs_to_upsert = {pair: rate for pair, rate in dynamic_rates.items() if pair not in static_pairs}
-
-    count = 0
-    for (base_cur, target_cur), rate in pairs_to_upsert.items():
-        MonthlyExchangeRate.objects.update_or_create(
-            effective_date=current_month,
-            base_currency=base_cur,
-            target_currency=target_cur,
-            defaults={"exchange_rate": rate, "rate_type": RateType.DYNAMIC},
-        )
-        count += 1
-
-    if backfill_past_months:
-        _backfill_missing_past_months(dynamic_rates, current_month)
-
-    return count
-
-
-def remove_monthly_rates(code):
-    """Remove all MonthlyExchangeRate rows (dynamic and static) involving the given currency for the current month.
-
-    Past months are finalized and read-only — only the current month is touched.
-    """
-    current_month = DateHelper().this_month_start.date()
-    deleted, _ = (
-        MonthlyExchangeRate.objects.filter(effective_date=current_month)
-        .filter(Q(base_currency=code) | Q(target_currency=code))
-        .delete()
-    )
-    LOG.info(log_json(msg="Removed MonthlyExchangeRate rows", code=code, deleted=deleted))
-    return deleted

--- a/koku/cost_models/monthly_exchange_rate_utils.py
+++ b/koku/cost_models/monthly_exchange_rate_utils.py
@@ -108,14 +108,41 @@ def _retention_months_before_current(current_month):
     return months
 
 
+def _collect_dynamic_rates(exchange_dict, enabled_codes, code=None):
+    """Build enabled currency-pair rates from ExchangeRateDictionary, with inverses."""
+    dynamic_rates = {}
+    for base_cur, rates_by_target in exchange_dict.items():
+        for target_cur, rate in rates_by_target.items():
+            if base_cur == target_cur:
+                continue
+            if base_cur not in enabled_codes or target_cur not in enabled_codes:
+                continue
+            if code and code != base_cur and code != target_cur:
+                continue
+
+            rate_dec = Decimal(str(rate))
+            if rate_dec <= 0:
+                LOG.warning(
+                    log_json(
+                        msg="Skipping non-positive rate from ExchangeRateDictionary",
+                        base_currency=base_cur,
+                        target_currency=target_cur,
+                        rate=str(rate),
+                    )
+                )
+                continue
+            dynamic_rates[(base_cur, target_cur)] = rate_dec
+            dynamic_rates.setdefault((target_cur, base_cur), Decimal(1) / rate_dec)
+    return dynamic_rates
+
+
 def _backfill_missing_past_months(dynamic_rates, past_months):
     """Insert today's rate for any missing MonthlyExchangeRate rows in past months.
 
-    Existing rows (static or dynamic) are never overwritten. Returns the number of
-    rows created.
+    Existing rows (static or dynamic) are never overwritten.
     """
     if not dynamic_rates or not past_months:
-        return 0
+        return
 
     existing = set(
         MonthlyExchangeRate.objects.filter(
@@ -137,7 +164,7 @@ def _backfill_missing_past_months(dynamic_rates, past_months):
         if (base_cur, target_cur, month) not in existing
     ]
     if not to_create:
-        return 0
+        return
 
     MonthlyExchangeRate.objects.bulk_create(to_create, ignore_conflicts=True)
     LOG.info(
@@ -147,34 +174,32 @@ def _backfill_missing_past_months(dynamic_rates, past_months):
             months=len(past_months),
         )
     )
-    return len(to_create)
 
 
-def populate_dynamic_monthly_rates(code=None):
-    """Populate dynamic MonthlyExchangeRate rows for the current month and backfill gaps.
+def populate_dynamic_monthly_rates(code=None, backfill_past_months=False):
+    """Populate dynamic MonthlyExchangeRate rows for the current month.
 
     Current month: upserted from ExchangeRateDictionary (daily refresh). Static
     overrides for the current month are preserved.
 
-    Past months within the tenant retention window: if a currency pair has no
-    MonthlyExchangeRate row for that month, today's rate is inserted. Existing
-    rows (static or dynamic) are left untouched — a no-op when coverage already
-    exists. This fills rates for newly enabled currencies and for months that
-    predate feature rollout, without requiring a migration.
+    When backfill_past_months is True, also insert
+    today's rate for any missing MonthlyExchangeRate rows in past months within
+    the tenant retention window. Existing rows (static or dynamic) are never
+    overwritten.
 
     When code is provided, only pairs involving that currency are processed.
     When None, all enabled currency pairs are processed.
     """
     enabled_codes = set(EnabledCurrency.objects.values_list("currency_code", flat=True))
     if not enabled_codes:
-        return 0
+        return
 
     erd = ExchangeRateDictionary.objects.first()
     if not erd or not erd.currency_exchange_dictionary:
-        return 0
+        return
 
-    exchange_dict = erd.currency_exchange_dictionary
     current_month = DateHelper().this_month_start.date()
+    dynamic_rates = _collect_dynamic_rates(erd.currency_exchange_dictionary, enabled_codes, code)
 
     static_pairs = set(
         MonthlyExchangeRate.objects.filter(
@@ -183,49 +208,18 @@ def populate_dynamic_monthly_rates(code=None):
         ).values_list("base_currency", "target_currency")
     )
 
-    # Collect rates and synthesize inverses when not already in the dictionary
-    dynamic_rates = {}
-    for base_cur, rates_by_target in exchange_dict.items():
-        for target_cur, rate in rates_by_target.items():
-            if base_cur == target_cur:
-                continue
-            if base_cur not in enabled_codes or target_cur not in enabled_codes:
-                continue
-            if code and code != base_cur and code != target_cur:
-                continue
-
-            forward_pair = (base_cur, target_cur)
-            inverse_pair = (target_cur, base_cur)
-
-            rate_dec = Decimal(str(rate))
-            if rate_dec <= 0:
-                LOG.warning(
-                    log_json(
-                        msg="Skipping non-positive rate from ExchangeRateDictionary",
-                        base_currency=base_cur,
-                        target_currency=target_cur,
-                        rate=str(rate),
-                    )
-                )
-                continue
-            dynamic_rates[forward_pair] = rate_dec
-            dynamic_rates.setdefault(inverse_pair, Decimal(1) / rate_dec)
-
-    # Exclude pairs that already have a static override for this month
-    pairs_to_upsert = {pair: rate for pair, rate in dynamic_rates.items() if pair not in static_pairs}
-
-    count = 0
-    for (base_cur, target_cur), rate in pairs_to_upsert.items():
+    for (base_cur, target_cur), rate in dynamic_rates.items():
+        if (base_cur, target_cur) in static_pairs:
+            continue
         MonthlyExchangeRate.objects.update_or_create(
             effective_date=current_month,
             base_currency=base_cur,
             target_currency=target_cur,
             defaults={"exchange_rate": rate, "rate_type": RateType.DYNAMIC},
         )
-        count += 1
 
-    count += _backfill_missing_past_months(dynamic_rates, _retention_months_before_current(current_month))
-    return count
+    if backfill_past_months:
+        _backfill_missing_past_months(dynamic_rates, _retention_months_before_current(current_month))
 
 
 def remove_monthly_rates(code):

--- a/koku/cost_models/monthly_exchange_rate_utils.py
+++ b/koku/cost_models/monthly_exchange_rate_utils.py
@@ -108,7 +108,7 @@ def populate_dynamic_monthly_rates(code=None, backfill_past_months=False):  # no
     """
     enabled_codes = set(EnabledCurrency.objects.values_list("currency_code", flat=True))
     if not enabled_codes:
-        LOG.info(log_json(msg="No enabled currencies; skipping monthly exchange rate populate"))
+        LOG.warning(log_json(msg="No enabled currencies; skipping monthly exchange rate populate"))
         return
 
     current_month = DateHelper().this_month_start.date()
@@ -209,6 +209,13 @@ def _backfill_missing_past_months(current_month, code=None, currency_pairs=None)
     """
     start = to_date(materialized_view_month_start(schema_name=getattr(connection, "schema_name", None)))
     if start >= current_month:
+        LOG.warning(
+            log_json(
+                msg="Skipping MER backfill; retention start is at or after current month",
+                retention_start=str(start),
+                current_month=str(current_month),
+            )
+        )
         return
 
     if currency_pairs is None:

--- a/koku/cost_models/monthly_exchange_rate_utils.py
+++ b/koku/cost_models/monthly_exchange_rate_utils.py
@@ -6,11 +6,14 @@
 import logging
 from decimal import Decimal
 
+from dateutil.relativedelta import relativedelta
+from django.db import connection
 from django.db.models import Q
 
 from api.common import log_json
 from api.currency.models import ExchangeRateDictionary
 from api.utils import DateHelper
+from api.utils import materialized_view_month_start
 from cost_models.models import EnabledCurrency
 from cost_models.models import MonthlyExchangeRate
 from cost_models.models import RateType
@@ -87,12 +90,77 @@ def replace_static_to_dynamic_monthly_rates(base_currency, target_currency, star
     populate_dynamic_monthly_rates(code=base_currency)
 
 
-def populate_dynamic_monthly_rates(code=None):
-    """Populate dynamic MonthlyExchangeRate rows for the current month only.
+def _retention_months_before_current(current_month):
+    """Return month-start dates in the tenant retention window before the current month.
 
-    Past months are finalized and read-only — only the current month is written.
-    Reads the latest rates from ExchangeRateDictionary and writes dynamic
-    MonthlyExchangeRate rows for each enabled currency pair. Static overrides are preserved.
+    Uses the same retention window as data purge (per-tenant when available).
+    """
+    schema_name = getattr(connection, "schema_name", None)
+    earliest = materialized_view_month_start(schema_name=schema_name)
+    if hasattr(earliest, "date"):
+        earliest = earliest.date()
+
+    months = []
+    month = earliest
+    while month < current_month:
+        months.append(month)
+        month += relativedelta(months=1)
+    return months
+
+
+def _backfill_missing_past_months(dynamic_rates, past_months):
+    """Insert today's rate for any missing MonthlyExchangeRate rows in past months.
+
+    Existing rows (static or dynamic) are never overwritten. Returns the number of
+    rows created.
+    """
+    if not dynamic_rates or not past_months:
+        return 0
+
+    existing = set(
+        MonthlyExchangeRate.objects.filter(
+            effective_date__gte=past_months[0],
+            effective_date__lte=past_months[-1],
+        ).values_list("base_currency", "target_currency", "effective_date")
+    )
+
+    to_create = [
+        MonthlyExchangeRate(
+            effective_date=month,
+            base_currency=base_cur,
+            target_currency=target_cur,
+            exchange_rate=rate,
+            rate_type=RateType.DYNAMIC,
+        )
+        for (base_cur, target_cur), rate in dynamic_rates.items()
+        for month in past_months
+        if (base_cur, target_cur, month) not in existing
+    ]
+    if not to_create:
+        return 0
+
+    MonthlyExchangeRate.objects.bulk_create(to_create, ignore_conflicts=True)
+    LOG.info(
+        log_json(
+            msg="Backfilled missing monthly exchange rates for retention window",
+            created=len(to_create),
+            months=len(past_months),
+        )
+    )
+    return len(to_create)
+
+
+def populate_dynamic_monthly_rates(code=None):
+    """Populate dynamic MonthlyExchangeRate rows for the current month and backfill gaps.
+
+    Current month: upserted from ExchangeRateDictionary (daily refresh). Static
+    overrides for the current month are preserved.
+
+    Past months within the tenant retention window: if a currency pair has no
+    MonthlyExchangeRate row for that month, today's rate is inserted. Existing
+    rows (static or dynamic) are left untouched — a no-op when coverage already
+    exists. This fills rates for newly enabled currencies and for months that
+    predate feature rollout, without requiring a migration.
 
     When code is provided, only pairs involving that currency are processed.
     When None, all enabled currency pairs are processed.
@@ -156,6 +224,7 @@ def populate_dynamic_monthly_rates(code=None):
         )
         count += 1
 
+    count += _backfill_missing_past_months(dynamic_rates, _retention_months_before_current(current_month))
     return count
 
 

--- a/koku/cost_models/monthly_exchange_rate_utils.py
+++ b/koku/cost_models/monthly_exchange_rate_utils.py
@@ -4,6 +4,7 @@
 #
 """Utilities for managing MonthlyExchangeRate side effects."""
 import logging
+from bisect import bisect_right
 from decimal import Decimal
 
 from dateutil.relativedelta import relativedelta
@@ -95,10 +96,9 @@ def populate_dynamic_monthly_rates(code=None, backfill_past_months=False):  # no
     """Populate dynamic MonthlyExchangeRate rows for the current month only.
 
     Past months are finalized and read-only — only the current month is written,
-    unless backfill_past_months is True (daily Celery crawl), in which case missing
-    MonthlyExchangeRate rows in the tenant retention window are filled using each
-    pair's oldest existing MonthlyExchangeRate. Existing past-month rows (static
-    or dynamic) are never overwritten.
+    unless backfill_past_months is True (daily Celery crawl), in which case each
+    missing month in the retention window is filled from the next later existing
+    MonthlyExchangeRate for that pair. Existing rows are never overwritten.
 
     Reads the latest rates from ExchangeRateDictionary and writes dynamic
     MonthlyExchangeRate rows for each enabled currency pair. Static overrides are preserved.
@@ -187,7 +187,11 @@ def remove_monthly_rates(code):
 
 
 def _backfill_missing_past_months(currency_pairs, current_month):
-    """Fill missing past months from each pair's oldest MonthlyExchangeRate rate."""
+    """Fill each missing month with the next later existing MER rate for that pair.
+
+    Example (retention months 1-6, current=6, existing rows at 2 and 4):
+    month 1 <- rate from 2, month 3 <- rate from 4, month 5 <- rate from 6.
+    """
     currency_pairs = set(currency_pairs)
     month = to_date(materialized_view_month_start(schema_name=getattr(connection, "schema_name", None)))
     past_months = []
@@ -197,7 +201,7 @@ def _backfill_missing_past_months(currency_pairs, current_month):
     if not currency_pairs or not past_months:
         return
 
-    oldest, covered = {}, set()
+    rates_by_pair = {}
     for base, target, effective, rate in (
         MonthlyExchangeRate.objects.filter(
             base_currency__in={b for b, _ in currency_pairs},
@@ -206,23 +210,29 @@ def _backfill_missing_past_months(currency_pairs, current_month):
         .order_by("effective_date")
         .values_list("base_currency", "target_currency", "effective_date", "exchange_rate")
     ):
-        if (base, target) not in currency_pairs:
-            continue
-        covered.add((base, target, effective))
-        oldest.setdefault((base, target), rate)
+        if (base, target) in currency_pairs:
+            rates_by_pair.setdefault((base, target), []).append((effective, rate))
 
-    to_create = [
-        MonthlyExchangeRate(
-            effective_date=m,
-            base_currency=base,
-            target_currency=target,
-            exchange_rate=rate,
-            rate_type=RateType.DYNAMIC,
-        )
-        for (base, target), rate in oldest.items()
-        for m in past_months
-        if (base, target, m) not in covered
-    ]
+    to_create = []
+    for (base, target), dated_rates in rates_by_pair.items():
+        dates = [effective for effective, _ in dated_rates]
+        covered = set(dates)
+        for missing in past_months:
+            if missing in covered:
+                continue
+            idx = bisect_right(dates, missing)
+            if idx >= len(dates):
+                continue
+            to_create.append(
+                MonthlyExchangeRate(
+                    effective_date=missing,
+                    base_currency=base,
+                    target_currency=target,
+                    exchange_rate=dated_rates[idx][1],
+                    rate_type=RateType.DYNAMIC,
+                )
+            )
+
     if to_create:
         MonthlyExchangeRate.objects.bulk_create(to_create, ignore_conflicts=True)
         LOG.info(

--- a/koku/cost_models/monthly_exchange_rate_utils.py
+++ b/koku/cost_models/monthly_exchange_rate_utils.py
@@ -96,8 +96,9 @@ def populate_dynamic_monthly_rates(code=None, backfill_past_months=False):  # no
 
     Past months are finalized and read-only — only the current month is written,
     unless backfill_past_months is True (daily Celery crawl), in which case missing
-    MonthlyExchangeRate rows in the tenant retention window are filled with today's rate.
-    Existing past-month rows (static or dynamic) are never overwritten.
+    MonthlyExchangeRate rows in the tenant retention window are filled using each
+    pair's oldest existing MonthlyExchangeRate. Existing past-month rows (static
+    or dynamic) are never overwritten.
 
     Reads the latest rates from ExchangeRateDictionary and writes dynamic
     MonthlyExchangeRate rows for each enabled currency pair. Static overrides are preserved.
@@ -165,7 +166,7 @@ def populate_dynamic_monthly_rates(code=None, backfill_past_months=False):  # no
         count += 1
 
     if backfill_past_months:
-        _backfill_missing_past_months(dynamic_rates, current_month)
+        _backfill_missing_past_months(dynamic_rates.keys(), current_month)
 
     return count
 
@@ -185,41 +186,66 @@ def remove_monthly_rates(code):
     return deleted
 
 
-def _backfill_missing_past_months(dynamic_rates, current_month):
-    """Insert today's rate for missing MonthlyExchangeRate rows in the retention window.
-
-    Existing rows (static or dynamic) are never overwritten.
-    """
-    if not dynamic_rates:
-        return
-
+def _retention_months_before_current(current_month):
+    """Return month-start dates in the tenant retention window before the current month."""
     schema_name = getattr(connection, "schema_name", None)
     earliest = to_date(materialized_view_month_start(schema_name=schema_name))
-    past_months = []
+    months = []
     month = earliest
     while month < current_month:
-        past_months.append(month)
+        months.append(month)
         month += relativedelta(months=1)
+    return months
+
+
+def _oldest_rates_and_coverage(currency_pairs):
+    """Return oldest exchange_rate per pair and the set of existing (pair, month) keys."""
+    existing_rows = (
+        MonthlyExchangeRate.objects.filter(
+            base_currency__in={pair[0] for pair in currency_pairs},
+            target_currency__in={pair[1] for pair in currency_pairs},
+        )
+        .order_by("effective_date")
+        .values_list("base_currency", "target_currency", "effective_date", "exchange_rate")
+    )
+
+    oldest_rate_by_pair = {}
+    existing = set()
+    for base_cur, target_cur, effective_date, exchange_rate in existing_rows:
+        pair = (base_cur, target_cur)
+        if pair not in currency_pairs:
+            continue
+        existing.add((base_cur, target_cur, effective_date))
+        if pair not in oldest_rate_by_pair:
+            oldest_rate_by_pair[pair] = exchange_rate
+    return oldest_rate_by_pair, existing
+
+
+def _backfill_missing_past_months(currency_pairs, current_month):
+    """Fill missing past months using each pair's oldest MonthlyExchangeRate.
+
+    Copies the exchange_rate from the earliest existing MER row for that pair
+    (not today's ExchangeRateDictionary value). Existing rows are never overwritten.
+    Pairs with no existing MER rows are skipped.
+    """
+    currency_pairs = set(currency_pairs)
+    if not currency_pairs:
+        return
+
+    past_months = _retention_months_before_current(current_month)
     if not past_months:
         return
 
-    existing = set(
-        MonthlyExchangeRate.objects.filter(
-            effective_date__gte=past_months[0],
-            effective_date__lte=past_months[-1],
-            base_currency__in={pair[0] for pair in dynamic_rates},
-            target_currency__in={pair[1] for pair in dynamic_rates},
-        ).values_list("base_currency", "target_currency", "effective_date")
-    )
+    oldest_rate_by_pair, existing = _oldest_rates_and_coverage(currency_pairs)
     to_create = [
         MonthlyExchangeRate(
             effective_date=month,
             base_currency=base_cur,
             target_currency=target_cur,
-            exchange_rate=rate,
+            exchange_rate=exchange_rate,
             rate_type=RateType.DYNAMIC,
         )
-        for (base_cur, target_cur), rate in dynamic_rates.items()
+        for (base_cur, target_cur), exchange_rate in oldest_rate_by_pair.items()
         for month in past_months
         if (base_cur, target_cur, month) not in existing
     ]

--- a/koku/cost_models/monthly_exchange_rate_utils.py
+++ b/koku/cost_models/monthly_exchange_rate_utils.py
@@ -108,6 +108,7 @@ def populate_dynamic_monthly_rates(code=None, backfill_past_months=False):  # no
     """
     enabled_codes = set(EnabledCurrency.objects.values_list("currency_code", flat=True))
     if not enabled_codes:
+        LOG.info(log_json(msg="No enabled currencies; skipping monthly exchange rate populate"))
         return
 
     current_month = DateHelper().this_month_start.date()

--- a/koku/cost_models/test/test_monthly_exchange_rate_utils.py
+++ b/koku/cost_models/test/test_monthly_exchange_rate_utils.py
@@ -323,12 +323,10 @@ class PopulateDynamicMonthlyRatesBackfillTest(MasuTestCase):
     def setUp(self):
         super().setUp()
         self.month_start = self.dh.this_month_start.date()
-        # Retention months 1..6 with current = 6
-        self.month_1 = (self.month_start - relativedelta(months=5)).replace(day=1)
-        self.month_2 = (self.month_start - relativedelta(months=4)).replace(day=1)
-        self.month_3 = (self.month_start - relativedelta(months=3)).replace(day=1)
-        self.month_4 = (self.month_start - relativedelta(months=2)).replace(day=1)
-        self.month_5 = (self.month_start - relativedelta(months=1)).replace(day=1)
+        # Retention months 1..3 with current = 4 (minimum for next-later + gap-after-latest).
+        self.month_1 = (self.month_start - relativedelta(months=3)).replace(day=1)
+        self.month_2 = (self.month_start - relativedelta(months=2)).replace(day=1)
+        self.month_3 = (self.month_start - relativedelta(months=1)).replace(day=1)
         ExchangeRateDictionary.objects.all().delete()
         ExchangeRateDictionary.objects.create(
             currency_exchange_dictionary={"USD": {"EUR": "0.87", "USD": "1.0"}, "EUR": {"USD": "1.15", "EUR": "1.0"}}
@@ -349,12 +347,12 @@ class PopulateDynamicMonthlyRatesBackfillTest(MasuTestCase):
                     effective_date=self.month_start, base_currency="USD", target_currency="EUR"
                 ).exists()
             )
-            self.assertFalse(MonthlyExchangeRate.objects.filter(effective_date=self.month_5).exists())
+            self.assertFalse(MonthlyExchangeRate.objects.filter(effective_date=self.month_3).exists())
             mock_backfill.assert_not_called()
 
     @patch("cost_models.monthly_exchange_rate_utils.materialized_view_month_start")
     def test_backfill_uses_next_later_existing_rate(self, mock_retention_start):
-        """Gaps use the next later MER rate: 1<-2, 3<-4, 5<-current."""
+        """Gaps use the next later MER rate: 1<-2, 3<-current."""
         mock_retention_start.return_value = self.month_1
 
         with tenant_context(self.tenant):
@@ -363,13 +361,6 @@ class PopulateDynamicMonthlyRatesBackfillTest(MasuTestCase):
                 base_currency="USD",
                 target_currency="EUR",
                 exchange_rate=Decimal("0.20"),
-                rate_type=RateType.DYNAMIC,
-            )
-            MonthlyExchangeRate.objects.create(
-                effective_date=self.month_4,
-                base_currency="USD",
-                target_currency="EUR",
-                exchange_rate=Decimal("0.40"),
                 rate_type=RateType.STATIC,
             )
 
@@ -385,24 +376,12 @@ class PopulateDynamicMonthlyRatesBackfillTest(MasuTestCase):
                 MonthlyExchangeRate.objects.get(
                     effective_date=self.month_3, base_currency="USD", target_currency="EUR"
                 ).exchange_rate,
-                Decimal("0.40"),
-            )
-            self.assertEqual(
-                MonthlyExchangeRate.objects.get(
-                    effective_date=self.month_5, base_currency="USD", target_currency="EUR"
-                ).exchange_rate,
                 Decimal("0.87"),
             )
-            # Existing rows preserved
+            # Existing row preserved
             self.assertEqual(
                 MonthlyExchangeRate.objects.get(
                     effective_date=self.month_2, base_currency="USD", target_currency="EUR"
-                ).exchange_rate,
-                Decimal("0.20"),
-            )
-            self.assertEqual(
-                MonthlyExchangeRate.objects.get(
-                    effective_date=self.month_4, base_currency="USD", target_currency="EUR"
                 ).rate_type,
                 RateType.STATIC,
             )
@@ -423,36 +402,23 @@ class PopulateDynamicMonthlyRatesBackfillTest(MasuTestCase):
                 effective_date=self.month_2,
                 base_currency="USD",
                 target_currency="EUR",
-                exchange_rate=Decimal("0.20"),
-                rate_type=RateType.DYNAMIC,
-            )
-            MonthlyExchangeRate.objects.create(
-                effective_date=self.month_4,
-                base_currency="USD",
-                target_currency="EUR",
                 exchange_rate=Decimal("0.40"),
                 rate_type=RateType.DYNAMIC,
             )
 
             _backfill_missing_past_months({("USD", "EUR")}, self.month_start)
 
-            # Latest available is month 4, so walk starts at month 3; month 5 stays empty.
+            # Latest available is month 2, so walk starts at month 1; month 3 stays empty.
             self.assertFalse(
                 MonthlyExchangeRate.objects.filter(
-                    effective_date=self.month_5, base_currency="USD", target_currency="EUR"
-                ).exists()
-            )
-            self.assertEqual(
-                MonthlyExchangeRate.objects.get(
                     effective_date=self.month_3, base_currency="USD", target_currency="EUR"
-                ).exchange_rate,
-                Decimal("0.40"),
+                ).exists()
             )
             self.assertEqual(
                 MonthlyExchangeRate.objects.get(
                     effective_date=self.month_1, base_currency="USD", target_currency="EUR"
                 ).exchange_rate,
-                Decimal("0.20"),
+                Decimal("0.40"),
             )
             self.assertFalse(
                 MonthlyExchangeRate.objects.filter(
@@ -462,12 +428,12 @@ class PopulateDynamicMonthlyRatesBackfillTest(MasuTestCase):
 
     @patch("cost_models.monthly_exchange_rate_utils.materialized_view_month_start")
     def test_backfill_fills_all_gaps_before_latest_with_same_rate(self, mock_retention_start):
-        """If only month 4 exists, months 3 and 2 (and 1) are filled with month 4's rate."""
+        """If only month 3 exists, months 1 and 2 are filled with month 3's rate."""
         mock_retention_start.return_value = self.month_1
 
         with tenant_context(self.tenant):
             MonthlyExchangeRate.objects.create(
-                effective_date=self.month_4,
+                effective_date=self.month_3,
                 base_currency="USD",
                 target_currency="EUR",
                 exchange_rate=Decimal("0.40"),
@@ -476,15 +442,10 @@ class PopulateDynamicMonthlyRatesBackfillTest(MasuTestCase):
 
             _backfill_missing_past_months({("USD", "EUR")}, self.month_start)
 
-            for month in (self.month_1, self.month_2, self.month_3):
+            for month in (self.month_1, self.month_2):
                 self.assertEqual(
                     MonthlyExchangeRate.objects.get(
                         effective_date=month, base_currency="USD", target_currency="EUR"
                     ).exchange_rate,
                     Decimal("0.40"),
                 )
-            self.assertFalse(
-                MonthlyExchangeRate.objects.filter(
-                    effective_date=self.month_5, base_currency="USD", target_currency="EUR"
-                ).exists()
-            )

--- a/koku/cost_models/test/test_monthly_exchange_rate_utils.py
+++ b/koku/cost_models/test/test_monthly_exchange_rate_utils.py
@@ -322,11 +322,11 @@ class PopulateDynamicMonthlyRatesBackfillTest(MasuTestCase):
 
     def setUp(self):
         super().setUp()
-        self.month_start = self.dh.this_month_start.date()
+        self.current_month_start = self.dh.this_month_start.date()
         # Retention months 1..3 with current = 4.
-        self.month_1 = (self.month_start - relativedelta(months=3)).replace(day=1)
-        self.month_2 = (self.month_start - relativedelta(months=2)).replace(day=1)
-        self.month_3 = (self.month_start - relativedelta(months=1)).replace(day=1)
+        self.month_1 = (self.current_month_start - relativedelta(months=3)).replace(day=1)
+        self.month_2 = (self.current_month_start - relativedelta(months=2)).replace(day=1)
+        self.month_3 = (self.current_month_start - relativedelta(months=1)).replace(day=1)
         ExchangeRateDictionary.objects.all().delete()
         ExchangeRateDictionary.objects.create(
             currency_exchange_dictionary={"USD": {"EUR": "0.87", "USD": "1.0"}, "EUR": {"USD": "1.15", "EUR": "1.0"}}
@@ -344,7 +344,7 @@ class PopulateDynamicMonthlyRatesBackfillTest(MasuTestCase):
             populate_dynamic_monthly_rates()
             self.assertTrue(
                 MonthlyExchangeRate.objects.filter(
-                    effective_date=self.month_start, base_currency="USD", target_currency="EUR"
+                    effective_date=self.current_month_start, base_currency="USD", target_currency="EUR"
                 ).exists()
             )
             self.assertFalse(MonthlyExchangeRate.objects.filter(effective_date=self.month_3).exists())
@@ -387,7 +387,7 @@ class PopulateDynamicMonthlyRatesBackfillTest(MasuTestCase):
             )
             self.assertEqual(
                 MonthlyExchangeRate.objects.get(
-                    effective_date=self.month_start, base_currency="USD", target_currency="EUR"
+                    effective_date=self.current_month_start, base_currency="USD", target_currency="EUR"
                 ).exchange_rate,
                 Decimal("0.87"),
             )
@@ -406,7 +406,7 @@ class PopulateDynamicMonthlyRatesBackfillTest(MasuTestCase):
                 rate_type=RateType.DYNAMIC,
             )
 
-            _backfill_missing_past_months({("USD", "EUR")}, self.month_start)
+            _backfill_missing_past_months({("USD", "EUR")}, self.current_month_start)
 
             # Latest available is month 2, so walk starts at month 1; month 3 stays empty.
             self.assertFalse(
@@ -422,7 +422,7 @@ class PopulateDynamicMonthlyRatesBackfillTest(MasuTestCase):
             )
             self.assertFalse(
                 MonthlyExchangeRate.objects.filter(
-                    effective_date=self.month_start, base_currency="USD", target_currency="EUR"
+                    effective_date=self.current_month_start, base_currency="USD", target_currency="EUR"
                 ).exists()
             )
 
@@ -440,7 +440,7 @@ class PopulateDynamicMonthlyRatesBackfillTest(MasuTestCase):
                 rate_type=RateType.DYNAMIC,
             )
 
-            _backfill_missing_past_months({("USD", "EUR")}, self.month_start)
+            _backfill_missing_past_months({("USD", "EUR")}, self.current_month_start)
 
             for month in (self.month_1, self.month_2):
                 self.assertEqual(

--- a/koku/cost_models/test/test_monthly_exchange_rate_utils.py
+++ b/koku/cost_models/test/test_monthly_exchange_rate_utils.py
@@ -441,7 +441,8 @@ class PopulateDynamicMonthlyRatesBackfillTest(MasuTestCase):
                 rate_type=RateType.DYNAMIC,
             )
 
-            _backfill_missing_past_months(self.current_month_start)
+            enabled_codes = set(EnabledCurrency.objects.values_list("currency_code", flat=True))
+            _backfill_missing_past_months(self.current_month_start, enabled_codes)
 
             for month in (self.month_1, self.month_2, self.month_3):
                 row = MonthlyExchangeRate.objects.get(effective_date=month, base_currency="USD", target_currency="EUR")

--- a/koku/cost_models/test/test_monthly_exchange_rate_utils.py
+++ b/koku/cost_models/test/test_monthly_exchange_rate_utils.py
@@ -342,6 +342,11 @@ class PopulateDynamicMonthlyRatesBackfillTest(MasuTestCase):
         """Currency enable and other callers leave past months untouched."""
         with tenant_context(self.tenant):
             populate_dynamic_monthly_rates()
+            current = MonthlyExchangeRate.objects.get(
+                effective_date=self.current_month_start, base_currency="USD", target_currency="EUR"
+            )
+            self.assertEqual(current.exchange_rate, Decimal("0.87"))
+            self.assertEqual(current.rate_type, RateType.DYNAMIC)
             self.assertFalse(
                 MonthlyExchangeRate.objects.filter(
                     effective_date__in=(self.month_1, self.month_2, self.month_3)

--- a/koku/cost_models/test/test_monthly_exchange_rate_utils.py
+++ b/koku/cost_models/test/test_monthly_exchange_rate_utils.py
@@ -323,6 +323,7 @@ class PopulateDynamicMonthlyRatesBackfillTest(MasuTestCase):
         super().setUp()
         self.month_start = self.dh.this_month_start.date()
         self.last_month = (self.month_start - relativedelta(months=1)).replace(day=1)
+        self.two_months_ago = (self.month_start - relativedelta(months=2)).replace(day=1)
         ExchangeRateDictionary.objects.all().delete()
         ExchangeRateDictionary.objects.create(
             currency_exchange_dictionary={"USD": {"EUR": "0.87", "USD": "1.0"}, "EUR": {"USD": "1.15", "EUR": "1.0"}}
@@ -349,9 +350,9 @@ class PopulateDynamicMonthlyRatesBackfillTest(MasuTestCase):
             mock_retention_start.assert_not_called()
 
     @patch("cost_models.monthly_exchange_rate_utils.materialized_view_month_start")
-    def test_backfill_fills_gaps_without_overwriting(self, mock_retention_start):
-        """Backfill inserts missing months and leaves existing static/dynamic rows alone."""
-        mock_retention_start.return_value = self.last_month
+    def test_backfill_uses_oldest_mer_rate_not_todays(self, mock_retention_start):
+        """Gaps are filled from the oldest MER row for the pair, not today's dictionary rate."""
+        mock_retention_start.return_value = self.two_months_ago
 
         with tenant_context(self.tenant):
             MonthlyExchangeRate.objects.create(
@@ -364,17 +365,21 @@ class PopulateDynamicMonthlyRatesBackfillTest(MasuTestCase):
 
             populate_dynamic_monthly_rates(backfill_past_months=True)
 
+            # Existing oldest row is preserved
             static = MonthlyExchangeRate.objects.get(
                 effective_date=self.last_month, base_currency="USD", target_currency="EUR"
             )
             self.assertEqual(static.rate_type, RateType.STATIC)
             self.assertEqual(static.exchange_rate, Decimal("0.50"))
 
-            # Inverse gap is filled; current month is upserted with today's rate
-            inverse = MonthlyExchangeRate.objects.get(
-                effective_date=self.last_month, base_currency="EUR", target_currency="USD"
+            # Gap before the oldest MER uses that oldest rate (0.50), not today's 0.87
+            backfilled = MonthlyExchangeRate.objects.get(
+                effective_date=self.two_months_ago, base_currency="USD", target_currency="EUR"
             )
-            self.assertEqual(inverse.rate_type, RateType.DYNAMIC)
+            self.assertEqual(backfilled.rate_type, RateType.DYNAMIC)
+            self.assertEqual(backfilled.exchange_rate, Decimal("0.50"))
+
+            # Current month is still upserted with today's dictionary rate
             current = MonthlyExchangeRate.objects.get(
                 effective_date=self.month_start, base_currency="USD", target_currency="EUR"
             )

--- a/koku/cost_models/test/test_monthly_exchange_rate_utils.py
+++ b/koku/cost_models/test/test_monthly_exchange_rate_utils.py
@@ -342,11 +342,6 @@ class PopulateDynamicMonthlyRatesBackfillTest(MasuTestCase):
         """Currency enable and other callers leave past months untouched."""
         with tenant_context(self.tenant):
             populate_dynamic_monthly_rates()
-            current = MonthlyExchangeRate.objects.get(
-                effective_date=self.current_month_start, base_currency="USD", target_currency="EUR"
-            )
-            self.assertEqual(current.exchange_rate, Decimal("0.87"))
-            self.assertEqual(current.rate_type, RateType.DYNAMIC)
             self.assertFalse(
                 MonthlyExchangeRate.objects.filter(
                     effective_date__in=(self.month_1, self.month_2, self.month_3)

--- a/koku/cost_models/test/test_monthly_exchange_rate_utils.py
+++ b/koku/cost_models/test/test_monthly_exchange_rate_utils.py
@@ -395,9 +395,10 @@ class PopulateDynamicMonthlyRatesBackfillTest(MasuTestCase):
             self.assertEqual(current.rate_type, RateType.DYNAMIC)
 
     @patch("cost_models.monthly_exchange_rate_utils.materialized_view_month_start")
-    def test_backfill_starts_from_month_before_latest_available(self, mock_retention_start):
-        """Walk starts at latest_month-1; months after the latest available are not filled."""
+    def test_backfill_without_erd_uses_existing_mer(self, mock_retention_start):
+        """Empty ERD still backfills from existing MER; does not write the current month."""
         mock_retention_start.return_value = self.month_1
+        ExchangeRateDictionary.objects.all().delete()
 
         with tenant_context(self.tenant):
             MonthlyExchangeRate.objects.create(
@@ -405,29 +406,21 @@ class PopulateDynamicMonthlyRatesBackfillTest(MasuTestCase):
                 base_currency="USD",
                 target_currency="EUR",
                 exchange_rate=Decimal("0.40"),
-                rate_type=RateType.DYNAMIC,
+                rate_type=RateType.STATIC,
             )
 
-            _backfill_missing_past_months({("USD", "EUR")}, self.current_month_start)
+            populate_dynamic_monthly_rates(backfill_past_months=True)
 
-            # Latest available is month 2, so walk starts at month 1; month 3 stays empty.
-            self.assertFalse(
-                MonthlyExchangeRate.objects.filter(
-                    effective_date=self.month_3, base_currency="USD", target_currency="EUR"
-                ).exists()
-            )
             month_1 = MonthlyExchangeRate.objects.get(
                 effective_date=self.month_1, base_currency="USD", target_currency="EUR"
             )
             self.assertEqual(month_1.exchange_rate, Decimal("0.40"))
             self.assertEqual(month_1.rate_type, RateType.DYNAMIC)
-
-            month_2 = MonthlyExchangeRate.objects.get(
-                effective_date=self.month_2, base_currency="USD", target_currency="EUR"
+            self.assertFalse(
+                MonthlyExchangeRate.objects.filter(
+                    effective_date=self.month_3, base_currency="USD", target_currency="EUR"
+                ).exists()
             )
-            self.assertEqual(month_2.exchange_rate, Decimal("0.40"))
-            self.assertEqual(month_2.rate_type, RateType.DYNAMIC)
-
             self.assertFalse(
                 MonthlyExchangeRate.objects.filter(
                     effective_date=self.current_month_start, base_currency="USD", target_currency="EUR"
@@ -448,7 +441,7 @@ class PopulateDynamicMonthlyRatesBackfillTest(MasuTestCase):
                 rate_type=RateType.DYNAMIC,
             )
 
-            _backfill_missing_past_months({("USD", "EUR")}, self.current_month_start)
+            _backfill_missing_past_months(self.current_month_start, currency_pairs={("USD", "EUR")})
 
             for month in (self.month_1, self.month_2, self.month_3):
                 row = MonthlyExchangeRate.objects.get(effective_date=month, base_currency="USD", target_currency="EUR")

--- a/koku/cost_models/test/test_monthly_exchange_rate_utils.py
+++ b/koku/cost_models/test/test_monthly_exchange_rate_utils.py
@@ -15,7 +15,6 @@ from cost_models.models import EnabledCurrency
 from cost_models.models import MonthlyExchangeRate
 from cost_models.models import RateType
 from cost_models.models import StaticExchangeRate
-from cost_models.monthly_exchange_rate_utils import _backfill_missing_past_months
 from cost_models.monthly_exchange_rate_utils import populate_dynamic_monthly_rates
 from cost_models.monthly_exchange_rate_utils import remove_monthly_rates
 from cost_models.monthly_exchange_rate_utils import replace_static_to_dynamic_monthly_rates
@@ -431,6 +430,7 @@ class PopulateDynamicMonthlyRatesBackfillTest(MasuTestCase):
     def test_backfill_fills_all_gaps_before_latest_with_same_rate(self, mock_retention_start):
         """If only month 3 exists, months 1 and 2 are filled with month 3's rate."""
         mock_retention_start.return_value = self.month_1
+        ExchangeRateDictionary.objects.all().delete()
 
         with tenant_context(self.tenant):
             MonthlyExchangeRate.objects.create(
@@ -441,10 +441,84 @@ class PopulateDynamicMonthlyRatesBackfillTest(MasuTestCase):
                 rate_type=RateType.DYNAMIC,
             )
 
-            enabled_codes = set(EnabledCurrency.objects.values_list("currency_code", flat=True))
-            _backfill_missing_past_months(self.current_month_start, enabled_codes)
+            populate_dynamic_monthly_rates(backfill_past_months=True)
 
             for month in (self.month_1, self.month_2, self.month_3):
                 row = MonthlyExchangeRate.objects.get(effective_date=month, base_currency="USD", target_currency="EUR")
                 self.assertEqual(row.exchange_rate, Decimal("0.40"))
                 self.assertEqual(row.rate_type, RateType.DYNAMIC)
+
+    @patch("cost_models.monthly_exchange_rate_utils.materialized_view_month_start")
+    def test_backfill_skips_when_retention_start_at_or_after_current_month(self, mock_retention_start):
+        """Backfill returns 0 when retention start is at or after the current month."""
+        mock_retention_start.return_value = self.current_month_start
+
+        with tenant_context(self.tenant):
+            populate_dynamic_monthly_rates(backfill_past_months=True)
+            past_months = MonthlyExchangeRate.objects.exclude(effective_date=self.current_month_start)
+            self.assertEqual(past_months.count(), 0)
+
+    @patch("cost_models.monthly_exchange_rate_utils.materialized_view_month_start")
+    def test_backfill_returns_zero_when_no_existing_rates(self, mock_retention_start):
+        """Backfill returns 0 when no MER rows exist in the retention window."""
+        mock_retention_start.return_value = self.month_1
+        ExchangeRateDictionary.objects.all().delete()
+
+        with tenant_context(self.tenant):
+            result = populate_dynamic_monthly_rates(backfill_past_months=True)
+            self.assertEqual(result, 0)
+
+    @patch("cost_models.monthly_exchange_rate_utils.materialized_view_month_start")
+    def test_backfill_scoped_by_code(self, mock_retention_start):
+        """Backfill with code= only fills gaps for pairs involving that currency."""
+        mock_retention_start.return_value = self.month_1
+
+        with tenant_context(self.tenant):
+            EnabledCurrency.objects.create(currency_code="GBP")
+            MonthlyExchangeRate.objects.create(
+                effective_date=self.month_3,
+                base_currency="USD",
+                target_currency="EUR",
+                exchange_rate=Decimal("0.87"),
+                rate_type=RateType.DYNAMIC,
+            )
+            MonthlyExchangeRate.objects.create(
+                effective_date=self.month_3,
+                base_currency="USD",
+                target_currency="GBP",
+                exchange_rate=Decimal("0.78"),
+                rate_type=RateType.DYNAMIC,
+            )
+
+            result = populate_dynamic_monthly_rates(code="EUR", backfill_past_months=True)
+            self.assertGreater(result, 0)
+
+            self.assertTrue(
+                MonthlyExchangeRate.objects.filter(
+                    effective_date=self.month_1, base_currency="USD", target_currency="EUR"
+                ).exists()
+            )
+            self.assertFalse(
+                MonthlyExchangeRate.objects.filter(
+                    effective_date=self.month_1, base_currency="USD", target_currency="GBP"
+                ).exists()
+            )
+
+    @patch("cost_models.monthly_exchange_rate_utils.materialized_view_month_start")
+    def test_backfill_noop_when_all_months_filled(self, mock_retention_start):
+        """Backfill returns 0 when every month in the retention window already has a rate."""
+        mock_retention_start.return_value = self.month_1
+        ExchangeRateDictionary.objects.all().delete()
+
+        with tenant_context(self.tenant):
+            for month in (self.month_1, self.month_2, self.month_3):
+                MonthlyExchangeRate.objects.create(
+                    effective_date=month,
+                    base_currency="USD",
+                    target_currency="EUR",
+                    exchange_rate=Decimal("0.87"),
+                    rate_type=RateType.DYNAMIC,
+                )
+
+            result = populate_dynamic_monthly_rates(backfill_past_months=True)
+            self.assertEqual(result, 0)

--- a/koku/cost_models/test/test_monthly_exchange_rate_utils.py
+++ b/koku/cost_models/test/test_monthly_exchange_rate_utils.py
@@ -4,6 +4,7 @@
 #
 """Tests for monthly_exchange_rate_utils MonthlyExchangeRate side effects."""
 from decimal import Decimal
+from unittest.mock import patch
 
 from dateutil.relativedelta import relativedelta
 from django.db.models import Q
@@ -14,6 +15,7 @@ from cost_models.models import EnabledCurrency
 from cost_models.models import MonthlyExchangeRate
 from cost_models.models import RateType
 from cost_models.models import StaticExchangeRate
+from cost_models.monthly_exchange_rate_utils import populate_dynamic_monthly_rates
 from cost_models.monthly_exchange_rate_utils import remove_monthly_rates
 from cost_models.monthly_exchange_rate_utils import replace_static_to_dynamic_monthly_rates
 from cost_models.monthly_exchange_rate_utils import upsert_static_monthly_rates
@@ -311,4 +313,127 @@ class RemoveMonthlyRatesTest(MasuTestCase):
                 MonthlyExchangeRate.objects.filter(effective_date=self.month_start)
                 .filter(Q(base_currency="USD") | Q(target_currency="USD"))
                 .exists()
+            )
+
+
+class PopulateDynamicMonthlyRatesBackfillTest(MasuTestCase):
+    """Tests for retention-window backfill in populate_dynamic_monthly_rates."""
+
+    def setUp(self):
+        super().setUp()
+        self.month_start = self.dh.this_month_start.date()
+        self.last_month = (self.month_start - relativedelta(months=1)).replace(day=1)
+        self.two_months_ago = (self.month_start - relativedelta(months=2)).replace(day=1)
+        ExchangeRateDictionary.objects.all().delete()
+        ExchangeRateDictionary.objects.create(
+            currency_exchange_dictionary={"USD": {"EUR": "0.87", "USD": "1.0"}, "EUR": {"USD": "1.15", "EUR": "1.0"}}
+        )
+        with tenant_context(self.tenant):
+            MonthlyExchangeRate.objects.all().delete()
+            EnabledCurrency.objects.all().delete()
+            EnabledCurrency.objects.create(currency_code="USD")
+            EnabledCurrency.objects.create(currency_code="EUR")
+
+    @patch("cost_models.monthly_exchange_rate_utils.materialized_view_month_start")
+    def test_backfills_missing_past_months_with_todays_rate(self, mock_retention_start):
+        """Missing past months in the retention window get today's dynamic rate."""
+        mock_retention_start.return_value = self.two_months_ago
+
+        with tenant_context(self.tenant):
+            populate_dynamic_monthly_rates()
+
+            for month in (self.two_months_ago, self.last_month, self.month_start):
+                forward = MonthlyExchangeRate.objects.get(
+                    effective_date=month, base_currency="USD", target_currency="EUR"
+                )
+                self.assertEqual(forward.rate_type, RateType.DYNAMIC)
+                self.assertEqual(forward.exchange_rate, Decimal("0.87"))
+
+                inverse = MonthlyExchangeRate.objects.get(
+                    effective_date=month, base_currency="EUR", target_currency="USD"
+                )
+                self.assertEqual(inverse.rate_type, RateType.DYNAMIC)
+
+    @patch("cost_models.monthly_exchange_rate_utils.materialized_view_month_start")
+    def test_backfill_is_noop_when_past_months_already_exist(self, mock_retention_start):
+        """Existing past-month rates are not overwritten on subsequent crawls."""
+        mock_retention_start.return_value = self.last_month
+
+        with tenant_context(self.tenant):
+            MonthlyExchangeRate.objects.create(
+                effective_date=self.last_month,
+                base_currency="USD",
+                target_currency="EUR",
+                exchange_rate=Decimal("0.99"),
+                rate_type=RateType.DYNAMIC,
+            )
+            MonthlyExchangeRate.objects.create(
+                effective_date=self.last_month,
+                base_currency="EUR",
+                target_currency="USD",
+                exchange_rate=Decimal("1.01"),
+                rate_type=RateType.DYNAMIC,
+            )
+
+            populate_dynamic_monthly_rates()
+
+            preserved = MonthlyExchangeRate.objects.get(
+                effective_date=self.last_month, base_currency="USD", target_currency="EUR"
+            )
+            self.assertEqual(preserved.exchange_rate, Decimal("0.99"))
+
+            # Current month is still upserted with today's rate
+            current = MonthlyExchangeRate.objects.get(
+                effective_date=self.month_start, base_currency="USD", target_currency="EUR"
+            )
+            self.assertEqual(current.exchange_rate, Decimal("0.87"))
+
+    @patch("cost_models.monthly_exchange_rate_utils.materialized_view_month_start")
+    def test_backfill_does_not_overwrite_static_past_months(self, mock_retention_start):
+        """Static rates in past months are left alone during backfill."""
+        mock_retention_start.return_value = self.last_month
+
+        with tenant_context(self.tenant):
+            MonthlyExchangeRate.objects.create(
+                effective_date=self.last_month,
+                base_currency="USD",
+                target_currency="EUR",
+                exchange_rate=Decimal("0.50"),
+                rate_type=RateType.STATIC,
+            )
+
+            populate_dynamic_monthly_rates()
+
+            static = MonthlyExchangeRate.objects.get(
+                effective_date=self.last_month, base_currency="USD", target_currency="EUR"
+            )
+            self.assertEqual(static.rate_type, RateType.STATIC)
+            self.assertEqual(static.exchange_rate, Decimal("0.50"))
+
+    @patch("cost_models.monthly_exchange_rate_utils.materialized_view_month_start")
+    def test_backfill_only_pairs_involving_enabled_code(self, mock_retention_start):
+        """When code is provided, only pairs involving that currency are backfilled."""
+        mock_retention_start.return_value = self.last_month
+        ExchangeRateDictionary.objects.all().delete()
+        ExchangeRateDictionary.objects.create(
+            currency_exchange_dictionary={
+                "USD": {"EUR": "0.87", "GBP": "0.78", "USD": "1.0"},
+                "EUR": {"USD": "1.15", "GBP": "0.90", "EUR": "1.0"},
+                "GBP": {"USD": "1.28", "EUR": "1.11", "GBP": "1.0"},
+            }
+        )
+
+        with tenant_context(self.tenant):
+            EnabledCurrency.objects.create(currency_code="GBP")
+            populate_dynamic_monthly_rates(code="GBP")
+
+            self.assertTrue(
+                MonthlyExchangeRate.objects.filter(
+                    effective_date=self.last_month, base_currency="USD", target_currency="GBP"
+                ).exists()
+            )
+            self.assertFalse(
+                MonthlyExchangeRate.objects.filter(
+                    effective_date=self.last_month, base_currency="USD", target_currency="EUR"
+                ).exists()
             )

--- a/koku/cost_models/test/test_monthly_exchange_rate_utils.py
+++ b/koku/cost_models/test/test_monthly_exchange_rate_utils.py
@@ -323,7 +323,7 @@ class PopulateDynamicMonthlyRatesBackfillTest(MasuTestCase):
     def setUp(self):
         super().setUp()
         self.month_start = self.dh.this_month_start.date()
-        # Retention months 1..3 with current = 4 (minimum for next-later + gap-after-latest).
+        # Retention months 1..3 with current = 4.
         self.month_1 = (self.month_start - relativedelta(months=3)).replace(day=1)
         self.month_2 = (self.month_start - relativedelta(months=2)).replace(day=1)
         self.month_3 = (self.month_start - relativedelta(months=1)).replace(day=1)

--- a/koku/cost_models/test/test_monthly_exchange_rate_utils.py
+++ b/koku/cost_models/test/test_monthly_exchange_rate_utils.py
@@ -323,7 +323,6 @@ class PopulateDynamicMonthlyRatesBackfillTest(MasuTestCase):
         super().setUp()
         self.month_start = self.dh.this_month_start.date()
         self.last_month = (self.month_start - relativedelta(months=1)).replace(day=1)
-        self.two_months_ago = (self.month_start - relativedelta(months=2)).replace(day=1)
         ExchangeRateDictionary.objects.all().delete()
         ExchangeRateDictionary.objects.create(
             currency_exchange_dictionary={"USD": {"EUR": "0.87", "USD": "1.0"}, "EUR": {"USD": "1.15", "EUR": "1.0"}}
@@ -341,7 +340,6 @@ class PopulateDynamicMonthlyRatesBackfillTest(MasuTestCase):
 
         with tenant_context(self.tenant):
             populate_dynamic_monthly_rates()
-
             self.assertTrue(
                 MonthlyExchangeRate.objects.filter(
                     effective_date=self.month_start, base_currency="USD", target_currency="EUR"
@@ -351,62 +349,8 @@ class PopulateDynamicMonthlyRatesBackfillTest(MasuTestCase):
             mock_retention_start.assert_not_called()
 
     @patch("cost_models.monthly_exchange_rate_utils.materialized_view_month_start")
-    def test_backfills_missing_past_months_with_todays_rate(self, mock_retention_start):
-        """Missing past months in the retention window get today's dynamic rate."""
-        mock_retention_start.return_value = self.two_months_ago
-
-        with tenant_context(self.tenant):
-            populate_dynamic_monthly_rates(backfill_past_months=True)
-
-            for month in (self.two_months_ago, self.last_month, self.month_start):
-                forward = MonthlyExchangeRate.objects.get(
-                    effective_date=month, base_currency="USD", target_currency="EUR"
-                )
-                self.assertEqual(forward.rate_type, RateType.DYNAMIC)
-                self.assertEqual(forward.exchange_rate, Decimal("0.87"))
-
-                inverse = MonthlyExchangeRate.objects.get(
-                    effective_date=month, base_currency="EUR", target_currency="USD"
-                )
-                self.assertEqual(inverse.rate_type, RateType.DYNAMIC)
-
-    @patch("cost_models.monthly_exchange_rate_utils.materialized_view_month_start")
-    def test_backfill_is_noop_when_past_months_already_exist(self, mock_retention_start):
-        """Existing past-month rates are not overwritten on subsequent crawls."""
-        mock_retention_start.return_value = self.last_month
-
-        with tenant_context(self.tenant):
-            MonthlyExchangeRate.objects.create(
-                effective_date=self.last_month,
-                base_currency="USD",
-                target_currency="EUR",
-                exchange_rate=Decimal("0.99"),
-                rate_type=RateType.DYNAMIC,
-            )
-            MonthlyExchangeRate.objects.create(
-                effective_date=self.last_month,
-                base_currency="EUR",
-                target_currency="USD",
-                exchange_rate=Decimal("1.01"),
-                rate_type=RateType.DYNAMIC,
-            )
-
-            populate_dynamic_monthly_rates(backfill_past_months=True)
-
-            preserved = MonthlyExchangeRate.objects.get(
-                effective_date=self.last_month, base_currency="USD", target_currency="EUR"
-            )
-            self.assertEqual(preserved.exchange_rate, Decimal("0.99"))
-
-            # Current month is still upserted with today's rate
-            current = MonthlyExchangeRate.objects.get(
-                effective_date=self.month_start, base_currency="USD", target_currency="EUR"
-            )
-            self.assertEqual(current.exchange_rate, Decimal("0.87"))
-
-    @patch("cost_models.monthly_exchange_rate_utils.materialized_view_month_start")
-    def test_backfill_does_not_overwrite_static_past_months(self, mock_retention_start):
-        """Static rates in past months are left alone during backfill."""
+    def test_backfill_fills_gaps_without_overwriting(self, mock_retention_start):
+        """Backfill inserts missing months and leaves existing static/dynamic rows alone."""
         mock_retention_start.return_value = self.last_month
 
         with tenant_context(self.tenant):
@@ -425,3 +369,13 @@ class PopulateDynamicMonthlyRatesBackfillTest(MasuTestCase):
             )
             self.assertEqual(static.rate_type, RateType.STATIC)
             self.assertEqual(static.exchange_rate, Decimal("0.50"))
+
+            # Inverse gap is filled; current month is upserted with today's rate
+            inverse = MonthlyExchangeRate.objects.get(
+                effective_date=self.last_month, base_currency="EUR", target_currency="USD"
+            )
+            self.assertEqual(inverse.rate_type, RateType.DYNAMIC)
+            current = MonthlyExchangeRate.objects.get(
+                effective_date=self.month_start, base_currency="USD", target_currency="EUR"
+            )
+            self.assertEqual(current.exchange_rate, Decimal("0.87"))

--- a/koku/cost_models/test/test_monthly_exchange_rate_utils.py
+++ b/koku/cost_models/test/test_monthly_exchange_rate_utils.py
@@ -16,6 +16,7 @@ from cost_models.models import MonthlyExchangeRate
 from cost_models.models import RateType
 from cost_models.models import StaticExchangeRate
 from cost_models.monthly_exchange_rate_utils import populate_dynamic_monthly_rates
+from cost_models.monthly_exchange_rate_utils import purge_expired_exchange_rates_for_all_tenants
 from cost_models.monthly_exchange_rate_utils import remove_monthly_rates
 from cost_models.monthly_exchange_rate_utils import replace_static_to_dynamic_monthly_rates
 from cost_models.monthly_exchange_rate_utils import upsert_static_monthly_rates
@@ -522,3 +523,45 @@ class PopulateDynamicMonthlyRatesBackfillTest(MasuTestCase):
 
             result = populate_dynamic_monthly_rates(backfill_past_months=True)
             self.assertEqual(result, 0)
+
+
+class PurgeExpiredMonthlyRatesTest(MasuTestCase):
+    """Tests for purge_expired_exchange_rates_for_all_tenants."""
+
+    def setUp(self):
+        super().setUp()
+        self.current_month = self.dh.this_month_start.date()
+        self.expired_month = (self.current_month - relativedelta(months=3)).replace(day=1)
+        with tenant_context(self.tenant):
+            MonthlyExchangeRate.objects.all().delete()
+            MonthlyExchangeRate.objects.create(
+                effective_date=self.expired_month,
+                base_currency="USD",
+                target_currency="EUR",
+                exchange_rate=Decimal("0.85"),
+                rate_type=RateType.DYNAMIC,
+            )
+
+    @patch("cost_models.monthly_exchange_rate_utils.materialized_view_month_start")
+    def test_purge_on_date(self, mock_retention_start):
+        """Rows at the retention boundary are preserved."""
+        mock_retention_start.return_value = self.expired_month
+        purge_expired_exchange_rates_for_all_tenants()
+        with tenant_context(self.tenant):
+            self.assertEqual(MonthlyExchangeRate.objects.count(), 1)
+
+    @patch("cost_models.monthly_exchange_rate_utils.materialized_view_month_start")
+    def test_purge_before_date(self, mock_retention_start):
+        """Retention boundary before data — nothing removed."""
+        mock_retention_start.return_value = (self.expired_month - relativedelta(months=1)).replace(day=1)
+        purge_expired_exchange_rates_for_all_tenants()
+        with tenant_context(self.tenant):
+            self.assertEqual(MonthlyExchangeRate.objects.count(), 1)
+
+    @patch("cost_models.monthly_exchange_rate_utils.materialized_view_month_start")
+    def test_purge_after_date(self, mock_retention_start):
+        """Retention boundary after data — expired rows removed."""
+        mock_retention_start.return_value = (self.expired_month + relativedelta(months=1)).replace(day=1)
+        purge_expired_exchange_rates_for_all_tenants()
+        with tenant_context(self.tenant):
+            self.assertEqual(MonthlyExchangeRate.objects.count(), 0)

--- a/koku/cost_models/test/test_monthly_exchange_rate_utils.py
+++ b/koku/cost_models/test/test_monthly_exchange_rate_utils.py
@@ -441,7 +441,7 @@ class PopulateDynamicMonthlyRatesBackfillTest(MasuTestCase):
                 rate_type=RateType.DYNAMIC,
             )
 
-            _backfill_missing_past_months(self.current_month_start, currency_pairs={("USD", "EUR")})
+            _backfill_missing_past_months(self.current_month_start)
 
             for month in (self.month_1, self.month_2, self.month_3):
                 row = MonthlyExchangeRate.objects.get(effective_date=month, base_currency="USD", target_currency="EUR")

--- a/koku/cost_models/test/test_monthly_exchange_rate_utils.py
+++ b/koku/cost_models/test/test_monthly_exchange_rate_utils.py
@@ -15,6 +15,7 @@ from cost_models.models import EnabledCurrency
 from cost_models.models import MonthlyExchangeRate
 from cost_models.models import RateType
 from cost_models.models import StaticExchangeRate
+from cost_models.monthly_exchange_rate_utils import _backfill_missing_past_months
 from cost_models.monthly_exchange_rate_utils import populate_dynamic_monthly_rates
 from cost_models.monthly_exchange_rate_utils import remove_monthly_rates
 from cost_models.monthly_exchange_rate_utils import replace_static_to_dynamic_monthly_rates
@@ -412,4 +413,80 @@ class PopulateDynamicMonthlyRatesBackfillTest(MasuTestCase):
                     effective_date=self.month_start, base_currency="USD", target_currency="EUR"
                 ).exchange_rate,
                 Decimal("0.87"),
+            )
+
+    @patch("cost_models.monthly_exchange_rate_utils.materialized_view_month_start")
+    def test_backfill_starts_from_month_before_latest_available(self, mock_retention_start):
+        """Walk starts at latest_month-1; months after the latest available are not filled."""
+        mock_retention_start.return_value = self.month_1
+
+        with tenant_context(self.tenant):
+            MonthlyExchangeRate.objects.create(
+                effective_date=self.month_2,
+                base_currency="USD",
+                target_currency="EUR",
+                exchange_rate=Decimal("0.20"),
+                rate_type=RateType.DYNAMIC,
+            )
+            MonthlyExchangeRate.objects.create(
+                effective_date=self.month_4,
+                base_currency="USD",
+                target_currency="EUR",
+                exchange_rate=Decimal("0.40"),
+                rate_type=RateType.DYNAMIC,
+            )
+
+            _backfill_missing_past_months({("USD", "EUR")}, self.month_start)
+
+            # Latest available is month 4, so walk starts at month 3; month 5 stays empty.
+            self.assertFalse(
+                MonthlyExchangeRate.objects.filter(
+                    effective_date=self.month_5, base_currency="USD", target_currency="EUR"
+                ).exists()
+            )
+            self.assertEqual(
+                MonthlyExchangeRate.objects.get(
+                    effective_date=self.month_3, base_currency="USD", target_currency="EUR"
+                ).exchange_rate,
+                Decimal("0.40"),
+            )
+            self.assertEqual(
+                MonthlyExchangeRate.objects.get(
+                    effective_date=self.month_1, base_currency="USD", target_currency="EUR"
+                ).exchange_rate,
+                Decimal("0.20"),
+            )
+            self.assertFalse(
+                MonthlyExchangeRate.objects.filter(
+                    effective_date=self.month_start, base_currency="USD", target_currency="EUR"
+                ).exists()
+            )
+
+    @patch("cost_models.monthly_exchange_rate_utils.materialized_view_month_start")
+    def test_backfill_fills_all_gaps_before_latest_with_same_rate(self, mock_retention_start):
+        """If only month 4 exists, months 3 and 2 (and 1) are filled with month 4's rate."""
+        mock_retention_start.return_value = self.month_1
+
+        with tenant_context(self.tenant):
+            MonthlyExchangeRate.objects.create(
+                effective_date=self.month_4,
+                base_currency="USD",
+                target_currency="EUR",
+                exchange_rate=Decimal("0.40"),
+                rate_type=RateType.DYNAMIC,
+            )
+
+            _backfill_missing_past_months({("USD", "EUR")}, self.month_start)
+
+            for month in (self.month_1, self.month_2, self.month_3):
+                self.assertEqual(
+                    MonthlyExchangeRate.objects.get(
+                        effective_date=month, base_currency="USD", target_currency="EUR"
+                    ).exchange_rate,
+                    Decimal("0.40"),
+                )
+            self.assertFalse(
+                MonthlyExchangeRate.objects.filter(
+                    effective_date=self.month_5, base_currency="USD", target_currency="EUR"
+                ).exists()
             )

--- a/koku/cost_models/test/test_monthly_exchange_rate_utils.py
+++ b/koku/cost_models/test/test_monthly_exchange_rate_utils.py
@@ -339,11 +339,9 @@ class PopulateDynamicMonthlyRatesBackfillTest(MasuTestCase):
             EnabledCurrency.objects.create(currency_code="USD")
             EnabledCurrency.objects.create(currency_code="EUR")
 
-    @patch("cost_models.monthly_exchange_rate_utils.materialized_view_month_start")
-    def test_default_does_not_backfill_past_months(self, mock_retention_start):
+    @patch("cost_models.monthly_exchange_rate_utils._backfill_missing_past_months")
+    def test_default_does_not_backfill_past_months(self, mock_backfill):
         """Currency enable and other callers leave past months untouched."""
-        mock_retention_start.return_value = self.month_5
-
         with tenant_context(self.tenant):
             populate_dynamic_monthly_rates()
             self.assertTrue(
@@ -352,7 +350,7 @@ class PopulateDynamicMonthlyRatesBackfillTest(MasuTestCase):
                 ).exists()
             )
             self.assertFalse(MonthlyExchangeRate.objects.filter(effective_date=self.month_5).exists())
-            mock_retention_start.assert_not_called()
+            mock_backfill.assert_not_called()
 
     @patch("cost_models.monthly_exchange_rate_utils.materialized_view_month_start")
     def test_backfill_uses_next_later_existing_rate(self, mock_retention_start):

--- a/koku/cost_models/test/test_monthly_exchange_rate_utils.py
+++ b/koku/cost_models/test/test_monthly_exchange_rate_utils.py
@@ -347,7 +347,11 @@ class PopulateDynamicMonthlyRatesBackfillTest(MasuTestCase):
                     effective_date=self.current_month_start, base_currency="USD", target_currency="EUR"
                 ).exists()
             )
-            self.assertFalse(MonthlyExchangeRate.objects.filter(effective_date=self.month_3).exists())
+            self.assertFalse(
+                MonthlyExchangeRate.objects.filter(
+                    effective_date__in=(self.month_1, self.month_2, self.month_3)
+                ).exists()
+            )
             mock_backfill.assert_not_called()
 
     @patch("cost_models.monthly_exchange_rate_utils.materialized_view_month_start")

--- a/koku/cost_models/test/test_monthly_exchange_rate_utils.py
+++ b/koku/cost_models/test/test_monthly_exchange_rate_utils.py
@@ -322,8 +322,12 @@ class PopulateDynamicMonthlyRatesBackfillTest(MasuTestCase):
     def setUp(self):
         super().setUp()
         self.month_start = self.dh.this_month_start.date()
-        self.last_month = (self.month_start - relativedelta(months=1)).replace(day=1)
-        self.two_months_ago = (self.month_start - relativedelta(months=2)).replace(day=1)
+        # Retention months 1..6 with current = 6
+        self.month_1 = (self.month_start - relativedelta(months=5)).replace(day=1)
+        self.month_2 = (self.month_start - relativedelta(months=4)).replace(day=1)
+        self.month_3 = (self.month_start - relativedelta(months=3)).replace(day=1)
+        self.month_4 = (self.month_start - relativedelta(months=2)).replace(day=1)
+        self.month_5 = (self.month_start - relativedelta(months=1)).replace(day=1)
         ExchangeRateDictionary.objects.all().delete()
         ExchangeRateDictionary.objects.create(
             currency_exchange_dictionary={"USD": {"EUR": "0.87", "USD": "1.0"}, "EUR": {"USD": "1.15", "EUR": "1.0"}}
@@ -337,7 +341,7 @@ class PopulateDynamicMonthlyRatesBackfillTest(MasuTestCase):
     @patch("cost_models.monthly_exchange_rate_utils.materialized_view_month_start")
     def test_default_does_not_backfill_past_months(self, mock_retention_start):
         """Currency enable and other callers leave past months untouched."""
-        mock_retention_start.return_value = self.last_month
+        mock_retention_start.return_value = self.month_5
 
         with tenant_context(self.tenant):
             populate_dynamic_monthly_rates()
@@ -346,41 +350,66 @@ class PopulateDynamicMonthlyRatesBackfillTest(MasuTestCase):
                     effective_date=self.month_start, base_currency="USD", target_currency="EUR"
                 ).exists()
             )
-            self.assertFalse(MonthlyExchangeRate.objects.filter(effective_date=self.last_month).exists())
+            self.assertFalse(MonthlyExchangeRate.objects.filter(effective_date=self.month_5).exists())
             mock_retention_start.assert_not_called()
 
     @patch("cost_models.monthly_exchange_rate_utils.materialized_view_month_start")
-    def test_backfill_uses_oldest_mer_rate_not_todays(self, mock_retention_start):
-        """Gaps are filled from the oldest MER row for the pair, not today's dictionary rate."""
-        mock_retention_start.return_value = self.two_months_ago
+    def test_backfill_uses_next_later_existing_rate(self, mock_retention_start):
+        """Gaps use the next later MER rate: 1<-2, 3<-4, 5<-current."""
+        mock_retention_start.return_value = self.month_1
 
         with tenant_context(self.tenant):
             MonthlyExchangeRate.objects.create(
-                effective_date=self.last_month,
+                effective_date=self.month_2,
                 base_currency="USD",
                 target_currency="EUR",
-                exchange_rate=Decimal("0.50"),
+                exchange_rate=Decimal("0.20"),
+                rate_type=RateType.DYNAMIC,
+            )
+            MonthlyExchangeRate.objects.create(
+                effective_date=self.month_4,
+                base_currency="USD",
+                target_currency="EUR",
+                exchange_rate=Decimal("0.40"),
                 rate_type=RateType.STATIC,
             )
 
             populate_dynamic_monthly_rates(backfill_past_months=True)
 
-            # Existing oldest row is preserved
-            static = MonthlyExchangeRate.objects.get(
-                effective_date=self.last_month, base_currency="USD", target_currency="EUR"
+            self.assertEqual(
+                MonthlyExchangeRate.objects.get(
+                    effective_date=self.month_1, base_currency="USD", target_currency="EUR"
+                ).exchange_rate,
+                Decimal("0.20"),
             )
-            self.assertEqual(static.rate_type, RateType.STATIC)
-            self.assertEqual(static.exchange_rate, Decimal("0.50"))
-
-            # Gap before the oldest MER uses that oldest rate (0.50), not today's 0.87
-            backfilled = MonthlyExchangeRate.objects.get(
-                effective_date=self.two_months_ago, base_currency="USD", target_currency="EUR"
+            self.assertEqual(
+                MonthlyExchangeRate.objects.get(
+                    effective_date=self.month_3, base_currency="USD", target_currency="EUR"
+                ).exchange_rate,
+                Decimal("0.40"),
             )
-            self.assertEqual(backfilled.rate_type, RateType.DYNAMIC)
-            self.assertEqual(backfilled.exchange_rate, Decimal("0.50"))
-
-            # Current month is still upserted with today's dictionary rate
-            current = MonthlyExchangeRate.objects.get(
-                effective_date=self.month_start, base_currency="USD", target_currency="EUR"
+            self.assertEqual(
+                MonthlyExchangeRate.objects.get(
+                    effective_date=self.month_5, base_currency="USD", target_currency="EUR"
+                ).exchange_rate,
+                Decimal("0.87"),
             )
-            self.assertEqual(current.exchange_rate, Decimal("0.87"))
+            # Existing rows preserved
+            self.assertEqual(
+                MonthlyExchangeRate.objects.get(
+                    effective_date=self.month_2, base_currency="USD", target_currency="EUR"
+                ).exchange_rate,
+                Decimal("0.20"),
+            )
+            self.assertEqual(
+                MonthlyExchangeRate.objects.get(
+                    effective_date=self.month_4, base_currency="USD", target_currency="EUR"
+                ).rate_type,
+                RateType.STATIC,
+            )
+            self.assertEqual(
+                MonthlyExchangeRate.objects.get(
+                    effective_date=self.month_start, base_currency="USD", target_currency="EUR"
+                ).exchange_rate,
+                Decimal("0.87"),
+            )

--- a/koku/cost_models/test/test_monthly_exchange_rate_utils.py
+++ b/koku/cost_models/test/test_monthly_exchange_rate_utils.py
@@ -342,11 +342,11 @@ class PopulateDynamicMonthlyRatesBackfillTest(MasuTestCase):
         """Currency enable and other callers leave past months untouched."""
         with tenant_context(self.tenant):
             populate_dynamic_monthly_rates()
-            self.assertTrue(
-                MonthlyExchangeRate.objects.filter(
-                    effective_date=self.current_month_start, base_currency="USD", target_currency="EUR"
-                ).exists()
+            current = MonthlyExchangeRate.objects.get(
+                effective_date=self.current_month_start, base_currency="USD", target_currency="EUR"
             )
+            self.assertEqual(current.exchange_rate, Decimal("0.87"))
+            self.assertEqual(current.rate_type, RateType.DYNAMIC)
             self.assertFalse(
                 MonthlyExchangeRate.objects.filter(
                     effective_date__in=(self.month_1, self.month_2, self.month_3)
@@ -370,31 +370,29 @@ class PopulateDynamicMonthlyRatesBackfillTest(MasuTestCase):
 
             populate_dynamic_monthly_rates(backfill_past_months=True)
 
-            self.assertEqual(
-                MonthlyExchangeRate.objects.get(
-                    effective_date=self.month_1, base_currency="USD", target_currency="EUR"
-                ).exchange_rate,
-                Decimal("0.20"),
+            month_1 = MonthlyExchangeRate.objects.get(
+                effective_date=self.month_1, base_currency="USD", target_currency="EUR"
             )
-            self.assertEqual(
-                MonthlyExchangeRate.objects.get(
-                    effective_date=self.month_3, base_currency="USD", target_currency="EUR"
-                ).exchange_rate,
-                Decimal("0.87"),
+            self.assertEqual(month_1.exchange_rate, Decimal("0.20"))
+            self.assertEqual(month_1.rate_type, RateType.DYNAMIC)
+
+            month_2 = MonthlyExchangeRate.objects.get(
+                effective_date=self.month_2, base_currency="USD", target_currency="EUR"
             )
-            # Existing row preserved
-            self.assertEqual(
-                MonthlyExchangeRate.objects.get(
-                    effective_date=self.month_2, base_currency="USD", target_currency="EUR"
-                ).rate_type,
-                RateType.STATIC,
+            self.assertEqual(month_2.exchange_rate, Decimal("0.20"))
+            self.assertEqual(month_2.rate_type, RateType.STATIC)
+
+            month_3 = MonthlyExchangeRate.objects.get(
+                effective_date=self.month_3, base_currency="USD", target_currency="EUR"
             )
-            self.assertEqual(
-                MonthlyExchangeRate.objects.get(
-                    effective_date=self.current_month_start, base_currency="USD", target_currency="EUR"
-                ).exchange_rate,
-                Decimal("0.87"),
+            self.assertEqual(month_3.exchange_rate, Decimal("0.87"))
+            self.assertEqual(month_3.rate_type, RateType.DYNAMIC)
+
+            current = MonthlyExchangeRate.objects.get(
+                effective_date=self.current_month_start, base_currency="USD", target_currency="EUR"
             )
+            self.assertEqual(current.exchange_rate, Decimal("0.87"))
+            self.assertEqual(current.rate_type, RateType.DYNAMIC)
 
     @patch("cost_models.monthly_exchange_rate_utils.materialized_view_month_start")
     def test_backfill_starts_from_month_before_latest_available(self, mock_retention_start):
@@ -418,12 +416,18 @@ class PopulateDynamicMonthlyRatesBackfillTest(MasuTestCase):
                     effective_date=self.month_3, base_currency="USD", target_currency="EUR"
                 ).exists()
             )
-            self.assertEqual(
-                MonthlyExchangeRate.objects.get(
-                    effective_date=self.month_1, base_currency="USD", target_currency="EUR"
-                ).exchange_rate,
-                Decimal("0.40"),
+            month_1 = MonthlyExchangeRate.objects.get(
+                effective_date=self.month_1, base_currency="USD", target_currency="EUR"
             )
+            self.assertEqual(month_1.exchange_rate, Decimal("0.40"))
+            self.assertEqual(month_1.rate_type, RateType.DYNAMIC)
+
+            month_2 = MonthlyExchangeRate.objects.get(
+                effective_date=self.month_2, base_currency="USD", target_currency="EUR"
+            )
+            self.assertEqual(month_2.exchange_rate, Decimal("0.40"))
+            self.assertEqual(month_2.rate_type, RateType.DYNAMIC)
+
             self.assertFalse(
                 MonthlyExchangeRate.objects.filter(
                     effective_date=self.current_month_start, base_currency="USD", target_currency="EUR"
@@ -446,10 +450,7 @@ class PopulateDynamicMonthlyRatesBackfillTest(MasuTestCase):
 
             _backfill_missing_past_months({("USD", "EUR")}, self.current_month_start)
 
-            for month in (self.month_1, self.month_2):
-                self.assertEqual(
-                    MonthlyExchangeRate.objects.get(
-                        effective_date=month, base_currency="USD", target_currency="EUR"
-                    ).exchange_rate,
-                    Decimal("0.40"),
-                )
+            for month in (self.month_1, self.month_2, self.month_3):
+                row = MonthlyExchangeRate.objects.get(effective_date=month, base_currency="USD", target_currency="EUR")
+                self.assertEqual(row.exchange_rate, Decimal("0.40"))
+                self.assertEqual(row.rate_type, RateType.DYNAMIC)

--- a/koku/cost_models/test/test_monthly_exchange_rate_utils.py
+++ b/koku/cost_models/test/test_monthly_exchange_rate_utils.py
@@ -317,7 +317,7 @@ class RemoveMonthlyRatesTest(MasuTestCase):
 
 
 class PopulateDynamicMonthlyRatesBackfillTest(MasuTestCase):
-    """Tests for retention-window backfill in populate_dynamic_monthly_rates."""
+    """Tests for retention-window backfill (Celery-only via backfill_past_months=True)."""
 
     def setUp(self):
         super().setUp()
@@ -335,12 +335,28 @@ class PopulateDynamicMonthlyRatesBackfillTest(MasuTestCase):
             EnabledCurrency.objects.create(currency_code="EUR")
 
     @patch("cost_models.monthly_exchange_rate_utils.materialized_view_month_start")
+    def test_default_does_not_backfill_past_months(self, mock_retention_start):
+        """Currency enable and other callers leave past months untouched."""
+        mock_retention_start.return_value = self.last_month
+
+        with tenant_context(self.tenant):
+            populate_dynamic_monthly_rates()
+
+            self.assertTrue(
+                MonthlyExchangeRate.objects.filter(
+                    effective_date=self.month_start, base_currency="USD", target_currency="EUR"
+                ).exists()
+            )
+            self.assertFalse(MonthlyExchangeRate.objects.filter(effective_date=self.last_month).exists())
+            mock_retention_start.assert_not_called()
+
+    @patch("cost_models.monthly_exchange_rate_utils.materialized_view_month_start")
     def test_backfills_missing_past_months_with_todays_rate(self, mock_retention_start):
         """Missing past months in the retention window get today's dynamic rate."""
         mock_retention_start.return_value = self.two_months_ago
 
         with tenant_context(self.tenant):
-            populate_dynamic_monthly_rates()
+            populate_dynamic_monthly_rates(backfill_past_months=True)
 
             for month in (self.two_months_ago, self.last_month, self.month_start):
                 forward = MonthlyExchangeRate.objects.get(
@@ -375,7 +391,7 @@ class PopulateDynamicMonthlyRatesBackfillTest(MasuTestCase):
                 rate_type=RateType.DYNAMIC,
             )
 
-            populate_dynamic_monthly_rates()
+            populate_dynamic_monthly_rates(backfill_past_months=True)
 
             preserved = MonthlyExchangeRate.objects.get(
                 effective_date=self.last_month, base_currency="USD", target_currency="EUR"
@@ -402,38 +418,10 @@ class PopulateDynamicMonthlyRatesBackfillTest(MasuTestCase):
                 rate_type=RateType.STATIC,
             )
 
-            populate_dynamic_monthly_rates()
+            populate_dynamic_monthly_rates(backfill_past_months=True)
 
             static = MonthlyExchangeRate.objects.get(
                 effective_date=self.last_month, base_currency="USD", target_currency="EUR"
             )
             self.assertEqual(static.rate_type, RateType.STATIC)
             self.assertEqual(static.exchange_rate, Decimal("0.50"))
-
-    @patch("cost_models.monthly_exchange_rate_utils.materialized_view_month_start")
-    def test_backfill_only_pairs_involving_enabled_code(self, mock_retention_start):
-        """When code is provided, only pairs involving that currency are backfilled."""
-        mock_retention_start.return_value = self.last_month
-        ExchangeRateDictionary.objects.all().delete()
-        ExchangeRateDictionary.objects.create(
-            currency_exchange_dictionary={
-                "USD": {"EUR": "0.87", "GBP": "0.78", "USD": "1.0"},
-                "EUR": {"USD": "1.15", "GBP": "0.90", "EUR": "1.0"},
-                "GBP": {"USD": "1.28", "EUR": "1.11", "GBP": "1.0"},
-            }
-        )
-
-        with tenant_context(self.tenant):
-            EnabledCurrency.objects.create(currency_code="GBP")
-            populate_dynamic_monthly_rates(code="GBP")
-
-            self.assertTrue(
-                MonthlyExchangeRate.objects.filter(
-                    effective_date=self.last_month, base_currency="USD", target_currency="GBP"
-                ).exists()
-            )
-            self.assertFalse(
-                MonthlyExchangeRate.objects.filter(
-                    effective_date=self.last_month, base_currency="USD", target_currency="EUR"
-                ).exists()
-            )

--- a/koku/masu/celery/tasks.py
+++ b/koku/masu/celery/tasks.py
@@ -319,8 +319,9 @@ def get_daily_currency_rates():
     for tenant in Tenant.objects.exclude(schema_name="public"):
         try:
             with schema_context(tenant.schema_name):
-                populate_dynamic_monthly_rates(backfill_past_months=True)
-                invalidate_view_cache_for_tenant_and_all_source_types(tenant.schema_name)
+                rates_changed = populate_dynamic_monthly_rates(backfill_past_months=True)
+                if rates_changed:
+                    invalidate_view_cache_for_tenant_and_all_source_types(tenant.schema_name)
         except Exception as e:
             LOG.error(
                 log_json(msg="Failed to populate monthly exchange rates", schema=tenant.schema_name, error=str(e))

--- a/koku/masu/celery/tasks.py
+++ b/koku/masu/celery/tasks.py
@@ -322,7 +322,7 @@ def get_daily_currency_rates():
     for tenant in Tenant.objects.exclude(schema_name="public"):
         try:
             with schema_context(tenant.schema_name):
-                populate_dynamic_monthly_rates()
+                populate_dynamic_monthly_rates(backfill_past_months=True)
                 invalidate_view_cache_for_tenant_and_all_source_types(tenant.schema_name)
         except Exception as e:
             LOG.error(

--- a/koku/masu/celery/tasks.py
+++ b/koku/masu/celery/tasks.py
@@ -311,14 +311,13 @@ def _fetch_and_store_exchange_rates(url):
 def get_daily_currency_rates():
     """Task to get latest daily conversion rates and upsert MonthlyExchangeRate per tenant."""
     url = settings.CURRENCY_URL
+    rate_metrics = {}
     if not url:
         LOG.info(log_json(msg="CURRENCY_URL not configured; skipping dynamic exchange rate fetch"))
-        return {}
+    else:
+        rate_metrics = _fetch_and_store_exchange_rates(url) or {}
 
-    rate_metrics = _fetch_and_store_exchange_rates(url)
-    if not rate_metrics:
-        return {}
-
+    # Always populate/backfill so MER gaps are filled even when the fetch is unavailable.
     for tenant in Tenant.objects.exclude(schema_name="public"):
         try:
             with schema_context(tenant.schema_name):

--- a/koku/masu/celery/tasks.py
+++ b/koku/masu/celery/tasks.py
@@ -26,6 +26,7 @@ from common.queues import DownloadQueue
 from common.queues import PriorityQueue
 from common.queues import SummaryQueue
 from cost_models.monthly_exchange_rate_utils import populate_dynamic_monthly_rates
+from cost_models.monthly_exchange_rate_utils import purge_expired_exchange_rates_for_all_tenants
 from koku import celery_app
 from koku.cache import invalidate_view_cache_for_tenant_and_all_source_types
 from koku.notifications import NotificationService
@@ -70,6 +71,7 @@ def remove_expired_data(simulate=False):
     orchestrator = Orchestrator()
     orchestrator.remove_expired_report_data(simulate)
     orchestrator.remove_expired_trino_partitions(simulate)
+    purge_expired_exchange_rates_for_all_tenants()
 
 
 @celery_app.task(name="masu.celery.tasks.purge_trino_files", queue=DEFAULT)

--- a/koku/masu/celery/tasks.py
+++ b/koku/masu/celery/tasks.py
@@ -11,8 +11,7 @@ from botocore.exceptions import ClientError
 from django.conf import settings
 from django_tenants.utils import schema_context
 from requests.adapters import HTTPAdapter
-from requests.exceptions import HTTPError
-from requests.exceptions import RetryError
+from requests.exceptions import RequestException
 from urllib3.util.retry import Retry
 
 from api.common import log_json
@@ -279,7 +278,7 @@ def _fetch_and_store_exchange_rates(url):
     try:
         response = session.get(url)
         response.raise_for_status()
-    except (HTTPError, RetryError) as e:
+    except RequestException as e:
         LOG.error(f"Couldn't pull latest conversion rates from {url}")
         LOG.error(e)
         return {}

--- a/koku/masu/celery/tasks.py
+++ b/koku/masu/celery/tasks.py
@@ -283,8 +283,14 @@ def _fetch_and_store_exchange_rates(url):
         LOG.error(e)
         return {}
 
+    try:
+        data = response.json()
+    except (ValueError, KeyError) as e:
+        LOG.error(f"Invalid or malformed response from {url}")
+        LOG.error(e)
+        return {}
+
     rate_metrics = {}
-    data = response.json()
     rates = data["rates"]
     for curr_type, value in rates.items():
         if not is_valid_iso_currency(curr_type):

--- a/koku/masu/celery/tasks.py
+++ b/koku/masu/celery/tasks.py
@@ -266,7 +266,7 @@ def autovacuum_tune_schemas():
 
 
 def _fetch_and_store_exchange_rates(url):
-    """Fetch exchange rates from the configured URL. Returns rate_metrics dict or None on failure."""
+    """Fetch exchange rates from the configured URL. Returns rate_metrics dict (empty on failure)."""
     retries = Retry(
         total=5,
         allowed_methods={"GET"},
@@ -282,7 +282,7 @@ def _fetch_and_store_exchange_rates(url):
     except (HTTPError, RetryError) as e:
         LOG.error(f"Couldn't pull latest conversion rates from {url}")
         LOG.error(e)
-        return None
+        return {}
 
     rate_metrics = {}
     data = response.json()
@@ -309,15 +309,14 @@ def _fetch_and_store_exchange_rates(url):
 
 @celery_app.task(name="masu.celery.tasks.get_daily_currency_rates", queue=DEFAULT)
 def get_daily_currency_rates():
-    """Task to get latest daily conversion rates and upsert MonthlyExchangeRate per tenant."""
+    """Fetch exchange rates when configured, then upsert/backfill MER per tenant."""
     url = settings.CURRENCY_URL
-    rate_metrics = {}
-    if not url:
-        LOG.info(log_json(msg="CURRENCY_URL not configured; skipping dynamic exchange rate fetch"))
+    if url:
+        rate_metrics = _fetch_and_store_exchange_rates(url)
     else:
-        rate_metrics = _fetch_and_store_exchange_rates(url) or {}
+        LOG.info(log_json(msg="CURRENCY_URL not configured; skipping dynamic exchange rate fetch"))
+        rate_metrics = {}
 
-    # Always populate/backfill so MER gaps are filled even when the fetch is unavailable.
     for tenant in Tenant.objects.exclude(schema_name="public"):
         try:
             with schema_context(tenant.schema_name):

--- a/koku/masu/test/celery/test_tasks.py
+++ b/koku/masu/test/celery/test_tasks.py
@@ -556,15 +556,13 @@ class TestCeleryTasks(MasuTestCase):
             self.assertEqual(MonthlyExchangeRate.objects.filter(effective_date=current_month).count(), 0)
 
     @override_settings(CURRENCY_URL="")
-    @patch("masu.celery.tasks.populate_dynamic_monthly_rates")
-    def test_get_daily_currency_rates_no_url(self, mock_populate):
-        """CURRENCY_URL empty skips fetch but still runs per-tenant MER backfill."""
+    def test_get_daily_currency_rates_no_url(self):
+        """Test that get_daily_currency_rates returns empty dict when CURRENCY_URL is empty."""
         with self.assertLogs("masu.celery.tasks", "INFO") as captured_logs:
             result = tasks.get_daily_currency_rates()
 
         self.assertEqual(result, {})
         self.assertIn("CURRENCY_URL not configured", str(captured_logs))
-        mock_populate.assert_called_with(backfill_past_months=True)
 
     def test_get_daily_currency_rates_upserts_mer(self):
         """Test end-to-end: get_daily_currency_rates fetches rates and upserts MER rows."""

--- a/koku/masu/test/celery/test_tasks.py
+++ b/koku/masu/test/celery/test_tasks.py
@@ -556,13 +556,15 @@ class TestCeleryTasks(MasuTestCase):
             self.assertEqual(MonthlyExchangeRate.objects.filter(effective_date=current_month).count(), 0)
 
     @override_settings(CURRENCY_URL="")
-    def test_get_daily_currency_rates_no_url(self):
-        """Test that get_daily_currency_rates returns empty dict when CURRENCY_URL is empty."""
+    @patch("masu.celery.tasks.populate_dynamic_monthly_rates")
+    def test_get_daily_currency_rates_no_url(self, mock_populate):
+        """CURRENCY_URL empty skips fetch but still runs per-tenant MER backfill."""
         with self.assertLogs("masu.celery.tasks", "INFO") as captured_logs:
             result = tasks.get_daily_currency_rates()
 
         self.assertEqual(result, {})
         self.assertIn("CURRENCY_URL not configured", str(captured_logs))
+        mock_populate.assert_called_with(backfill_past_months=True)
 
     def test_get_daily_currency_rates_upserts_mer(self):
         """Test end-to-end: get_daily_currency_rates fetches rates and upserts MER rows."""


### PR DESCRIPTION
## Summary
- Add `_purge_expired_monthly_rates()` to delete MonthlyExchangeRate rows older than the retention window (`materialized_view_month_start`)
- Add `purge_expired_exchange_rates_for_all_tenants()` wrapper that iterates all tenants with `schema_context`
- Hook into the existing `remove_expired_data` Celery task (1st of month) alongside report data and Trino partition cleanup

## Test plan
- [x] Unit tests: on/before/after retention boundary (3 tests in `PurgeExpiredMonthlyRatesTest`)
- [x] Manual verification: seeded a 2020-01 MER row, ran purge, confirmed deletion with `expired_date=2026-04-01`


Made with [Cursor](https://cursor.com)