### PR TITLE
[COST-8000] Add an unleash flag to disable delay

### DIFF
--- a/docs/architecture/celery-tasks.md
+++ b/docs/architecture/celery-tasks.md
@@ -836,6 +836,15 @@ instead of immediately enqueueing `update_cost_model_costs` on the PriorityQueue
   delayed row is deleted immediately so `pre_delete` fires the real task promptly.
   Uses `fallback_development_true` so local/CI skip the stall when Unleash is
   unavailable. Unit tests that assert delayed rows persist must mock the flag OFF.
+- **Which `is_celery_task_delay_disabled` to mock**: both `delayed_summarize_current_month`
+  and `delayed_update_cost_model_costs` live in
+  [`masu/processor/tasks.py`](../../koku/masu/processor/tasks.py) and import the
+  checker from `masu.processor`. Always patch the **import site**, regardless of
+  which higher-level caller triggers it (e.g. tag-mapping's
+  `resummarize_current_month_by_tag_keys` or the cost-model API):
+  `@patch("masu.processor.tasks.is_celery_task_delay_disabled", return_value=False)`.
+  Patching `masu.processor.is_celery_task_delay_disabled` (the definition site) has
+  no effect on the caller's already-bound reference.
 
 Pipeline (`update_summary_tables` / OCP-on-cloud) still enqueues immediately.
 The Masu `update_cost_model_costs` API defaults to immediate enqueue; pass

--- a/docs/architecture/celery-tasks.md
+++ b/docs/architecture/celery-tasks.md
@@ -831,8 +831,10 @@ instead of immediately enqueueing `update_cost_model_costs` on the PriorityQueue
   (`DateHelper.list_month_tuples`)
 - **Latency**: after the last edit, wait is approximately `DELAYED_TASK_TIME`
   (default 3600s) plus up to one Beat poll interval (`DELAYED_TASK_POLLING_MINUTES`)
-- **QE**: when `schema_name == settings.QE_SCHEMA`, the delayed row is deleted
-  immediately so `pre_delete` fires the real task promptly
+- **QE / bypass**: when `schema_name == settings.QE_SCHEMA`, the schema matches
+  `SCHEMA_SUFFIX`, or Unleash flag
+  `cost-management.backend.disable-celery-task-delay` is ON for the schema, the
+  delayed row is deleted immediately so `pre_delete` fires the real task promptly
 
 Pipeline (`update_summary_tables` / OCP-on-cloud) still enqueues immediately.
 The Masu `update_cost_model_costs` API defaults to immediate enqueue; pass

--- a/docs/architecture/celery-tasks.md
+++ b/docs/architecture/celery-tasks.md
@@ -833,7 +833,9 @@ instead of immediately enqueueing `update_cost_model_costs` on the PriorityQueue
   (default 3600s) plus up to one Beat poll interval (`DELAYED_TASK_POLLING_MINUTES`)
 - **Bypass**: when Unleash flag
   `cost-management.backend.disable-celery-task-delay` is ON for the schema, the
-  delayed row is deleted immediately so `pre_delete` fires the real task promptly
+  delayed row is deleted immediately so `pre_delete` fires the real task promptly.
+  Uses `fallback_development_true` so local/CI skip the stall when Unleash is
+  unavailable. Unit tests that assert delayed rows persist must mock the flag OFF.
 
 Pipeline (`update_summary_tables` / OCP-on-cloud) still enqueues immediately.
 The Masu `update_cost_model_costs` API defaults to immediate enqueue; pass

--- a/docs/architecture/celery-tasks.md
+++ b/docs/architecture/celery-tasks.md
@@ -831,8 +831,7 @@ instead of immediately enqueueing `update_cost_model_costs` on the PriorityQueue
   (`DateHelper.list_month_tuples`)
 - **Latency**: after the last edit, wait is approximately `DELAYED_TASK_TIME`
   (default 3600s) plus up to one Beat poll interval (`DELAYED_TASK_POLLING_MINUTES`)
-- **QE / bypass**: when `schema_name == settings.QE_SCHEMA`, the schema matches
-  `SCHEMA_SUFFIX`, or Unleash flag
+- **Bypass**: when Unleash flag
   `cost-management.backend.disable-celery-task-delay` is ON for the schema, the
   delayed row is deleted immediately so `pre_delete` fires the real task promptly
 

--- a/koku/api/settings/test/tags/mappings/test_utils.py
+++ b/koku/api/settings/test/tags/mappings/test_utils.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django_tenants.utils import tenant_context
 
 from api.models import Provider
@@ -20,7 +22,8 @@ class TestTagMappingUtils(MasuTestCase):
             Provider.PROVIDER_OCP: self.ocp_provider.uuid,
         }
 
-    def test_find_tag_key_providers(self):
+    @patch("masu.processor.tasks.is_celery_task_delay_disabled", return_value=False)
+    def test_find_tag_key_providers(self, _mock_delay_disabled):
         with tenant_context(self.tenant):
             for ptype, uuid in self.test_matrix.items():
                 with self.subTest(ptype=ptype, uuid=uuid):
@@ -28,14 +31,16 @@ class TestTagMappingUtils(MasuTestCase):
                     resummarize_current_month_by_tag_keys(uuids, self.schema_name)
                     self.assertTrue(DelayedCeleryTasks.objects.filter(provider_uuid=uuid).exists())
 
-    def test_multiple_returns(self):
+    @patch("masu.processor.tasks.is_celery_task_delay_disabled", return_value=False)
+    def test_multiple_returns(self, _mock_delay_disabled):
         with tenant_context(self.tenant):
             uuids = EnabledTagKeys.objects.all().values_list("uuid", flat=True)
             resummarize_current_month_by_tag_keys(uuids, self.schema_name)
             for uuid in self.test_matrix.values():
                 self.assertTrue(DelayedCeleryTasks.objects.filter(provider_uuid=uuid).exists())
 
-    def test_ocp_on_cloud_resummarize(self):
+    @patch("masu.processor.tasks.is_celery_task_delay_disabled", return_value=False)
+    def test_ocp_on_cloud_resummarize(self, _mock_delay_disabled):
         with tenant_context(self.tenant):
             infra_map = ProviderInfrastructureMap.objects.create(
                 infrastructure_type=Provider.PROVIDER_AWS, infrastructure_provider=self.aws_provider

--- a/koku/api/settings/test/tags/mappings/test_view.py
+++ b/koku/api/settings/test/tags/mappings/test_view.py
@@ -24,6 +24,10 @@ class TestSettingsTagMappingView(MasuTestCase):
         """Set up the tests."""
         super().setUp()
         self.client = APIClient()
+        # Keep delay enabled so resummarize does not send_task against Redis in CI/dev.
+        delay_patcher = patch("masu.processor.tasks.is_celery_task_delay_disabled", return_value=False)
+        delay_patcher.start()
+        self.addCleanup(delay_patcher.stop)
 
         with tenant_context(self.tenant):
             self.enabled_uuid_list = list(EnabledTagKeys.objects.filter(enabled=True).values_list("uuid", flat=True))

--- a/koku/koku/middleware.py
+++ b/koku/koku/middleware.py
@@ -41,6 +41,7 @@ from koku.cache import CacheEnum
 from koku.metrics import DB_CONNECTION_ERRORS_COUNTER
 from koku.rbac import RbacConnectionError
 from koku.rbac import RbacService
+from masu.processor import is_celery_task_delay_disabled
 
 MAX_CACHE_SIZE = 10000
 USER_CACHE = TTLCache(maxsize=MAX_CACHE_SIZE, ttl=settings.MIDDLEWARE_TIME_TO_LIVE)
@@ -53,12 +54,14 @@ UNIQUE_ACCOUNT_COUNTER = Counter("hccm_unique_account", "Unique Account Counter"
 UNIQUE_USER_COUNTER = Counter("hccm_unique_user", "Unique User Counter", ["account", "user"])
 
 
-def is_qe_schema(schema_name: str) -> bool:
+def is_delay_disabled(schema_name: str) -> bool:
     if settings.QE_SCHEMA and schema_name == settings.QE_SCHEMA:
         return True
     # Must guard: "".endswith("") is True in Python
     suffix = settings.SCHEMA_SUFFIX
-    return bool(suffix) and schema_name.endswith(suffix)
+    if bool(suffix) and schema_name.endswith(suffix):
+        return True
+    return is_celery_task_delay_disabled(schema_name)
 
 
 def is_no_auth(request):

--- a/koku/koku/middleware.py
+++ b/koku/koku/middleware.py
@@ -41,7 +41,6 @@ from koku.cache import CacheEnum
 from koku.metrics import DB_CONNECTION_ERRORS_COUNTER
 from koku.rbac import RbacConnectionError
 from koku.rbac import RbacService
-from masu.processor import is_celery_task_delay_disabled
 
 MAX_CACHE_SIZE = 10000
 USER_CACHE = TTLCache(maxsize=MAX_CACHE_SIZE, ttl=settings.MIDDLEWARE_TIME_TO_LIVE)
@@ -52,16 +51,6 @@ MASU = settings.MASU
 SOURCES = settings.SOURCES
 UNIQUE_ACCOUNT_COUNTER = Counter("hccm_unique_account", "Unique Account Counter")
 UNIQUE_USER_COUNTER = Counter("hccm_unique_user", "Unique User Counter", ["account", "user"])
-
-
-def is_delay_disabled(schema_name: str) -> bool:
-    if settings.QE_SCHEMA and schema_name == settings.QE_SCHEMA:
-        return True
-    # Must guard: "".endswith("") is True in Python
-    suffix = settings.SCHEMA_SUFFIX
-    if bool(suffix) and schema_name.endswith(suffix):
-        return True
-    return is_celery_task_delay_disabled(schema_name)
 
 
 def is_no_auth(request):

--- a/koku/koku/test_middleware.py
+++ b/koku/koku/test_middleware.py
@@ -680,3 +680,30 @@ class SentryBeforeSendTest(IamTestCase):
         hint = {}
         result = sentry_before_send(event, hint)
         self.assertEqual(result, event)
+
+
+class IsDelayDisabledTest(IamTestCase):
+    """Test is_delay_disabled bypass conditions."""
+
+    @override_settings(QE_SCHEMA="org_qe", SCHEMA_SUFFIX="")
+    @patch("koku.middleware.is_celery_task_delay_disabled", return_value=False)
+    def test_qe_schema_disables_delay(self, _mock_flag):
+        self.assertTrue(MD.is_delay_disabled("org_qe"))
+        self.assertFalse(MD.is_delay_disabled("org1234567"))
+
+    @override_settings(QE_SCHEMA=None, SCHEMA_SUFFIX="_dev")
+    @patch("koku.middleware.is_celery_task_delay_disabled", return_value=False)
+    def test_schema_suffix_disables_delay(self, _mock_flag):
+        self.assertTrue(MD.is_delay_disabled("org1234567_dev"))
+        self.assertFalse(MD.is_delay_disabled("org1234567"))
+
+    @override_settings(QE_SCHEMA=None, SCHEMA_SUFFIX="")
+    @patch("koku.middleware.is_celery_task_delay_disabled", return_value=True)
+    def test_unleash_flag_disables_delay(self, mock_flag):
+        self.assertTrue(MD.is_delay_disabled("org1234567"))
+        mock_flag.assert_called_once_with("org1234567")
+
+    @override_settings(QE_SCHEMA=None, SCHEMA_SUFFIX="")
+    @patch("koku.middleware.is_celery_task_delay_disabled", return_value=False)
+    def test_delay_enabled_by_default(self, _mock_flag):
+        self.assertFalse(MD.is_delay_disabled("org1234567"))

--- a/koku/koku/test_middleware.py
+++ b/koku/koku/test_middleware.py
@@ -680,30 +680,3 @@ class SentryBeforeSendTest(IamTestCase):
         hint = {}
         result = sentry_before_send(event, hint)
         self.assertEqual(result, event)
-
-
-class IsDelayDisabledTest(IamTestCase):
-    """Test is_delay_disabled bypass conditions."""
-
-    @override_settings(QE_SCHEMA="org_qe", SCHEMA_SUFFIX="")
-    @patch("koku.middleware.is_celery_task_delay_disabled", return_value=False)
-    def test_qe_schema_disables_delay(self, _mock_flag):
-        self.assertTrue(MD.is_delay_disabled("org_qe"))
-        self.assertFalse(MD.is_delay_disabled("org1234567"))
-
-    @override_settings(QE_SCHEMA=None, SCHEMA_SUFFIX="_dev")
-    @patch("koku.middleware.is_celery_task_delay_disabled", return_value=False)
-    def test_schema_suffix_disables_delay(self, _mock_flag):
-        self.assertTrue(MD.is_delay_disabled("org1234567_dev"))
-        self.assertFalse(MD.is_delay_disabled("org1234567"))
-
-    @override_settings(QE_SCHEMA=None, SCHEMA_SUFFIX="")
-    @patch("koku.middleware.is_celery_task_delay_disabled", return_value=True)
-    def test_unleash_flag_disables_delay(self, mock_flag):
-        self.assertTrue(MD.is_delay_disabled("org1234567"))
-        mock_flag.assert_called_once_with("org1234567")
-
-    @override_settings(QE_SCHEMA=None, SCHEMA_SUFFIX="")
-    @patch("koku.middleware.is_celery_task_delay_disabled", return_value=False)
-    def test_delay_enabled_by_default(self, _mock_flag):
-        self.assertFalse(MD.is_delay_disabled("org1234567"))

--- a/koku/masu/processor/__init__.py
+++ b/koku/masu/processor/__init__.py
@@ -110,9 +110,9 @@ def is_customer_penalty(schema):  # pragma: no cover
 
 
 def is_celery_task_delay_disabled(schema):  # pragma: no cover
-    """Disable DelayedCeleryTasks wait so the task fires immediately (like QE_SCHEMA)."""
+    """Disable DelayedCeleryTasks wait so the task fires immediately."""
     context = {"schema": schema}
-    return UNLEASH_CLIENT.is_enabled(DISABLE_CELERY_TASK_DELAY_FLAG, context)
+    return UNLEASH_CLIENT.is_enabled(DISABLE_CELERY_TASK_DELAY_FLAG, context, fallback_development_true)
 
 
 def is_rate_limit_customer_large(schema):  # pragma: no cover

--- a/koku/masu/processor/__init__.py
+++ b/koku/masu/processor/__init__.py
@@ -28,6 +28,7 @@ COST_BREAKDOWN_RTU_UNLEASH_FLAG = "cost-management.backend.cost_breakdown_rates_
 CROSS_ORG_CLUSTER_LOOKUP_FLAG = "cost-management.backend.is_cross_org_cluster_lookup_enabled"
 OCP_POST_WRITE_PARQUET_DEDUP_FLAG = "cost-management.backend.ocp_post_write_parquet_dedup"
 CONSTANT_CURRENCY_FLAG = "cost-management.backend.constant-currency"
+DISABLE_CELERY_TASK_DELAY_FLAG = "cost-management.backend.disable-celery-task-delay"
 
 
 def is_feature_flag_enabled_by_schema(schema, feature_flag, dev_fallback=False):  # pragma: no cover
@@ -106,6 +107,12 @@ def is_customer_penalty(schema):  # pragma: no cover
     """Flag the customer as penalised."""
     context = {"schema": schema}
     return UNLEASH_CLIENT.is_enabled("cost-management.backend.penalty-customer", context)
+
+
+def is_celery_task_delay_disabled(schema):  # pragma: no cover
+    """Disable DelayedCeleryTasks wait so the task fires immediately (like QE_SCHEMA)."""
+    context = {"schema": schema}
+    return UNLEASH_CLIENT.is_enabled(DISABLE_CELERY_TASK_DELAY_FLAG, context)
 
 
 def is_rate_limit_customer_large(schema):  # pragma: no cover

--- a/koku/masu/processor/tasks.py
+++ b/koku/masu/processor/tasks.py
@@ -34,7 +34,7 @@ from common.queues import PriorityQueue
 from common.queues import RefreshQueue
 from common.queues import SummaryQueue
 from koku import celery_app
-from koku.middleware import is_qe_schema
+from koku.middleware import is_delay_disabled
 from koku.middleware import KokuTenantMiddleware
 from koku.trino_database import TrinoQueryNotFoundError
 from masu.database.report_manifest_db_accessor import ReportManifestDBAccessor
@@ -221,7 +221,7 @@ def delayed_summarize_current_month(schema_name: str, provider_uuids: list, prov
             provider_uuid=provider_uuid,
             queue_name=queue,
         )
-        if is_qe_schema(schema_name):
+        if is_delay_disabled(schema_name):
             # bypass the wait for QE
             id.delete()
 
@@ -276,7 +276,7 @@ def delayed_update_cost_model_costs(schema_name, provider_uuid, start_date, end_
             billing_month=billing_month,
             merge_date_range=True,
         )
-        if is_qe_schema(schema_name):
+        if is_delay_disabled(schema_name):
             row.delete()
 
 

--- a/koku/masu/processor/tasks.py
+++ b/koku/masu/processor/tasks.py
@@ -34,7 +34,6 @@ from common.queues import PriorityQueue
 from common.queues import RefreshQueue
 from common.queues import SummaryQueue
 from koku import celery_app
-from koku.middleware import is_delay_disabled
 from koku.middleware import KokuTenantMiddleware
 from koku.trino_database import TrinoQueryNotFoundError
 from masu.database.report_manifest_db_accessor import ReportManifestDBAccessor
@@ -42,6 +41,7 @@ from masu.exceptions import MasuProcessingError
 from masu.exceptions import MasuProviderError
 from masu.external.downloader.report_downloader_base import ReportDownloaderWarning
 from masu.external.report_downloader import ReportDownloaderError
+from masu.processor import is_celery_task_delay_disabled
 from masu.processor import is_cost_model_processing_disabled
 from masu.processor import is_ocp_on_cloud_summary_disabled
 from masu.processor import is_rate_limit_customer_large
@@ -221,8 +221,7 @@ def delayed_summarize_current_month(schema_name: str, provider_uuids: list, prov
             provider_uuid=provider_uuid,
             queue_name=queue,
         )
-        if is_delay_disabled(schema_name):
-            # bypass the wait for QE
+        if is_celery_task_delay_disabled(schema_name):
             id.delete()
 
 
@@ -276,7 +275,7 @@ def delayed_update_cost_model_costs(schema_name, provider_uuid, start_date, end_
             billing_month=billing_month,
             merge_date_range=True,
         )
-        if is_delay_disabled(schema_name):
+        if is_celery_task_delay_disabled(schema_name):
             row.delete()
 
 

--- a/koku/reporting_common/test_reporting_common.py
+++ b/koku/reporting_common/test_reporting_common.py
@@ -7,7 +7,6 @@ from datetime import date
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
-from django.test import override_settings
 from django.utils import timezone
 from django_tenants.utils import schema_context
 
@@ -124,8 +123,9 @@ class TestCostUsageReportStatus(MasuTestCase):
         self.assertIsNotNone(stats.failed_status)
         self.assertEqual(stats.status, CombinedChoices.FAILED)
 
+    @patch("masu.processor.tasks.is_celery_task_delay_disabled", return_value=False)
     @patch("masu.processor.tasks.get_customer_queue")
-    def test_delayed_summarize_current_month(self, mock_get_customer_queue):
+    def test_delayed_summarize_current_month(self, mock_get_customer_queue, _mock_delay_disabled):
         mock_get_customer_queue.return_value = SummaryQueue.DEFAULT
         test_matrix = {
             Provider.PROVIDER_AWS: self.aws_provider,
@@ -153,13 +153,32 @@ class TestCostUsageReportStatus(MasuTestCase):
                     self.assertEqual(db_entry.task_args, [self.schema_name])
                     self.assertEqual(db_entry.queue_name, SummaryQueue.DEFAULT)
 
+    @patch("masu.processor.tasks.is_celery_task_delay_disabled", return_value=False)
     @patch("masu.processor.tasks.get_customer_queue")
-    def test_large_customer(self, mock_get_customer_queue):
+    def test_large_customer(self, mock_get_customer_queue, _mock_delay_disabled):
         mock_get_customer_queue.return_value = SummaryQueue.XL
         delayed_summarize_current_month(self.schema_name, [self.aws_provider.uuid], Provider.PROVIDER_AWS)
         with schema_context(self.schema):
             db_entry = DelayedCeleryTasks.objects.get(provider_uuid=self.aws_provider.uuid)
             self.assertEqual(db_entry.queue_name, SummaryQueue.XL)
+
+    @patch("reporting_common.models.celery_app")
+    @patch("masu.processor.tasks.is_celery_task_delay_disabled", return_value=True)
+    @patch("masu.processor.tasks.get_customer_queue")
+    def test_delayed_summarize_bypasses_when_flag_enabled(
+        self, mock_get_customer_queue, _mock_delay_disabled, mock_celery_app
+    ):
+        """When disable-celery-task-delay is ON, the row is deleted and send_task fires."""
+        mock_get_customer_queue.return_value = SummaryQueue.DEFAULT
+        result = MagicMock()
+        result.id = "mocked_result_id"
+        mock_celery_app.send_task.return_value = result
+
+        delayed_summarize_current_month(self.schema_name, [self.aws_provider.uuid], Provider.PROVIDER_AWS)
+
+        with schema_context(self.schema):
+            self.assertFalse(DelayedCeleryTasks.objects.filter(provider_uuid=self.aws_provider.uuid).exists())
+        mock_celery_app.send_task.assert_called_once()
 
     @patch("reporting_common.models.celery_app")
     def test_trigger_celery_task(self, mock_celery_app):
@@ -271,7 +290,8 @@ class TestCostUsageReportStatus(MasuTestCase):
             1,
         )
 
-    def test_delayed_update_cost_model_costs_coalesces_max_range(self):
+    @patch("masu.processor.tasks.is_celery_task_delay_disabled", return_value=False)
+    def test_delayed_update_cost_model_costs_coalesces_max_range(self, _mock_delay_disabled):
         """Same-month edits coalesce to one row with the widest date range."""
         provider_uuid = self.aws_provider.uuid
         delayed_update_cost_model_costs(
@@ -301,7 +321,8 @@ class TestCostUsageReportStatus(MasuTestCase):
         self.assertEqual(row.queue_name, PriorityQueue.XL)
         self.assertEqual(row.task_kwargs.get("tracing_id"), "trace-2")
 
-    def test_delayed_update_cost_model_costs_splits_cross_month(self):
+    @patch("masu.processor.tasks.is_celery_task_delay_disabled", return_value=False)
+    def test_delayed_update_cost_model_costs_splits_cross_month(self, _mock_delay_disabled):
         """Cross-month ranges create one delayed row per calendar month."""
         provider_uuid = self.aws_provider.uuid
         delayed_update_cost_model_costs(
@@ -326,7 +347,8 @@ class TestCostUsageReportStatus(MasuTestCase):
         self.assertEqual(rows[1].task_kwargs.get("start_date"), "2026-08-01")
         self.assertEqual(rows[1].task_kwargs.get("end_date"), "2026-08-05")
 
-    def test_delayed_update_cost_model_costs_invalid_date_range(self):
+    @patch("masu.processor.tasks.is_celery_task_delay_disabled", return_value=False)
+    def test_delayed_update_cost_model_costs_invalid_date_range(self, _mock_delay_disabled):
         """Inverted start/end creates no delayed rows."""
         provider_uuid = self.aws_provider.uuid
         delayed_update_cost_model_costs(
@@ -345,7 +367,8 @@ class TestCostUsageReportStatus(MasuTestCase):
             0,
         )
 
-    def test_delayed_update_cost_model_costs_independent_months(self):
+    @patch("masu.processor.tasks.is_celery_task_delay_disabled", return_value=False)
+    def test_delayed_update_cost_model_costs_independent_months(self, _mock_delay_disabled):
         """A new month slice does not change an existing prior-month delayed row."""
         provider_uuid = self.aws_provider.uuid
         delayed_update_cost_model_costs(
@@ -378,16 +401,16 @@ class TestCostUsageReportStatus(MasuTestCase):
         )
 
     @patch("reporting_common.models.celery_app")
-    @override_settings(QE_SCHEMA="org1234567")
-    def test_delayed_update_cost_model_costs_qe_bypass(self, mock_celery_app):
-        """QE schema deletes the delayed row immediately, firing the real task."""
+    @patch("masu.processor.tasks.is_celery_task_delay_disabled", return_value=True)
+    def test_delayed_update_cost_model_costs_delay_bypass(self, _mock_delay_disabled, mock_celery_app):
+        """When disable-celery-task-delay is ON, the row is deleted and send_task fires."""
         result = MagicMock()
         result.id = "qe_result_id"
         mock_celery_app.send_task.return_value = result
 
         provider_uuid = self.aws_provider.uuid
         delayed_update_cost_model_costs(
-            "org1234567",
+            self.schema_name,
             provider_uuid,
             date(2026, 7, 1),
             date(2026, 7, 15),
@@ -404,7 +427,7 @@ class TestCostUsageReportStatus(MasuTestCase):
         mock_celery_app.send_task.assert_called_once()
         args, kwargs = mock_celery_app.send_task.call_args
         self.assertEqual(args[0], UPDATE_COST_MODEL_COSTS_TASK)
-        self.assertEqual(kwargs["args"], ["org1234567", str(provider_uuid)])
+        self.assertEqual(kwargs["args"], [self.schema_name, str(provider_uuid)])
         self.assertEqual(kwargs["kwargs"]["start_date"], "2026-07-01")
         self.assertEqual(kwargs["kwargs"]["end_date"], "2026-07-15")
         self.assertEqual(kwargs["queue"], PriorityQueue.DEFAULT)


### PR DESCRIPTION
## Jira Ticket

[COST-####](https://issues.redhat.com/browse/COST-####)

## Description

This change will add an unleash flag to disable the delay. 

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Release Notes
- [ ] proposed release note

```markdown
* [COST-####](https://issues.redhat.com/browse/COST-####) Fix some things
```

## Summary by Sourcery

Introduce a configurable mechanism to bypass delayed Celery tasks based on schema and an Unleash feature flag.

New Features:
- Add an Unleash-driven flag to disable Celery task delay per schema.

Enhancements:
- Extend delay bypass logic to include QE schema, schema suffix, and the new Unleash flag via a unified is_delay_disabled helper.
- Update Celery task documentation to describe all delay bypass conditions.

Tests:
- Add middleware tests covering QE schema, schema suffix, Unleash flag, and default behavior for delay disabling.