### PR TITLE
[COST-7345] Add MonthlyExchangeRate retention cleanup

### DIFF
--- a/koku/cost_models/monthly_exchange_rate_utils.py
+++ b/koku/cost_models/monthly_exchange_rate_utils.py
@@ -197,10 +197,9 @@ def _purge_expired_monthly_rates(simulate=False):
     """
     expired_date = to_date(materialized_view_month_start(schema_name=connection.schema_name))
     query = MonthlyExchangeRate.objects.filter(effective_date__lt=expired_date)
-    if simulate:
-        deleted = query.count()
-    else:
-        deleted, _ = query.delete()
+    deleted = query.count()
+    if not simulate:
+        query.delete()
     if deleted:
         LOG.info(
             log_json(

--- a/koku/cost_models/monthly_exchange_rate_utils.py
+++ b/koku/cost_models/monthly_exchange_rate_utils.py
@@ -197,9 +197,10 @@ def _purge_expired_monthly_rates(simulate=False):
     """
     expired_date = to_date(materialized_view_month_start(schema_name=connection.schema_name))
     query = MonthlyExchangeRate.objects.filter(effective_date__lt=expired_date)
-    deleted = query.count()
-    if not simulate:
-        query.delete()
+    if simulate:
+        deleted = query.count()
+    else:
+        deleted, _ = query.delete()
     if deleted:
         LOG.info(
             log_json(

--- a/koku/cost_models/monthly_exchange_rate_utils.py
+++ b/koku/cost_models/monthly_exchange_rate_utils.py
@@ -9,9 +9,11 @@ from decimal import Decimal
 from dateutil.relativedelta import relativedelta
 from django.db import connection
 from django.db.models import Q
+from django_tenants.utils import schema_context
 
 from api.common import log_json
 from api.currency.models import ExchangeRateDictionary
+from api.iam.models import Tenant
 from api.utils import DateHelper
 from api.utils import materialized_view_month_start
 from api.utils import to_date
@@ -185,6 +187,41 @@ def remove_monthly_rates(code):
     )
     LOG.info(log_json(msg="Removed MonthlyExchangeRate rows", code=code, deleted=deleted))
     return deleted
+
+
+def _purge_expired_monthly_rates():
+    """Delete MonthlyExchangeRate rows older than the retention window.
+
+    Uses the same retention boundary as backfill (materialized_view_month_start).
+    Must be called within a schema_context.
+    """
+    expired_date = to_date(materialized_view_month_start(schema_name=connection.schema_name))
+    deleted, _ = MonthlyExchangeRate.objects.filter(effective_date__lt=expired_date).delete()
+    if deleted:
+        LOG.info(
+            log_json(
+                msg="Purged expired MonthlyExchangeRate rows",
+                deleted=deleted,
+                expired_date=str(expired_date),
+            )
+        )
+    return deleted
+
+
+def purge_expired_exchange_rates_for_all_tenants():
+    """Purge expired MonthlyExchangeRate rows for all tenants."""
+    for tenant in Tenant.objects.exclude(schema_name="public"):
+        try:
+            with schema_context(tenant.schema_name):
+                _purge_expired_monthly_rates()
+        except Exception as e:
+            LOG.error(
+                log_json(
+                    msg="Failed to purge expired monthly exchange rates",
+                    schema=tenant.schema_name,
+                    error=str(e),
+                )
+            )
 
 
 def _get_existing_rates_by_pair(start, end, enabled_codes, code=None):

--- a/koku/cost_models/monthly_exchange_rate_utils.py
+++ b/koku/cost_models/monthly_exchange_rate_utils.py
@@ -189,18 +189,23 @@ def remove_monthly_rates(code):
     return deleted
 
 
-def _purge_expired_monthly_rates():
+def _purge_expired_monthly_rates(simulate=False):
     """Delete MonthlyExchangeRate rows older than the retention window.
 
     Uses the same retention boundary as backfill (materialized_view_month_start).
     Must be called within a schema_context.
     """
     expired_date = to_date(materialized_view_month_start(schema_name=connection.schema_name))
-    deleted, _ = MonthlyExchangeRate.objects.filter(effective_date__lt=expired_date).delete()
+    query = MonthlyExchangeRate.objects.filter(effective_date__lt=expired_date)
+    if simulate:
+        deleted = query.count()
+    else:
+        deleted, _ = query.delete()
     if deleted:
         LOG.info(
             log_json(
                 msg="Purged expired MonthlyExchangeRate rows",
+                simulate=simulate,
                 deleted=deleted,
                 expired_date=str(expired_date),
             )
@@ -208,12 +213,12 @@ def _purge_expired_monthly_rates():
     return deleted
 
 
-def purge_expired_exchange_rates_for_all_tenants():
+def purge_expired_exchange_rates_for_all_tenants(simulate=False):
     """Purge expired MonthlyExchangeRate rows for all tenants."""
     for tenant in Tenant.objects.exclude(schema_name="public"):
         try:
             with schema_context(tenant.schema_name):
-                _purge_expired_monthly_rates()
+                _purge_expired_monthly_rates(simulate=simulate)
         except Exception as e:
             LOG.error(
                 log_json(

--- a/koku/cost_models/test/test_monthly_exchange_rate_utils.py
+++ b/koku/cost_models/test/test_monthly_exchange_rate_utils.py
@@ -565,3 +565,11 @@ class PurgeExpiredMonthlyRatesTest(MasuTestCase):
         purge_expired_exchange_rates_for_all_tenants()
         with tenant_context(self.tenant):
             self.assertEqual(MonthlyExchangeRate.objects.count(), 0)
+
+    @patch("cost_models.monthly_exchange_rate_utils.materialized_view_month_start")
+    def test_simulate_does_not_delete(self, mock_retention_start):
+        """Simulate mode counts but does not delete expired rows."""
+        mock_retention_start.return_value = (self.expired_month + relativedelta(months=1)).replace(day=1)
+        purge_expired_exchange_rates_for_all_tenants(simulate=True)
+        with tenant_context(self.tenant):
+            self.assertEqual(MonthlyExchangeRate.objects.count(), 1)

--- a/koku/cost_models/test/test_monthly_exchange_rate_utils.py
+++ b/koku/cost_models/test/test_monthly_exchange_rate_utils.py
@@ -16,6 +16,7 @@ from cost_models.models import MonthlyExchangeRate
 from cost_models.models import RateType
 from cost_models.models import StaticExchangeRate
 from cost_models.monthly_exchange_rate_utils import populate_dynamic_monthly_rates
+from cost_models.monthly_exchange_rate_utils import purge_expired_exchange_rates_for_all_tenants
 from cost_models.monthly_exchange_rate_utils import remove_monthly_rates
 from cost_models.monthly_exchange_rate_utils import replace_static_to_dynamic_monthly_rates
 from cost_models.monthly_exchange_rate_utils import upsert_static_monthly_rates
@@ -522,3 +523,45 @@ class PopulateDynamicMonthlyRatesBackfillTest(MasuTestCase):
 
             result = populate_dynamic_monthly_rates(backfill_past_months=True)
             self.assertEqual(result, 0)
+
+
+class PurgeExpiredMonthlyRatesTest(MasuTestCase):
+    """Tests for purge_expired_exchange_rates_for_all_tenants."""
+
+    def setUp(self):
+        super().setUp()
+        self.current_month = self.dh.this_month_start.date()
+        self.expired_month = (self.current_month - relativedelta(months=3)).replace(day=1)
+        with tenant_context(self.tenant):
+            MonthlyExchangeRate.objects.all().delete()
+            MonthlyExchangeRate.objects.create(
+                effective_date=self.expired_month,
+                base_currency="USD",
+                target_currency="EUR",
+                exchange_rate=Decimal("0.85"),
+                rate_type=RateType.DYNAMIC,
+            )
+
+    @patch("cost_models.monthly_exchange_rate_utils.materialized_view_month_start")
+    def test_purge_on_date(self, mock_retention_start):
+        """Rows at the retention boundary are preserved."""
+        mock_retention_start.return_value = self.expired_month
+        purge_expired_exchange_rates_for_all_tenants()
+        with tenant_context(self.tenant):
+            self.assertEqual(MonthlyExchangeRate.objects.count(), 1)
+
+    @patch("cost_models.monthly_exchange_rate_utils.materialized_view_month_start")
+    def test_purge_before_date(self, mock_retention_start):
+        """Retention boundary before data — nothing removed."""
+        mock_retention_start.return_value = (self.expired_month - relativedelta(months=1)).replace(day=1)
+        purge_expired_exchange_rates_for_all_tenants()
+        with tenant_context(self.tenant):
+            self.assertEqual(MonthlyExchangeRate.objects.count(), 1)
+
+    @patch("cost_models.monthly_exchange_rate_utils.materialized_view_month_start")
+    def test_purge_after_date(self, mock_retention_start):
+        """Retention boundary after data — expired rows removed."""
+        mock_retention_start.return_value = (self.expired_month + relativedelta(months=1)).replace(day=1)
+        purge_expired_exchange_rates_for_all_tenants()
+        with tenant_context(self.tenant):
+            self.assertEqual(MonthlyExchangeRate.objects.count(), 0)

--- a/koku/masu/celery/tasks.py
+++ b/koku/masu/celery/tasks.py
@@ -26,6 +26,7 @@ from common.queues import DownloadQueue
 from common.queues import PriorityQueue
 from common.queues import SummaryQueue
 from cost_models.monthly_exchange_rate_utils import populate_dynamic_monthly_rates
+from cost_models.monthly_exchange_rate_utils import purge_expired_exchange_rates_for_all_tenants
 from koku import celery_app
 from koku.cache import invalidate_view_cache_for_tenant_and_all_source_types
 from koku.notifications import NotificationService
@@ -70,6 +71,7 @@ def remove_expired_data(simulate=False):
     orchestrator = Orchestrator()
     orchestrator.remove_expired_report_data(simulate)
     orchestrator.remove_expired_trino_partitions(simulate)
+    purge_expired_exchange_rates_for_all_tenants()
 
 
 @celery_app.task(name="masu.celery.tasks.purge_trino_files", queue=DEFAULT)

--- a/koku/masu/celery/tasks.py
+++ b/koku/masu/celery/tasks.py
@@ -71,7 +71,7 @@ def remove_expired_data(simulate=False):
     orchestrator = Orchestrator()
     orchestrator.remove_expired_report_data(simulate)
     orchestrator.remove_expired_trino_partitions(simulate)
-    purge_expired_exchange_rates_for_all_tenants()
+    purge_expired_exchange_rates_for_all_tenants(simulate=simulate)
 
 
 @celery_app.task(name="masu.celery.tasks.purge_trino_files", queue=DEFAULT)


### PR DESCRIPTION
## Summary
- Add `_purge_expired_monthly_rates()` to delete MonthlyExchangeRate rows older than the retention window (`materialized_view_month_start`)
- Add `purge_expired_exchange_rates_for_all_tenants()` wrapper that iterates all tenants with `schema_context`
- Hook into the existing `remove_expired_data` Celery task (1st of month) alongside report data and Trino partition cleanup

## Test plan
- [x] Unit tests: on/before/after retention boundary (3 tests in `PurgeExpiredMonthlyRatesTest`)
- [x] Manual verification: seeded a 2020-01 MER row, ran purge, confirmed deletion with `expired_date=2026-04-01`


Made with [Cursor](https://cursor.com)