### PR TITLE
Capture API timeout stacks before proxy timeout

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -113,6 +113,8 @@ objects:
           value: ${GUNICORN_WORKERS}
         - name: GUNICORN_THREADS
           value: ${GUNICORN_THREADS}
+        - name: REQUEST_SOFT_TIMEOUT
+          value: ${REQUEST_SOFT_TIMEOUT}
         - name: REQUEST_FAULTHANDLER_TIMEOUT
           value: ${REQUEST_FAULTHANDLER_TIMEOUT}
         - name: CACHED_VIEWS_DISABLED
@@ -302,6 +304,8 @@ objects:
           value: ${GUNICORN_WORKERS}
         - name: GUNICORN_THREADS
           value: ${GUNICORN_THREADS}
+        - name: REQUEST_SOFT_TIMEOUT
+          value: ${REQUEST_SOFT_TIMEOUT}
         - name: REQUEST_FAULTHANDLER_TIMEOUT
           value: ${REQUEST_FAULTHANDLER_TIMEOUT}
         - name: CACHED_VIEWS_DISABLED
@@ -5834,6 +5838,11 @@ parameters:
 - displayName: Enable threads in Gunicorn
   name: GUNICORN_THREADS
   value: "True"
+- description: Seconds before a sync request is aborted and reported with request
+    context
+  displayName: Soft request timeout
+  name: REQUEST_SOFT_TIMEOUT
+  value: "90"
 - description: Seconds before a stuck sync request's Python stacks are written to
     stderr
   displayName: Faulthandler request timeout

--- a/deploy/kustomize/base/base.yaml
+++ b/deploy/kustomize/base/base.yaml
@@ -415,6 +415,10 @@ parameters:
 - displayName: Enable threads in Gunicorn
   name: GUNICORN_THREADS
   value: "True"
+- description: Seconds before a sync request is aborted and reported with request context
+  displayName: Soft request timeout
+  name: REQUEST_SOFT_TIMEOUT
+  value: "90"
 - description: Seconds before a stuck sync request's Python stacks are written to stderr
   displayName: Faulthandler request timeout
   name: REQUEST_FAULTHANDLER_TIMEOUT

--- a/deploy/kustomize/patches/koku-reads.yaml
+++ b/deploy/kustomize/patches/koku-reads.yaml
@@ -106,6 +106,8 @@
           value: ${GUNICORN_WORKERS}
         - name: GUNICORN_THREADS
           value: ${GUNICORN_THREADS}
+        - name: REQUEST_SOFT_TIMEOUT
+          value: ${REQUEST_SOFT_TIMEOUT}
         - name: REQUEST_FAULTHANDLER_TIMEOUT
           value: ${REQUEST_FAULTHANDLER_TIMEOUT}
         - name: CACHED_VIEWS_DISABLED

--- a/deploy/kustomize/patches/koku-writes.yaml
+++ b/deploy/kustomize/patches/koku-writes.yaml
@@ -113,6 +113,8 @@
           value: ${GUNICORN_WORKERS}
         - name: GUNICORN_THREADS
           value: ${GUNICORN_THREADS}
+        - name: REQUEST_SOFT_TIMEOUT
+          value: ${REQUEST_SOFT_TIMEOUT}
         - name: REQUEST_FAULTHANDLER_TIMEOUT
           value: ${REQUEST_FAULTHANDLER_TIMEOUT}
         - name: CACHED_VIEWS_DISABLED

--- a/koku/koku/middleware.py
+++ b/koku/koku/middleware.py
@@ -531,6 +531,23 @@ class RequestTimeoutMiddleware(MiddlewareMixin):
             faulthandler.cancel_dump_traceback_later()
         return response
 
+    def process_exception(self, request, exception):
+        """Report a soft timeout and return before the upstream proxy deadline."""
+        if not isinstance(exception, RequestTimeoutError):
+            return None
+
+        try:
+            import sentry_sdk
+
+            sentry_sdk.capture_exception(exception)
+        except Exception:
+            LOG.warning("Unable to send request-timeout stack trace to Sentry.", exc_info=True)
+
+        return JsonResponse(
+            {"errors": [{"detail": "Request timed out.", "status": HTTPStatus.GATEWAY_TIMEOUT}]},
+            status=HTTPStatus.GATEWAY_TIMEOUT,
+        )
+
 
 class DisableCSRF(MiddlewareMixin):
     """Middleware to disable CSRF for 3scale usecase."""

--- a/koku/koku/test_middleware.py
+++ b/koku/koku/test_middleware.py
@@ -653,6 +653,21 @@ class RequestTimeoutMiddlewareTest(IamTestCase):
         self.assertIn("POST", str(ctx.exception))
         self.assertIn("/api/v1/cost-models/", str(ctx.exception))
 
+    def test_process_exception_reports_soft_timeout_and_returns_gateway_timeout(self):
+        sentry_sdk = Mock()
+        request = Mock()
+        timeout = RequestTimeoutError("Request exceeded 28s")
+
+        with patch.dict(sys.modules, {"sentry_sdk": sentry_sdk}):
+            response = self.middleware.process_exception(request, timeout)
+
+        sentry_sdk.capture_exception.assert_called_once_with(timeout)
+        self.assertEqual(response.status_code, 504)
+        self.assertJSONEqual(response.content, {"errors": [{"detail": "Request timed out.", "status": 504}]})
+
+    def test_process_exception_ignores_other_exceptions(self):
+        self.assertIsNone(self.middleware.process_exception(Mock(), ValueError("not a timeout")))
+
     @patch("koku.middleware.signal.alarm")
     @patch("koku.middleware.signal.signal")
     @patch("koku.middleware.faulthandler.dump_traceback_later")


### PR DESCRIPTION
## Problem

3scale returns a client 504 at about 30 seconds, while Koku currently raises its diagnostic soft timeout at 90 seconds and dumps faulthandler stacks at 95 seconds. Those Koku diagnostics therefore cannot capture proxy-bound report requests.

## Change

- expose REQUEST_SOFT_TIMEOUT in both API deployments;
- preserve the existing 90-second default;
- report a caught soft timeout to GlitchTip and return JSON 504; and
- add focused middleware coverage.

App-interface will configure the deployed values after this reaches stage: 27 seconds for faulthandler and 28 seconds for the soft timeout.

## Validation

- make clowdapp
- python3 -m py_compile koku/koku/middleware.py koku/koku/test_middleware.py
- focused Django tests could not run locally: Pipenv/Django is not installed in this environment.