### PR TITLE
fix: daily Slack digest still posts when GH cron is late

### DIFF
--- a/.github/scripts/daily_slack_digest.py
+++ b/.github/scripts/daily_slack_digest.py
@@ -22,6 +22,9 @@ FORCE_RUN = os.environ.get("FORCE_RUN", "").lower() in {"1", "true", "yes"}
 
 TIMEZONE = ZoneInfo("Europe/Lisbon")
 POST_HOUR = 7
+# GitHub schedule jobs are often delayed; accept the next Lisbon hour too so a
+# late 06:00 UTC fire (or the 07:00 UTC backup) still posts during DST.
+POST_HOUR_LATE = POST_HOUR + 1
 
 JIRA_PROJECT = "COST"
 # Cost Management Dev Board — counts must use this board, not project-wide status.
@@ -75,7 +78,7 @@ def should_run() -> bool:
     if os.environ.get("GITHUB_EVENT_NAME") == "workflow_dispatch":
         return True
     if os.environ.get("GITHUB_EVENT_NAME") == "schedule":
-        return lisbon_now().hour == POST_HOUR
+        return lisbon_now().hour in {POST_HOUR, POST_HOUR_LATE}
     return True
 
 
@@ -264,7 +267,7 @@ def post_slack(text: str) -> None:
 
 def main() -> None:
     if not should_run():
-        print(f"Skipping: Lisbon hour is {lisbon_now().hour}, want {POST_HOUR}")
+        print(f"Skipping: Lisbon hour is {lisbon_now().hour}, " f"want {POST_HOUR} or {POST_HOUR_LATE}")
         return
 
     missing = [

--- a/.github/scripts/daily_slack_digest.py
+++ b/.github/scripts/daily_slack_digest.py
@@ -10,6 +10,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from datetime import datetime
+from pathlib import Path
 from zoneinfo import ZoneInfo
 
 JIRA_BASE_URL = os.environ.get("JIRA_BASE_URL", "https://redhat.atlassian.net").rstrip("/")
@@ -21,10 +22,12 @@ DRY_RUN = os.environ.get("DRY_RUN", "").lower() in {"1", "true", "yes"}
 FORCE_RUN = os.environ.get("FORCE_RUN", "").lower() in {"1", "true", "yes"}
 
 TIMEZONE = ZoneInfo("Europe/Lisbon")
-POST_HOUR = 7
-# GitHub schedule jobs are often delayed; accept the next Lisbon hour too so a
-# late 06:00 UTC fire (or the 07:00 UTC backup) still posts during DST.
-POST_HOUR_LATE = POST_HOUR + 1
+# GitHub schedule jobs are often delayed; accept 7 and 8 Lisbon so a late
+# 06:00 UTC fire (or the 07:00 UTC backup) still posts during DST.
+# Dedup is via DIGEST_POSTED_MARKER (Actions cache) so both crons cannot
+# double-post on the same Lisbon calendar day.
+ACCEPTED_HOURS = frozenset({7, 8})
+DIGEST_POSTED_MARKER = Path(os.environ.get("DIGEST_POSTED_MARKER", ".digest-posted"))
 
 JIRA_PROJECT = "COST"
 # Cost Management Dev Board — counts must use this board, not project-wide status.
@@ -72,14 +75,22 @@ def lisbon_now() -> datetime:
     return datetime.now(tz=TIMEZONE)
 
 
-def should_run() -> bool:
+def should_run(hour: int) -> bool:
     if FORCE_RUN:
         return True
     if os.environ.get("GITHUB_EVENT_NAME") == "workflow_dispatch":
         return True
     if os.environ.get("GITHUB_EVENT_NAME") == "schedule":
-        return lisbon_now().hour in {POST_HOUR, POST_HOUR_LATE}
+        return hour in ACCEPTED_HOURS
     return True
+
+
+def already_posted_today() -> bool:
+    return DIGEST_POSTED_MARKER.is_file()
+
+
+def mark_posted_today() -> None:
+    DIGEST_POSTED_MARKER.write_text(f"{lisbon_now().isoformat()}\n", encoding="utf-8")
 
 
 def request_json(
@@ -266,8 +277,15 @@ def post_slack(text: str) -> None:
 
 
 def main() -> None:
-    if not should_run():
-        print(f"Skipping: Lisbon hour is {lisbon_now().hour}, " f"want {POST_HOUR} or {POST_HOUR_LATE}")
+    now = lisbon_now()
+    if not should_run(now.hour):
+        accepted = ", ".join(str(h) for h in sorted(ACCEPTED_HOURS))
+        print(f"Skipping: Lisbon hour is {now.hour}, want {accepted}")
+        return
+
+    # Schedule-only: Actions cache restores this marker after a successful post.
+    if os.environ.get("GITHUB_EVENT_NAME") == "schedule" and already_posted_today():
+        print(f"Skipping: digest already posted for {now.date().isoformat()}")
         return
 
     missing = [
@@ -303,6 +321,8 @@ def main() -> None:
 
     print("Posting to Slack…")
     post_slack(message)
+    if os.environ.get("GITHUB_EVENT_NAME") == "schedule":
+        mark_posted_today()
     print("Done.")
 
 

--- a/.github/workflows/daily-slack-digest.yml
+++ b/.github/workflows/daily-slack-digest.yml
@@ -9,6 +9,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: write
   contents: read
   pull-requests: read
 
@@ -16,6 +17,10 @@ jobs:
   digest:
     name: Post digest
     runs-on: ubuntu-latest
+    # Serialize schedule slots so the second cron sees today's cache marker.
+    concurrency:
+      group: daily-slack-digest
+      cancel-in-progress: false
 
     steps:
       - name: Harden Runner
@@ -31,6 +36,18 @@ jobs:
         with:
           python-version: "3.12"
 
+      # One Slack post per Lisbon calendar day across the 06:00 and 07:00 UTC crons.
+      - name: Lisbon date
+        id: lisbon
+        run: echo "date=$(TZ=Europe/Lisbon date +%F)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore today's post marker
+        if: github.event_name == 'schedule'
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .digest-posted
+          key: daily-slack-digest-${{ steps.lisbon.outputs.date }}
+
       - name: Post daily digest
         env:
           JIRA_BASE_URL: https://redhat.atlassian.net
@@ -40,5 +57,6 @@ jobs:
           DIGEST_JIRA_ACCOUNT_IDS: ${{ secrets.DIGEST_JIRA_ACCOUNT_IDS }}
           DIGEST_GITHUB_LOGINS: ${{ secrets.DIGEST_GITHUB_LOGINS }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DIGEST_POSTED_MARKER: .digest-posted
           FORCE_RUN: ${{ github.event_name == 'workflow_dispatch' && '1' || '' }}
         run: python3 .github/scripts/daily_slack_digest.py

--- a/.github/workflows/daily-slack-digest.yml
+++ b/.github/workflows/daily-slack-digest.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     # Weekdays only. GitHub cron is UTC-only, so fire at 06:00 and 07:00 UTC
     # to cover Lisbon 07:00 in both WEST (UTC+0) and WEST DST (UTC+1).
-    # The script posts only when Europe/Lisbon local hour is 7 (one Slack message).
+    # The script posts when Europe/Lisbon local hour is 7 or 8 (GH delays).
     - cron: "0 6,7 * * 1-5"
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary
- Today's scheduled run succeeded but skipped posting: `Lisbon hour is 8, want 7` (07:02 UTC = 08:00 Lisbon in DST; the 06:00 UTC slot that should hit hour 7 did not fire).
- Accept Lisbon hours **7 and 8** on schedule events so delayed GitHub Actions crons still post during DST.

## Test plan
- [x] Triggered manual `workflow_dispatch` on `main` for today's digest (independent of this PR)
- [ ] After merge, confirm next weekday schedule posts (or skips only outside 7–8 Lisbon)


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Bug Fixes:
- Ensure the daily Slack digest still posts when the scheduled GitHub Actions cron job is delayed into the next Lisbon hour.