### PR TITLE
Fix OCP distinct-array rank grouping

### DIFF
--- a/koku/api/report/queries.py
+++ b/koku/api/report/queries.py
@@ -24,6 +24,7 @@ import pandas as pd
 from django.contrib.postgres.aggregates import ArrayAgg
 from django.db.models import Case
 from django.db.models import CharField
+from django.db.models import Count
 from django.db.models import DecimalField
 from django.db.models import F
 from django.db.models import Max
@@ -1395,6 +1396,13 @@ class ReportQueryHandler(QueryHandler):
         # Otherwise Django raises ValueError
         for grouped_col in rank_group_by:
             rank_annotations.pop(grouped_col, None)
+
+        if self._distinct_arrays_split_enabled and not rank_annotations:
+            # A ranked query must aggregate to produce one row per
+            # rank_group_by tuple. Ordering by a rank group field removes it
+            # from rank_annotations, so use an internal aggregate to retain
+            # SQL grouping. _ranked_list drops rank fields from the response.
+            rank_annotations["rank_group_count"] = Count("pk")
 
         rank_metadata_annotations = self._rank_metadata_annotations()
         ranks = (

--- a/koku/api/report/test/ocp/test_distinct_arrays_parallel.py
+++ b/koku/api/report/test/ocp/test_distinct_arrays_parallel.py
@@ -145,6 +145,7 @@ class OCPReportDistinctArraysParallelTest(IamTestCase):
         node = "node-distinct-arrays"
         rows = [
             {"mig_profile": "1g.5gb", "mig_instance_id": "MIG-DISTINCT-0001"},
+            {"mig_profile": "1g.5gb", "mig_instance_id": "MIG-DISTINCT-0001"},
             {"mig_profile": "1g.5gb", "mig_instance_id": "MIG-DISTINCT-0002"},
             {"mig_profile": "1g.5gb", "mig_instance_id": "MIG-DISTINCT-0003"},
             {"mig_profile": "4g.20gb", "mig_instance_id": "MIG-DISTINCT-0004"},
@@ -170,10 +171,15 @@ class OCPReportDistinctArraysParallelTest(IamTestCase):
             )
             output = OCPReportQueryHandler(query_params).execute_query()
 
-        returned = sum(
-            len(profile.get("values", [])) for entry in output["data"] for profile in entry.get("mig_profiles", [])
-        )
-        self.assertEqual(returned, 3)
+        returned = [
+            (value["mig_id"], profile["mig_profile"])
+            for entry in output["data"]
+            for profile in entry.get("mig_profiles", [])
+            for value in profile.get("values", [])
+        ]
+        self.assertEqual(len(returned), 3)
+        self.assertEqual(len({mig_id for mig_id, _ in returned}), 3)
+        self.assertEqual({profile for _, profile in returned}, {"1g.5gb"})
 
     def test_distinct_arrays_parity_with_category(self):
         """Split path matches legacy arrays when a category param is active."""

--- a/koku/api/report/test/ocp/test_distinct_arrays_parallel.py
+++ b/koku/api/report/test/ocp/test_distinct_arrays_parallel.py
@@ -14,14 +14,19 @@ paths).
 """
 from unittest.mock import patch
 
+from django_tenants.utils import schema_context
+from model_bakery import baker
+
 from api.iam.test.iam_test_case import IamTestCase
 from api.report.ocp.query_handler import OCPReportQueryHandler
 from api.report.ocp.view import OCPCostView
 from api.report.ocp.view import OCPCpuView
 from api.report.ocp.view import OCPMemoryView
+from api.report.ocp.view import OCPMigProfilesView
 from api.report.ocp.view import OCPNetworkView
 from api.report.ocp.view import OCPVolumeView
 from masu.processor import OCP_REPORT_DISTINCT_ARRAYS_PARALLEL_FLAG
+from reporting.provider.ocp.models import OCPGpuSummaryP
 
 FLAG_TARGET = "api.report.ocp.query_handler.is_feature_flag_enabled_by_schema"
 
@@ -127,8 +132,48 @@ class OCPReportDistinctArraysParallelTest(IamTestCase):
             (OCPCostView, "group_by[node]=*&filter[limit]=2"),
             (OCPCpuView, "group_by[cluster]=*&filter[limit]=1"),
             (OCPCostView, "group_by[project]=*&filter[limit]=1"),
+            # With an order field already in rank_group_by, the moved arrays
+            # must not be the only aggregate that preserves SQL grouping.
+            (OCPCpuView, "group_by[cluster]=*&order_by[cluster]=asc&filter[limit]=2"),
         ]
         self._assert_parity(matrix)
+
+    def test_mig_profiles_limit_groups_before_ranking_when_split_enabled(self):
+        """The split path must rank distinct MIG instances, not source rows."""
+        vendor = "nvidia-distinct-arrays"
+        model = "A100-distinct-arrays"
+        node = "node-distinct-arrays"
+        rows = [
+            {"mig_profile": "1g.5gb", "mig_instance_id": "MIG-DISTINCT-0001"},
+            {"mig_profile": "1g.5gb", "mig_instance_id": "MIG-DISTINCT-0002"},
+            {"mig_profile": "1g.5gb", "mig_instance_id": "MIG-DISTINCT-0003"},
+            {"mig_profile": "4g.20gb", "mig_instance_id": "MIG-DISTINCT-0004"},
+        ]
+        with schema_context(self.schema_name):
+            for row in rows:
+                baker.make(
+                    OCPGpuSummaryP,
+                    vendor_name=vendor,
+                    model_name=model,
+                    node=node,
+                    gpu_mode="MIG",
+                    raw_currency="USD",
+                    **row,
+                )
+
+        url = f"?filter[gpu_vendor]={vendor}&filter[gpu_model]={model}&filter[node]={node}" "&filter[limit]=3"
+        with patch(FLAG_TARGET, return_value=True):
+            query_params = self.mocked_query_params(
+                url,
+                OCPMigProfilesView,
+                path="/api/cost-management/v1/reports/openshift/gpu/mig_profiles/",
+            )
+            output = OCPReportQueryHandler(query_params).execute_query()
+
+        returned = sum(
+            len(profile.get("values", [])) for entry in output["data"] for profile in entry.get("mig_profiles", [])
+        )
+        self.assertEqual(returned, 3)
 
     def test_distinct_arrays_parity_with_category(self):
         """Split path matches legacy arrays when a category param is active."""


### PR DESCRIPTION
## Summary
- preserve SQL grouping in flagged OCP rank queries when the moved metadata arrays were the only aggregate
- cover grouped name ordering and MIG profile limit behavior on the split path

## Verification
- `PROMETHEUS_MULTIPROC_DIR=/private/tmp/koku-prometheus-multiproc .venv/bin/python koku/manage.py test api.report.test.ocp.test_distinct_arrays_parallel --noinput --verbosity 2`
- ephemeral, flag off: 39 targeted IQE cases passed
- ephemeral, flag on before this fix: 9 failed / 30 passed (cluster/project ordering and MIG limits)

Ephemeral validation of this exact commit is in progress.