### PR TITLE
 TATS-1: Fix typo in testing documentation

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -44,7 +44,7 @@ For example:
 
 If you observe the following error when running the unit tests, it may
 be a false error. This can be due to some tests expecting the DEBUG
-setting to be TRUE:
+setting to be True:
 
     FAIL: test_delete_single_provider_skips_delete_archived_data_if_customer_is_none
     (api.provider.test.tests_models.ProviderModelTest)


### PR DESCRIPTION
## Summary
Corrects Python boolean casing in the unit testing docs example (`TRUE` → `True`) so it matches actual Django settings usage.

## Test plan
- [ ] Skim `docs/testing.md` for the updated DEBUG settings note
- [ ] No code or test changes expected

## Summary by Sourcery

Documentation:
- Update testing documentation to use the correct `True` value for the DEBUG setting example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the `DEBUG` setting must be enabled for certain unit tests to run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->