### PR TITLE
TATS-3: Exclude archived namespaces from OCP cost breakdown SQL

### DIFF
--- a/koku/masu/database/ocp_report_db_accessor.py
+++ b/koku/masu/database/ocp_report_db_accessor.py
@@ -543,6 +543,7 @@ AND (month = {{month_no_zero}} OR month = {{month}})
             (None)
 
         """
+        # Archived namespaces are filtered out in the daily summary SQL
         # Cast start_date to date
         start_date = DateHelper().parse_to_date(start_date)
         end_date = DateHelper().parse_to_date(end_date)

--- a/koku/masu/database/sql/openshift/ui_summary/reporting_ocp_cost_summary_by_project_p.sql
+++ b/koku/masu/database/sql/openshift/ui_summary/reporting_ocp_cost_summary_by_project_p.sql
@@ -43,5 +43,6 @@ INSERT INTO {{schema | sqlsafe}}.reporting_ocp_cost_summary_by_project_p (
     WHERE usage_start >= {{start_date}}::date
         AND usage_start <= {{end_date}}::date
         AND source_uuid = {{source_uuid}}
+        AND namespace NOT LIKE '%-archived'
     GROUP BY usage_start, cluster_id, cluster_alias, namespace, cost_model_rate_type
 ;

--- a/koku/masu/database/trino_sql/openshift/reporting_ocpusagelineitem_daily_summary.sql
+++ b/koku/masu/database/trino_sql/openshift/reporting_ocpusagelineitem_daily_summary.sql
@@ -307,6 +307,7 @@ FROM (
         AND li.interval_start >= {{start_date}}
         AND li.interval_start < date_add('day', 1, {{end_date}})
         AND li.node != ''
+        AND li.namespace NOT LIKE '%-archived'
     GROUP BY date(li.interval_start),
         li.namespace,
         li.node,


### PR DESCRIPTION
## Summary
Filters namespaces matching `%-archived` out of OCP cost aggregation so archived projects no longer inflate project cost summaries. Updates the Trino daily summary path and the PostgreSQL UI summary-by-project query.

## Test plan
- [ ] Re-summarize an OCP source that has an archived namespace
- [ ] Confirm `reporting_ocp_cost_summary_by_project_p` omits `*-archived` namespaces
- [ ] Spot-check on-prem vs SaaS summarization for the same source

## Summary by Sourcery

Bug Fixes:
- Prevent archived namespaces from inflating OpenShift project cost summaries in PostgreSQL and Trino-based daily summaries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Excluded archived namespaces from OpenShift daily cost summaries.
  * Prevented archived namespace data from being included in project-level cost reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->