### PR TITLE
[COST-8112] Lock populate_usage_rates_to_usage against concurrent RTU writers

### DIFF
--- a/koku/masu/database/ocp_report_db_accessor.py
+++ b/koku/masu/database/ocp_report_db_accessor.py
@@ -1397,6 +1397,18 @@ AND (month = {{month_no_zero}} OR month = {{month}})
         cost_model_rate via SQL JOIN.  Distribution is read directly from the
         cost_model table; cte_node_cost computes allocation fractions only;
         rate multiplication happens in Component 6.
+
+        COST-7249 deadlock preflight, COST-8112: this is the very first write
+        into rates_to_usage in the whole RTU pipeline, and does the same
+        DELETE-then-INSERT for the same provider/date-range as every other RTU
+        write step (populate_distributed_cost_sql, aggregate_rates_to_daily_
+        summary, populate_markup_rates_to_usage, _populate_cost_breakdown_ui_
+        summary_table) -- all of which already run under
+        _distribution_provider_lock. This one didn't, leaving it exposed to
+        the same concurrent-Provider.delete() FK-violation crash as Finding B
+        (see test_ocp_provider_delete_rtu_race.py) for an uncoordinated
+        writer. Runs under _distribution_provider_lock (see its docstring) to
+        close that gap.
         """
         sql = pkgutil.get_data(
             "masu.database",
@@ -1413,7 +1425,8 @@ AND (month = {{month_no_zero}} OR month = {{month}})
         }
 
         LOG.info(log_json(msg="populating rates_to_usage (single-pass)", context=sql_params))
-        self._prepare_and_execute_raw_sql_query("rates_to_usage", sql, sql_params, operation="INSERT")
+        with self._distribution_provider_lock(provider_uuid):
+            self._prepare_and_execute_raw_sql_query("rates_to_usage", sql, sql_params, operation="INSERT")
 
     def populate_markup_rates_to_usage(self, start_date, end_date, source_uuid, cluster_id, cost_model_id):
         """Write markup costs as RatesToUsage rows with metric_type='markup'.

--- a/koku/masu/test/database/test_populate_usage_rates_to_usage_lock_gap.py
+++ b/koku/masu/test/database/test_populate_usage_rates_to_usage_lock_gap.py
@@ -37,6 +37,7 @@ import time
 import uuid
 from datetime import datetime
 from decimal import Decimal
+from unittest.mock import patch
 
 import django.test
 from django.conf import settings
@@ -121,8 +122,6 @@ class PopulateUsageRatesToUsageLockGapTest(django.test.TransactionTestCase):
             RatesToUsage.objects.filter(report_period_id=self.report_period.id).delete()
             OCPUsageLineItemDailySummary.objects.filter(report_period_id=self.report_period.id).delete()
             OCPUsageReportPeriod.objects.filter(pk=self.report_period.pk).delete()
-        from unittest.mock import patch
-
         with patch("masu.celery.tasks.delete_archived_data.delay", lambda *a, **k: None):
             try:
                 self.provider.delete()

--- a/koku/masu/test/database/test_populate_usage_rates_to_usage_lock_gap.py
+++ b/koku/masu/test/database/test_populate_usage_rates_to_usage_lock_gap.py
@@ -1,0 +1,204 @@
+#
+# Copyright 2026 Red Hat Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Spike/regression: does populate_usage_rates_to_usage serialize against other RTU writers?
+
+COST-7249 deadlock preflight, COST-8112. populate_usage_rates_to_usage -- the
+first write into rates_to_usage in the whole RTU pipeline -- performs a
+DELETE-then-INSERT for a given provider/date-range via raw SQL, structurally
+identical to populate_distributed_cost_sql / aggregate_rates_to_daily_summary /
+populate_markup_rates_to_usage / _populate_cost_breakdown_ui_summary_table,
+all of which already run under OCPReportDBAccessor._distribution_provider_lock.
+This method did not, leaving it exposed to the same class of race as Finding B
+(see test_ocp_provider_delete_rtu_race.py): a concurrent report-period
+delete's deferred FK cascade to rates_to_usage can interleave with this
+method's own unprotected write for the same provider.
+
+This test verifies the fix directly and deterministically via timing, rather
+than via a data-integrity crash: a concurrent thread acquires
+_distribution_provider_lock(provider_uuid) and holds it for a fixed,
+measurable duration. Without the fix, populate_usage_rates_to_usage never
+contends for that lock and returns almost immediately regardless of the
+holder. With the fix, it must block until the holder releases, so its total
+elapsed time is bounded below by the holder's hold duration -- a real,
+reproducible signal rather than a timing-window-dependent crash.
+
+Uses real (unmocked) SQL execution against the fixture cost model / price
+list / rate already seeded for the OCP test provider by
+ModelBakeryDataLoader, plus one dedicated OCPUsageLineItemDailySummary row so
+the INSERT branch has something to write.
+
+Fix: populate_usage_rates_to_usage now acquires the same
+_distribution_provider_lock(provider_uuid) as its RTU-pipeline siblings.
+"""
+import threading
+import time
+import uuid
+from datetime import datetime
+from decimal import Decimal
+
+import django.test
+from django.conf import settings
+from django.db import connection
+from django_tenants.utils import schema_context
+
+from api.iam.models import Customer
+from api.provider.models import Provider
+from cost_models.models import CostModelMap
+from koku.test_provider_delete_cascade import create_test_provider
+from masu.database.ocp_report_db_accessor import OCPReportDBAccessor
+from reporting.provider.ocp.models import OCPUsageLineItemDailySummary
+from reporting.provider.ocp.models import OCPUsageReportPeriod
+from reporting.provider.ocp.models import RatesToUsage
+
+
+class PopulateUsageRatesToUsageLockGapTest(django.test.TransactionTestCase):
+    """COST-8112 spike: populate_usage_rates_to_usage vs. a concurrent RTU lock holder."""
+
+    HOLD_SECONDS = 1.5
+
+    def _fixture_teardown(self):
+        """Skip TRUNCATE flush -- django-tenants FK graph breaks TransactionTestCase flush."""
+
+    def setUp(self):
+        from koku.koku_test_runner import KokuTestRunner
+
+        self.schema = KokuTestRunner.schema
+        with schema_context(self.schema):
+            self.customer = Customer.objects.filter(schema_name=self.schema).first()
+        if not self.customer:
+            self.skipTest("No test customer fixture available")
+
+        self.provider = Provider(
+            uuid=uuid.uuid4(),
+            name=f"spike-8112-{uuid.uuid4().hex[:8]}",
+            type=Provider.PROVIDER_OCP,
+            setup_complete=False,
+            active=True,
+            customer=self.customer,
+        )
+        self.provider.save()
+        create_test_provider(self.schema, self.provider)
+
+        self.period_start = datetime(2026, 6, 1, tzinfo=settings.UTC)
+        self.period_end = datetime(2026, 7, 1, tzinfo=settings.UTC)
+        with schema_context(self.schema):
+            self.report_period = OCPUsageReportPeriod.objects.create(
+                cluster_id=f"spike-8112-cluster-{uuid.uuid4().hex[:8]}",
+                report_period_start=self.period_start,
+                report_period_end=self.period_end,
+                provider_id=self.provider.uuid,
+            )
+            # Reuse the already-seeded cost model / price list / rate (any OCP one works --
+            # populate_usage_rates_to_usage's rate lookup is keyed by cost_model_id only, not
+            # by provider) so this test doesn't need to hand-build a full price list + rate
+            # fixture just to get the INSERT branch to have something to write.
+            cmm = CostModelMap.objects.exclude(cost_model__isnull=True).first()
+            if not cmm:
+                self.skipTest("No seeded cost model fixture available")
+            self.cost_model_id = cmm.cost_model_id
+
+            OCPUsageLineItemDailySummary.objects.create(
+                uuid=uuid.uuid4(),
+                report_period=self.report_period,
+                cluster_id=self.report_period.cluster_id,
+                source_uuid=self.provider.uuid,
+                namespace="spike-8112-ns",
+                node="spike-8112-node",
+                data_source="Pod",
+                usage_start=self.period_start.date(),
+                usage_end=self.period_start.date(),
+                pod_effective_usage_cpu_core_hours=Decimal("4.0"),
+                pod_usage_cpu_core_hours=Decimal("4.0"),
+                node_capacity_cpu_cores=Decimal("8"),
+                node_capacity_cpu_core_hours=Decimal("192"),
+                cluster_capacity_cpu_core_hours=Decimal("768"),
+            )
+
+    def tearDown(self):
+        with schema_context(self.schema):
+            RatesToUsage.objects.filter(report_period_id=self.report_period.id).delete()
+            OCPUsageLineItemDailySummary.objects.filter(report_period_id=self.report_period.id).delete()
+            OCPUsageReportPeriod.objects.filter(pk=self.report_period.pk).delete()
+        from unittest.mock import patch
+
+        with patch("masu.celery.tasks.delete_archived_data.delay", lambda *a, **k: None):
+            try:
+                self.provider.delete()
+            except Provider.DoesNotExist:
+                pass
+
+    def _hold_lock_then_release(self, results, barrier):
+        try:
+            with schema_context(self.schema):
+                with OCPReportDBAccessor(self.schema) as accessor:
+                    with accessor._distribution_provider_lock(self.provider.uuid):
+                        barrier.wait()
+                        time.sleep(self.HOLD_SECONDS)
+            results["holder"] = "ok"
+        except Exception as exc:  # noqa: BLE001 -- spike wants to see everything
+            results["holder"] = f"{type(exc).__name__}: {exc}"
+        finally:
+            connection.close()
+
+    def _run_populate(self, results, barrier):
+        try:
+            barrier.wait()
+            t0 = time.monotonic()
+            with schema_context(self.schema):
+                with OCPReportDBAccessor(self.schema) as accessor:
+                    accessor.populate_usage_rates_to_usage(
+                        self.period_start.date(),
+                        self.period_start.date(),
+                        self.provider.uuid,
+                        self.report_period.id,
+                        self.cost_model_id,
+                    )
+            results["populate_elapsed"] = time.monotonic() - t0
+            results["populate"] = "ok"
+        except Exception as exc:  # noqa: BLE001
+            results["populate"] = f"{type(exc).__name__}: {exc}"
+        finally:
+            connection.close()
+
+    def test_populate_blocks_on_concurrent_distribution_lock_holder(self):
+        """Fix verification: populate_usage_rates_to_usage now contends for the same
+        _distribution_provider_lock as its RTU-pipeline siblings.
+
+        Deterministic by construction: a concurrent thread holds the lock for a fixed
+        HOLD_SECONDS after signaling readiness via a barrier. With the fix,
+        populate_usage_rates_to_usage cannot begin its DELETE-then-INSERT until that lock is
+        released, so its total elapsed time must be at least close to HOLD_SECONDS. Before
+        the fix (verified manually by reverting the lock wrap in ocp_report_db_accessor.py),
+        this same test fails: populate_usage_rates_to_usage never contends for the lock and
+        returns in a small fraction of HOLD_SECONDS regardless of the concurrent holder,
+        proving it was not serialized against other RTU writers for the same provider.
+        """
+        barrier = threading.Barrier(2, timeout=15)
+        results = {"holder": None, "populate": None, "populate_elapsed": None}
+
+        t_holder = threading.Thread(target=self._hold_lock_then_release, args=(results, barrier))
+        t_populate = threading.Thread(target=self._run_populate, args=(results, barrier))
+        t_holder.start()
+        t_populate.start()
+        t_holder.join(timeout=20)
+        t_populate.join(timeout=20)
+
+        self.assertEqual(results["holder"], "ok", f"lock-holder thread failed: {results['holder']}")
+        self.assertEqual(results["populate"], "ok", f"populate_usage_rates_to_usage failed: {results['populate']}")
+        self.assertIsNotNone(results["populate_elapsed"], "populate_usage_rates_to_usage never completed")
+        self.assertGreaterEqual(
+            results["populate_elapsed"],
+            self.HOLD_SECONDS * 0.8,
+            f"populate_usage_rates_to_usage returned in {results['populate_elapsed']:.3f}s, well under "
+            f"the {self.HOLD_SECONDS}s the concurrent writer held _distribution_provider_lock -- it did "
+            "not wait for the lock, meaning it is not serialized against other RTU writers for the same "
+            "provider (COST-8112 regression).",
+        )
+
+        with schema_context(self.schema):
+            inserted = RatesToUsage.objects.filter(report_period_id=self.report_period.id).count()
+        self.assertGreater(
+            inserted, 0, "populate_usage_rates_to_usage should have inserted at least one rates_to_usage row"
+        )

--- a/koku/masu/test/database/test_populate_usage_rates_to_usage_lock_gap.py
+++ b/koku/masu/test/database/test_populate_usage_rates_to_usage_lock_gap.py
@@ -66,10 +66,15 @@ class PopulateUsageRatesToUsageLockGapTest(django.test.TransactionTestCase):
         from koku.koku_test_runner import KokuTestRunner
 
         self.schema = KokuTestRunner.schema
-        with schema_context(self.schema):
-            self.customer = Customer.objects.filter(schema_name=self.schema).first()
-        if not self.customer:
-            self.skipTest("No test customer fixture available")
+        # Customer is a public-schema model -- looking it up under schema_context here would
+        # be harmless in practice (the query is schema-agnostic), but it's misleading and
+        # inconsistent with the rest of the codebase's convention of never wrapping
+        # public-schema queries in tenant/schema context.
+        self.customer = Customer.objects.filter(schema_name=self.schema).first()
+        self.assertIsNotNone(
+            self.customer,
+            f"No Customer fixture for schema {self.schema}; the RTU lock-gap regression cannot run.",
+        )
 
         self.provider = Provider(
             uuid=uuid.uuid4(),
@@ -96,8 +101,9 @@ class PopulateUsageRatesToUsageLockGapTest(django.test.TransactionTestCase):
             # by provider) so this test doesn't need to hand-build a full price list + rate
             # fixture just to get the INSERT branch to have something to write.
             cmm = CostModelMap.objects.exclude(cost_model__isnull=True).first()
-            if not cmm:
-                self.skipTest("No seeded cost model fixture available")
+            self.assertIsNotNone(
+                cmm, "No seeded CostModelMap fixture available; the RTU lock-gap regression cannot run."
+            )
             self.cost_model_id = cmm.cost_model_id
 
             OCPUsageLineItemDailySummary.objects.create(


### PR DESCRIPTION
## Summary

`populate_usage_rates_to_usage` is the first write into `rates_to_usage` in the RTU pipeline. It performs a DELETE-then-INSERT for a given provider/date-range via raw SQL, structurally identical to `populate_distributed_cost_sql` / `aggregate_rates_to_daily_summary` / `populate_markup_rates_to_usage` / `_populate_cost_breakdown_ui_summary_table` — all of which already acquire `OCPReportDBAccessor._distribution_provider_lock`. This method did not.

`rates_to_usage`'s FKs to `reporting_ocpusagereportperiod` / `reporting_tenant_api_provider` are `ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED` (migration 0353), so an uncoordinated writer here is exposed to the same concurrent-delete FK-violation crash characterized for `Provider.delete()` in `test_ocp_provider_delete_rtu_race.py` (Finding B, #6102) — but for *any* concurrent event that deletes the report period, not just provider deletion. Blast radius is broader than the cost-breakdown UI: `rates_to_usage` rows feed both `aggregate_rates_to_daily_summary` (the core OCP daily-summary table every OCP cost report reads from) and the cost-breakdown tree.

Fixes [COST-8112](https://redhat.atlassian.net/browse/COST-8112), filed as part of the broader COST-7249 deadlock preflight audit.

## Changes

- Wrap `populate_usage_rates_to_usage`'s body in `_distribution_provider_lock(provider_uuid)`, the same primitive already used by its RTU-pipeline siblings.
- Add a deterministic regression test (`test_populate_usage_rates_to_usage_lock_gap.py`) that races `populate_usage_rates_to_usage` against a concurrent thread already holding `_distribution_provider_lock` for the same provider, and asserts it now blocks for the lock's full hold duration instead of running unserialized. Verified the test fails deterministically (returns in ~0.02s instead of waiting ~1.5s) when the lock is reverted, and passes with the fix applied.

## Testing performed

- New regression test passes with the fix, and was manually confirmed to fail deterministically with the fix reverted.
- Ran the full `masu.test.processor.ocp.test_phase2_rates_to_usage` suite (125 tests) — no new failures introduced. Two pre-existing failures (`test_api_cost_total_matches_daily_summary`, `test_rtu_custom_name_fallback`) reproduce identically with or without this change (confirmed by running that suite alone, without this PR's new test file).
- `black --line-length 119` and `flake8` clean on both changed files.

## Related

- Epic: [COST-7249](https://redhat.atlassian.net/browse/COST-7249)
- Related deadlock-preflight fixes: #6268 (COST-8113), #6269 (COST-8114), #6270 (COST-8115), #6271 (COST-8116)