### PR TITLE
fix(dashboard): auto-discover variables, tighten datasource filters, add help

### DIFF
--- a/dashboards/grafana-dashboard-insights-hccm.configmap.yaml
+++ b/dashboards/grafana-dashboard-insights-hccm.configmap.yaml
@@ -31,6 +31,18 @@ data:
       "liveNow": false,
       "panels": [
         {
+          "gridPos": {"h": 2, "w": 24, "x": 0, "y": 0},
+          "id": 9999,
+          "options": {
+            "code": {"language": "plaintext", "showLineNumbers": false, "showMiniMap": false},
+            "content": "**Quick start:** Select **Datasource** (`crcp01ue1` = prod, `crcs02ue1` = stage) — namespace auto-selects.<br>For RDS panels, also select **RDS Datasource** (`appsrep11ue1` = prod, `appsres11ue1` = stage) — db_instance auto-selects.",
+            "mode": "markdown"
+          },
+          "title": "",
+          "transparent": true,
+          "type": "text"
+        },
+        {
           "collapsed": false,
           "datasource": {
             "type": "prometheus",
@@ -6667,97 +6679,78 @@ data:
       "templating": {
         "list": [
           {
-            "current": {
-              "selected": true,
-              "text": "prod",
-              "value": "{\"namespace\":\"hccm-prod\",\"db_instance\":\"cost-management-prod\",\"datasource\":\"crcp01ue1-prometheus\",\"rds_datasource\":\"appsrep11ue1-prometheus\"}"
-            },
+            "current": {},
             "hide": 0,
-            "includeAll": false,
-            "label": "Environment",
-            "multi": false,
-            "name": "env",
-            "options": [
-              {
-                "selected": true,
-                "text": "prod",
-                "value": "{\"namespace\":\"hccm-prod\",\"db_instance\":\"cost-management-prod\",\"datasource\":\"crcp01ue1-prometheus\",\"rds_datasource\":\"appsrep11ue1-prometheus\"}"
-              },
-              {
-                "selected": false,
-                "text": "stage",
-                "value": "{\"namespace\":\"hccm-stage\",\"db_instance\":\"koku-stage\",\"datasource\":\"crcs02ue1-prometheus\",\"rds_datasource\":\"appsres11ue1-prometheus\"}"
-              }
-            ],
-            "query": "prod : {\"namespace\":\"hccm-prod\",\"db_instance\":\"cost-management-prod\",\"datasource\":\"crcp01ue1-prometheus\",\"rds_datasource\":\"appsrep11ue1-prometheus\"}, stage : {\"namespace\":\"hccm-stage\",\"db_instance\":\"koku-stage\",\"datasource\":\"crcs02ue1-prometheus\",\"rds_datasource\":\"appsres11ue1-prometheus\"}",
-            "queryValue": "",
-            "skipUrlSync": false,
-            "type": "custom",
-            "valuesFormat": "json"
-          },
-          {
-            "current": {
-              "selected": false,
-              "text": "crcp01ue1-prometheus",
-              "value": "crcp01ue1-prometheus"
-            },
-            "hide": 2,
             "includeAll": false,
             "label": "Datasource",
             "multi": false,
             "name": "Datasource",
-            "query": "${env.datasource}",
+            "options": [],
+            "query": "prometheus",
             "queryValue": "",
+            "refresh": 1,
+            "regex": "/^crc[ps]\\d+ue1-prometheus$/",
             "skipUrlSync": false,
-            "type": "custom"
+            "type": "datasource"
           },
           {
-            "current": {
-              "selected": false,
-              "text": "hccm-prod",
-              "value": "hccm-prod"
+            "current": {},
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${Datasource}"
             },
-            "hide": 2,
+            "definition": "label_values(up{namespace=~\"hccm-.*\"}, namespace)",
+            "hide": 0,
             "includeAll": false,
             "label": "namespace",
             "multi": false,
             "name": "namespace",
-            "query": "${env.namespace}",
-            "queryValue": "",
+            "options": [],
+            "query": {
+              "query": "label_values(up{namespace=~\"hccm-.*\"}, namespace)",
+              "refId": "namespace"
+            },
+            "refresh": 1,
             "skipUrlSync": false,
-            "type": "custom"
+            "sort": 1,
+            "type": "query"
           },
           {
-            "current": {
-              "selected": false,
-              "text": "cost-management-prod",
-              "value": "cost-management-prod"
-            },
-            "hide": 2,
-            "includeAll": false,
-            "label": "db_instance",
-            "multi": false,
-            "name": "db_instance",
-            "query": "${env.db_instance}",
-            "queryValue": "",
-            "skipUrlSync": false,
-            "type": "custom"
-          },
-          {
-            "current": {
-              "selected": false,
-              "text": "appsrep11ue1-prometheus",
-              "value": "appsrep11ue1-prometheus"
-            },
-            "hide": 2,
+            "current": {},
+            "hide": 0,
             "includeAll": false,
             "label": "RDS Datasource",
             "multi": false,
             "name": "rds_datasource",
-            "query": "${env.rds_datasource}",
+            "options": [],
+            "query": "prometheus",
             "queryValue": "",
+            "refresh": 1,
+            "regex": "/^appsre[ps]11ue1-prometheus$/",
             "skipUrlSync": false,
-            "type": "custom"
+            "type": "datasource"
+          },
+          {
+            "current": {},
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${rds_datasource}"
+            },
+            "definition": "label_values(rdsosmetrics_cpuUtilization_user{exported_instance=~\"cost-management-.*|koku-.*\"}, exported_instance)",
+            "hide": 0,
+            "includeAll": false,
+            "label": "db_instance",
+            "multi": false,
+            "name": "db_instance",
+            "options": [],
+            "query": {
+              "query": "label_values(rdsosmetrics_cpuUtilization_user{exported_instance=~\"cost-management-.*|koku-.*\"}, exported_instance)",
+              "refId": "db_instance"
+            },
+            "refresh": 1,
+            "skipUrlSync": false,
+            "sort": 1,
+            "type": "query"
           }
         ]
       },


### PR DESCRIPTION
## Summary

Fixes the broken multi-property env variable from #6241 (valuesFormat: json not supported by provisioned Grafana dashboards) and replaces it with auto-discovery query variables.

**What changed:**
- **namespace**: auto-discovers from selected Datasource via `label_values(up{namespace=~"hccm-.*"}, namespace)`
- **db_instance**: auto-discovers from selected RDS Datasource via `label_values(rdsosmetrics_cpuUtilization_user{exported_instance=~"cost-management-.*|koku-.*"}, exported_instance)`
- **Datasource regex**: tightened from `/.*crc.*/` to `/^crc[ps]\d+ue1-prometheus$/` — shows only prod + stage
- **RDS Datasource regex**: tightened to `/^appsre[ps]11ue1-prometheus$/` — shows only prod + stage
- **Help text panel**: added at top explaining which datasources to select

## Test plan

Tested live on stage Grafana by creating a test dashboard (R0HueuFGk-test) via API:
- [x] Datasource dropdown shows only 2 options (prod + stage)
- [x] namespace auto-populates when Datasource is selected
- [x] RDS Datasource dropdown shows only 2 options
- [x] db_instance auto-populates when RDS Datasource is selected
- [x] Help text panel renders correctly
- [x] Test dashboard cleaned up after testing

## Summary by Sourcery

Replace hard-coded environment selection with auto-discovered Grafana variables and tighten datasource selection for the HCCM insights dashboard.

Enhancements:
- Add a top-of-dashboard help text panel guiding users on selecting the correct Prometheus and RDS datasources.
- Replace the custom JSON-based env variable with separate auto-discovered variables for namespace and db_instance driven by Prometheus queries.
- Restrict selectable Prometheus and RDS datasources to specific prod and stage instances via tighter datasource regex filters.