### PR TITLE
Reapply the RTU migrations

### DIFF
--- a/koku/reporting/migrations/0353_rtu_schema_improvements.py
+++ b/koku/reporting/migrations/0353_rtu_schema_improvements.py
@@ -1,0 +1,269 @@
+# rates_to_usage schema improvements (GAP-2, GAP-4, GAP-5):
+# - TRUNCATE existing RTU rows (prerequisite: smart revert #6172, Unleash flag OFF)
+# - Indexes on rate_id and cost_model_id
+# - CASCADE on rate/cost_model FKs (ORM + PostgreSQL)
+# - FK wiring for source_uuid (TenantAPIProvider) and report_period (OCPUsageReportPeriod)
+# - Drop duplicate Django auto-named indexes (keep explicit ratestousage_* from Meta.indexes)
+import django.db.models.deletion
+from django.db import migrations
+from django.db import models
+
+
+RTU_FK_CASCADE_SQL = """
+DO $$
+DECLARE
+    con record;
+BEGIN
+    FOR con IN
+        SELECT c.conname,
+               a.attname AS column_name,
+               cc.relname AS ref_table,
+               array_agg(ac.attname ORDER BY ck.ord) AS ref_columns
+        FROM pg_constraint c
+        JOIN pg_class t ON t.oid = c.conrelid
+        JOIN pg_namespace tn ON tn.oid = t.relnamespace
+        JOIN pg_attribute a
+          ON a.attrelid = c.conrelid
+         AND a.attnum = ANY (c.conkey)
+        JOIN pg_class cc ON cc.oid = c.confrelid
+        JOIN unnest(c.confkey) WITH ORDINALITY AS ck(attnum, ord) ON TRUE
+        JOIN pg_attribute ac
+          ON ac.attrelid = c.confrelid
+         AND ac.attnum = ck.attnum
+        WHERE tn.nspname = current_schema()
+          AND t.relname = 'rates_to_usage'
+          AND NOT t.relispartition
+          AND c.contype = 'f'
+          AND a.attname IN ('report_period_id', 'source_uuid', 'rate_id', 'cost_model_id')
+        GROUP BY c.conname, a.attname, cc.relname
+    LOOP
+        EXECUTE format('ALTER TABLE rates_to_usage DROP CONSTRAINT %I', con.conname);
+        EXECUTE format(
+            'ALTER TABLE rates_to_usage ADD CONSTRAINT %I '
+            'FOREIGN KEY (%I) REFERENCES %I (%s) '
+            'ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED',
+            con.conname,
+            con.column_name,
+            con.ref_table,
+            array_to_string(con.ref_columns, ', ')
+        );
+    END LOOP;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint c
+        JOIN pg_class t ON t.oid = c.conrelid
+        JOIN pg_namespace tn ON tn.oid = t.relnamespace
+        JOIN pg_attribute a
+          ON a.attrelid = c.conrelid
+         AND a.attnum = ANY (c.conkey)
+        WHERE tn.nspname = current_schema()
+          AND t.relname = 'rates_to_usage'
+          AND NOT t.relispartition
+          AND c.contype = 'f'
+          AND a.attname = 'report_period_id'
+    ) THEN
+        ALTER TABLE rates_to_usage
+            ADD CONSTRAINT rates_to_usage_report_period_id_fk
+            FOREIGN KEY (report_period_id)
+            REFERENCES reporting_ocpusagereportperiod (id)
+            ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED;
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint c
+        JOIN pg_class t ON t.oid = c.conrelid
+        JOIN pg_namespace tn ON tn.oid = t.relnamespace
+        JOIN pg_attribute a
+          ON a.attrelid = c.conrelid
+         AND a.attnum = ANY (c.conkey)
+        WHERE tn.nspname = current_schema()
+          AND t.relname = 'rates_to_usage'
+          AND NOT t.relispartition
+          AND c.contype = 'f'
+          AND a.attname = 'source_uuid'
+    ) THEN
+        ALTER TABLE rates_to_usage
+            ADD CONSTRAINT rates_to_usage_source_uuid_fk
+            FOREIGN KEY (source_uuid)
+            REFERENCES reporting_tenant_api_provider (uuid)
+            ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED;
+    END IF;
+END $$;
+"""
+
+# Drop any non-explicit index that duplicates rate_id, cost_model_id, or the pipeline
+# composite key (covers rates_to_usage_* auto names and suffix variants like _idx1).
+RTU_DROP_DUPLICATE_INDEXES_SQL = """
+DO $$
+DECLARE
+    idx record;
+    keep_indexes name[] := ARRAY[
+        'ratestousage_rate_id_idx',
+        'ratestousage_cost_model_id_idx',
+        'ratestousage_start_src_rp_idx'
+    ];
+BEGIN
+    FOR idx IN
+        SELECT
+            ic.relname AS index_name,
+            array_agg(a.attname ORDER BY k.ordinality) AS cols
+        FROM pg_class t
+        JOIN pg_namespace n ON n.oid = t.relnamespace
+        JOIN pg_index i ON i.indrelid = t.oid
+        JOIN pg_class ic ON ic.oid = i.indexrelid
+        JOIN unnest(i.indkey) WITH ORDINALITY AS k(attnum, ordinality) ON TRUE
+        JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = k.attnum
+        WHERE n.nspname = current_schema()
+          AND t.relname = 'rates_to_usage'
+          AND NOT t.relispartition
+          AND NOT i.indisprimary
+        GROUP BY ic.relname
+    LOOP
+        IF idx.index_name = ANY(keep_indexes) THEN
+            CONTINUE;
+        END IF;
+        IF idx.cols = ARRAY['rate_id']::name[]
+           OR idx.cols = ARRAY['cost_model_id']::name[]
+           OR idx.cols = ARRAY['usage_start', 'source_uuid', 'report_period_id']::name[] THEN
+            EXECUTE format('DROP INDEX IF EXISTS %I', idx.index_name);
+        END IF;
+    END LOOP;
+END $$;
+"""
+
+# Remove legacy FK auto-indexes from 0348 before adding explicit ratestousage_* indexes.
+RTU_DROP_LEGACY_FK_INDEXES_SQL = """
+DO $$
+DECLARE
+    idx record;
+BEGIN
+    FOR idx IN
+        SELECT
+            ic.relname AS index_name,
+            array_agg(a.attname ORDER BY k.ordinality) AS cols
+        FROM pg_class t
+        JOIN pg_namespace n ON n.oid = t.relnamespace
+        JOIN pg_index i ON i.indrelid = t.oid
+        JOIN pg_class ic ON ic.oid = i.indexrelid
+        JOIN unnest(i.indkey) WITH ORDINALITY AS k(attnum, ordinality) ON TRUE
+        JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = k.attnum
+        WHERE n.nspname = current_schema()
+          AND t.relname = 'rates_to_usage'
+          AND NOT t.relispartition
+          AND NOT i.indisprimary
+        GROUP BY ic.relname
+    LOOP
+        IF idx.cols = ARRAY['rate_id']::name[]
+           OR idx.cols = ARRAY['cost_model_id']::name[] THEN
+            EXECUTE format('DROP INDEX IF EXISTS %I', idx.index_name);
+        END IF;
+    END LOOP;
+END $$;
+"""
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("reporting", "0352_rtu_schema_improvements"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql="TRUNCATE TABLE rates_to_usage;",
+            reverse_sql=migrations.RunSQL.noop,
+        ),
+        migrations.RunSQL(sql=RTU_DROP_LEGACY_FK_INDEXES_SQL, reverse_sql=migrations.RunSQL.noop),
+        migrations.AddIndex(
+            model_name="ratestousage",
+            index=models.Index(fields=["rate_id"], name="ratestousage_rate_id_idx"),
+        ),
+        migrations.AddIndex(
+            model_name="ratestousage",
+            index=models.Index(fields=["cost_model_id"], name="ratestousage_cost_model_id_idx"),
+        ),
+        migrations.SeparateDatabaseAndState(
+            database_operations=[],
+            state_operations=[
+                migrations.AlterField(
+                    model_name="ratestousage",
+                    name="rate",
+                    field=models.ForeignKey(
+                        db_index=False,
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to="cost_models.rate",
+                    ),
+                ),
+            ],
+        ),
+        migrations.SeparateDatabaseAndState(
+            database_operations=[],
+            state_operations=[
+                migrations.AlterField(
+                    model_name="ratestousage",
+                    name="cost_model",
+                    field=models.ForeignKey(
+                        db_index=False,
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to="cost_models.costmodel",
+                    ),
+                ),
+            ],
+        ),
+        migrations.RemoveIndex(
+            model_name="ratestousage",
+            name="ratestousage_start_src_rp_idx",
+        ),
+        migrations.SeparateDatabaseAndState(
+            database_operations=[],
+            state_operations=[
+                migrations.RenameField(
+                    model_name="ratestousage",
+                    old_name="report_period_id",
+                    new_name="report_period",
+                ),
+            ],
+        ),
+        migrations.SeparateDatabaseAndState(
+            database_operations=[],
+            state_operations=[
+                migrations.AlterField(
+                    model_name="ratestousage",
+                    name="report_period",
+                    field=models.ForeignKey(
+                        db_column="report_period_id",
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to="reporting.ocpusagereportperiod",
+                    ),
+                ),
+            ],
+        ),
+        migrations.SeparateDatabaseAndState(
+            database_operations=[],
+            state_operations=[
+                migrations.AlterField(
+                    model_name="ratestousage",
+                    name="source_uuid",
+                    field=models.ForeignKey(
+                        db_column="source_uuid",
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to="reporting.tenantapiprovider",
+                    ),
+                ),
+            ],
+        ),
+        migrations.AddIndex(
+            model_name="ratestousage",
+            index=models.Index(
+                fields=["usage_start", "source_uuid", "report_period"],
+                name="ratestousage_start_src_rp_idx",
+            ),
+        ),
+        migrations.RunSQL(sql=RTU_FK_CASCADE_SQL, reverse_sql=migrations.RunSQL.noop),
+        migrations.RunSQL(sql=RTU_DROP_DUPLICATE_INDEXES_SQL, reverse_sql=migrations.RunSQL.noop),
+    ]

--- a/koku/reporting/migrations/0353_rtu_schema_improvements.py
+++ b/koku/reporting/migrations/0353_rtu_schema_improvements.py
@@ -1,12 +1,13 @@
-# rates_to_usage schema improvements (GAP-2, GAP-4, GAP-5):
+# rates_to_usage schema improvements (GAP-2, GAP-4, GAP-5) — database DDL only.
+# Django project state was updated in 0352 (state-only). This migration applies:
 # - TRUNCATE existing RTU rows (prerequisite: smart revert #6172, Unleash flag OFF)
 # - Indexes on rate_id and cost_model_id
-# - CASCADE on rate/cost_model FKs (ORM + PostgreSQL)
-# - FK wiring for source_uuid (TenantAPIProvider) and report_period (OCPUsageReportPeriod)
+# - CASCADE on rate/cost_model/source_uuid/report_period FKs (PostgreSQL)
 # - Drop duplicate Django auto-named indexes (keep explicit ratestousage_* from Meta.indexes)
-import django.db.models.deletion
+#
+# Index DDL uses IF NOT EXISTS so Stage (which already applied the original 0352 DDL)
+# can re-run safely.
 from django.db import migrations
-from django.db import models
 
 
 RTU_FK_CASCADE_SQL = """
@@ -163,6 +164,11 @@ BEGIN
 END $$;
 """
 
+RTU_CREATE_FK_INDEXES_SQL = """
+CREATE INDEX IF NOT EXISTS ratestousage_rate_id_idx ON rates_to_usage (rate_id);
+CREATE INDEX IF NOT EXISTS ratestousage_cost_model_id_idx ON rates_to_usage (cost_model_id);
+"""
+
 
 class Migration(migrations.Migration):
 
@@ -176,94 +182,7 @@ class Migration(migrations.Migration):
             reverse_sql=migrations.RunSQL.noop,
         ),
         migrations.RunSQL(sql=RTU_DROP_LEGACY_FK_INDEXES_SQL, reverse_sql=migrations.RunSQL.noop),
-        migrations.AddIndex(
-            model_name="ratestousage",
-            index=models.Index(fields=["rate_id"], name="ratestousage_rate_id_idx"),
-        ),
-        migrations.AddIndex(
-            model_name="ratestousage",
-            index=models.Index(fields=["cost_model_id"], name="ratestousage_cost_model_id_idx"),
-        ),
-        migrations.SeparateDatabaseAndState(
-            database_operations=[],
-            state_operations=[
-                migrations.AlterField(
-                    model_name="ratestousage",
-                    name="rate",
-                    field=models.ForeignKey(
-                        db_index=False,
-                        null=True,
-                        on_delete=django.db.models.deletion.CASCADE,
-                        to="cost_models.rate",
-                    ),
-                ),
-            ],
-        ),
-        migrations.SeparateDatabaseAndState(
-            database_operations=[],
-            state_operations=[
-                migrations.AlterField(
-                    model_name="ratestousage",
-                    name="cost_model",
-                    field=models.ForeignKey(
-                        db_index=False,
-                        null=True,
-                        on_delete=django.db.models.deletion.CASCADE,
-                        to="cost_models.costmodel",
-                    ),
-                ),
-            ],
-        ),
-        migrations.RemoveIndex(
-            model_name="ratestousage",
-            name="ratestousage_start_src_rp_idx",
-        ),
-        migrations.SeparateDatabaseAndState(
-            database_operations=[],
-            state_operations=[
-                migrations.RenameField(
-                    model_name="ratestousage",
-                    old_name="report_period_id",
-                    new_name="report_period",
-                ),
-            ],
-        ),
-        migrations.SeparateDatabaseAndState(
-            database_operations=[],
-            state_operations=[
-                migrations.AlterField(
-                    model_name="ratestousage",
-                    name="report_period",
-                    field=models.ForeignKey(
-                        db_column="report_period_id",
-                        null=True,
-                        on_delete=django.db.models.deletion.CASCADE,
-                        to="reporting.ocpusagereportperiod",
-                    ),
-                ),
-            ],
-        ),
-        migrations.SeparateDatabaseAndState(
-            database_operations=[],
-            state_operations=[
-                migrations.AlterField(
-                    model_name="ratestousage",
-                    name="source_uuid",
-                    field=models.ForeignKey(
-                        db_column="source_uuid",
-                        on_delete=django.db.models.deletion.CASCADE,
-                        to="reporting.tenantapiprovider",
-                    ),
-                ),
-            ],
-        ),
-        migrations.AddIndex(
-            model_name="ratestousage",
-            index=models.Index(
-                fields=["usage_start", "source_uuid", "report_period"],
-                name="ratestousage_start_src_rp_idx",
-            ),
-        ),
+        migrations.RunSQL(sql=RTU_CREATE_FK_INDEXES_SQL, reverse_sql=migrations.RunSQL.noop),
         migrations.RunSQL(sql=RTU_FK_CASCADE_SQL, reverse_sql=migrations.RunSQL.noop),
         migrations.RunSQL(sql=RTU_DROP_DUPLICATE_INDEXES_SQL, reverse_sql=migrations.RunSQL.noop),
     ]

--- a/koku/reporting/provider/ocp/test/test_rtu_migrations.py
+++ b/koku/reporting/provider/ocp/test/test_rtu_migrations.py
@@ -2,7 +2,7 @@
 # Copyright 2026 Red Hat Inc.
 # SPDX-License-Identifier: Apache-2.0
 #
-"""Tests for rates_to_usage schema migration 0352."""
+"""Tests for rates_to_usage schema migrations 0352 (state) and 0353 (DDL)."""
 from datetime import date
 from decimal import Decimal
 
@@ -24,7 +24,8 @@ from reporting.models import TenantAPIProvider
 from reporting.provider.ocp.models import RatesToUsage
 
 MIGRATE_FROM = ("reporting", "0351_create_ocp_cost_breakdown_p")
-MIGRATE_TO = ("reporting", "0352_rtu_schema_improvements")
+MIGRATE_STATE = ("reporting", "0352_rtu_schema_improvements")
+MIGRATE_TO = ("reporting", "0353_rtu_schema_improvements")
 
 
 class _RatesToUsageMigrationMixin:
@@ -189,10 +190,10 @@ class RatesToUsageTruncateMigrationTest(_RatesToUsageMigrationMixin, Transaction
     def _fixture_teardown(self):
         """Skip global TRUNCATE flush; django-tenants FK graph breaks TransactionTestCase flush."""
 
-    def test_0352_truncates_rates_to_usage(self):
-        """Migration 0352 removes all existing RTU rows."""
+    def test_0353_truncates_rates_to_usage(self):
+        """Migration 0353 removes all existing RTU rows."""
         with tenant_context(self.tenant):
-            self._run_migration(MIGRATE_FROM)
+            self._run_migration(MIGRATE_STATE)
             cost_model, rate = self._create_cost_model_rate()
             self._create_rtu_row(rate=rate, cost_model=cost_model)
             self.assertEqual(RatesToUsage.objects.count(), 1)
@@ -205,11 +206,11 @@ class RatesToUsageTruncateMigrationTest(_RatesToUsageMigrationMixin, Transaction
 class RatesToUsageMigrationTest(_RatesToUsageMigrationMixin, MasuTestCase):
     """Test RTU index and CASCADE FK migrations."""
 
-    def test_0352_adds_fk_indexes(self):
-        """Migration 0352 creates indexes on rate_id and cost_model_id."""
+    def test_0353_adds_fk_indexes(self):
+        """Migration 0353 creates indexes on rate_id and cost_model_id."""
         with tenant_context(self.tenant):
-            # Roll back and re-apply so AddIndex runs even when django_migrations
-            # already records 0352 (e.g. CI tenant setup vs MigrationExecutor state).
+            # Roll back and re-apply so DDL runs even when django_migrations
+            # already records 0353 (e.g. CI tenant setup vs MigrationExecutor state).
             self._run_migration(MIGRATE_FROM)
             self._run_migration(MIGRATE_TO)
             self.assertEqual(
@@ -217,8 +218,8 @@ class RatesToUsageMigrationTest(_RatesToUsageMigrationMixin, MasuTestCase):
                 {"ratestousage_rate_id_idx", "ratestousage_cost_model_id_idx"},
             )
 
-    def test_0352_drops_duplicate_auto_named_indexes(self):
-        """Migration 0352 keeps ratestousage_* indexes and removes Django auto-named duplicates."""
+    def test_0353_drops_duplicate_auto_named_indexes(self):
+        """Migration 0353 keeps ratestousage_* indexes and removes Django auto-named duplicates."""
         with tenant_context(self.tenant):
             self._run_migration(MIGRATE_FROM)
             self._run_migration(MIGRATE_TO)

--- a/koku/reporting/provider/ocp/test/test_rtu_migrations.py
+++ b/koku/reporting/provider/ocp/test/test_rtu_migrations.py
@@ -198,7 +198,7 @@ class RatesToUsageTruncateMigrationTest(_RatesToUsageMigrationMixin, Transaction
     def test_0353_truncates_rates_to_usage(self):
         """Migration 0353 removes all existing RTU rows."""
         with tenant_context(self.tenant):
-            self._run_migration(MIGRATE_STATE)
+            self._run_migration(MIGRATE_FROM)
             cost_model, rate = self._create_cost_model_rate()
             self._create_rtu_row(rate=rate, cost_model=cost_model)
             self.assertEqual(RatesToUsage.objects.count(), 1)


### PR DESCRIPTION
## Jira Ticket

[COST-####](https://issues.redhat.com/browse/COST-####)

## Description

This change will ...

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Release Notes
- [ ] proposed release note

```markdown
* [COST-####](https://issues.redhat.com/browse/COST-####) Fix some things
```

## Summary by Sourcery

Reapply and adjust the rates-to-usage (RTU) schema migration to align the model and database with the intended foreign key and indexing behavior.

Bug Fixes:
- Ensure RTU foreign keys to rates, cost models, report periods, and sources are consistently configured with ON DELETE CASCADE.
- Remove duplicate and legacy RTU indexes so only the intended explicit indexes remain active.

Enhancements:
- Truncate existing RTU data as a prerequisite for safely reapplying the RTU schema changes.
- Add explicit indexes on RTU rate and cost model foreign keys and on the pipeline composite key to improve query performance.
- Align the RTU Django model fields with the underlying database columns, including renaming and remapping the report period foreign key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Database Improvements**
  * Improved the rates-to-usage table by enforcing cascading deletes on key foreign keys.
  * Cleaned up redundant/legacy auto-generated indexes and added explicit, consistent FK-related indexes for the table.
  * Updated the migration flow to truncate and apply DDL steps in a deterministic order for reliable results.
* **Tests**
  * Updated migration tests to run against migration 0353, including the truncate path and updated FK/index expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->