### PR TITLE
Guard against unsaved Customer in _get_cloud_providers_using_currency

### DIFF
--- a/koku/api/settings/currency_views.py
+++ b/koku/api/settings/currency_views.py
@@ -44,6 +44,8 @@ LOG = logging.getLogger(__name__)
 
 def _get_cloud_providers_using_currency(code, customer):
     """Return cloud providers whose billing data uses ``code`` as a base currency."""
+    if not customer or not customer.pk:
+        return []
     aws_uuids = AWSCostSummaryP.objects.filter(currency_code=code).values_list("source_uuid", flat=True).distinct()
     azure_uuids = AzureCostSummaryP.objects.filter(currency=code).values_list("source_uuid", flat=True).distinct()
     gcp_uuids = GCPCostSummaryP.objects.filter(currency=code).values_list("source_uuid", flat=True).distinct()


### PR DESCRIPTION
## Summary

`_get_cloud_providers_using_currency` crashes with a 500 when the `Customer` instance passed to it has no `pk` (not yet persisted). Django raises a `ValueError` when a filter receives an unsaved model instance.

Add an early return guard to short-circuit before the query is attempted.

## Reproducer

```
python manage.py test koku.api.settings.test.test_currency_views.test_api_settings_currency_enablement_disable_default_negative
```

## Changes

- `koku/api/settings/currency_views.py`: add `if not customer or not customer.pk: return []` at the top of `_get_cloud_providers_using_currency`

## Test plan

- [ ] Run `test_api_settings_currency_enablement_disable_default_negative` — should pass instead of raising 500

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Bug Fixes:
- Prevent _get_cloud_providers_using_currency from raising a ValueError when called with an unsaved or missing Customer by short-circuiting with an empty result.