### PR TITLE
fix(dashboard): RDS datasource regex to match both stage and prod

### DIFF
--- a/dashboards/grafana-dashboard-insights-hccm.configmap.yaml
+++ b/dashboards/grafana-dashboard-insights-hccm.configmap.yaml
@@ -6756,7 +6756,7 @@ data:
             "query": "prometheus",
             "queryValue": "",
             "refresh": 1,
-            "regex": "/.*appsrep\\d+ue1.*/",
+            "regex": "/.*appsre[ps]\\d+ue1.*/",
             "skipUrlSync": false,
             "type": "datasource"
           }


### PR DESCRIPTION
## Summary

Follow-up to #6225. The RDS datasource regex `/.*appsrep\d+ue1.*/` only matches prod datasource names (`appsrep11ue1-prometheus`). Stage datasources use `appsres` (with an `s`), e.g. `appsres09ue1-prometheus`.

Changed regex to `/.*appsre[ps]\d+ue1.*/` to match both.

## Test plan

- [ ] Open dashboard on stage Grafana — verify RDS Datasource dropdown shows the stage datasource
- [ ] Open dashboard on prod Grafana — verify prod still works (no regression)

## Summary by Sourcery

Bug Fixes:
- Fix RDS datasource regex so the dashboard shows both stage and production Prometheus datasources in the dropdown.