### PR TITLE
[COST-8179] Decouple on-prem source provider creation from HTTP request

### DIFF
--- a/koku/api/iam/test/iam_test_case.py
+++ b/koku/api/iam/test/iam_test_case.py
@@ -34,7 +34,7 @@ from api.query_params import QueryParameters
 from api.utils import DateHelper
 from koku.dev_middleware import DevelopmentIdentityHeaderMiddleware
 from koku.koku_test_runner import KokuTestRunner
-from sources.kafka_listener import storage_callback
+from sources.kafka_listener import STORAGE_CALLBACK_DISPATCH_UID
 
 
 class FakeTrinoCur(trino.dbapi.Cursor):
@@ -79,7 +79,7 @@ class IamTestCase(TestCase):
     def setUpClass(cls):
         """Set up each test class."""
         super().setUpClass()
-        post_save.disconnect(storage_callback, sender=Sources)
+        post_save.disconnect(dispatch_uid=STORAGE_CALLBACK_DISPATCH_UID, sender=Sources)
         post_save.disconnect(provider_post_save_refresh_cache, sender=Provider)
 
         cls.dh = DateHelper()

--- a/koku/koku/celery.py
+++ b/koku/koku/celery.py
@@ -37,6 +37,7 @@ SAAS_ONLY_BEAT_NAMES = (
     "source_status_beat",
     "delete_source_beat",
 )
+ONPREM_ONLY_BEAT_NAMES = ("create_source_beat",)
 
 
 def register_daily_currency_rates_beat(beat_schedule, currency_url, schedule=None):
@@ -50,6 +51,18 @@ def register_daily_currency_rates_beat(beat_schedule, currency_url, schedule=Non
     beat_schedule[CURRENCY_RATES_BEAT_NAME] = {
         "task": "masu.celery.tasks.get_daily_currency_rates",
         "schedule": schedule or crontab(hour=1, minute=0),
+    }
+    return True
+
+
+def register_onprem_only_beats(beat_schedule, *, onprem=False):
+    """Register on-prem-only Celery beats; skip entirely when not on-prem."""
+    if not onprem:
+        return False
+
+    beat_schedule["create_source_beat"] = {
+        "task": "sources.tasks.create_source_beat",
+        "schedule": crontab(minute="*/5"),
     }
     return True
 
@@ -276,6 +289,9 @@ if not register_saas_only_beats(
     source_status_schedule=source_status_schedule,
 ):
     LOG.info("SaaS-only Celery beats not registered (ONPREM=%s)", settings.ONPREM)
+
+if not register_onprem_only_beats(app.conf.beat_schedule, onprem=settings.ONPREM):
+    LOG.info("On-prem-only Celery beats not registered (ONPREM=%s)", settings.ONPREM)
 
 # Beat used to fetch daily rates (only when CURRENCY_URL is configured)
 if not register_daily_currency_rates_beat(app.conf.beat_schedule, settings.CURRENCY_URL):

--- a/koku/sources/api/serializers.py
+++ b/koku/sources/api/serializers.py
@@ -207,6 +207,10 @@ class AdminSourcesSerializer(SourcesSerializer):
         auth_header = get_auth_header(self.context.get("request"))
         validated_data["auth_header"] = auth_header
         source = Sources.objects.create(**validated_data)
+        if settings.ONPREM:
+            # Provider/schema creation is queued asynchronously (see storage_callback).
+            LOG.info("Admin created Source on-prem; provider creation queued.")
+            return source
         manager = ProviderBuilder(source.auth_header, source.account_id, source.org_id)
         try:
             provider = manager.create_provider_from_source(source)

--- a/koku/sources/apps.py
+++ b/koku/sources/apps.py
@@ -10,3 +10,7 @@ class SourcesConfig(AppConfig):
     """Sources application configuration."""
 
     name = "sources"
+
+    def ready(self):
+        """Register Sources post_save handlers for provider synchronization."""
+        import sources.kafka_listener  # noqa: F401

--- a/koku/sources/apps.py
+++ b/koku/sources/apps.py
@@ -4,6 +4,7 @@
 #
 """Sources application configuration module."""
 from django.apps import AppConfig
+from django.conf import settings
 
 
 class SourcesConfig(AppConfig):
@@ -12,5 +13,6 @@ class SourcesConfig(AppConfig):
     name = "sources"
 
     def ready(self):
-        """Register Sources post_save handlers for provider synchronization."""
-        import sources.kafka_listener  # noqa: F401
+        """Register Sources post_save handlers for on-prem provider synchronization."""
+        if settings.ONPREM:
+            import sources.kafka_listener  # noqa: F401

--- a/koku/sources/kafka_listener.py
+++ b/koku/sources/kafka_listener.py
@@ -48,6 +48,7 @@ LOG = logging.getLogger(__name__)
 
 PROCESS_QUEUE = queue.PriorityQueue()
 COUNT = itertools.count()  # next(COUNT) returns next sequential number
+STORAGE_CALLBACK_DISPATCH_UID = "sources.kafka_listener.storage_callback"
 
 
 class SourcesIntegrationError(ValidationError):
@@ -96,7 +97,7 @@ def _dispatch_onprem_provider_create(source_id):
         )
 
 
-@receiver(post_save, sender=Sources)
+@receiver(post_save, sender=Sources, dispatch_uid=STORAGE_CALLBACK_DISPATCH_UID)
 def storage_callback(sender, instance, **kwargs):
     """Load Sources ready for Koku Synchronization when Sources table is updated."""
     queued_sync = False

--- a/koku/sources/kafka_listener.py
+++ b/koku/sources/kafka_listener.py
@@ -87,7 +87,13 @@ def _dispatch_onprem_provider_create(source_id):
     """Enqueue on-prem provider creation after the source row is committed."""
     from sources.tasks import create_provider
 
-    create_provider.delay(source_id)
+    try:
+        create_provider.delay(source_id)
+    except Exception as error:
+        LOG.error(
+            f"[storage_callback] failed to enqueue on-prem provider creation "
+            f"(source_id={source_id}): {type(error).__name__}: {error}"
+        )
 
 
 @receiver(post_save, sender=Sources)

--- a/koku/sources/kafka_listener.py
+++ b/koku/sources/kafka_listener.py
@@ -111,12 +111,15 @@ def storage_callback(sender, instance, **kwargs):
 
     process_event = storage.screen_and_build_provider_sync_create_event(instance)
     if process_event:
-        _log_process_queue_event(PROCESS_QUEUE, process_event, "storage_callback")
-        LOG.debug(f"Create Event Queued for:\n{str(instance)}")
         if settings.ONPREM:
             source_id = instance.source_id
+            LOG.info(
+                f"[storage_callback] dispatching on-prem provider creation for {instance.name} (source_id={source_id})"
+            )
             transaction.on_commit(lambda: _dispatch_onprem_provider_create(source_id))
         else:
+            _log_process_queue_event(PROCESS_QUEUE, process_event, "storage_callback")
+            LOG.debug(f"Create Event Queued for:\n{str(instance)}")
             PROCESS_QUEUE.put_nowait((next(COUNT), process_event))
             queued_sync = True
 

--- a/koku/sources/kafka_listener.py
+++ b/koku/sources/kafka_listener.py
@@ -12,6 +12,7 @@ import threading
 import time
 
 from confluent_kafka import TopicPartition
+from django.conf import settings
 from django.db import connections
 from django.db import DEFAULT_DB_ALIAS
 from django.db import IntegrityError
@@ -82,28 +83,45 @@ def _log_process_queue_event(queue, event, trigger=""):
     LOG.info(f"[{trigger}] adding operation {operation} for {name} to process queue (size: {queue.qsize()})")
 
 
+def _dispatch_onprem_provider_create(source_id):
+    """Enqueue on-prem provider creation after the source row is committed."""
+    from sources.tasks import create_provider
+
+    create_provider.delay(source_id)
+
+
 @receiver(post_save, sender=Sources)
 def storage_callback(sender, instance, **kwargs):
     """Load Sources ready for Koku Synchronization when Sources table is updated."""
+    queued_sync = False
+
     if instance.koku_uuid and instance.pending_update and not instance.pending_delete:
         update_event = {"operation": "update", "provider": instance}
         _log_process_queue_event(PROCESS_QUEUE, update_event, "storage_callback")
         LOG.debug(f"Update Event Queued for:\n{str(instance)}")
         PROCESS_QUEUE.put_nowait((next(COUNT), update_event))
+        queued_sync = True
 
     if instance.pending_delete:
         delete_event = {"operation": "destroy", "provider": instance}
         _log_process_queue_event(PROCESS_QUEUE, delete_event, "storage_callback")
         LOG.debug(f"Delete Event Queued for:\n{str(instance)}")
         PROCESS_QUEUE.put_nowait((next(COUNT), delete_event))
+        queued_sync = True
 
     process_event = storage.screen_and_build_provider_sync_create_event(instance)
     if process_event:
         _log_process_queue_event(PROCESS_QUEUE, process_event, "storage_callback")
         LOG.debug(f"Create Event Queued for:\n{str(instance)}")
-        PROCESS_QUEUE.put_nowait((next(COUNT), process_event))
+        if settings.ONPREM:
+            source_id = instance.source_id
+            transaction.on_commit(lambda: _dispatch_onprem_provider_create(source_id))
+        else:
+            PROCESS_QUEUE.put_nowait((next(COUNT), process_event))
+            queued_sync = True
 
-    execute_process_queue()
+    if queued_sync:
+        execute_process_queue()
 
 
 def execute_process_queue():

--- a/koku/sources/tasks.py
+++ b/koku/sources/tasks.py
@@ -7,6 +7,9 @@ import logging
 
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
+from django.db import IntegrityError
+from django.db import InterfaceError
+from django.db import OperationalError
 
 from api.common import log_json
 from api.provider.models import Sources
@@ -16,6 +19,8 @@ from common.queues import SummaryQueue
 from koku import celery_app
 from sources.api.source_status import SourceStatus
 from sources.sources_provider_coordinator import SourcesProviderCoordinator
+from sources.sources_provider_coordinator import SourcesProviderCoordinatorError
+from sources.storage import load_providers_to_create
 from sources.storage import load_providers_to_delete
 from sources.storage import mark_provider_as_inactive
 
@@ -39,6 +44,44 @@ def delete_source(self, source_id, auth_header, koku_uuid, account_number, org_i
     coordinator = SourcesProviderCoordinator(source_id, auth_header, account_number, org_id)
     coordinator.destroy_account(koku_uuid, self.request.retries)  # noqa: F821
     LOG.info(log_json(msg="deleted provider", provider_uuid=koku_uuid, source_id=source_id))
+
+
+@celery_app.task(
+    name="sources.tasks.create_provider",
+    bind=True,
+    autoretry_for=(IntegrityError, InterfaceError, OperationalError, SourcesProviderCoordinatorError),
+    retry_backoff=True,
+    max_retries=settings.MAX_SOURCE_DELETE_RETRIES,
+    queue=PriorityQueue.DEFAULT,
+)
+def create_provider(self, source_id):
+    """Create a Koku provider for an on-prem source that is not yet linked."""
+    source = Sources.objects.filter(source_id=source_id).first()
+    if not source or source.koku_uuid or source.pending_delete:
+        LOG.info(
+            log_json(
+                msg="skipping on-prem provider create",
+                context={"source_id": source_id, "has_koku_uuid": bool(source and source.koku_uuid)},
+            )
+        )
+        return
+
+    LOG.info(log_json(msg="creating on-prem provider from source", context={"source_id": source_id}))
+    coordinator = SourcesProviderCoordinator(source.source_id, source.auth_header, source.account_id, source.org_id)
+    coordinator.create_account(source)
+    LOG.info(log_json(msg="created on-prem provider from source", context={"source_id": source_id}))
+
+
+@celery_app.task(name="sources.tasks.create_source_beat", queue=SummaryQueue.DEFAULT)
+def create_source_beat():
+    """Re-enqueue on-prem sources that still need a linked provider."""
+    if not settings.ONPREM:
+        return
+
+    for event in load_providers_to_create():
+        provider = event.get("provider")
+        if provider:
+            create_provider.delay(provider.source_id)
 
 
 @celery_app.task(name="sources.tasks.delete_source_beat", queue=SummaryQueue.DEFAULT)

--- a/koku/sources/tasks.py
+++ b/koku/sources/tasks.py
@@ -51,6 +51,7 @@ def delete_source(self, source_id, auth_header, koku_uuid, account_number, org_i
     bind=True,
     autoretry_for=(IntegrityError, InterfaceError, OperationalError, SourcesProviderCoordinatorError),
     retry_backoff=True,
+    # Reuses MAX_SOURCE_DELETE_RETRIES (shared Celery retry budget for sources tasks).
     max_retries=settings.MAX_SOURCE_DELETE_RETRIES,
     queue=PriorityQueue.DEFAULT,
 )

--- a/koku/sources/test/api/test_serializers.py
+++ b/koku/sources/test/api/test_serializers.py
@@ -8,6 +8,7 @@ from datetime import timezone
 from unittest.mock import Mock
 from unittest.mock import patch
 
+from django.db.models.signals import post_save
 from django.test.utils import override_settings
 from faker import Faker
 from model_bakery import baker
@@ -26,6 +27,7 @@ from sources.api.serializers import AdminSourcesSerializer
 from sources.api.serializers import SourcesSerializer
 from sources.api.source_type_mapping import PROVIDER_TYPE_TO_CMMO_ID
 from sources.config import Config
+from sources.kafka_listener import storage_callback
 
 fake = Faker()
 
@@ -415,6 +417,32 @@ class AdminSourcesSerializerOnPremTest(IamTestCase):
         with patch.object(ProviderAccessor, "cost_usage_source_ready", returns=True):
             self.assertTrue(serializer.is_valid(raise_exception=True))
             self.assertEqual(serializer.validated_data["source_type"], Provider.PROVIDER_OCP)
+
+    @override_settings(ONPREM=True)
+    @patch("sources.kafka_listener._dispatch_onprem_provider_create")
+    @patch("api.provider.provider_builder.ProviderBuilder.create_provider_from_source")
+    def test_create_onprem_returns_before_provider_linked(self, mock_create_provider, mock_dispatch):
+        """On-prem create returns quickly without waiting for provider/schema creation."""
+        source_data = {
+            "name": "onprem-ocp-async",
+            "source_type": "OCP",
+            "authentication": {"credentials": {"cluster_id": "onprem-cluster-async"}},
+        }
+        serializer = AdminSourcesSerializer(data=source_data, context=self.context)
+        post_save.connect(storage_callback, sender=Sources)
+        try:
+            with (
+                patch.object(ProviderAccessor, "cost_usage_source_ready", returns=True),
+                self.captureOnCommitCallbacks(execute=True),
+            ):
+                self.assertTrue(serializer.is_valid(raise_exception=True))
+                instance = serializer.save()
+        finally:
+            post_save.disconnect(storage_callback, sender=Sources)
+
+        self.assertIsNone(instance.koku_uuid)
+        mock_create_provider.assert_not_called()
+        mock_dispatch.assert_called_once_with(instance.source_id)
 
     @override_settings(ONPREM=True)
     def test_update_rejects_aws_source_type_id_when_onprem(self):

--- a/koku/sources/test/api/test_serializers.py
+++ b/koku/sources/test/api/test_serializers.py
@@ -420,9 +420,9 @@ class AdminSourcesSerializerOnPremTest(IamTestCase):
             self.assertEqual(serializer.validated_data["source_type"], Provider.PROVIDER_OCP)
 
     @override_settings(ONPREM=True)
-    @patch("sources.kafka_listener._dispatch_onprem_provider_create")
+    @patch("sources.tasks.create_provider.delay")
     @patch("api.provider.provider_builder.ProviderBuilder.create_provider_from_source")
-    def test_create_onprem_returns_before_provider_linked(self, mock_create_provider, mock_dispatch):
+    def test_create_onprem_returns_before_provider_linked(self, mock_create_provider, mock_create_provider_delay):
         """On-prem create returns quickly without waiting for provider/schema creation."""
         source_data = {
             "name": "onprem-ocp-async",
@@ -444,7 +444,7 @@ class AdminSourcesSerializerOnPremTest(IamTestCase):
 
         self.assertIsNone(instance.koku_uuid)
         mock_create_provider.assert_not_called()
-        mock_dispatch.assert_called_once_with(instance.source_id)
+        mock_create_provider_delay.assert_called_once_with(instance.source_id)
 
     @override_settings(ONPREM=True)
     def test_update_rejects_aws_source_type_id_when_onprem(self):

--- a/koku/sources/test/api/test_serializers.py
+++ b/koku/sources/test/api/test_serializers.py
@@ -8,7 +8,6 @@ from datetime import timezone
 from unittest.mock import Mock
 from unittest.mock import patch
 
-from django.db.models.signals import post_save
 from django.test.utils import override_settings
 from faker import Faker
 from model_bakery import baker
@@ -27,7 +26,6 @@ from sources.api.serializers import AdminSourcesSerializer
 from sources.api.serializers import SourcesSerializer
 from sources.api.source_type_mapping import PROVIDER_TYPE_TO_CMMO_ID
 from sources.config import Config
-from sources.kafka_listener import storage_callback
 
 fake = Faker()
 
@@ -429,16 +427,12 @@ class AdminSourcesSerializerOnPremTest(IamTestCase):
             "authentication": {"credentials": {"cluster_id": "onprem-cluster-async"}},
         }
         serializer = AdminSourcesSerializer(data=source_data, context=self.context)
-        post_save.connect(storage_callback, sender=Sources)
-        try:
-            with (
-                patch.object(ProviderAccessor, "cost_usage_source_ready", returns=True),
-                self.captureOnCommitCallbacks(execute=True),
-            ):
-                self.assertTrue(serializer.is_valid(raise_exception=True))
-                instance = serializer.save()
-        finally:
-            post_save.disconnect(storage_callback, sender=Sources)
+        with (
+            patch.object(ProviderAccessor, "cost_usage_source_ready", returns=True),
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            self.assertTrue(serializer.is_valid(raise_exception=True))
+            instance = serializer.save()
 
         self.assertIsNone(instance.koku_uuid)
         mock_create_provider.assert_not_called()

--- a/koku/sources/test/api/test_serializers.py
+++ b/koku/sources/test/api/test_serializers.py
@@ -8,6 +8,7 @@ from datetime import timezone
 from unittest.mock import Mock
 from unittest.mock import patch
 
+from django.db.models.signals import post_save
 from django.test.utils import override_settings
 from faker import Faker
 from model_bakery import baker
@@ -26,6 +27,8 @@ from sources.api.serializers import AdminSourcesSerializer
 from sources.api.serializers import SourcesSerializer
 from sources.api.source_type_mapping import PROVIDER_TYPE_TO_CMMO_ID
 from sources.config import Config
+from sources.kafka_listener import storage_callback
+from sources.kafka_listener import STORAGE_CALLBACK_DISPATCH_UID
 
 fake = Faker()
 
@@ -427,6 +430,11 @@ class AdminSourcesSerializerOnPremTest(IamTestCase):
             "authentication": {"credentials": {"cluster_id": "onprem-cluster-async"}},
         }
         serializer = AdminSourcesSerializer(data=source_data, context=self.context)
+        post_save.connect(
+            storage_callback,
+            sender=Sources,
+            dispatch_uid=STORAGE_CALLBACK_DISPATCH_UID,
+        )
         with (
             patch.object(ProviderAccessor, "cost_usage_source_ready", returns=True),
             self.captureOnCommitCallbacks(execute=True),

--- a/koku/sources/test/test_kafka_listener.py
+++ b/koku/sources/test/test_kafka_listener.py
@@ -939,6 +939,7 @@ class SourcesKafkaMsgHandlerTest(IamTestCase):
     #         process_synchronize_sources_msg((0, msg), test_queue)
     #         mock_clear_flag.assert_not_called()
 
+    @override_settings(ONPREM=False)
     def test_storage_callback_create(self):
         """Test storage callback puts create task onto queue."""
         local_source = Sources(**self.aws_local_source, pending_update=True)
@@ -948,6 +949,19 @@ class SourcesKafkaMsgHandlerTest(IamTestCase):
             storage_callback("", local_source)
             _, msg = PROCESS_QUEUE.get_nowait()
             self.assertEqual(msg.get("operation"), "create")
+
+    @override_settings(ONPREM=True)
+    @patch("sources.kafka_listener._dispatch_onprem_provider_create")
+    def test_storage_callback_create_onprem_dispatches_celery(self, mock_dispatch):
+        """On-prem create events are dispatched to Celery instead of the in-process queue."""
+        local_source = Sources(**self.aws_local_source, pending_update=True)
+        local_source.save()
+
+        with self.captureOnCommitCallbacks(execute=True):
+            storage_callback("", local_source)
+
+        mock_dispatch.assert_called_once_with(local_source.source_id)
+        self.assertTrue(PROCESS_QUEUE.empty())
 
     def test_storage_callback_update(self):
         """Test storage callback puts update task onto queue."""

--- a/koku/sources/test/test_kafka_listener.py
+++ b/koku/sources/test/test_kafka_listener.py
@@ -31,6 +31,7 @@ from providers.provider_access import ProviderAccessor
 from providers.provider_errors import SkipStatusPush
 from sources import storage
 from sources.config import Config
+from sources.kafka_listener import _dispatch_onprem_provider_create
 from sources.kafka_listener import PROCESS_QUEUE
 from sources.kafka_listener import process_synchronize_sources_msg
 from sources.kafka_listener import SourcesIntegrationError
@@ -962,6 +963,15 @@ class SourcesKafkaMsgHandlerTest(IamTestCase):
 
         mock_dispatch.assert_called_once_with(local_source.source_id)
         self.assertTrue(PROCESS_QUEUE.empty())
+
+    @patch("sources.tasks.create_provider.delay", side_effect=ConnectionError("broker down"))
+    def test_dispatch_onprem_provider_create_logs_enqueue_failure(self, mock_delay):
+        """Failed Celery enqueue is logged; create_source_beat can recover later."""
+        with self.assertLogs("sources.kafka_listener", level="ERROR") as logs:
+            _dispatch_onprem_provider_create(42)
+
+        self.assertIn("failed to enqueue on-prem provider creation", logs.output[0])
+        mock_delay.assert_called_once_with(42)
 
     def test_storage_callback_update(self):
         """Test storage callback puts update task onto queue."""

--- a/koku/sources/test/test_kafka_listener.py
+++ b/koku/sources/test/test_kafka_listener.py
@@ -36,6 +36,7 @@ from sources.kafka_listener import PROCESS_QUEUE
 from sources.kafka_listener import process_synchronize_sources_msg
 from sources.kafka_listener import SourcesIntegrationError
 from sources.kafka_listener import storage_callback
+from sources.kafka_listener import STORAGE_CALLBACK_DISPATCH_UID
 from sources.kafka_message_processor import ApplicationMsgProcessor
 from sources.kafka_message_processor import AUTH_TYPES
 from sources.kafka_message_processor import AuthenticationMsgProcessor
@@ -124,10 +125,16 @@ class SourcesKafkaMsgHandlerTest(IamTestCase):
     def setUpClass(cls):
         """Set up the test class."""
         super().setUpClass()
-        post_save.disconnect(storage_callback, sender=Sources)
+        post_save.disconnect(dispatch_uid=STORAGE_CALLBACK_DISPATCH_UID, sender=Sources)
         account = "10001"
         org_id = "1234567"
         IdentityHeaderMiddleware.create_customer(account, org_id, "POST")
+
+    @classmethod
+    def tearDownClass(cls):
+        """Restore the application post_save handler for other tests."""
+        post_save.connect(storage_callback, sender=Sources, dispatch_uid=STORAGE_CALLBACK_DISPATCH_UID)
+        super().tearDownClass()
 
     def setUp(self):
         """Setup the test method."""

--- a/koku/sources/test/test_kafka_message_processor.py
+++ b/koku/sources/test/test_kafka_message_processor.py
@@ -19,7 +19,7 @@ from api.provider.models import Provider
 from api.provider.models import Sources
 from koku.middleware import IdentityHeaderMiddleware
 from sources.config import Config
-from sources.kafka_listener import storage_callback
+from sources.kafka_listener import STORAGE_CALLBACK_DISPATCH_UID
 from sources.kafka_message_processor import ApplicationMsgProcessor
 from sources.kafka_message_processor import AuthenticationMsgProcessor
 from sources.kafka_message_processor import create_msg_processor
@@ -139,7 +139,7 @@ class KafkaMessageProcessorTest(IamTestCase):
     def setUpClass(cls):
         """Set up the test class."""
         super().setUpClass()
-        post_save.disconnect(storage_callback, sender=Sources)
+        post_save.disconnect(dispatch_uid=STORAGE_CALLBACK_DISPATCH_UID, sender=Sources)
         account = "10001"
         org_id = "1234567"
         IdentityHeaderMiddleware.create_customer(account, org_id, "POST")

--- a/koku/sources/test/test_sources_http_client.py
+++ b/koku/sources/test/test_sources_http_client.py
@@ -17,7 +17,7 @@ from requests.exceptions import RequestException
 from api.provider.models import Provider
 from api.provider.models import Sources
 from sources.config import Config
-from sources.kafka_listener import storage_callback
+from sources.kafka_listener import STORAGE_CALLBACK_DISPATCH_UID
 from sources.sources_http_client import APP_EXTRA_FIELD_MAP
 from sources.sources_http_client import AUTH_TYPES
 from sources.sources_http_client import convert_header_to_dict
@@ -79,7 +79,7 @@ class SourcesHTTPClientTest(TestCase):
     def setUp(self):
         """Test case setup."""
         super().setUp()
-        post_save.disconnect(storage_callback, sender=Sources)
+        post_save.disconnect(dispatch_uid=STORAGE_CALLBACK_DISPATCH_UID, sender=Sources)
         self.name = "Test Source"
         self.application_type = COST_MGMT_APP_TYPE_ID
         self.source_id = 1

--- a/koku/sources/test/test_storage.py
+++ b/koku/sources/test/test_storage.py
@@ -9,6 +9,7 @@ from unittest.mock import Mock
 from unittest.mock import patch
 
 from django.db import InterfaceError
+from django.db.models.signals import post_save
 from django.test import TestCase
 from faker import Faker
 
@@ -19,6 +20,8 @@ from api.provider.models import ProviderBillingSource
 from api.provider.models import Sources
 from sources import storage
 from sources.config import Config
+from sources.kafka_listener import storage_callback
+from sources.kafka_listener import STORAGE_CALLBACK_DISPATCH_UID
 
 faker = Faker()
 
@@ -56,6 +59,18 @@ class MockProvider:
 
 class SourcesStorageTest(TestCase):
     """Test cases for Sources Storage."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Disable async source sync while testing storage helpers in isolation."""
+        super().setUpClass()
+        post_save.disconnect(dispatch_uid=STORAGE_CALLBACK_DISPATCH_UID, sender=Sources)
+
+    @classmethod
+    def tearDownClass(cls):
+        """Restore the application post_save handler for other tests."""
+        post_save.connect(storage_callback, sender=Sources, dispatch_uid=STORAGE_CALLBACK_DISPATCH_UID)
+        super().tearDownClass()
 
     def setUp(self):
         """Test case setup."""

--- a/koku/sources/test/test_tasks.py
+++ b/koku/sources/test/test_tasks.py
@@ -15,6 +15,8 @@ from koku.middleware import IdentityHeaderMiddleware
 from sources.api.source_status import SourceStatus
 from sources.config import Config
 from sources.kafka_listener import storage_callback
+from sources.tasks import create_provider
+from sources.tasks import create_source_beat
 from sources.tasks import delete_source
 from sources.tasks import delete_source_beat
 from sources.tasks import source_status_beat
@@ -134,3 +136,47 @@ class SourcesTasksTest(TestCase):
         with patch.object(SourceStatus, "push_status") as mock_push:
             source_status_beat()
             mock_push.assert_not_called()
+
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+    @patch("sources.tasks.SourcesProviderCoordinator.create_account")
+    def test_create_provider_links_source(self, mock_create_account):
+        """Test on-prem provider create task delegates to SourcesProviderCoordinator."""
+        provider = Sources(**self.aws_local_source)
+        provider.koku_uuid = None
+        provider.save()
+
+        create_provider(provider.source_id)
+        mock_create_account.assert_called_once()
+        self.assertEqual(mock_create_account.call_args.args[0].source_id, provider.source_id)
+
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+    @patch("sources.tasks.SourcesProviderCoordinator.create_account")
+    def test_create_provider_skips_when_already_linked(self, mock_create_account):
+        """Test on-prem provider create task is a no-op when koku_uuid exists."""
+        provider = Sources(**self.aws_local_source)
+        provider.save()
+
+        create_provider(provider.source_id)
+        mock_create_account.assert_not_called()
+
+    @override_settings(ONPREM=True, CELERY_TASK_ALWAYS_EAGER=True)
+    @patch("sources.tasks.create_provider.delay")
+    def test_create_source_beat_onprem(self, mock_create_delay):
+        """Test on-prem beat re-enqueues sources missing providers."""
+        provider = Sources(**self.aws_local_source)
+        provider.koku_uuid = None
+        provider.save()
+
+        create_source_beat()
+        mock_create_delay.assert_called_once_with(provider.source_id)
+
+    @override_settings(ONPREM=False, CELERY_TASK_ALWAYS_EAGER=True)
+    @patch("sources.tasks.create_provider.delay")
+    def test_create_source_beat_skips_saas(self, mock_create_delay):
+        """Test create source beat is a no-op outside on-prem."""
+        provider = Sources(**self.aws_local_source)
+        provider.koku_uuid = None
+        provider.save()
+
+        create_source_beat()
+        mock_create_delay.assert_not_called()

--- a/koku/sources/test/test_tasks.py
+++ b/koku/sources/test/test_tasks.py
@@ -15,6 +15,7 @@ from koku.middleware import IdentityHeaderMiddleware
 from sources.api.source_status import SourceStatus
 from sources.config import Config
 from sources.kafka_listener import storage_callback
+from sources.kafka_listener import STORAGE_CALLBACK_DISPATCH_UID
 from sources.tasks import create_provider
 from sources.tasks import create_source_beat
 from sources.tasks import delete_source
@@ -29,10 +30,16 @@ class SourcesTasksTest(TestCase):
     def setUpClass(cls):
         """Set up the test class."""
         super().setUpClass()
-        post_save.disconnect(storage_callback, sender=Sources)
+        post_save.disconnect(dispatch_uid=STORAGE_CALLBACK_DISPATCH_UID, sender=Sources)
         account = "12345"
         org_id = "3333333"
         IdentityHeaderMiddleware.create_customer(account, org_id, "POST")
+
+    @classmethod
+    def tearDownClass(cls):
+        """Restore the application post_save handler for other tests."""
+        post_save.connect(storage_callback, sender=Sources, dispatch_uid=STORAGE_CALLBACK_DISPATCH_UID)
+        super().tearDownClass()
 
     def setUp(self):
         """Setup the test method."""


### PR DESCRIPTION
## Jira Ticket
[COST-8179](https://redhat.atlassian.net/browse/COST-8179)

## Summary
- On `ONPREM=True`, `POST /api/cost-management/v1/sources/` no longer runs `ProviderBuilder.create_provider_from_source()` synchronously in the HTTP request.
- Provider and tenant schema creation are queued via the existing `storage_callback` → Celery `create_provider` path (aligned with SaaS Kafka flow).
- Register `kafka_listener` in `sources.apps.ready()` so koku-server runs the `post_save` handler.
- Add `create_provider` and `create_source_beat` Celery tasks for on-prem recovery.

## Why
First source create for a fresh org blocks on `clone_schema` inside the HTTP handler, causing 504s through Envoy/nginx (~60s) while the source eventually commits in the DB.

## Testing
- `pipenv run tox -e py39 -- sources.test.api.test_serializers sources.test.test_kafka_listener sources.test.test_tasks` (ONPREM-focused tests)
- Local docker `ONPREM=True`: POST `/sources/` returns 201 quickly; `koku_uuid` links within a few seconds via Celery

## Release Notes
```markdown
* [COST-8179](https://redhat.atlassian.net/browse/COST-8179) Queue on-prem provider creation after source create instead of blocking the HTTP request
```

Made with [Cursor](https://cursor.com)