### PR TITLE
Add ingress backup scripts

### DIFF
--- a/scripts/incident/.gitignore
+++ b/scripts/incident/.gitignore
@@ -1,0 +1,9 @@
+# Customer payload backups and sensitive exports — do not commit
+payloads/
+payloads-midnight/
+state-farm-downloading-payload-raw.json
+manifest.csv
+manifest-midnight-only.csv
+urls.tsv
+urls-midnight-only.tsv
+download-log.csv

--- a/scripts/incident/2026-09-state-farm-s3-backup-plan.md
+++ b/scripts/incident/2026-09-state-farm-s3-backup-plan.md
@@ -1,0 +1,246 @@
+# Plano: backup S3 State Farm via logs Kibana
+
+**Incidente:** listeners `koku-clowder-listener` wedged — ingest OCP bloqueada
+**Customer:** State Farm — `org16594026` / account `11439097`
+**Responsáveis:** Lucas Bacciotti + Victor Sizilio
+**Data do plano:** 2026-09-01
+**Status:** 262/262 payloads baixados localmente; scripts no repo; upload S3 pendente
+
+---
+
+## O que já sabemos (Dev Tools)
+
+| Item | Valor |
+|------|-------|
+| Índice correto | `cwl-hccm-prod-YYYY.MM.DD` (ex.: `cwl-hccm-prod-2026.08.31`) |
+| Campo principal | `@message` (string; dict Python embutido) |
+| Log group / stream | `@log_group`: `hccm-prod`; `@log_stream`: `koku-clowder-listener-*` |
+| Linha alvo | `Downloading Payload for msg: {...}` |
+| Filtro org | `"org_id': '16594026'"` ou `11439097` em `@message` |
+| Total na janela do incidente | **263 hits** (`2026-08-31T22:00:00Z` → `2026-09-01T23:59:59Z`) |
+| Início do incidente (1º SF) | `2026-08-31T22:00:01Z` — `request_id` `5d6d808644034498acee1784418b8778` |
+| Bucket origem | `insights-ingress-prod` (URL presigned no log) |
+| Expiração URL | `X-Amz-Expires=86400` → **24h** após `X-Amz-Date` |
+| `oc logs` (72h) | ~34 linhas — **insuficiente**; Kibana é a fonte definitiva |
+
+**Campos a extrair do `@message`:**
+
+- `request_id` (= `tracing_id`)
+- `url` (presigned S3)
+- `size` (bytes)
+- `timestamp` (timestamp Kafka / ingress)
+- `b64_identity` → `cluster_id` (para agrupar por cluster OpenShift)
+
+---
+
+## Objetivo do backup
+
+Salvar os **tar.gz do ingress** antes que sumam do quarantine (~24h), para reprocessamento futuro (path Kafka novo — Cody/David).
+
+**Escopo acordado com o time:** foco no **midnight payload** (relatório completo do dia), não em todo upload incremental.
+
+---
+
+## Critério: o que é “midnight payload”
+
+Heurística inicial (validar com Luke se a contagem parecer errada):
+
+1. **`size >= 100_000`** (100 KB) — elimina metadata ~1.5–5 KB
+2. **Janela UTC `00:00–02:00`** do `timestamp` no payload Kafka (não só `@timestamp` do log)
+3. Opcional: **um payload por `cluster_id` por dia** — o maior `size` na janela
+
+Dias prioritários:
+
+| Dia (UTC) | Índice ES | Nota |
+|-----------|-----------|------|
+| 2026-08-31 | `cwl-hccm-prod-2026.08.31` | Início incidente ~22:00; midnight batch ~00:00 dia 01 |
+| 2026-09-01 | `cwl-hccm-prod-2026.09.01` | Continuação + midnight do dia 01 |
+
+---
+
+## URGÊNCIA: expiração das URLs
+
+| `X-Amz-Date` | Expira aprox. |
+|--------------|---------------|
+| `20260831T22*` | ~2026-09-01 22:00 UTC |
+| `20260901T00*` | ~2026-09-02 00:00 UTC |
+| `20260901T12*` | ~2026-09-02 12:00 UTC |
+
+**Ação:** baixar **hoje** tudo com `X-Amz-Date` de 2026-09-01. URLs de 31/ago podem já retornar **403** do laptop — tentar de **dentro do cluster** (`hccm-prod`).
+
+Se 403: pedir ao time de ingress se o objeto ainda existe em `s3://insights-ingress-prod/{request_id}`.
+
+---
+
+## Plano de execução
+
+### Fase 0 — Agora (15 min)
+
+- [x] Exportar **todos os 263** hits → `state-farm-downloading-payload-raw.json`
+- [x] Script de parse → `parse_kibana_state_farm_logs.py`
+- [x] Rodar parse e revisar `manifest.csv` / `manifest-midnight-only.csv`
+- [x] Download local (262 payloads) via `download_payloads.py`
+- [x] Midnight subset em `payloads-midnight/` via `split_midnight_payloads.py`
+- [ ] Testar **1 download** de URL recente (`X-Amz-Date=20260901*`) de dentro do cluster (se reexportar)
+
+### Fase 1 — Export completo do ES (30 min)
+
+**Query base** (Kibana Dev Tools):
+
+```http
+GET cwl-hccm-prod-*/_search
+{
+  "size": 500,
+  "sort": [{ "@timestamp": "asc" }, { "_id": "asc" }],
+  "query": {
+    "bool": {
+      "filter": [
+        { "range": { "@timestamp": { "gte": "2026-08-31T22:00:00Z", "lte": "2026-09-01T23:59:59Z" } } }
+      ],
+      "must": [
+        { "query_string": {
+            "query": "\"Downloading Payload\" AND (16594026 OR 11439097)",
+            "default_field": "@message"
+        }}
+      ]
+    }
+  },
+  "_source": ["@timestamp", "@message", "@log_stream"]
+}
+```
+
+Paginação: repetir com `search_after` usando o último `sort` da página anterior até `hits.hits` vazio.
+
+Alternativa: Kibana **Discover** → index `cwl-hccm-prod-*` → export CSV.
+
+### Fase 2 — Parse + manifest (30 min)
+
+```bash
+cd scripts/incident
+python3 parse_kibana_state_farm_logs.py
+```
+
+Gera: `manifest.csv`, `manifest-midnight-only.csv`, `urls.tsv`, `urls-midnight-only.tsv`
+
+- [x] Script Python: JSON → `manifest.csv`
+- [ ] Colunas: `request_id`, `kafka_timestamp`, `log_timestamp`, `size`, `url`, `cluster_id`, `pod`, `x_amz_date`, `url_expires_utc`
+- [ ] Dedupe por `request_id`
+- [ ] Aplicar filtro midnight (`size >= 100KB` + janela 00:00–02:00 UTC)
+- [ ] Gerar `manifest-midnight-only.csv` para o backup final
+
+### Fase 3 — Download (1–2 h)
+
+- [ ] Ordenar por `url_expires_utc` ascendente (mais urgentes primeiro)
+- [ ] Download de **dentro** de `hccm-prod` (curl/wget em job temporário ou pod listener)
+- [ ] Registrar status: `OK` / `403` / `timeout` por `request_id`
+
+```bash
+oc project hccm-prod
+
+# Teste único (substituir URL e request_id)
+oc run sf-backup-test --rm -i --restart=Never \
+  --image=registry.access.redhat.com/ubi9/ubi-minimal \
+  --command -- curl -fsSL -o /tmp/test.tgz "PRESIGNED_URL" && ls -la /tmp/test.tgz
+```
+
+### Fase 4 — Upload para bucket do time (30 min)
+
+Destino sugerido (confirmar com Cody/Luke):
+
+```
+s3://hccm-prod-s3/incident-backup/state-farm/2026-08-31/{request_id}.tgz
+s3://hccm-prod-s3/incident-backup/state-farm/2026-09-01/{request_id}.tgz
+```
+
+- [ ] Usar creds do namespace (`koku-aws` / `hccm-s3`)
+- [ ] Subir `manifest.csv` + `manifest-midnight-only.csv` junto dos `.tgz`
+- [ ] Postar link do prefixo S3 + contagem no thread do incidente (Slack)
+
+### Fase 5 — Handoff para reingest (Cody/David)
+
+Entregar:
+
+- Caminho S3 dos backups
+- `manifest-midnight-only.csv` com `request_id` + `kafka_timestamp` + `size`
+- Janela temporal do incidente
+- Nota: URLs presigned originais provavelmente expiradas; backup é a cópia local
+
+---
+
+## Queries úteis (validação)
+
+**Contagem por dia:**
+
+```http
+GET cwl-hccm-prod-*/_search
+{
+  "size": 0,
+  "query": {
+    "bool": {
+      "filter": [{ "range": { "@timestamp": { "gte": "2026-08-31T22:00:00Z", "lte": "2026-09-01T23:59:59Z" } } }],
+      "must": [{ "query_string": { "query": "\"Downloading Payload\" AND 16594026", "default_field": "@message" } }]
+    }
+  },
+  "aggs": {
+    "by_day": { "date_histogram": { "field": "@timestamp", "calendar_interval": "day" } }
+  }
+}
+```
+
+**Só payloads grandes (pré-filtro midnight):**
+
+Adicionar ao `must_not`:
+
+```json
+{ "regexp": { "@message": ".*'size': [0-9]{1,5},.*" } }
+```
+
+(exclui `size` com 1–5 dígitos = &lt; 100 KB na maioria dos casos)
+
+---
+
+## Riscos e mitigações
+
+| Risco | Mitigação |
+|-------|-----------|
+| URL expirada (403) | Download urgente; fallback ingress S3 por `request_id` |
+| 263 ≠ midnight-only | Filtro `size` + janela horária; validar com Luke |
+| Download lento / pods grandes | Job paralelo com limite (ex. 5 concurrent) |
+| Presigned não funciona fora do cluster | Sempre rodar curl de `hccm-prod` |
+| Quarantine 24h no ingress | Priorizar URLs mais antigas **agora** |
+
+---
+
+## O que fazer AGORA (ordem)
+
+1. **Exportar os 263** — query acima, `size: 500`, paginar se necessário → salvar JSON nesta pasta
+2. **Testar 1 curl** no cluster com URL de `20260901*` (ex. `e2c7eacccf1f44eab0c8ef15decb590c`)
+3. **Avisar Victor** no Slack: “263 hits no Kibana, começando download; URLs de 31/ago expiram ~22:00 UTC hoje”
+4. **Rodar script de parse** (próximo artefato: `parse_kibana_logs.py` nesta pasta)
+5. **Download em lote** das URLs ainda válidas → upload `hccm-prod-s3`
+
+Não esperar o script perfeito para o passo 2 — a janela de 24h é o blocker real.
+
+---
+
+## Referências
+
+- Kibana prod: `https://kibana.apps.crcp01ue1.o9m8.p1.openshiftapps.com`
+- Índice: `cwl-hccm-prod-*`
+- Código do log: `koku/masu/external/kafka_msg_handler.py` → `Downloading Payload for msg:`
+- Namespace: `hccm-prod` / cluster `crcp01ue1`
+- Plano maior do time: backup S3 (item 1) + novo path Kafka com flag (item 2, Cody)
+
+---
+
+## Checklist rápido (copiar pro Slack)
+
+```
+State Farm S3 backup — status
+[ ] 263 logs exportados do Kibana (cwl-hccm-prod-*)
+[ ] manifest.csv com request_id + url + size
+[ ] midnight-only filtrado (size >= 100KB, 00:00-02:00 UTC)
+[ ] download testado de dentro do hccm-prod
+[ ] .tgz no s3://hccm-prod-s3/incident-backup/state-farm/
+[ ] handoff para Cody com manifest
+```

--- a/scripts/incident/2026-09-state-farm-s3-backup-plan.md
+++ b/scripts/incident/2026-09-state-farm-s3-backup-plan.md
@@ -1,91 +1,91 @@
-# Plano: backup S3 State Farm via logs Kibana
+# Plan: State Farm S3 backup via Kibana logs
 
-**Incidente:** listeners `koku-clowder-listener` wedged — ingest OCP bloqueada
+**Incident:** `koku-clowder-listener` pods wedged — OCP ingest blocked
 **Customer:** State Farm — `org16594026` / account `11439097`
-**Responsáveis:** Lucas Bacciotti + Victor Sizilio
-**Data do plano:** 2026-09-01
-**Status:** 262/262 payloads baixados localmente; scripts no repo; upload S3 pendente
+**Owners:** Lucas Bacciotti + Victor Sizilio
+**Plan date:** 2026-09-01
+**Status:** 262/262 payloads downloaded locally; scripts in repo; S3 upload pending
 
 ---
 
-## O que já sabemos (Dev Tools)
+## What we already know (Dev Tools)
 
-| Item | Valor |
+| Item | Value |
 |------|-------|
-| Índice correto | `cwl-hccm-prod-YYYY.MM.DD` (ex.: `cwl-hccm-prod-2026.08.31`) |
-| Campo principal | `@message` (string; dict Python embutido) |
+| Correct index | `cwl-hccm-prod-YYYY.MM.DD` (e.g. `cwl-hccm-prod-2026.08.31`) |
+| Primary field | `@message` (string; embedded Python dict) |
 | Log group / stream | `@log_group`: `hccm-prod`; `@log_stream`: `koku-clowder-listener-*` |
-| Linha alvo | `Downloading Payload for msg: {...}` |
-| Filtro org | `"org_id': '16594026'"` ou `11439097` em `@message` |
-| Total na janela do incidente | **263 hits** (`2026-08-31T22:00:00Z` → `2026-09-01T23:59:59Z`) |
-| Início do incidente (1º SF) | `2026-08-31T22:00:01Z` — `request_id` `5d6d808644034498acee1784418b8778` |
-| Bucket origem | `insights-ingress-prod` (URL presigned no log) |
-| Expiração URL | `X-Amz-Expires=86400` → **24h** após `X-Amz-Date` |
-| `oc logs` (72h) | ~34 linhas — **insuficiente**; Kibana é a fonte definitiva |
+| Target line | `Downloading Payload for msg: {...}` |
+| Org filter | `"org_id': '16594026'"` or `11439097` in `@message` |
+| Total in incident window | **263 hits** (`2026-08-31T22:00:00Z` → `2026-09-01T23:59:59Z`) |
+| Incident start (1st SF) | `2026-08-31T22:00:01Z` — `request_id` `5d6d808644034498acee1784418b8778` |
+| Source bucket | `insights-ingress-prod` (presigned URL in log) |
+| URL expiry | `X-Amz-Expires=86400` → **24h** after `X-Amz-Date` |
+| `oc logs` (72h) | ~34 lines — **insufficient**; Kibana is the source of truth |
 
-**Campos a extrair do `@message`:**
+**Fields to extract from `@message`:**
 
 - `request_id` (= `tracing_id`)
 - `url` (presigned S3)
 - `size` (bytes)
-- `timestamp` (timestamp Kafka / ingress)
-- `b64_identity` → `cluster_id` (para agrupar por cluster OpenShift)
+- `timestamp` (Kafka / ingress timestamp)
+- `b64_identity` → `cluster_id` (to group by OpenShift cluster)
 
 ---
 
-## Objetivo do backup
+## Backup goal
 
-Salvar os **tar.gz do ingress** antes que sumam do quarantine (~24h), para reprocessamento futuro (path Kafka novo — Cody/David).
+Save **ingress tar.gz** files before they leave quarantine (~24h), for future reprocessing (new Kafka path — Cody/David).
 
-**Escopo acordado com o time:** foco no **midnight payload** (relatório completo do dia), não em todo upload incremental.
-
----
-
-## Critério: o que é “midnight payload”
-
-Heurística inicial (validar com Luke se a contagem parecer errada):
-
-1. **`size >= 100_000`** (100 KB) — elimina metadata ~1.5–5 KB
-2. **Janela UTC `00:00–02:00`** do `timestamp` no payload Kafka (não só `@timestamp` do log)
-3. Opcional: **um payload por `cluster_id` por dia** — o maior `size` na janela
-
-Dias prioritários:
-
-| Dia (UTC) | Índice ES | Nota |
-|-----------|-----------|------|
-| 2026-08-31 | `cwl-hccm-prod-2026.08.31` | Início incidente ~22:00; midnight batch ~00:00 dia 01 |
-| 2026-09-01 | `cwl-hccm-prod-2026.09.01` | Continuação + midnight do dia 01 |
+**Team-agreed scope:** focus on **midnight payload** (full-day report), not every incremental upload.
 
 ---
 
-## URGÊNCIA: expiração das URLs
+## Criterion: what is a “midnight payload”
 
-| `X-Amz-Date` | Expira aprox. |
-|--------------|---------------|
+Initial heuristic (validate with Luke if the count looks wrong):
+
+1. **`size >= 100_000`** (100 KB) — excludes metadata ~1.5–5 KB
+2. **UTC window `00:00–02:00`** on the Kafka payload `timestamp` (not just log `@timestamp`)
+3. Optional: **one payload per `cluster_id` per day** — largest `size` in the window
+
+Priority days:
+
+| Day (UTC) | ES index | Note |
+|-----------|----------|------|
+| 2026-08-31 | `cwl-hccm-prod-2026.08.31` | Incident start ~22:00; midnight batch ~00:00 on the 1st |
+| 2026-09-01 | `cwl-hccm-prod-2026.09.01` | Continuation + midnight for the 1st |
+
+---
+
+## URGENCY: URL expiration
+
+| `X-Amz-Date` | Approx. expiry |
+|--------------|----------------|
 | `20260831T22*` | ~2026-09-01 22:00 UTC |
 | `20260901T00*` | ~2026-09-02 00:00 UTC |
 | `20260901T12*` | ~2026-09-02 12:00 UTC |
 
-**Ação:** baixar **hoje** tudo com `X-Amz-Date` de 2026-09-01. URLs de 31/ago podem já retornar **403** do laptop — tentar de **dentro do cluster** (`hccm-prod`).
+**Action:** download **today** everything with `X-Amz-Date` on 2026-09-01. Aug 31 URLs may already return **403** from a laptop — try from **inside the cluster** (`hccm-prod`).
 
-Se 403: pedir ao time de ingress se o objeto ainda existe em `s3://insights-ingress-prod/{request_id}`.
+If 403: ask the ingress team whether the object still exists at `s3://insights-ingress-prod/{request_id}`.
 
 ---
 
-## Plano de execução
+## Execution plan
 
-### Fase 0 — Agora (15 min)
+### Phase 0 — Now (15 min)
 
-- [x] Exportar **todos os 263** hits → `state-farm-downloading-payload-raw.json`
-- [x] Script de parse → `parse_kibana_state_farm_logs.py`
-- [x] Rodar parse e revisar `manifest.csv` / `manifest-midnight-only.csv`
-- [x] Download local (262 payloads) via `download_payloads.py`
-- [x] Midnight subset em `payloads-midnight/` via `split_midnight_payloads.py`
-- [ ] Testar **1 download** de URL recente (`X-Amz-Date=20260901*`) de dentro do cluster (se reexportar)
+- [x] Export **all 263** hits → `state-farm-downloading-payload-raw.json`
+- [x] Parse script → `parse_kibana_state_farm_logs.py`
+- [x] Run parse and review `manifest.csv` / `manifest-midnight-only.csv`
+- [x] Local download (262 payloads) via `download_payloads.py`
+- [x] Midnight subset in `payloads-midnight/` via `split_midnight_payloads.py`
+- [ ] Test **1 download** of a recent URL (`X-Amz-Date=20260901*`) from inside the cluster (if re-exporting)
 
-### Fase 1 — Export completo do ES (30 min)
+### Phase 1 — Full ES export (30 min)
 
-**Query base** (Kibana Dev Tools):
+**Base query** (Kibana Dev Tools):
 
 ```http
 GET cwl-hccm-prod-*/_search
@@ -109,67 +109,68 @@ GET cwl-hccm-prod-*/_search
 }
 ```
 
-Paginação: repetir com `search_after` usando o último `sort` da página anterior até `hits.hits` vazio.
+Pagination: repeat with `search_after` using the last page's `sort` until `hits.hits` is empty.
 
-Alternativa: Kibana **Discover** → index `cwl-hccm-prod-*` → export CSV.
+Alternative: Kibana **Discover** → index `cwl-hccm-prod-*` → export CSV.
 
-### Fase 2 — Parse + manifest (30 min)
+### Phase 2 — Parse + manifest (30 min)
 
 ```bash
 cd scripts/incident
 python3 parse_kibana_state_farm_logs.py
 ```
 
-Gera: `manifest.csv`, `manifest-midnight-only.csv`, `urls.tsv`, `urls-midnight-only.tsv`
+Produces: `manifest.csv`, `manifest-midnight-only.csv`, `urls.tsv`, `urls-midnight-only.tsv`
 
-- [x] Script Python: JSON → `manifest.csv`
-- [ ] Colunas: `request_id`, `kafka_timestamp`, `log_timestamp`, `size`, `url`, `cluster_id`, `pod`, `x_amz_date`, `url_expires_utc`
-- [ ] Dedupe por `request_id`
-- [ ] Aplicar filtro midnight (`size >= 100KB` + janela 00:00–02:00 UTC)
-- [ ] Gerar `manifest-midnight-only.csv` para o backup final
+- [x] Python script: JSON → `manifest.csv`
+- [x] Columns: `request_id`, `kafka_timestamp`, `log_timestamp`, `size`, `url`, `cluster_id`, `log_stream`, `x_amz_date`, `url_expires_utc`
+- [x] Dedupe by `request_id`
+- [x] Apply midnight filter (`size >= 100KB` + 00:00–02:00 UTC window)
+- [x] Generate `manifest-midnight-only.csv` for final backup
 
-### Fase 3 — Download (1–2 h)
+### Phase 3 — Download (1–2 h)
 
-- [ ] Ordenar por `url_expires_utc` ascendente (mais urgentes primeiro)
-- [ ] Download de **dentro** de `hccm-prod` (curl/wget em job temporário ou pod listener)
-- [ ] Registrar status: `OK` / `403` / `timeout` por `request_id`
+- [x] Download from laptop (262/262 OK for exported set)
+- [ ] Sort by `url_expires_utc` ascending (most urgent first) — for future re-runs
+- [ ] Download from **inside** `hccm-prod` if laptop gets 403 (curl/wget in temp job or listener pod)
+- [x] Log status per `request_id` in `download-log.csv`
 
 ```bash
 oc project hccm-prod
 
-# Teste único (substituir URL e request_id)
+# Single test (replace URL and request_id)
 oc run sf-backup-test --rm -i --restart=Never \
   --image=registry.access.redhat.com/ubi9/ubi-minimal \
   --command -- curl -fsSL -o /tmp/test.tgz "PRESIGNED_URL" && ls -la /tmp/test.tgz
 ```
 
-### Fase 4 — Upload para bucket do time (30 min)
+### Phase 4 — Upload to team bucket (30 min)
 
-Destino sugerido (confirmar com Cody/Luke):
+Suggested destination (confirm with Cody/Luke):
 
 ```
-s3://hccm-prod-s3/incident-backup/state-farm/2026-08-31/{request_id}.tgz
-s3://hccm-prod-s3/incident-backup/state-farm/2026-09-01/{request_id}.tgz
+s3://hccm-prod-s3/incident-backup/state-farm/all/{request_id}.tgz
+s3://hccm-prod-s3/incident-backup/state-farm/midnight/{request_id}.tgz
 ```
 
-- [ ] Usar creds do namespace (`koku-aws` / `hccm-s3`)
-- [ ] Subir `manifest.csv` + `manifest-midnight-only.csv` junto dos `.tgz`
-- [ ] Postar link do prefixo S3 + contagem no thread do incidente (Slack)
+- [ ] Use namespace creds (`koku-aws` / `hccm-s3`)
+- [ ] Upload `manifest.csv` + `manifest-midnight-only.csv` alongside `.tgz` files
+- [ ] Post S3 prefix link + counts in the incident Slack thread
 
-### Fase 5 — Handoff para reingest (Cody/David)
+### Phase 5 — Handoff for reingest (Cody/David)
 
-Entregar:
+Deliver:
 
-- Caminho S3 dos backups
-- `manifest-midnight-only.csv` com `request_id` + `kafka_timestamp` + `size`
-- Janela temporal do incidente
-- Nota: URLs presigned originais provavelmente expiradas; backup é a cópia local
+- S3 path for backups (`payloads/` = full set, `payloads-midnight/` = reingest scope)
+- `manifest-midnight-only.csv` with `request_id` + `kafka_timestamp` + `size`
+- Incident time window
+- Note: original presigned URLs are likely expired; the backup copy is the durable artifact
 
 ---
 
-## Queries úteis (validação)
+## Useful queries (validation)
 
-**Contagem por dia:**
+**Count by day:**
 
 ```http
 GET cwl-hccm-prod-*/_search
@@ -187,60 +188,61 @@ GET cwl-hccm-prod-*/_search
 }
 ```
 
-**Só payloads grandes (pré-filtro midnight):**
+**Large payloads only (pre-midnight filter):**
 
-Adicionar ao `must_not`:
+Add to `must_not`:
 
 ```json
 { "regexp": { "@message": ".*'size': [0-9]{1,5},.*" } }
 ```
 
-(exclui `size` com 1–5 dígitos = &lt; 100 KB na maioria dos casos)
+(excludes `size` with 1–5 digits = &lt; 100 KB in most cases)
 
 ---
 
-## Riscos e mitigações
+## Risks and mitigations
 
-| Risco | Mitigação |
-|-------|-----------|
-| URL expirada (403) | Download urgente; fallback ingress S3 por `request_id` |
-| 263 ≠ midnight-only | Filtro `size` + janela horária; validar com Luke |
-| Download lento / pods grandes | Job paralelo com limite (ex. 5 concurrent) |
-| Presigned não funciona fora do cluster | Sempre rodar curl de `hccm-prod` |
-| Quarantine 24h no ingress | Priorizar URLs mais antigas **agora** |
-
----
-
-## O que fazer AGORA (ordem)
-
-1. **Exportar os 263** — query acima, `size: 500`, paginar se necessário → salvar JSON nesta pasta
-2. **Testar 1 curl** no cluster com URL de `20260901*` (ex. `e2c7eacccf1f44eab0c8ef15decb590c`)
-3. **Avisar Victor** no Slack: “263 hits no Kibana, começando download; URLs de 31/ago expiram ~22:00 UTC hoje”
-4. **Rodar script de parse** (próximo artefato: `parse_kibana_logs.py` nesta pasta)
-5. **Download em lote** das URLs ainda válidas → upload `hccm-prod-s3`
-
-Não esperar o script perfeito para o passo 2 — a janela de 24h é o blocker real.
+| Risk | Mitigation |
+|------|------------|
+| Expired URL (403) | Urgent download; fallback to ingress S3 by `request_id` |
+| 263 ≠ midnight-only | `size` + time window filter; validate with Luke |
+| Slow download / large pods | Parallel job with limit (e.g. 5 concurrent) |
+| Presigned URL fails outside cluster | Run curl from `hccm-prod` |
+| 24h ingress quarantine | Prioritize oldest URLs first |
 
 ---
 
-## Referências
+## What to do NOW (order)
+
+1. **Export the 263** — query above, `size: 500`, paginate if needed → save JSON in this folder
+2. **Test 1 curl** in cluster with a `20260901*` URL (e.g. `e2c7eacccf1f44eab0c8ef15decb590c`)
+3. **Notify Victor** on Slack: “263 Kibana hits, starting download; Aug 31 URLs expire ~22:00 UTC today”
+4. **Run parse script** → `parse_kibana_state_farm_logs.py`
+5. **Batch download** valid URLs → upload to `hccm-prod-s3`
+6. **Split midnight** → `split_midnight_payloads.py` → upload `payloads-midnight/` separately
+
+Do not wait for a perfect script before step 2 — the 24h window is the real blocker.
+
+---
+
+## References
 
 - Kibana prod: `https://kibana.apps.crcp01ue1.o9m8.p1.openshiftapps.com`
-- Índice: `cwl-hccm-prod-*`
-- Código do log: `koku/masu/external/kafka_msg_handler.py` → `Downloading Payload for msg:`
+- Index: `cwl-hccm-prod-*`
+- Log source: `koku/masu/external/kafka_msg_handler.py` → `Downloading Payload for msg:`
 - Namespace: `hccm-prod` / cluster `crcp01ue1`
-- Plano maior do time: backup S3 (item 1) + novo path Kafka com flag (item 2, Cody)
+- Broader team plan: S3 backup (item 1) + new Kafka path behind flag (item 2, Cody)
 
 ---
 
-## Checklist rápido (copiar pro Slack)
+## Quick checklist (copy to Slack)
 
 ```
 State Farm S3 backup — status
-[ ] 263 logs exportados do Kibana (cwl-hccm-prod-*)
-[ ] manifest.csv com request_id + url + size
-[ ] midnight-only filtrado (size >= 100KB, 00:00-02:00 UTC)
-[ ] download testado de dentro do hccm-prod
-[ ] .tgz no s3://hccm-prod-s3/incident-backup/state-farm/
-[ ] handoff para Cody com manifest
+[x] 263 logs exported from Kibana (cwl-hccm-prod-*)
+[x] manifest.csv with request_id + url + size
+[x] midnight-only filtered (size >= 100KB, 00:00-02:00 UTC) — 32 payloads
+[x] 262/262 downloaded locally (~1.1 GB full, ~190 MB midnight)
+[ ] .tgz in s3://hccm-prod-s3/incident-backup/state-farm/
+[ ] handoff to Cody with manifest-midnight-only.csv
 ```

--- a/scripts/incident/download_payloads.py
+++ b/scripts/incident/download_payloads.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Download ingress payload archives from manifest.csv or urls.tsv.
+
+Input:  manifest.csv (or urls.tsv / urls-midnight-only.tsv)
+Output: payloads/{request_id}.tgz, download-log.csv
+
+Usage:
+    python download_payloads.py
+    python download_payloads.py --manifest manifest-midnight-only.csv --output-dir payloads-midnight
+    python download_payloads.py --workers 5 --skip-existing
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import sys
+import urllib.error
+import urllib.request
+from concurrent.futures import as_completed
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+DEFAULT_MANIFEST = SCRIPT_DIR / "manifest.csv"
+DEFAULT_OUTPUT_DIR = SCRIPT_DIR / "payloads"
+DEFAULT_LOG = SCRIPT_DIR / "download-log.csv"
+
+LOG_FIELDS = ["request_id", "status", "bytes", "error"]
+
+
+def load_rows(path: Path) -> list[dict]:
+    if path.suffix == ".tsv" or path.name.startswith("urls"):
+        rows = []
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            request_id, url = line.split("\t", 1)
+            rows.append({"request_id": request_id, "url": url})
+        return rows
+
+    with path.open(encoding="utf-8") as fh:
+        return list(csv.DictReader(fh))
+
+
+def download_one(request_id: str, url: str, output_dir: Path, skip_existing: bool) -> dict:
+    out_path = output_dir / f"{request_id}.tgz"
+    if skip_existing and out_path.is_file() and out_path.stat().st_size > 0:
+        return {
+            "request_id": request_id,
+            "status": "skipped",
+            "bytes": out_path.stat().st_size,
+            "error": "",
+        }
+
+    try:
+        req = urllib.request.Request(url, headers={"User-Agent": "koku-incident-backup/1.0"})
+        with urllib.request.urlopen(req, timeout=300) as resp:
+            data = resp.read()
+        out_path.write_bytes(data)
+        return {"request_id": request_id, "status": "ok", "bytes": len(data), "error": ""}
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        return {"request_id": request_id, "status": "error", "bytes": 0, "error": str(exc)}
+
+
+def write_log(path: Path, rows: list[dict]) -> None:
+    with path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=LOG_FIELDS)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument("--log", type=Path, default=DEFAULT_LOG)
+    parser.add_argument("--workers", type=int, default=3)
+    parser.add_argument("--skip-existing", action="store_true")
+    args = parser.parse_args()
+
+    if not args.manifest.is_file():
+        print(f"Manifest not found: {args.manifest}", file=sys.stderr)
+        return 1
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    rows = load_rows(args.manifest)
+    if not rows:
+        print("No rows to download", file=sys.stderr)
+        return 1
+
+    results: list[dict] = []
+    with ThreadPoolExecutor(max_workers=max(1, args.workers)) as pool:
+        futures = {
+            pool.submit(
+                download_one,
+                row["request_id"],
+                row["url"],
+                args.output_dir,
+                args.skip_existing,
+            ): row["request_id"]
+            for row in rows
+        }
+        for future in as_completed(futures):
+            result = future.result()
+            results.append(result)
+            print(f"{result['status']:>7}  {result['request_id']}  {result['bytes']}")
+
+    results.sort(key=lambda r: r["request_id"])
+    write_log(args.log, results)
+
+    ok = sum(1 for r in results if r["status"] in ("ok", "skipped"))
+    errors = [r for r in results if r["status"] == "error"]
+    print(f"\nDone: {ok}/{len(results)} ok/skipped, {len(errors)} errors")
+    print(f"Wrote: {args.log}")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/incident/parse_kibana_state_farm_logs.py
+++ b/scripts/incident/parse_kibana_state_farm_logs.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Parse Kibana ES export and extract State Farm ingress payload URLs.
+
+Input:  state-farm-downloading-payload-raw.json (Kibana Dev Tools export)
+Output: manifest.csv (all unique request_ids)
+        manifest-midnight-only.csv (size >= 100KB, kafka timestamp 00:00-02:00 UTC)
+        urls.tsv (request_id<TAB>url) for batch curl inside the cluster
+
+Usage:
+    python parse_kibana_state_farm_logs.py
+    python parse_kibana_state_farm_logs.py --input /path/to/export.json --output-dir ./out
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import csv
+import json
+import re
+import sys
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from pathlib import Path
+from urllib.parse import parse_qs
+from urllib.parse import urlparse
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+DEFAULT_INPUT = SCRIPT_DIR / "state-farm-downloading-payload-raw.json"
+DEFAULT_OUTPUT_DIR = SCRIPT_DIR
+
+HIT_BLOCK_RE = re.compile(
+    r'"@message"\s*:\s*"""(.*?)"""\s*,\s*\n\s*"@timestamp"\s*:\s*"([^"]+)"'
+    r'(?:\s*,\s*\n\s*"@log_stream"\s*:\s*"([^"]*)")?',
+    re.DOTALL,
+)
+MSG_PREFIX = "Downloading Payload for msg: "
+
+REQUEST_ID_RE = re.compile(r"'request_id': '([^']+)'")
+URL_RE = re.compile(r"'url': '(https://[^']+)'")
+SIZE_RE = re.compile(r"'size': (\d+)")
+KAFKA_TS_RE = re.compile(r"'timestamp': '([^']+)'")
+ACCOUNT_RE = re.compile(r"'account': '([^']*)'")
+ORG_ID_RE = re.compile(r"'org_id': '([^']+)'")
+B64_IDENTITY_RE = re.compile(r"'b64_identity': '([^']+)'")
+MIDNIGHT_MIN_SIZE_BYTES = 100_000
+MIDNIGHT_HOUR_START = 0
+MIDNIGHT_HOUR_END = 2  # exclusive upper bound: 00:00 <= t < 02:00 UTC
+
+
+def load_hits_from_export(path: Path) -> list[dict]:
+    """Extract hit fields from Kibana export (not strict JSON)."""
+    text = path.read_text(encoding="utf-8")
+    hits = []
+    for match in HIT_BLOCK_RE.finditer(text):
+        message, log_timestamp, log_stream = match.group(1), match.group(2), match.group(3) or ""
+        hits.append(
+            {
+                "@message": message,
+                "@timestamp": log_timestamp,
+                "@log_stream": log_stream,
+            }
+        )
+    if not hits:
+        raise ValueError(f"No log hits found in {path} — check export format")
+    return hits
+
+
+def _regex_field(pattern: re.Pattern[str], message: str, name: str) -> str:
+    match = pattern.search(message)
+    if not match:
+        raise ValueError(f"missing {name}")
+    return match.group(1)
+
+
+def _extract_kafka_fields(message: str) -> dict:
+    return {
+        "request_id": _regex_field(REQUEST_ID_RE, message, "request_id"),
+        "url": _regex_field(URL_RE, message, "url"),
+        "size": int(_regex_field(SIZE_RE, message, "size")),
+        "timestamp": _regex_field(KAFKA_TS_RE, message, "timestamp"),
+        "account": _regex_field(ACCOUNT_RE, message, "account"),
+        "org_id": _regex_field(ORG_ID_RE, message, "org_id"),
+        "b64_identity": (B64_IDENTITY_RE.search(message) or [None, ""])[1],
+    }
+
+
+def _cluster_id_from_identity(b64_identity: str) -> str:
+    if not b64_identity:
+        return ""
+    try:
+        padding = "=" * (-len(b64_identity) % 4)
+        payload = json.loads(base64.b64decode(b64_identity + padding))
+    except (json.JSONDecodeError, ValueError):
+        return ""
+    identity = payload.get("identity", {})
+    system = identity.get("system", {}) or {}
+    return system.get("cluster_id", "") or ""
+
+
+def _url_expiry_utc(url: str) -> datetime | None:
+    query = parse_qs(urlparse(url).query)
+    amz_date = (query.get("X-Amz-Date") or [None])[0]
+    expires = (query.get("X-Amz-Expires") or ["86400"])[0]
+    if not amz_date:
+        return None
+    signed_at = datetime.strptime(amz_date, "%Y%m%dT%H%M%SZ").replace(tzinfo=timezone.utc)
+    return signed_at + timedelta(seconds=int(expires))
+
+
+def parse_hit(hit: dict) -> dict:
+    source = hit if "@message" in hit else hit.get("_source", hit)
+    message = source["@message"]
+    if MSG_PREFIX not in message:
+        raise ValueError("missing Downloading Payload prefix")
+    kafka = _extract_kafka_fields(message)
+    url = kafka["url"]
+    b64_identity = kafka.get("b64_identity", "")
+    expiry = _url_expiry_utc(url)
+    return {
+        "request_id": kafka["request_id"],
+        "account": kafka.get("account", ""),
+        "org_id": kafka.get("org_id", ""),
+        "size": int(kafka["size"]),
+        "url": url,
+        "kafka_timestamp": kafka["timestamp"],
+        "log_timestamp": source.get("@timestamp", ""),
+        "log_stream": source.get("@log_stream", ""),
+        "cluster_id": _cluster_id_from_identity(b64_identity),
+        "x_amz_date": (parse_qs(urlparse(url).query).get("X-Amz-Date") or [""])[0],
+        "url_expires_utc": expiry.isoformat() if expiry else "",
+    }
+
+
+def is_midnight_payload(row: dict) -> bool:
+    if row["size"] < MIDNIGHT_MIN_SIZE_BYTES:
+        return False
+    try:
+        ts = datetime.fromisoformat(row["kafka_timestamp"].replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    ts = ts.astimezone(timezone.utc)
+    return MIDNIGHT_HOUR_START <= ts.hour < MIDNIGHT_HOUR_END
+
+
+def dedupe_rows(rows: list[dict]) -> list[dict]:
+    by_id: dict[str, dict] = {}
+    for row in rows:
+        existing = by_id.get(row["request_id"])
+        if existing is None or row["log_timestamp"] > existing["log_timestamp"]:
+            by_id[row["request_id"]] = row
+    return sorted(by_id.values(), key=lambda r: (r["kafka_timestamp"], r["request_id"]))
+
+
+def write_csv(path: Path, rows: list[dict]) -> None:
+    fieldnames = [
+        "request_id",
+        "kafka_timestamp",
+        "log_timestamp",
+        "size",
+        "url",
+        "url_expires_utc",
+        "x_amz_date",
+        "cluster_id",
+        "account",
+        "org_id",
+        "log_stream",
+    ]
+    with path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def write_urls_tsv(path: Path, rows: list[dict]) -> None:
+    with path.open("w", encoding="utf-8") as fh:
+        for row in rows:
+            fh.write(f"{row['request_id']}\t{row['url']}\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", type=Path, default=DEFAULT_INPUT)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument(
+        "--midnight-only",
+        action="store_true",
+        help="Only write midnight-filtered outputs (default: write both manifests)",
+    )
+    args = parser.parse_args()
+
+    if not args.input.is_file():
+        print(f"Input not found: {args.input}", file=sys.stderr)
+        return 1
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    raw_hits = load_hits_from_export(args.input)
+    parsed = []
+    errors = 0
+    for hit in raw_hits:
+        try:
+            parsed.append(parse_hit(hit))
+        except (ValueError, SyntaxError, KeyError) as exc:
+            errors += 1
+            print(f"WARN: skip hit: {exc}", file=sys.stderr)
+
+    rows = dedupe_rows(parsed)
+    midnight_rows = [r for r in rows if is_midnight_payload(r)]
+
+    manifest_path = args.output_dir / "manifest.csv"
+    midnight_path = args.output_dir / "manifest-midnight-only.csv"
+    urls_path = args.output_dir / "urls.tsv"
+    midnight_urls_path = args.output_dir / "urls-midnight-only.tsv"
+
+    if args.midnight_only:
+        write_csv(midnight_path, midnight_rows)
+        write_urls_tsv(midnight_urls_path, midnight_rows)
+    else:
+        write_csv(manifest_path, rows)
+        write_csv(midnight_path, midnight_rows)
+        write_urls_tsv(urls_path, rows)
+        write_urls_tsv(midnight_urls_path, midnight_rows)
+
+    print(f"Parsed hits:     {len(raw_hits)}")
+    print(f"Parse errors:    {errors}")
+    print(f"Unique payloads: {len(rows)}")
+    print(f"Midnight filter: {len(midnight_rows)} (size>={MIDNIGHT_MIN_SIZE_BYTES}, 00:00-02:00 UTC)")
+    if not args.midnight_only:
+        print(f"Wrote: {manifest_path}")
+        print(f"Wrote: {urls_path}")
+    print(f"Wrote: {midnight_path}")
+    print(f"Wrote: {midnight_urls_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/incident/split_midnight_payloads.py
+++ b/scripts/incident/split_midnight_payloads.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Copy midnight-filtered payloads into a separate directory.
+
+Reads request_ids from manifest-midnight-only.csv and copies matching
+{request_id}.tgz files from payloads/ to payloads-midnight/.
+
+Usage:
+    python split_midnight_payloads.py
+    python split_midnight_payloads.py --source payloads --dest payloads-midnight
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import shutil
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+DEFAULT_MANIFEST = SCRIPT_DIR / "manifest-midnight-only.csv"
+DEFAULT_SOURCE = SCRIPT_DIR / "payloads"
+DEFAULT_DEST = SCRIPT_DIR / "payloads-midnight"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--source", type=Path, default=DEFAULT_SOURCE)
+    parser.add_argument("--dest", type=Path, default=DEFAULT_DEST)
+    parser.add_argument("--symlink", action="store_true", help="Use symlinks instead of copies")
+    args = parser.parse_args()
+
+    if not args.manifest.is_file():
+        print(f"Manifest not found: {args.manifest}", file=sys.stderr)
+        return 1
+    if not args.source.is_dir():
+        print(f"Source dir not found: {args.source}", file=sys.stderr)
+        return 1
+
+    args.dest.mkdir(parents=True, exist_ok=True)
+
+    with args.manifest.open(encoding="utf-8") as fh:
+        request_ids = [row["request_id"] for row in csv.DictReader(fh)]
+
+    copied = 0
+    missing = []
+    for request_id in request_ids:
+        src = args.source / f"{request_id}.tgz"
+        dst = args.dest / f"{request_id}.tgz"
+        if not src.is_file():
+            missing.append(request_id)
+            continue
+        if args.symlink:
+            if dst.is_symlink() or dst.exists():
+                dst.unlink()
+            dst.symlink_to(src.resolve())
+        else:
+            shutil.copy2(src, dst)
+        copied += 1
+
+    print(f"Midnight payloads: {len(request_ids)} in manifest")
+    print(f"Copied:            {copied} -> {args.dest}")
+    if missing:
+        print(f"Missing:           {len(missing)}", file=sys.stderr)
+        for request_id in missing:
+            print(f"  - {request_id}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add incident runbook and tooling under `scripts/incident/` for backing up ingress payloads from Kibana `Downloading Payload` logs
- `parse_kibana_logs.py` — parse Kibana ES export → manifest CSV/TSV (full + midnight filter)
- `download_payloads.py` — download `.tgz` archives from presigned URLs
- `split_midnight_payloads.py` — copy midnight-filtered payloads into `payloads-midnight/`
- `.gitignore` excludes customer payloads, raw Kibana export, and manifests with presigned URLs

## Context
P1 incident: `koku-clowder-listener` pods wedged Kafka ingest. Team item 1 was to backup ingress S3 payloads before quarantine expiry.

**Operational status (not in this PR):** 262 payloads downloaded locally for window 2026-08-31T22:00Z → 2026-09-01T14:44Z; 32 midnight payloads isolated in `payloads-midnight/`. Upload to `hccm-prod-s3` still pending.

## Test plan
- [ ] `python scripts/incident/parse_kibana_state_farm_logs.py --help`
- [ ] `python scripts/incident/download_payloads.py --help`
- [ ] `python scripts/incident/split_midnight_payloads.py --help`
- [ ] Confirm no customer data or presigned URLs are committed


Made with [Cursor](https://cursor.com)