### PR TITLE
[COST-8031] - Add retry logic to sync_hive_partitions for transient errors

### DIFF
--- a/koku/masu/processor/report_parquet_processor_base.py
+++ b/koku/masu/processor/report_parquet_processor_base.py
@@ -29,6 +29,8 @@ from reporting.models import TenantAPIProvider
 
 LOG = logging.getLogger(__name__)
 
+_RETRYABLE_TRINO_ERRORS = frozenset({"ALREADY_EXISTS", "HIVE_METASTORE_ERROR", "HIVE_FILESYSTEM_ERROR", "JDBC_ERROR"})
+
 
 class PostgresSummaryTableError(Exception):
     """Postgres summary table is not defined."""
@@ -209,10 +211,11 @@ class ReportParquetProcessorBase:
         return created
 
     def _execute_trino_sql_with_retries(self, sql, schema_name: str, caller="", max_retries=3):
-        """Execute Trino SQL with retries on transient TrinoQueryError exceptions.
+        """Execute Trino SQL with retries on known transient TrinoQueryError exceptions.
 
-        Returns the result rows on success, or an empty list on failure.
-        Non-retryable errors (ProgrammingError, Error) are logged and return immediately.
+        Only errors in _RETRYABLE_TRINO_ERRORS are retried with exponential backoff.
+        Unknown TrinoQueryErrors are logged at ERROR (with error_name) and return [] immediately.
+        ProgrammingError and Django Error are also non-retryable and return [] immediately.
         """
         for attempt in range(max_retries + 1):
             try:
@@ -229,6 +232,17 @@ class ReportParquetProcessorBase:
                         LOG.debug(f"{caller} returned {len(rows)} rows")
                 return rows
             except TrinoQueryError as err:
+                if err.error_name not in _RETRYABLE_TRINO_ERRORS:
+                    LOG.error(
+                        log_json(
+                            msg=f"{caller} failed with non-retryable TrinoQueryError",
+                            schema=schema_name,
+                            table=self._table_name,
+                            error_name=err.error_name,
+                        ),
+                        exc_info=err,
+                    )
+                    return []
                 if attempt < max_retries:
                     backoff = min(2**attempt, 30) + random.uniform(0, 1)
                     LOG.warning(
@@ -236,6 +250,7 @@ class ReportParquetProcessorBase:
                             msg=f"{caller} retrying (attempt {attempt + 1})",
                             schema=schema_name,
                             table=self._table_name,
+                            error_name=err.error_name,
                         ),
                         exc_info=err,
                     )
@@ -246,6 +261,7 @@ class ReportParquetProcessorBase:
                             msg=f"{caller} failed after {attempt + 1} attempts",
                             schema=schema_name,
                             table=self._table_name,
+                            error_name=err.error_name,
                         ),
                         exc_info=err,
                     )

--- a/koku/masu/processor/report_parquet_processor_base.py
+++ b/koku/masu/processor/report_parquet_processor_base.py
@@ -4,6 +4,7 @@
 #
 """Processor for Parquet files."""
 import logging
+import random
 import time
 
 from dateutil.relativedelta import relativedelta
@@ -207,6 +208,69 @@ class ReportParquetProcessorBase:
 
         return created
 
+    def _execute_trino_sql_with_retries(self, sql, schema_name: str, caller="", max_retries=3):  # pragma: no cover
+        """Execute Trino SQL with retries on transient TrinoQueryError exceptions.
+
+        Returns the result rows on success, or an empty list on failure.
+        Non-retryable errors (ProgrammingError, Error) are logged and return immediately.
+        """
+        for attempt in range(max_retries + 1):
+            try:
+                with get_report_db_accessor().connect(
+                    host=settings.TRINO_HOST,
+                    port=settings.TRINO_PORT,
+                    user="admin",
+                    catalog="hive",
+                    schema=schema_name,
+                ) as conn:
+                    with conn.cursor() as cur:
+                        cur.execute(sql)
+                        rows = cur.fetchall()
+                        LOG.debug(f"{caller} returned {len(rows)} rows")
+                return rows
+            except TrinoQueryError as err:
+                if attempt < max_retries:
+                    backoff = min(2**attempt, 30) + random.uniform(0, 1)
+                    LOG.warning(
+                        log_json(
+                            msg=f"{caller} retrying (attempt {attempt + 1})",
+                            schema=schema_name,
+                            table=self._table_name,
+                            exc_info=err,
+                        )
+                    )
+                    time.sleep(backoff)
+                else:
+                    LOG.error(
+                        log_json(
+                            msg=f"{caller} failed after {attempt + 1} attempts",
+                            schema=schema_name,
+                            table=self._table_name,
+                            exc_info=err,
+                        )
+                    )
+            except ProgrammingError as err:
+                LOG.warning(
+                    log_json(
+                        msg=f"{caller} failed with non-retryable error",
+                        schema=schema_name,
+                        table=self._table_name,
+                        exc_info=err,
+                    )
+                )
+                return []
+            except Error as err:
+                LOG.error(
+                    log_json(
+                        msg=f"{caller} failed with non-retryable error",
+                        schema=schema_name,
+                        table=self._table_name,
+                        exc_info=err,
+                    )
+                )
+                return []
+        return []
+
     def sync_hive_partitions(self):
         """Sync hive partition metadata."""
         LOG.info(
@@ -218,42 +282,7 @@ class ReportParquetProcessorBase:
         )
         sql = "CALL system.sync_partition_metadata('" f"{self._schema_name}', " f"'{self._table_name}', " "'FULL')"
         LOG.info(sql)
-        max_retries = 3
-        for attempt in range(max_retries + 1):
-            try:
-                with get_report_db_accessor().connect(
-                    host=settings.TRINO_HOST,
-                    port=settings.TRINO_PORT,
-                    user="admin",
-                    catalog="hive",
-                    schema=self._schema_name,
-                ) as conn:
-                    with conn.cursor() as cur:
-                        cur.execute(sql)
-                        rows = cur.fetchall()
-                        LOG.debug(f"sync_hive_partitions rows: {str(rows)}. Type: {type(rows)}")
-                return
-            except (TrinoQueryError, ProgrammingError, Error) as err:
-                if attempt < max_retries:
-                    backoff = min(2**attempt, 30)
-                    LOG.warning(
-                        log_json(
-                            msg=f"sync_hive_partitions retrying (attempt {attempt + 1})",
-                            schema=self._schema_name,
-                            table=self._table_name,
-                            exc_info=err,
-                        )
-                    )
-                    time.sleep(backoff)
-                else:
-                    LOG.error(
-                        log_json(
-                            msg=f"sync_hive_partitions failed after {attempt + 1} attempts",
-                            schema=self._schema_name,
-                            table=self._table_name,
-                            exc_info=err,
-                        )
-                    )
+        self._execute_trino_sql_with_retries(sql, self._schema_name, caller="sync_hive_partitions")
 
     def write_to_self_hosted_table(self, data_frame, metadata):
         """Write dataframe to self-hosted PostgreSQL table.

--- a/koku/masu/processor/report_parquet_processor_base.py
+++ b/koku/masu/processor/report_parquet_processor_base.py
@@ -4,6 +4,7 @@
 #
 """Processor for Parquet files."""
 import logging
+import time
 
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
@@ -207,7 +208,7 @@ class ReportParquetProcessorBase:
         return created
 
     def sync_hive_partitions(self):
-        """Sync hive partition metadata for new partitions."""
+        """Sync hive partition metadata."""
         LOG.info(
             log_json(
                 msg="syncing trino/hive partitions",
@@ -217,7 +218,42 @@ class ReportParquetProcessorBase:
         )
         sql = "CALL system.sync_partition_metadata('" f"{self._schema_name}', " f"'{self._table_name}', " "'FULL')"
         LOG.info(sql)
-        self._execute_trino_sql(sql, self._schema_name)
+        max_retries = 3
+        for attempt in range(max_retries + 1):
+            try:
+                with get_report_db_accessor().connect(
+                    host=settings.TRINO_HOST,
+                    port=settings.TRINO_PORT,
+                    user="admin",
+                    catalog="hive",
+                    schema=self._schema_name,
+                ) as conn:
+                    with conn.cursor() as cur:
+                        cur.execute(sql)
+                        rows = cur.fetchall()
+                        LOG.debug(f"sync_hive_partitions rows: {str(rows)}. Type: {type(rows)}")
+                return
+            except (TrinoQueryError, ProgrammingError, Error) as err:
+                if attempt < max_retries:
+                    backoff = min(2**attempt, 30)
+                    LOG.warning(
+                        log_json(
+                            msg=f"sync_hive_partitions retrying (attempt {attempt + 1})",
+                            schema=self._schema_name,
+                            table=self._table_name,
+                            exc_info=err,
+                        )
+                    )
+                    time.sleep(backoff)
+                else:
+                    LOG.error(
+                        log_json(
+                            msg=f"sync_hive_partitions failed after {attempt + 1} attempts",
+                            schema=self._schema_name,
+                            table=self._table_name,
+                            exc_info=err,
+                        )
+                    )
 
     def write_to_self_hosted_table(self, data_frame, metadata):
         """Write dataframe to self-hosted PostgreSQL table.

--- a/koku/masu/processor/report_parquet_processor_base.py
+++ b/koku/masu/processor/report_parquet_processor_base.py
@@ -208,7 +208,7 @@ class ReportParquetProcessorBase:
 
         return created
 
-    def _execute_trino_sql_with_retries(self, sql, schema_name: str, caller="", max_retries=3):  # pragma: no cover
+    def _execute_trino_sql_with_retries(self, sql, schema_name: str, caller="", max_retries=3):
         """Execute Trino SQL with retries on transient TrinoQueryError exceptions.
 
         Returns the result rows on success, or an empty list on failure.
@@ -236,8 +236,8 @@ class ReportParquetProcessorBase:
                             msg=f"{caller} retrying (attempt {attempt + 1})",
                             schema=schema_name,
                             table=self._table_name,
-                            exc_info=err,
-                        )
+                        ),
+                        exc_info=err,
                     )
                     time.sleep(backoff)
                 else:
@@ -246,8 +246,8 @@ class ReportParquetProcessorBase:
                             msg=f"{caller} failed after {attempt + 1} attempts",
                             schema=schema_name,
                             table=self._table_name,
-                            exc_info=err,
-                        )
+                        ),
+                        exc_info=err,
                     )
             except ProgrammingError as err:
                 LOG.warning(
@@ -255,8 +255,8 @@ class ReportParquetProcessorBase:
                         msg=f"{caller} failed with non-retryable error",
                         schema=schema_name,
                         table=self._table_name,
-                        exc_info=err,
-                    )
+                    ),
+                    exc_info=err,
                 )
                 return []
             except Error as err:
@@ -265,8 +265,8 @@ class ReportParquetProcessorBase:
                         msg=f"{caller} failed with non-retryable error",
                         schema=schema_name,
                         table=self._table_name,
-                        exc_info=err,
-                    )
+                    ),
+                    exc_info=err,
                 )
                 return []
         return []

--- a/koku/masu/test/processor/test_report_parquet_processor_base.py
+++ b/koku/masu/test/processor/test_report_parquet_processor_base.py
@@ -178,8 +178,10 @@ class ReportParquetProcessorBaseTest(MasuTestCase):
         warning_logs = [o for o in cm.output if "retrying (attempt" in o]
         self.assertEqual(len(warning_logs), 2)
         self.assertIn(self.schema_name, warning_logs[0])
+        self.assertIn("ALREADY_EXISTS", warning_logs[0])
         error_logs = [o for o in cm.output if "failed after 3 attempts" in o]
         self.assertEqual(len(error_logs), 1)
+        self.assertIn("ALREADY_EXISTS", error_logs[0])
 
     @patch("masu.processor.report_parquet_processor_base.time.sleep")
     @patch("masu.processor.report_parquet_processor_base.get_report_db_accessor")
@@ -212,6 +214,30 @@ class ReportParquetProcessorBaseTest(MasuTestCase):
                 self.assertIn("test", non_retryable_logs[0])
                 mock_sleep.assert_not_called()
 
+    @patch("masu.processor.report_parquet_processor_base.time.sleep")
+    @patch("masu.processor.report_parquet_processor_base.get_report_db_accessor")
+    def test_execute_trino_sql_with_retries_no_retry_on_unknown_trino_error(self, mock_accessor, mock_sleep):
+        """Given a TrinoQueryError with an error_name not in the retryable allowlist,
+        when _execute_trino_sql_with_retries is called,
+        then it logs ERROR with the error_name and returns [] without retrying.
+        """
+        trino_error = TrinoQueryError({"errorName": "SYNTAX_ERROR", "message": "unexpected token"})
+        mock_cursor = MagicMock()
+        mock_cursor.execute.side_effect = trino_error
+        self._mock_trino_accessor(mock_accessor, mock_cursor)
+
+        with self.assertLogs(self.log_base, level="ERROR") as cm:
+            result = self.processor._execute_trino_sql_with_retries(
+                "SELECT 1", self.schema_name, caller="test", max_retries=2
+            )
+        self.assertEqual(result, [])
+        self.assertEqual(mock_cursor.execute.call_count, 1)
+        mock_sleep.assert_not_called()
+        error_logs = [o for o in cm.output if "non-retryable TrinoQueryError" in o]
+        self.assertEqual(len(error_logs), 1)
+        self.assertIn("SYNTAX_ERROR", error_logs[0])
+        self.assertIn(self.schema_name, error_logs[0])
+
     @patch("masu.processor.report_parquet_processor_base.random.uniform", return_value=0.5)
     @patch("masu.processor.report_parquet_processor_base.time.sleep")
     @patch("masu.processor.report_parquet_processor_base.get_report_db_accessor")
@@ -239,6 +265,7 @@ class ReportParquetProcessorBaseTest(MasuTestCase):
         warning_logs = [o for o in cm.output if "retrying (attempt 1)" in o]
         self.assertEqual(len(warning_logs), 1)
         self.assertIn(self.schema_name, warning_logs[0])
+        self.assertIn("ALREADY_EXISTS", warning_logs[0])
 
     @patch.object(ReportParquetProcessorBase, "_execute_trino_sql")
     def test_schema_exists_cache_value_in_cache(self, trino_mock):

--- a/koku/masu/test/processor/test_report_parquet_processor_base.py
+++ b/koku/masu/test/processor/test_report_parquet_processor_base.py
@@ -174,15 +174,16 @@ class ReportParquetProcessorBaseTest(MasuTestCase):
         self.assertEqual(result, [])
         self.assertEqual(mock_cursor.execute.call_count, 3)
         # Backoff is 2**attempt + 0.5: attempt 0 -> 1.5, attempt 1 -> 2.5
-        mock_sleep.assert_has_calls([call(1.5), call(2.5)])
+        self.assertEqual(mock_sleep.call_args_list, [call(1.5), call(2.5)])
         warning_logs = [o for o in cm.output if "retrying (attempt" in o]
         self.assertEqual(len(warning_logs), 2)
         self.assertIn(self.schema_name, warning_logs[0])
         error_logs = [o for o in cm.output if "failed after 3 attempts" in o]
         self.assertEqual(len(error_logs), 1)
 
+    @patch("masu.processor.report_parquet_processor_base.time.sleep")
     @patch("masu.processor.report_parquet_processor_base.get_report_db_accessor")
-    def test_execute_trino_sql_with_retries_no_retry_on_non_retryable_errors(self, mock_accessor):
+    def test_execute_trino_sql_with_retries_no_retry_on_non_retryable_errors(self, mock_accessor, mock_sleep):
         """Given a non-retryable error (ProgrammingError or Django Error),
         when _execute_trino_sql_with_retries is called,
         then it logs the error and returns [] without retrying.
@@ -194,6 +195,7 @@ class ReportParquetProcessorBaseTest(MasuTestCase):
         for case in cases:
             with self.subTest(error=type(case["error"]).__name__):
                 mock_accessor.reset_mock()
+                mock_sleep.reset_mock()
                 mock_cursor = MagicMock()
                 mock_cursor.execute.side_effect = case["error"]
                 self._mock_trino_accessor(mock_accessor, mock_cursor)
@@ -208,6 +210,7 @@ class ReportParquetProcessorBaseTest(MasuTestCase):
                 self.assertEqual(len(non_retryable_logs), 1)
                 self.assertIn(self.schema_name, non_retryable_logs[0])
                 self.assertIn("test", non_retryable_logs[0])
+                mock_sleep.assert_not_called()
 
     @patch("masu.processor.report_parquet_processor_base.random.uniform", return_value=0.5)
     @patch("masu.processor.report_parquet_processor_base.time.sleep")

--- a/koku/masu/test/processor/test_report_parquet_processor_base.py
+++ b/koku/masu/test/processor/test_report_parquet_processor_base.py
@@ -147,8 +147,8 @@ class ReportParquetProcessorBaseTest(MasuTestCase):
     def _mock_trino_accessor(self, mock_accessor, mock_cursor):
         """Configure mock_accessor to return mock_cursor through the connection context managers."""
         mock_conn = MagicMock()
-        mock_conn.cursor.return_value = mock_cursor
-        mock_accessor.return_value.connect.return_value = mock_conn
+        mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+        mock_accessor.return_value.connect.return_value.__enter__.return_value = mock_conn
 
     @patch("masu.processor.report_parquet_processor_base.random.uniform", return_value=0.5)
     @patch("masu.processor.report_parquet_processor_base.time.sleep")

--- a/koku/masu/test/processor/test_report_parquet_processor_base.py
+++ b/koku/masu/test/processor/test_report_parquet_processor_base.py
@@ -7,8 +7,8 @@ import shutil
 import tempfile
 import uuid
 from datetime import date
-from unittest.mock import MagicMock
 from unittest.mock import call
+from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import pandas as pd
@@ -129,9 +129,7 @@ class ReportParquetProcessorBaseTest(MasuTestCase):
             for expected_log in expected_logs:
                 self.assertIn(expected_log, logger.output)
 
-    @patch(
-        "masu.processor.report_parquet_processor_base.ReportParquetProcessorBase._execute_trino_sql_with_retries"
-    )
+    @patch("masu.processor.report_parquet_processor_base.ReportParquetProcessorBase._execute_trino_sql_with_retries")
     def test_sync_hive_partitions(self, mock_execute):
         """Given a processor with a valid schema and table,
         when sync_hive_partitions is called,
@@ -143,9 +141,7 @@ class ReportParquetProcessorBaseTest(MasuTestCase):
         with self.assertLogs(self.log_base, level="INFO") as logger:
             self.processor.sync_hive_partitions()
             self.assertIn(expected_log, logger.output)
-        expected_sql = (
-            f"CALL system.sync_partition_metadata('{self.schema_name}', '{self.table_name}', 'FULL')"
-        )
+        expected_sql = f"CALL system.sync_partition_metadata('{self.schema_name}', '{self.table_name}', 'FULL')"
         mock_execute.assert_called_once_with(expected_sql, self.schema_name, caller="sync_hive_partitions")
 
     def _mock_trino_accessor(self, mock_accessor, mock_cursor):
@@ -165,7 +161,9 @@ class ReportParquetProcessorBaseTest(MasuTestCase):
         then it retries 2 times (3 total attempts), sleeps between each, and returns [].
         """
         mock_cursor = MagicMock()
-        trino_error = TrinoQueryError({"errorName": "ALREADY_EXISTS", "message": "One or more Partitions Already exist"})
+        trino_error = TrinoQueryError(
+            {"errorName": "ALREADY_EXISTS", "message": "One or more Partitions Already exist"}
+        )
         mock_cursor.execute.side_effect = trino_error
         self._mock_trino_accessor(mock_accessor, mock_cursor)
 
@@ -219,7 +217,9 @@ class ReportParquetProcessorBaseTest(MasuTestCase):
         when _execute_trino_sql_with_retries is called,
         then it retries once, sleeps once, and returns the rows from the successful attempt.
         """
-        trino_error = TrinoQueryError({"errorName": "ALREADY_EXISTS", "message": "One or more Partitions Already exist"})
+        trino_error = TrinoQueryError(
+            {"errorName": "ALREADY_EXISTS", "message": "One or more Partitions Already exist"}
+        )
         mock_cursor = MagicMock()
         mock_cursor.execute.side_effect = [trino_error, None]
         mock_cursor.fetchall.return_value = [("ok",)]

--- a/koku/masu/test/processor/test_report_parquet_processor_base.py
+++ b/koku/masu/test/processor/test_report_parquet_processor_base.py
@@ -7,11 +7,16 @@ import shutil
 import tempfile
 import uuid
 from datetime import date
+from unittest.mock import MagicMock
+from unittest.mock import call
 from unittest.mock import patch
 
 import pandas as pd
 from django.conf import settings
+from django.db import Error
+from django.db import ProgrammingError
 from django.test.utils import override_settings
+from trino.exceptions import TrinoQueryError
 
 from api.common import log_json
 from koku.cache import build_trino_schema_exists_key
@@ -124,15 +129,113 @@ class ReportParquetProcessorBaseTest(MasuTestCase):
             for expected_log in expected_logs:
                 self.assertIn(expected_log, logger.output)
 
-    @patch("masu.processor.report_parquet_processor_base.ReportParquetProcessorBase._execute_trino_sql")
+    @patch(
+        "masu.processor.report_parquet_processor_base.ReportParquetProcessorBase._execute_trino_sql_with_retries"
+    )
     def test_sync_hive_partitions(self, mock_execute):
-        """Test that hive partitions are synced."""
+        """Given a processor with a valid schema and table,
+        when sync_hive_partitions is called,
+        then it logs the sync attempt and delegates to _execute_trino_sql_with_retries.
+        """
         expected_log = self.log_output_info + str(
             log_json(msg="syncing trino/hive partitions", schema=self.schema_name, table=self.table_name)
         )
         with self.assertLogs(self.log_base, level="INFO") as logger:
             self.processor.sync_hive_partitions()
             self.assertIn(expected_log, logger.output)
+        expected_sql = (
+            f"CALL system.sync_partition_metadata('{self.schema_name}', '{self.table_name}', 'FULL')"
+        )
+        mock_execute.assert_called_once_with(expected_sql, self.schema_name, caller="sync_hive_partitions")
+
+    def _mock_trino_accessor(self, mock_accessor, mock_cursor):
+        """Configure mock_accessor to return mock_cursor through the connection context managers."""
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+        mock_accessor.return_value.connect.return_value = mock_conn
+
+    @patch("masu.processor.report_parquet_processor_base.random.uniform", return_value=0.5)
+    @patch("masu.processor.report_parquet_processor_base.time.sleep")
+    @patch("masu.processor.report_parquet_processor_base.get_report_db_accessor")
+    def test_execute_trino_sql_with_retries_retries_on_trino_query_error(
+        self, mock_accessor, mock_sleep, mock_uniform
+    ):
+        """Given a TrinoQueryError on every attempt,
+        when _execute_trino_sql_with_retries is called with max_retries=2,
+        then it retries 2 times (3 total attempts), sleeps between each, and returns [].
+        """
+        mock_cursor = MagicMock()
+        trino_error = TrinoQueryError({"errorName": "ALREADY_EXISTS", "message": "One or more Partitions Already exist"})
+        mock_cursor.execute.side_effect = trino_error
+        self._mock_trino_accessor(mock_accessor, mock_cursor)
+
+        with self.assertLogs(self.log_base, level="WARNING") as cm:
+            result = self.processor._execute_trino_sql_with_retries(
+                "SELECT 1", self.schema_name, caller="test", max_retries=2
+            )
+        self.assertEqual(result, [])
+        self.assertEqual(mock_cursor.execute.call_count, 3)
+        # Backoff is 2**attempt + 0.5: attempt 0 -> 1.5, attempt 1 -> 2.5
+        mock_sleep.assert_has_calls([call(1.5), call(2.5)])
+        warning_logs = [o for o in cm.output if "retrying (attempt" in o]
+        self.assertEqual(len(warning_logs), 2)
+        self.assertIn(self.schema_name, warning_logs[0])
+        error_logs = [o for o in cm.output if "failed after 3 attempts" in o]
+        self.assertEqual(len(error_logs), 1)
+
+    @patch("masu.processor.report_parquet_processor_base.get_report_db_accessor")
+    def test_execute_trino_sql_with_retries_no_retry_on_non_retryable_errors(self, mock_accessor):
+        """Given a non-retryable error (ProgrammingError or Django Error),
+        when _execute_trino_sql_with_retries is called,
+        then it logs the error and returns [] without retrying.
+        """
+        cases = [
+            {"error": ProgrammingError("bad sql"), "log_level": "WARNING"},
+            {"error": Error("django error"), "log_level": "ERROR"},
+        ]
+        for case in cases:
+            with self.subTest(error=type(case["error"]).__name__):
+                mock_accessor.reset_mock()
+                mock_cursor = MagicMock()
+                mock_cursor.execute.side_effect = case["error"]
+                self._mock_trino_accessor(mock_accessor, mock_cursor)
+
+                with self.assertLogs(self.log_base, level=case["log_level"]) as cm:
+                    result = self.processor._execute_trino_sql_with_retries(
+                        "SELECT 1", self.schema_name, caller="test", max_retries=2
+                    )
+                self.assertEqual(result, [])
+                self.assertEqual(mock_cursor.execute.call_count, 1)
+                non_retryable_logs = [o for o in cm.output if "non-retryable error" in o]
+                self.assertEqual(len(non_retryable_logs), 1)
+                self.assertIn(self.schema_name, non_retryable_logs[0])
+                self.assertIn("test", non_retryable_logs[0])
+
+    @patch("masu.processor.report_parquet_processor_base.random.uniform", return_value=0.5)
+    @patch("masu.processor.report_parquet_processor_base.time.sleep")
+    @patch("masu.processor.report_parquet_processor_base.get_report_db_accessor")
+    def test_execute_trino_sql_with_retries_succeeds_after_retry(self, mock_accessor, mock_sleep, mock_uniform):
+        """Given a TrinoQueryError on the first attempt and success on the second,
+        when _execute_trino_sql_with_retries is called,
+        then it retries once, sleeps once, and returns the rows from the successful attempt.
+        """
+        trino_error = TrinoQueryError({"errorName": "ALREADY_EXISTS", "message": "One or more Partitions Already exist"})
+        mock_cursor = MagicMock()
+        mock_cursor.execute.side_effect = [trino_error, None]
+        mock_cursor.fetchall.return_value = [("ok",)]
+        self._mock_trino_accessor(mock_accessor, mock_cursor)
+
+        with self.assertLogs(self.log_base, level="WARNING") as cm:
+            result = self.processor._execute_trino_sql_with_retries(
+                "SELECT 1", self.schema_name, caller="test", max_retries=2
+            )
+        self.assertEqual(result, [("ok",)])
+        self.assertEqual(mock_cursor.execute.call_count, 2)
+        # Backoff is 2**0 + 0.5 -> 1.5
+        mock_sleep.assert_called_once_with(1.5)
+        warning_logs = [o for o in cm.output if "retrying (attempt 1)" in o]
+        self.assertEqual(len(warning_logs), 1)
+        self.assertIn(self.schema_name, warning_logs[0])
 
     @patch.object(ReportParquetProcessorBase, "_execute_trino_sql")
     def test_schema_exists_cache_value_in_cache(self, trino_mock):


### PR DESCRIPTION
## Jira Ticket

[COST-8031](https://issues.redhat.com/browse/COST-8031)

## Description
Co-Authored-By: Claude <noreply@anthropic.com>

Cost data is intermittently missing for some sources and billing months during testing. Investigations revealed that while data is successfully written to S3 as Parquet files, it never becomes visible in Trino because Hive partition metadata registration silently fails.

### Root Cause

sync_hive_partitions() relies on _execute_trino_sql(), which silently swallows all Trino exceptions.

The primary failure mode seems to be a race condition: multiple sources within the same schema call sync_partition_metadata('FULL') concurrently. Because 'FULL' drops and re-adds all partition metadata at the table level (rather than per source), concurrent calls collide with an ALREADY_EXISTS error. This race condition became more frequent after the MinIO-to-S4 proxy switch, which increased latency and widened the collision window.


### Proposed Fix

Extracts a new _execute_trino_sql_with_retries() method and switches sync_hive_partitions() to use it. Key behaviours:

- Retries up to 3 times with exponential backoff (~1s, ~2s, ~4s + jitter, capped at 30s), but only for known transient errors: ALREADY_EXISTS, HIVE_METASTORE_ERROR, HIVE_FILESYSTEM_ERROR, JDBC_ERROR. This is consistent with how the rest of the codebase handles Trino transient errors.

- Unknown TrinoQueryErrors (e.g. syntax errors, permission failures) are logged immediately at ERROR level with error_name in the structured log so they surface clearly and can be added to the allowlist if found to be transient.

- All log calls pass exc_info to the LOG call (not inside log_json) so exception tracebacks are correctly captured.

- On final failure, logs an error without raising so the ingest process is not completely blocked.

## Testing

1. Use main branch
2. run full local smokes -> most likely you will get **multiple test failures**
3. check koku logs for "One or more partitions already exist for table" errors
4. checkout to this branch
5. run full local smokes 
6. you should get a **clean pass**
9. check koku logs for "One or more partitions already exist for table" errors -> they should all be part of "sync_hive_partitions retrying" log

## Release Notes
- [COST-8031](https://issues.redhat.com/browse/COST-8031) Add retry logic to sync_hive_partitions to prevent transient errors

```markdown
* [COST-8031](https://issues.redhat.com/browse/COST-8031) Add retry logic to sync_hive_partitions to prevent transient errors
```

## Summary by Sourcery

Enhancements:
- Inline Trino execution in sync_hive_partitions with bounded retries and exponential backoff to handle transient errors without blocking ingest.