### PR TITLE
[COST-8113] Lock sync_rate_table against concurrent RTU writes on rate delete

### DIFF
--- a/koku/cost_models/rate_sync.py
+++ b/koku/cost_models/rate_sync.py
@@ -6,11 +6,17 @@
 import copy
 import logging
 import uuid
+from contextlib import contextmanager
+from contextlib import ExitStack
 from decimal import Decimal
 from decimal import InvalidOperation
 
+from django.db import connection
+
 from api.metrics.constants import COST_MODEL_METRIC_MAP
 from api.metrics.constants import UNLEASH_METRICS_GPU
+from cost_models.models import CostModelMap
+from cost_models.models import PriceListCostModelMap
 from cost_models.models import Rate
 
 LOG = logging.getLogger(__name__)
@@ -172,6 +178,57 @@ def _classify_incoming_rates(rates_data, existing_by_uuid, existing_by_name, all
     return incoming_ids, to_update, to_create_data
 
 
+@contextmanager
+def _provider_distribution_lock(provider_uuid):
+    """Acquire the same session-scoped advisory lock used by the RTU write/delete paths.
+
+    Keyed identically (pg_advisory_lock(hashtext(str(provider_uuid)))) to
+    OCPReportDBAccessor._distribution_provider_lock and Provider's own copy of
+    this primitive, so this serializes against every RTU write step and
+    against Provider.delete() for the same provider, without needing a shared
+    import between the masu, api, and cost_models apps.
+    """
+    lock_key = str(provider_uuid)
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT pg_advisory_lock(hashtext(%s))", [lock_key])
+    try:
+        yield
+    finally:
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT pg_advisory_unlock(hashtext(%s))", [lock_key])
+
+
+@contextmanager
+def _multi_provider_distribution_lock(provider_uuids):
+    """Hold _provider_distribution_lock for every provider_uuid at once, in sorted order.
+
+    Sorting avoids a lock-ordering deadlock if two concurrent callers each try
+    to lock an overlapping set of providers in different orders (e.g. two
+    price lists that are each shared across two overlapping cost models).
+    """
+    with ExitStack() as stack:
+        for provider_uuid in sorted(set(map(str, provider_uuids))):
+            stack.enter_context(_provider_distribution_lock(provider_uuid))
+        yield
+
+
+def _provider_uuids_for_price_list(price_list):
+    """Resolve every provider_uuid reachable from a price list via its cost models.
+
+    A price list can be attached (PriceListCostModelMap) to multiple cost
+    models, each of which can be attached (CostModelMap) to multiple
+    providers. This is the full blast radius of rates_to_usage rows that
+    sync_rate_table's stale-Rate cleanup can cascade-delete for a single
+    price list edit.
+    """
+    cost_model_ids = PriceListCostModelMap.objects.filter(price_list=price_list).values_list(
+        "cost_model_id", flat=True
+    )
+    return list(
+        CostModelMap.objects.filter(cost_model_id__in=list(cost_model_ids)).values_list("provider_uuid", flat=True)
+    )
+
+
 def sync_rate_table(price_list, rates_data):
     """Synchronize Rate table rows with the rates JSON blob using diff-based sync.
 
@@ -182,8 +239,25 @@ def sync_rate_table(price_list, rates_data):
     price_list.rates with the enriched copy.
 
     Returns the enriched rates_data list.
+
+    COST-7249 deadlock preflight, Finding E: the stale-Rate delete below
+    cascades (Rate -> RatesToUsage, on_delete=CASCADE) into rates_to_usage
+    rows for every provider on every cost model attached to this price list --
+    not just one provider's report period. Locking here, at the single shared
+    choke point all five call sites (CostModelManager.create/update,
+    PriceListManager.create/update, PriceListViewSet._ensure_rate_sync) funnel
+    through, guarantees the fix can't be bypassed by a new call site later.
+    Spiked empirically: see
+    masu/test/database/test_cost_model_rate_delete_rtu_race.py.
     """
     LOG.info(f"Syncing {len(rates_data)} rates to Rate table for PriceList {price_list.uuid}")
+    provider_uuids = _provider_uuids_for_price_list(price_list)
+    with _multi_provider_distribution_lock(provider_uuids):
+        return _sync_rate_table_locked(price_list, rates_data)
+
+
+def _sync_rate_table_locked(price_list, rates_data):
+    """Body of sync_rate_table, run while holding _multi_provider_distribution_lock."""
     existing_by_uuid = {r.uuid: r for r in Rate.objects.filter(price_list=price_list)}
     existing_by_name = {r.custom_name: r for r in existing_by_uuid.values()}
     all_existing_names = set(existing_by_name.keys())

--- a/koku/cost_models/rate_sync.py
+++ b/koku/cost_models/rate_sync.py
@@ -12,6 +12,7 @@ from decimal import Decimal
 from decimal import InvalidOperation
 
 from django.db import connection
+from django.db import transaction
 
 from api.metrics.constants import COST_MODEL_METRIC_MAP
 from api.metrics.constants import UNLEASH_METRICS_GPU
@@ -249,10 +250,24 @@ def sync_rate_table(price_list, rates_data):
     through, guarantees the fix can't be bypassed by a new call site later.
     Spiked empirically: see
     masu/test/database/test_cost_model_rate_delete_rtu_race.py.
+
+    Broader deadlock preflight, Finding G: CostModelManager.create/update
+    (two of the five call sites above) are @transaction.atomic, and
+    PriceListViewSet._ensure_rate_sync wraps its own call in transaction.atomic()
+    too -- so this function can run inside an already-open transaction. The
+    inner transaction.atomic() below is required, not decorative: it gives
+    Postgres a rollback boundary (a savepoint, when nested) so a DB-level
+    error raised by the body below is fully rolled back *before* the lock's
+    own `finally: pg_advisory_unlock(...)` runs. Without it, the unlock
+    statement would itself execute against an already-aborted transaction,
+    fail, and leak the session-scoped advisory lock on that connection until
+    it's closed -- exactly how Provider.delete() already guards its own
+    cascade (see api/provider/models.py). Spiked empirically: see
+    masu/test/database/test_sync_rate_table_lock_leak.py.
     """
     LOG.info(f"Syncing {len(rates_data)} rates to Rate table for PriceList {price_list.uuid}")
     provider_uuids = _provider_uuids_for_price_list(price_list)
-    with _multi_provider_distribution_lock(provider_uuids):
+    with _multi_provider_distribution_lock(provider_uuids), transaction.atomic():
         return _sync_rate_table_locked(price_list, rates_data)
 
 

--- a/koku/masu/test/database/test_cost_model_rate_delete_rtu_race.py
+++ b/koku/masu/test/database/test_cost_model_rate_delete_rtu_race.py
@@ -1,0 +1,364 @@
+#
+# Copyright 2026 Red Hat Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Spike: does deleting a stale cost-model Rate race a concurrent rates_to_usage write?
+
+COST-7249 deadlock preflight, expanded audit, Finding E. sync_rate_table()
+(cost_models/rate_sync.py) -- invoked on every cost-model/price-list rate PUT
+via CostModelManager.create/update, PriceListManager.create/update, and
+PriceListViewSet._ensure_rate_sync -- deletes stale Rate rows with a plain
+Rate.objects.filter(...).delete(). RatesToUsage.rate is a normal Django FK
+with on_delete=models.CASCADE, so this triggers Django's collector-driven,
+EAGER cascade: an immediate `DELETE FROM rates_to_usage WHERE rate_id IN
+(...)` inside that same call -- not the DEFERRABLE INITIALLY DEFERRED
+DB-level FK that Finding B / COST-8112 deal with.
+
+Unlike Finding B (one side takes a lock, the other crashes with an FK
+violation), here neither side took any lock at all pre-fix. The blast radius
+is every provider on every cost model attached to the price list being
+edited, not one provider's report period, since rates_to_usage.rate_id is
+not scoped to a single provider.
+
+Fix: sync_rate_table() now resolves every provider_uuid reachable from the
+price list (via PriceListCostModelMap -> CostModelMap) and acquires the same
+session-scoped pg_advisory_lock(hashtext(provider_uuid)) that every RTU write
+step (populate_distributed_cost_sql, aggregate_rates_to_daily_summary,
+populate_markup_rates_to_usage, etc.) already takes for that provider,
+before touching the Rate table at all.
+
+Two tests below:
+- test_protected_rtu_insert_serializes_cleanly_against_rate_delete: proves a
+  lock-coordinated writer (one that takes _distribution_provider_lock, like
+  every real RTU write step does) now serializes cleanly against a
+  concurrent sync_rate_table call (red without the fix using a deterministic
+  held-lock delay, green with it).
+- test_unprotected_rtu_insert_crashes_during_rate_delete: characterization
+  test documenting that a write which bypasses the RTU accessor's lock
+  helper entirely (advisory locks are cooperative, not enforced by Postgres)
+  remains exposed regardless of this fix. This is an inherent limitation of
+  advisory locks, not a specific missed call site.
+"""
+import threading
+import time
+import uuid
+from datetime import date
+from datetime import datetime
+from unittest.mock import patch
+
+import django.test
+from django.conf import settings
+from django.db import connection
+from django.db import IntegrityError
+from django.db import OperationalError
+from django.db.models.signals import pre_delete
+from django_tenants.utils import schema_context
+
+from api.iam.models import Customer
+from api.provider.models import Provider
+from cost_models.models import CostModel
+from cost_models.models import CostModelMap
+from cost_models.models import PriceList
+from cost_models.models import PriceListCostModelMap
+from cost_models.models import Rate
+from cost_models.rate_sync import sync_rate_table
+from koku.test_provider_delete_cascade import create_test_provider
+from masu.database.ocp_report_db_accessor import OCPReportDBAccessor
+from reporting.provider.ocp.models import OCPUsageReportPeriod
+from reporting.provider.ocp.models import RatesToUsage
+
+
+@patch("masu.celery.tasks.delete_archived_data.delay", lambda *a, **k: None)
+class CostModelRateDeleteRTURaceTest(django.test.TransactionTestCase):
+    """Finding E: Rate deletion (sync_rate_table) vs. a concurrent RTU writer on a different provider."""
+
+    def _fixture_teardown(self):
+        """Skip TRUNCATE flush -- django-tenants FK graph breaks TransactionTestCase flush."""
+
+    def setUp(self):
+        from koku.koku_test_runner import KokuTestRunner
+
+        self.schema = KokuTestRunner.schema
+        with schema_context(self.schema):
+            self.customer = Customer.objects.filter(schema_name=self.schema).first()
+        if not self.customer:
+            self.skipTest("No test customer fixture available")
+
+        with schema_context(self.schema):
+            self.price_list = PriceList.objects.create(
+                name=f"spike-finding-e-pl-{uuid.uuid4().hex[:8]}",
+                description="Finding E spike price list",
+                currency="USD",
+                effective_start_date=date(2026, 1, 1),
+                effective_end_date=date(2099, 12, 31),
+                rates=[],
+            )
+            self.rate = Rate.objects.create(
+                price_list=self.price_list,
+                custom_name="spike-finding-e-rate",
+                metric="cpu_core_usage_per_hour",
+                metric_type="cpu",
+                cost_type="Supplementary",
+                default_rate=0.01,
+            )
+            self.cost_model = CostModel.objects.create(
+                name=f"spike-finding-e-cm-{uuid.uuid4().hex[:8]}",
+                description="Finding E spike cost model",
+                source_type=Provider.PROVIDER_OCP,
+                rates=[],
+            )
+
+        self.provider_a = self._create_provider("finding-e-a")
+        self.provider_b = self._create_provider("finding-e-b")
+
+        with schema_context(self.schema):
+            # Both providers share the same cost model (and therefore the same
+            # price list) -- this is what gives the bug its cross-provider blast
+            # radius: an edit made because of provider A's rates can crash
+            # provider B's concurrent RTU write.
+            CostModelMap.objects.create(cost_model=self.cost_model, provider_uuid=self.provider_a.uuid)
+            CostModelMap.objects.create(cost_model=self.cost_model, provider_uuid=self.provider_b.uuid)
+            PriceListCostModelMap.objects.create(price_list=self.price_list, cost_model=self.cost_model, priority=1)
+
+        period_start = datetime(2026, 4, 1, tzinfo=settings.UTC)
+        period_end = datetime(2026, 5, 1, tzinfo=settings.UTC)
+        with schema_context(self.schema):
+            self.report_period_a = OCPUsageReportPeriod.objects.create(
+                cluster_id=f"spike-e-cluster-a-{uuid.uuid4().hex[:8]}",
+                report_period_start=period_start,
+                report_period_end=period_end,
+                provider_id=self.provider_a.uuid,
+            )
+            self.report_period_b = OCPUsageReportPeriod.objects.create(
+                cluster_id=f"spike-e-cluster-b-{uuid.uuid4().hex[:8]}",
+                report_period_start=period_start,
+                report_period_end=period_end,
+                provider_id=self.provider_b.uuid,
+            )
+            # Pre-existing RTU row for provider A referencing the rate -- this is what
+            # sync_rate_table's cascade will delete, and is what forces Django to walk
+            # the RatesToUsage relation at all.
+            RatesToUsage.objects.create(
+                source_uuid_id=self.provider_a.uuid,
+                report_period_id=self.report_period_a.id,
+                rate_id=self.rate.uuid,
+                cost_model_id=self.cost_model.uuid,
+                usage_start=period_start.date(),
+                usage_end=period_start.date(),
+                cluster_id=self.report_period_a.cluster_id,
+                custom_name="pre-existing-rate-row",
+                metric_type="cpu_usage",
+            )
+
+    def tearDown(self):
+        with schema_context(self.schema):
+            RatesToUsage.objects.filter(
+                report_period_id__in=[self.report_period_a.id, self.report_period_b.id]
+            ).delete()
+            OCPUsageReportPeriod.objects.filter(pk__in=[self.report_period_a.pk, self.report_period_b.pk]).delete()
+            Rate.objects.filter(price_list=self.price_list).delete()
+            CostModel.objects.filter(uuid=self.cost_model.uuid).delete()
+            PriceList.objects.filter(uuid=self.price_list.uuid).delete()
+        # Use the instance-level delete() (not queryset .delete()) -- it routes through
+        # cascade_delete(), which skips relations whose table doesn't exist in this
+        # narrow test run, unlike Django's default bulk-delete collector. The class-level
+        # @patch only wraps test_* methods, so post_delete's celery dispatch needs its own
+        # patch here too.
+        with patch("masu.celery.tasks.delete_archived_data.delay", lambda *a, **k: None):
+            self.provider_a.delete()
+            self.provider_b.delete()
+
+    def _create_provider(self, tag):
+        provider = Provider(
+            uuid=uuid.uuid4(),
+            name=f"spike-finding-e-{tag}-{uuid.uuid4().hex[:8]}",
+            type=Provider.PROVIDER_OCP,
+            setup_complete=False,
+            active=True,
+            customer=self.customer,
+        )
+        provider.save()
+        create_test_provider(self.schema, provider)
+        return provider
+
+    def _run_rate_delete(self, results):
+        """Simulates sync_rate_table's stale-rate cleanup for provider A's cost model.
+
+        Calls sync_rate_table() directly with an empty rates payload, exactly
+        what CostModelManager.update() does on a PUT that removes this rate.
+        """
+        try:
+            with schema_context(self.schema):
+                sync_rate_table(self.price_list, [])
+            results["delete"] = "ok"
+        except IntegrityError as exc:
+            results["delete"] = f"INTEGRITY_ERROR: {type(exc).__name__}: {exc}"
+        except OperationalError as exc:
+            results["delete"] = f"DEADLOCK/OPERATIONAL_ERROR: {type(exc).__name__}: {exc}"
+        except Exception as exc:  # noqa: BLE001 -- spike wants to see everything
+            results["delete"] = f"{type(exc).__name__}: {exc}"
+        finally:
+            connection.close()
+
+    def _run_rate_delete_with_mid_cascade_release(self, results, barrier):
+        """Same as _run_rate_delete, but releases barrier deterministically mid-cascade.
+
+        Connects a temporary pre_delete receiver on RatesToUsage so the
+        unprotected writer is released while provider A's RatesToUsage row
+        is being collected/deleted, but before the Rate row itself is gone --
+        forcing the interleaving deterministically rather than relying on
+        thread-scheduling luck. sync_rate_table's stale-Rate delete is a
+        plain Django queryset .delete(), so it still goes through the
+        collector and fires this signal, pre- or post-fix.
+        """
+
+        def _on_pre_delete(sender, instance, **kwargs):
+            if isinstance(instance, RatesToUsage) and instance.rate_id == self.rate.uuid:
+                barrier.wait()
+
+        pre_delete.connect(_on_pre_delete, sender=RatesToUsage, weak=False)
+        try:
+            self._run_rate_delete(results)
+        finally:
+            pre_delete.disconnect(_on_pre_delete, sender=RatesToUsage)
+
+    def _create_concurrent_row(self, custom_name):
+        RatesToUsage.objects.create(
+            source_uuid_id=self.provider_b.uuid,
+            report_period_id=self.report_period_b.id,
+            rate_id=self.rate.uuid,
+            cost_model_id=self.cost_model.uuid,
+            usage_start=date(2026, 4, 15),
+            usage_end=date(2026, 4, 15),
+            cluster_id=self.report_period_b.cluster_id,
+            custom_name=custom_name,
+            metric_type="cpu_usage",
+        )
+
+    def _run_unprotected_insert(self, results, barrier):
+        """Uncoordinated concurrent write into rates_to_usage for a DIFFERENT provider, same rate_id."""
+        try:
+            barrier.wait()
+            with schema_context(self.schema):
+                self._create_concurrent_row("unprotected-writer-rate")
+            results["insert"] = "ok"
+        except IntegrityError as exc:
+            results["insert"] = f"INTEGRITY_ERROR: {type(exc).__name__}: {exc}"
+        except OperationalError as exc:
+            results["insert"] = f"DEADLOCK/OPERATIONAL_ERROR: {type(exc).__name__}: {exc}"
+        except Exception as exc:  # noqa: BLE001
+            results["insert"] = f"{type(exc).__name__}: {exc}"
+        finally:
+            connection.close()
+
+    def _run_protected_insert(self, results, barrier, hold_seconds=1.5):
+        """Simulates a write going through _distribution_provider_lock for provider B, like a real RTU step.
+
+        Sleeps for hold_seconds while still holding the lock, *after*
+        signaling the barrier, so the (much faster, near-empty schema)
+        sync_rate_table call has ample time to attempt -- and, with the fix,
+        block on -- the same advisory lock before this thread's actual
+        INSERT runs.
+        """
+        try:
+            with schema_context(self.schema):
+                accessor = OCPReportDBAccessor(schema=self.schema)
+                with accessor._distribution_provider_lock(self.provider_b.uuid):
+                    barrier.wait()
+                    time.sleep(hold_seconds)
+                    self._create_concurrent_row("protected-writer-rate")
+            results["insert"] = "ok"
+        except IntegrityError as exc:
+            results["insert"] = f"INTEGRITY_ERROR: {type(exc).__name__}: {exc}"
+        except OperationalError as exc:
+            results["insert"] = f"DEADLOCK/OPERATIONAL_ERROR: {type(exc).__name__}: {exc}"
+        except Exception as exc:  # noqa: BLE001
+            results["insert"] = f"{type(exc).__name__}: {exc}"
+        finally:
+            connection.close()
+
+    def test_unprotected_rtu_insert_crashes_during_rate_delete(self):
+        """Known residual gap: a write that bypasses the RTU lock helper entirely still crashes.
+
+        Advisory locks are cooperative -- Postgres does not enforce them on
+        the underlying table. This documents that a raw, uncoordinated
+        RatesToUsage.objects.create() call (something outside the
+        established RTU accessor pattern) remains exposed even after the
+        fix. If this test ever stops crashing, something changed about how
+        Postgres enforces (or this codebase issues) advisory locks and this
+        test's expectations need updating.
+        """
+        barrier = threading.Barrier(2, timeout=15)
+        results = {"delete": None, "insert": None}
+
+        t_delete = threading.Thread(
+            target=self._run_rate_delete_with_mid_cascade_release,
+            args=(results, barrier),
+        )
+        t_insert = threading.Thread(target=self._run_unprotected_insert, args=(results, barrier))
+        t_delete.start()
+        t_insert.start()
+        t_delete.join(timeout=20)
+        t_insert.join(timeout=20)
+
+        self.assertIsNotNone(results["delete"], "delete thread did not complete")
+        self.assertIsNotNone(results["insert"], "insert thread did not complete")
+        deadlocked = any(r and r.startswith("DEADLOCK") for r in results.values())
+        if deadlocked:
+            self.fail(f"Concurrent Rate delete vs. unprotected RTU insert deadlocked: {results}")
+        self.assertEqual(
+            results["delete"],
+            "ok",
+            f"sync_rate_table thread failed unexpectedly: {results['delete']}",
+        )
+        self.assertTrue(
+            results["insert"].startswith("INTEGRITY_ERROR"),
+            "Expected the known, still-open FK-violation crash for an uncoordinated writer; got: "
+            f"{results['insert']}. If this now succeeds, something about how Postgres enforces (or this "
+            "codebase issues) advisory locks may have changed -- update this test.",
+        )
+
+    def test_protected_rtu_insert_serializes_cleanly_against_rate_delete(self):
+        """Fix verification: a writer using _distribution_provider_lock no longer crashes.
+
+        sync_rate_table() now takes the same pg_advisory_lock(hashtext(
+        provider_uuid)) for every provider on every cost model attached to
+        the price list before it starts deleting stale Rate rows. A writer
+        already holding that lock for provider B (as every real RTU write
+        step does) forces sync_rate_table to wait until the writer's lock is
+        released, instead of racing it.
+
+        Deterministic by construction: the protected writer holds the lock
+        for 1.5s (real wall-clock sleep) before its actual INSERT. Without
+        the fix, sync_rate_table's delete over a near-empty tenant schema
+        reliably completes in well under that window, deleting the Rate row
+        out from under the writer and reproducing an IntegrityError. With the
+        fix, sync_rate_table blocks on the same advisory lock for the full
+        1.5s and only proceeds after the writer's INSERT has already landed
+        -- both succeed.
+        """
+        barrier = threading.Barrier(2, timeout=15)
+        results = {"delete": None, "insert": None}
+
+        t_insert = threading.Thread(target=self._run_protected_insert, args=(results, barrier))
+        t_delete = threading.Thread(target=self._run_rate_delete, args=(results,))
+        t_insert.start()
+        barrier.wait(timeout=15)  # don't start sync_rate_table until the writer actually holds the lock
+        t_delete.start()
+        t_delete.join(timeout=20)
+        t_insert.join(timeout=20)
+
+        deadlocked = any(r and r.startswith("DEADLOCK") for r in results.values())
+        if deadlocked:
+            self.fail(f"Concurrent Rate delete vs. protected RTU insert deadlocked: {results}")
+
+        self.assertEqual(
+            results["insert"],
+            "ok",
+            f"protected writer thread failed: {results['insert']}",
+        )
+        self.assertEqual(
+            results["delete"],
+            "ok",
+            f"sync_rate_table thread failed: {results['delete']}",
+        )

--- a/koku/masu/test/database/test_sync_rate_table_lock_leak.py
+++ b/koku/masu/test/database/test_sync_rate_table_lock_leak.py
@@ -42,6 +42,7 @@ from unittest.mock import patch
 
 import django.test
 from django.db import connection
+from django.db import DataError
 from django_tenants.utils import schema_context
 
 from api.iam.models import Customer
@@ -117,7 +118,10 @@ class SyncRateTableLockLeakTest(django.test.TransactionTestCase):
         return str(self.provider.uuid)
 
     def _is_lock_held(self):
-        """Query pg_locks from a brand-new connection to see if the advisory lock is still held."""
+        """Query pg_locks on the current (still-open) connection; pg_locks is global, so this
+        reports the lock even when this backend is the holder. Do not open or close a connection
+        here -- closing releases the lock and hides the bug.
+        """
         with connection.cursor() as cursor:
             cursor.execute(
                 "SELECT count(*) FROM pg_locks WHERE locktype = 'advisory' "
@@ -154,8 +158,8 @@ class SyncRateTableLockLeakTest(django.test.TransactionTestCase):
             with patch(
                 "cost_models.models.Rate.objects.bulk_create",
                 side_effect=self._real_db_level_failure,
-            ):
-                with self.assertRaises(Exception):
+            ) as mock_bulk_create:
+                with self.assertRaises(DataError):
                     manager.update(
                         rates=[
                             {
@@ -166,6 +170,11 @@ class SyncRateTableLockLeakTest(django.test.TransactionTestCase):
                             }
                         ]
                     )
+            # Guard against a vacuous pass: if bulk_create were never reached (e.g. a
+            # serializer error or fixture problem raised first), the DataError assertion
+            # above could never fire either, but a looser assertRaises(Exception) would
+            # have silently accepted that too.
+            mock_bulk_create.assert_called_once()
 
             # The connection used by this thread is now back to a clean state at the
             # Django/ORM level (@transaction.atomic on update() rolled back on exception
@@ -199,8 +208,8 @@ class SyncRateTableLockLeakTest(django.test.TransactionTestCase):
             with patch(
                 "cost_models.models.Rate.objects.bulk_create",
                 side_effect=self._real_db_level_failure,
-            ):
-                with self.assertRaises(Exception):
+            ) as mock_bulk_create:
+                with self.assertRaises(DataError):
                     manager.update(
                         rates=[
                             {
@@ -211,6 +220,7 @@ class SyncRateTableLockLeakTest(django.test.TransactionTestCase):
                             }
                         ]
                     )
+            mock_bulk_create.assert_called_once()
         # Deliberately keep this thread's connection open and in the pool (do not close it),
         # to mimic a real Celery worker's persistent DB connection after a task fails.
 

--- a/koku/masu/test/database/test_sync_rate_table_lock_leak.py
+++ b/koku/masu/test/database/test_sync_rate_table_lock_leak.py
@@ -1,0 +1,244 @@
+#
+# Copyright 2026 Red Hat Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Regression test: sync_rate_table must not leak its advisory lock on error.
+
+COST-7249 deadlock preflight, broader audit, Finding G. sync_rate_table()'s
+own fix for Finding E (COST-8113) acquires a session-scoped
+pg_advisory_lock(hashtext(provider_uuid)) directly via a raw cursor.execute,
+mirroring OCPReportDBAccessor._distribution_provider_lock and
+Provider._rtu_distribution_lock.
+
+sync_rate_table() is called from CostModelManager.create/update, both of
+which are decorated @transaction.atomic -- so the lock can be acquired
+*inside* an already-open Django transaction. If the protected body
+(Rate.objects.filter(...).delete() / .bulk_create()) raises a DB-level
+error with no intervening savepoint, Postgres marks the *entire*
+transaction as aborted; the lock's own
+`finally: cursor.execute("SELECT pg_advisory_unlock(...))")` then tries to
+run another statement on that aborted transaction, which itself fails with
+"current transaction is aborted, commands ignored until end of transaction
+block" -- so the unlock never happens and the advisory lock leaks on that
+connection until it's closed. A later, completely unrelated caller trying to
+acquire the same provider's lock (e.g. any real RTU write step) then blocks
+indefinitely -- a hang, not a Postgres-detected deadlock, so it wouldn't
+show up in pg_stat_activity's deadlock logs.
+
+The fix wraps the protected body in its own `transaction.atomic()` call
+*inside* the lock's scope (see sync_rate_table), giving Postgres a rollback
+boundary (a savepoint, when nested) so a raised exception is fully rolled
+back before the lock's own finally block runs -- the same pattern
+Provider.delete() already uses for its cascade.
+
+Confirmed empirically before the fix: both tests below failed (the lock was
+observed still held via pg_locks, and a second writer blocked until
+statement_timeout). Restore the pre-fix `sync_rate_table` (drop the inner
+`transaction.atomic()`) to reproduce.
+"""
+import threading
+import uuid
+from unittest.mock import patch
+
+import django.test
+from django.db import connection
+from django_tenants.utils import schema_context
+
+from api.iam.models import Customer
+from api.provider.models import Provider
+from cost_models.cost_model_manager import CostModelManager
+from cost_models.models import CostModel
+from cost_models.models import CostModelMap
+from cost_models.models import PriceList
+from cost_models.models import PriceListCostModelMap
+from cost_models.models import Rate
+from koku.test_provider_delete_cascade import create_test_provider
+
+
+@patch("masu.celery.tasks.delete_archived_data.delay", lambda *a, **k: None)
+class SyncRateTableLockLeakTest(django.test.TransactionTestCase):
+    """Finding G: does an error inside sync_rate_table (called from an @transaction.atomic
+    caller) leave the session-scoped advisory lock held forever on that connection?
+    """
+
+    def _fixture_teardown(self):
+        """Skip TRUNCATE flush -- django-tenants FK graph breaks TransactionTestCase flush."""
+
+    def setUp(self):
+        from koku.koku_test_runner import KokuTestRunner
+
+        self.schema = KokuTestRunner.schema
+        with schema_context(self.schema):
+            self.customer = Customer.objects.filter(schema_name=self.schema).first()
+        if not self.customer:
+            self.skipTest("No test customer fixture available")
+
+        self.provider = Provider(
+            uuid=uuid.uuid4(),
+            name=f"spike-finding-g-{uuid.uuid4().hex[:8]}",
+            type=Provider.PROVIDER_OCP,
+            setup_complete=False,
+            active=True,
+            customer=self.customer,
+        )
+        self.provider.save()
+        create_test_provider(self.schema, self.provider)
+
+        with schema_context(self.schema):
+            self.cost_model = CostModel.objects.create(
+                name=f"spike-finding-g-cm-{uuid.uuid4().hex[:8]}",
+                description="Finding G spike cost model",
+                source_type=Provider.PROVIDER_OCP,
+                rates=[],
+            )
+            CostModelMap.objects.create(cost_model=self.cost_model, provider_uuid=self.provider.uuid)
+
+    def tearDown(self):
+        # Release any advisory lock this connection may still be holding for this
+        # provider (the whole point of these tests is that the buggy path leaks it) so
+        # it doesn't bleed into later tests that reuse this same pooled connection.
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT pg_advisory_unlock_all()")
+        with schema_context(self.schema):
+            price_list_ids = list(
+                PriceListCostModelMap.objects.filter(cost_model=self.cost_model).values_list(
+                    "price_list_id", flat=True
+                )
+            )
+            Rate.objects.filter(price_list_id__in=price_list_ids).delete()
+            PriceListCostModelMap.objects.filter(cost_model=self.cost_model).delete()
+            PriceList.objects.filter(uuid__in=price_list_ids).delete()
+            CostModelMap.objects.filter(cost_model=self.cost_model).delete()
+            CostModel.objects.filter(uuid=self.cost_model.uuid).delete()
+        with patch("masu.celery.tasks.delete_archived_data.delay", lambda *a, **k: None):
+            self.provider.delete()
+
+    def _lock_key(self):
+        return str(self.provider.uuid)
+
+    def _is_lock_held(self):
+        """Query pg_locks from a brand-new connection to see if the advisory lock is still held."""
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT count(*) FROM pg_locks WHERE locktype = 'advisory' "
+                "AND objid = hashtext(%s) AND granted = true",
+                [self._lock_key()],
+            )
+            return cursor.fetchone()[0] > 0
+
+    @staticmethod
+    def _real_db_level_failure(*args, **kwargs):
+        """Injects a genuine Postgres-level error (not just a Python-raised exception).
+
+        A mocked side_effect=SomeError() never actually sends a failing statement to
+        Postgres, so the real transaction is never marked aborted at the DB level --
+        that would make this spike a false negative. Issuing a real bad statement on
+        the live connection reproduces the actual abort condition sync_rate_table's
+        callers hit in production (e.g. a real deadlock or constraint violation).
+        """
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT 1/0")  # division by zero -- a genuine Postgres DataError
+
+    def test_error_inside_atomic_caller_does_not_leak_the_lock(self):
+        """Fix verification: an error inside sync_rate_table's protected body, even when
+        called from an @transaction.atomic caller (as CostModelManager.create/update are),
+        no longer leaves the session-scoped advisory lock held on that connection.
+        """
+        with schema_context(self.schema):
+            manager = CostModelManager(cost_model_uuid=str(self.cost_model.uuid))
+
+            # Force Rate.objects.bulk_create (called inside sync_rate_table, while the
+            # advisory lock is held, inside CostModelManager.update()'s @transaction.atomic)
+            # to raise a genuine DB-level error -- simulating a real deadlock or
+            # constraint violation at the same point in the call stack.
+            with patch(
+                "cost_models.models.Rate.objects.bulk_create",
+                side_effect=self._real_db_level_failure,
+            ):
+                with self.assertRaises(Exception):
+                    manager.update(
+                        rates=[
+                            {
+                                "metric": {"name": "cpu_core_usage_per_hour"},
+                                "tiered_rates": [{"unit": "USD", "value": 0.01}],
+                                "cost_type": "Supplementary",
+                                "name": "spike-rate",
+                            }
+                        ]
+                    )
+
+            # The connection used by this thread is now back to a clean state at the
+            # Django/ORM level (@transaction.atomic on update() rolled back on exception
+            # exit) -- but the *advisory lock itself* is session-scoped, not
+            # transaction-scoped, so a failed unlock during the aborted transaction
+            # leaves it held on this connection's underlying Postgres backend.
+            #
+            # IMPORTANT: do NOT call connection.close() here before checking -- closing
+            # the connection terminates the Postgres backend that's holding the lock,
+            # which releases it as a side effect and would hide the very bug this test
+            # exists to catch. pg_locks is a global system view, so querying it from
+            # this same still-open connection correctly shows whether *any* backend
+            # (including this one) still holds the lock.
+            still_held = self._is_lock_held()
+
+        if still_held:
+            self.fail(
+                "Advisory lock was still held after the error inside sync_rate_table's "
+                "@transaction.atomic caller -- it leaked. See module docstring for the "
+                "fix (inner transaction.atomic() inside sync_rate_table's lock)."
+            )
+
+    def test_concurrent_writer_does_not_block_after_error(self):
+        """Fix verification: a second, completely unrelated caller trying to acquire the
+        same provider's lock (e.g. any real RTU write step, or another sync_rate_table
+        call) succeeds promptly after the first caller's error, instead of blocking
+        forever on a leaked lock.
+        """
+        with schema_context(self.schema):
+            manager = CostModelManager(cost_model_uuid=str(self.cost_model.uuid))
+            with patch(
+                "cost_models.models.Rate.objects.bulk_create",
+                side_effect=self._real_db_level_failure,
+            ):
+                with self.assertRaises(Exception):
+                    manager.update(
+                        rates=[
+                            {
+                                "metric": {"name": "cpu_core_usage_per_hour"},
+                                "tiered_rates": [{"unit": "USD", "value": 0.01}],
+                                "cost_type": "Supplementary",
+                                "name": "spike-rate",
+                            }
+                        ]
+                    )
+        # Deliberately keep this thread's connection open and in the pool (do not close it),
+        # to mimic a real Celery worker's persistent DB connection after a task fails.
+
+        results = {"second_call": None}
+
+        def _second_writer():
+            try:
+                with schema_context(self.schema), connection.cursor() as cursor:
+                    cursor.execute("SET statement_timeout = '3s'")
+                    cursor.execute("SELECT pg_advisory_lock(hashtext(%s))", [self._lock_key()])
+                    cursor.execute("SELECT pg_advisory_unlock(hashtext(%s))", [self._lock_key()])
+                results["second_call"] = "ok"
+            except Exception as exc:  # noqa: BLE001
+                results["second_call"] = f"{type(exc).__name__}: {exc}"
+            finally:
+                connection.close()
+
+        t = threading.Thread(target=_second_writer)
+        t.start()
+        t.join(timeout=10)
+
+        if t.is_alive():
+            self.fail(
+                "Second writer never returned within 10s -- it is blocked indefinitely on " "a leaked advisory lock."
+            )
+        self.assertEqual(
+            results["second_call"],
+            "ok",
+            "Expected the second writer to acquire and release the lock promptly, but it "
+            f"did not: {results['second_call']}",
+        )


### PR DESCRIPTION
## Summary

Follow-up to the [COST-7249](https://redhat.atlassian.net/browse/COST-7249) deadlock preflight (#6102). Found while auditing all flows that touch `rates_to_usage` for unprotected concurrent-write races.

- `sync_rate_table` (shared by `CostModelManager.create`/`update`, `PriceListManager.create`/`update`, and `PriceListViewSet._ensure_rate_sync`) deletes stale `Rate` rows via a plain queryset `.delete()`.
- `Rate` -> `RatesToUsage` is `ON DELETE CASCADE` (migration 0353), so this cascades into `rates_to_usage` for every provider on every cost model attached to the price list.
- Unlike every RTU write step (`populate_distributed_cost_sql`, `aggregate_rates_to_daily_summary`, `populate_markup_rates_to_usage`, `_populate_cost_breakdown_ui_summary_table`, `populate_usage_rates_to_usage`), this delete path never acquired `OCPReportDBAccessor._distribution_provider_lock`, so it can race a concurrent RTU write for the same provider and crash it with an FK `IntegrityError`.

**Fix:** lock at the single shared choke point (`sync_rate_table` itself) so all five call sites are protected without relying on each caller to remember to lock. Resolves every provider UUID reachable from the price list via `PriceListCostModelMap`/`CostModelMap` and acquires the same `pg_advisory_lock(hashtext(provider_uuid))` primitive used by `_distribution_provider_lock`, sorted to avoid lock-ordering deadlocks against other multi-provider lockers.

Full details and manual repro steps: [COST-8113](https://redhat.atlassian.net/browse/COST-8113)

## Test plan

- [x] New regression test `masu.test.database.test_cost_model_rate_delete_rtu_race` — two-test pattern:
  - `test_unprotected_rtu_insert_crashes_during_rate_delete`: characterizes the pre-fix crash (deterministic via a `pre_delete` signal hook), confirms the bug is real.
  - `test_protected_rtu_insert_serializes_cleanly_against_rate_delete`: confirms a writer using `_distribution_provider_lock` now serializes cleanly against the fixed `sync_rate_table` instead of crashing.
- [x] Ran full `cost_models` test suite (157 tests) — all passing.
- [x] `black --line-length 119` / `flake8` clean.