### PR TITLE
[COST-7962] fix 500 error on GET/HEAD

### DIFF
--- a/koku/koku/middleware.py
+++ b/koku/koku/middleware.py
@@ -367,6 +367,7 @@ class IdentityHeaderMiddleware(MiddlewareMixin):
                 LOG.debug(f"User added to cache: {user_key}")
             else:
                 user = USER_CACHE[user_key]
+                user.customer = customer
 
             user.identity_header = {"encoded": rh_auth_header, "decoded": json_rh_auth}
             user.admin = is_admin

--- a/koku/koku/test_middleware.py
+++ b/koku/koku/test_middleware.py
@@ -245,6 +245,48 @@ class IdentityHeaderMiddlewareTest(IamTestCase):
         dup_cust = IdentityHeaderMiddleware.create_customer(account_id, org_id, "POST")
         self.assertEqual(orig_cust, dup_cust)
 
+    @patch("koku.middleware.IdentityHeaderMiddleware.customer_cache", TTLCache(5, 0.1))
+    @patch("koku.middleware.USER_CACHE", TTLCache(5, 0.1))
+    @patch("koku.rbac.RbacService.get_access_for_user", return_value={})
+    def test_user_cache_hit_syncs_customer_after_get_then_write(self, _get_access_mock):
+        """USER_CACHE hit must sync customer after GET leaves an unsaved instance cached."""
+        org_id = "7962001"
+        account_id = "7962001"
+        customer_data = self._create_customer_data(account=account_id, org_id=org_id)
+        user_data = self._create_user_data()
+        request_context = self._create_request_context(
+            customer_data, user_data, create_customer=False, create_user=False
+        )
+        mock_request = request_context["request"]
+        mock_request.path = "/api/v1/tags/aws/"
+        mock_request.META["QUERY_STRING"] = ""
+        middleware = IdentityHeaderMiddleware(self.mock_get_response)
+
+        mock_request.method = "GET"
+        middleware.process_request(mock_request)
+        self.assertIsNone(mock_request.user.customer.pk)
+        self.assertFalse(Customer.objects.filter(org_id=org_id).exists())
+
+        mock_request.method = "DELETE"
+        middleware.process_request(mock_request)
+        persisted = Customer.objects.get(org_id=org_id)
+        self.assertIsNotNone(mock_request.user.customer.pk)
+        self.assertEqual(mock_request.user.customer.pk, persisted.pk)
+
+        user_key = f"{org_id}_{user_data['username']}"
+        self.assertEqual(MD.USER_CACHE[user_key].customer.pk, persisted.pk)
+
+    def test_create_customer_get_does_not_persist(self):
+        """GET/HEAD must not persist a Customer for a brand-new org (COST-5198)."""
+        org_id = "7962002"
+        account_id = "7962002"
+        for method in ("GET", "HEAD"):
+            with self.subTest(method=method):
+                Customer.objects.filter(org_id=org_id).delete()
+                customer = IdentityHeaderMiddleware.create_customer(account_id, org_id, method)
+                self.assertIsNone(customer.pk)
+                self.assertFalse(Customer.objects.filter(org_id=org_id).exists())
+
     @override_settings(CACHES={CacheEnum.rbac: {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}})
     @patch("koku.rbac.RbacService.get_access_for_user")
     def test_process_non_admin(self, get_access_mock):


### PR DESCRIPTION
## Jira Ticket

[COST-7962](https://issues.redhat.com/browse/COST-7962)

## Description

This change fixes a 500 on `DELETE /api/cost-management/v1/settings/currency/enabled/<code>/` for brand-new orgs whose first Cost Management request was GET or HEAD.

`IdentityHeaderMiddleware` intentionally does not persist a `Customer` on GET/HEAD (COST-5198 read-replica design). That unsaved customer was attached to a `User` and stored in `USER_CACHE`. On a later write, middleware created and saved a real `Customer`, but a cache hit kept the stale unsaved instance on `request.user.customer`. Currency disable then filtered `Provider` by that customer and Django raised `ValueError: Model instances passed to related filters must be saved.`

On `USER_CACHE` hit, the middleware now syncs `user.customer` to the customer resolved for the current request. GET/HEAD still do not call `customer.save()`.

## Testing

1. Checkout Branch
2. Ensure PostgreSQL test DB is available (`localhost:15432`)
3. Run middleware tests (includes GET→DELETE cache sync and GET/HEAD no-persist regression):

```bash
pipenv run tox -- -- koku.test_middleware
```

4. Run currency settings regression suite:

```bash
pipenv run tox -- -- api.settings.test.test_currency_views
```

5. Optional manual check (fresh org / cleared middleware caches):
    1. Issue a GET for a brand-new `org_id` (no `Customer` row) — confirm no customer is persisted
    2. Issue `DELETE /api/cost-management/v1/settings/currency/enabled/<code>/` for that identity
    3. You should see `400` (e.g. system default USD) or `204` when disable is allowed — not `500`

## Release Notes
- [ ] proposed release note

```markdown
* [COST-7962](https://issues.redhat.com/browse/COST-7962) Fix 500 when disabling a currency for newly entitled organizations
```

## Summary by Sourcery

Resolve middleware customer caching inconsistencies that caused 500 errors when performing write operations after initial GET/HEAD requests for new organizations.

Bug Fixes:
- Ensure user.customer is synchronized with the resolved Customer on USER_CACHE hits so subsequent write operations use a saved customer instance.
- Preserve the design where GET/HEAD requests for new organizations do not persist a Customer while avoiding stale unsaved instances in caches.

Tests:
- Add middleware tests covering GET followed by DELETE to verify user cache customer synchronization and absence of 500 errors.
- Add tests ensuring create_customer does not persist a Customer for brand-new organizations on GET/HEAD requests.