### PR TITLE
Unleash flag disable cost model updates

### DIFF
--- a/koku/masu/processor/__init__.py
+++ b/koku/masu/processor/__init__.py
@@ -66,6 +66,16 @@ def is_summary_processing_disabled(schema):  # pragma: no cover
     return res
 
 
+def is_cost_model_processing_disabled(schema):  # pragma: no cover
+    """Disable cost model processing."""
+    context = {"schema": schema}
+    res = UNLEASH_CLIENT.is_enabled("cost-management.backend.disable-cost-model-processing", context)
+    if res:
+        LOG.info(log_json(msg="cost model processing disabled", context=context))
+
+    return res
+
+
 def is_ocp_on_cloud_summary_disabled(schema):  # pragma: no cover
     """Disable OCP on Cloud summary."""
     context = {"schema": schema}

--- a/koku/masu/processor/report_summary_updater.py
+++ b/koku/masu/processor/report_summary_updater.py
@@ -212,12 +212,12 @@ class ReportSummaryUpdater:
 
         LOG.info(log_json(tracing_id, msg="summary processing complete", context=context))
 
-        try:
-            enable_cloud_bill_currencies(self._schema, self._provider, start_date=start_date, end_date=end_date)
-        except Exception as err:
-            LOG.warning(
-                log_json(tracing_id, msg="failed to enable cloud bill currencies", context=context, error=str(err))
-            )
+        # try:
+        #     enable_cloud_bill_currencies(self._schema, self._provider, start_date=start_date, end_date=end_date)
+        # except Exception as err:
+        #     LOG.warning(
+        #         log_json(tracing_id, msg="failed to enable cloud bill currencies", context=context, error=str(err))
+        #     )
 
         invalidate_view_cache_for_tenant_and_source_type(self._schema, self._provider.type)
 

--- a/koku/masu/processor/report_summary_updater.py
+++ b/koku/masu/processor/report_summary_updater.py
@@ -212,6 +212,7 @@ class ReportSummaryUpdater:
 
         LOG.info(log_json(tracing_id, msg="summary processing complete", context=context))
 
+        # Commented out to get a hot fix to production
         # try:
         #     enable_cloud_bill_currencies(self._schema, self._provider, start_date=start_date, end_date=end_date)
         # except Exception as err:

--- a/koku/masu/processor/tasks.py
+++ b/koku/masu/processor/tasks.py
@@ -933,6 +933,18 @@ def update_cost_model_costs(  # noqa: C901
 
     """
     if is_cost_model_processing_disabled(schema_name) or is_source_disabled(provider_uuid):
+        LOG.info(
+            log_json(
+                tracing_id,
+                msg="skipping cost model update - processing disabled",
+                context={
+                    "schema": schema_name,
+                    "provider_uuid": provider_uuid,
+                    "start_date": start_date,
+                    "end_date": end_date,
+                },
+            )
+        )
         return
     task_name = "masu.processor.tasks.update_cost_model_costs"
     cache_args = [schema_name, provider_uuid, start_date, end_date]

--- a/koku/masu/processor/tasks.py
+++ b/koku/masu/processor/tasks.py
@@ -932,7 +932,7 @@ def update_cost_model_costs(  # noqa: C901
         None
 
     """
-    if is_cost_model_processing_disabled(schema_name) or is_source_disabled(provider_uuid):
+    if is_cost_model_processing_disabled(schema_name):
         LOG.info(
             log_json(
                 tracing_id,

--- a/koku/masu/processor/tasks.py
+++ b/koku/masu/processor/tasks.py
@@ -40,6 +40,7 @@ from masu.exceptions import MasuProcessingError
 from masu.exceptions import MasuProviderError
 from masu.external.downloader.report_downloader_base import ReportDownloaderWarning
 from masu.external.report_downloader import ReportDownloaderError
+from masu.processor import is_cost_model_processing_disabled
 from masu.processor import is_ocp_on_cloud_summary_disabled
 from masu.processor import is_rate_limit_customer_large
 from masu.processor import is_source_disabled
@@ -931,6 +932,8 @@ def update_cost_model_costs(  # noqa: C901
         None
 
     """
+    if is_cost_model_processing_disabled(schema_name) or is_source_disabled(provider_uuid):
+        return
     task_name = "masu.processor.tasks.update_cost_model_costs"
     cache_args = [schema_name, provider_uuid, start_date, end_date]
     if not synchronous:

--- a/koku/masu/test/processor/test_report_summary_updater.py
+++ b/koku/masu/test/processor/test_report_summary_updater.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 """Test the ReportSummaryUpdater object."""
+import unittest
 from unittest.mock import patch
 from uuid import uuid4
 
@@ -117,6 +118,7 @@ class ReportSummaryUpdaterTest(MasuTestCase):
                 )
         return provider
 
+    @unittest.skip("Hotfix: enable_cloud_bill_currencies call in update_summary_tables is temporarily disabled")
     @patch("masu.processor.report_summary_updater.populate_dynamic_monthly_rates")
     def test_enable_cloud_bill_currencies_enables_missing(self, mock_populate):
         """Cloud bill currencies missing from EnabledCurrency are enabled."""
@@ -132,6 +134,7 @@ class ReportSummaryUpdaterTest(MasuTestCase):
             self.assertTrue(EnabledCurrency.objects.filter(currency_code="AUD").exists())
         mock_populate.assert_called_once_with(code="AUD")
 
+    @unittest.skip("Hotfix: enable_cloud_bill_currencies call in update_summary_tables is temporarily disabled")
     @patch("masu.processor.report_summary_updater.populate_dynamic_monthly_rates")
     def test_enable_cloud_bill_currencies_skips_invalid_iso(self, mock_populate):
         """Invalid ISO currency codes are skipped without enabling."""
@@ -147,6 +150,7 @@ class ReportSummaryUpdaterTest(MasuTestCase):
         with tenant_context(self.tenant):
             self.assertFalse(EnabledCurrency.objects.filter(currency_code="FOO").exists())
 
+    @unittest.skip("Hotfix: enable_cloud_bill_currencies call in update_summary_tables is temporarily disabled")
     @patch("masu.processor.report_summary_updater.populate_dynamic_monthly_rates")
     def test_enable_cloud_bill_currencies_skips_already_enabled(self, mock_populate):
         """Currencies already in EnabledCurrency do not trigger rate population."""
@@ -161,6 +165,7 @@ class ReportSummaryUpdaterTest(MasuTestCase):
 
         mock_populate.assert_not_called()
 
+    @unittest.skip("Hotfix: enable_cloud_bill_currencies call in update_summary_tables is temporarily disabled")
     @patch("masu.processor.report_summary_updater.populate_dynamic_monthly_rates")
     @patch("masu.processor.report_summary_updater.EnabledCurrency.objects")
     def test_enable_cloud_bill_currencies_noop_for_non_cloud(self, mock_enabled_currency, mock_populate):
@@ -171,6 +176,7 @@ class ReportSummaryUpdaterTest(MasuTestCase):
         mock_enabled_currency.get_or_create.assert_not_called()
         mock_populate.assert_not_called()
 
+    @unittest.skip("Hotfix: enable_cloud_bill_currencies call in update_summary_tables is temporarily disabled")
     @patch("masu.processor.report_summary_updater.invalidate_view_cache_for_tenant_and_source_type")
     @patch(
         "masu.processor.report_summary_updater.enable_cloud_bill_currencies",

--- a/koku/masu/test/processor/test_tasks.py
+++ b/koku/masu/test/processor/test_tasks.py
@@ -1729,6 +1729,27 @@ class TestWorkerCacheThrottling(MasuTestCase):
             update_cost_model_costs(self.schema, self.aws_provider_uuid, expected_start_date, expected_end_date)
             self.assertFalse(self.single_task_is_running(task_name, cache_args))
 
+    @patch(
+        "masu.processor.tasks.is_cost_model_processing_disabled",
+        return_value=True,
+    )
+    @patch("masu.processor.tasks.CostModelCostUpdater")
+    @patch("masu.processor.tasks.update_cost_model_costs.s")
+    @patch("masu.processor.tasks.WorkerCache.lock_single_task")
+    @patch("masu.processor.worker_cache.CELERY_INSPECT")
+    def test_update_cost_model_costs_unleash_disabled(
+        self, mock_inspect, mock_lock, mock_delay, mock_updater, mock_unleash
+    ):
+        """Test that cost model processing is skipped when the Unleash flag is enabled."""
+        start_date = self.dh.last_month_start.strftime("%Y-%m-%d")
+        end_date = self.dh.today.strftime("%Y-%m-%d")
+
+        update_cost_model_costs(self.schema, self.aws_provider_uuid, start_date, end_date)
+
+        mock_updater.assert_not_called()
+        mock_delay.assert_not_called()
+        mock_lock.assert_not_called()
+
     @patch("masu.processor.tasks.ReportSummaryUpdater.update_openshift_on_cloud_summary_tables")
     @patch("masu.processor.tasks.update_openshift_on_cloud.s")
     @patch("masu.processor.tasks.WorkerCache.release_single_task")


### PR DESCRIPTION
## Jira Ticket

[COST-####](https://issues.redhat.com/browse/COST-####)

## Description

This change will ...

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Release Notes
- [ ] proposed release note

```markdown
* [COST-####](https://issues.redhat.com/browse/COST-####) Fix some things
```

## Summary by Sourcery

Gate cost model cost update processing behind an Unleash feature flag and skip processing when disabled.

New Features:
- Introduce an Unleash-driven toggle to disable cost model processing per schema.

Enhancements:
- Short-circuit cost model cost update tasks when processing or the source is disabled, with structured logging for skipped runs.

Tests:
- Add a unit test verifying that cost model updates are not scheduled when the Unleash cost model processing flag is disabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a feature flag to disable cost model processing for a schema when needed.
  * When disabled, cost model updates are short-circuited early and emit an informational log with context.

* **Bug Fixes**
  * Avoided unnecessary cost model update work, including skipping lock/rate-limiting steps.

* **Bug Fixes**
  * Temporarily disabled the cloud bill currency enablement step during report summary updates.

* **Tests**
  * Added coverage verifying no updater calls, task queuing, or lock acquisition when the feature flag is disabled.
  * Skipped affected currency/summary updater tests due to the temporary change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->