### PR TITLE
fix: handle missing ocp_files_to_process key in summarize_manifest

### DIFF
--- a/koku/masu/external/kafka_msg_handler.py
+++ b/koku/masu/external/kafka_msg_handler.py
@@ -658,7 +658,7 @@ def summarize_manifest(report_meta, manifest_uuid):
     if "0001-01-01 00:00:00+00:00" not in [str(start_date), str(end_date)]:
         dates = {
             datetime.strptime(meta["meta_reportdatestart"], "%Y-%m-%d").date()
-            for meta in report_meta["ocp_files_to_process"].values()
+            for meta in report_meta.get("ocp_files_to_process", {}).values()
         }
         min_date = min(dates)
         max_date = max(dates)


### PR DESCRIPTION
## Summary

Fix `KeyError: 'ocp_files_to_process'` in the Kafka listener when an OCP manifest arrives without split files.

**GlitchTip:** [INSIGHTS-HCCM-PROD-5VP](https://glitchtip.devshift.net/insights-hccm-prod/issues/4571086?project=83) (1 event, 2026-08-03)

## Root Cause

`ocp_files_to_process` is set at line 524 only when `split_files` is non-empty. But line 661 accesses it with a direct dict lookup (`report_meta["ocp_files_to_process"]`), which raises `KeyError` when the key is missing.

Lines 731 and 792 already use the safe `.get()` pattern — line 661 was the only inconsistent access.

## Changes

```python
# Before (unsafe)
for meta in report_meta["ocp_files_to_process"].values()

# After (safe, consistent with lines 731/792)
for meta in report_meta.get("ocp_files_to_process", {}).values()
```

## Test plan

- [ ] Verify existing OCP processing tests pass
- [ ] Verify a manifest without split files does not crash the listener

## Summary by Sourcery

Bug Fixes:
- Prevent KeyError when summarizing manifests that lack the ocp_files_to_process field by safely accessing the metadata.