### PR TITLE
[COST-8005] Add RequestTimeoutMiddleware to replace gunicorn SIGABRT noise

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -15,6 +15,7 @@ omit =
   *feature_flags.py
   *probe_server.py
   *settings.py
+  *sentry.py
   *urls.py
   *wsgi.py
   */migrations/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -15,7 +15,6 @@ omit =
   *feature_flags.py
   *probe_server.py
   *settings.py
-  *sentry.py
   *urls.py
   *wsgi.py
   */migrations/*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,9 @@ docs/specs/openapi.json     # OpenAPI spec (main API)
 Jira/GitHub issue when known (e.g. `COST-1234: Add MIG slice support`).
 
 1. Open PRs as **DRAFT**.  Mark **Ready for Review** when done.
-2. Add the `smoke-test` label to kick off IQE smoke tests.
+2. Add the `smoke-tests` label to kick off IQE smoke tests.
+   Also add `smokes-required` (Konflux CI gate).
+   For non-code PRs (docs, dashboards), use `ok-to-skip-smokes` instead.
 3. Smoke tests **must pass** before merging (unless the PR only touches
    non-build files like docs).
 4. Merges to `main` **auto-deploy to stage**.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,9 +34,9 @@ docs/specs/openapi.json     # OpenAPI spec (main API)
 Jira/GitHub issue when known (e.g. `COST-1234: Add MIG slice support`).
 
 1. Open PRs as **DRAFT**.  Mark **Ready for Review** when done.
-2. Add the `smoke-tests` label to kick off IQE smoke tests.
-   Also add `smokes-required` (Konflux CI gate).
-   For non-code PRs (docs, dashboards), use `ok-to-skip-smokes` instead.
+2. Add `smokes-required` + `hot-fix-smoke-tests` labels (Konflux CI gate +
+   IQE smoke tests).  For non-code PRs (docs, dashboards), use
+   `ok-to-skip-smokes` instead.
 3. Smoke tests **must pass** before merging (unless the PR only touches
    non-build files like docs).
 4. Merges to `main` **auto-deploy to stage**.

--- a/koku/gunicorn_conf.py
+++ b/koku/gunicorn_conf.py
@@ -44,7 +44,7 @@ workers = ENVIRONMENT.int("GUNICORN_WORKERS", default=(cpu_resources * 2 + 1))
 gunicorn_threads = ENVIRONMENT.bool("GUNICORN_THREADS", default=False)
 if gunicorn_threads:
     threads = cpu_resources * 2 + 1
-timeout = ENVIRONMENT.int("TIMEOUT", default=90)
+timeout = ENVIRONMENT.int("TIMEOUT", default=92)
 graceful_timeout = ENVIRONMENT.int("GRACEFUL_TIMEOUT", default=180)
 
 

--- a/koku/gunicorn_conf.py
+++ b/koku/gunicorn_conf.py
@@ -44,7 +44,7 @@ workers = ENVIRONMENT.int("GUNICORN_WORKERS", default=(cpu_resources * 2 + 1))
 gunicorn_threads = ENVIRONMENT.bool("GUNICORN_THREADS", default=False)
 if gunicorn_threads:
     threads = cpu_resources * 2 + 1
-timeout = ENVIRONMENT.int("TIMEOUT", default=92)
+timeout = ENVIRONMENT.int("TIMEOUT", default=100)
 graceful_timeout = ENVIRONMENT.int("GRACEFUL_TIMEOUT", default=180)
 
 

--- a/koku/koku/middleware.py
+++ b/koku/koku/middleware.py
@@ -463,16 +463,31 @@ class RequestTimeoutError(Exception):
     """Raised when a request exceeds the soft timeout."""
 
 
+def _parse_soft_timeout(default=90):
+    raw = os.environ.get("REQUEST_SOFT_TIMEOUT")
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return default
+
+
 class RequestTimeoutMiddleware(MiddlewareMixin):
     """Abort requests that exceed a soft timeout, before gunicorn kills the worker.
 
     Uses SIGALRM to raise RequestTimeoutError with full request context,
     replacing the uninformative SystemExit:1 that gunicorn's SIGABRT produces.
+    Only active in the main thread (sync workers); with threaded workers,
+    gunicorn's hard timeout remains the fallback.
     """
 
-    SOFT_TIMEOUT = int(os.environ.get("REQUEST_SOFT_TIMEOUT", 90))
+    SOFT_TIMEOUT = _parse_soft_timeout()
 
     def process_request(self, request):
+        if threading.current_thread() is not threading.main_thread():
+            return
+
         def handler(signum, frame):
             duration = time.time() - getattr(request, "start_time", time.time())
             raise RequestTimeoutError(
@@ -483,7 +498,8 @@ class RequestTimeoutMiddleware(MiddlewareMixin):
         signal.alarm(self.SOFT_TIMEOUT)
 
     def process_response(self, request, response):
-        signal.alarm(0)
+        if threading.current_thread() is threading.main_thread():
+            signal.alarm(0)
         return response
 
 

--- a/koku/koku/middleware.py
+++ b/koku/koku/middleware.py
@@ -463,6 +463,13 @@ class RequestTimeoutError(Exception):
     """Raised when a request exceeds the soft timeout."""
 
 
+def sentry_before_send(event, hint):
+    exc_info = hint.get("exc_info")
+    if exc_info and exc_info[0] is RequestTimeoutError:
+        event.setdefault("tags", {})["timeout"] = "soft"
+    return event
+
+
 def _parse_soft_timeout(default=90):
     raw = os.environ.get("REQUEST_SOFT_TIMEOUT")
     if raw is None:

--- a/koku/koku/middleware.py
+++ b/koku/koku/middleware.py
@@ -5,6 +5,8 @@
 """Custom Koku Middleware."""
 import binascii
 import logging
+import os
+import signal
 import threading
 import time
 from http import HTTPStatus
@@ -454,6 +456,34 @@ class RequestTimingMiddleware(MiddlewareMixin):
             time_taken_ms = int((time.time() - request.start_time) * 1000)
             stmt.update({"response_time": time_taken_ms})
             LOG.info(stmt)
+        return response
+
+
+class RequestTimeoutError(Exception):
+    """Raised when a request exceeds the soft timeout."""
+
+
+class RequestTimeoutMiddleware(MiddlewareMixin):
+    """Abort requests that exceed a soft timeout, before gunicorn kills the worker.
+
+    Uses SIGALRM to raise RequestTimeoutError with full request context,
+    replacing the uninformative SystemExit:1 that gunicorn's SIGABRT produces.
+    """
+
+    SOFT_TIMEOUT = int(os.environ.get("REQUEST_SOFT_TIMEOUT", 90))
+
+    def process_request(self, request):
+        def handler(signum, frame):
+            duration = time.time() - getattr(request, "start_time", time.time())
+            raise RequestTimeoutError(
+                f"Request exceeded {self.SOFT_TIMEOUT}s: {request.method} {request.path} ({duration:.1f}s elapsed)"
+            )
+
+        signal.signal(signal.SIGALRM, handler)
+        signal.alarm(self.SOFT_TIMEOUT)
+
+    def process_response(self, request, response):
+        signal.alarm(0)
         return response
 
 

--- a/koku/koku/sentry.py
+++ b/koku/koku/sentry.py
@@ -19,11 +19,21 @@ def traces_sampler(sampling_context):
     return 0.05
 
 
+def before_send(event, hint):
+    from koku.middleware import RequestTimeoutError
+
+    exc_info = hint.get("exc_info")
+    if exc_info and exc_info[0] is RequestTimeoutError:
+        event.setdefault("tags", {})["timeout"] = "soft"
+    return event
+
+
 if ENVIRONMENT.bool("KOKU_ENABLE_SENTRY", default=False):
     sentry_sdk.init(
         dsn=ENVIRONMENT("KOKU_SENTRY_DSN"),
         environment=ENVIRONMENT("KOKU_SENTRY_ENVIRONMENT"),
         traces_sampler=traces_sampler,
+        before_send=before_send,
     )
     print("Sentry setup.")
 else:

--- a/koku/koku/sentry.py
+++ b/koku/koku/sentry.py
@@ -2,7 +2,6 @@
 import sentry_sdk
 
 from .env import ENVIRONMENT
-from .middleware import sentry_before_send
 
 BLOCK_LIST = {
     "/api/cost-management/v1/status/",
@@ -20,12 +19,18 @@ def traces_sampler(sampling_context):
     return 0.05
 
 
+def before_send(event, hint):
+    from koku.middleware import sentry_before_send
+
+    return sentry_before_send(event, hint)
+
+
 if ENVIRONMENT.bool("KOKU_ENABLE_SENTRY", default=False):
     sentry_sdk.init(
         dsn=ENVIRONMENT("KOKU_SENTRY_DSN"),
         environment=ENVIRONMENT("KOKU_SENTRY_ENVIRONMENT"),
         traces_sampler=traces_sampler,
-        before_send=sentry_before_send,
+        before_send=before_send,
     )
     print("Sentry setup.")
 else:

--- a/koku/koku/sentry.py
+++ b/koku/koku/sentry.py
@@ -2,6 +2,7 @@
 import sentry_sdk
 
 from .env import ENVIRONMENT
+from .middleware import sentry_before_send
 
 BLOCK_LIST = {
     "/api/cost-management/v1/status/",
@@ -19,21 +20,12 @@ def traces_sampler(sampling_context):
     return 0.05
 
 
-def before_send(event, hint):
-    from koku.middleware import RequestTimeoutError
-
-    exc_info = hint.get("exc_info")
-    if exc_info and exc_info[0] is RequestTimeoutError:
-        event.setdefault("tags", {})["timeout"] = "soft"
-    return event
-
-
 if ENVIRONMENT.bool("KOKU_ENABLE_SENTRY", default=False):
     sentry_sdk.init(
         dsn=ENVIRONMENT("KOKU_SENTRY_DSN"),
         environment=ENVIRONMENT("KOKU_SENTRY_ENVIRONMENT"),
         traces_sampler=traces_sampler,
-        before_send=before_send,
+        before_send=sentry_before_send,
     )
     print("Sentry setup.")
 else:

--- a/koku/koku/settings.py
+++ b/koku/koku/settings.py
@@ -121,6 +121,7 @@ PROMETHEUS_AFTER_MIDDLEWARE = "django_prometheus.middleware.PrometheusAfterMiddl
 MIDDLEWARE = [
     PROMETHEUS_BEFORE_MIDDLEWARE,
     "koku.middleware.RequestTimingMiddleware",
+    "koku.middleware.RequestTimeoutMiddleware",
     "corsheaders.middleware.CorsMiddleware",
     "koku.middleware.DisableCSRF",
     "django.middleware.security.SecurityMiddleware",

--- a/koku/koku/test_middleware.py
+++ b/koku/koku/test_middleware.py
@@ -658,25 +658,25 @@ class SentryBeforeSendTest(IamTestCase):
     """Tests for the sentry before_send hook."""
 
     def test_before_send_tags_timeout_events(self):
-        from koku.sentry import before_send
+        from koku.middleware import sentry_before_send
 
         event = {}
         hint = {"exc_info": (RequestTimeoutError, RequestTimeoutError("test"), None)}
-        result = before_send(event, hint)
+        result = sentry_before_send(event, hint)
         self.assertEqual(result["tags"]["timeout"], "soft")
 
     def test_before_send_passes_through_other_events(self):
-        from koku.sentry import before_send
+        from koku.middleware import sentry_before_send
 
         event = {"tags": {"existing": "value"}}
         hint = {"exc_info": (ValueError, ValueError("test"), None)}
-        result = before_send(event, hint)
+        result = sentry_before_send(event, hint)
         self.assertEqual(result["tags"], {"existing": "value"})
 
     def test_before_send_handles_no_exc_info(self):
-        from koku.sentry import before_send
+        from koku.middleware import sentry_before_send
 
         event = {"message": "test"}
         hint = {}
-        result = before_send(event, hint)
+        result = sentry_before_send(event, hint)
         self.assertEqual(result, event)

--- a/koku/koku/test_middleware.py
+++ b/koku/koku/test_middleware.py
@@ -36,6 +36,8 @@ from koku.middleware import HttpResponseUnauthorizedRequest
 from koku.middleware import IdentityHeaderMiddleware
 from koku.middleware import KokuTenantMiddleware
 from koku.middleware import KokuTenantSchemaExistsMiddleware
+from koku.middleware import RequestTimeoutError
+from koku.middleware import RequestTimeoutMiddleware
 from koku.middleware import RequestTimingMiddleware
 from koku.test_rbac import mocked_requests_get_500_text
 
@@ -583,3 +585,68 @@ class RequestTimingMiddlewareTest(IamTestCase):
                 if "response_time" in msg:
                     logged = True
             self.assertTrue(logged)
+
+
+class RequestTimeoutMiddlewareTest(IamTestCase):
+    """Tests for the request timeout middleware."""
+
+    def setUp(self):
+        super().setUp()
+        self.middleware = RequestTimeoutMiddleware(Mock())
+
+    @patch("koku.middleware.signal.alarm")
+    @patch("koku.middleware.signal.signal")
+    def test_process_request_sets_alarm(self, mock_signal, mock_alarm):
+        request = Mock(method="GET", path="/api/v1/reports/aws/costs/")
+        self.middleware.process_request(request)
+        mock_signal.assert_called_once()
+        mock_alarm.assert_called_once_with(RequestTimeoutMiddleware.SOFT_TIMEOUT)
+
+    @patch("koku.middleware.signal.alarm")
+    def test_process_response_cancels_alarm(self, mock_alarm):
+        request = Mock()
+        response = Mock(status_code=200)
+        result = self.middleware.process_response(request, response)
+        mock_alarm.assert_called_once_with(0)
+        self.assertEqual(result, response)
+
+    def test_timeout_raises_request_timeout_error(self):
+        request = Mock(method="GET", path="/api/v1/reports/openshift/costs/", start_time=time.time() - 85)
+        with patch("koku.middleware.signal.signal") as mock_signal:
+            self.middleware.process_request(request)
+            handler = mock_signal.call_args[0][1]
+        with self.assertRaises(RequestTimeoutError) as ctx:
+            handler(None, None)
+        self.assertIn("GET", str(ctx.exception))
+        self.assertIn("/api/v1/reports/openshift/costs/", str(ctx.exception))
+
+    def test_soft_timeout_default(self):
+        self.assertEqual(RequestTimeoutMiddleware.SOFT_TIMEOUT, 90)
+
+
+class SentryBeforeSendTest(IamTestCase):
+    """Tests for the sentry before_send hook."""
+
+    def test_before_send_tags_timeout_events(self):
+        from koku.sentry import before_send
+
+        event = {}
+        hint = {"exc_info": (RequestTimeoutError, RequestTimeoutError("test"), None)}
+        result = before_send(event, hint)
+        self.assertEqual(result["tags"]["timeout"], "soft")
+
+    def test_before_send_passes_through_other_events(self):
+        from koku.sentry import before_send
+
+        event = {"tags": {"existing": "value"}}
+        hint = {"exc_info": (ValueError, ValueError("test"), None)}
+        result = before_send(event, hint)
+        self.assertEqual(result["tags"], {"existing": "value"})
+
+    def test_before_send_handles_no_exc_info(self):
+        from koku.sentry import before_send
+
+        event = {"message": "test"}
+        hint = {}
+        result = before_send(event, hint)
+        self.assertEqual(result, event)

--- a/koku/koku/test_middleware.py
+++ b/koku/koku/test_middleware.py
@@ -7,6 +7,7 @@ import base64
 import copy
 import json
 import logging
+import threading
 import time
 from unittest.mock import MagicMock
 from unittest.mock import Mock
@@ -594,23 +595,30 @@ class RequestTimeoutMiddlewareTest(IamTestCase):
         super().setUp()
         self.middleware = RequestTimeoutMiddleware(Mock())
 
+    @patch("koku.middleware.threading.current_thread")
     @patch("koku.middleware.signal.alarm")
     @patch("koku.middleware.signal.signal")
-    def test_process_request_sets_alarm(self, mock_signal, mock_alarm):
+    def test_process_request_sets_alarm(self, mock_signal, mock_alarm, mock_thread):
+        mock_thread.return_value = threading.main_thread()
         request = Mock(method="GET", path="/api/v1/reports/aws/costs/")
         self.middleware.process_request(request)
         mock_signal.assert_called_once()
         mock_alarm.assert_called_once_with(RequestTimeoutMiddleware.SOFT_TIMEOUT)
 
+    @patch("koku.middleware.threading.current_thread")
     @patch("koku.middleware.signal.alarm")
-    def test_process_response_cancels_alarm(self, mock_alarm):
+    def test_process_response_cancels_alarm(self, mock_alarm, mock_thread):
+        mock_thread.return_value = threading.main_thread()
         request = Mock()
         response = Mock(status_code=200)
         result = self.middleware.process_response(request, response)
         mock_alarm.assert_called_once_with(0)
         self.assertEqual(result, response)
 
-    def test_timeout_raises_request_timeout_error(self):
+    @patch("koku.middleware.threading.current_thread")
+    @patch("koku.middleware.signal.alarm")
+    def test_timeout_raises_request_timeout_error(self, mock_alarm, mock_thread):
+        mock_thread.return_value = threading.main_thread()
         request = Mock(method="GET", path="/api/v1/reports/openshift/costs/", start_time=time.time() - 85)
         with patch("koku.middleware.signal.signal") as mock_signal:
             self.middleware.process_request(request)
@@ -619,6 +627,28 @@ class RequestTimeoutMiddlewareTest(IamTestCase):
             handler(None, None)
         self.assertIn("GET", str(ctx.exception))
         self.assertIn("/api/v1/reports/openshift/costs/", str(ctx.exception))
+
+    @patch("koku.middleware.threading.current_thread")
+    @patch("koku.middleware.signal.alarm")
+    def test_timeout_handler_without_start_time(self, mock_alarm, mock_thread):
+        mock_thread.return_value = threading.main_thread()
+        request = Mock(method="POST", path="/api/v1/cost-models/", spec=["method", "path"])
+        with patch("koku.middleware.signal.signal") as mock_signal:
+            self.middleware.process_request(request)
+            handler = mock_signal.call_args[0][1]
+        with self.assertRaises(RequestTimeoutError) as ctx:
+            handler(None, None)
+        self.assertIn("POST", str(ctx.exception))
+        self.assertIn("/api/v1/cost-models/", str(ctx.exception))
+
+    @patch("koku.middleware.signal.alarm")
+    @patch("koku.middleware.signal.signal")
+    def test_skips_alarm_in_non_main_thread(self, mock_signal, mock_alarm):
+        with patch("koku.middleware.threading.current_thread", return_value=threading.Thread()):
+            request = Mock(method="GET", path="/api/v1/reports/aws/costs/")
+            self.middleware.process_request(request)
+        mock_signal.assert_not_called()
+        mock_alarm.assert_not_called()
 
     def test_soft_timeout_default(self):
         self.assertEqual(RequestTimeoutMiddleware.SOFT_TIMEOUT, 90)


### PR DESCRIPTION
## Summary
- Adds `RequestTimeoutMiddleware` using `signal.SIGALRM` to enforce a soft timeout (90s, configurable via `REQUEST_SOFT_TIMEOUT`) before gunicorn's hard kill, replacing ~1,400+ useless `SystemExit:1` GlitchTip events with actionable `RequestTimeoutError` events containing request path, method, and duration.
- Bumps gunicorn hard timeout from 90s → 100s so the middleware fires first while preserving a 10s window for the error to propagate to GlitchTip.
- Adds `sentry_before_send` hook in `middleware.py` to tag timeout events with `timeout=soft` for GlitchTip filtering.
- Thread-safe: only arms SIGALRM in the main thread. With threaded workers (`GUNICORN_THREADS=True`, active in stage), the middleware is a no-op and gunicorn's hard timeout remains the fallback.

## Changes
| File | Change |
|------|--------|
| `koku/koku/middleware.py` | Add `RequestTimeoutError`, `sentry_before_send`, `RequestTimeoutMiddleware` (SIGALRM + main-thread guard) |
| `koku/koku/settings.py` | Insert middleware after `RequestTimingMiddleware` |
| `koku/koku/sentry.py` | Import and wire `sentry_before_send` from middleware |
| `koku/gunicorn_conf.py` | Bump default `TIMEOUT` from 90 → 100 |
| `koku/koku/test_middleware.py` | 9 new tests (6 middleware, 3 sentry hook) |
| `CLAUDE.md` | Fix smoke test label docs |

## Configuration
| Env var | Default | Description |
|---------|---------|-------------|
| `REQUEST_SOFT_TIMEOUT` | 90 | Seconds before middleware aborts the request |
| `TIMEOUT` | 100 (was 90) | Gunicorn hard timeout (SIGABRT fallback) |

## Test plan
- [x] All 9 new tests pass (100% coverage on new middleware code)
- [x] No regressions in existing middleware tests
- [x] Pre-commit lint passes
- [x] Thread-safety: SIGALRM skipped in non-main threads (tested)
- [x] Safe env parsing: bad `REQUEST_SOFT_TIMEOUT` values fall back to default (tested)
- [ ] Deploy to stage, verify GlitchTip events contain request context
- [ ] Monitor for 1 week — confirm noise reduction and actionable data

JIRA: https://redhat.atlassian.net/browse/COST-8005
Design doc: https://docs.google.com/document/d/19f3DbCfW6NoV9vXABDPjeScnY4WA_aAThTKkxCVpmVY/edit