### PR TITLE
fix(dashboard): add koku-stage to db_instance dropdown

### DIFF
--- a/dashboards/grafana-dashboard-insights-hccm.configmap.yaml
+++ b/dashboards/grafana-dashboard-insights-hccm.configmap.yaml
@@ -6668,22 +6668,48 @@ data:
         "list": [
           {
             "current": {
+              "selected": true,
+              "text": "prod",
+              "value": "{\"namespace\":\"hccm-prod\",\"db_instance\":\"cost-management-prod\",\"datasource\":\"crcp01ue1-prometheus\",\"rds_datasource\":\"appsrep11ue1-prometheus\"}"
+            },
+            "hide": 0,
+            "includeAll": false,
+            "label": "Environment",
+            "multi": false,
+            "name": "env",
+            "options": [
+              {
+                "selected": true,
+                "text": "prod",
+                "value": "{\"namespace\":\"hccm-prod\",\"db_instance\":\"cost-management-prod\",\"datasource\":\"crcp01ue1-prometheus\",\"rds_datasource\":\"appsrep11ue1-prometheus\"}"
+              },
+              {
+                "selected": false,
+                "text": "stage",
+                "value": "{\"namespace\":\"hccm-stage\",\"db_instance\":\"koku-stage\",\"datasource\":\"crcs02ue1-prometheus\",\"rds_datasource\":\"appsres11ue1-prometheus\"}"
+              }
+            ],
+            "query": "prod : {\"namespace\":\"hccm-prod\",\"db_instance\":\"cost-management-prod\",\"datasource\":\"crcp01ue1-prometheus\",\"rds_datasource\":\"appsrep11ue1-prometheus\"}, stage : {\"namespace\":\"hccm-stage\",\"db_instance\":\"koku-stage\",\"datasource\":\"crcs02ue1-prometheus\",\"rds_datasource\":\"appsres11ue1-prometheus\"}",
+            "queryValue": "",
+            "skipUrlSync": false,
+            "type": "custom",
+            "valuesFormat": "json"
+          },
+          {
+            "current": {
               "selected": false,
               "text": "crcp01ue1-prometheus",
               "value": "crcp01ue1-prometheus"
             },
-            "hide": 0,
+            "hide": 2,
             "includeAll": false,
             "label": "Datasource",
             "multi": false,
             "name": "Datasource",
-            "options": [],
-            "query": "prometheus",
+            "query": "${env.datasource}",
             "queryValue": "",
-            "refresh": 1,
-            "regex": "/.*crc.*/",
             "skipUrlSync": false,
-            "type": "datasource"
+            "type": "custom"
           },
           {
             "current": {
@@ -6691,24 +6717,12 @@ data:
               "text": "hccm-prod",
               "value": "hccm-prod"
             },
-            "hide": 0,
+            "hide": 2,
             "includeAll": false,
             "label": "namespace",
             "multi": false,
             "name": "namespace",
-            "options": [
-              {
-                "selected": false,
-                "text": "hccm-stage",
-                "value": "hccm-stage"
-              },
-              {
-                "selected": true,
-                "text": "hccm-prod",
-                "value": "hccm-prod"
-              }
-            ],
-            "query": "hccm-stage,hccm-prod",
+            "query": "${env.namespace}",
             "queryValue": "",
             "skipUrlSync": false,
             "type": "custom"
@@ -6719,29 +6733,12 @@ data:
               "text": "cost-management-prod",
               "value": "cost-management-prod"
             },
-            "hide": 0,
+            "hide": 2,
             "includeAll": false,
             "label": "db_instance",
             "multi": false,
             "name": "db_instance",
-            "options": [
-              {
-                "selected": false,
-                "text": "cost-management-stage",
-                "value": "cost-management-stage"
-              },
-              {
-                "selected": true,
-                "text": "cost-management-prod",
-                "value": "cost-management-prod"
-              },
-              {
-                "selected": false,
-                "text": "koku-stage",
-                "value": "koku-stage"
-              }
-            ],
-            "query": "cost-management-stage, cost-management-prod, koku-stage",
+            "query": "${env.db_instance}",
             "queryValue": "",
             "skipUrlSync": false,
             "type": "custom"
@@ -6752,18 +6749,15 @@ data:
               "text": "appsrep11ue1-prometheus",
               "value": "appsrep11ue1-prometheus"
             },
-            "hide": 0,
+            "hide": 2,
             "includeAll": false,
             "label": "RDS Datasource",
             "multi": false,
             "name": "rds_datasource",
-            "options": [],
-            "query": "prometheus",
+            "query": "${env.rds_datasource}",
             "queryValue": "",
-            "refresh": 1,
-            "regex": "/.*appsre[ps]\\d+ue1.*/",
             "skipUrlSync": false,
-            "type": "datasource"
+            "type": "custom"
           }
         ]
       },

--- a/dashboards/grafana-dashboard-insights-hccm.configmap.yaml
+++ b/dashboards/grafana-dashboard-insights-hccm.configmap.yaml
@@ -6734,9 +6734,14 @@ data:
                 "selected": true,
                 "text": "cost-management-prod",
                 "value": "cost-management-prod"
+              },
+              {
+                "selected": false,
+                "text": "koku-stage",
+                "value": "koku-stage"
               }
             ],
-            "query": "cost-management-stage, cost-management-prod",
+            "query": "cost-management-stage, cost-management-prod, koku-stage",
             "queryValue": "",
             "skipUrlSync": false,
             "type": "custom"


### PR DESCRIPTION
## Summary

The stage RDS instance is named `koku-stage`, not `cost-management-stage`. The dashboard's `db_instance` variable only had `cost-management-stage` and `cost-management-prod` as options, so stage RDS panels showed no data even with the correct datasource.

Follow-up to #6225 and #6240.

## Changes

- Added `koku-stage` to the `db_instance` custom variable options

## Test plan

- [ ] Open stage Grafana dashboard, select `koku-stage` from db_instance dropdown
- [ ] Verify RDS panels show stage data

## Summary by Sourcery

Add the koku-stage RDS instance option to the Grafana dashboard db_instance variable so stage dashboards display data correctly.

New Features:
- Expose the koku-stage RDS instance as a selectable option in the dashboard db_instance dropdown.

Bug Fixes:
- Ensure stage RDS panels on the Grafana dashboard show data by including the correct koku-stage db_instance in the variable query.