### PR TITLE
[COST-7993] Add is_disableable to GET /settings/currency/ response

### DIFF
--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -7486,6 +7486,50 @@
                     }
                 ]
             },
+            "CurrencySettingsItem": {
+                "required": [
+                    "code",
+                    "symbol",
+                    "name",
+                    "description",
+                    "enabled",
+                    "has_dynamic_rate",
+                    "is_disableable",
+                    "static_rates"
+                ],
+                "properties": {
+                    "code": {
+                        "type": "string",
+                        "example": "USD"
+                    },
+                    "symbol": {
+                        "type": "string",
+                        "example": "$"
+                    },
+                    "name": {
+                        "type": "string",
+                        "example": "US Dollar"
+                    },
+                    "description": {
+                        "type": "string",
+                        "example": "USD ($) - US Dollar"
+                    },
+                    "enabled": {
+                        "type": "boolean"
+                    },
+                    "has_dynamic_rate": {
+                        "type": "boolean"
+                    },
+                    "is_disableable": {
+                        "type": "boolean",
+                        "description": "Whether this currency can currently be disabled. False if the currency is already disabled, is the sole enabled currency, or is referenced by a cost model, price list, cloud provider billing data, or the system/account default."
+                    },
+                    "static_rates": {
+                        "type": "array",
+                        "items": {}
+                    }
+                }
+            },
             "Currencies": {
                 "required": [
                     "code",

--- a/koku/api/settings/currency_views.py
+++ b/koku/api/settings/currency_views.py
@@ -44,6 +44,8 @@ LOG = logging.getLogger(__name__)
 
 def _get_cloud_providers_using_currency(code, customer):
     """Return cloud providers whose billing data uses ``code`` as a base currency."""
+    if not customer or not customer.pk:
+        return []
     aws_uuids = AWSCostSummaryP.objects.filter(currency_code=code).values_list("source_uuid", flat=True).distinct()
     azure_uuids = AzureCostSummaryP.objects.filter(currency=code).values_list("source_uuid", flat=True).distinct()
     gcp_uuids = GCPCostSummaryP.objects.filter(currency=code).values_list("source_uuid", flat=True).distinct()
@@ -54,6 +56,29 @@ def _get_cloud_providers_using_currency(code, customer):
             customer=customer,
         ).values("uuid", "name", "type")
     )
+
+
+def _get_non_disableable_codes():
+    """Return the set of currency codes that cannot be disabled.
+
+    Uses batched queries — one per blocking criterion — to avoid N+1 when
+    building the currency list in the GET response.
+    """
+    blocked = {KOKU_DEFAULT_CURRENCY}
+
+    account_settings = UserSettings.objects.first()
+    if account_settings:
+        account_currency = account_settings.settings.get("currency")
+        if account_currency:
+            blocked.add(account_currency)
+
+    blocked |= set(CostModel.objects.values_list("currency", flat=True).distinct())
+    blocked |= set(PriceList.objects.values_list("currency", flat=True).distinct())
+    blocked |= set(AWSCostSummaryP.objects.values_list("currency_code", flat=True).distinct())
+    blocked |= set(AzureCostSummaryP.objects.values_list("currency", flat=True).distinct())
+    blocked |= set(GCPCostSummaryP.objects.values_list("currency", flat=True).distinct())
+
+    return blocked
 
 
 class CurrencySettingsView(APIView):
@@ -86,12 +111,17 @@ class CurrencySettingsView(APIView):
             all_codes = get_all_iso_currency_codes()
             sorted_codes = sorted(enabled_codes) + sorted(all_codes - enabled_codes)
 
+        only_one_enabled = len(enabled_codes) == 1
+        non_disableable = _get_non_disableable_codes()
+
         result = []
         for code in sorted_codes:
             info = get_currency_info(code)
-            info["enabled"] = code in enabled_codes
+            is_enabled = code in enabled_codes
+            info["enabled"] = is_enabled
             info["has_dynamic_rate"] = code.lower() in dynamic_codes
             info["static_rates"] = rates_by_base.get(code, [])
+            info["is_disableable"] = is_enabled and not only_one_enabled and code not in non_disableable
             result.append(info)
 
         search_term = request.query_params.get("search", "").strip().upper()

--- a/koku/api/settings/currency_views.py
+++ b/koku/api/settings/currency_views.py
@@ -58,25 +58,35 @@ def _get_cloud_providers_using_currency(code, customer):
     )
 
 
-def _get_non_disableable_codes():
+def _get_non_disableable_codes(enabled_codes):
     """Return the set of currency codes that cannot be disabled.
 
     Uses batched queries — one per blocking criterion — to avoid N+1 when
-    building the currency list in the GET response.
+    building the currency list in the GET response. Cloud summary queries are
+    scoped to ``enabled_codes`` since is_disableable is only meaningful for
+    currently enabled currencies.
     """
     blocked = {KOKU_DEFAULT_CURRENCY}
 
     account_settings = UserSettings.objects.first()
-    if account_settings:
+    if account_settings and isinstance(account_settings.settings, dict):
         account_currency = account_settings.settings.get("currency")
         if account_currency:
             blocked.add(account_currency)
 
     blocked |= set(CostModel.objects.values_list("currency", flat=True).distinct())
     blocked |= set(PriceList.objects.values_list("currency", flat=True).distinct())
-    blocked |= set(AWSCostSummaryP.objects.values_list("currency_code", flat=True).distinct())
-    blocked |= set(AzureCostSummaryP.objects.values_list("currency", flat=True).distinct())
-    blocked |= set(GCPCostSummaryP.objects.values_list("currency", flat=True).distinct())
+    blocked |= set(
+        AWSCostSummaryP.objects.filter(currency_code__in=enabled_codes)
+        .values_list("currency_code", flat=True)
+        .distinct()
+    )
+    blocked |= set(
+        AzureCostSummaryP.objects.filter(currency__in=enabled_codes).values_list("currency", flat=True).distinct()
+    )
+    blocked |= set(
+        GCPCostSummaryP.objects.filter(currency__in=enabled_codes).values_list("currency", flat=True).distinct()
+    )
 
     return blocked
 
@@ -112,7 +122,7 @@ class CurrencySettingsView(APIView):
             sorted_codes = sorted(enabled_codes) + sorted(all_codes - enabled_codes)
 
         only_one_enabled = len(enabled_codes) == 1
-        non_disableable = _get_non_disableable_codes()
+        non_disableable = _get_non_disableable_codes(enabled_codes)
 
         result = []
         for code in sorted_codes:

--- a/koku/api/settings/test/test_currency_views.py
+++ b/koku/api/settings/test/test_currency_views.py
@@ -218,11 +218,14 @@ class CurrencySettingsViewTest(IamTestCase):
             EnabledCurrency.objects.create(currency_code="USD")
             for provider_type, summary_model, currency_field, code in cloud_providers:
                 EnabledCurrency.objects.create(currency_code=code)
-                provider = Provider.objects.create(
-                    name=f"{provider_type} {code}",
-                    type=provider_type,
-                    customer=self.customer,
-                )
+
+        for provider_type, summary_model, currency_field, code in cloud_providers:
+            provider = Provider.objects.create(
+                name=f"{provider_type} {code}",
+                type=provider_type,
+                customer=self.customer,
+            )
+            with tenant_context(self.tenant):
                 tenant_provider = TenantAPIProvider.objects.create(
                     uuid=provider.uuid, name=provider.name, type=provider.type, provider=provider
                 )
@@ -376,13 +379,13 @@ class EnabledCurrencyViewTest(IamTestCase):
             (Provider.PROVIDER_AZURE, AzureCostSummaryP, "currency", "CAD"),
             (Provider.PROVIDER_GCP, GCPCostSummaryP, "currency", "EUR"),
         ]
-        with tenant_context(self.tenant):
-            for provider_type, summary_model, currency_field, code in cloud_providers:
-                provider = Provider.objects.create(
-                    name=f"{provider_type} {code} Source",
-                    type=provider_type,
-                    customer=self.customer,
-                )
+        for provider_type, summary_model, currency_field, code in cloud_providers:
+            provider = Provider.objects.create(
+                name=f"{provider_type} {code} Source",
+                type=provider_type,
+                customer=self.customer,
+            )
+            with tenant_context(self.tenant):
                 tenant_provider = TenantAPIProvider.objects.create(
                     uuid=provider.uuid, name=provider.name, type=provider.type, provider=provider
                 )
@@ -394,6 +397,7 @@ class EnabledCurrencyViewTest(IamTestCase):
                     **{currency_field: code},
                 )
 
+        with tenant_context(self.tenant):
             EnabledCurrency.objects.all().delete()
             EnabledCurrency.objects.create(currency_code="USD")
             EnabledCurrency.objects.create(currency_code="AUD")

--- a/koku/api/settings/test/test_currency_views.py
+++ b/koku/api/settings/test/test_currency_views.py
@@ -25,6 +25,7 @@ from reporting.provider.aws.models import AWSCostSummaryP
 from reporting.provider.azure.models import AzureCostSummaryP
 from reporting.provider.gcp.models import GCPCostSummaryP
 from reporting.provider.models import TenantAPIProvider
+from reporting.user_settings.models import UserSettings
 
 
 CACHE_OVERRIDE = {
@@ -104,6 +105,142 @@ class CurrencySettingsViewTest(IamTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         codes = [c["code"] for c in response.data["data"]]
         self.assertEqual(codes, ["USD"])
+
+    def test_is_disableable_true_for_free_enabled_currency(self):
+        """A freely enabled currency with no dependencies returns is_disableable=True."""
+        with tenant_context(self.tenant):
+            EnabledCurrency.objects.create(currency_code="USD")
+            EnabledCurrency.objects.create(currency_code="CHF")
+
+        url = reverse("currency-list") + "?search=CHF"
+        response = self.client.get(url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        chf = response.data["data"][0]
+        self.assertTrue(chf["is_disableable"])
+
+    def test_is_disableable_false_for_disabled_currency(self):
+        """A disabled currency always returns is_disableable=False."""
+        with tenant_context(self.tenant):
+            EnabledCurrency.objects.create(currency_code="USD")
+
+        url = reverse("currency-list") + "?search=CHF"
+        response = self.client.get(url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        chf = response.data["data"][0]
+        self.assertFalse(chf["is_disableable"])
+
+    @override_settings(KOKU_DEFAULT_CURRENCY="USD")
+    def test_is_disableable_false_for_system_default_currency(self):
+        """System default currency returns is_disableable=False."""
+        with tenant_context(self.tenant):
+            EnabledCurrency.objects.create(currency_code="USD")
+            EnabledCurrency.objects.create(currency_code="CHF")
+
+        url = reverse("currency-list") + "?search=USD"
+        response = self.client.get(url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        usd = response.data["data"][0]
+        self.assertFalse(usd["is_disableable"])
+
+    def test_is_disableable_false_when_only_one_enabled(self):
+        """The sole enabled currency returns is_disableable=False."""
+        with tenant_context(self.tenant):
+            EnabledCurrency.objects.create(currency_code="CHF")
+
+        url = reverse("currency-list") + "?search=CHF"
+        response = self.client.get(url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        chf = response.data["data"][0]
+        self.assertFalse(chf["is_disableable"])
+
+    def test_is_disableable_false_for_currency_used_by_cost_model(self):
+        """Currency used by a CostModel returns is_disableable=False."""
+        with tenant_context(self.tenant):
+            EnabledCurrency.objects.create(currency_code="USD")
+            EnabledCurrency.objects.create(currency_code="GBP")
+            CostModel.objects.create(
+                name="GBP Model",
+                description="test",
+                source_type="OCP",
+                rates={},
+                markup={},
+                currency="GBP",
+            )
+
+        url = reverse("currency-list") + "?search=GBP"
+        response = self.client.get(url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        gbp = response.data["data"][0]
+        self.assertFalse(gbp["is_disableable"])
+
+    def test_is_disableable_false_for_currency_used_by_price_list(self):
+        """Currency used by a PriceList returns is_disableable=False."""
+        with tenant_context(self.tenant):
+            EnabledCurrency.objects.create(currency_code="USD")
+            EnabledCurrency.objects.create(currency_code="EUR")
+            PriceList.objects.create(
+                name="EUR PL",
+                description="test",
+                currency="EUR",
+                effective_start_date="2026-01-01",
+                effective_end_date="2026-12-31",
+                rates=[],
+            )
+
+        url = reverse("currency-list") + "?search=EUR"
+        response = self.client.get(url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        eur = response.data["data"][0]
+        self.assertFalse(eur["is_disableable"])
+
+    def test_is_disableable_false_for_account_default_currency(self):
+        """Account default currency (UserSettings) returns is_disableable=False."""
+        with tenant_context(self.tenant):
+            EnabledCurrency.objects.create(currency_code="USD")
+            EnabledCurrency.objects.create(currency_code="NOK")
+            UserSettings.objects.all().delete()
+            UserSettings.objects.create(settings={"currency": "NOK"})
+
+        url = reverse("currency-list") + "?search=NOK"
+        response = self.client.get(url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        nok = response.data["data"][0]
+        self.assertFalse(nok["is_disableable"])
+
+    def test_is_disableable_false_for_cloud_provider_base_currencies(self):
+        """Currencies used by cloud billing summary data return is_disableable=False."""
+        cloud_providers = [
+            (Provider.PROVIDER_AWS, AWSCostSummaryP, "currency_code", "AUD"),
+            (Provider.PROVIDER_AZURE, AzureCostSummaryP, "currency", "CAD"),
+            (Provider.PROVIDER_GCP, GCPCostSummaryP, "currency", "NZD"),
+        ]
+        with tenant_context(self.tenant):
+            EnabledCurrency.objects.create(currency_code="USD")
+            for provider_type, summary_model, currency_field, code in cloud_providers:
+                EnabledCurrency.objects.create(currency_code=code)
+                provider = Provider.objects.create(
+                    name=f"{provider_type} {code}",
+                    type=provider_type,
+                    customer=self.customer,
+                )
+                tenant_provider = TenantAPIProvider.objects.create(
+                    uuid=provider.uuid, name=provider.name, type=provider.type, provider=provider
+                )
+                summary_model.objects.create(
+                    id=uuid4(),
+                    usage_start="2026-01-01",
+                    usage_end="2026-01-01",
+                    source_uuid=tenant_provider,
+                    **{currency_field: code},
+                )
+
+        for _, _, _, code in cloud_providers:
+            with self.subTest(code=code):
+                url = reverse("currency-list") + f"?search={code}"
+                response = self.client.get(url, **self.headers)
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+                entry = response.data["data"][0]
+                self.assertFalse(entry["is_disableable"], f"{code} should not be disableable")
 
 
 class EnabledCurrencyViewTest(IamTestCase):
@@ -281,8 +418,6 @@ class EnabledCurrencyViewTest(IamTestCase):
 
     def test_disable_account_default_currency_blocked(self):
         """Disabling the account default currency must return 400."""
-        from reporting.user_settings.models import UserSettings
-
         with tenant_context(self.tenant):
             EnabledCurrency.objects.create(currency_code="USD")
             EnabledCurrency.objects.create(currency_code="GBP")


### PR DESCRIPTION
## Summary

- Adds `is_disableable` boolean field to every currency entry returned by `GET /settings/currency/`
- Allows the UI to render the enable/disable toggle correctly **before** a user attempts a `DELETE`, without needing to rely on a `400` error response

## Changes

- `currency_views.py`: new `_get_non_disableable_codes()` helper using **batched queries** (one per blocking criterion, not N per currency) to determine which codes cannot be disabled
- Also includes the `if not customer or not customer.pk: return []` guard on `_get_cloud_providers_using_currency` (defensive fix for unsaved customer instances)

## `is_disableable` logic

Returns `true` only when **all** of the following hold:
- The currency is currently enabled
- It is not the only enabled currency
- It is not the system default currency (`KOKU_DEFAULT_CURRENCY`)
- It is not the account default currency (`UserSettings`)
- It is not used by any Cost Model
- It is not used by any Price List
- It is not a base currency in AWS/Azure/GCP billing data

## Test plan

- [ ] `GET /settings/currency/?search=USD` → `is_disableable: false` (system default)
- [ ] Enable a free currency (e.g. CHF) with no cost models/price lists → `is_disableable: true`
- [ ] Assign CHF to a cost model → `is_disableable: false`
- [ ] Disabled currency → `is_disableable: false`

Closes #COST-7993

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Expose disableability metadata for currencies in settings API and guard currency usage checks for unsaved customers.

New Features:
- Add is_disableable flag to each currency returned by GET /settings/currency/ based on enablement and usage constraints.

Bug Fixes:
- Avoid querying cloud provider usage when the customer object is missing or unsaved in _get_cloud_providers_using_currency.

Tests:
- Add comprehensive tests covering is_disableable behavior for enabled, disabled, default, cost model, price list, account default, and cloud provider base currencies.