### PR TITLE
[COST-7847] Modify manifest purge to have inclusive cutoff

### DIFF
--- a/koku/masu/database/report_manifest_db_accessor.py
+++ b/koku/masu/database/report_manifest_db_accessor.py
@@ -162,19 +162,23 @@ class ReportManifestDBAccessor:
 
     def purge_expired_report_manifest(self, provider_type, expired_date):
         """
-        Deletes Cost usage Report Manifests older than expired_date.
+        Deletes CostUsageReportManifests for billing periods on or before expired_date.
+
+        Inclusive of expired_date so manifest cleanup matches report-period and
+        partition purge (keep last N calendar months).
 
         Args:
             provider_type   (String) the provider type to delete associated manifests
-            expired_date (datetime.datetime) delete all manifests older than this date, exclusive.
+            expired_date (datetime.datetime) delete manifests with billing_period_start
+                on or before this date (inclusive).
         """
         manifests_to_delete = CostUsageReportManifest.objects.filter(
-            provider__type=provider_type, billing_period_start_datetime__lt=expired_date
+            provider__type=provider_type, billing_period_start_datetime__lte=expired_date
         )
         count = manifests_to_delete.count()
         cascade_delete(manifests_to_delete.query.model, manifests_to_delete)
         LOG.info(
-            "Removed %s CostUsageReportManifest(s) for provider type %s that had a billing period start date before %s",
+            "Removed %s CostUsageReportManifest(s) for provider type %s " "with billing period start on or before %s",
             count,
             provider_type,
             expired_date,
@@ -182,19 +186,23 @@ class ReportManifestDBAccessor:
 
     def purge_expired_report_manifest_provider_uuid(self, provider_uuid, expired_date):
         """
-        Delete cost usage reports older than expired_date and provider_uuid.
+        Delete CostUsageReportManifests for a provider with billing periods on or before expired_date.
+
+        Inclusive of expired_date so manifest cleanup matches report-period and
+        partition purge (keep last N calendar months).
 
         Args:
             provider_uuid (uuid) The provider uuid to use to delete associated manifests
-            expired_date (datetime.datetime) delete all manifests older than this date, exclusive.
+            expired_date (datetime.datetime) delete manifests with billing_period_start
+                on or before this date (inclusive).
         """
         manifests_to_delete = CostUsageReportManifest.objects.filter(
-            provider_id=provider_uuid, billing_period_start_datetime__lt=expired_date
+            provider_id=provider_uuid, billing_period_start_datetime__lte=expired_date
         )
         count = manifests_to_delete.count()
         cascade_delete(manifests_to_delete.query.model, manifests_to_delete)
         LOG.info(
-            "Removed %s CostUsageReportManifest(s) for provider_uuid %s that had a billing period start date before %s",
+            "Removed %s CostUsageReportManifest(s) for provider_uuid %s " "with billing period start on or before %s",
             count,
             provider_uuid,
             expired_date,

--- a/koku/masu/test/processor/test_expired_data_remover.py
+++ b/koku/masu/test/processor/test_expired_data_remover.py
@@ -145,8 +145,8 @@ class ExpiredDataRemoverTest(MasuTestCase):
         Test that expired CostUsageReportManifests are removed.
 
         This test inserts CostUsageReportManifest objects,
-        And then deletes CostUsageReportManifest objects older than
-        the calculated expiration_date.
+        And then deletes CostUsageReportManifest objects with billing periods
+        on or before the calculated expiration_date (inclusive).
         """
 
         provider_type_dict = {
@@ -173,7 +173,7 @@ class ExpiredDataRemoverTest(MasuTestCase):
                     "provider_id": provider_type_dict[provider_type],
                 }
                 uuids.append(uuid)
-                if date == day_before_cutoff:
+                if date in (day_before_cutoff, expiration_date):
                     uuids_to_be_deleted.append(uuid)
                 manifest_entry = CostUsageReportManifest(**data)
                 manifest_entry.save()
@@ -225,16 +225,16 @@ class ExpiredDataRemoverTest(MasuTestCase):
         Test that calling remove(provider_uuid) deletes CostUsageReportManifests.
 
         CostUsageReportManifests that are associated with the provider_uuid
-        should be deleted.
+        should be deleted when their billing period is on or before the cutoff.
         """
         remover = ExpiredDataRemover(self.schema, Provider.PROVIDER_AWS_LOCAL)
         expiration_date = remover._calculate_expiration_date()
         current_month = datetime.today().replace(day=1)
         day_before_cutoff = expiration_date - relativedelta(days=1)
         fixture_records = [
-            (self.aws_provider_uuid, expiration_date),  # not expired, should not delete
-            (self.aws_provider_uuid, day_before_cutoff),  # expired, should delete
-            (self.azure_provider_uuid, day_before_cutoff),  # expired, should not delete
+            (self.aws_provider_uuid, expiration_date),  # at cutoff, should delete
+            (self.aws_provider_uuid, day_before_cutoff),  # before cutoff, should delete
+            (self.azure_provider_uuid, day_before_cutoff),  # other provider, should not delete
         ]
         manifest_uuids = []
         manifest_uuids_to_be_deleted = []
@@ -250,7 +250,7 @@ class ExpiredDataRemoverTest(MasuTestCase):
             }
             CostUsageReportManifest(**data).save()
             manifest_uuids.append(manifest_uuid)
-            if fixture_record[1] == day_before_cutoff and fixture_record[0] == self.aws_provider_uuid:
+            if fixture_record[0] == self.aws_provider_uuid:
                 manifest_uuids_to_be_deleted.append(manifest_uuid)
         remover.remove(provider_uuid=self.aws_provider_uuid)
 


### PR DESCRIPTION
## Jira Ticket

[COST-7847](https://issues.redhat.com/browse/COST-7847)

## Description

This change will modify manifest purge to have inclusive cuttoff.

## Testing

1. Checkout Branch
2. Restart Koku
3. Hit endpoint or launch shell
    1. You should see ...
4. Do more things...

## Release Notes
- [ ] proposed release note

```markdown
* [COST-####](https://issues.redhat.com/browse/COST-####) Fix some things
```

## Summary by Sourcery

Use an inclusive cutoff when purging expired report manifests.

Bug Fixes:
- Make report manifest purging delete manifests whose billing period starts on or before the expiration cutoff.

Enhancements:
- Align manifest cleanup behavior and logging with inclusive report-period and partition purging.

Tests:
- Update expiration-removal tests to verify manifests at the cutoff are deleted while unrelated providers remain unaffected.