### PR TITLE
[COST-8120] Fix source_uuid type mismatch across GPU/VM cost-model SQL

### DIFF
--- a/koku/masu/database/self_hosted_sql/openshift/cost_model/hourly_cost_virtual_machine.sql
+++ b/koku/masu/database/self_hosted_sql/openshift/cost_model/hourly_cost_virtual_machine.sql
@@ -40,7 +40,7 @@ JOIN (
         usage_start as interval_day,
         sum(vm_uptime_total_seconds) / 3600 AS vm_interval_hours
     FROM {{schema | sqlsafe}}.openshift_vm_usage_line_items
-    WHERE source = {{source_uuid}}
+    WHERE source = {{source_uuid | string}}
       AND year = {{year}}
       AND month = {{month}}
     GROUP BY 1, 2
@@ -55,7 +55,7 @@ JOIN (
         count(interval_start) AS vm_interval_hours
     FROM {{schema | sqlsafe}}.openshift_pod_usage_line_items
     WHERE strpos(pod_labels, 'vm_kubevirt_io_name') != 0
-      AND source = {{source_uuid}}
+      AND source = {{source_uuid | string}}
       AND year = {{year}}
       AND month = {{month}}
     GROUP BY 1, 2

--- a/koku/masu/database/self_hosted_sql/openshift/cost_model/hourly_cost_virtual_machine_rtu.sql
+++ b/koku/masu/database/self_hosted_sql/openshift/cost_model/hourly_cost_virtual_machine_rtu.sql
@@ -51,7 +51,7 @@ JOIN (
         usage_start as interval_day,
         sum(vm_uptime_total_seconds) / 3600 AS vm_interval_hours
     FROM {{schema | sqlsafe}}.openshift_vm_usage_line_items
-    WHERE source = {{source_uuid}}
+    WHERE source = {{source_uuid | string}}
       AND year = {{year}}
       AND month = {{month}}
     GROUP BY 1, 2
@@ -66,7 +66,7 @@ JOIN (
         count(interval_start) AS vm_interval_hours
     FROM {{schema | sqlsafe}}.openshift_pod_usage_line_items
     WHERE strpos(pod_labels, 'vm_kubevirt_io_name') != 0
-      AND source = {{source_uuid}}
+      AND source = {{source_uuid | string}}
       AND year = {{year}}
       AND month = {{month}}
     GROUP BY 1, 2

--- a/koku/masu/database/self_hosted_sql/openshift/cost_model/hourly_cost_vm_tag_based.sql
+++ b/koku/masu/database/self_hosted_sql/openshift/cost_model/hourly_cost_vm_tag_based.sql
@@ -54,7 +54,7 @@ JOIN (
         usage_start AS interval_day,
         sum(vm_uptime_total_seconds) / 3600 AS vm_interval_hours
     FROM {{schema | sqlsafe}}.openshift_vm_usage_line_items
-    WHERE source = {{source_uuid}}
+    WHERE source = {{source_uuid | string}}
       AND year = {{year}}
       AND month = {{month}}
     GROUP BY 1, 2
@@ -65,7 +65,7 @@ JOIN (
         count(interval_start) AS vm_interval_hours
     FROM {{schema | sqlsafe}}.openshift_pod_usage_line_items
     WHERE strpos(pod_labels, 'vm_kubevirt_io_name') != 0
-      AND source = {{source_uuid}}
+      AND source = {{source_uuid | string}}
       AND year = {{year}}
       AND month = {{month}}
     GROUP BY 1, 2

--- a/koku/masu/database/self_hosted_sql/openshift/cost_model/hourly_cost_vm_tag_based_rtu.sql
+++ b/koku/masu/database/self_hosted_sql/openshift/cost_model/hourly_cost_vm_tag_based_rtu.sql
@@ -63,7 +63,7 @@ JOIN (
         usage_start AS interval_day,
         sum(vm_uptime_total_seconds) / 3600 AS vm_interval_hours
     FROM {{schema | sqlsafe}}.openshift_vm_usage_line_items
-    WHERE source = {{source_uuid}}
+    WHERE source = {{source_uuid | string}}
       AND year = {{year}}
       AND month = {{month}}
     GROUP BY 1, 2
@@ -74,7 +74,7 @@ JOIN (
         count(interval_start) AS vm_interval_hours
     FROM {{schema | sqlsafe}}.openshift_pod_usage_line_items
     WHERE strpos(pod_labels, 'vm_kubevirt_io_name') != 0
-      AND source = {{source_uuid}}
+      AND source = {{source_uuid | string}}
       AND year = {{year}}
       AND month = {{month}}
     GROUP BY 1, 2

--- a/koku/masu/database/self_hosted_sql/openshift/cost_model/hourly_vm_core_tag_based.sql
+++ b/koku/masu/database/self_hosted_sql/openshift/cost_model/hourly_vm_core_tag_based.sql
@@ -24,7 +24,7 @@ WITH
             max(interval_start) AS max_interval_start
         FROM {{schema | sqlsafe}}.openshift_vm_usage_line_items
         WHERE
-            source = {{source_uuid}}
+            source = {{source_uuid | string}}
             AND year = {{year}}
             AND month = {{month}}
         GROUP BY
@@ -40,7 +40,7 @@ WITH
             ON node_info.vm_name = vmi.vm_name
             AND node_info.interval_start = vmi.max_interval_start
         WHERE
-           node_info.source = {{source_uuid}}
+           node_info.source = {{source_uuid | string}}
             AND node_info.year = {{year}}
             AND node_info.month = {{month}}
     ),

--- a/koku/masu/database/self_hosted_sql/openshift/cost_model/hourly_vm_core_tag_based_rtu.sql
+++ b/koku/masu/database/self_hosted_sql/openshift/cost_model/hourly_vm_core_tag_based_rtu.sql
@@ -29,7 +29,7 @@ WITH
             max(interval_start) AS max_interval_start
         FROM {{schema | sqlsafe}}.openshift_vm_usage_line_items
         WHERE
-            source = {{source_uuid}}
+            source = {{source_uuid | string}}
             AND year = {{year}}
             AND month = {{month}}
         GROUP BY
@@ -45,7 +45,7 @@ WITH
             ON node_info.vm_name = vmi.vm_name
             AND node_info.interval_start = vmi.max_interval_start
         WHERE
-           node_info.source = {{source_uuid}}
+           node_info.source = {{source_uuid | string}}
             AND node_info.year = {{year}}
             AND node_info.month = {{month}}
     ),

--- a/koku/masu/database/self_hosted_sql/openshift/cost_model/monthly_cost_gpu.sql
+++ b/koku/masu/database/self_hosted_sql/openshift/cost_model/monthly_cost_gpu.sql
@@ -91,7 +91,7 @@ LEFT JOIN {{schema | sqlsafe}}.reporting_ocp_cost_category_namespace AS cat_ns
     ON gpu.namespace LIKE cat_ns.namespace
 WHERE gpu.usage_start >= DATE({{start_date}})
   AND gpu.usage_start <= DATE({{end_date}})
-  AND gpu.source = {{source_uuid}}
+  AND gpu.source = {{source_uuid | string}}
   AND gpu.year = {{year}}
   AND gpu.month = {{month}}
   AND gpu.gpu_vendor_name = '{{tag_key | sqlsafe}}'
@@ -148,7 +148,7 @@ WITH cte_unutilized_uptime_hours AS (
             gpu.gpu_model_name,
             gpu.usage_start as interval_date
         FROM {{schema | sqlsafe}}.openshift_gpu_usage_line_items_daily as gpu
-        WHERE gpu.source = {{source_uuid}}
+        WHERE gpu.source = {{source_uuid | string}}
             AND gpu.year = {{year}}
             AND gpu.month = {{month}}
             AND gpu.usage_start >= DATE({{start_date}})
@@ -162,7 +162,7 @@ WITH cte_unutilized_uptime_hours AS (
         AND node_ut.usage_start <= DATE({{end_date}})
         AND node_ut.month = {{month}}
         AND node_ut.year = {{year}}
-        AND node_ut.source = {{source_uuid}}
+        AND node_ut.source = {{source_uuid | string}}
         AND node_ut.node_labels like '%%"nvidia_com_gpu_present": "True"%%'
     GROUP BY node_ut.node, gpu.gpu_model_name, node_ut.usage_start, gpu.max_slices_per_gpu,
              gpu.physical_gpu_count, gpu.aggregated_slice_uptime, node_ut.node_labels

--- a/koku/masu/database/self_hosted_sql/openshift/cost_model/monthly_cost_gpu_rtu.sql
+++ b/koku/masu/database/self_hosted_sql/openshift/cost_model/monthly_cost_gpu_rtu.sql
@@ -118,7 +118,7 @@ LEFT JOIN {{schema | sqlsafe}}.reporting_ocp_cost_category_namespace AS cat_ns
     ON gpu.namespace LIKE cat_ns.namespace
 WHERE gpu.usage_start >= DATE({{start_date}})
   AND gpu.usage_start <= DATE({{end_date}})
-  AND gpu.source = {{source_uuid}}
+  AND gpu.source = {{source_uuid | string}}
   AND gpu.year = {{year}}
   AND gpu.month = {{month}}
   AND gpu.gpu_vendor_name = '{{tag_key | sqlsafe}}'
@@ -184,7 +184,7 @@ WITH cte_unutilized_uptime_hours AS (
             gpu.gpu_model_name,
             gpu.usage_start as interval_date
         FROM {{schema | sqlsafe}}.openshift_gpu_usage_line_items_daily as gpu
-        WHERE gpu.source = {{source_uuid}}
+        WHERE gpu.source = {{source_uuid | string}}
             AND gpu.year = {{year}}
             AND gpu.month = {{month}}
             AND gpu.usage_start >= DATE({{start_date}})
@@ -198,7 +198,7 @@ WITH cte_unutilized_uptime_hours AS (
         AND node_ut.usage_start <= DATE({{end_date}})
         AND node_ut.month = {{month}}
         AND node_ut.year = {{year}}
-        AND node_ut.source = {{source_uuid}}
+        AND node_ut.source = {{source_uuid | string}}
         AND node_ut.node_labels like '%%"nvidia_com_gpu_present": "True"%%'
     GROUP BY node_ut.node, gpu.gpu_model_name, node_ut.usage_start, gpu.max_slices_per_gpu,
              gpu.physical_gpu_count, gpu.aggregated_slice_uptime, node_ut.node_labels

--- a/koku/masu/database/self_hosted_sql/openshift/cost_model/monthly_vm_core_tag_based.sql
+++ b/koku/masu/database/self_hosted_sql/openshift/cost_model/monthly_vm_core_tag_based.sql
@@ -24,7 +24,7 @@ WITH
             max(interval_start) AS max_interval_start
         FROM {{schema | sqlsafe}}.openshift_vm_usage_line_items
         WHERE
-            source = {{source_uuid}}
+            source = {{source_uuid | string}}
             AND year = {{year}}
             AND month = {{month}}
         GROUP BY
@@ -40,7 +40,7 @@ WITH
             ON node_info.vm_name = vmi.vm_name
             AND node_info.interval_start = vmi.max_interval_start
         WHERE
-            node_info.source = {{source_uuid}}
+            node_info.source = {{source_uuid | string}}
             AND node_info.year = {{year}}
             AND node_info.month = {{month}}
     ),

--- a/koku/masu/database/self_hosted_sql/openshift/cost_model/monthly_vm_core_tag_based_rtu.sql
+++ b/koku/masu/database/self_hosted_sql/openshift/cost_model/monthly_vm_core_tag_based_rtu.sql
@@ -29,7 +29,7 @@ WITH
             max(interval_start) AS max_interval_start
         FROM {{schema | sqlsafe}}.openshift_vm_usage_line_items
         WHERE
-            source = {{source_uuid}}
+            source = {{source_uuid | string}}
             AND year = {{year}}
             AND month = {{month}}
         GROUP BY
@@ -45,7 +45,7 @@ WITH
             ON node_info.vm_name = vmi.vm_name
             AND node_info.interval_start = vmi.max_interval_start
         WHERE
-            node_info.source = {{source_uuid}}
+            node_info.source = {{source_uuid | string}}
             AND node_info.year = {{year}}
             AND node_info.month = {{month}}
     ),

--- a/koku/masu/database/self_hosted_sql/openshift/ui_summary/reporting_ocp_gpu_summary_p_usage_only.sql
+++ b/koku/masu/database/self_hosted_sql/openshift/ui_summary/reporting_ocp_gpu_summary_p_usage_only.sql
@@ -51,7 +51,7 @@ SELECT uuid_generate_v4(),
 FROM {{schema | sqlsafe}}.openshift_gpu_usage_line_items AS gpu
 LEFT JOIN {{schema | sqlsafe}}.reporting_ocp_cost_category_namespace AS cat_ns
         ON gpu.namespace LIKE cat_ns.namespace
-WHERE gpu.source = {{source_uuid}}
+WHERE gpu.source = {{source_uuid | string}}
     AND gpu.year = {{year}}
     AND lpad(gpu.month, 2, '0') = {{month}}
     AND gpu.usage_start >= date({{start_date}})

--- a/koku/masu/database/trino_sql/openshift/cost_model/hourly_cost_virtual_machine.sql
+++ b/koku/masu/database/trino_sql/openshift/cost_model/hourly_cost_virtual_machine.sql
@@ -40,7 +40,7 @@ JOIN (
         DATE(interval_start) as interval_day,
         sum(vm_uptime_total_seconds) / 3600 AS vm_interval_hours
     FROM hive.{{schema | sqlsafe}}.openshift_vm_usage_line_items
-    WHERE source = {{source_uuid}}
+    WHERE source = {{source_uuid | string}}
       AND year = {{year}}
       AND month = {{month}}
     GROUP BY 1, 2
@@ -55,7 +55,7 @@ JOIN (
         count(interval_start) AS vm_interval_hours
     FROM hive.{{schema | sqlsafe}}.openshift_pod_usage_line_items
     WHERE strpos(pod_labels, 'vm_kubevirt_io_name') != 0
-      AND source = {{source_uuid}}
+      AND source = {{source_uuid | string}}
       AND year = {{year}}
       AND month = {{month}}
     GROUP BY 1, 2

--- a/koku/masu/database/trino_sql/openshift/cost_model/hourly_cost_virtual_machine_rtu.sql
+++ b/koku/masu/database/trino_sql/openshift/cost_model/hourly_cost_virtual_machine_rtu.sql
@@ -51,7 +51,7 @@ JOIN (
         DATE(interval_start) as interval_day,
         sum(vm_uptime_total_seconds) / 3600 AS vm_interval_hours
     FROM hive.{{schema | sqlsafe}}.openshift_vm_usage_line_items
-    WHERE source = {{source_uuid}}
+    WHERE source = {{source_uuid | string}}
       AND year = {{year}}
       AND month = {{month}}
     GROUP BY 1, 2
@@ -66,7 +66,7 @@ JOIN (
         count(interval_start) AS vm_interval_hours
     FROM hive.{{schema | sqlsafe}}.openshift_pod_usage_line_items
     WHERE strpos(pod_labels, 'vm_kubevirt_io_name') != 0
-      AND source = {{source_uuid}}
+      AND source = {{source_uuid | string}}
       AND year = {{year}}
       AND month = {{month}}
     GROUP BY 1, 2

--- a/koku/masu/database/trino_sql/openshift/cost_model/hourly_cost_vm_tag_based.sql
+++ b/koku/masu/database/trino_sql/openshift/cost_model/hourly_cost_vm_tag_based.sql
@@ -54,7 +54,7 @@ JOIN (
         DATE(interval_start) AS interval_day,
         sum(vm_uptime_total_seconds) / 3600 AS vm_interval_hours
     FROM hive.{{schema | sqlsafe}}.openshift_vm_usage_line_items
-    WHERE source = {{source_uuid}}
+    WHERE source = {{source_uuid | string}}
       AND year = {{year}}
       AND month = {{month}}
     GROUP BY 1, 2
@@ -65,7 +65,7 @@ JOIN (
         count(interval_start) AS vm_interval_hours
     FROM hive.{{schema | sqlsafe}}.openshift_pod_usage_line_items
     WHERE strpos(pod_labels, 'vm_kubevirt_io_name') != 0
-      AND source = {{source_uuid}}
+      AND source = {{source_uuid | string}}
       AND year = {{year}}
       AND month = {{month}}
     GROUP BY 1, 2

--- a/koku/masu/database/trino_sql/openshift/cost_model/hourly_cost_vm_tag_based_rtu.sql
+++ b/koku/masu/database/trino_sql/openshift/cost_model/hourly_cost_vm_tag_based_rtu.sql
@@ -63,7 +63,7 @@ JOIN (
         DATE(interval_start) AS interval_day,
         sum(vm_uptime_total_seconds) / 3600 AS vm_interval_hours
     FROM hive.{{schema | sqlsafe}}.openshift_vm_usage_line_items
-    WHERE source = {{source_uuid}}
+    WHERE source = {{source_uuid | string}}
       AND year = {{year}}
       AND month = {{month}}
     GROUP BY 1, 2
@@ -74,7 +74,7 @@ JOIN (
         count(interval_start) AS vm_interval_hours
     FROM hive.{{schema | sqlsafe}}.openshift_pod_usage_line_items
     WHERE strpos(pod_labels, 'vm_kubevirt_io_name') != 0
-      AND source = {{source_uuid}}
+      AND source = {{source_uuid | string}}
       AND year = {{year}}
       AND month = {{month}}
     GROUP BY 1, 2

--- a/koku/masu/database/trino_sql/openshift/cost_model/hourly_vm_core_tag_based.sql
+++ b/koku/masu/database/trino_sql/openshift/cost_model/hourly_vm_core_tag_based.sql
@@ -24,7 +24,7 @@ WITH
             max(interval_start) AS max_interval_start
         FROM hive.{{schema | sqlsafe}}.openshift_vm_usage_line_items
         WHERE
-            source = {{source_uuid}}
+            source = {{source_uuid | string}}
             AND year = {{year}}
             AND month = {{month}}
         GROUP BY
@@ -40,7 +40,7 @@ WITH
             ON node_info.vm_name = vmi.vm_name
             AND node_info.interval_start = vmi.max_interval_start
         WHERE
-           node_info.source = {{source_uuid}}
+           node_info.source = {{source_uuid | string}}
             AND node_info.year = {{year}}
             AND node_info.month = {{month}}
     ),

--- a/koku/masu/database/trino_sql/openshift/cost_model/hourly_vm_core_tag_based_rtu.sql
+++ b/koku/masu/database/trino_sql/openshift/cost_model/hourly_vm_core_tag_based_rtu.sql
@@ -28,7 +28,7 @@ WITH
             max(interval_start) AS max_interval_start
         FROM hive.{{schema | sqlsafe}}.openshift_vm_usage_line_items
         WHERE
-            source = {{source_uuid}}
+            source = {{source_uuid | string}}
             AND year = {{year}}
             AND month = {{month}}
         GROUP BY
@@ -44,7 +44,7 @@ WITH
             ON node_info.vm_name = vmi.vm_name
             AND node_info.interval_start = vmi.max_interval_start
         WHERE
-           node_info.source = {{source_uuid}}
+           node_info.source = {{source_uuid | string}}
             AND node_info.year = {{year}}
             AND node_info.month = {{month}}
     ),

--- a/koku/masu/database/trino_sql/openshift/cost_model/monthly_cost_gpu.sql
+++ b/koku/masu/database/trino_sql/openshift/cost_model/monthly_cost_gpu.sql
@@ -94,7 +94,7 @@ LEFT JOIN postgres.{{schema | sqlsafe}}.reporting_ocp_cost_category_namespace AS
     ON gpu.namespace LIKE cat_ns.namespace
 WHERE date(gpu.interval_start) >= DATE({{start_date}})
   AND date(gpu.interval_start) <= DATE({{end_date}})
-  AND gpu.source = {{source_uuid}}
+  AND gpu.source = {{source_uuid | string}}
   AND gpu.year = {{year}}
   AND gpu.month = {{month}}
   AND gpu.gpu_vendor_name LIKE '{{tag_key | sqlsafe}}%'
@@ -148,7 +148,7 @@ WITH cte_unutilized_uptime_hours AS (
             gpu.gpu_model_name,
             DATE(gpu.interval_start) as interval_date
         FROM hive.{{schema | sqlsafe}}.openshift_gpu_usage_line_items_daily as gpu
-        WHERE gpu.source = {{source_uuid}}
+        WHERE gpu.source = {{source_uuid | string}}
             AND gpu.year = {{year}}
             AND gpu.month = {{month}}
             AND date(gpu.interval_start) >= DATE({{start_date}})
@@ -162,7 +162,7 @@ WITH cte_unutilized_uptime_hours AS (
         AND date(node_ut.interval_start) <= DATE({{end_date}})
         AND node_ut.month = {{month}}
         AND node_ut.year = {{year}}
-        AND node_ut.source = {{source_uuid}}
+        AND node_ut.source = {{source_uuid | string}}
         AND node_labels like '%"nvidia_com_gpu_present": "True"%'
     GROUP BY node_ut.node, gpu.gpu_model_name, json_extract_scalar(node_ut.node_labels, '$.nvidia_com_gpu_product'),
              DATE(node_ut.interval_start), gpu.max_slices_per_gpu,

--- a/koku/masu/database/trino_sql/openshift/cost_model/monthly_cost_gpu_rtu.sql
+++ b/koku/masu/database/trino_sql/openshift/cost_model/monthly_cost_gpu_rtu.sql
@@ -123,7 +123,7 @@ LEFT JOIN postgres.{{schema | sqlsafe}}.reporting_ocp_cost_category_namespace AS
     ON gpu.namespace LIKE cat_ns.namespace
 WHERE date(gpu.interval_start) >= DATE({{start_date}})
   AND date(gpu.interval_start) <= DATE({{end_date}})
-  AND gpu.source = {{source_uuid}}
+  AND gpu.source = {{source_uuid | string}}
   AND gpu.year = {{year}}
   AND gpu.month = {{month}}
   AND gpu.gpu_vendor_name LIKE '{{tag_key | sqlsafe}}%'
@@ -186,7 +186,7 @@ WITH cte_unutilized_uptime_hours AS (
             gpu.gpu_model_name,
             DATE(gpu.interval_start) as interval_date
         FROM hive.{{schema | sqlsafe}}.openshift_gpu_usage_line_items_daily as gpu
-        WHERE gpu.source = {{source_uuid}}
+        WHERE gpu.source = {{source_uuid | string}}
             AND gpu.year = {{year}}
             AND gpu.month = {{month}}
             AND date(gpu.interval_start) >= DATE({{start_date}})
@@ -200,7 +200,7 @@ WITH cte_unutilized_uptime_hours AS (
         AND date(node_ut.interval_start) <= DATE({{end_date}})
         AND node_ut.month = {{month}}
         AND node_ut.year = {{year}}
-        AND node_ut.source = {{source_uuid}}
+        AND node_ut.source = {{source_uuid | string}}
         AND node_labels like '%"nvidia_com_gpu_present": "True"%'
     GROUP BY node_ut.node, gpu.gpu_model_name, json_extract_scalar(node_ut.node_labels, '$.nvidia_com_gpu_product'),
              DATE(node_ut.interval_start), gpu.max_slices_per_gpu,

--- a/koku/masu/database/trino_sql/openshift/cost_model/monthly_vm_core_tag_based.sql
+++ b/koku/masu/database/trino_sql/openshift/cost_model/monthly_vm_core_tag_based.sql
@@ -24,7 +24,7 @@ WITH
             max(interval_start) AS max_interval_start
         FROM hive.{{schema | sqlsafe}}.openshift_vm_usage_line_items
         WHERE
-            source = {{source_uuid}}
+            source = {{source_uuid | string}}
             AND year = {{year}}
             AND month = {{month}}
         GROUP BY
@@ -40,7 +40,7 @@ WITH
             ON node_info.vm_name = vmi.vm_name
             AND node_info.interval_start = vmi.max_interval_start
         WHERE
-            node_info.source = {{source_uuid}}
+            node_info.source = {{source_uuid | string}}
             AND node_info.year = {{year}}
             AND node_info.month = {{month}}
     ),

--- a/koku/masu/database/trino_sql/openshift/cost_model/monthly_vm_core_tag_based_rtu.sql
+++ b/koku/masu/database/trino_sql/openshift/cost_model/monthly_vm_core_tag_based_rtu.sql
@@ -28,7 +28,7 @@ WITH
             max(interval_start) AS max_interval_start
         FROM hive.{{schema | sqlsafe}}.openshift_vm_usage_line_items
         WHERE
-            source = {{source_uuid}}
+            source = {{source_uuid | string}}
             AND year = {{year}}
             AND month = {{month}}
         GROUP BY
@@ -44,7 +44,7 @@ WITH
             ON node_info.vm_name = vmi.vm_name
             AND node_info.interval_start = vmi.max_interval_start
         WHERE
-           node_info.source = {{source_uuid}}
+           node_info.source = {{source_uuid | string}}
             AND node_info.year = {{year}}
             AND node_info.month = {{month}}
     ),

--- a/koku/masu/database/trino_sql/openshift/ui_summary/reporting_ocp_gpu_summary_p_usage_only.sql
+++ b/koku/masu/database/trino_sql/openshift/ui_summary/reporting_ocp_gpu_summary_p_usage_only.sql
@@ -45,7 +45,7 @@ SELECT uuid(),
 FROM hive.{{schema | sqlsafe}}.openshift_gpu_usage_line_items_daily AS gpu
 LEFT JOIN postgres.{{schema | sqlsafe}}.reporting_ocp_cost_category_namespace AS cat_ns
         ON gpu.namespace LIKE cat_ns.namespace
-WHERE gpu.source = {{source_uuid}}
+WHERE gpu.source = {{source_uuid | string}}
     AND gpu.year = {{year}}
     AND lpad(gpu.month, 2, '0') = {{month}} -- Zero pad the month when fewer than 2 characters
     AND date(gpu.interval_start) >= date({{start_date}})

--- a/koku/masu/test/database/test_source_uuid_varchar_type_cast.py
+++ b/koku/masu/test/database/test_source_uuid_varchar_type_cast.py
@@ -1,0 +1,167 @@
+#
+# Copyright 2026 Red Hat Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Regression: on-prem GPU/VM cost-model SQL must not bind a raw UUID against a varchar column.
+
+Found while triaging a PR #6102 review comment on distribute_unallocated_gpu_cost.sql
+(source = {{source_uuid}} with no cast/filter). openshift_gpu_usage_line_items_daily.source
+and openshift_vm_usage_line_items.source are both deliberately `varchar` (see
+OCPLineItemBase.source in reporting/provider/ocp/self_hosted_models.py: "source is stored
+as varchar to match Trino/parquet storage and existing SQL joins"), but every GPU/VM
+cost-model call site passes source_uuid as a Python uuid.UUID (Provider.uuid / self._provider_uuid),
+not a string. Confirmed live against Postgres: binding a raw uuid.UUID against a varchar
+column with psycopg2/Django's UUID adaptation raises:
+
+    ProgrammingError: operator does not exist: character varying = uuid
+
+This is not a cosmetic inconsistency -- it is the exact class of bug already fixed for
+distribute_unallocated_gpu_cost_rtu.sql (which applies the `| string` Jinja filter at its
+equivalent comparison). At the time of this fix, the SAME bare `<col> = {{source_uuid}}`
+pattern (no cast, no filter) existed -- unfixed -- in 22 template files across both
+self_hosted_sql/ and trino_sql/ (VM hourly/monthly tag-based costs, GPU monthly costs, and
+the GPU UI-summary template), none of which had any test coverage that executes against a
+real database with a real uuid.UUID: the only existing coverage
+(test_gpu_sql_template_includes_unmatched_models_with_zero_cost et al. in
+test_ocp_report_db_accessor.py) renders the SQL text with a plain *string* source_uuid
+param via JinjaSql.prepare_query and only asserts on the rendered SQL text, never executing
+it -- so it could not have caught this.
+
+Two things below:
+  1. A minimal, direct reproduction of the underlying Postgres mechanism against the actual
+     production tables/columns (openshift_gpu_usage_line_items_daily.source and
+     openshift_vm_usage_line_items.source), using the exact same JinjaSql param_style
+     ("pyformat") that ReportDBAccessorBase.prepare_query uses for the self_hosted_sql path.
+     This generalizes to every one of the 22 fixed files, since they all share these same
+     two columns and the same binding mechanism.
+  2. A static guard scanning every self_hosted_sql/ and trino_sql/ template for a
+     reintroduced bare `<col>.source = {{source_uuid}}` (or `source = {{source_uuid}}`)
+     comparison, to catch regressions or new call sites mechanically instead of relying on
+     manual review.
+
+Fix: apply the `| string` Jinja filter (matches the already-correct RTU sibling) to every
+affected comparison. See PR description / COST-8120 for the fixed file list.
+"""
+import re
+import uuid
+from pathlib import Path
+
+import django.test
+from django.db import connection
+from django.db import ProgrammingError
+from django.db import transaction
+from django_tenants.utils import schema_context
+from jinjasql import JinjaSql
+
+from koku.koku_test_runner import KokuTestRunner
+
+
+# Columns confirmed to be varchar (OCPLineItemBase.source / OCPUsageLineItemDailySummaryStaging.source)
+# that GPU/VM cost-model SQL compares against a bound source_uuid parameter.
+_VARCHAR_SOURCE_TABLES = [
+    "openshift_gpu_usage_line_items_daily",
+    "openshift_vm_usage_line_items",
+]
+
+# Directories containing the affected templates, relative to the `masu/` package root.
+# distribute_unallocated_gpu_cost*.sql is intentionally excluded here -- it already has its
+# own coverage/fix (see PR #6102).
+_SQL_TEMPLATE_DIRS = [
+    "database/self_hosted_sql/openshift",
+    "database/trino_sql/openshift",
+]
+
+# Matches a bare `<optional table alias.>source = {{source_uuid}}` with no `| string` filter
+# and no `::uuid`/`::varchar` cast on either side -- the exact unsafe pattern this test guards
+# against. Deliberately does NOT match `{{source_uuid}}::uuid` (a real uuid column elsewhere)
+# or `{{source_uuid | string}}` (the fixed form).
+_UNSAFE_PATTERN = re.compile(r"\b[a-zA-Z_.]*source\s*=\s*\{\{\s*source_uuid\s*\}\}(?!\s*::)")
+
+
+class SourceUUIDVarcharTypeCastTest(django.test.TransactionTestCase):
+    """Direct reproduction: binding a raw uuid.UUID against these varchar `source` columns."""
+
+    def _fixture_teardown(self):
+        """Skip TRUNCATE flush -- django-tenants FK graph breaks TransactionTestCase flush."""
+
+    def setUp(self):
+        self.schema = KokuTestRunner.schema
+        self.source_uuid = uuid.uuid4()
+        self.jinjasql = JinjaSql(param_style="pyformat")
+
+    def _render_and_count(self, table, source_uuid_expr):
+        """Render `SELECT count(*) FROM <table> WHERE <source_uuid_expr>` and execute it.
+
+        Uses the exact JinjaSql param_style ("pyformat") that
+        ReportDBAccessorBase.prepare_query uses for every self_hosted_sql template, and a
+        real uuid.UUID object for source_uuid -- exactly what every GPU/VM cost-model call
+        site actually passes (Provider.uuid / self._provider_uuid), never a plain string.
+        """
+        template = f"SELECT count(*) FROM {{{{schema | sqlsafe}}}}.{table} WHERE {source_uuid_expr}"
+        sql, params = self.jinjasql.prepare_query(template, {"schema": self.schema, "source_uuid": self.source_uuid})
+        with schema_context(self.schema), connection.cursor() as cursor:
+            cursor.execute(sql, params)
+            return cursor.fetchone()[0]
+
+    def test_bare_source_uuid_binds_uuid_type_and_fails_against_varchar_column(self):
+        """Red: the pre-fix pattern (no filter) fails for both affected tables.
+
+        If this test ever starts passing, something changed about how Django/psycopg2
+        adapts uuid.UUID parameters or about these columns' types -- re-evaluate whether
+        the `| string` fix is still needed before removing it.
+        """
+        for table in _VARCHAR_SOURCE_TABLES:
+            with self.subTest(table=table):
+                with transaction.atomic(), self.assertRaises(ProgrammingError) as ctx:
+                    self._render_and_count(table, "source = {{source_uuid}}")
+                self.assertIn(
+                    "operator does not exist",
+                    str(ctx.exception),
+                    f"Expected a type-mismatch error binding a raw uuid.UUID against {table}.source "
+                    f"(varchar), got: {ctx.exception}",
+                )
+
+    def test_string_filtered_source_uuid_succeeds_against_varchar_column(self):
+        """Green: the fix (`| string` Jinja filter) resolves the type mismatch for both tables."""
+        for table in _VARCHAR_SOURCE_TABLES:
+            with self.subTest(table=table):
+                # Zero matching rows is expected and fine -- the point is that the query
+                # plans and executes without a type error, not that it finds data.
+                count = self._render_and_count(table, "source = {{source_uuid | string}}")
+                self.assertEqual(count, 0)
+
+
+class SourceUUIDVarcharTypeCastStaticGuardTest(django.test.SimpleTestCase):
+    """Static guard: no self_hosted_sql/trino_sql template may reintroduce the unsafe pattern.
+
+    Scans every .sql file under the affected directories for a bare
+    `<alias.>source = {{source_uuid}}` comparison with no `| string` filter or `::` cast.
+    Catches both regressions to the 22 files fixed here and any new call site that copies
+    the old (unsafe) pattern instead of an existing (fixed) sibling.
+    """
+
+    def test_no_template_binds_raw_uuid_against_a_varchar_source_column(self):
+        repo_masu_dir = Path(__file__).resolve().parents[2]  # .../koku/masu
+        offenders = []
+        for rel_dir in _SQL_TEMPLATE_DIRS:
+            search_root = repo_masu_dir / rel_dir
+            if not search_root.exists():
+                continue
+            for sql_file in search_root.rglob("*.sql"):
+                if sql_file.name == "distribute_unallocated_gpu_cost.sql":
+                    # Fixed separately in PR #6102 (still open at the time of writing) --
+                    # excluded here to avoid a merge-order dependency between the two PRs.
+                    continue
+                text = sql_file.read_text()
+                if _UNSAFE_PATTERN.search(text):
+                    offenders.append(str(sql_file.relative_to(repo_masu_dir.parent)))
+        self.assertEqual(
+            offenders,
+            [],
+            "Found bare `source = {{source_uuid}}` (no `| string` filter, no cast) against what "
+            "must be assumed to be a varchar `source` column in: "
+            f"{offenders}. Add the `| string` Jinja filter (see monthly_cost_gpu.sql for the "
+            "established pattern) unless the compared column is genuinely uuid-typed, in which "
+            "case use an explicit `{{source_uuid}}::uuid` cast instead and exclude it from "
+            "_UNSAFE_PATTERN's scope by adding the cast.",
+        )


### PR DESCRIPTION
## Summary

- `openshift_gpu_usage_line_items_daily.source` and `openshift_vm_usage_line_items.source` are deliberately `varchar` (see `OCPLineItemBase.source`), but every GPU/VM cost-model SQL template binds `source_uuid` as a raw Python `uuid.UUID`, not a string — Postgres rejects this with `ProgrammingError: operator does not exist: character varying = uuid`.
- Found while triaging a [PR #6102 review comment](https://github.com/project-koku/koku/pull/6102) on `distribute_unallocated_gpu_cost.sql` (already fixed there). Auditing sibling templates found the *same, unfixed* bug in 22 files across both `self_hosted_sql/` and `trino_sql/`: hourly/monthly VM tag-based cost templates, monthly GPU cost templates (+ `_rtu` siblings), and the GPU UI-summary template.
- Fix: apply the `| string` Jinja filter to every affected comparison, matching the already-correct RTU sibling pattern.

## Why existing tests didn't catch this

The only prior coverage renders SQL text via `JinjaSql.prepare_query` with a plain **string** `source_uuid` param and asserts only on the rendered text — it never executes against a real database, so the type mismatch (which only manifests at Postgres bind/plan time with a real `uuid.UUID`) was invisible.

## Testing performed

- Added `koku/masu/test/database/test_source_uuid_varchar_type_cast.py`:
  - A direct reproduction against the two affected production tables/columns using the exact `pyformat` JinjaSql bind mechanism production code uses — confirmed **red** (raises `ProgrammingError`) before the fix, **green** after.
  - A static guard that scans every `self_hosted_sql/`/`trino_sql/` template for a reintroduced bare `<col> = {{source_uuid}}` pattern with no cast/filter — fails on `main` today (finds all 22 files), passes with this fix. Prevents regression / future copy-paste of the unsafe pattern.
- Ran the new test file, `test_ocp_report_db_accessor.py`, and `test_phase4_distribution.py` together (113 tests): only 2 pre-existing, unrelated failures (confirmed to reproduce identically on `main` without this change — flaky/environment, not a regression).
- Verified `pre-commit` (`reorder-python-imports`, `black`, `flake8`) passes on the new test file.

JIRA: [COST-8120](https://redhat.atlassian.net/browse/COST-8120) (related: [COST-7249](https://redhat.atlassian.net/browse/COST-7249))

## Test plan

- [ ] CI unit tests pass
- [ ] Manual: ingest OCP data with GPU/VM workloads, assign a GPU/VM cost model, trigger `update_cost_model_costs`, confirm no `ProgrammingError` and costs populate correctly