### PR TITLE
fix(dashboard): update RDS datasource default and regex

### DIFF
--- a/dashboards/grafana-dashboard-insights-hccm.configmap.yaml
+++ b/dashboards/grafana-dashboard-insights-hccm.configmap.yaml
@@ -6744,8 +6744,8 @@ data:
           {
             "current": {
               "selected": false,
-              "text": "app-sre-prod-01-prometheus",
-              "value": "app-sre-prod-01-prometheus"
+              "text": "appsrep11ue1-prometheus",
+              "value": "appsrep11ue1-prometheus"
             },
             "hide": 0,
             "includeAll": false,
@@ -6756,7 +6756,7 @@ data:
             "query": "prometheus",
             "queryValue": "",
             "refresh": 1,
-            "regex": "/.*app-sre.*01.*/",
+            "regex": "/.*appsrep\\d+ue1.*/",
             "skipUrlSync": false,
             "type": "datasource"
           }


### PR DESCRIPTION
## Summary

- Fix Grafana Cost Management dashboard RDS panels showing no data
- The RDS Prometheus datasource was renamed from `app-sre-prod-01-prometheus` to `appsrep11ue1-prometheus` during the SRE appsrep07 migration (Feb 2025, app-interface commit `17709c5a242`)
- The dashboard's `rds_datasource` variable still had the old default and a regex filter that didn't match the new name

## Changes

- Update default value: `app-sre-prod-01-prometheus` → `appsrep11ue1-prometheus`
- Update regex filter: `/.*app-sre.*01.*/` → `/.*appsrep\d+ue1.*/`

## Test plan

- [ ] Open [Cost Management dashboard](https://grafana.app-sre.devshift.net/d/R0HueuFGk/cost-management?orgId=1) without any URL variable overrides
- [ ] Verify RDS Datasource dropdown defaults to `appsrep11ue1-prometheus`
- [ ] Verify RDS panels (Database section) show data

## Summary by Sourcery

Update Grafana Cost Management dashboard RDS datasource configuration to align with the renamed Prometheus datasource and restore RDS metrics visibility.

Bug Fixes:
- Correct RDS datasource default value to point to the current Prometheus datasource instance.
- Adjust RDS datasource selection regex so it matches the new Prometheus datasource naming pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Grafana dashboard’s default Prometheus data source selection.
  * Improved data source matching to support the current application monitoring environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->