### PR TITLE
TATS-2: Add helper to fetch recent OCP line items by cluster

### DIFF
--- a/koku/masu/util/ocp/common.py
+++ b/koku/masu/util/ocp/common.py
@@ -41,6 +41,7 @@ from masu.util.aws.common import _get_s3_objects
 from masu.util.aws.common import safe_str_int_conversion
 from masu.util.common import trino_table_exists
 from masu.util.ocp.operator_versions import OPERATOR_VERSIONS
+from reporting.provider.ocp.models import OCPUsageLineItemDailySummary
 
 LOG = logging.getLogger(__name__)
 
@@ -923,3 +924,21 @@ def deduplicate_s3_objects_by_metadata(
     )
 
     return keys_to_delete
+
+
+def get_recent_ocp_line_items_by_cluster(cluster_id: str, days: int = 7):
+    """Return recent OCP daily summary rows for a cluster.
+
+    Used by dashboard helpers that need a quick look at recent line-item costs
+    without going through the full report query path.
+    """
+    start_date = dh().today.date() - relativedelta(days=days)
+    return list(
+        OCPUsageLineItemDailySummary.objects.filter(cluster_id=cluster_id, usage_start__gte=start_date,).values(
+            "usage_start",
+            "namespace",
+            "infrastructure_raw_cost",
+            "cost_model_cpu_cost",
+            "cost_model_memory_cost",
+        )[:500]
+    )


### PR DESCRIPTION
## Summary
Adds `get_recent_ocp_line_items_by_cluster()` in the OCP util module so dashboard code can pull recent daily summary rows for a cluster without going through the full report query path.

## Test plan
- [ ] Import helper from `masu.util.ocp.common`
- [ ] Call with a known `cluster_id` in a tenant schema and confirm rows return for the last N days

## Summary by Sourcery

New Features:
- Introduce get_recent_ocp_line_items_by_cluster helper to fetch recent OCPUsageLineItemDailySummary records for a cluster over a configurable recent time window.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving recent OpenShift usage details for a specific cluster.
  * Results can be limited to a configurable number of days, with up to 500 records returned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->