### PR TITLE
[COST-7840] Schedule currency rates beat only when CURRENCY_URL is set

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,8 +21,9 @@ ONPREM=False
 # DJANGO_LOG_LEVEL=DEBUG
 
 PROMETHEUS_MULTIPROC_DIR='/tmp'
-# Set for SaaS / local dynamic rates. Leave empty on-prem to disable the daily currency beat.
-CURRENCY_URL=https://open.er-api.com/v6/latest/USD
+# Optional. Set to enable daily dynamic exchange-rate fetch (SaaS / local).
+# Leave empty on-prem / airgapped so the currency beat is not scheduled.
+CURRENCY_URL=
 UNLEASH_ADMIN_TOKEN='*:*.dbffffc83b1f92eeaf133a7eb878d4c58231acc159b5e1478ce53cfc'
 UNLEASH_TOKEN='*:development.dbffffc83b1f92eeaf133a7eb878d4c58231acc159b5e1478ce53cfc'
 UNLEASH_PAT='user:6188b62f2f59348f3c195b66983147111682f4bb78a3f7ed9626bd84'

--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,7 @@ ONPREM=False
 # DJANGO_LOG_LEVEL=DEBUG
 
 PROMETHEUS_MULTIPROC_DIR='/tmp'
+# Set for SaaS / local dynamic rates. Leave empty on-prem to disable the daily currency beat.
 CURRENCY_URL=https://open.er-api.com/v6/latest/USD
 UNLEASH_ADMIN_TOKEN='*:*.dbffffc83b1f92eeaf133a7eb878d4c58231acc159b5e1478ce53cfc'
 UNLEASH_TOKEN='*:development.dbffffc83b1f92eeaf133a7eb878d4c58231acc159b5e1478ce53cfc'

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -5651,7 +5651,8 @@ parameters:
 - description: toggles onprem data processing logic
   name: ONPREM
   value: "False"
-- description: Exchange rate API URL for dynamic currency rates. Empty disables the daily currency beat.
+- description: Exchange rate API URL for dynamic currency rates. Empty disables the
+    daily currency beat.
   name: CURRENCY_URL
   value: ""
 - description: Image tag

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -66,6 +66,8 @@ objects:
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: GUNICORN_LOG_LEVEL
           value: ${GUNICORN_LOG_LEVEL}
         - name: KOKU_LOG_LEVEL
@@ -251,6 +253,8 @@ objects:
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: GUNICORN_LOG_LEVEL
           value: ${GUNICORN_LOG_LEVEL}
         - name: KOKU_LOG_LEVEL
@@ -488,6 +492,8 @@ objects:
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: KOKU_LOG_LEVEL
           value: ${LISTENER_KOKU_LOG_LEVEL}
         - name: UNLEASH_LOG_LEVEL
@@ -648,6 +654,8 @@ objects:
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: GUNICORN_LOG_LEVEL
           value: ${GUNICORN_LOG_LEVEL}
         - name: KOKU_LOG_LEVEL
@@ -816,6 +824,8 @@ objects:
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: CELERY_LOG_LEVEL
           value: ${CELERY_LOG_LEVEL}
         - name: KOKU_LOG_LEVEL
@@ -988,6 +998,8 @@ objects:
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: GUNICORN_LOG_LEVEL
           value: ${GUNICORN_LOG_LEVEL}
         - name: GUNICORN_WORKERS
@@ -1147,6 +1159,8 @@ objects:
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: KOKU_LOG_LEVEL
           value: ${SOURCES_LISTENER_KOKU_LOG_LEVEL}
         - name: UNLEASH_LOG_LEVEL
@@ -1289,6 +1303,8 @@ objects:
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: CELERY_LOG_LEVEL
           value: ${CELERY_LOG_LEVEL}
         - name: KOKU_LOG_LEVEL
@@ -1475,6 +1491,8 @@ objects:
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: CELERY_LOG_LEVEL
           value: ${CELERY_LOG_LEVEL}
         - name: KOKU_LOG_LEVEL
@@ -1666,6 +1684,8 @@ objects:
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: CELERY_LOG_LEVEL
           value: ${CELERY_LOG_LEVEL}
         - name: KOKU_LOG_LEVEL
@@ -1857,6 +1877,8 @@ objects:
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: CELERY_LOG_LEVEL
           value: ${CELERY_LOG_LEVEL}
         - name: KOKU_LOG_LEVEL
@@ -2048,6 +2070,8 @@ objects:
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: CELERY_LOG_LEVEL
           value: ${CELERY_LOG_LEVEL}
         - name: KOKU_LOG_LEVEL
@@ -2243,6 +2267,8 @@ objects:
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: CELERY_LOG_LEVEL
           value: ${CELERY_LOG_LEVEL}
         - name: KOKU_LOG_LEVEL
@@ -2438,6 +2464,8 @@ objects:
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: CELERY_LOG_LEVEL
           value: ${CELERY_LOG_LEVEL}
         - name: KOKU_LOG_LEVEL
@@ -2633,6 +2661,8 @@ objects:
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: CELERY_LOG_LEVEL
           value: ${CELERY_LOG_LEVEL}
         - name: KOKU_LOG_LEVEL
@@ -2826,6 +2856,8 @@ objects:
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: CELERY_LOG_LEVEL
           value: ${CELERY_LOG_LEVEL}
         - name: KOKU_LOG_LEVEL
@@ -3019,6 +3051,8 @@ objects:
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: CELERY_LOG_LEVEL
           value: ${CELERY_LOG_LEVEL}
         - name: KOKU_LOG_LEVEL
@@ -3200,6 +3234,8 @@ objects:
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: CELERY_LOG_LEVEL
           value: ${CELERY_LOG_LEVEL}
         - name: KOKU_LOG_LEVEL
@@ -3388,6 +3424,8 @@ objects:
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: CELERY_LOG_LEVEL
           value: ${CELERY_LOG_LEVEL}
         - name: KOKU_LOG_LEVEL
@@ -3576,6 +3614,8 @@ objects:
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: CELERY_LOG_LEVEL
           value: ${CELERY_LOG_LEVEL}
         - name: KOKU_LOG_LEVEL
@@ -3764,6 +3804,8 @@ objects:
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: CELERY_LOG_LEVEL
           value: ${CELERY_LOG_LEVEL}
         - name: KOKU_LOG_LEVEL
@@ -3944,6 +3986,8 @@ objects:
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: CELERY_LOG_LEVEL
           value: ${CELERY_LOG_LEVEL}
         - name: KOKU_LOG_LEVEL
@@ -4124,6 +4168,8 @@ objects:
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: CELERY_LOG_LEVEL
           value: ${CELERY_LOG_LEVEL}
         - name: KOKU_LOG_LEVEL
@@ -4316,6 +4362,8 @@ objects:
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: CELERY_LOG_LEVEL
           value: ${CELERY_LOG_LEVEL}
         - name: KOKU_LOG_LEVEL
@@ -4511,6 +4559,8 @@ objects:
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: CELERY_LOG_LEVEL
           value: ${CELERY_LOG_LEVEL}
         - name: KOKU_LOG_LEVEL
@@ -4706,6 +4756,8 @@ objects:
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: CELERY_LOG_LEVEL
           value: ${CELERY_LOG_LEVEL}
         - name: KOKU_LOG_LEVEL
@@ -4889,6 +4941,8 @@ objects:
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: ENABLE_HCS_DEBUG
           value: ${ENABLE_HCS_DEBUG}
         - name: CELERY_LOG_LEVEL
@@ -5071,6 +5125,8 @@ objects:
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: ENABLE_SUBS_DEBUG
           value: ${ENABLE_SUBS_DEBUG}
         - name: CELERY_LOG_LEVEL
@@ -5245,6 +5301,8 @@ objects:
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: ENABLE_SUBS_DEBUG
           value: ${ENABLE_SUBS_DEBUG}
         - name: CELERY_LOG_LEVEL
@@ -5593,6 +5651,9 @@ parameters:
 - description: toggles onprem data processing logic
   name: ONPREM
   value: "False"
+- description: Exchange rate API URL for dynamic currency rates. Empty disables the daily currency beat.
+  name: CURRENCY_URL
+  value: ""
 - description: Image tag
   name: IMAGE_TAG
   required: true

--- a/deploy/kustomize/base/base.yaml
+++ b/deploy/kustomize/base/base.yaml
@@ -284,6 +284,9 @@ parameters:
 - name: ONPREM
   description: toggles onprem data processing logic
   value: "False"
+- name: CURRENCY_URL
+  description: Exchange rate API URL for dynamic currency rates. Empty disables the daily currency beat.
+  value: ""
 - description: Image tag
   name: IMAGE_TAG
   required: true

--- a/deploy/kustomize/patches/koku-reads.yaml
+++ b/deploy/kustomize/patches/koku-reads.yaml
@@ -59,6 +59,8 @@
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: GUNICORN_LOG_LEVEL
           value: ${GUNICORN_LOG_LEVEL}
         - name: KOKU_LOG_LEVEL

--- a/deploy/kustomize/patches/koku-writes.yaml
+++ b/deploy/kustomize/patches/koku-writes.yaml
@@ -66,6 +66,8 @@
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: GUNICORN_LOG_LEVEL
           value: ${GUNICORN_LOG_LEVEL}
         - name: KOKU_LOG_LEVEL

--- a/deploy/kustomize/patches/listener.yaml
+++ b/deploy/kustomize/patches/listener.yaml
@@ -53,6 +53,8 @@
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: KOKU_LOG_LEVEL
           value: ${LISTENER_KOKU_LOG_LEVEL}
         - name: UNLEASH_LOG_LEVEL

--- a/deploy/kustomize/patches/masu.yaml
+++ b/deploy/kustomize/patches/masu.yaml
@@ -67,6 +67,8 @@
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: GUNICORN_LOG_LEVEL
           value: ${GUNICORN_LOG_LEVEL}
         - name: KOKU_LOG_LEVEL

--- a/deploy/kustomize/patches/scheduler.yaml
+++ b/deploy/kustomize/patches/scheduler.yaml
@@ -57,6 +57,8 @@
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: CELERY_LOG_LEVEL
           value: ${CELERY_LOG_LEVEL}
         - name: KOKU_LOG_LEVEL

--- a/deploy/kustomize/patches/sources-client.yaml
+++ b/deploy/kustomize/patches/sources-client.yaml
@@ -67,6 +67,8 @@
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: GUNICORN_LOG_LEVEL
           value: ${GUNICORN_LOG_LEVEL}
         - name: GUNICORN_WORKERS

--- a/deploy/kustomize/patches/sources-listener.yaml
+++ b/deploy/kustomize/patches/sources-listener.yaml
@@ -71,6 +71,8 @@
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: KOKU_LOG_LEVEL
           value: ${SOURCES_LISTENER_KOKU_LOG_LEVEL}
         - name: UNLEASH_LOG_LEVEL

--- a/deploy/kustomize/patches/worker-celery.yaml
+++ b/deploy/kustomize/patches/worker-celery.yaml
@@ -59,6 +59,8 @@
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: CELERY_LOG_LEVEL
           value: ${CELERY_LOG_LEVEL}
         - name: KOKU_LOG_LEVEL

--- a/deploy/kustomize/patches/worker-cost-model-penalty.yaml
+++ b/deploy/kustomize/patches/worker-cost-model-penalty.yaml
@@ -58,6 +58,8 @@
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: CELERY_LOG_LEVEL
           value: ${CELERY_LOG_LEVEL}
         - name: KOKU_LOG_LEVEL

--- a/deploy/kustomize/patches/worker-cost-model-xl.yaml
+++ b/deploy/kustomize/patches/worker-cost-model-xl.yaml
@@ -58,6 +58,8 @@
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: CELERY_LOG_LEVEL
           value: ${CELERY_LOG_LEVEL}
         - name: KOKU_LOG_LEVEL

--- a/deploy/kustomize/patches/worker-cost-model.yaml
+++ b/deploy/kustomize/patches/worker-cost-model.yaml
@@ -58,6 +58,8 @@
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: CELERY_LOG_LEVEL
           value: ${CELERY_LOG_LEVEL}
         - name: KOKU_LOG_LEVEL

--- a/deploy/kustomize/patches/worker-download-penalty.yaml
+++ b/deploy/kustomize/patches/worker-download-penalty.yaml
@@ -58,6 +58,8 @@
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: CELERY_LOG_LEVEL
           value: ${CELERY_LOG_LEVEL}
         - name: KOKU_LOG_LEVEL

--- a/deploy/kustomize/patches/worker-download-xl.yaml
+++ b/deploy/kustomize/patches/worker-download-xl.yaml
@@ -58,6 +58,8 @@
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: CELERY_LOG_LEVEL
           value: ${CELERY_LOG_LEVEL}
         - name: KOKU_LOG_LEVEL

--- a/deploy/kustomize/patches/worker-download.yaml
+++ b/deploy/kustomize/patches/worker-download.yaml
@@ -58,6 +58,8 @@
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: CELERY_LOG_LEVEL
           value: ${CELERY_LOG_LEVEL}
         - name: KOKU_LOG_LEVEL

--- a/deploy/kustomize/patches/worker-hcs.yaml
+++ b/deploy/kustomize/patches/worker-hcs.yaml
@@ -59,6 +59,8 @@
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: ENABLE_HCS_DEBUG
           value: ${ENABLE_HCS_DEBUG}
         - name: CELERY_LOG_LEVEL

--- a/deploy/kustomize/patches/worker-ocp-penalty.yaml
+++ b/deploy/kustomize/patches/worker-ocp-penalty.yaml
@@ -58,6 +58,8 @@
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: CELERY_LOG_LEVEL
           value: ${CELERY_LOG_LEVEL}
         - name: KOKU_LOG_LEVEL

--- a/deploy/kustomize/patches/worker-ocp-xl.yaml
+++ b/deploy/kustomize/patches/worker-ocp-xl.yaml
@@ -58,6 +58,8 @@
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: CELERY_LOG_LEVEL
           value: ${CELERY_LOG_LEVEL}
         - name: KOKU_LOG_LEVEL

--- a/deploy/kustomize/patches/worker-ocp.yaml
+++ b/deploy/kustomize/patches/worker-ocp.yaml
@@ -58,6 +58,8 @@
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: CELERY_LOG_LEVEL
           value: ${CELERY_LOG_LEVEL}
         - name: KOKU_LOG_LEVEL

--- a/deploy/kustomize/patches/worker-priority-penalty.yaml
+++ b/deploy/kustomize/patches/worker-priority-penalty.yaml
@@ -59,6 +59,8 @@
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: CELERY_LOG_LEVEL
           value: ${CELERY_LOG_LEVEL}
         - name: KOKU_LOG_LEVEL

--- a/deploy/kustomize/patches/worker-priority-xl.yaml
+++ b/deploy/kustomize/patches/worker-priority-xl.yaml
@@ -59,6 +59,8 @@
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: CELERY_LOG_LEVEL
           value: ${CELERY_LOG_LEVEL}
         - name: KOKU_LOG_LEVEL

--- a/deploy/kustomize/patches/worker-priority.yaml
+++ b/deploy/kustomize/patches/worker-priority.yaml
@@ -59,6 +59,8 @@
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: CELERY_LOG_LEVEL
           value: ${CELERY_LOG_LEVEL}
         - name: KOKU_LOG_LEVEL

--- a/deploy/kustomize/patches/worker-refresh-penalty.yaml
+++ b/deploy/kustomize/patches/worker-refresh-penalty.yaml
@@ -59,6 +59,8 @@
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: CELERY_LOG_LEVEL
           value: ${CELERY_LOG_LEVEL}
         - name: KOKU_LOG_LEVEL

--- a/deploy/kustomize/patches/worker-refresh-xl.yaml
+++ b/deploy/kustomize/patches/worker-refresh-xl.yaml
@@ -59,6 +59,8 @@
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: CELERY_LOG_LEVEL
           value: ${CELERY_LOG_LEVEL}
         - name: KOKU_LOG_LEVEL

--- a/deploy/kustomize/patches/worker-refresh.yaml
+++ b/deploy/kustomize/patches/worker-refresh.yaml
@@ -59,6 +59,8 @@
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: CELERY_LOG_LEVEL
           value: ${CELERY_LOG_LEVEL}
         - name: KOKU_LOG_LEVEL

--- a/deploy/kustomize/patches/worker-subs-extraction.yaml
+++ b/deploy/kustomize/patches/worker-subs-extraction.yaml
@@ -59,6 +59,8 @@
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: ENABLE_SUBS_DEBUG
           value: ${ENABLE_SUBS_DEBUG}
         - name: CELERY_LOG_LEVEL

--- a/deploy/kustomize/patches/worker-subs-transmission.yaml
+++ b/deploy/kustomize/patches/worker-subs-transmission.yaml
@@ -59,6 +59,8 @@
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: ENABLE_SUBS_DEBUG
           value: ${ENABLE_SUBS_DEBUG}
         - name: CELERY_LOG_LEVEL

--- a/deploy/kustomize/patches/worker-summary-penalty.yaml
+++ b/deploy/kustomize/patches/worker-summary-penalty.yaml
@@ -58,6 +58,8 @@
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: CELERY_LOG_LEVEL
           value: ${CELERY_LOG_LEVEL}
         - name: KOKU_LOG_LEVEL

--- a/deploy/kustomize/patches/worker-summary-xl.yaml
+++ b/deploy/kustomize/patches/worker-summary-xl.yaml
@@ -58,6 +58,8 @@
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: CELERY_LOG_LEVEL
           value: ${CELERY_LOG_LEVEL}
         - name: KOKU_LOG_LEVEL

--- a/deploy/kustomize/patches/worker-summary.yaml
+++ b/deploy/kustomize/patches/worker-summary.yaml
@@ -58,6 +58,8 @@
           value: ${DEVELOPMENT}
         - name: ONPREM
           value: ${ONPREM}
+        - name: CURRENCY_URL
+          value: ${CURRENCY_URL}
         - name: CELERY_LOG_LEVEL
           value: ${CELERY_LOG_LEVEL}
         - name: KOKU_LOG_LEVEL

--- a/docs/architecture/celery-tasks.md
+++ b/docs/architecture/celery-tasks.md
@@ -742,9 +742,9 @@ The following tasks are scheduled via Celery Beat in `koku/koku/celery.py`:
 
 **Schedule**: Daily at 01:00
 
-**Always Enabled**: Yes
+**Enabled**: When `CURRENCY_URL` is a non-empty value (skipped on-prem by default)
 
-**Description**: Fetches latest currency exchange rates.
+**Description**: Fetches latest currency exchange rates from the configured API and upserts monthly dynamic rates per tenant. When `CURRENCY_URL` is unset/empty (typical on-prem / airgapped), the beat is not registered so the worker does not attempt outbound requests.
 
 ---
 
@@ -821,16 +821,17 @@ The following tasks are scheduled via Celery Beat in `koku/koku/celery.py`:
 
 **Queue**: `DEFAULT`
 
-**Description**: Fetches and updates daily currency exchange rates.
+**Description**: Fetches and updates daily currency exchange rates. Celery Beat schedules this task only when `CURRENCY_URL` is set.
 
 **Configuration**:
-- URL: `settings.CURRENCY_URL`
-- Retry strategy: 5 retries with exponential backoff
+- URL: `settings.CURRENCY_URL` (empty by default when `ONPREM=True`; SaaS default is `https://open.er-api.com/v6/latest/USD`)
+- Retry strategy: 5 retries with exponential backoff on the HTTP fetch
 
 **Workflow**:
-1. Fetches exchange rates from external API
-2. Updates `ExchangeRates` model for valid currencies
-3. Updates exchange rate cache
+1. If `CURRENCY_URL` is empty, skips the API fetch (logs and continues without dynamic discovery)
+2. Otherwise fetches exchange rates from the external API
+3. Updates `ExchangeRates` model for valid currencies and rebuilds the exchange rate cache
+4. Upserts `MonthlyExchangeRate` dynamic rows per tenant (and may invalidate report view cache)
 
 ---
 

--- a/docs/architecture/celery-tasks.md
+++ b/docs/architecture/celery-tasks.md
@@ -742,7 +742,7 @@ The following tasks are scheduled via Celery Beat in `koku/koku/celery.py`:
 
 **Schedule**: Daily at 01:00
 
-**Enabled**: When `CURRENCY_URL` is a non-empty value (skipped on-prem by default)
+**Enabled**: When `CURRENCY_URL` is a non-empty value (configured via environment / app-interface)
 
 **Description**: Fetches latest currency exchange rates from the configured API and upserts monthly dynamic rates per tenant. When `CURRENCY_URL` is unset/empty (typical on-prem / airgapped), the beat is not registered so the worker does not attempt outbound requests.
 
@@ -824,7 +824,7 @@ The following tasks are scheduled via Celery Beat in `koku/koku/celery.py`:
 **Description**: Fetches and updates daily currency exchange rates. Celery Beat schedules this task only when `CURRENCY_URL` is set.
 
 **Configuration**:
-- URL: `settings.CURRENCY_URL` (empty by default when `ONPREM=True`; SaaS default is `https://open.er-api.com/v6/latest/USD`)
+- URL: `settings.CURRENCY_URL` (empty by default; set via environment / app-interface for SaaS)
 - Retry strategy: 5 retries with exponential backoff on the HTTP fetch
 
 **Workflow**:

--- a/koku/api/currency/test/test_views.py
+++ b/koku/api/currency/test/test_views.py
@@ -2,11 +2,14 @@
 # Copyright 2021 Red Hat Inc.
 # SPDX-License-Identifier: Apache-2.0
 #
+from unittest.mock import patch
+
 from django.urls import reverse
 from django_tenants.utils import schema_context
 from rest_framework import status
 from rest_framework.test import APIClient
 
+from api.currency.models import ExchangeRateDictionary
 from api.iam.test.iam_test_case import IamTestCase
 from cost_models.models import EnabledCurrency
 
@@ -32,3 +35,25 @@ class CurrencyViewTest(IamTestCase):
         codes = [c["code"] for c in response.data["data"]]
         self.assertIn("USD", codes)
         self.assertNotIn("GBP", codes)
+
+    @patch("masu.celery.tasks.get_daily_currency_rates")
+    def test_get_exchange_rates_returns_404_when_dictionary_missing(self, mock_fetch):
+        """When no ExchangeRateDictionary exists after fetch, return 404 instead of AttributeError."""
+        ExchangeRateDictionary.objects.all().delete()
+        mock_fetch.return_value = {}
+
+        response = APIClient().get(reverse("exchange-rates"), **self.headers)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertIn("No exchange rates are available", response.data["detail"])
+        mock_fetch.assert_called_once()
+
+    def test_get_exchange_rates_returns_dictionary(self):
+        """When ExchangeRateDictionary exists, return its payload."""
+        ExchangeRateDictionary.objects.all().delete()
+        ExchangeRateDictionary.objects.create(currency_exchange_dictionary={"USD": {"EUR": 0.9}})
+
+        response = APIClient().get(reverse("exchange-rates"), **self.headers)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, {"USD": {"EUR": 0.9}})

--- a/koku/api/currency/view.py
+++ b/koku/api/currency/view.py
@@ -4,6 +4,7 @@
 #
 """View for Currency."""
 from rest_framework import permissions
+from rest_framework import status
 from rest_framework.decorators import api_view
 from rest_framework.decorators import permission_classes
 from rest_framework.decorators import renderer_classes
@@ -43,4 +44,14 @@ def get_exchange_rates(request):
 
         get_daily_currency_rates()
         exchange_rates = ExchangeRateDictionary.objects.all().first()
+    if not exchange_rates:
+        return Response(
+            {
+                "detail": (
+                    "No exchange rates are available. Configure CURRENCY_URL for dynamic rates "
+                    "or ensure exchange rate data has been loaded."
+                )
+            },
+            status=status.HTTP_404_NOT_FOUND,
+        )
     return Response(exchange_rates.currency_exchange_dictionary)

--- a/koku/koku/celery.py
+++ b/koku/koku/celery.py
@@ -33,7 +33,7 @@ def register_daily_currency_rates_beat(beat_schedule, currency_url, schedule=Non
     On-prem / airgapped deployments leave CURRENCY_URL empty so this beat is
     not scheduled and workers do not attempt outbound exchange-rate API calls.
     """
-    if not currency_url:
+    if not (currency_url or "").strip():
         return False
     beat_schedule[CURRENCY_RATES_BEAT_NAME] = {
         "task": "masu.celery.tasks.get_daily_currency_rates",

--- a/koku/koku/celery.py
+++ b/koku/koku/celery.py
@@ -220,7 +220,8 @@ app.conf.beat_schedule["crawl_account_hierarchy"] = {
 }
 
 # Beat used to fetch daily rates (only when CURRENCY_URL is configured)
-register_daily_currency_rates_beat(app.conf.beat_schedule, settings.CURRENCY_URL)
+if not register_daily_currency_rates_beat(app.conf.beat_schedule, settings.CURRENCY_URL):
+    LOG.info("Daily currency rates beat not registered (CURRENCY_URL is empty)")
 
 # Beat used for HCS report finalization
 app.conf.beat_schedule["finalize_hcs_reports"] = {

--- a/koku/koku/celery.py
+++ b/koku/koku/celery.py
@@ -24,6 +24,23 @@ from koku.probe_server import start_probe_server
 
 LOG = logging.getLogger(__name__)
 
+CURRENCY_RATES_BEAT_NAME = "get_daily_currency_rates"
+
+
+def register_daily_currency_rates_beat(beat_schedule, currency_url, schedule=None):
+    """Register the daily currency rates beat only when CURRENCY_URL is set.
+
+    On-prem / airgapped deployments leave CURRENCY_URL empty so this beat is
+    not scheduled and workers do not attempt outbound exchange-rate API calls.
+    """
+    if not currency_url:
+        return False
+    beat_schedule[CURRENCY_RATES_BEAT_NAME] = {
+        "task": "masu.celery.tasks.get_daily_currency_rates",
+        "schedule": schedule or crontab(hour=1, minute=0),
+    }
+    return True
+
 
 class LogErrorsTask(Task):  # pragma: no cover
     """Log Celery task exceptions."""
@@ -202,11 +219,8 @@ app.conf.beat_schedule["crawl_account_hierarchy"] = {
     "schedule": crontab(hour=0, minute=0),
 }
 
-# Beat used to fetch daily rates
-app.conf.beat_schedule["get_daily_currency_rates"] = {
-    "task": "masu.celery.tasks.get_daily_currency_rates",
-    "schedule": crontab(hour=1, minute=0),
-}
+# Beat used to fetch daily rates (only when CURRENCY_URL is configured)
+register_daily_currency_rates_beat(app.conf.beat_schedule, settings.CURRENCY_URL)
 
 # Beat used for HCS report finalization
 app.conf.beat_schedule["finalize_hcs_reports"] = {

--- a/koku/koku/settings.py
+++ b/koku/koku/settings.py
@@ -174,7 +174,12 @@ UNLEASH_CACHE_DIR = ENVIRONMENT.get_value("UNLEASH_CACHE_DIR", default=os.path.j
 MAX_GROUP_BY = ENVIRONMENT.int("MAX_GROUP_BY_OVERRIDE", default=3)
 
 ### Currency URL
-CURRENCY_URL = ENVIRONMENT.get_value("CURRENCY_URL", default="https://open.er-api.com/v6/latest/USD")
+# Empty when unset on-prem so the daily beat is not scheduled (no external API).
+# SaaS keeps the open.er-api.com default unless CURRENCY_URL is overridden.
+CURRENCY_URL = ENVIRONMENT.get_value(
+    "CURRENCY_URL",
+    default="" if ONPREM else "https://open.er-api.com/v6/latest/USD",
+)
 
 ### End Middleware
 

--- a/koku/koku/settings.py
+++ b/koku/koku/settings.py
@@ -174,12 +174,9 @@ UNLEASH_CACHE_DIR = ENVIRONMENT.get_value("UNLEASH_CACHE_DIR", default=os.path.j
 MAX_GROUP_BY = ENVIRONMENT.int("MAX_GROUP_BY_OVERRIDE", default=3)
 
 ### Currency URL
-# Empty when unset on-prem so the daily beat is not scheduled (no external API).
-# SaaS keeps the open.er-api.com default unless CURRENCY_URL is overridden.
-CURRENCY_URL = ENVIRONMENT.get_value(
-    "CURRENCY_URL",
-    default="" if ONPREM else "https://open.er-api.com/v6/latest/USD",
-)
+# Empty by default. SaaS sets this via app-interface / deploy parameters.
+# When unset, the daily get_daily_currency_rates Celery beat is not scheduled.
+CURRENCY_URL = (ENVIRONMENT.get_value("CURRENCY_URL", default="") or "").strip()
 
 ### End Middleware
 

--- a/koku/koku/test/test_celery.py
+++ b/koku/koku/test/test_celery.py
@@ -87,9 +87,11 @@ class CurrencyRatesBeatScheduleTest(SimpleTestCase):
         )
 
     def test_register_daily_currency_rates_beat_without_url(self):
-        """Beat is not registered when CURRENCY_URL is empty (on-prem default)."""
-        beat_schedule = {}
-        scheduled = register_daily_currency_rates_beat(beat_schedule, "")
+        """Beat is not registered when CURRENCY_URL is empty, None, or whitespace."""
+        for invalid_url in ("", "   ", None):
+            with self.subTest(invalid_url=invalid_url):
+                beat_schedule = {}
+                scheduled = register_daily_currency_rates_beat(beat_schedule, invalid_url)
 
-        self.assertFalse(scheduled)
-        self.assertNotIn(CURRENCY_RATES_BEAT_NAME, beat_schedule)
+                self.assertFalse(scheduled)
+                self.assertNotIn(CURRENCY_RATES_BEAT_NAME, beat_schedule)

--- a/koku/koku/test/test_celery.py
+++ b/koku/koku/test/test_celery.py
@@ -76,7 +76,7 @@ class CurrencyRatesBeatScheduleTest(SimpleTestCase):
         """Beat is registered when CURRENCY_URL is set."""
         beat_schedule = {}
         scheduled = register_daily_currency_rates_beat(
-            beat_schedule, "https://open.er-api.com/v6/latest/USD", schedule=crontab(hour=1, minute=0)
+            beat_schedule, "https://exchange-rates.example/v6/latest/USD", schedule=crontab(hour=1, minute=0)
         )
 
         self.assertTrue(scheduled)

--- a/koku/koku/test/test_celery.py
+++ b/koku/koku/test/test_celery.py
@@ -5,8 +5,13 @@
 """Test Celery utility functions."""
 from unittest.mock import patch
 
+from celery.schedules import crontab
+from django.test import SimpleTestCase
+
 from api.iam.test.iam_test_case import IamTestCase
 from koku import is_task_currently_running
+from koku.celery import CURRENCY_RATES_BEAT_NAME
+from koku.celery import register_daily_currency_rates_beat
 
 
 class CeleryTest(IamTestCase):
@@ -62,3 +67,29 @@ class CeleryTest(IamTestCase):
         )
         # A different task
         self.assertFalse(is_task_currently_running("masu.processor.tasks.update_cost_model_costs", None))
+
+
+class CurrencyRatesBeatScheduleTest(SimpleTestCase):
+    """Tests for conditional registration of the daily currency rates beat."""
+
+    def test_register_daily_currency_rates_beat_with_url(self):
+        """Beat is registered when CURRENCY_URL is set."""
+        beat_schedule = {}
+        scheduled = register_daily_currency_rates_beat(
+            beat_schedule, "https://open.er-api.com/v6/latest/USD", schedule=crontab(hour=1, minute=0)
+        )
+
+        self.assertTrue(scheduled)
+        self.assertIn(CURRENCY_RATES_BEAT_NAME, beat_schedule)
+        self.assertEqual(
+            beat_schedule[CURRENCY_RATES_BEAT_NAME]["task"],
+            "masu.celery.tasks.get_daily_currency_rates",
+        )
+
+    def test_register_daily_currency_rates_beat_without_url(self):
+        """Beat is not registered when CURRENCY_URL is empty (on-prem default)."""
+        beat_schedule = {}
+        scheduled = register_daily_currency_rates_beat(beat_schedule, "")
+
+        self.assertFalse(scheduled)
+        self.assertNotIn(CURRENCY_RATES_BEAT_NAME, beat_schedule)

--- a/koku/masu/test/celery/test_tasks.py
+++ b/koku/masu/test/celery/test_tasks.py
@@ -7,7 +7,6 @@ from unittest.mock import patch
 
 import faker
 import requests_mock
-from django.conf import settings
 from django.test import override_settings
 from django_tenants.utils import tenant_context
 from model_bakery import baker
@@ -30,6 +29,8 @@ from masu.test.celery import test_azure_scrape_output
 from masu.util.azure.azure_disk_size_scraper import AzureDiskSizeScraper
 from reporting.models import TRINO_MANAGED_TABLES
 from reporting_common.models import DiskCapacity
+
+TEST_CURRENCY_URL = "https://exchange-rates.example/v6/latest/USD"
 
 fake = faker.Faker()
 DummyS3Object = namedtuple("DummyS3Object", "key")
@@ -81,22 +82,29 @@ class TestCeleryTasks(MasuTestCase):
         mock_orch.remove_expired_report_data.assert_called()
 
     # Check to see if exchange rates are being created or updated
+    @override_settings(CURRENCY_URL=TEST_CURRENCY_URL)
     def test_get_currency_conversion_rates(self):
-        with self.assertLogs("masu.celery.tasks", "INFO") as captured_logs:
-            tasks.get_daily_currency_rates()
+        mock_response = {"result": "success", "rates": {"AUD": 1.37}}
+        with requests_mock.Mocker() as reqmock:
+            reqmock.register_uri("GET", TEST_CURRENCY_URL, json=mock_response)
+            with self.assertLogs("masu.celery.tasks", "INFO") as captured_logs:
+                tasks.get_daily_currency_rates()
 
-        self.assertIn("Creating the exchange rate" or "Updating currency", str(captured_logs))
+        logs = str(captured_logs)
+        self.assertTrue("Creating the exchange rate" in logs or "Updating currency" in logs)
 
+    @override_settings(CURRENCY_URL=TEST_CURRENCY_URL)
     def test_error_get_currency_conversion_rates(self):
         with self.assertLogs("masu.celery.tasks", "ERROR") as captured_logs:
             with requests_mock.Mocker() as reqmock:
-                reqmock.register_uri("GET", settings.CURRENCY_URL, exc=HTTPError("Raised intentionally"))
+                reqmock.register_uri("GET", TEST_CURRENCY_URL, exc=HTTPError("Raised intentionally"))
                 result = tasks.get_daily_currency_rates()
 
         self.assertEqual({}, result)
         self.assertIn("Couldn't pull latest conversion rates", captured_logs.output[0])
         self.assertIn("Raised intentionally", captured_logs.output[1])
 
+    @override_settings(CURRENCY_URL=TEST_CURRENCY_URL)
     def test_get_currency_conversion_rates_successful(self):
         beforeRows = ExchangeRates.objects.count()
         self.assertEqual(beforeRows, 2)
@@ -106,12 +114,13 @@ class TestCeleryTasks(MasuTestCase):
             "rates": {"AUD": 1.37, "CAD": 1.25, "CHF": 0.928},
         }
         with requests_mock.Mocker() as reqmock:
-            reqmock.register_uri("GET", settings.CURRENCY_URL, status_code=201, json=result)
+            reqmock.register_uri("GET", TEST_CURRENCY_URL, status_code=201, json=result)
             tasks.get_daily_currency_rates()
 
         afterRows = ExchangeRates.objects.count()
         self.assertEqual(afterRows, 5)
 
+    @override_settings(CURRENCY_URL=TEST_CURRENCY_URL)
     def test_get_currency_conversion_rates_unsupported_currency(self):
         beforeRows = ExchangeRates.objects.count()
         self.assertEqual(beforeRows, 2)
@@ -121,7 +130,7 @@ class TestCeleryTasks(MasuTestCase):
             "rates": {"AUD": 1.37, "CAD": 1.25, "CHF": 0.928, "FOO": 12.34},
         }
         with requests_mock.Mocker() as reqmock:
-            reqmock.register_uri("GET", settings.CURRENCY_URL, status_code=201, json=result)
+            reqmock.register_uri("GET", TEST_CURRENCY_URL, status_code=201, json=result)
             tasks.get_daily_currency_rates()
 
         afterRows = ExchangeRates.objects.count()
@@ -460,12 +469,13 @@ class TestCeleryTasks(MasuTestCase):
         self.assertIn("Unable to retrieve azure disk capacities", captured_logs.output[0])
         self.assertIn("Raised intentionally", captured_logs.output[0])
 
+    @override_settings(CURRENCY_URL=TEST_CURRENCY_URL)
     def test_fetch_and_store_exchange_rates_success(self):
         """Test that _fetch_and_store_exchange_rates fetches, stores, and returns rates."""
         mock_response = {"result": "success", "rates": {"EUR": 0.87, "GBP": 0.78}}
         with requests_mock.Mocker() as reqmock:
-            reqmock.register_uri("GET", settings.CURRENCY_URL, json=mock_response)
-            result = tasks._fetch_and_store_exchange_rates(settings.CURRENCY_URL)
+            reqmock.register_uri("GET", TEST_CURRENCY_URL, json=mock_response)
+            result = tasks._fetch_and_store_exchange_rates(TEST_CURRENCY_URL)
 
         self.assertIsNotNone(result)
         self.assertIn("EUR", result)
@@ -564,6 +574,7 @@ class TestCeleryTasks(MasuTestCase):
         self.assertEqual(result, {})
         self.assertIn("CURRENCY_URL not configured", str(captured_logs))
 
+    @override_settings(CURRENCY_URL=TEST_CURRENCY_URL)
     def test_get_daily_currency_rates_upserts_mer(self):
         """Test end-to-end: get_daily_currency_rates fetches rates and upserts MER rows."""
         current_month = DateHelper().this_month_start.date()
@@ -575,7 +586,7 @@ class TestCeleryTasks(MasuTestCase):
 
         mock_response = {"result": "success", "rates": {"USD": 1.0, "CAD": 1.25}}
         with requests_mock.Mocker() as reqmock:
-            reqmock.register_uri("GET", settings.CURRENCY_URL, json=mock_response)
+            reqmock.register_uri("GET", TEST_CURRENCY_URL, json=mock_response)
             result = tasks.get_daily_currency_rates()
 
         self.assertIn("CAD", result)


### PR DESCRIPTION
## Jira Ticket
[COST-7840](https://issues.redhat.com/browse/COST-7840)

## Description

This change registers the daily `get_daily_currency_rates` Celery Beat entry only when `CURRENCY_URL` is configured. On-prem / airgapped deployments leave the URL unset by default (`ONPREM=True` → empty `CURRENCY_URL`), so the beat is not scheduled and workers do not attempt outbound exchange-rate API calls. SaaS keeps the existing `open.er-api.com` default when `ONPREM=False`.

## Testing

1. Checkout this branch and restart `koku-beat` / workers so `celery.py` is reloaded.
2. **With URL set** (SaaS / local `.env` with `CURRENCY_URL=...`):
   ```bash
   docker compose exec koku-beat python -c "from koku.celery import app; print('get_daily_currency_rates' in app.conf.beat_schedule)"
   ```
   Expect `True`.
3. **Without URL** (on-prem style):
   ```bash
   ONPREM=True CURRENCY_URL= docker compose exec -e ONPREM=True -e CURRENCY_URL= koku-beat \
     python -c "from django.conf import settings; from koku.celery import app; print(repr(settings.CURRENCY_URL)); print('get_daily_currency_rates' in app.conf.beat_schedule)"
   ```
   Expect empty URL and `False` (restart beat after env change so import-time schedule is rebuilt).
4. Unit tests:
   ```bash
   pipenv run tox -- koku.koku.test.test_celery.CurrencyRatesBeatScheduleTest
   ```

## Release Notes
- [x] proposed release note

```markdown
* [COST-7840](https://issues.redhat.com/browse/COST-7840) Only schedule the daily currency exchange-rate Celery beat when CURRENCY_URL is set (disabled by default on-prem)
```

Made with [Cursor](https://cursor.com)