### PR TITLE
Add Kafka upload lag dashboard

### DIFF
--- a/dashboards/grafana-dashboard-insights-hccm.configmap.yaml
+++ b/dashboards/grafana-dashboard-insights-hccm.configmap.yaml
@@ -35,7 +35,7 @@ data:
           "id": 9999,
           "options": {
             "code": {"language": "plaintext", "showLineNumbers": false, "showMiniMap": false},
-            "content": "**Quick start:** Select **Datasource** (`crcp01ue1` = prod, `crcs02ue1` = stage) — namespace auto-selects.<br>For RDS panels, also select **RDS Datasource** (`appsrep11ue1` = prod, `appsres11ue1` = stage) — db_instance auto-selects.",
+            "content": "**Quick start:** Select **Datasource** (`crcp01ue1` = prod, `crcs02ue1` = stage) — namespace auto-selects.<br>For RDS and Kafka panels, also select **RDS / AWS Metrics Datasource** (`appsrep11ue1` = prod, `appsres11ue1` = stage) — db_instance auto-selects.",
             "mode": "markdown"
           },
           "title": "",
@@ -6671,6 +6671,104 @@ data:
           "yaxis": {
             "align": false
           }
+        },
+        {
+          "collapsed": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${rds_datasource}"
+          },
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 174
+          },
+          "id": 114,
+          "panels": [],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${rds_datasource}"
+              },
+              "refId": "A"
+            }
+          ],
+          "title": "Kafka",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${rds_datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "Messages",
+                "axisPlacement": "auto",
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 10000
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 175
+          },
+          "id": 113,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${rds_datasource}"
+              },
+              "expr": "aws_kafka_sum_offset_lag_sum{consumer_group=\"hccm-group\", topic=\"platform.upload.announce\"}",
+              "legendFormat": "{{cluster_name}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Upload Announcement Consumer Lag",
+          "type": "timeseries"
         }
       ],
       "refresh": "",
@@ -6719,7 +6817,7 @@ data:
             "current": {},
             "hide": 0,
             "includeAll": false,
-            "label": "RDS Datasource",
+            "label": "RDS / AWS Metrics Datasource",
             "multi": false,
             "name": "rds_datasource",
             "options": [],


### PR DESCRIPTION
## Summary
- add an Upload Announcement Consumer Lag panel for the hccm-group consumer of platform.upload.announce
- bind the panel to the existing AWS Metrics datasource selector so it works for production and stage
- visualize the existing 10,000-message high-lag threshold and clarify datasource selection

## Validation
- imported a temporary dashboard copy in stage Grafana and verified the panel renders live production and stage series
- python3 dev/scripts/validate_dashboards.py dashboards/grafana-dashboard-insights-hccm.configmap.yaml
- git diff --check
- 
<img width="2384" height="1600" alt="image" src="https://github.com/user-attachments/assets/f1eb7f3f-415c-43d2-905a-3a7a2a160ad8" />
