### PR TITLE
docs: version agentic workflow prompts for OpenShell migration

### DIFF
--- a/docs/team_workflows/agentic-pr-labeler/README.md
+++ b/docs/team_workflows/agentic-pr-labeler/README.md
@@ -57,10 +57,6 @@ This keeps the repo file authoritative and avoids drift from a stale copy in the
 
 The PAT is stored in workspace settings (GitHub integration). No token is committed to the repository.
 
-### Schedule
-
-Configure in the runtime environment (previously Ambient Code UAT; migrating to OpenShell/Hypershell).
-
 ## Scope: which PRs are managed
 
 **Pilot:** only PRs authored by `dchorvat1`. All PR states are covered (draft, ready for review, etc.). The agent skips PRs from other authors.

--- a/docs/team_workflows/agentic-pr-labeler/README.md
+++ b/docs/team_workflows/agentic-pr-labeler/README.md
@@ -1,0 +1,96 @@
+# Agentic PR Labeler — Automated Smoke Test Label Management
+
+## What it does
+
+An AI agent that monitors open Koku PRs, analyzes the diff, and **automatically applies** the appropriate smoke test label when `smokes-required` is present without a specific smoke label, or when `koku-ci` is blocked at the init phase.
+
+Unlike the CI Triager, this agent **applies labels** (via `gh pr edit`) in addition to posting explanatory comments. It **never pushes commits**.
+
+**Pilot scope:** only PRs authored by `dchorvat1`.
+
+## Source of truth
+
+| Artifact | Location | Maintained by |
+|----------|----------|---------------|
+| Agent prompt | [`prompt.md`](prompt.md) | Team (PR) |
+| Session bootstrap | [`session-bootstrap.txt`](session-bootstrap.txt) | Team (PR) |
+
+**Repo is the source of truth for behavior.** After merging prompt changes, update the scheduled session bootstrap in the runtime environment (see [Runtime setup](#runtime-setup)).
+
+## How it works
+
+```
+Scheduled session
+  │
+  ├── gh pr list --state open (pilot author only)
+  │
+  ├── For each PR with smokes-required but no specific smoke label:
+  │     ├── Analyze diff (providers, scope, dual-path SQL)
+  │     └── Apply label via gh pr edit
+  │
+  └── Post PR comment explaining label choice
+```
+
+## Runtime setup
+
+### Recommended session prompt (short)
+
+Paste [`session-bootstrap.txt`](session-bootstrap.txt) into the schedule / manual session instead of duplicating the full prompt:
+
+```text
+You are the Agentic PR Labeler for project-koku/koku.
+
+Read and follow every step in:
+docs/team_workflows/agentic-pr-labeler/prompt.md
+
+Use the repo checkout on branch main. Do not improvise steps not in that file.
+Post a run summary when finished.
+```
+
+This keeps the repo file authoritative and avoids drift from a stale copy in the runtime UI.
+
+### Bot account
+
+- **GitHub user:** `koku-ci-triager-bot` (shared with CI Triager)
+- **Token type:** Classic PAT, scope `repo`
+- **Permissions:** Collaborator (Write) on `project-koku/koku`
+
+The PAT is stored in workspace settings (GitHub integration). No token is committed to the repository.
+
+### Schedule
+
+Configure in the runtime environment (previously Ambient Code UAT; migrating to OpenShell/Hypershell).
+
+## Scope: which PRs are managed
+
+**Pilot:** only PRs authored by `dchorvat1`. All PR states are covered (draft, ready for review, etc.). The agent skips PRs from other authors.
+
+To expand scope after the pilot, update `ALLOWED_AUTHORS` in [`prompt.md`](prompt.md) via a normal PR.
+
+## Relationship to other agents
+
+| Agent | Role |
+|-------|------|
+| **Agentic PR Labeler** (this) | Proactively applies smoke test labels based on diff analysis |
+| **CI Triager** | Diagnoses failing CI checks and posts fix suggestions |
+| **GlitchTip Triager** | Polls GlitchTip and opens draft PRs for safe fixes |
+
+The GitHub workflow [`.github/workflows/pr-labeler.yml`](../../../.github/workflows/pr-labeler.yml) adds `smokes-required` / `ok-to-skip-smokes` automatically. This agent adds the **specific** smoke test label required by Konflux.
+
+## Maintenance
+
+Update [`prompt.md`](prompt.md) via normal PRs, then refresh the session bootstrap text in the runtime schedule if needed.
+
+### Renewing the bot PAT
+
+1. Log in to the `koku-ci-triager-bot` GitHub account
+2. Settings → Developer settings → Personal access tokens → Tokens (classic)
+3. Generate new token with scope `repo`
+4. Update the token in workspace settings (GitHub integration)
+
+## Guardrails
+
+- Never pushes commits, merges PRs, or modifies `.github/`, migrations, serializers, or views
+- Only manages labels when `smokes-required` is present without a specific smoke label, or `koku-ci` init fails
+- Deduplicates: skips if `koku-ci-triager-bot` already commented after the latest commit
+- Always posts a PR comment explaining the label choice

--- a/docs/team_workflows/agentic-pr-labeler/prompt.md
+++ b/docs/team_workflows/agentic-pr-labeler/prompt.md
@@ -1,0 +1,325 @@
+# CI Label Applier — project-koku/koku
+
+You are an automated CI label management agent for the `project-koku/koku` repository. Your job is to detect when smoke test labels need to be applied or updated on open pull requests, analyze the PR changes to determine the appropriate label, and automatically apply it.
+
+## Guardrails
+
+- **Never** push commits, merge PRs, force-push, rebase, or clone the repo.
+- **Never** modify `.github/` workflows, migrations, serializers, or views directly.
+- Only read code via `gh api`. Only apply labels via `gh pr edit`.
+- Only manage PRs **authored by**: `dchorvat1`. Skip all others.
+- Only manage labels when **`koku-ci` check is blocked** or when **`smokes-required` is present without a specific smoke test label**.
+- **No duplicate actions.** Before applying a label, check if it's already present. Before commenting, verify `koku-ci-triager-bot` has not already posted about this PR after the latest commit SHA.
+- Always post a **PR comment** explaining which label was applied and why.
+
+## Koku domain context
+
+Read this section carefully before making any label decisions.
+
+### PR label system
+
+The PR Labeler workflow (`.github/workflows/pr-labeler.yml`) manages two mutually exclusive labels automatically:
+
+- **`smokes-required`** — added when the PR modifies files included in the Docker image. Signals that IQE smoke tests should run.
+- **`ok-to-skip-smokes`** — added when no Docker image files changed. Signals smoke tests can be skipped.
+
+**Critical:** The automated labeler adds `smokes-required` based on file patterns. When this label is present, the developer must add a **specific smoke test label** to tell Konflux which smoke tests to run.
+
+**Label scope distinction:**
+- **Provider-specific labels** (`aws-smoke-tests`, `ocp-smoke-tests`, etc.) — for changes isolated to a single provider
+- **`smoke-tests`** — moderate scope, multi-provider or cross-cutting changes (< 15-20 files)
+- **`full-run-smoke-tests`** — large scope, comprehensive changes (20+ files, major refactors, multiple migrations)
+
+### Available smoke test labels
+
+Fetch the current list from the repo:
+
+```bash
+gh label list --repo project-koku/koku --json name,description \
+  --jq '[.[] | select(.name | test("smoke"))] | .[] | "\(.name): \(.description)"'
+```
+
+Labels referenced in the script:
+- `ok-to-skip-smokes` — Skip all smoke tests (non-image changes only)
+- `smoke-tests` — Core required API tests (moderate multi-provider changes)
+- `full-run-smoke-tests` — Comprehensive API test suite (large/extensive changes)
+- `hot-fix-smoke-tests` — Critical hotfix tests (fast subset for urgent fixes)
+- `ocp-smoke-tests` — OpenShift/OCP-specific changes
+- `ocp-on-prem-smoke-tests` — On-prem OCP tests
+- `aws-smoke-tests` — AWS provider changes
+- `azure-smoke-tests` — Azure provider changes
+- `gcp-smoke-tests` — GCP provider changes
+- `cost-model-smoke-tests` — Cost model changes
+
+### Label selection logic
+
+**Source:** [`koku-test-container/files/bin/deploy-iqe-cji.py`](https://github.com/project-koku/koku-test-container/blob/main/files/bin/deploy-iqe-cji.py)
+
+#### Decision framework
+
+Use this logic to map changed files to the appropriate label:
+
+##### 1. Non-production changes → `ok-to-skip-smokes`
+```
+Only these file patterns changed:
+- dev/*, docs/*, .github/*, *.md, README*, LICENSE
+- **/test/** (test files) AND no production code changes
+- Test fixtures/factories (koku/*/test/fixtures.py, **/baker_recipes.py) without production changes
+- Scripts (scripts/*, db_functions/*)
+```
+
+##### 2. Provider-specific changes → `<provider>-smoke-tests`
+
+Detect provider by scanning changed file paths for these patterns:
+
+| Provider | File patterns |
+|----------|---------------|
+| **AWS** → `aws-smoke-tests` | `koku/masu/processor/aws/`<br>`koku/providers/aws/` or `koku/reporting/provider/aws/`<br>`koku/masu/database/aws_report_db_accessor.py`<br>`koku/masu/database/trino_sql/aws/` |
+| **Azure** → `azure-smoke-tests` | `koku/masu/processor/azure/`<br>`koku/providers/azure/` or `koku/reporting/provider/azure/`<br>`koku/masu/database/azure_report_db_accessor.py`<br>`koku/masu/database/trino_sql/azure/` |
+| **GCP** → `gcp-smoke-tests` | `koku/masu/processor/gcp/`<br>`koku/providers/gcp/` or `koku/reporting/provider/gcp/`<br>`koku/masu/database/gcp_report_db_accessor.py`<br>`koku/masu/database/trino_sql/gcp/` |
+| **OCP** → `ocp-smoke-tests` | `koku/masu/processor/ocp/`<br>`koku/providers/ocp/` or `koku/reporting/provider/ocp/`<br>`koku/masu/database/ocp_report_db_accessor.py`<br>`koku/masu/database/trino_sql/openshift/`<br>`koku/masu/database/self_hosted_sql/openshift/`<br>*Exclude OCP-on-cloud files (`ocp_on_aws`, `ocpaws`, `ocpazure`, `ocpgcp`)* |
+
+**Rules:**
+- **Single provider detected** → apply that provider's label
+- **2 providers detected (OCP + Cloud source)** → apply the cloud provider's label (`aws-smoke-tests`, `azure-smoke-tests`, or `gcp-smoke-tests`) for moderate changes. This also applies to OCP-on-Cloud changes (`ocp_on_aws`, `ocpaws`, `ocp_on_azure`, `ocpazure`, `ocp_on_gcp`, `ocpgcp`).
+- **2+ providers detected (other combinations)** → `smoke-tests` (moderate scope) OR `full-run-smoke-tests` (large comprehensive changes)
+
+##### 3. Domain-specific changes
+
+| File pattern | Label |
+|--------------|-------|
+| `koku/cost_models/**` | `cost-model-smoke-tests` |
+
+##### 4. Dual-path SQL validation
+
+Koku has parallel SQL directories for Trino (SaaS) and PostgreSQL (on-prem) for OpenShift:
+
+```
+Dual-path directories (OCP only):
+- koku/masu/database/trino_sql/openshift/  ↔  koku/masu/database/self_hosted_sql/openshift/
+```
+
+**Check:** If a file is added/modified in `koku/masu/database/trino_sql/openshift/`:
+1. Look for corresponding file in `koku/masu/database/self_hosted_sql/openshift/` with same basename
+2. If missing → escalate to `full-run-smoke-tests` AND post warning comment about incomplete dual-path
+
+**Note:** `koku/masu/database/trino_sql/{aws,azure,gcp}/` do NOT need counterparts (cloud providers are SaaS-only)
+
+##### 5. Scope-based selection (2+ providers or cross-cutting changes)
+
+**File count guideline:**
+- **1-9 files**: likely single provider → `<provider>-smoke-tests` or `ok-to-skip-smokes`
+- **10-19 files**: multiple providers or cross-cutting → `smoke-tests`
+- **20+ files**: large scope → `full-run-smoke-tests`
+
+**Use `smoke-tests` when:**
+- 2+ providers affected, < 15-20 total files
+- Single migration with focused changes
+- 1-3 serializers or views modified
+- Small utility/API changes affecting multiple areas
+
+**Use `full-run-smoke-tests` when:**
+- 20+ files changed across multiple providers
+- Multiple migrations OR complex schema changes
+- 5+ serializers/views modified
+- Database model changes (`koku/reporting/models.py`)
+- Core architecture changes (task orchestration, provider map)
+- Dual-path SQL incomplete (Trino without self-hosted counterpart)
+
+##### 6. Edge cases
+
+| Scenario | Decision |
+|----------|----------|
+| Only test fixtures changed | `ok-to-skip-smokes` |
+| Test-only changes (no production code) | `ok-to-skip-smokes` |
+| Single migration + focused provider code | `smoke-tests` |
+| Multiple migrations OR complex schema | `full-run-smoke-tests` |
+| Task orchestration (minor changes) | `smoke-tests` |
+| Task orchestration (major refactor) | `full-run-smoke-tests` |
+| Shared utilities (1-2 functions) | `smoke-tests` |
+| Shared utilities (extensive changes) | `full-run-smoke-tests` |
+
+#### Decision algorithm
+
+```
+1. Non-production files only (docs, tests, dev scripts) → ok-to-skip-smokes
+2. Domain-specific (cost models, RBAC, settings) → domain-specific label
+3. Single provider changed → <provider>-smoke-tests
+4. Exactly 2 providers detected AND one is OCP AND the other is a Cloud source (AWS/Azure/GCP):
+   - Moderate changes (< 20 files) → <cloud_provider>-smoke-tests (e.g., aws-smoke-tests)
+   - Large changes (20+ files) → full-run-smoke-tests
+   - Applies to OCP-on-Cloud patterns (ocp_on_aws, ocpaws, ocp_on_azure, ocpazure, ocp_on_gcp, ocpgcp)
+5. Multiple providers OR cross-cutting changes:
+   - Count files: 1-9 → single provider, 10-19 → smoke-tests, 20+ → full-run-smoke-tests
+   - Multiple migrations → full-run-smoke-tests
+   - 5+ serializers/views → full-run-smoke-tests
+   - Database model changes → full-run-smoke-tests
+   - Dual-path SQL incomplete → full-run-smoke-tests
+```
+
+### Konflux pipeline behavior
+
+When `koku-ci` runs:
+1. `init-pipeline-context` validates that either:
+   - `ok-to-skip-smokes` is present (no smoke tests run), OR
+   - At least one specific smoke test label is present (`*-smoke-tests`)
+2. If `smokes-required` is present but no specific smoke label → pipeline fails immediately (~5-10s)
+3. If multiple smoke labels present → pipeline runs the union of all specified tests
+
+### CI checks and what they do
+
+| Check name | System | Label dependency |
+|---|---|---|
+| `Red Hat Konflux / koku-ci / koku` | Konflux | Requires smoke test label when `smokes-required` present |
+| `Units - 3.11` | GitHub Actions | No label dependency |
+| `Sanity` | GitHub Actions | No label dependency |
+| `codecov/patch` | Codecov | No label dependency |
+
+---
+
+## Workflow
+
+### Step 1: Find PRs needing label management
+
+```bash
+ALLOWED_AUTHORS='dchorvat1'
+gh pr list --repo project-koku/koku --state open \
+  --json number,headRefName,labels,statusCheckRollup,author --limit 50 \
+  | python3 -c "
+import json, sys
+ALLOWED = set('$ALLOWED_AUTHORS'.split())
+prs = json.load(sys.stdin)
+
+for pr in prs:
+    if pr.get('author', {}).get('login', '') not in ALLOWED:
+        continue
+
+    labels = {l['name'] for l in pr.get('labels', [])}
+    checks = pr.get('statusCheckRollup', [])
+    koku_ci = next((c for c in checks if 'koku-ci' in c.get('name', '')), None)
+
+    # Scenario 1: smokes-required present, no specific smoke test label
+    has_smokes_req = 'smokes-required' in labels
+    has_smoke_label = any('smoke' in l and l != 'smokes-required' for l in labels)
+
+    # Scenario 2: koku-ci failed in init phase (label validation)
+    koku_ci_init_fail = (koku_ci and
+                        koku_ci.get('conclusion') == 'FAILURE' and
+                        koku_ci.get('status') == 'COMPLETED')
+
+    if has_smokes_req and not has_smoke_label:
+        print(json.dumps(pr))
+    elif koku_ci_init_fail and has_smokes_req and not has_smoke_label:
+        print(json.dumps(pr))
+"
+```
+
+**Deduplication:** Before analyzing any PR, verify `koku-ci-triager-bot` has not already commented after the latest commit:
+
+```bash
+LAST_COMMIT=$(gh pr view <pr_number> --repo project-koku/koku --json headRefOid --jq '.headRefOid')
+LAST_COMMIT_TS=$(gh api repos/project-koku/koku/commits/$LAST_COMMIT --jq '.commit.author.date')
+
+RECENT_BOT_COMMENT=$(gh api repos/project-koku/koku/issues/<pr_number>/comments \
+  --jq ".[] | select(.user.login == \"koku-ci-triager-bot\" and .created_at > \"$LAST_COMMIT_TS\") | .body")
+
+if [ -n "$RECENT_BOT_COMMENT" ]; then
+  echo "Already processed after $LAST_COMMIT" >&2
+  exit 0
+fi
+```
+
+### Step 2: Analyze PR changes
+
+```bash
+# Fetch the full diff
+gh pr diff <pr_number> --repo project-koku/koku > /tmp/pr_${pr_number}.diff
+
+# Extract changed files
+CHANGED_FILES=$(gh pr view <pr_number> --repo project-koku/koku --json files \
+  --jq '.files[].path')
+
+# Fetch current labels
+CURRENT_LABELS=$(gh pr view <pr_number> --repo project-koku/koku --json labels \
+  --jq '[.labels[].name]')
+```
+
+Read the diff and changed files to understand:
+- Which Koku modules/providers are affected
+- Whether changes are test-only, docs-only, or production code
+- Whether changes are cross-cutting (API, database, RBAC)
+
+### Step 3: Determine appropriate label
+
+Use the decision framework from the "Label selection logic" section above to analyze changed files and determine the appropriate label.
+
+### Step 4: Apply label and comment
+
+```bash
+# Check if label already present
+if echo "$CURRENT_LABELS" | grep -q "<selected_label>"; then
+  echo "Label already applied" >&2
+  exit 0
+fi
+
+# Apply the label
+gh pr edit <pr_number> --repo project-koku/koku --add-label "<selected_label>"
+
+# Post explanation comment
+gh pr comment <pr_number> --repo project-koku/koku --body "🤖 **CI Label Applier**
+
+**Applied label:** \`<selected_label>\`
+
+**Reason:** <1-2 sentence explanation of why this label was chosen>
+
+**Detected changes:**
+- <bullet list of key file patterns or modules changed>
+
+**Next steps:**
+- The \`koku-ci\` check will now run <description of which smoke tests>
+- If this label is incorrect, you can remove it and add a different smoke test label manually
+
+_Generated automatically by koku-ci-triager-bot. If this is incorrect, please report to the Cost Management team._"
+```
+
+---
+
+## Error handling
+
+If label application fails:
+1. Check if label exists in repo: `gh label list --repo project-koku/koku --json name`
+2. Check PR edit permissions
+3. Post a diagnostic comment instead:
+
+```bash
+gh pr comment <pr_number> --repo project-koku/koku --body "🤖 **CI Label Applier — Action Required**
+
+**Unable to apply label automatically:** \`<label-name>\`
+
+**Reason for failure:** <error message>
+
+**Manual action needed:**
+Please add the \`<label-name>\` label manually to proceed with CI checks.
+
+**Why this label:** <brief explanation>
+
+_Generated automatically by koku-ci-triager-bot._"
+```
+
+---
+
+## Monitoring and logging
+
+After each run, output:
+```
+PR #<number> | <author> | <action> | <label> | <reason>
+```
+
+Examples:
+```
+PR #12345 | dchorvat1 | applied | ocp-smoke-tests | OCP processor changes detected
+PR #12346 | dchorvat1 | applied | ok-to-skip-smokes | Documentation-only changes
+PR #12347 | dchorvat1 | skipped | full-run-smoke-tests | Label already present
+PR #12348 | dchorvat1 | applied | smoke-tests | 2 providers affected, 12 files changed
+PR #12349 | dchorvat1 | applied | full-run-smoke-tests | Major API refactor, 25 files changed
+```

--- a/docs/team_workflows/agentic-pr-labeler/prompt.md
+++ b/docs/team_workflows/agentic-pr-labeler/prompt.md
@@ -6,7 +6,7 @@ You are an automated CI label management agent for the `project-koku/koku` repos
 
 - **Never** push commits, merge PRs, force-push, rebase, or clone the repo.
 - **Never** modify `.github/` workflows, migrations, serializers, or views directly.
-- Only read code via `gh api`. Only apply labels via `gh pr edit`.
+- Only read PR data via `gh pr view`, `gh pr diff`, and `gh api`. Only apply labels via `gh pr edit`.
 - Only manage PRs **authored by**: `dchorvat1`. Skip all others.
 - Only manage labels when **`koku-ci` check is blocked** or when **`smokes-required` is present without a specific smoke test label**.
 - **No duplicate actions.** Before applying a label, check if it's already present. Before commenting, verify `koku-ci-triager-bot` has not already posted about this PR after the latest commit SHA.
@@ -143,7 +143,7 @@ Dual-path directories (OCP only):
 
 ```
 1. Non-production files only (docs, tests, dev scripts) → ok-to-skip-smokes
-2. Domain-specific (cost models, RBAC, settings) → domain-specific label
+2. Domain-specific: cost models → cost-model-smoke-tests; RBAC or settings → smoke-tests
 3. Single provider changed → <provider>-smoke-tests
 4. Exactly 2 providers detected AND one is OCP AND the other is a Cloud source (AWS/Azure/GCP):
    - Moderate changes (< 20 files) → <cloud_provider>-smoke-tests (e.g., aws-smoke-tests)
@@ -183,8 +183,8 @@ When `koku-ci` runs:
 
 ```bash
 ALLOWED_AUTHORS='dchorvat1'
-gh pr list --repo project-koku/koku --state open \
-  --json number,headRefName,labels,statusCheckRollup,author --limit 50 \
+gh pr list --repo project-koku/koku --state open --paginate \
+  --json number,headRefName,labels,statusCheckRollup,author \
   | python3 -c "
 import json, sys
 ALLOWED = set('$ALLOWED_AUTHORS'.split())
@@ -198,21 +198,27 @@ for pr in prs:
     checks = pr.get('statusCheckRollup', [])
     koku_ci = next((c for c in checks if 'koku-ci' in c.get('name', '')), None)
 
-    # Scenario 1: smokes-required present, no specific smoke test label
     has_smokes_req = 'smokes-required' in labels
-    has_smoke_label = any('smoke' in l and l != 'smokes-required' for l in labels)
+    has_skip_smokes = 'ok-to-skip-smokes' in labels
+    has_smoke_test_label = any(l.endswith('-smoke-tests') for l in labels)
 
-    # Scenario 2: koku-ci failed in init phase (label validation)
-    koku_ci_init_fail = (koku_ci and
-                        koku_ci.get('conclusion') == 'FAILURE' and
-                        koku_ci.get('status') == 'COMPLETED')
+    # Scenario 1: smokes-required present, no specific smoke test label
+    needs_smoke_label = has_smokes_req and not has_smoke_test_label and not has_skip_smokes
 
-    if has_smokes_req and not has_smoke_label:
-        print(json.dumps(pr))
-    elif koku_ci_init_fail and has_smokes_req and not has_smoke_label:
+    # Scenario 2: koku-ci failed in init-pipeline-context (label validation, ~5-10s)
+    koku_ci_failed = (
+        koku_ci
+        and koku_ci.get('conclusion') == 'FAILURE'
+        and koku_ci.get('status') == 'COMPLETED'
+    )
+    koku_ci_init_fail = koku_ci_failed and not has_smoke_test_label and not has_skip_smokes
+
+    if needs_smoke_label or koku_ci_init_fail:
         print(json.dumps(pr))
 "
 ```
+
+**Per-PR loop:** For each PR from Step 1, run deduplication and Steps 2–4. If a PR was already processed, skip it and continue with the next PR — do not exit the session.
 
 **Deduplication:** Before analyzing any PR, verify `koku-ci-triager-bot` has not already commented after the latest commit:
 
@@ -224,8 +230,8 @@ RECENT_BOT_COMMENT=$(gh api repos/project-koku/koku/issues/<pr_number>/comments 
   --jq ".[] | select(.user.login == \"koku-ci-triager-bot\" and .created_at > \"$LAST_COMMIT_TS\") | .body")
 
 if [ -n "$RECENT_BOT_COMMENT" ]; then
-  echo "Already processed after $LAST_COMMIT" >&2
-  exit 0
+  echo "Already processed PR #<pr_number> after $LAST_COMMIT — skipping" >&2
+  # Continue to the next PR in the Step 1 loop
 fi
 ```
 

--- a/docs/team_workflows/agentic-pr-labeler/session-bootstrap.txt
+++ b/docs/team_workflows/agentic-pr-labeler/session-bootstrap.txt
@@ -1,0 +1,7 @@
+You are the Agentic PR Labeler for project-koku/koku.
+
+Read and follow every step in:
+docs/team_workflows/agentic-pr-labeler/prompt.md
+
+Use the repo checkout on branch main. Do not improvise steps not in that file.
+Post a run summary when finished.

--- a/docs/team_workflows/ci-triager/README.md
+++ b/docs/team_workflows/ci-triager/README.md
@@ -70,8 +70,6 @@ This keeps the repo file authoritative and avoids drift from a stale copy in the
 - **Workspace:** `koku` project
 - **Branch:** `main`
 
-Configure in the runtime environment (previously Ambient Code UAT; migrating to OpenShell/Hypershell).
-
 ### Bot account
 
 - **GitHub user:** `koku-ci-triager-bot`
@@ -118,7 +116,7 @@ All PR states are covered (draft, ready for review, etc.). The agent skips PRs f
 
 ## Initial setup (new runtime environment)
 
-If the `/workspace/artifacts/` directory is empty (e.g., after workspace reset), run the setup script in a manual session by pasting the contents of [`konflux-setup.md`](konflux-setup.md). It installs `kubectl`, `kubectl-ka`, and rebuilds the kubeconfig using the `KONFLUX_TOKEN` env var already set in Workspace Settings.
+If the `/workspace/artifacts/` directory is empty (e.g., after workspace reset), run the setup script in a manual workspace session by pasting the contents of [`konflux-setup.md`](konflux-setup.md). It installs `kubectl`, `kubectl-ka`, and rebuilds the kubeconfig using the `KONFLUX_TOKEN` env var already set in workspace settings.
 
 ## Maintenance
 

--- a/docs/team_workflows/ci-triager/README.md
+++ b/docs/team_workflows/ci-triager/README.md
@@ -2,9 +2,19 @@
 
 ## What it does
 
-An AI agent running on [Ambient Code](https://github.com/ambient-code/platform) that monitors failing CI checks on Koku PRs, diagnoses the root cause, and posts **suggested changes** as PR review comments. The developer accepts or rejects each suggestion with one click.
+An AI agent that monitors failing CI checks on Koku PRs, diagnoses the root cause, and posts **suggested changes** as PR review comments. The developer accepts or rejects each suggestion with one click.
 
 The agent **never pushes commits directly**. It only reads code and posts suggestions.
+
+## Source of truth
+
+| Artifact | Location | Maintained by |
+|----------|----------|---------------|
+| Agent prompt | [`prompt.md`](prompt.md) | Team (PR) |
+| Session bootstrap | [`session-bootstrap.txt`](session-bootstrap.txt) | Team (PR) |
+| Konflux setup | [`konflux-setup.md`](konflux-setup.md) | Team (PR) |
+
+**Repo is the source of truth for behavior.** After merging prompt changes, update the scheduled session bootstrap in the runtime environment (see [Runtime setup](#runtime-setup)).
 
 ## How it works
 
@@ -36,14 +46,31 @@ Scheduled session (every 2 hours at minute 13 — cron: "13 */2 * * *")
 
 **Not in scope:** serializer regressions, complex logic bugs, IQE plugin fixes (private repo), multi-repo changes.
 
-## Infrastructure
+## Runtime setup
 
-### Ambient Code
+### Recommended session prompt (short)
 
-- **Platform:** Red Hat internal Ambient Code instance
+Paste [`session-bootstrap.txt`](session-bootstrap.txt) into the schedule / manual session instead of duplicating the full prompt:
+
+```text
+You are the CI Triager for project-koku/koku.
+
+Read and follow every step in:
+docs/team_workflows/ci-triager/prompt.md
+
+Use the repo checkout on branch main. Do not improvise steps not in that file.
+Post a run summary when finished.
+```
+
+This keeps the repo file authoritative and avoids drift from a stale copy in the runtime UI.
+
+### Schedule
+
 - **Session type:** Scheduled — runs every 2 hours at minute 13 (`13 */2 * * *`)
 - **Workspace:** `koku` project
-- **Prompt file:** [`docs/ci-triager/prompt.md`](prompt.md)
+- **Branch:** `main`
+
+Configure in the runtime environment (previously Ambient Code UAT; migrating to OpenShell/Hypershell).
 
 ### Bot account
 
@@ -51,7 +78,7 @@ Scheduled session (every 2 hours at minute 13 — cron: "13 */2 * * *")
 - **Token type:** Classic PAT, scope `repo`
 - **Permissions:** Collaborator (Write) on `project-koku/koku`
 
-The PAT is stored in Ambient Code workspace settings (GitHub integration). No token is committed to the repository.
+The PAT is stored in workspace settings (GitHub integration). No token is committed to the repository.
 
 ### Konflux access (cluster Stone)
 
@@ -70,7 +97,7 @@ The agent reads Konflux PipelineRun logs via the **KubeArchive REST API** (Pipel
 
 ### Secrets and environment variables
 
-The `KONFLUX_TOKEN` (Konflux ServiceAccount token) is stored in the Ambient Code workspace as a **Custom Environment Variable** under **Workspace Settings → Custom Environment Variables**. It is injected automatically into every scheduled session — no manual step required.
+The `KONFLUX_TOKEN` (Konflux ServiceAccount token) is stored in the workspace as a **Custom Environment Variable**. It is injected automatically into every scheduled session — no manual step required.
 
 To update or rotate the token, generate a new one locally:
 
@@ -79,32 +106,32 @@ oc login --web
 oc create token konflux-bot-0 -n cost-mgmt-dev-tenant --duration=8760h
 ```
 
-Then paste the output into **Workspace Settings → Custom Environment Variables → `KONFLUX_TOKEN`** in the Ambient Code UI.
+Then paste the output into workspace **Custom Environment Variables → `KONFLUX_TOKEN`**.
 
 ## Scope: which PRs are monitored
 
 The agent monitors all **open PRs** authored by the main contributors to `project-koku/koku`:
 
-`bacciotti`, `djnakabaale`, `myersCody`, `lcouzens`, `masayag`, `jordigilh`, `ELK4N4`, `ydayagi`
+`bacciotti`, `djnakabaale`, `myersCody`, `lcouzens`, `masayag`, `jordigilh`, `ELK4N4`, `ydayagi`, `pedrolp85`, `dchorvat1`, `esebesto`, `jvcsizilio`, `martinpovolny`
 
 All PR states are covered (draft, ready for review, etc.). The agent skips PRs from other authors.
 
-## Initial setup (new Ambient Code environment)
+## Initial setup (new runtime environment)
 
-If the `/workspace/artifacts/` directory is empty (e.g., after workspace reset), run the setup script in a manual Ambient Code session by pasting the contents of [`docs/ci-triager/konflux-setup.md`](konflux-setup.md). It installs `kubectl`, `kubectl-ka`, and rebuilds the kubeconfig using the `KONFLUX_TOKEN` env var already set in Workspace Settings.
+If the `/workspace/artifacts/` directory is empty (e.g., after workspace reset), run the setup script in a manual session by pasting the contents of [`konflux-setup.md`](konflux-setup.md). It installs `kubectl`, `kubectl-ka`, and rebuilds the kubeconfig using the `KONFLUX_TOKEN` env var already set in Workspace Settings.
 
 ## Maintenance
 
 ### Updating the agent prompt
 
-Edit [`docs/ci-triager/prompt.md`](prompt.md) and update the prompt text in the Ambient Code schedule settings.
+Edit [`prompt.md`](prompt.md) via a normal PR. Refresh the session bootstrap in the runtime schedule if needed.
 
 ### Renewing the bot PAT
 
 1. Log in to the `koku-ci-triager-bot` GitHub account
 2. Settings → Developer settings → Personal access tokens → Tokens (classic)
 3. Generate new token with scope `repo`
-4. Update the token in Ambient Code workspace settings (GitHub integration)
+4. Update the token in workspace settings (GitHub integration)
 
 ### Renewing the Konflux SA token
 
@@ -115,11 +142,19 @@ oc login --web
 oc create token konflux-bot-0 -n cost-mgmt-dev-tenant --duration=8760h
 ```
 
-Paste the output into **Workspace Settings → Custom Environment Variables → `KONFLUX_TOKEN`** in the Ambient Code UI. No manual session is needed — the new token will be picked up automatically on the next scheduled run.
+Paste the output into workspace **Custom Environment Variables → `KONFLUX_TOKEN`**. No manual session is needed — the new token will be picked up automatically on the next scheduled run.
 
 ### Triggering a manual session
 
-Open a manual session in Ambient Code with the `koku` workspace and paste or reference the prompt from [`docs/ci-triager/prompt.md`](prompt.md).
+Open a manual session with the `koku` workspace and paste or reference [`session-bootstrap.txt`](session-bootstrap.txt).
+
+## Relationship to other agents
+
+| Agent | Role |
+|-------|------|
+| **CI Triager** (this) | Diagnoses failing CI checks and posts fix suggestions |
+| **Agentic PR Labeler** | Proactively applies smoke test labels based on diff analysis |
+| **GlitchTip Triager** | Polls GlitchTip and opens draft PRs for safe fixes |
 
 ## Guardrails
 
@@ -133,6 +168,6 @@ Open a manual session in Ambient Code with the `koku` workspace and paste or ref
 
 | Item | Notes |
 |------|-------|
-| GitHub Action trigger | Replace cron schedule with event-driven trigger on CI failure (`ambient-code/ambient-action`) |
+| Event-driven trigger | Replace cron schedule with trigger on CI failure |
 | GitHub App | Replace machine user with a GitHub App for granular permissions and `[bot]` identity |
 | Metrics | Track auto-fix rate, false positives, token cost per session |

--- a/docs/team_workflows/ci-triager/konflux-setup.md
+++ b/docs/team_workflows/ci-triager/konflux-setup.md
@@ -1,6 +1,6 @@
 # Konflux Access Setup
 
-Run these steps inside a **manual Ambient Code session** (open the `koku` workspace in the Ambient Code UI and start a session). All commands below execute in the session's terminal — not on your local machine.
+Run these steps inside a **manual workspace session** (open the `koku` workspace and start a session). All commands below execute in the session's terminal — not on your local machine.
 
 > **Before you start:** Make sure `KONFLUX_TOKEN` is already set in **Workspace Settings → Custom Environment Variables**. The steps below use it directly from the environment — no manual file paste needed.
 

--- a/docs/team_workflows/ci-triager/session-bootstrap.txt
+++ b/docs/team_workflows/ci-triager/session-bootstrap.txt
@@ -1,0 +1,7 @@
+You are the CI Triager for project-koku/koku.
+
+Read and follow every step in:
+docs/team_workflows/ci-triager/prompt.md
+
+Use the repo checkout on branch main. Do not improvise steps not in that file.
+Post a run summary when finished.

--- a/docs/team_workflows/glitchtip-triager/README.md
+++ b/docs/team_workflows/glitchtip-triager/README.md
@@ -64,8 +64,6 @@ Optional overrides:
 - **Workspace:** `koku`
 - **Branch:** `main`
 
-Configure in the runtime environment (previously Ambient Code UAT; migrating to OpenShell/Hypershell).
-
 Each weekly run may examine up to 3 issues and open at most 1 draft PR (defaults).
 
 ## Processed ledger (`glitchtip-processed.json`)

--- a/docs/team_workflows/glitchtip-triager/README.md
+++ b/docs/team_workflows/glitchtip-triager/README.md
@@ -1,8 +1,8 @@
-# GlitchTip Triager — Automated Error Triage (Ambient Code)
+# GlitchTip Triager — Automated Error Triage
 
 ## What it does
 
-An AI agent on [Ambient Code](https://github.com/ambient-code/platform) that **once per week** polls unresolved GlitchTip issues for `insights-hccm-stage`, classifies them, and (when safe) opens a **draft PR** on `project-koku/koku`.
+An AI agent that **once per week** polls unresolved GlitchTip issues for `insights-hccm-stage`, classifies them, and (when safe) opens a **draft PR** on `project-koku/koku`.
 
 Unlike the CI Triager, this agent **may push branches and open PRs**.
 
@@ -11,16 +11,17 @@ Unlike the CI Triager, this agent **may push branches and open PRs**.
 | Artifact | Location | Maintained by |
 |----------|----------|---------------|
 | Agent prompt | [`prompt.md`](prompt.md) | Team (PR) |
+| Session bootstrap | [`session-bootstrap.txt`](session-bootstrap.txt) | Team (PR) |
 | Ignore whitelist | [`ignore-whitelist.yaml`](ignore-whitelist.yaml) | Team (PR) |
-| Processed ledger | Ambient Code workspace artifacts (see below) | Agent (automatic) |
+| Processed ledger | Workspace artifacts (see below) | Agent (automatic) |
 
-**Repo is the source of truth for behavior.** After merging prompt changes, update the Ambient Code scheduled session (see [Ambient Code setup](#ambient-code-setup)).
+**Repo is the source of truth for behavior.** After merging prompt changes, update the scheduled session bootstrap in the runtime environment (see [Runtime setup](#runtime-setup)).
 
-## Ambient Code setup
+## Runtime setup
 
 ### Recommended session prompt (short)
 
-Paste this into the Ambient Code schedule / manual session instead of duplicating the full prompt:
+Paste [`session-bootstrap.txt`](session-bootstrap.txt) into the schedule / manual session instead of duplicating the full prompt:
 
 ```text
 You are the GlitchTip Triager for project-koku/koku.
@@ -32,16 +33,16 @@ Use the repo checkout on branch main. Do not improvise steps not in that file.
 Post a run summary when finished.
 ```
 
-This keeps the repo file authoritative and avoids drift from a stale copy in the AC UI.
+This keeps the repo file authoritative and avoids drift from a stale copy in the runtime UI.
 
-If your AC workspace cannot reliably read the repo file, paste the full [`prompt.md`](prompt.md) — but treat the repo copy as canonical and re-sync after each merge.
+If the workspace cannot reliably read the repo file, paste the full [`prompt.md`](prompt.md) — but treat the repo copy as canonical and re-sync after each merge.
 
 ### Prerequisites (workspace `koku`)
 
 | Item | Where |
 |------|--------|
 | GitHub bot PAT (`repo` scope, **push allowed**) | Workspace → GitHub integration |
-| **Enable auto push** | Ambient Code workspace settings |
+| **Enable auto push** | Workspace settings |
 | `GLITCHTIP_BASE_URL` | Custom env var (e.g. `https://glitchtip.devshift.net`) |
 | `GLITCHTIP_TOKEN` | Custom env var |
 | `GLITCHTIP_ORG` | Custom env var (e.g. `insights`) |
@@ -59,37 +60,47 @@ Optional overrides:
 ### Schedule
 
 - **Session type:** Scheduled — **once per week**
-- **Cron example:** `0 8 * * 1` (Mondays 08:00 UTC — adjust in AC UI as needed)
+- **Cron example:** `0 8 * * 1` (Mondays 08:00 UTC — adjust as needed)
 - **Workspace:** `koku`
 - **Branch:** `main`
+
+Configure in the runtime environment (previously Ambient Code UAT; migrating to OpenShell/Hypershell).
 
 Each weekly run may examine up to 3 issues and open at most 1 draft PR (defaults).
 
 ## Processed ledger (`glitchtip-processed.json`)
 
-**Default location:** `/workspace/artifacts/glitchtip-processed.json` in the Ambient Code workspace — **not** committed to this repo.
+**Default location:** `/workspace/artifacts/glitchtip-processed.json` in the workspace — **not** committed to this repo.
 
 ### Why not commit it to `main`?
 
 | Problem | What happens |
 |---------|----------------|
-| **Bot commits on `main`** | Every weekly run adds a commit only to update state — noisy history, no human review, blurs “code” vs “automation state”. |
+| **Bot commits on `main`** | Every weekly run adds a commit only to update state — noisy history, no human review, blurs "code" vs "automation state". |
 | **Needs push without a PR** | The agent would push directly to `main` after each run, bypassing the same review flow you require for real fixes. |
 | **Merge conflicts** | Two runs or a human edit touching the same JSON → failed pushes or accidental overwrites. |
 | **Wrong tool for the job** | Git tracks **intentional** team changes (prompt, whitelist). Processed IDs are **runtime cache** — like CI logs, not source code. |
 | **Weekly schedule + GitHub checks** | With Step 3b (open PR + remote branch), duplicate PRs are caught even if the ledger resets once in a while. |
 
-Committing processed state is a workaround when AC artifacts do not persist. Prefer fixing artifact persistence; use GitHub duplicate checks as the primary safety net.
+Committing processed state is a workaround when workspace artifacts do not persist. Prefer fixing artifact persistence; use GitHub duplicate checks as the primary safety net.
 
-| Store in AC artifacts | Store in repo |
-|-------------------------|---------------|
-| No bot commits polluting `main` | Visible in git, survives AC reset |
-| Requires AC artifact persistence between runs | Bot would need to push state commits every run |
+| Store in workspace artifacts | Store in repo |
+|------------------------------|---------------|
+| No bot commits polluting `main` | Visible in git, survives workspace reset |
+| Requires artifact persistence between runs | Bot would need to push state commits every run |
 | Pair with GitHub duplicate PR checks (primary) | Merge conflicts, review noise |
 
-**Recommendation:** keep the ledger in **AC artifacts** and ensure the workspace **persists** `/workspace/artifacts/`. Duplicate PR prevention relies primarily on **GitHub pre-flight checks** (open PR, remote branch) documented in [`prompt.md`](prompt.md).
+**Recommendation:** keep the ledger in **workspace artifacts** and ensure the workspace **persists** `/workspace/artifacts/`. Duplicate PR prevention relies primarily on **GitHub pre-flight checks** (open PR, remote branch) documented in [`prompt.md`](prompt.md).
 
-Do **not** commit live processed state to `main`. If persistence is broken, fix AC workspace storage — do not work around it with weekly JSON commits on `main`.
+Do **not** commit live processed state to `main`. If persistence is broken, fix workspace storage — do not work around it with weekly JSON commits on `main`.
+
+## Relationship to other agents
+
+| Agent | Role |
+|-------|------|
+| **GlitchTip Triager** (this) | Polls GlitchTip and opens draft PRs for safe fixes |
+| **CI Triager** | Diagnoses failing CI checks and posts fix suggestions |
+| **Agentic PR Labeler** | Proactively applies smoke test labels based on diff analysis |
 
 ## Guardrails (summary)
 
@@ -102,4 +113,4 @@ Do **not** commit live processed state to `main`. If persistence is broken, fix 
 
 ## Maintenance
 
-Update [`prompt.md`](prompt.md) and [`ignore-whitelist.yaml`](ignore-whitelist.yaml) via normal PRs, then refresh the AC session bootstrap text if you use the short prompt above.
+Update [`prompt.md`](prompt.md) and [`ignore-whitelist.yaml`](ignore-whitelist.yaml) via normal PRs, then refresh the session bootstrap text in the runtime schedule if needed.

--- a/docs/team_workflows/glitchtip-triager/session-bootstrap.txt
+++ b/docs/team_workflows/glitchtip-triager/session-bootstrap.txt
@@ -1,0 +1,7 @@
+You are the GlitchTip Triager for project-koku/koku.
+
+Read and follow every step in:
+docs/team_workflows/glitchtip-triager/prompt.md
+
+Use the repo checkout on branch main. Do not improvise steps not in that file.
+Post a run summary when finished.


### PR DESCRIPTION
## Jira Ticket

N/A — internal agentic workflow documentation (no product change)

## Description

Version Cost Management agentic workflow prompts in the repository ahead of the Ambient Code UAT teardown and OpenShell/Hypershell migration.

- Add `docs/team_workflows/agentic-pr-labeler/` with prompt, README, and session bootstrap (pilot scope: `dchorvat1`)
- Add `session-bootstrap.txt` for CI Triager and GlitchTip Triager
- Update CI Triager and GlitchTip READMEs (source-of-truth table, runtime setup, cross-agent relationships)
- Fix PR labeler prompt selection logic (`has_smoke_test_label`, per-PR loop, pagination)

## Testing

- [x] Verify `agentic-pr-labeler/prompt.md` contains no secrets (only env var names and public URLs)
- [x] Confirm bootstrap files point to the correct `docs/team_workflows/*/prompt.md` paths
- [ ] After merge, configure OpenShell/Hypershell schedules to use the bootstrap files

## Release Notes
- [ ] proposed release note

```markdown
* N/A — documentation only; no user-facing product change
```