### PR TITLE
use versioned rhel base-image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9-minimal:latest AS base
+FROM registry.access.redhat.com/ubi9-minimal:9.8-1785214301 AS base
 
 USER root
 

--- a/renovate.json
+++ b/renovate.json
@@ -50,7 +50,7 @@
                 "dockerfile"
             ],
             "addLabels": [
-                "base-image"
+                "smoke-tests"
             ]
         }
     ],

--- a/renovate.json
+++ b/renovate.json
@@ -44,6 +44,14 @@
                 "pin"
             ],
             "enabled": false
+        },
+        {
+            "matchManagers": [
+                "dockerfile"
+            ],
+            "addLabels": [
+                "base-image"
+            ]
         }
     ],
     "schedule": [


### PR DESCRIPTION
## Description

This change will 
* update dockerfile to use versioned base rhel image vs latest tag.
* configure renovate to auto update rhel base-image versions.

## Testing

1. Successful konflux builds


## Release Notes
- [ ] proposed release note

```markdown
* Use versioned rhel base-image
```

## Summary by Sourcery

Build:
- Update Dockerfile to use a specific ubi9-minimal:9.8-1785214301 base image tag instead of latest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned the container’s base image to a specific UBI9 Minimal version for more consistent builds.
  * Improved automated tracking of base image updates with clearer update labeling (smoke-tests).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->